### PR TITLE
New group uses query to store space ID 

### DIFF
--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -232,20 +232,26 @@ abstract class AppRoutes {
               pageBuilder: (context, state) => defaultPageBuilder(
                 context,
                 state,
-                const NewGroup(),
+                NewGroup(
+                  // #Pangea
+                  spaceId: state.uri.queryParameters['spaceId'],
+                  // Pangea#
+                ),
               ),
               redirect: loggedOutRedirect,
-              routes: [
-                GoRoute(
-                  path: ':spaceid',
-                  pageBuilder: (context, state) => defaultPageBuilder(
-                    context,
-                    state,
-                    const NewGroup(),
-                  ),
-                  redirect: loggedOutRedirect,
-                ),
-              ],
+              // #Pangea
+              // routes: [
+              //   GoRoute(
+              //     path: ':spaceid',
+              //     pageBuilder: (context, state) => defaultPageBuilder(
+              //       context,
+              //       state,
+              //       const NewGroup(),
+              //     ),
+              //     redirect: loggedOutRedirect,
+              //   ),
+              // ],
+              // Pangea#
             ),
             GoRoute(
               path: 'newspace',

--- a/lib/pages/chat_list/start_chat_fab.dart
+++ b/lib/pages/chat_list/start_chat_fab.dart
@@ -30,7 +30,8 @@ class StartChatFloatingActionButton extends StatelessWidget {
   void _onPressed(BuildContext context) async {
     //#Pangea
     if (controller.activeSpaceId != null) {
-      context.go('/rooms/newgroup/${controller.activeSpaceId ?? ''}');
+      // context.go('/rooms/newgroup/${controller.activeSpaceId ?? ''}');
+      context.go('/rooms/newgroup?spaceId=${controller.activeSpaceId ?? ''}');
       return;
     }
     //Pangea#
@@ -44,7 +45,8 @@ class StartChatFloatingActionButton extends StatelessWidget {
       case ActiveFilter.groups:
         // #Pangea
         // context.go('/rooms/newgroup');
-        context.go('/rooms/newgroup/${controller.activeSpaceId ?? ''}');
+        // context.go('/rooms/newgroup/${controller.activeSpaceId ?? ''}');
+        context.go('/rooms/newgroup?spaceId=${controller.activeSpaceId ?? ''}');
         // Pangea#
         break;
       case ActiveFilter.spaces:

--- a/lib/pages/chat_list/start_chat_fab.dart
+++ b/lib/pages/chat_list/start_chat_fab.dart
@@ -30,7 +30,6 @@ class StartChatFloatingActionButton extends StatelessWidget {
   void _onPressed(BuildContext context) async {
     //#Pangea
     if (controller.activeSpaceId != null) {
-      // context.go('/rooms/newgroup/${controller.activeSpaceId ?? ''}');
       context.go('/rooms/newgroup?spaceId=${controller.activeSpaceId ?? ''}');
       return;
     }
@@ -45,7 +44,6 @@ class StartChatFloatingActionButton extends StatelessWidget {
       case ActiveFilter.groups:
         // #Pangea
         // context.go('/rooms/newgroup');
-        // context.go('/rooms/newgroup/${controller.activeSpaceId ?? ''}');
         context.go('/rooms/newgroup?spaceId=${controller.activeSpaceId ?? ''}');
         // Pangea#
         break;

--- a/lib/pages/new_group/new_group.dart
+++ b/lib/pages/new_group/new_group.dart
@@ -57,7 +57,7 @@ class NewGroupController extends State<NewGroup> {
   void setVocab(List<Lemma> vocab) => setState(() => chatTopic.vocab = vocab);
 
   String? get activeSpaceId =>
-      GoRouterState.of(context).pathParameters['spaceid'];
+      GoRouterState.of(context).uri.queryParameters['spaceId'];
   // Pangea#
 
   void setPublicGroup(bool b) => setState(() => publicGroup = b);

--- a/lib/pages/new_group/new_group.dart
+++ b/lib/pages/new_group/new_group.dart
@@ -17,7 +17,14 @@ import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart' as sdk;
 
 class NewGroup extends StatefulWidget {
-  const NewGroup({super.key});
+  // #Pangea
+  final String? spaceId;
+
+  const NewGroup({
+    super.key,
+    this.spaceId,
+  });
+  // Pangea#
 
   @override
   NewGroupController createState() => NewGroupController();


### PR DESCRIPTION
When a user creates a new group from inside a class, the space ID will be stored via query instead of path. Fixes issue where user had to back out of new group screen twice to leave.