### PR TITLE
Only admins can remove a room from a space

### DIFF
--- a/lib/pages/chat_list/space_view.dart
+++ b/lib/pages/chat_list/space_view.dart
@@ -237,6 +237,10 @@ class _SpaceViewState extends State<SpaceView> {
             icon: Icons.send_outlined,
           ),
         if (spaceChild != null &&
+            // #Pangea
+            room != null &&
+            room.ownPowerLevel >= ClassDefaultValues.powerLevelOfAdmin &&
+            // Pangea#
             (activeSpace?.canChangeStateEvent(EventTypes.spaceChild) ?? false))
           SheetAction(
             key: SpaceChildContextAction.removeFromSpace,


### PR DESCRIPTION
When user selects a room, checks that the user is a member of the room and has admin privileges before showing them the option to remove room from space.