### PR TITLE
Non-text messages cannot be edited

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1078,6 +1078,9 @@ class ChatController extends State<ChatPageWithRoom>
   bool get canEditSelectedEvents {
     if (isArchived ||
         selectedEvents.length != 1 ||
+        // #Pangea
+        selectedEvents.single.messageType != MessageTypes.Text ||
+        // Pangea#
         !selectedEvents.first.status.isSent) {
       return false;
     }


### PR DESCRIPTION
When a message is selected, it only shows the edit option if it's a text message