### PR TITLE
Fixing toolbar bugs for newly-sent messages

### DIFF
--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -344,11 +344,6 @@ class MessageContent extends StatelessWidget {
                       MatrixLocals(L10n.of(context)!),
                       hideReply: true,
                     );
-                // #Pangea
-                // toolbarController?.toolbar?.textSelection.setMessageText(
-                //   messageText,
-                // );
-                // Pangea#
                 return SelectableLinkify(
                   onSelectionChanged: (selection, cause) {
                     if (cause == SelectionChangedCause.longPress &&
@@ -365,11 +360,7 @@ class MessageContent extends StatelessWidget {
                         .onTextSelection(selection);
                   },
                   onTap: () => toolbarController?.showToolbar(context),
-                  // #Pangea
-                  // text: toolbarController?.toolbar?.textSelection.messageText ??
-                  //     messageText,
                   text: messageText,
-                  // Pangea#
                   contextMenuBuilder: (context, state) =>
                       (toolbarController?.highlighted ?? false)
                           ? const SizedBox.shrink()

--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -365,8 +365,11 @@ class MessageContent extends StatelessWidget {
                         .onTextSelection(selection);
                   },
                   onTap: () => toolbarController?.showToolbar(context),
-                  text: toolbarController?.toolbar?.textSelection.messageText ??
-                      messageText,
+                  // #Pangea
+                  // text: toolbarController?.toolbar?.textSelection.messageText ??
+                  //     messageText,
+                  text: messageText,
+                  // Pangea#
                   contextMenuBuilder: (context, state) =>
                       (toolbarController?.highlighted ?? false)
                           ? const SizedBox.shrink()

--- a/lib/pages/chat/events/message_content.dart
+++ b/lib/pages/chat/events/message_content.dart
@@ -344,9 +344,11 @@ class MessageContent extends StatelessWidget {
                       MatrixLocals(L10n.of(context)!),
                       hideReply: true,
                     );
-                toolbarController?.toolbar?.textSelection.setMessageText(
-                  messageText,
-                );
+                // #Pangea
+                // toolbarController?.toolbar?.textSelection.setMessageText(
+                //   messageText,
+                // );
+                // Pangea#
                 return SelectableLinkify(
                   onSelectionChanged: (selection, cause) {
                     if (cause == SelectionChangedCause.longPress &&

--- a/lib/pangea/widgets/chat/message_toolbar.dart
+++ b/lib/pangea/widgets/chat/message_toolbar.dart
@@ -188,10 +188,13 @@ class MessageToolbarState extends State<MessageToolbar> {
       return;
     }
 
-    setState(() {
-      currentMode = newMode;
-      updatingMode = true;
-    });
+    if (mounted) {
+      setState(() {
+        currentMode = newMode;
+        updatingMode = true;
+      });
+    }
+
     if (!subscribed) {
       toolbarContent = MessageUnsubscribedCard(
         languageTool: newMode.title(context),
@@ -221,9 +224,11 @@ class MessageToolbarState extends State<MessageToolbar> {
           break;
       }
     }
-    setState(() {
-      updatingMode = false;
-    });
+    if (mounted) {
+      setState(() {
+        updatingMode = false;
+      });
+    }
   }
 
   void showTranslation() {
@@ -289,7 +294,7 @@ class MessageToolbarState extends State<MessageToolbar> {
       final bool autoplay = MatrixState.pangeaController.pStoreService.read(
             PLocalKey.autoPlayMessages,
           ) ??
-          true;
+          false;
 
       if (widget.pangeaMessageEvent.isAudioMessage) {
         updateMode(MessageMode.speechToText);

--- a/lib/pangea/widgets/chat/message_translation_card.dart
+++ b/lib/pangea/widgets/chat/message_translation_card.dart
@@ -113,7 +113,9 @@ class MessageTranslationCardState extends State<MessageTranslationCard> {
     l2Code = MatrixState.pangeaController.languageController.activeL2Code(
       roomID: widget.messageEvent.room.id,
     );
-    setState(() {});
+    if (mounted) {
+      setState(() {});
+    }
 
     loadTranslation(() async {
       if (widget.selection.selectedText != null) {

--- a/lib/pangea/widgets/igc/pangea_rich_text.dart
+++ b/lib/pangea/widgets/igc/pangea_rich_text.dart
@@ -61,9 +61,11 @@ class PangeaRichTextState extends State<PangeaRichText> {
     widget.toolbarController?.toolbar?.textSelection.setMessageText(
       newTextSpan,
     );
-    setState(() {
-      textSpan = newTextSpan;
-    });
+    if (mounted) {
+      setState(() {
+        textSpan = newTextSpan;
+      });
+    }
   }
 
   void setTextSpan() {


### PR DESCRIPTION
Stopped FlutterError from throwing when toolbar closed on its own

Kept translated word length from affecting Define and Translate in toolbar

Made autoplay default value in toolbar false