### PR TITLE
Situationally remove copy option on selection

### DIFF
--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -42,11 +42,15 @@ class ChatView extends StatelessWidget {
             tooltip: L10n.of(context)!.edit,
             onPressed: controller.editSelectedEventAction,
           ),
-        IconButton(
-          icon: const Icon(Icons.copy_outlined),
-          tooltip: L10n.of(context)!.copy,
-          onPressed: controller.copyEventsAction,
-        ),
+        // #Pangea
+        if (controller.selectedEvents.length == 1 &&
+            controller.selectedEvents.single.messageType == MessageTypes.Text)
+          // Pangea#
+          IconButton(
+            icon: const Icon(Icons.copy_outlined),
+            tooltip: L10n.of(context)!.copy,
+            onPressed: controller.copyEventsAction,
+          ),
         if (controller.canSaveSelectedEvent)
           // Use builder context to correctly position the share dialog on iPad
           Builder(
@@ -116,8 +120,10 @@ class ChatView extends StatelessWidget {
       // #Pangea
     } else {
       return [
-        ChatSettingsPopupMenu(controller.room,
-            (!controller.room.isDirectChat && !controller.room.isArchived)),
+        ChatSettingsPopupMenu(
+          controller.room,
+          (!controller.room.isDirectChat && !controller.room.isArchived),
+        ),
       ];
     }
 


### PR DESCRIPTION
Copy option doesn't show for when non-text message or multiple messages are selected