### PR TITLE
Invitation page returns to details

### DIFF
--- a/lib/pages/invitation_selection/invitation_selection_view.dart
+++ b/lib/pages/invitation_selection/invitation_selection_view.dart
@@ -4,6 +4,7 @@ import 'package:fluffychat/widgets/layouts/max_width_body.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
+import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
 class InvitationSelectionView extends StatelessWidget {
@@ -31,7 +32,14 @@ class InvitationSelectionView extends StatelessWidget {
     // Pangea#
     return Scaffold(
       appBar: AppBar(
-        leading: const Center(child: BackButton()),
+        // #Pangea
+        // leading: const Center(child: BackButton()),
+        leading: Center(
+          child: BackButton(
+            onPressed: () => context.go("/rooms/${controller.roomId}/details"),
+          ),
+        ),
+// Pangea#
         titleSpacing: 0,
         title: Text(L10n.of(context)!.inviteContact),
       ),


### PR DESCRIPTION
When pressing the back button to exit the 'invite contact' page, return to chat/exchange/class details