### PR TITLE
Added instructions for tooltips

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3951,5 +3951,8 @@
     "leaveRoomDescription": "The chat will be moved to the archive. Other users will be able to see that you have left the chat.",
     "archiveSpaceDescription": "All chats within this space will be moved to the archive for yourself and other non-admin users.",
     "leaveSpaceDescription": "All chats within this space will be moved to the archive. Other users will be able to see that you have left the space.",
-    "onlyAdminDescription": "Since there are no other admins, all other participants will also be removed."
+    "onlyAdminDescription": "Since there are no other admins, all other participants will also be removed.",
+    "tooltipInstructionsTitle": "Not sure what that does?",
+    "tooltipInstructionsMobileBody": "Press and hold items to view tooltips.",
+    "tooltipInstructionsBrowserBody": "Hover over items to view tooltips."
 }

--- a/lib/pangea/controllers/user_controller.dart
+++ b/lib/pangea/controllers/user_controller.dart
@@ -138,8 +138,6 @@ class UserController extends BaseController {
         migratedProfileInfo(MatrixProfile.showedClickMessage);
     final bool? showBlurMeansTranslate =
         migratedProfileInfo(MatrixProfile.showedBlurMeansTranslate);
-    final bool? showTooltipInstructions =
-        migratedProfileInfo(MatrixProfile.showedTooltipInstructions);
 
     await updateMatrixProfile(
       dateOfBirth: dob,
@@ -153,7 +151,6 @@ class UserController extends BaseController {
       showedItInstructions: showItInstructions,
       showedClickMessage: showClickMessage,
       showedBlurMeansTranslate: showBlurMeansTranslate,
-      showedTooltipInstructions: showTooltipInstructions,
       createdAt: createdAt,
       targetLanguage: targetLanguage,
       sourceLanguage: sourceLanguage,

--- a/lib/pangea/controllers/user_controller.dart
+++ b/lib/pangea/controllers/user_controller.dart
@@ -138,6 +138,8 @@ class UserController extends BaseController {
         migratedProfileInfo(MatrixProfile.showedClickMessage);
     final bool? showBlurMeansTranslate =
         migratedProfileInfo(MatrixProfile.showedBlurMeansTranslate);
+    final bool? showTooltipInstructions =
+        migratedProfileInfo(MatrixProfile.showedTooltipInstructions);
 
     await updateMatrixProfile(
       dateOfBirth: dob,
@@ -151,6 +153,7 @@ class UserController extends BaseController {
       showedItInstructions: showItInstructions,
       showedClickMessage: showClickMessage,
       showedBlurMeansTranslate: showBlurMeansTranslate,
+      showedTooltipInstructions: showTooltipInstructions,
       createdAt: createdAt,
       targetLanguage: targetLanguage,
       sourceLanguage: sourceLanguage,
@@ -232,6 +235,7 @@ class UserController extends BaseController {
     bool? showedItInstructions,
     bool? showedClickMessage,
     bool? showedBlurMeansTranslate,
+    bool? showedTooltipInstructions,
     String? createdAt,
     String? targetLanguage,
     String? sourceLanguage,
@@ -302,6 +306,12 @@ class UserController extends BaseController {
       await _pangeaController.pStoreService.save(
         MatrixProfile.showedBlurMeansTranslate.title,
         showedBlurMeansTranslate,
+      );
+    }
+    if (showedTooltipInstructions != null) {
+      await _pangeaController.pStoreService.save(
+        MatrixProfile.showedTooltipInstructions.title,
+        showedTooltipInstructions,
       );
     }
     if (createdAt != null) {

--- a/lib/pangea/models/user_model.dart
+++ b/lib/pangea/models/user_model.dart
@@ -63,6 +63,7 @@ enum MatrixProfile {
   showedItInstructions,
   showedClickMessage,
   showedBlurMeansTranslate,
+  showedTooltipInstructions,
   createdAt,
   targetLanguage,
   sourceLanguage,
@@ -95,6 +96,8 @@ extension MatrixProfileExtension on MatrixProfile {
         return InstructionsEnum.clickMessage.toString();
       case MatrixProfile.showedBlurMeansTranslate:
         return InstructionsEnum.blurMeansTranslate.toString();
+      case MatrixProfile.showedTooltipInstructions:
+        return InstructionsEnum.tooltipInstructions.toString();
       case MatrixProfile.createdAt:
         return ModelKey.userCreatedAt;
       case MatrixProfile.targetLanguage:

--- a/lib/pangea/utils/instructions.dart
+++ b/lib/pangea/utils/instructions.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 
@@ -102,6 +103,7 @@ enum InstructionsEnum {
   itInstructions,
   clickMessage,
   blurMeansTranslate,
+  tooltipInstructions,
 }
 
 extension Copy on InstructionsEnum {
@@ -113,6 +115,8 @@ extension Copy on InstructionsEnum {
         return L10n.of(context)!.clickMessageTitle;
       case InstructionsEnum.blurMeansTranslate:
         return L10n.of(context)!.blurMeansTranslateTitle;
+      case InstructionsEnum.tooltipInstructions:
+        return L10n.of(context)!.tooltipInstructionsTitle;
     }
   }
 
@@ -124,6 +128,10 @@ extension Copy on InstructionsEnum {
         return L10n.of(context)!.clickMessageBody;
       case InstructionsEnum.blurMeansTranslate:
         return L10n.of(context)!.blurMeansTranslateBody;
+      case InstructionsEnum.tooltipInstructions:
+        return PlatformInfos.isMobile
+            ? L10n.of(context)!.tooltipInstructionsMobileBody
+            : L10n.of(context)!.tooltipInstructionsBrowserBody;
     }
   }
 }

--- a/lib/pangea/widgets/chat/message_speech_to_text_card.dart
+++ b/lib/pangea/widgets/chat/message_speech_to_text_card.dart
@@ -3,6 +3,7 @@ import 'dart:developer';
 import 'package:fluffychat/pangea/matrix_event_wrappers/pangea_message_event.dart';
 import 'package:fluffychat/pangea/models/speech_to_text_models.dart';
 import 'package:fluffychat/pangea/utils/error_handler.dart';
+import 'package:fluffychat/pangea/utils/instructions.dart';
 import 'package:fluffychat/pangea/widgets/chat/toolbar_content_loading_indicator.dart';
 import 'package:fluffychat/pangea/widgets/common/icon_number_widget.dart';
 import 'package:fluffychat/pangea/widgets/igc/card_error_widget.dart';
@@ -175,12 +176,24 @@ class MessageSpeechToTextCardState extends State<MessageSpeechToTextCard> {
               number:
                   "${selectedToken?.confidence ?? speechToTextResponse!.transcript.confidence}%",
               toolTip: L10n.of(context)!.accuracy,
+              onPressed: () => MatrixState.pangeaController.instructions.show(
+                context,
+                InstructionsEnum.tooltipInstructions,
+                widget.messageEvent.eventId,
+                true,
+              ),
             ),
             IconNumberWidget(
               icon: Icons.speed,
               number:
                   wordsPerMinuteString != null ? "$wordsPerMinuteString" : "??",
               toolTip: L10n.of(context)!.wordsPerMinute,
+              onPressed: () => MatrixState.pangeaController.instructions.show(
+                context,
+                InstructionsEnum.tooltipInstructions,
+                widget.messageEvent.eventId,
+                true,
+              ),
             ),
           ],
         ),

--- a/lib/pangea/widgets/common/icon_number_widget.dart
+++ b/lib/pangea/widgets/common/icon_number_widget.dart
@@ -6,6 +6,7 @@ class IconNumberWidget extends StatelessWidget {
   final Color? iconColor;
   final double? iconSize;
   final String? toolTip;
+  final VoidCallback onPressed;
 
   const IconNumberWidget({
     super.key,
@@ -14,16 +15,20 @@ class IconNumberWidget extends StatelessWidget {
     this.toolTip,
     this.iconColor,
     this.iconSize,
+    required this.onPressed,
   });
 
   Widget _content(BuildContext context) {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        Icon(
-          icon,
-          color: iconColor ?? Theme.of(context).iconTheme.color,
-          size: iconSize ?? Theme.of(context).iconTheme.size,
+        IconButton(
+          icon: Icon(
+            icon,
+            color: iconColor ?? Theme.of(context).iconTheme.color,
+            size: iconSize ?? Theme.of(context).iconTheme.size,
+          ),
+          onPressed: onPressed,
         ),
         const SizedBox(width: 8),
         Text(

--- a/needed-translations.txt
+++ b/needed-translations.txt
@@ -841,7 +841,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "be": [
@@ -2281,7 +2285,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "bn": [
@@ -3183,7 +3191,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "bo": [
@@ -4085,7 +4097,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "ca": [
@@ -4987,7 +5003,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "cs": [
@@ -5889,7 +5909,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "de": [
@@ -6738,7 +6762,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "el": [
@@ -7640,7 +7668,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "eo": [
@@ -8542,7 +8574,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "es": [
@@ -8550,7 +8586,11 @@
     "suggestToChatDesc",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "et": [
@@ -9395,7 +9435,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "eu": [
@@ -10240,7 +10284,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "fa": [
@@ -11142,7 +11190,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "fi": [
@@ -12044,7 +12096,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "fr": [
@@ -12946,7 +13002,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "ga": [
@@ -13848,7 +13908,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "gl": [
@@ -14693,7 +14757,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "he": [
@@ -15595,7 +15663,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "hi": [
@@ -16497,7 +16569,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "hr": [
@@ -17386,7 +17462,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "hu": [
@@ -18288,7 +18368,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "ia": [
@@ -19714,7 +19798,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "id": [
@@ -20616,7 +20704,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "ie": [
@@ -21518,7 +21610,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "it": [
@@ -22405,7 +22501,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "ja": [
@@ -23307,7 +23407,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "ko": [
@@ -24209,7 +24313,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "lt": [
@@ -25111,7 +25219,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "lv": [
@@ -26013,7 +26125,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "nb": [
@@ -26915,7 +27031,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "nl": [
@@ -27817,7 +27937,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "pl": [
@@ -28719,7 +28843,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "pt": [
@@ -29621,7 +29749,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "pt_BR": [
@@ -30492,7 +30624,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "pt_PT": [
@@ -31394,7 +31530,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "ro": [
@@ -32296,7 +32436,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "ru": [
@@ -33141,7 +33285,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "sk": [
@@ -34043,7 +34191,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "sl": [
@@ -34945,7 +35097,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "sr": [
@@ -35847,7 +36003,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "sv": [
@@ -36714,7 +36874,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "ta": [
@@ -37616,7 +37780,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "th": [
@@ -38518,7 +38686,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "tr": [
@@ -39405,7 +39577,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "uk": [
@@ -40250,7 +40426,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "vi": [
@@ -41152,7 +41332,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "zh": [
@@ -41997,7 +42181,11 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ],
 
   "zh_Hant": [
@@ -42899,6 +43087,10 @@
     "wordsPerMinute",
     "leaveRoomDescription",
     "archiveSpaceDescription",
-    "leaveSpaceDescription"
+    "leaveSpaceDescription",
+    "onlyAdminDescription",
+    "tooltipInstructionsTitle",
+    "tooltipInstructionsMobileBody",
+    "tooltipInstructionsBrowserBody"
   ]
 }


### PR DESCRIPTION
When the user presses a button without an associated text label or press-activated action, instructions will show explaining how to view tooltips.

So far, the only situation I've found that matches this criteria is Accuracy/Words per minute in the speech to text toolbar. Let me know if you find anywhere else for me to add it.