### PR TITLE
No duplicate selection

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1327,9 +1327,18 @@ class ChatController extends State<ChatPageWithRoom>
     }
     // Pangea#
     if (!event.redacted) {
-      if (selectedEvents.contains(event)) {
+      // #Pangea
+      // If previous selectedEvent has same eventId, delete previous selectedEvent
+      final matches =
+          selectedEvents.where((e) => e.eventId == event.eventId).toList();
+      if (matches.isNotEmpty) {
+        // if (selectedEvents.contains(event)) {
+        // Pangea#
         setState(
-          () => selectedEvents.remove(event),
+          // #Pangea
+          () => selectedEvents.remove(matches.first),
+          // () => selectedEvents.remove(event),
+          // Pangea#
         );
       } else {
         setState(


### PR DESCRIPTION
Check for eventId match instead of exact match when selecting/deselecting, so that duplicate selection cannot occur if an event parameter changes