### PR TITLE
Limit add to space

### DIFF
--- a/assets/l10n/intl_en.arb
+++ b/assets/l10n/intl_en.arb
@@ -3970,5 +3970,8 @@
   "capacitySetTooLow": "Room capacity cannot be set below the current number of non-admins.",
   "roomCapacityExplanation": "Room capacity limits the number of non-admins allowed in a room.",
   "enterNumber": "Please enter a whole number value.",
-  "buildTranslation": "Build your translation from the choices above"
+  "buildTranslation": "Build your translation from the choices above",
+  "nonexistentSelection": "Selection no longer exists.",
+  "cantAddSpaceChild": "You do not have permission to add a child to this space.",
+  "roomAddedToSpace": "Room(s) have been added to the selected space."
 }

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -819,6 +819,8 @@ class ChatListController extends State<ChatList>
                 &&
                 selectedRoomIds
                     .map((id) => Matrix.of(context).client.getRoomById(id))
+                    // Only show non-recursion-causing spaces
+                    // Performs a few other checks as well
                     .every((e) => r.canAddAsParentOf(e)),
             //Pangea#
           )
@@ -829,6 +831,7 @@ class ChatListController extends State<ChatList>
               // label: space
               //     .getLocalizedDisplayname(MatrixLocals(L10n.of(context)!)),
               label: space.nameIncludingParents(context),
+              // If user is not admin of space, button is grayed out
               textStyle: TextStyle(
                 color: (firstSelectedRoom == null ||
                         (firstSelectedRoom.isSpace && !space.isRoomAdmin))
@@ -849,6 +852,7 @@ class ChatListController extends State<ChatList>
         if (firstSelectedRoom == null) {
           throw L10n.of(context)!.nonexistentSelection;
         }
+        // If user is not admin of the would-be parent space, does not allow
         if (firstSelectedRoom.isSpace && !space.isRoomAdmin) {
           throw L10n.of(context)!.cantAddSpaceChild;
         }

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -815,7 +815,6 @@ class ChatListController extends State<ChatList>
                 &&
                 selectedRoomIds
                     .map((id) => Matrix.of(context).client.getRoomById(id))
-                    // .where((e) => !(e?.isPangeaClass ?? true))
                     .every((e) => r.canAddAsParentOf(e)),
             //Pangea#
           )

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -815,8 +815,8 @@ class ChatListController extends State<ChatList>
                 &&
                 selectedRoomIds
                     .map((id) => Matrix.of(context).client.getRoomById(id))
-                    .where((e) => !(e?.isPangeaClass ?? true))
-                    .every((e) => r.canIAddSpaceChild(e)),
+                    // .where((e) => !(e?.isPangeaClass ?? true))
+                    .every((e) => r.canAddAsParentOf(e)),
             //Pangea#
           )
           .map(

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -797,6 +797,10 @@ class ChatListController extends State<ChatList>
   // Pangea#
 
   Future<void> addToSpace() async {
+    // #Pangea
+    final firstSelectedRoom =
+        Matrix.of(context).client.getRoomById(selectedRoomIds.toList().first);
+    // Pangea#
     final selectedSpace = await showConfirmationDialog<String>(
       context: context,
       title: L10n.of(context)!.addToSpace,
@@ -825,6 +829,12 @@ class ChatListController extends State<ChatList>
               // label: space
               //     .getLocalizedDisplayname(MatrixLocals(L10n.of(context)!)),
               label: space.nameIncludingParents(context),
+              textStyle: TextStyle(
+                color: (firstSelectedRoom == null ||
+                        (firstSelectedRoom.isSpace && !space.isRoomAdmin))
+                    ? Theme.of(context).colorScheme.outline
+                    : Theme.of(context).colorScheme.surfaceTint,
+              ),
               // Pangea#
             ),
           )
@@ -836,12 +846,19 @@ class ChatListController extends State<ChatList>
       future: () async {
         final space = Matrix.of(context).client.getRoomById(selectedSpace)!;
         // #Pangea
+        if (firstSelectedRoom == null) {
+          throw L10n.of(context)!.nonexistentSelection;
+        }
+        if (firstSelectedRoom.isSpace && !space.isRoomAdmin) {
+          throw L10n.of(context)!.cantAddSpaceChild;
+        }
         await pangeaAddToSpace(
           space,
           selectedRoomIds.toList(),
           context,
           pangeaController,
         );
+
         // if (space.canSendDefaultStates) {
         //   for (final roomId in selectedRoomIds) {
         //     await space.setSpaceChild(roomId);
@@ -854,7 +871,10 @@ class ChatListController extends State<ChatList>
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text(L10n.of(context)!.chatHasBeenAddedToThisSpace),
+          // #Pangea
+          // content: Text(L10n.of(context)!.chatHasBeenAddedToThisSpace),
+          content: Text(L10n.of(context)!.roomAddedToSpace),
+          // Pangea#
         ),
       );
     }

--- a/lib/pangea/extensions/pangea_room_extension/children_and_parents_extension.dart
+++ b/lib/pangea/extensions/pangea_room_extension/children_and_parents_extension.dart
@@ -128,15 +128,13 @@ extension ChildrenAndParentsRoomExtension on Room {
     return childIds;
   }
 
-  // Checks if has permissions to add child to space
-  // And whether potential child space is ancestor of this
+  // Checks if has permissions to add child chat
+  // Or whether potential child space is ancestor of this
   bool _canAddAsParentOf(Room? child) {
     if (child == null || !child.isSpace) {
       return _canIAddSpaceChild(child);
     }
     if (id == child.id) return false;
-    return _isRoomAdmin &&
-        child._isRoomAdmin &&
-        !child._allSpaceChildRoomIds.contains(id);
+    return !child._allSpaceChildRoomIds.contains(id);
   }
 }

--- a/lib/pangea/extensions/pangea_room_extension/children_and_parents_extension.dart
+++ b/lib/pangea/extensions/pangea_room_extension/children_and_parents_extension.dart
@@ -127,4 +127,14 @@ extension ChildrenAndParentsRoomExtension on Room {
     }
     return childIds;
   }
+
+  // Checks if can add chat as child
+  // Or whether potential child space is ancestor of this
+  bool _canAddAsParentOf(Room? child) {
+    if (child == null || !child.isSpace) {
+      return _canIAddSpaceChild(child);
+    }
+    if (id == child.id) return false;
+    return !child._allSpaceChildRoomIds.contains(id);
+  }
 }

--- a/lib/pangea/extensions/pangea_room_extension/children_and_parents_extension.dart
+++ b/lib/pangea/extensions/pangea_room_extension/children_and_parents_extension.dart
@@ -128,13 +128,15 @@ extension ChildrenAndParentsRoomExtension on Room {
     return childIds;
   }
 
-  // Checks if can add chat as child
-  // Or whether potential child space is ancestor of this
+  // Checks if has permissions to add child to space
+  // And whether potential child space is ancestor of this
   bool _canAddAsParentOf(Room? child) {
     if (child == null || !child.isSpace) {
       return _canIAddSpaceChild(child);
     }
     if (id == child.id) return false;
-    return !child._allSpaceChildRoomIds.contains(id);
+    return _isRoomAdmin &&
+        child._isRoomAdmin &&
+        !child._allSpaceChildRoomIds.contains(id);
   }
 }

--- a/lib/pangea/extensions/pangea_room_extension/pangea_room_extension.dart
+++ b/lib/pangea/extensions/pangea_room_extension/pangea_room_extension.dart
@@ -114,6 +114,8 @@ extension PangeaRoom on Room {
 
   List<String> get allSpaceChildRoomIds => _allSpaceChildRoomIds;
 
+  bool canAddAsParentOf(Room? child) => _canAddAsParentOf(child);
+
 // class_and_exchange_settings
 
   DateTime? get rulesUpdatedAt => _rulesUpdatedAt;

--- a/lib/pangea/widgets/class/add_space_toggles.dart
+++ b/lib/pangea/widgets/class/add_space_toggles.dart
@@ -146,7 +146,7 @@ class AddToSpaceState extends State<AddToSpaceToggles> {
     final Room possibleParent = possibleParents[index];
     final bool canAdd = !(!possibleParent.isRoomAdmin &&
             widget.mode == AddToClassMode.exchange) &&
-        possibleParent.canIAddSpaceChild(room);
+        possibleParent.canAddAsParentOf(room);
 
     return Opacity(
       opacity: canAdd ? 1 : 0.5,

--- a/lib/pangea/widgets/class/add_space_toggles.dart
+++ b/lib/pangea/widgets/class/add_space_toggles.dart
@@ -144,9 +144,13 @@ class AddToSpaceState extends State<AddToSpaceToggles> {
 
   Widget getAddToSpaceToggleItem(int index) {
     final Room possibleParent = possibleParents[index];
-    final bool canAdd = !(!possibleParent.isRoomAdmin &&
-            widget.mode == AddToClassMode.exchange) &&
-        possibleParent.canAddAsParentOf(room);
+    final bool canAdd = (room?.isSpace ?? false)
+        // Room is space
+        ? possibleParent.isRoomAdmin &&
+            room!.isRoomAdmin &&
+            possibleParent.canAddAsParentOf(room)
+        // Room is null or chat
+        : possibleParent.canAddAsParentOf(room);
 
     return Opacity(
       opacity: canAdd ? 1 : 0.5,


### PR DESCRIPTION
When viewing possible parents (in Add to Space menu, or in class details page), the potential child cannot be added as a child to itself, or to its descendants. 

(not implemented yet) If the user does not have adequate permissions, the option to add to that space will be grayed out, and will notify the user if they attempt to click on it.