### PR TITLE
Archive subspaces properly

### DIFF
--- a/lib/pangea/extensions/pangea_room_extension/pangea_room_extension.dart
+++ b/lib/pangea/extensions/pangea_room_extension/pangea_room_extension.dart
@@ -152,8 +152,12 @@ extension PangeaRoom on Room {
   }) async =>
       await _archiveSpace(context, client, onlyAdmin: onlyAdmin);
 
+  Future<void> archiveSubspace() async => await _archiveSubspace();
+
   Future<bool> leaveSpace(BuildContext context, Client client) async =>
       await _leaveSpace(context, client);
+
+  Future<void> leaveSubspace() async => await _leaveSubspace();
 
   Future<Event?> sendPangeaEvent({
     required Map<String, dynamic> content,


### PR DESCRIPTION
Archiving/leaving spaces is applied recursively to any subspaces. Previously, the subspaces were archived like a normal chat would be archived.