### PR TITLE
Fix audio overflow

### DIFF
--- a/lib/pages/chat/events/audio_player.dart
+++ b/lib/pages/chat/events/audio_player.dart
@@ -298,7 +298,10 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
     final statusText = this.statusText ??= _durationString ?? '00:00';
     final audioPlayer = this.audioPlayer;
     return Padding(
+      // #Pangea
+      // padding: const EdgeInsets.all(12.0),
       padding: const EdgeInsets.all(5.0),
+      // Pangea#
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
@@ -332,7 +335,10 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
                     },
                   ),
           ),
+          // #Pangea
+          // const SizedBox(width: 8),
           const SizedBox(width: 5),
+          // Pangea#
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -368,7 +374,10 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
                 ),
             ],
           ),
+          // #Pangea
+          // const SizedBox(width: 8),
           const SizedBox(width: 5),
+          // Pangea#
           SizedBox(
             width: 36,
             child: Text(

--- a/lib/pages/chat/events/audio_player.dart
+++ b/lib/pages/chat/events/audio_player.dart
@@ -298,7 +298,7 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
     final statusText = this.statusText ??= _durationString ?? '00:00';
     final audioPlayer = this.audioPlayer;
     return Padding(
-      padding: const EdgeInsets.all(12.0),
+      padding: const EdgeInsets.all(5.0),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
@@ -332,7 +332,7 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
                     },
                   ),
           ),
-          const SizedBox(width: 8),
+          const SizedBox(width: 5),
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -368,7 +368,7 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
                 ),
             ],
           ),
-          const SizedBox(width: 8),
+          const SizedBox(width: 5),
           SizedBox(
             width: 36,
             child: Text(


### PR DESCRIPTION
Decrease unecessary padding in toolbar audio tab

I haven't gotten the overflow issue myself, so I wasn't able to test whether this resolved the error. 