### PR TITLE
Silences null timeline error

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -486,12 +486,6 @@ class ChatController extends State<ChatPageWithRoom>
 
     final timeline = this.timeline;
     if (timeline == null || timeline.events.isEmpty) {
-      // #Pangea
-      ErrorHandler.logError(
-        e: PangeaWarningError("Timeline is null or empty"),
-        s: StackTrace.current,
-      );
-      // Pangea#
       return;
     }
 


### PR DESCRIPTION
Ignores 'PangeaWarningError: Pangea Warning Error: Timeline is null or empty' error