### PR TITLE
Chat list is shown when rooms are loaded

### DIFF
--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -933,8 +933,17 @@ class ChatListController extends State<ChatList>
     }
 
     // #Pangea
+    _lessImportantSyncs(client);
+    // Pangea#
+    if (!mounted) return;
+    setState(() {
+      waitForFirstSync = true;
+    });
+  }
+
+  // #Pangea
+  Future<void> _lessImportantSyncs(Client client) async {
     if (mounted) {
-      // TODO try not to await so much
       GoogleAnalytics.analyticsUserUpdate(client.userID);
       await pangeaController.subscriptionController.initialize();
       await pangeaController.myAnalytics.initialize();
@@ -946,14 +955,9 @@ class ChatListController extends State<ChatList>
       ErrorHandler.logError(
         m: "didn't run afterSyncAndFirstLoginInitialization because not mounted",
       );
-      // debugger(when: kDebugMode);
     }
-    // Pangea#
-    if (!mounted) return;
-    setState(() {
-      waitForFirstSync = true;
-    });
   }
+  // Pangea#
 
   void cancelAction() {
     if (selectMode == SelectMode.share) {

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -911,11 +911,12 @@ class ChatListController extends State<ChatList>
     await client.roomsLoading;
     await client.accountDataLoading;
     await client.userDeviceKeysLoading;
-    if (client.prevBatch == null) {
+    // #Pangea
+    // See here for explanation of this change: https://github.com/pangeachat/client/pull/539
+    // if (client.prevBatch == null) {
+    if (client.onSync.value?.nextBatch == null) {
+      // Pangea#
       await client.onSync.stream.first;
-      // #Pangea
-      pangeaController.startChatWithBotIfNotPresent();
-      //Pangea#
 
       // Display first login bootstrap if enabled
       // #Pangea
@@ -930,7 +931,7 @@ class ChatListController extends State<ChatList>
     }
 
     // #Pangea
-    _lessImportantSyncs(client);
+    await _initPangeaControllers(client);
     // Pangea#
     if (!mounted) return;
     setState(() {
@@ -939,9 +940,10 @@ class ChatListController extends State<ChatList>
   }
 
   // #Pangea
-  Future<void> _lessImportantSyncs(Client client) async {
+  Future<void> _initPangeaControllers(Client client) async {
     if (mounted) {
       GoogleAnalytics.analyticsUserUpdate(client.userID);
+      pangeaController.startChatWithBotIfNotPresent();
       await pangeaController.subscriptionController.initialize();
       await pangeaController.myAnalytics.initialize();
       pangeaController.afterSyncAndFirstLoginInitialization(context);

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -909,6 +909,9 @@ class ChatListController extends State<ChatList>
   Future<void> _waitForFirstSync() async {
     final client = Matrix.of(context).client;
     await client.roomsLoading;
+    // #Pangea
+    setState(() {});
+    // Pangea#
     await client.accountDataLoading;
     await client.userDeviceKeysLoading;
     if (client.prevBatch == null) {

--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -909,9 +909,6 @@ class ChatListController extends State<ChatList>
   Future<void> _waitForFirstSync() async {
     final client = Matrix.of(context).client;
     await client.roomsLoading;
-    // #Pangea
-    setState(() {});
-    // Pangea#
     await client.accountDataLoading;
     await client.userDeviceKeysLoading;
     if (client.prevBatch == null) {

--- a/lib/pages/chat_list/chat_list_body.dart
+++ b/lib/pages/chat_list/chat_list_body.dart
@@ -187,7 +187,12 @@ class ChatListViewBody extends StatelessWidget {
                     ],
                   ),
                 ),
-                if (client.prevBatch == null)
+                // #Pangea
+                // Only show loading screen if room list is empty
+                // because it is still loading
+                // if (client.prevBatch == null)
+                if (rooms.isEmpty && client.prevBatch == null)
+                  // Pangea#
                   SliverList(
                     delegate: SliverChildBuilderDelegate(
                       (context, i) => Opacity(
@@ -245,7 +250,10 @@ class ChatListViewBody extends StatelessWidget {
                       childCount: dummyChatCount,
                     ),
                   ),
-                if (client.prevBatch != null)
+                // #Pangea
+                // if (client.prevBatch != null)
+                if (rooms.isNotEmpty)
+                  // Pangea#
                   SliverList.builder(
                     itemCount: rooms.length,
                     itemBuilder: (BuildContext context, int i) {

--- a/lib/pages/chat_list/chat_list_body.dart
+++ b/lib/pages/chat_list/chat_list_body.dart
@@ -187,12 +187,7 @@ class ChatListViewBody extends StatelessWidget {
                     ],
                   ),
                 ),
-                // #Pangea
-                // Only show loading screen if room list is empty
-                // because it is still loading
-                // if (client.prevBatch == null)
-                if (rooms.isEmpty && client.prevBatch == null)
-                  // Pangea#
+                if (client.prevBatch == null)
                   SliverList(
                     delegate: SliverChildBuilderDelegate(
                       (context, i) => Opacity(
@@ -250,10 +245,7 @@ class ChatListViewBody extends StatelessWidget {
                       childCount: dummyChatCount,
                     ),
                   ),
-                // #Pangea
-                // if (client.prevBatch != null)
-                if (rooms.isNotEmpty)
-                  // Pangea#
+                if (client.prevBatch != null)
                   SliverList.builder(
                     itemCount: rooms.length,
                     itemBuilder: (BuildContext context, int i) {


### PR DESCRIPTION
When a user logs in, the chat list is shown as soon as the account's rooms are loaded.

Also, moves less important syncs (analytics, etc) to run in background.