### PR TITLE
Remove option to report user

### DIFF
--- a/lib/pages/user_bottom_sheet/user_bottom_sheet_view.dart
+++ b/lib/pages/user_bottom_sheet/user_bottom_sheet_view.dart
@@ -370,15 +370,17 @@ class UserBottomSheetView extends StatelessWidget {
                     onTap: () => controller
                         .participantAction(UserBottomSheetAction.unban),
                   ),
-                if (user != null && user.id != client.userID)
-                  ListTile(
-                    textColor: Theme.of(context).colorScheme.onErrorContainer,
-                    iconColor: Theme.of(context).colorScheme.onErrorContainer,
-                    title: Text(L10n.of(context)!.reportUser),
-                    leading: const Icon(Icons.report_outlined),
-                    onTap: () => controller
-                        .participantAction(UserBottomSheetAction.report),
-                  ),
+                // #Pangea
+                // if (user != null && user.id != client.userID)
+                //   ListTile(
+                //     textColor: Theme.of(context).colorScheme.onErrorContainer,
+                //     iconColor: Theme.of(context).colorScheme.onErrorContainer,
+                //     title: Text(L10n.of(context)!.reportUser),
+                //     leading: const Icon(Icons.report_outlined),
+                //     onTap: () => controller
+                //         .participantAction(UserBottomSheetAction.report),
+                //   ),
+                // Pangea#
                 if (profileSearchError != null)
                   ListTile(
                     leading: const Icon(


### PR DESCRIPTION
The Report User button (accessed by selecting another user's avatar in a chat) can not be used to report a user, since it doesn't have an associated message to report. 
Since the button doesn't work for its intended purpose, I hid it. 

<img width="240" alt="Screenshot 2024-08-06 at 10 14 13 AM" src="https://github.com/user-attachments/assets/92c10303-e866-4161-839f-8aabbd89abf3">

Users can still be reported by reporting the offensive message directly.
