### PR TITLE
Bigger chat gap

### DIFF
--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -440,7 +440,7 @@ class ChatView extends StatelessWidget {
                             // #Pangea
                             // Keep messages above minimum input bar height
                             const SizedBox(
-                              height: 60,
+                              height: 100,
                             ),
                             // Pangea#
                           ],


### PR DESCRIPTION
Increases space beneath messages in the chat, so if the input bar size increases (for example, a message is selected, and the reaction picker shows up) the most recent message will still be visible.