### PR TITLE
when navigating to learning settings from chat popup menu, show page …

### DIFF
--- a/lib/pangea/pages/settings_learning/settings_learning.dart
+++ b/lib/pangea/pages/settings_learning/settings_learning.dart
@@ -8,7 +8,11 @@ import 'package:fluffychat/widgets/matrix.dart';
 import 'package:flutter/material.dart';
 
 class SettingsLearning extends StatefulWidget {
-  const SettingsLearning({super.key});
+  final bool isPopup;
+  const SettingsLearning({
+    this.isPopup = false,
+    super.key,
+  });
 
   @override
   SettingsLearningController createState() => SettingsLearningController();

--- a/lib/pangea/pages/settings_learning/settings_learning_view.dart
+++ b/lib/pangea/pages/settings_learning/settings_learning_view.dart
@@ -19,6 +19,12 @@ class SettingsLearningView extends StatelessWidget {
         title: Text(
           L10n.of(context)!.learningSettings,
         ),
+        leading: controller.widget.isPopup
+            ? IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: Navigator.of(context).pop,
+              )
+            : null,
       ),
       body: ListTileTheme(
         iconColor: Theme.of(context).textTheme.bodyLarge!.color,

--- a/lib/widgets/chat_settings_popup_menu.dart
+++ b/lib/widgets/chat_settings_popup_menu.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 
 import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension/pangea_room_extension.dart';
+import 'package:fluffychat/pangea/pages/settings_learning/settings_learning.dart';
 import 'package:fluffychat/pangea/utils/download_chat.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/l10n.dart';
 import 'package:future_loading_dialog/future_loading_dialog.dart';
@@ -171,7 +173,24 @@ class ChatSettingsPopupMenuState extends State<ChatSettingsPopupMenu> {
                 );
                 break;
               case ChatPopupMenuActions.learningSettings:
-                context.go('/rooms/settings/learning');
+                showDialog(
+                  context: context,
+                  builder: (c) {
+                    return kIsWeb
+                        ? Dialog(
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(maxWidth: 600),
+                              child: ClipRRect(
+                                borderRadius: BorderRadius.circular(20.0),
+                                child: const SettingsLearning(isPopup: true),
+                              ),
+                            ),
+                          )
+                        : const Dialog.fullscreen(
+                            child: SettingsLearning(isPopup: true),
+                          );
+                  },
+                );
                 break;
               // Pangea#
             }


### PR DESCRIPTION
…in popup instead of redirecting to settings

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS