### PR TITLE
Fix hidden word listening activity to limit sequences to 2 words

### DIFF
--- a/lib/pangea/controllers/message_analytics_controller.dart
+++ b/lib/pangea/controllers/message_analytics_controller.dart
@@ -186,8 +186,11 @@ class MessageAnalyticsEntry {
       (a, b) => a.length > b.length ? a : b,
     );
 
+    // Truncate the sequence to a maximum of 2 words
+    final truncatedSequence = longestSequence.take(2).toList();
+
     return TargetTokensAndActivityType(
-      tokens: longestSequence,
+      tokens: truncatedSequence,
       activityType: ActivityTypeEnum.hiddenWordListening,
     );
   }


### PR DESCRIPTION
Fixes #1038

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/pangeachat/client/pull/1039?shareId=f33c0f89-b61a-438c-9408-b997154b8a2e).