### PR TITLE
fix: make learning settings dropdowns stand out against background

### DIFF
--- a/lib/pangea/learning_settings/pages/settings_learning_view.dart
+++ b/lib/pangea/learning_settings/pages/settings_learning_view.dart
@@ -80,6 +80,9 @@ class SettingsLearningView extends StatelessWidget {
                                   }
                                   return null;
                                 },
+                                backgroundColor: Theme.of(context)
+                                    .colorScheme
+                                    .surfaceContainerHigh,
                               ),
                               PLanguageDropdown(
                                 onChange: (lang) =>

--- a/lib/pangea/learning_settings/widgets/country_picker_tile.dart
+++ b/lib/pangea/learning_settings/widgets/country_picker_tile.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:country_picker/country_picker.dart';
@@ -46,8 +47,12 @@ class CountryPickerDropdownState extends State<CountryPickerDropdown> {
       decoration: InputDecoration(
         labelText: L10n.of(context).countryInformation,
       ),
-      dropdownStyleData: const DropdownStyleData(
-        maxHeight: 300,
+      dropdownStyleData: DropdownStyleData(
+        maxHeight: kIsWeb ? 500 : null,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(14),
+          color: Theme.of(context).colorScheme.surfaceContainerHigh,
+        ),
       ),
       items: [
         ...countries.map(

--- a/lib/pangea/learning_settings/widgets/p_language_dropdown.dart
+++ b/lib/pangea/learning_settings/widgets/p_language_dropdown.dart
@@ -1,5 +1,6 @@
 // Flutter imports:
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:dropdown_button2/dropdown_button2.dart';
@@ -18,6 +19,7 @@ class PLanguageDropdown extends StatefulWidget {
   final String decorationText;
   final String? error;
   final String? Function(LanguageModel?)? validator;
+  final Color? backgroundColor;
 
   const PLanguageDropdown({
     super.key,
@@ -29,6 +31,7 @@ class PLanguageDropdown extends StatefulWidget {
     this.isL2List = false,
     this.error,
     this.validator,
+    this.backgroundColor,
   });
 
   @override
@@ -90,8 +93,12 @@ class PLanguageDropdownState extends State<PLanguageDropdown> {
               : null,
           decoration: InputDecoration(labelText: widget.decorationText),
           isExpanded: true,
-          dropdownStyleData: const DropdownStyleData(
-            maxHeight: 400,
+          dropdownStyleData: DropdownStyleData(
+            maxHeight: kIsWeb ? 500 : null,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(14),
+              color: widget.backgroundColor,
+            ),
           ),
           items: [
             if (widget.showMultilingual)


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS