### PR TITLE
fix: force room settings header onto one line with ellipsis for overflow

### DIFF
--- a/lib/pangea/extensions/room_settings_extension.dart
+++ b/lib/pangea/extensions/room_settings_extension.dart
@@ -49,6 +49,8 @@ extension RoomSettingsRoomExtension on Room {
   }
 
   Text nameAndRoomTypeIcon([TextStyle? textStyle]) => Text.rich(
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
         style: textStyle,
         TextSpan(
           children: [


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS