### PR TITLE
chore: after adding to stop audio stream to stop other audio messages…

### DIFF
--- a/lib/pages/chat/events/audio_player.dart
+++ b/lib/pages/chat/events/audio_player.dart
@@ -171,8 +171,11 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
   void _playAction() async {
     final audioPlayer = this.audioPlayer ??= AudioPlayer();
     // #Pangea
-    // if there's another audio playing, stop it
+    // If there's another audio playing, stop it. Wait for this to come through
+    // the stream so that the listener doesn't stop the audio that just started
+    final future = widget.chatController.stopAudioStream.stream.first;
     widget.chatController.stopAudioStream.add(null);
+    await future;
 
     // if (AudioPlayerWidget.currentId != widget.event.eventId) {
     if (AudioPlayerWidget.currentId != widget.event?.eventId) {
@@ -363,8 +366,7 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
           : _downloadAction();
     }
 
-    _onShowToolbar =
-        widget.chatController.stopAudioStream.stream.listen((eventID) {
+    _onShowToolbar = widget.chatController.stopAudioStream.stream.listen((_) {
       audioPlayer?.pause();
       audioPlayer?.seek(Duration.zero);
     });


### PR DESCRIPTION
… on play another audio message, wait for stream to go through before playing so it doesn't stop the just-clicked audio

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS