### PR TITLE
Add background to activity card X buttons for visibility

### DIFF
--- a/lib/pangea/activity_suggestions/activity_suggestion_dialog.dart
+++ b/lib/pangea/activity_suggestions/activity_suggestion_dialog.dart
@@ -540,8 +540,14 @@ class ActivitySuggestionDialogState extends State<ActivitySuggestionDialog> {
           Positioned(
             top: 4.0,
             left: 4.0,
-            child: IconButton(
-              icon: const Icon(Icons.close_outlined),
+            child: IconButton.filled(
+              style: IconButton.styleFrom(
+                backgroundColor: theme.colorScheme.surface.withAlpha(170),
+              ),
+              icon: Icon(
+                Icons.close_outlined,
+                color: theme.colorScheme.onSurface,
+              ),
               onPressed: Navigator.of(context).pop,
               tooltip: L10n.of(context).close,
             ),


### PR DESCRIPTION
- Add dark/light background behind X button on activity cards, depending whether the user uses dark/light mode
- Changes X to black/white instead of gray