### PR TITLE
Use activity icon on home page

### DIFF
--- a/lib/pangea/activity_suggestions/activity_suggestions_area.dart
+++ b/lib/pangea/activity_suggestions/activity_suggestions_area.dart
@@ -206,7 +206,7 @@ class ActivitySuggestionsAreaState extends State<ActivitySuggestionsArea> {
                 ),
               ),
               IconButton(
-                icon: const Icon(Icons.menu_outlined),
+                icon: const Icon(Icons.event_note_outlined),
                 onPressed: () => context.go('/rooms/homepage/planner'),
                 tooltip: L10n.of(context).activityPlannerTitle,
               ),


### PR DESCRIPTION
In the 'Chat with activities' section of the home page, use the activity planner icon for consistency, instead of a generic menu icon.