### PR TITLE
Add more visible activity outline color in dark mode

### DIFF
--- a/lib/pangea/message_token_text/message_token_button.dart
+++ b/lib/pangea/message_token_text/message_token_button.dart
@@ -296,13 +296,18 @@ class MessageTokenButtonContent extends StatelessWidget {
       BorderRadius.circular(AppConfig.borderRadius - 4);
 
   Color _color(BuildContext context) {
+    final bool isLight = Theme.of(context).brightness == Brightness.light;
     if (activity == null) {
-      return Theme.of(context).colorScheme.primary;
+      return isLight
+          ? Theme.of(context).colorScheme.primary
+          : Theme.of(context).colorScheme.primaryContainer;
     }
     if (isActivityCompleteOrNullForToken) {
       return AppConfig.gold;
     }
-    return Theme.of(context).colorScheme.primary;
+    return isLight
+        ? Theme.of(context).colorScheme.primary
+        : Theme.of(context).colorScheme.primaryContainer;
   }
 
   @override
@@ -384,10 +389,15 @@ class MessageTokenButtonContent extends StatelessWidget {
           borderRadius: _borderRadius,
           child: CustomPaint(
             painter: DottedBorderPainter(
-              color: Theme.of(context)
-                  .colorScheme
-                  .primary
-                  .withAlpha((colorAlpha * 255).toInt()),
+              color: Theme.of(context).brightness == Brightness.light
+                  ? Theme.of(context)
+                      .colorScheme
+                      .primary
+                      .withAlpha((colorAlpha * 255).toInt())
+                  : Theme.of(context)
+                      .colorScheme
+                      .primaryContainer
+                      .withAlpha((colorAlpha * 275).toInt()),
               borderRadius: _borderRadius,
             ),
             child: Container(


### PR DESCRIPTION
In reading assistance activity mode, use darker color for puzzle pieces/dotted outlines in dark mode.


*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ x ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ x ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ x ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS