### PR TITLE
Add account creation future loading dialog

### DIFF
--- a/lib/pangea/login/pages/user_settings.dart
+++ b/lib/pangea/login/pages/user_settings.dart
@@ -16,6 +16,7 @@ import 'package:fluffychat/pangea/learning_settings/utils/p_language_store.dart'
 import 'package:fluffychat/pangea/login/pages/user_settings_view.dart';
 import 'package:fluffychat/utils/file_selector.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
+import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 class UserSettingsPage extends StatefulWidget {
@@ -226,11 +227,15 @@ class UserSettingsState extends State<UserSettingsPage> {
           level: 1,
         ),
       ];
-      await Future.wait(updateFuture).timeout(
-        const Duration(seconds: 30),
-        onTimeout: () {
-          throw TimeoutException(L10n.of(context).oopsSomethingWentWrong);
-        },
+
+      await showFutureLoadingDialog(
+        context: context,
+        future: () => Future.wait(updateFuture).timeout(
+          const Duration(seconds: 30),
+          onTimeout: () {
+            throw TimeoutException(L10n.of(context).oopsSomethingWentWrong);
+          },
+        ),
       );
       context.go(
         _pangeaController.classController.cachedClassCode == null


### PR DESCRIPTION
Use future loading dialog when account is created, so user can't further edit fields

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [x] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS