### PR TITLE
Remove option to start conversation to self

### DIFF
--- a/lib/widgets/member_actions_popup_menu_button.dart
+++ b/lib/widgets/member_actions_popup_menu_button.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/analytics_misc/level_display_name.dart';
 import 'package:fluffychat/pangea/bot/utils/bot_name.dart';
 import 'package:fluffychat/widgets/avatar.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/permission_slider_dialog.dart';
 import 'adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'adaptive_dialogs/user_dialog.dart';
@@ -90,20 +91,21 @@ void showMemberActionsPopupMenu({
       ),
       const PopupMenuDivider(),
       // #Pangea
-      PopupMenuItem(
-        value: _MemberActions.chat,
-        child: Row(
-          children: [
-            const Icon(Icons.forum_outlined),
-            const SizedBox(width: 18),
-            Text(
-              dmRoomId == null
-                  ? L10n.of(context).startConversation
-                  : L10n.of(context).sendAMessage,
-            ),
-          ],
+      if (Matrix.of(context).client.userID != user.id)
+        PopupMenuItem(
+          value: _MemberActions.chat,
+          child: Row(
+            children: [
+              const Icon(Icons.forum_outlined),
+              const SizedBox(width: 18),
+              Text(
+                dmRoomId == null
+                    ? L10n.of(context).startConversation
+                    : L10n.of(context).sendAMessage,
+              ),
+            ],
+          ),
         ),
-      ),
       // Pangea#
       if (onMention != null)
         PopupMenuItem(


### PR DESCRIPTION
Does not show option to start a conversation for the user's own profile popup

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS