### PR TITLE
chore: add border around word card for emphasis

### DIFF
--- a/lib/pangea/toolbar/widgets/reading_assistance_content.dart
+++ b/lib/pangea/toolbar/widgets/reading_assistance_content.dart
@@ -138,6 +138,10 @@ class ReadingAssistanceContentState extends State<ReadingAssistanceContent> {
         child: Container(
           decoration: BoxDecoration(
             color: Theme.of(context).cardColor,
+            border: Border.all(
+              color: Theme.of(context).colorScheme.primary,
+              width: 4.0,
+            ),
             borderRadius: const BorderRadius.all(
               Radius.circular(AppConfig.borderRadius),
             ),


### PR DESCRIPTION
Adds a small, primary color border around the outside of the zoomed in word card so it stands out against the background.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS