### PR TITLE
chore: make audio marker color more consistent

### DIFF
--- a/lib/pages/chat/events/audio_player.dart
+++ b/lib/pages/chat/events/audio_player.dart
@@ -540,8 +540,8 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
                                   thumbColor: widget.senderId ==
                                           Matrix.of(context).client.userID
                                       // Pangea#
-                                      ? theme.colorScheme.onPrimary
-                                      : theme.colorScheme.primary,
+                                      ? widget.color
+                                      : theme.colorScheme.onSurface,
                                   activeColor: waveform == null
                                       ? widget.color
                                       : Colors.transparent,


### PR DESCRIPTION
Change the color of audio messages to match the other audio components around the message, dark purple for user's own and dark/light theme color for received messages.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS