### PR TITLE
Change toolbar button error behavior

### DIFF
--- a/lib/pangea/toolbar/widgets/select_mode_buttons.dart
+++ b/lib/pangea/toolbar/widgets/select_mode_buttons.dart
@@ -488,25 +488,28 @@ class SelectModeButtonsState extends State<SelectModeButtons> {
         spacing: 4.0,
         children: [
           for (final mode in modes)
-            Tooltip(
-              message: _isError ? null : mode.tooltip(context),
-              child: PressableButton(
-                depressed: mode == _selectedMode,
-                borderRadius: BorderRadius.circular(20),
-                color: Theme.of(context).colorScheme.primaryContainer,
-                onPressed: () => _updateMode(mode),
-                playSound: mode != SelectMode.audio,
-                colorFactor: Theme.of(context).brightness == Brightness.light
-                    ? 0.55
-                    : 0.3,
-                child: Container(
-                  height: buttonSize,
-                  width: buttonSize,
-                  decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.primaryContainer,
-                    shape: BoxShape.circle,
+            TooltipVisibility(
+              visible: (!_isError || mode != _selectedMode),
+              child: Tooltip(
+                message: mode.tooltip(context),
+                child: PressableButton(
+                  depressed: mode == _selectedMode,
+                  borderRadius: BorderRadius.circular(20),
+                  color: Theme.of(context).colorScheme.primaryContainer,
+                  onPressed: () => _updateMode(mode),
+                  playSound: mode != SelectMode.audio,
+                  colorFactor: Theme.of(context).brightness == Brightness.light
+                      ? 0.55
+                      : 0.3,
+                  child: Container(
+                    height: buttonSize,
+                    width: buttonSize,
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.primaryContainer,
+                      shape: BoxShape.circle,
+                    ),
+                    child: icon(mode),
                   ),
-                  child: icon(mode),
                 ),
               ),
             ),

--- a/lib/pangea/toolbar/widgets/select_mode_buttons.dart
+++ b/lib/pangea/toolbar/widgets/select_mode_buttons.dart
@@ -125,7 +125,8 @@ class SelectModeButtonsState extends State<SelectModeButtons> {
 
   void _clear() {
     setState(() {
-      _audioError = null;
+      // Audio errors do not go away when I switch modes and back
+      // Is there any reason to wipe error records on clear?
       _translationError = null;
       _speechTranslationError = null;
     });
@@ -148,8 +149,10 @@ class SelectModeButtonsState extends State<SelectModeButtons> {
     }
 
     setState(
-      () => _selectedMode =
-          _selectedMode == mode && mode != SelectMode.audio ? null : mode,
+      () => _selectedMode = _selectedMode == mode &&
+              (mode != SelectMode.audio || _audioError != null)
+          ? null
+          : mode,
     );
 
     if (_selectedMode == SelectMode.audio) {
@@ -486,7 +489,7 @@ class SelectModeButtonsState extends State<SelectModeButtons> {
         children: [
           for (final mode in modes)
             Tooltip(
-              message: mode.tooltip(context),
+              message: _isError ? null : mode.tooltip(context),
               child: PressableButton(
                 depressed: mode == _selectedMode,
                 borderRadius: BorderRadius.circular(20),


### PR DESCRIPTION
- Removes audio error reset on clear
- Removes tooltip on selected button with error
- Prevents user from playing/pausing audio button with error

As far as I can tell, audio is retrieved on the initial button selection after message selection, and the results of that are saved. 

Since that initial access is where errors are caught, setting the error to null on clear prevents the error from showing properly when the user switches modes back and forth. 

Should error reset on clear be removed for other modes as well? Or is there a situation where the user can have a problem when they open a mode, but that problem no longer applies when they deselect and reselect that mode?

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS