### PR TITLE
Only shows text messages in chat search

### DIFF
--- a/lib/pages/chat_search/chat_search_message_tab.dart
+++ b/lib/pages/chat_search/chat_search_message_tab.dart
@@ -6,7 +6,6 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/date_time_extension.dart';
-import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:fluffychat/widgets/avatar.dart';
@@ -55,7 +54,6 @@ class ChatSearchMessageTab extends StatelessWidget {
         // #Pangea
         events.removeWhere(
           (event) =>
-              !event.isVisibleInGui ||
               event.type != EventTypes.Message ||
               event.messageType != MessageTypes.Text,
         );

--- a/lib/pages/chat_search/chat_search_message_tab.dart
+++ b/lib/pages/chat_search/chat_search_message_tab.dart
@@ -53,7 +53,12 @@ class ChatSearchMessageTab extends StatelessWidget {
         }
         final events = snapshot.data?.$1 ?? [];
         // #Pangea
-        events.removeWhere((event) => !event.isVisibleInGui);
+        events.removeWhere(
+          (event) =>
+              !event.isVisibleInGui ||
+              event.type != EventTypes.Message ||
+              event.messageType != MessageTypes.Text,
+        );
         // Pangea#
 
         return SelectionArea(


### PR DESCRIPTION
When a user searches the chat for a message, filters the following from the results:

- non-message events
- non-text messages

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [x] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS