### PR TITLE
Only change pin list if redacted event is pinned

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1377,7 +1377,8 @@ class ChatController extends State<ChatPageWithRoom>
             if (event.canRedact) {
               // #Pangea
               // https://github.com/pangeachat/client/issues/3353
-              if (room.canChangeStateEvent(EventTypes.RoomPinnedEvents)) {
+              if (room.pinnedEventIds.contains(event.eventId) &&
+                  room.canChangeStateEvent(EventTypes.RoomPinnedEvents)) {
                 final pinnedEvents = room.pinnedEventIds
                     .where((e) => e != event.eventId)
                     .toList();


### PR DESCRIPTION
[This PR](https://github.com/pangeachat/client/pull/3373) sets pinned events every time a message is redacted, which leads to a lot of unnecessary network requests.

Minimize network requests by checking whether a redacted message is pinned before unpinning it

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS