### PR TITLE
3505 make level bar and search bar have same background and hover color

### DIFF
--- a/lib/pangea/analytics_summary/learning_progress_indicators.dart
+++ b/lib/pangea/analytics_summary/learning_progress_indicators.dart
@@ -1,9 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
-
-import 'package:go_router/go_router.dart';
-
 import 'package:fluffychat/pangea/analytics_misc/construct_list_model.dart';
 import 'package:fluffychat/pangea/analytics_misc/construct_type_enum.dart';
 import 'package:fluffychat/pangea/analytics_misc/get_analytics_controller.dart';
@@ -12,7 +8,10 @@ import 'package:fluffychat/pangea/analytics_summary/learning_progress_indicator_
 import 'package:fluffychat/pangea/analytics_summary/progress_indicator.dart';
 import 'package:fluffychat/pangea/analytics_summary/progress_indicators_enum.dart';
 import 'package:fluffychat/pangea/learning_settings/pages/settings_learning.dart';
+import 'package:fluffychat/widgets/hover_builder.dart';
 import 'package:fluffychat/widgets/matrix.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 /// A summary of "My Analytics" shown at the top of the chat list
 /// It shows a variety of progress indicators such as
@@ -166,35 +165,55 @@ class LearningProgressIndicatorsState
               const SizedBox(height: 6),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                child: MouseRegion(
-                  cursor: SystemMouseCursors.click,
-                  child: GestureDetector(
-                    onTap: () {
-                      context.go("/rooms/analytics?mode=level");
-                    },
-                    child: Row(
-                      spacing: 8.0,
-                      children: [
-                        Expanded(
-                          child: LearningProgressBar(
-                            level: _constructsModel.level,
-                            totalXP: _constructsModel.totalXP,
-                            height: 24.0,
+                child: HoverBuilder(
+                  builder: (context, hovered) {
+                    return Container(
+                      decoration: BoxDecoration(
+                        color: hovered
+                            ? Theme.of(context)
+                                .colorScheme
+                                .primary
+                                .withAlpha((0.2 * 255).round())
+                            : Colors.transparent,
+                        borderRadius: BorderRadius.circular(36.0),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 2.0,
+                        horizontal: 4.0,
+                      ),
+                      child: MouseRegion(
+                        cursor: SystemMouseCursors.click,
+                        child: GestureDetector(
+                          onTap: () {
+                            context.go("/rooms/analytics?mode=level");
+                          },
+                          child: Row(
+                            spacing: 8.0,
+                            children: [
+                              Expanded(
+                                child: LearningProgressBar(
+                                  level: _constructsModel.level,
+                                  totalXP: _constructsModel.totalXP,
+                                  height: 24.0,
+                                ),
+                              ),
+                              Text(
+                                "⭐ ${_constructsModel.level}",
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .titleLarge
+                                    ?.copyWith(
+                                      fontWeight: FontWeight.bold,
+                                      color:
+                                          Theme.of(context).colorScheme.primary,
+                                    ),
+                              ),
+                            ],
                           ),
                         ),
-                        Text(
-                          "⭐ ${_constructsModel.level}",
-                          style: Theme.of(context)
-                              .textTheme
-                              .titleLarge
-                              ?.copyWith(
-                                fontWeight: FontWeight.bold,
-                                color: Theme.of(context).colorScheme.primary,
-                              ),
-                        ),
-                      ],
-                    ),
-                  ),
+                      ),
+                    );
+                  },
                 ),
               ),
               const SizedBox(height: 16.0),

--- a/lib/pangea/analytics_summary/progress_bar/progress_bar.dart
+++ b/lib/pangea/analytics_summary/progress_bar/progress_bar.dart
@@ -1,8 +1,7 @@
-import 'package:flutter/material.dart';
-
 import 'package:fluffychat/pangea/analytics_summary/progress_bar/level_bar.dart';
 import 'package:fluffychat/pangea/analytics_summary/progress_bar/progress_bar_background.dart';
 import 'package:fluffychat/pangea/analytics_summary/progress_bar/progress_bar_details.dart';
+import 'package:flutter/material.dart';
 
 // Provide an order list of level indicators, each with it's color
 // and stream. Also provide an overall width and pointsPerLevel.
@@ -31,7 +30,7 @@ class ProgressBarState extends State<ProgressBar> {
 
   get progressBarDetails => ProgressBarDetails(
         totalWidth: width,
-        borderColor: Theme.of(context).colorScheme.primary.withAlpha(128),
+        borderColor: Theme.of(context).colorScheme.secondaryContainer,
         height: widget.height ?? 14,
       );
 

--- a/lib/pangea/analytics_summary/progress_bar/progress_bar_background.dart
+++ b/lib/pangea/analytics_summary/progress_bar/progress_bar_background.dart
@@ -1,7 +1,6 @@
-import 'package:flutter/material.dart';
-
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pangea/analytics_summary/progress_bar/progress_bar_details.dart';
+import 'package:flutter/material.dart';
 
 class ProgressBarBackground extends StatelessWidget {
   final ProgressBarDetails details;
@@ -22,7 +21,7 @@ class ProgressBarBackground extends StatelessWidget {
           borderRadius: const BorderRadius.all(
             Radius.circular(AppConfig.borderRadius),
           ),
-          color: details.borderColor.withAlpha(50),
+          color: details.borderColor,
         ),
       ),
     );


### PR DESCRIPTION
Changed the background color of progress bar to match search bar for consistency, and added the same hover behavior that the other analytics buttons have.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS