### PR TITLE
fix: row two and more of reactions add normally

### DIFF
--- a/lib/pages/chat/events/pangea_message_reactions.dart
+++ b/lib/pages/chat/events/pangea_message_reactions.dart
@@ -120,49 +120,43 @@ class _PangeaMessageReactionsState extends State<PangeaMessageReactions> {
         .aggregatedEvents(widget.timeline, RelationshipTypes.reaction)
         .toList();
 
-    return AnimatedSize(
-      duration: FluffyThemes.animationDuration,
-      curve: FluffyThemes.animationCurve,
-      alignment: ownMessage ? Alignment.bottomRight : Alignment.bottomLeft,
-      clipBehavior: Clip.none,
-      child: Wrap(
-        crossAxisAlignment: WrapCrossAlignment.center,
-        runSpacing: 4.0,
-        alignment: ownMessage ? WrapAlignment.end : WrapAlignment.start,
-        children: [
-          if (allReactionEvents.any((e) => e.status.isSending) && ownMessage)
-            const SizedBox(
-              width: 24,
-              height: 24,
-              child: Padding(
-                padding: EdgeInsets.all(4.0),
-                child: CircularProgressIndicator.adaptive(strokeWidth: 1),
+    return Directionality(
+      textDirection: ownMessage ? TextDirection.rtl : TextDirection.ltr,
+      child: AnimatedSize(
+        duration: FluffyThemes.animationDuration,
+        curve: FluffyThemes.animationCurve,
+        alignment: ownMessage ? Alignment.bottomRight : Alignment.bottomLeft,
+        clipBehavior: Clip.none,
+        child: Wrap(
+          crossAxisAlignment: WrapCrossAlignment.center,
+          runSpacing: 4.0,
+          alignment: WrapAlignment.start,
+          children: [
+            ...reactionList.map(
+              (r) => _Reaction(
+                key: ValueKey(r.key),
+                firstReact: _newlyAddedReactions.contains(r.key),
+                reactionKey: r.key,
+                count: r.count,
+                reacted: r.reacted,
+                onTap: () => _handleReactionTap(r, allReactionEvents),
+                onLongPress: () async => await _AdaptableReactorsDialog(
+                  client: client,
+                  reactionEntry: r,
+                ).show(context),
               ),
             ),
-          ...reactionList.map(
-            (r) => _Reaction(
-              key: ValueKey(r.key),
-              firstReact: _newlyAddedReactions.contains(r.key),
-              reactionKey: r.key,
-              count: r.count,
-              reacted: r.reacted,
-              onTap: () => _handleReactionTap(r, allReactionEvents),
-              onLongPress: () async => await _AdaptableReactorsDialog(
-                client: client,
-                reactionEntry: r,
-              ).show(context),
-            ),
-          ),
-          if (allReactionEvents.any((e) => e.status.isSending) && !ownMessage)
-            const SizedBox(
-              width: 24,
-              height: 24,
-              child: Padding(
-                padding: EdgeInsets.all(4.0),
-                child: CircularProgressIndicator.adaptive(strokeWidth: 1),
+            if (allReactionEvents.any((e) => e.status.isSending))
+              const SizedBox(
+                width: 24,
+                height: 24,
+                child: Padding(
+                  padding: EdgeInsets.all(4.0),
+                  child: CircularProgressIndicator.adaptive(strokeWidth: 1),
+                ),
               ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
and loading symbol is always placed at the very end, not the end of the first row.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [x] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS