### PR TITLE
Reenable try again button for activity search timeout

### DIFF
--- a/lib/pangea/activity_suggestions/activity_suggestions_area.dart
+++ b/lib/pangea/activity_suggestions/activity_suggestions_area.dart
@@ -213,19 +213,17 @@ class ActivitySuggestionsAreaState extends State<ActivitySuggestionsArea> {
                             ? L10n.of(context).activitySuggestionTimeoutMessage
                             : L10n.of(context).errorFetchingActivitiesMessage,
                       ),
-                      if (!_timeout)
-                        ElevatedButton(
-                          onPressed: _setActivityItems,
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: theme.colorScheme.primaryContainer,
-                            foregroundColor:
-                                theme.colorScheme.onPrimaryContainer,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 12.0,
-                            ),
+                      ElevatedButton(
+                        onPressed: _setActivityItems,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: theme.colorScheme.primaryContainer,
+                          foregroundColor: theme.colorScheme.onPrimaryContainer,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 12.0,
                           ),
-                          child: Text(L10n.of(context).tryAgain),
                         ),
+                        child: Text(L10n.of(context).tryAgain),
+                      ),
                     ],
                   ),
                 )


### PR DESCRIPTION
Reverts the change in [this issue](https://github.com/pangeachat/client/issues/3452), to account for situations where activity search times out (discussed [here](https://github.com/pangeachat/2-step-choreographer/issues/1015#issuecomment-3140157692))

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS