### PR TITLE
3607 pinned message highlight persists after unpinning

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1818,7 +1818,10 @@ class ChatController extends State<ChatPageWithRoom>
     final unpin = selectedEventIds.length == 1 &&
         pinnedEventIds.contains(selectedEventIds.single);
     if (unpin) {
-      pinnedEventIds.removeWhere(selectedEventIds.contains);
+      // #Pangea
+      //pinnedEventIds.removeWhere(selectedEventIds.contains);
+      unpinEvent(selectedEventIds.single);
+      // Pangea#
     } else {
       pinnedEventIds.addAll(selectedEventIds);
     }

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1795,6 +1795,13 @@ class ChatController extends State<ChatPageWithRoom>
     if (response == OkCancelResult.ok) {
       final events = room.pinnedEventIds
         ..removeWhere((oldEvent) => oldEvent == eventId);
+      // #Pangea
+      if (scrollToEventIdMarker == eventId) {
+        setState(() {
+          scrollToEventIdMarker = null;
+        });
+      }
+      // Pangea#
       showFutureLoadingDialog(
         context: context,
         future: () => room.setPinnedEvents(events),

--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -1795,13 +1795,6 @@ class ChatController extends State<ChatPageWithRoom>
     if (response == OkCancelResult.ok) {
       final events = room.pinnedEventIds
         ..removeWhere((oldEvent) => oldEvent == eventId);
-      // #Pangea
-      if (scrollToEventIdMarker == eventId) {
-        setState(() {
-          scrollToEventIdMarker = null;
-        });
-      }
-      // Pangea#
       showFutureLoadingDialog(
         context: context,
         future: () => room.setPinnedEvents(events),

--- a/lib/pages/chat/events/message.dart
+++ b/lib/pages/chat/events/message.dart
@@ -360,7 +360,13 @@ class Message extends StatelessWidget {
                                     borderRadius: BorderRadius.circular(
                                       AppConfig.borderRadius / 2,
                                     ),
-                                    color: selected || highlightMarker
+                                    // #Pangea
+                                    //color: selected || highlightMarker
+                                    color: selected ||
+                                            (highlightMarker &&
+                                                event.room.pinnedEventIds
+                                                    .contains(event.eventId))
+                                        // Pangea#
                                         ? theme.colorScheme.secondaryContainer
                                             .withAlpha(128)
                                         : Colors.transparent,

--- a/lib/pages/chat/events/message.dart
+++ b/lib/pages/chat/events/message.dart
@@ -360,13 +360,7 @@ class Message extends StatelessWidget {
                                     borderRadius: BorderRadius.circular(
                                       AppConfig.borderRadius / 2,
                                     ),
-                                    // #Pangea
-                                    //color: selected || highlightMarker
-                                    color: selected ||
-                                            (highlightMarker &&
-                                                event.room.pinnedEventIds
-                                                    .contains(event.eventId))
-                                        // Pangea#
+                                    color: selected || highlightMarker
                                         ? theme.colorScheme.secondaryContainer
                                             .withAlpha(128)
                                         : Colors.transparent,


### PR DESCRIPTION
Calls the same unpin function from both places you can unpin, so the same dialog shows and the pin highlight is removed.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS