### PR TITLE
chore: hide activity chat UI elements for older activity chats

### DIFF
--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 
 import 'package:scroll_to_index/scroll_to_index.dart';
 
-import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/pages/chat/chat.dart';
 import 'package:fluffychat/pages/chat/events/message.dart';
@@ -94,53 +93,30 @@ class ChatEventList extends StatelessWidget {
             // Request history button or progress indicator:
             if (i == events.length + 1) {
               if (timeline.isRequestingHistory) {
-                // #Pangea
-                // return const Center(
-                //   child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                // );
-                return const Column(
-                  children: [
-                    SizedBox(height: AppConfig.toolbarMaxHeight),
-                    Center(
-                      child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                    ),
-                  ],
+                return const Center(
+                  child: CircularProgressIndicator.adaptive(strokeWidth: 2),
                 );
-                // Pangea#
               }
               if (timeline.canRequestHistory) {
                 return Builder(
                   builder: (context) {
                     // #Pangea
-                    WidgetsBinding.instance
-                        .addPostFrameCallback((_) => controller.requestHistory);
-                    return Column(
-                      children: [
-                        const SizedBox(height: AppConfig.toolbarMaxHeight),
-                        Center(
-                          child: IconButton(
-                            onPressed: controller.requestHistory,
-                            icon: const Icon(Icons.refresh_outlined),
-                          ),
-                        ),
-                      ],
-                    );
                     // WidgetsBinding.instance
                     //     .addPostFrameCallback(controller.requestHistory);
-                    // return Center(
-                    //   child: IconButton(
-                    //     onPressed: controller.requestHistory,
-                    //     icon: const Icon(Icons.refresh_outlined),
-                    //   ),
-                    // );
+                    WidgetsBinding.instance.addPostFrameCallback(
+                      (_) => controller.requestHistory(),
+                    );
                     // Pangea#
+                    return Center(
+                      child: IconButton(
+                        onPressed: controller.requestHistory,
+                        icon: const Icon(Icons.refresh_outlined),
+                      ),
+                    );
                   },
                 );
               }
-              // #Pangea
-              // return const SizedBox.shrink();
-              return const SizedBox(height: AppConfig.toolbarMaxHeight);
-              // Pangea#
+              return const SizedBox.shrink();
             }
             i--;
 

--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -424,8 +424,9 @@ class ChatView extends StatelessWidget {
                             if (!controller.room.isAbandonedDMRoom &&
                                 controller.room.canSendDefaultMessages &&
                                 controller.room.membership == Membership.join &&
-                                controller.room.hasJoinedActivity &&
-                                !controller.room.hasFinishedActivity)
+                                (controller.room.activityPlan == null ||
+                                    !controller.room.showActivityChatUI ||
+                                    controller.room.isActiveInActivity))
                               AnimatedSize(
                                 duration: const Duration(milliseconds: 200),
                                 child: SizedBox(
@@ -441,8 +442,9 @@ class ChatView extends StatelessWidget {
                         if (!controller.room.isAbandonedDMRoom &&
                             controller.room.canSendDefaultMessages &&
                             controller.room.membership == Membership.join &&
-                            controller.room.hasJoinedActivity &&
-                            !controller.room.hasFinishedActivity)
+                            (controller.room.activityPlan == null ||
+                                !controller.room.showActivityChatUI ||
+                                controller.room.isActiveInActivity))
                           Positioned(
                             left: 0,
                             right: 0,

--- a/lib/pangea/activity_planner/activity_pinned_message.dart
+++ b/lib/pangea/activity_planner/activity_pinned_message.dart
@@ -64,7 +64,9 @@ class ActivityPinnedMessageState extends State<ActivityPinnedMessage> {
 
   @override
   Widget build(BuildContext context) {
-    if (!room.hasJoinedActivity || room.activityPlan == null) {
+    // if the room has no activity, or if it doesn't have the permission
+    // levels for sending the required events, don't show the pinned message
+    if (!room.showActivityChatUI) {
       return const SizedBox.shrink();
     }
 
@@ -91,27 +93,25 @@ class ActivityPinnedMessageState extends State<ActivityPinnedMessage> {
               leading: const SizedBox(width: 18.0),
               trailing: Padding(
                 padding: const EdgeInsets.only(right: 12.0),
-                child: room.hasFinishedActivity
-                    ? null
-                    : ElevatedButton(
-                        onPressed:
-                            _showDropdown ? null : () => _setShowDropdown(true),
-                        style: ElevatedButton.styleFrom(
-                          minimumSize: Size.zero,
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 12.0,
-                            vertical: 4.0,
-                          ),
-                          backgroundColor: theme.colorScheme.onSurface,
-                          foregroundColor: theme.colorScheme.surface,
-                        ),
-                        child: Text(
-                          L10n.of(context).done,
-                          style: const TextStyle(
-                            fontSize: 12.0,
-                          ),
-                        ),
-                      ),
+                child: ElevatedButton(
+                  onPressed:
+                      _showDropdown ? null : () => _setShowDropdown(true),
+                  style: ElevatedButton.styleFrom(
+                    minimumSize: Size.zero,
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12.0,
+                      vertical: 4.0,
+                    ),
+                    backgroundColor: theme.colorScheme.onSurface,
+                    foregroundColor: theme.colorScheme.surface,
+                  ),
+                  child: Text(
+                    L10n.of(context).done,
+                    style: const TextStyle(
+                      fontSize: 12.0,
+                    ),
+                  ),
+                ),
               ),
               onTap: _scrollToActivity,
             ),

--- a/lib/pangea/activity_planner/activity_room_extension.dart
+++ b/lib/pangea/activity_planner/activity_room_extension.dart
@@ -196,13 +196,22 @@ extension ActivityRoomExtension on Room {
         .toList();
   }
 
-  bool get hasJoinedActivity {
-    return activityPlan == null || activityRole(client.userID!) != null;
+  bool get showActivityChatUI {
+    return activityPlan != null &&
+        powerForChangingStateEvent(PangeaEventTypes.activityRole) == 0 &&
+        powerForChangingStateEvent(PangeaEventTypes.activitySummary) == 0;
   }
 
-  bool get hasFinishedActivity {
+  bool get isActiveInActivity {
+    if (!showActivityChatUI) return false;
     final role = activityRole(client.userID!);
-    return role != null && role.isFinished;
+    return role != null && !role.isFinished;
+  }
+
+  bool get isInactiveInActivity {
+    if (!showActivityChatUI) return false;
+    final role = activityRole(client.userID!);
+    return role == null || role.isFinished;
   }
 
   bool get activityIsFinished {

--- a/lib/pangea/activity_planner/activity_status_message.dart
+++ b/lib/pangea/activity_planner/activity_status_message.dart
@@ -33,10 +33,14 @@ class ActivityStatusMessageState extends State<ActivityStatusMessage> {
 
   @override
   Widget build(BuildContext context) {
+    if (!widget.room.showActivityChatUI) {
+      return const SizedBox.shrink();
+    }
+
     return Material(
       child: AnimatedSize(
         duration: FluffyThemes.animationDuration,
-        child: !widget.room.hasJoinedActivity || widget.room.activityIsFinished
+        child: widget.room.isInactiveInActivity
             ? Padding(
                 padding: EdgeInsets.only(
                   bottom: FluffyThemes.isColumnMode(context) ? 32.0 : 16.0,


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS