### PR TITLE
fix: don't show end activity button until activity has started

### DIFF
--- a/lib/pangea/chat_settings/widgets/chat_context_menu_action.dart
+++ b/lib/pangea/chat_settings/widgets/chat_context_menu_action.dart
@@ -147,7 +147,7 @@ void chatContextMenuAction(
             ),
           ),
       ],
-      if (room.isActiveInActivity)
+      if (room.isActiveInActivity && room.activityHasStarted)
         PopupMenuItem(
           value: ChatContextAction.endActivity,
           child: Row(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS