### PR TITLE
4172 color inconsistency of activity elements

### DIFF
--- a/lib/pangea/activity_sessions/activity_session_chat/activity_stats_button.dart
+++ b/lib/pangea/activity_sessions/activity_session_chat/activity_stats_button.dart
@@ -178,41 +178,40 @@ class _ActivityStatsButtonState extends State<ActivityStatsButton> {
       color: _xpCount > 0
           ? (theme.brightness == Brightness.light
               ? AppConfig.yellowLight
-              : Colors.transparent) 
+              : Color.lerp(AppConfig.gold, Colors.black, 0.3)!)
           : theme.colorScheme.surface,
       depressed: _xpCount <= 0 || widget.controller.showActivityDropdown,
       child: AnimatedContainer(
         duration: FluffyThemes.animationDuration,
-        height: 35,
+        width: 300,
+        height: 55,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         decoration: BoxDecoration(
           color: _xpCount > 0
               ? theme.brightness == Brightness.light
                   ? AppConfig.yellowLight
-                  : AppConfig.goldLight.withValues(alpha: 80)
+                  : Color.lerp(AppConfig.gold, Colors.black, 0.3)!
               : theme.colorScheme.surface,
           borderRadius: BorderRadius.circular(12),
         ),
         child: analytics == null
             ? const CircularProgressIndicator.adaptive()
-            : Padding(
-                padding: const EdgeInsets.only(left: 8, right: 8),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    _StatsBadge(
-                      icon: Icons.radar,
-                      value: "$_xpCount XP",
-                    ),
-                    _StatsBadge(
-                      icon: Symbols.dictionary,
-                      value: "$_vocabCount",
-                    ),
-                    _StatsBadge(
-                      icon: Symbols.toys_and_games,
-                      value: "$_grammarCount",
-                    ),
-                  ],
-                ),
+            : Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  _StatsBadge(
+                    icon: Icons.radar,
+                    value: "$_xpCount XP",
+                  ),
+                  _StatsBadge(
+                    icon: Symbols.dictionary,
+                    value: "$_vocabCount",
+                  ),
+                  _StatsBadge(
+                    icon: Symbols.toys_and_games,
+                    value: "$_grammarCount",
+                  ),
+                ],
               ),
       ),
     );
@@ -232,34 +231,31 @@ class _StatsBadge extends StatelessWidget {
     final theme = Theme.of(context);
     final screenWidth = MediaQuery.of(context).size.width;
     final baseStyle = theme.textTheme.bodyMedium;
-    final double fontSize = (screenWidth < 400) ? 10 : 14;
-    final double iconSize = (screenWidth < 400) ? 14 : 18;
-    return Padding(
-      padding: const EdgeInsets.only(left: 8, right: 8),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            icon,
-            size: iconSize,
-            color: theme.colorScheme.onSurface,
-          ),
-          const SizedBox(width: 4),
-          Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                value,
-                style: baseStyle?.copyWith(
-                  fontWeight: FontWeight.bold,
-                  color: theme.colorScheme.onSurface,
-                  fontSize: fontSize,
-                ),
+    final double fontSize = (screenWidth < 400) ? 14 : 18;
+    final double iconSize = (screenWidth < 400) ? 18 : 22;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          icon,
+          size: iconSize,
+          color: theme.colorScheme.onSurface,
+        ),
+        const SizedBox(width: 4),
+        Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              value,
+              style: baseStyle?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: theme.colorScheme.onSurface,
+                fontSize: fontSize,
               ),
-            ],
-          ),
-        ],
-      ),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/pangea/activity_sessions/activity_user_summaries_widget.dart
+++ b/lib/pangea/activity_sessions/activity_user_summaries_widget.dart
@@ -125,7 +125,7 @@ class ButtonControlledCarouselView extends StatelessWidget {
                 decoration: ShapeDecoration(
                   color: Theme.of(context).brightness == Brightness.light
                       ? AppConfig.yellowLight
-                      : AppConfig.goldLight.withValues(alpha: 80),
+                      : Color.lerp(AppConfig.gold, Colors.black, 0.3),
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(12),
                   ),


### PR DESCRIPTION
Changes color of stats bar and user activity summaries in dark and light mode to be consistent with each other and closer to the figma version, and the height/width of the stats activity button. It's a variable width and smaller height now, to not take up more space than it needs.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS