### PR TITLE
4201 providing emoji options for the game based on vocabulary analytics

### DIFF
--- a/lib/pangea/practice_activities/practice_selection.dart
+++ b/lib/pangea/practice_activities/practice_selection.dart
@@ -1,4 +1,3 @@
-import 'dart:collection';
 import 'dart:developer';
 
 import 'package:flutter/foundation.dart';
@@ -161,27 +160,22 @@ class PracticeSelection {
       return [];
     }
 
-    final uniqueTokens = LinkedHashSet<PangeaToken>(
-      equals: (token1, token2) =>
-          token1.text.content.toLowerCase() ==
-          token2.text.content.toLowerCase(),
-      hashCode: (token) => token.text.content.toLowerCase().hashCode,
-    )..addAll(tokens);
+    //remove duplicates
+    final seenTexts = <String>{};
+    tokens.retainWhere((token) => seenTexts.add(token.text.content.toLowerCase()));
 
-    final uniqueTokensList = uniqueTokens.toList();
-
-    if (uniqueTokensList.length > 8) {
+    if (tokens.length > 8) {
       // Remove the last third (floored) of tokens, only greater than 8 items so at least 5 remain
-      final int removeCount = (uniqueTokensList.length / 3).floor();
-      final int keepCount = uniqueTokensList.length - removeCount;
-      uniqueTokensList.removeRange(keepCount, uniqueTokensList.length);
+      final int removeCount = (tokens.length / 3).floor();
+      final int keepCount = tokens.length - removeCount;
+      tokens.removeRange(keepCount, tokens.length);
     }
 
     //shuffle leftover list so if there are enough, each activity gets different tokens
-    uniqueTokensList.shuffle();
+    tokens.shuffle();
 
     final List<PangeaToken> activityTokens = [];
-    for (final t in uniqueTokensList) {
+    for (final t in tokens) {
       if (activityTokens.length >= _maxQueueLength) {
         break;
       }


### PR DESCRIPTION
Instead of shuffling whole list of eligible tokens to randomize activity practice, first remove the most recently used 1/3 of words, then shuffle and take 5. This balances the desire to practice new words with a bit of variety between activities, if there are enough tokens (must be at least 9 in message, otherwise they are shuffled randomly).

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [x] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [x] The commit message describes what has been changed, why it has been changed and how it has been changed
- [x] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS