### PR TITLE
Checkout-not-pay

### DIFF
--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -3884,7 +3884,7 @@
   "yeCountryDisplayName": "اليمن",
   "zmCountryDisplayName": "زامبيا",
   "zwCountryDisplayName": "زيمبابوي",
-  "pay": "دفع",
+  "pay": "إنهاء الشراء",
   "allPrivateChats": "الدردشات المباشرة",
   "unknownPrivateChat": "دردشة خاصة غير معروفة",
   "invitedToSpace": "{user} دعاك للانضمام إلى دورة: {space}! هل ترغب في القبول؟",

--- a/lib/l10n/intl_be.arb
+++ b/lib/l10n/intl_be.arb
@@ -1401,7 +1401,7 @@
   "yeCountryDisplayName": "Ямен",
   "zmCountryDisplayName": "Замбія",
   "zwCountryDisplayName": "Зімбабвэ",
-  "pay": "Аплаціць",
+  "pay": "Checkout",
   "allPrivateChats": "Прыватныя чаты",
   "unknownPrivateChat": "Невядомы прыватны чат",
   "invitedToSpace": "{user} запрасіў вас далучыцца да курса: {space}! Ці жадаеце прыняць запрашэнне?",

--- a/lib/l10n/intl_bn.arb
+++ b/lib/l10n/intl_bn.arb
@@ -3993,7 +3993,7 @@
   "yeCountryDisplayName": "ইয়েমেন",
   "zmCountryDisplayName": "জাম্বিয়া",
   "zwCountryDisplayName": "জিম্বাবোয়ে",
-  "pay": "পরিশোধ করুন",
+  "pay": "Checkout",
   "allPrivateChats": "প্রতক্ষ্য চ্যাট",
   "unknownPrivateChat": "অজানা ব্যক্তিগত চ্যাট",
   "invitedToSpace": "{user} আপনাকে একটি কোর্সে যোগ দেওয়ার জন্য আমন্ত্রণ জানিয়েছেন: {space}! আপনি কি গ্রহণ করতে চান?",

--- a/lib/l10n/intl_bo.arb
+++ b/lib/l10n/intl_bo.arb
@@ -3848,7 +3848,7 @@
   "yeCountryDisplayName": "Yemen",
   "zmCountryDisplayName": "زامبیا",
   "zwCountryDisplayName": "زیمبابوې",
-  "pay": "پیسہ ادا کریں",
+  "pay": "Checkout",
   "allPrivateChats": "مستقیم چیٹ",
   "unknownPrivateChat": "نامعلوم نجی گفتگو",
   "invitedToSpace": "{user} تہاڈے نوں اکورس: {space} وچ شامل ہون لئی بلایا اے! کی تسی قبول کرنا چاہو گے؟",

--- a/lib/l10n/intl_ca.arb
+++ b/lib/l10n/intl_ca.arb
@@ -3971,7 +3971,7 @@
   "yeCountryDisplayName": "Iemen",
   "zmCountryDisplayName": "Zàmbia",
   "zwCountryDisplayName": "Zimbàbue",
-  "pay": "Paga",
+  "pay": "Checkout",
   "allPrivateChats": "Xats privats",
   "unknownPrivateChat": "Xat privat desconegut",
   "invitedToSpace": "{user} t'ha convidat a unir-te a un curs: {space}! Desitges acceptar?",

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -3528,7 +3528,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambie",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Platba",
+  "pay": "Pokladna",
   "allPrivateChats": "Přímé chaty",
   "unknownPrivateChat": "Neznámý soukromý chat",
   "invitedToSpace": "{user} vás pozval připojit se ke kurzu: {space}! Chcete přijmout?",

--- a/lib/l10n/intl_da.arb
+++ b/lib/l10n/intl_da.arb
@@ -1420,7 +1420,7 @@
   "yeCountryDisplayName": "Yemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Betal",
+  "pay": "Til betaling",
   "allPrivateChats": "Private beskeder",
   "unknownPrivateChat": "Ukendt privat chat",
   "invitedToSpace": "{user} har inviteret dig til at deltage i et kursus: {space}! Vil du acceptere?",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -4006,7 +4006,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Sambia",
   "zwCountryDisplayName": "Simbabwe",
-  "pay": "Bezahlen",
+  "pay": "Zur Kasse",
   "allPrivateChats": "Private Chats",
   "unknownPrivateChat": "Unbekannter Privatchat",
   "invitedToSpace": "{user} hat Sie eingeladen, an einem Kurs teilzunehmen: {space}! Möchten Sie annehmen?",

--- a/lib/l10n/intl_el.arb
+++ b/lib/l10n/intl_el.arb
@@ -3946,7 +3946,7 @@
   "yeCountryDisplayName": "Υεμένη",
   "zmCountryDisplayName": "Ζάμπια",
   "zwCountryDisplayName": "Ζιμπάμπουε",
-  "pay": "Πληρωμή",
+  "pay": "Checkout",
   "allPrivateChats": "Άμεσες συνομιλίες",
   "unknownPrivateChat": "Άγνωστη ιδιωτική συνομιλία",
   "invitedToSpace": "{user} σας έχει προσκαλέσει να συμμετάσχετε σε ένα μάθημα: {space}! Θέλετε να αποδεχθείτε;",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -3899,7 +3899,7 @@
   "yeCountryDisplayName": "Yemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Pay",
+  "pay": "Checkout",
   "allPrivateChats": "Direct chats",
   "unknownPrivateChat": "Unknown private chat",
   "invitedToSpace": "{user} has invited you to join a course: {space}! Do you wish to accept?",

--- a/lib/l10n/intl_eo.arb
+++ b/lib/l10n/intl_eo.arb
@@ -3125,7 +3125,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambio",
   "zwCountryDisplayName": "Zimbabvo",
-  "pay": "Pagu",
+  "pay": "Checkout",
   "allPrivateChats": "Privataj konversacioj",
   "unknownPrivateChat": "Nekonata privata konversacio",
   "invitedToSpace": "{user} invitis vin aliĝi al kurso: {space}! Ĉu vi volas akcepti?",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -4438,7 +4438,7 @@
   "toggleToolSettingsDescription": "Aquí puedes cambiar la configuración individual de la herramienta de idioma. Para los chats dentro de un espacio, la configuración del espacio tendrá prioridad y puede anular esta configuración.",
   "classRoster": "Participantes",
   "welcomeBack": "¡Bienvenido de nuevo! Si formó parte del piloto 2023-2024, póngase en contacto con nosotros para obtener su suscripción especial de piloto. Si es usted un profesor que ha adquirido (o cuya institución ha adquirido) licencias para su clase, póngase en contacto con nosotros para obtener su suscripción de profesor.",
-  "pay": "Pagar",
+  "pay": "Finalizar compra",
   "inviteUsersFromPangea": "Añadir profesores",
   "addToClass": "Añadir intercambio a la clase",
   "myLearning": "Mis análisis",

--- a/lib/l10n/intl_et.arb
+++ b/lib/l10n/intl_et.arb
@@ -4011,7 +4011,7 @@
   "yeCountryDisplayName": "Jeemen",
   "zmCountryDisplayName": "Sambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Maksa",
+  "pay": "Checkout",
   "allPrivateChats": "Otsevestlused",
   "unknownPrivateChat": "Tundmatu privaatvestlus",
   "copyClassCodeDesc": "Kasutajad, kes on juba rakenduses, saavad peamenüüst 'Liitu ruumiga'.",

--- a/lib/l10n/intl_eu.arb
+++ b/lib/l10n/intl_eu.arb
@@ -3999,7 +3999,7 @@
   "yeCountryDisplayName": "Yemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Ordaindu",
+  "pay": "Checkout",
   "allPrivateChats": "Pribatutasun txat guztiak",
   "unknownPrivateChat": "Pribatutasun txalungorik eza",
   "invitedToSpace": "{user}k gonbidatu zaitu ikastaro batean parte hartzera: {space}! Onartu nahi duzu?",

--- a/lib/l10n/intl_fa.arb
+++ b/lib/l10n/intl_fa.arb
@@ -3419,7 +3419,7 @@
   "yeCountryDisplayName": "یمن",
   "zmCountryDisplayName": "زامبیا",
   "zwCountryDisplayName": "زیمبابوه",
-  "pay": "پرداخت",
+  "pay": "Checkout",
   "allPrivateChats": "گفتگوهای مستقیم",
   "unknownPrivateChat": "گفتگوی خصوصی ناشناخته",
   "invitedToSpace": "{user} شما را به یک دوره دعوت کرده است: {space}! آیا مایل به پذیرش هستید؟",

--- a/lib/l10n/intl_fi.arb
+++ b/lib/l10n/intl_fi.arb
@@ -3521,7 +3521,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Sambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Maksa",
+  "pay": "Kassalle",
   "allPrivateChats": "Yksityiset keskustelut",
   "unknownPrivateChat": "Tuntematon yksityinen keskustelu",
   "invitedToSpace": "{user} on kutsunut sinut liittymään kurssille: {space}! Haluatko hyväksyä?",

--- a/lib/l10n/intl_fil.arb
+++ b/lib/l10n/intl_fil.arb
@@ -2265,7 +2265,7 @@
   "yeCountryDisplayName": "Yemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Magbayad",
+  "pay": "Checkout",
   "allPrivateChats": "Direktang mga chat",
   "unknownPrivateChat": "Hindi kilalang pribadong chat",
   "invitedToSpace": "{user} ay nag-imbita sa iyo na sumali sa isang kurso: {space}! Nais mo bang tanggapin?",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -3829,7 +3829,7 @@
   "yeCountryDisplayName": "Yémen",
   "zmCountryDisplayName": "Zambie",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Payer",
+  "pay": "Finaliser l'achat",
   "allPrivateChats": "Chats privés directs",
   "unknownPrivateChat": "Chat privé inconnu",
   "invitedToSpace": "{user} vous a invité à rejoindre un cours : {space} ! Souhaitez-vous accepter ?",

--- a/lib/l10n/intl_ga.arb
+++ b/lib/l10n/intl_ga.arb
@@ -4007,7 +4007,7 @@
   "yeCountryDisplayName": "Yemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Íoc",
+  "pay": "Checkout",
   "allPrivateChats": "Comhráite díreacha",
   "unknownPrivateChat": "Comhrá príobháideach anaithnid",
   "invitedToSpace": "{user} thú cuireadh a thabhairt chun páirt a ghlacadh i gcúrsa: {space}! An bhfuil tú ag iarraidh glacadh leis?",

--- a/lib/l10n/intl_gl.arb
+++ b/lib/l10n/intl_gl.arb
@@ -4000,7 +4000,7 @@
   "yeCountryDisplayName": "Iemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabue",
-  "pay": "Pagar",
+  "pay": "Checkout",
   "allPrivateChats": "Chats directos",
   "unknownPrivateChat": "Chat privado descoñecido",
   "invitedToSpace": "{user} invitouno a unirse a un curso: {space}! Queres aceptar?",

--- a/lib/l10n/intl_he.arb
+++ b/lib/l10n/intl_he.arb
@@ -2585,7 +2585,7 @@
   "yeCountryDisplayName": "תימן",
   "zmCountryDisplayName": "זמביה",
   "zwCountryDisplayName": "זימבבואה",
-  "pay": "שלם",
+  "pay": "Checkout",
   "allPrivateChats": "שיחות פרטיות ישירות",
   "unknownPrivateChat": "שיחה פרטית לא ידועה",
   "invitedToSpace": "{user} הזמין אותך להצטרף לקורס: {space}! האם ברצונך לקבל?",

--- a/lib/l10n/intl_hi.arb
+++ b/lib/l10n/intl_hi.arb
@@ -3973,7 +3973,7 @@
   "yeCountryDisplayName": "यमन",
   "zmCountryDisplayName": "ज़ाम्बिया",
   "zwCountryDisplayName": "ज़िम्बाब्वे",
-  "pay": "भुगतान करें",
+  "pay": "चेकआउट",
   "allPrivateChats": "प्रत्यक्ष चैट",
   "unknownPrivateChat": "अज्ञात निजी चैट",
   "invitedToSpace": "{user} ने आपको एक कोर्स में शामिल होने के लिए आमंत्रित किया है: {space}! क्या आप स्वीकार करना चाहेंगे?",

--- a/lib/l10n/intl_hr.arb
+++ b/lib/l10n/intl_hr.arb
@@ -3755,7 +3755,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambija",
   "zwCountryDisplayName": "Zimbabve",
-  "pay": "Plaćanje",
+  "pay": "Checkout",
   "allPrivateChats": "Privatni razgovori",
   "unknownPrivateChat": "Nepoznati privatni razgovor",
   "invitedToSpace": "{user} vas je pozvao da se pridružite tečaju: {space}! Želite li prihvatiti?",

--- a/lib/l10n/intl_hu.arb
+++ b/lib/l10n/intl_hu.arb
@@ -4000,7 +4000,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Fizetés",
+  "pay": "Checkout",
   "allPrivateChats": "Közvetlen beszélgetések",
   "unknownPrivateChat": "Ismeretlen privát beszélgetés",
   "invitedToSpace": "{user} meghívott, hogy csatlakozzon egy kurzushoz: {space}! Elfogadod?",

--- a/lib/l10n/intl_ia.arb
+++ b/lib/l10n/intl_ia.arb
@@ -1448,7 +1448,7 @@
   "yeCountryDisplayName": "Yemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Paga",
+  "pay": "Checkout",
   "allPrivateChats": "Chats private directe",
   "unknownPrivateChat": "Chat private ignote",
   "invitedToSpace": "{user} te ha invitate a junger un curso: {space}! Tu vole acceptar?",

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -4001,7 +4001,7 @@
   "yeCountryDisplayName": "Yaman",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Bayar",
+  "pay": "Checkout",
   "allPrivateChats": "Obrolan Pribadi",
   "unknownPrivateChat": "Obrolan pribadi tidak diketahui",
   "invitedToSpace": "{user} telah mengundang Anda untuk bergabung dalam kursus: {space}! Apakah Anda ingin menerima?",

--- a/lib/l10n/intl_ie.arb
+++ b/lib/l10n/intl_ie.arb
@@ -3862,7 +3862,7 @@
   "yeCountryDisplayName": "Yemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zambia",
-  "pay": "Paga",
+  "pay": "Checkout",
   "allPrivateChats": "Chat privet",
   "unknownPrivateChat": "Chat privet ignot",
   "invitedToSpace": "{user} ha invitato te a un curso: {space}! Vuoi acceptar?",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -3978,7 +3978,7 @@
   "yeCountryDisplayName": "Yemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Paga",
+  "pay": "Checkout",
   "allPrivateChats": "Chat diretti",
   "unknownPrivateChat": "Chat privato sconosciuto",
   "invitedToSpace": "{user} ti ha invitato a partecipare a un corso: {space}! Vuoi accettare?",

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -3342,7 +3342,7 @@
   "yeCountryDisplayName": "イエメン",
   "zmCountryDisplayName": "ザンビア",
   "zwCountryDisplayName": "ジンバブエ",
-  "pay": "支払う",
+  "pay": "チェックアウト",
   "allPrivateChats": "ダイレクトチャット",
   "unknownPrivateChat": "不明なプライベートチャット",
   "invitedToSpace": "{user}さんがあなたをコース「{space}」に招待しました。参加しますか？",

--- a/lib/l10n/intl_ka.arb
+++ b/lib/l10n/intl_ka.arb
@@ -2084,7 +2084,7 @@
   "yeCountryDisplayName": "იემენი",
   "zmCountryDisplayName": "ზამბია",
   "zwCountryDisplayName": "ზიმბაბვე",
-  "pay": "გადახდა",
+  "pay": "Checkout",
   "allPrivateChats": "მხოლოდ პირადი ჩეთები",
   "unknownPrivateChat": "უცნობი პირადი ჩათი",
   "invitedToSpace": "{user} გეპატიჟება გაერთო კურსში: {space}! გსურთ მიიღოთ?",

--- a/lib/l10n/intl_lt.arb
+++ b/lib/l10n/intl_lt.arb
@@ -3351,7 +3351,7 @@
   "yeCountryDisplayName": "Jemenas",
   "zmCountryDisplayName": "Zambija",
   "zwCountryDisplayName": "Zimbabvė",
-  "pay": "Mokėti",
+  "pay": "Checkout",
   "allPrivateChats": "Tiesioginiai pokalbiai",
   "unknownPrivateChat": "Nežinomas privatų pokalbis",
   "invitedToSpace": "{user} pakvietė jus prisijungti prie kurso: {space}! Ar norite priimti?",

--- a/lib/l10n/intl_lv.arb
+++ b/lib/l10n/intl_lv.arb
@@ -3987,7 +3987,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambija",
   "zwCountryDisplayName": "Zimbabve",
-  "pay": "Maksāt",
+  "pay": "Checkout",
   "allPrivateChats": "Tiešās sarunas",
   "unknownPrivateChat": "Nezināma privāta saruna",
   "invitedToSpace": "{user} ir ielūdzis jūs pievienoties kursam: {space}! Vai vēlaties pieņemt?",

--- a/lib/l10n/intl_nb.arb
+++ b/lib/l10n/intl_nb.arb
@@ -2914,7 +2914,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Betal",
+  "pay": "Til betaling",
   "allPrivateChats": "Direktmeldinger",
   "unknownPrivateChat": "Ukjent privat samtale",
   "invitedToSpace": "{user} har invitert deg til å bli med på et kurs: {space}! Vil du akseptere?",

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -3998,7 +3998,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Betalen",
+  "pay": "Afrekenen",
   "allPrivateChats": "Directe gesprekken",
   "unknownPrivateChat": "Onbekend privégesprek",
   "invitedToSpace": "{user} heeft je uitgenodigd om deel te nemen aan een cursus: {space}! Wil je accepteren?",

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -3999,7 +3999,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Zapłać",
+  "pay": "Do kasy",
   "allPrivateChats": "Czaty prywatne",
   "unknownPrivateChat": "Nieznany czat prywatny",
   "invitedToSpace": "{user} zaprosił Cię do dołączenia do kursu: {space}! Czy chcesz przyjąć zaproszenie?",

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -3989,7 +3989,7 @@
   "yeCountryDisplayName": "Iêmen",
   "zmCountryDisplayName": "Zâmbia",
   "zwCountryDisplayName": "Zimbábue",
-  "pay": "Pagar",
+  "pay": "Finalizar compra",
   "allPrivateChats": "Conversas privadas",
   "unknownPrivateChat": "Conversa privada desconhecida",
   "invitedToSpace": "{user} convidou você para participar de um curso: {space}! Deseja aceitar?",

--- a/lib/l10n/intl_pt_BR.arb
+++ b/lib/l10n/intl_pt_BR.arb
@@ -3746,7 +3746,7 @@
   "yeCountryDisplayName": "Iêmen",
   "zmCountryDisplayName": "Zâmbia",
   "zwCountryDisplayName": "Zimbábue",
-  "pay": "Pagar",
+  "pay": "Finalizar compra",
   "allPrivateChats": "Conversas diretas",
   "unknownPrivateChat": "Conversa privada desconhecida",
   "invitedToSpace": "{user} convidou você para participar de um curso: {space}! Deseja aceitar?",

--- a/lib/l10n/intl_pt_PT.arb
+++ b/lib/l10n/intl_pt_PT.arb
@@ -2809,7 +2809,7 @@
   "yeCountryDisplayName": "Iémen",
   "zmCountryDisplayName": "Zâmbia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Pagar",
+  "pay": "Finalizar compra",
   "allPrivateChats": "Conversas privadas",
   "unknownPrivateChat": "Conversa privada desconhecida",
   "invitedToSpace": "{user} convidou-o a participar num curso: {space}! Deseja aceitar?",

--- a/lib/l10n/intl_ro.arb
+++ b/lib/l10n/intl_ro.arb
@@ -3418,7 +3418,7 @@
   "yeCountryDisplayName": "Iordania",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Plătește",
+  "pay": "Checkout",
   "allPrivateChats": "Chat-uri private",
   "unknownPrivateChat": "Chat privat necunoscut",
   "invitedToSpace": "{user} te-a invitat să te alături unui curs: {space}! Vrei să accepți?",

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -3937,7 +3937,7 @@
   "yeCountryDisplayName": "Йемен",
   "zmCountryDisplayName": "Замбия",
   "zwCountryDisplayName": "Зимбабве",
-  "pay": "Оплатить",
+  "pay": "Оформить заказ",
   "allPrivateChats": "Личные сообщения",
   "unknownPrivateChat": "Неизвестный личный чат",
   "invitedToSpace": "{user} пригласил вас присоединиться к курсу: {space}! Хотите принять приглашение?",

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -2622,7 +2622,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Platiť",
+  "pay": "Checkout",
   "allPrivateChats": "Priame správy",
   "unknownPrivateChat": "Neznáma súkromná správa",
   "invitedToSpace": "{user} vás pozval na kurz: {space}! Chcete prijať?",

--- a/lib/l10n/intl_sl.arb
+++ b/lib/l10n/intl_sl.arb
@@ -1954,7 +1954,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambija",
   "zwCountryDisplayName": "Zimbabve",
-  "pay": "Plačaj",
+  "pay": "Checkout",
   "allPrivateChats": "Neposredni pogovori",
   "unknownPrivateChat": "Neznan zasebni klepet",
   "invitedToSpace": "{user} vas je povabil, da se pridružite tečaju: {space}! Ali želite sprejeti?",

--- a/lib/l10n/intl_sr.arb
+++ b/lib/l10n/intl_sr.arb
@@ -3035,7 +3035,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambija",
   "zwCountryDisplayName": "Zimbabve",
-  "pay": "Plati",
+  "pay": "Checkout",
   "allPrivateChats": "Direktni razgovori",
   "unknownPrivateChat": "Nepoznati privatni razgovor",
   "invitedToSpace": "{user} vas je pozvao da se pridružite kursu: {space}! Da li želite da prihvatite?",

--- a/lib/l10n/intl_sv.arb
+++ b/lib/l10n/intl_sv.arb
@@ -3660,7 +3660,7 @@
   "yeCountryDisplayName": "Jemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Betala",
+  "pay": "Till kassan",
   "allPrivateChats": "Privata chattar",
   "unknownPrivateChat": "Okänd privat chatt",
   "invitedToSpace": "{user} har bjudit in dig att delta i en kurs: {space}! Vill du acceptera?",

--- a/lib/l10n/intl_ta.arb
+++ b/lib/l10n/intl_ta.arb
@@ -3875,7 +3875,7 @@
   "yeCountryDisplayName": "யேமன்",
   "zmCountryDisplayName": "சம்பியா",
   "zwCountryDisplayName": "சிம்பாப்வே",
-  "pay": "பணம் செலுத்தவும்",
+  "pay": "Checkout",
   "allPrivateChats": "நேரடி உரைகள்",
   "unknownPrivateChat": "அறியப்படாத தனிப்பட்ட உரை",
   "invitedToSpace": "{user} உங்களை ஒரு பாடத்திற்குக் கூப்பிடினார்: {space}! நீங்கள் ஏற்க விரும்புகிறீர்களா?",

--- a/lib/l10n/intl_te.arb
+++ b/lib/l10n/intl_te.arb
@@ -1410,7 +1410,7 @@
   "yeCountryDisplayName": "యెమెన్",
   "zmCountryDisplayName": "జాంబియా",
   "zwCountryDisplayName": "జింబాబ్వే",
-  "pay": "చెల్లించండి",
+  "pay": "Checkout",
   "allPrivateChats": "నేరుగా చాట్లు",
   "unknownPrivateChat": "అజ్ఞాత ప్రైవేట్ చాట్",
   "invitedToSpace": "{user} మీరు కోర్సులో చేరేందుకు ఆహ్వానించారు: {space}! మీరు అంగీకరించాలనుకుంటున్నారా?",

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -3946,7 +3946,7 @@
   "yeCountryDisplayName": "เยเมน",
   "zmCountryDisplayName": "แซมเบีย",
   "zwCountryDisplayName": "ซิมบับเว",
-  "pay": "ชำระเงิน",
+  "pay": "Checkout",
   "allPrivateChats": "แชทส่วนตัวทั้งหมด",
   "unknownPrivateChat": "แชทส่วนตัวที่ไม่รู้จัก",
   "invitedToSpace": "{user} ได้เชิญคุณเข้าร่วมคอร์ส: {space}! คุณต้องการยอมรับไหม?",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -3882,7 +3882,7 @@
   "yeCountryDisplayName": "Yemen",
   "zmCountryDisplayName": "Zambiya",
   "zwCountryDisplayName": "Zimbabve",
-  "pay": "Öde",
+  "pay": "Ödeme",
   "allPrivateChats": "Özel mesajlar",
   "unknownPrivateChat": "Bilinmeyen özel sohbet",
   "invitedToSpace": "{user} sizi {space} adlı kursa katılmaya davet etti! Kabul etmek istiyor musunuz?",

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -4001,7 +4001,7 @@
   "yeCountryDisplayName": "Ємен",
   "zmCountryDisplayName": "Замбія",
   "zwCountryDisplayName": "Зімбабве",
-  "pay": "Оплатити",
+  "pay": "Оформити замовлення",
   "allPrivateChats": "Прямі чати",
   "unknownPrivateChat": "Невідомий приватний чат",
   "invitedToSpace": "{user} запросив вас приєднатися до курсу: {space}! Бажаєте прийняти?",

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -2416,7 +2416,7 @@
   "yeCountryDisplayName": "Yemen",
   "zmCountryDisplayName": "Zambia",
   "zwCountryDisplayName": "Zimbabwe",
-  "pay": "Thanh toán",
+  "pay": "Checkout",
   "allPrivateChats": "Trò chuyện riêng",
   "unknownPrivateChat": "Cuộc trò chuyện riêng chưa xác định",
   "declinedInvitation": "Đã từ chối lời mời",

--- a/lib/l10n/intl_yue.arb
+++ b/lib/l10n/intl_yue.arb
@@ -1333,7 +1333,7 @@
   "yeCountryDisplayName": "也門",
   "zmCountryDisplayName": "尚比亞",
   "zwCountryDisplayName": "津巴布韋",
-  "pay": "付款",
+  "pay": "Checkout",
   "allPrivateChats": "私密對話",
   "unknownPrivateChat": "未知私密對話",
   "invitedToSpace": "{user} 已邀請你加入課程：{space}！你想接受嗎？",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -4002,7 +4002,7 @@
   "yeCountryDisplayName": "也门",
   "zmCountryDisplayName": "赞比亚",
   "zwCountryDisplayName": "津巴布韦",
-  "pay": "支付",
+  "pay": "结账",
   "allPrivateChats": "私聊",
   "unknownPrivateChat": "未知私聊",
   "invitedToSpace": "{user} 邀请你加入课程：{space}！你是否愿意接受？",

--- a/lib/l10n/intl_zh_Hant.arb
+++ b/lib/l10n/intl_zh_Hant.arb
@@ -3978,7 +3978,7 @@
   "yeCountryDisplayName": "也门",
   "zmCountryDisplayName": "赞比亚",
   "zwCountryDisplayName": "津巴布韦",
-  "pay": "支付",
+  "pay": "結帳",
   "allPrivateChats": "私密聊天",
   "unknownPrivateChat": "未知私密聊天",
   "invitedToSpace": "{user} 邀请你加入课程：{space}！你想接受吗？",


### PR DESCRIPTION
In the subscription page, "Pay" suggests that they're going to immediately pay and users are wondering where the code will go. "Checkout" should be more clear.