### PR TITLE
fix: if activity is considered famous, don't revent to 'start activit…

### DIFF
--- a/lib/pangea/activity_sessions/activity_room_extension.dart
+++ b/lib/pangea/activity_sessions/activity_room_extension.dart
@@ -410,6 +410,7 @@ extension ActivityRoomExtension on Room {
   }
 
   bool get isActivityStarted =>
+      isActivityFinished ||
       (activityPlan?.roles.length ?? 0) - (assignedRoles?.length ?? 0) <= 0;
 
   bool get isActivityFinished {


### PR DESCRIPTION
…y' UI when a member leaves

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS