### PR TITLE
fix: hide ability to change bot chat settings from non-admins

### DIFF
--- a/lib/pangea/bot/widgets/bot_settings_language_icon.dart
+++ b/lib/pangea/bot/widgets/bot_settings_language_icon.dart
@@ -5,6 +5,7 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/pangea/bot/utils/bot_room_extension.dart';
 import 'package:fluffychat/pangea/bot/widgets/bot_chat_settings_dialog.dart';
+import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 
 class BotSettingsLanguageIcon extends StatelessWidget {
   final Room room;
@@ -27,10 +28,12 @@ class BotSettingsLanguageIcon extends StatelessWidget {
     langCode = langCode.split('-').first;
     return InkWell(
       borderRadius: BorderRadius.circular(32.0),
-      onTap: () => BotChatSettingsDialog.show(
-        context: context,
-        room: room,
-      ),
+      onTap: room.isRoomAdmin
+          ? () => BotChatSettingsDialog.show(
+                context: context,
+                room: room,
+              )
+          : null,
       child: Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(16.0),

--- a/lib/widgets/member_actions_popup_menu_button.dart
+++ b/lib/widgets/member_actions_popup_menu_button.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/analytics_misc/level_display_name.dart';
 import 'package:fluffychat/pangea/bot/utils/bot_name.dart';
 import 'package:fluffychat/pangea/bot/widgets/bot_chat_settings_dialog.dart';
+import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/permission_slider_dialog.dart';
 import 'adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
@@ -123,7 +124,7 @@ void showMemberActionsPopupMenu({
             ],
           ),
         ),
-      if (user.id == BotName.byEnvironment && room != null)
+      if (user.id == BotName.byEnvironment && room != null && room.isRoomAdmin)
         PopupMenuItem(
           value: _MemberActions.botSettings,
           child: Row(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Please make sure that your Pull Request meet the following **acceptance criteria**:

- [ ] Code formatting and import sorting has been done with `dart format lib/ test/` and `dart run import_sorter:main --no-comments`
- [ ] The commit message uses the format of [Conventional Commits](https://www.conventionalcommits.org)
- [ ] The commit message describes what has been changed, why it has been changed and how it has been changed
- [ ] Every new feature or change of the design/GUI is linked to an approved design proposal in an issue
- [ ] Every new feature in the app or the build system has a strategy how this will be tested and maintained from now on for every release, e.g. a volunteer who takes over maintainership


### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS