### PR TITLE
Add score field to LLMFeedbackModel for human audit integration

### DIFF
--- a/lib/pangea/common/constants/model_keys.dart
+++ b/lib/pangea/common/constants/model_keys.dart
@@ -109,6 +109,7 @@ class ModelKey {
   static const String feedbackLang = "feedback_lang";
   static const String feedback = "feedback";
   static const String content = "content";
+  static const String score = "score";
 
   static const String transcription = "transcription";
   static const String botTranscription = 'bot_transcription';

--- a/lib/pangea/common/models/llm_feedback_model.dart
+++ b/lib/pangea/common/models/llm_feedback_model.dart
@@ -12,14 +12,21 @@ class LLMFeedbackModel<T> {
   /// Function to serialize the content to JSON
   final Map<String, dynamic> Function(T) contentToJson;
 
+  /// Optional 0-10 score for the content being reviewed.
+  /// Not yet used by any caller — field established for future
+  /// human audit / contributor score integration.
+  final int? score;
+
   const LLMFeedbackModel({
     required this.feedback,
     required this.content,
     required this.contentToJson,
+    this.score,
   });
 
   Map<String, dynamic> toJson() => {
     ModelKey.feedback: feedback,
     ModelKey.content: contentToJson(content),
+    if (score != null) ModelKey.score: score,
   };
 }


### PR DESCRIPTION
## Summary

Add `score` field to `LLMFeedbackModel` to match the backend's `LLMFeedbackSchema.score`. This enables future human audit / contributor score integration where native speakers can approve (9-10) or reject (0-6) LLM-generated content.

### Changes

- **`model_keys.dart`**: Add `static const String score = "score"`
- **`llm_feedback_model.dart`**: Add `final int? score` with conditional JSON serialization (`if (score != null)`)
- **`choreographer.instructions.md`**: Added feedback architecture section documenting what the client sends, what the server does, and native speaker approval flow.

### Notes

- Purely additive — no callers pass `score` yet
- Backend counterpart: pangeachat/2-step-choreographer#1717