### PR TITLE
fix: attach metadata for emoji constructs on specific message event

### DIFF
--- a/lib/pangea/analytics_misc/lemma_emoji_setter_mixin.dart
+++ b/lib/pangea/analytics_misc/lemma_emoji_setter_mixin.dart
@@ -15,6 +15,8 @@ mixin LemmaEmojiSetter {
     String langCode,
     String emoji,
     String? targetId,
+    String? roomId,
+    String? eventId,
   ) async {
     final userL2 =
         MatrixState.pangeaController.userController.userL2?.langCodeShort;
@@ -24,7 +26,12 @@ mixin LemmaEmojiSetter {
     }
 
     if (constructId.userSetEmoji == null) {
-      _getEmojiAnalytics(constructId, targetId: targetId);
+      _getEmojiAnalytics(
+        constructId,
+        targetId: targetId,
+        roomId: roomId,
+        eventId: eventId,
+      );
     }
 
     await MatrixState

--- a/lib/pangea/toolbar/word_card/lemma_reaction_picker.dart
+++ b/lib/pangea/toolbar/word_card/lemma_reaction_picker.dart
@@ -93,6 +93,8 @@ class LemmaReactionPickerState extends State<LemmaReactionPicker> {
       widget.langCode,
       emoji,
       targetId,
+      widget.event?.roomId,
+      widget.event?.eventId,
     );
     messenger = ScaffoldMessenger.of(context);
     widget.showLemmaEmojiSnackbar(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS