### PR TITLE
fix: upload Sentry source maps for staging and production

### DIFF
--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -76,9 +76,8 @@ jobs:
     environment: staging
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-      SENTRY_RELEASE: ${{ github.sha }}
-      SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
-      SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+      SENTRY_PROJECT: client
+      SENTRY_ORG: pangea-chat
     steps:
       - uses: actions/checkout@v6
       - run: cat .github/workflows/versions.env >> $GITHUB_ENV

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -198,3 +198,27 @@ jobs:
       - name: AWS CloudFront Invalidation
         run: |
           aws cloudfront create-invalidation --distribution-id $CF_DISTRIBUTION_ID --paths "/*"
+
+  update_sentry:
+    runs-on: ubuntu-latest
+    needs: build_web
+    environment: production
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_PROJECT: client
+      SENTRY_ORG: pangea-chat
+    steps:
+      - uses: actions/checkout@v6
+      - run: cat .github/workflows/versions.env >> $GITHUB_ENV
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+      - name: Download web
+        uses: actions/download-artifact@v4
+        with:
+          name: web
+          path: build/web
+      - name: Update packages
+        run: flutter pub get
+      - name: Upload source maps to Sentry
+        run: flutter packages pub run sentry_dart_plugin


### PR DESCRIPTION
## Problem

Client Sentry issues have minified/obfuscated stack traces (e.g. `d03.$1` instead of real class/method names), making production errors impossible to triage.

Three issues were compounding:

1. **Staging: release tag mismatch** — `SENTRY_RELEASE` was set to `${{ github.sha }}`, but `SentryFlutter.init()` auto-generates the release as `fluffychat@<version>+<build>` from `pubspec.yaml`. Source maps uploaded under the commit SHA couldn't be matched to errors tagged with the pubspec version.

2. **Production: no source map upload at all** — `release.yaml` had no `update_sentry` job. Source maps were generated at build time (`--source-maps`) but never uploaded.

3. **Both: `SENTRY_ORG` and `SENTRY_PROJECT` were unset** — They referenced `${{ vars.SENTRY_PROJECT }}` and `${{ vars.SENTRY_ORG }}`, but these were never configured as GitHub environment variables. The `sentry_dart_plugin` was silently failing.

## Changes

- **Remove `SENTRY_RELEASE` override** in `main_deploy.yaml` so the plugin auto-detects the same version the SDK uses
- **Add `update_sentry` job** to `release.yaml` (mirrors the staging workflow)
- **Hardcode `SENTRY_ORG: pangea-chat` and `SENTRY_PROJECT: client`** in both workflows since they're not sensitive and were never set as variables