### PR TITLE
fix: give default text style to error indicator rich text

### DIFF
--- a/lib/pangea/common/widgets/error_indicator.dart
+++ b/lib/pangea/common/widgets/error_indicator.dart
@@ -20,6 +20,8 @@ class ErrorIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final defaultStyle = DefaultTextStyle.of(context).style;
+    final style = defaultStyle.merge(this.style ?? defaultStyle);
     final content = RichText(
       text: TextSpan(
         children: [


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS