### PR TITLE
fix: add back spacing between activity preview page CTA buttons

### DIFF
--- a/lib/pangea/activity_sessions/activity_session_button_widget.dart
+++ b/lib/pangea/activity_sessions/activity_session_button_widget.dart
@@ -144,6 +144,7 @@ class _ActivityRoleConfirmedButtons extends StatelessWidget {
     final showPlayWithBot = !controller.isBotRoomMember;
 
     return Column(
+      spacing: 16.0,
       mainAxisSize: .min,
       children: [
         if (showPingCourse)


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS