### PR TITLE
Enable Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,13 @@
-# version: 2
-# updates:
-#   - package-ecosystem: "pub"
-#     directory: "/"
-#     schedule:
-#       interval: "daily"
-#     allow:
-#       - dependency-name: "*"
-#     commit-message:
-#       prefix: "build: "
-#       include: "scope"
-#     assignees:
-#       - "krille-chan"
-#     open-pull-requests-limit: 5
-#   - package-ecosystem: "github-actions"
-#     directory: "/"
-#     schedule:
-#       interval: "daily"
-#     allow:
-#       - dependency-name: "*"
-#     commit-message:
-#       prefix: "build: "
-#       include: "scope"
+version: 2
+updates:
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## What
Enable Dependabot for pub and github-actions ecosystems.

Uncommented and cleaned up the existing commented-out config: switched from daily to weekly, removed unused assignees/commit-message/allow settings.

## Why
Addresses pangeachat/security#34 — zero repos had active Dependabot despite ISP claiming it.

## Testing
No client testing needed — config-only change. GitHub validates the YAML on push.

## Deploy Notes
None