### PR TITLE
fix: set size of fallback icon in morph SVG display

### DIFF
--- a/lib/pangea/morphs/morph_icon.dart
+++ b/lib/pangea/morphs/morph_icon.dart
@@ -42,7 +42,7 @@ class MorphIcon extends StatelessWidget {
       colorReplacements: theme.brightness == Brightness.dark
           ? {"white": theme.cardColor.hexValue.toString(), "black": "white"}
           : {},
-      errorIcon: Icon(morphFeature.fallbackIcon),
+      errorIcon: Icon(morphFeature.fallbackIcon, size: size?.width ?? 24.0),
       width: size?.width,
       height: size?.height,
     );


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS