### PR TITLE
fix: pass power levels via powerLevelContentOverride instead of initialState

### DIFF
--- a/lib/pages/chat_details/chat_details.dart
+++ b/lib/pages/chat_details/chat_details.dart
@@ -306,7 +306,6 @@ class ChatDetailsController extends State<ChatDetails>
         final newRoomId = await Matrix.of(context).client.createPangeaGroupChat(
           groupName,
           initialState: [
-            RoomDefaults.defaultPowerLevels(Matrix.of(context).client.userID!),
             await Matrix.of(context).client.pangeaJoinRules(
               'knock_restricted',
               allow: roomId != null
@@ -316,6 +315,9 @@ class ChatDetailsController extends State<ChatDetails>
                   : null,
             ),
           ],
+          powerLevelContentOverride: RoomDefaults.defaultPowerLevels(
+            Matrix.of(context).client.userID!,
+          ).content,
         );
 
         try {

--- a/lib/pangea/chat/extensions/create_room_extension.dart
+++ b/lib/pangea/chat/extensions/create_room_extension.dart
@@ -42,18 +42,21 @@ extension CreateRoomExtension on Client {
   Future<String> createPangeaDirectChat(
     String mxid, {
     List<StateEvent>? initialState,
+    Map<String, dynamic>? powerLevelContentOverride,
   }) => createPangeaRoom(
     startDirectChat(
       mxid,
       initialState: initialState,
       enableEncryption: false,
       waitForSync: false,
+      powerLevelContentOverride: powerLevelContentOverride,
     ),
   );
 
   Future<String> createPangeaGroupChat(
     String name, {
     List<StateEvent>? initialState,
+    Map<String, dynamic>? powerLevelContentOverride,
   }) => createPangeaRoom(
     createGroupChat(
       visibility: Visibility.private,
@@ -61,6 +64,7 @@ extension CreateRoomExtension on Client {
       initialState: initialState,
       enableEncryption: false,
       waitForSync: false,
+      powerLevelContentOverride: powerLevelContentOverride,
     ),
   );
 }

--- a/lib/pangea/chat_settings/utils/bot_client_extension.dart
+++ b/lib/pangea/chat_settings/utils/bot_client_extension.dart
@@ -109,8 +109,8 @@ extension BotClientExtension on Client {
         ).toJson(),
         type: PangeaEventTypes.botOptions,
       ),
-      RoomDefaults.defaultPowerLevels(userID!),
     ],
+    powerLevelContentOverride: RoomDefaults.defaultPowerLevels(userID!).content,
   );
 
   Future<void> updateBotOptions(UserSettings userSettings) async {

--- a/lib/pangea/course_chats/course_default_chats_enum.dart
+++ b/lib/pangea/course_chats/course_default_chats_enum.dart
@@ -28,12 +28,10 @@ enum CourseDefaultChatsEnum {
     CourseDefaultChatsEnum.announcements => l10n.announcementsChatDesc,
   };
 
-  dynamic powerLevels(String userID) => switch (this) {
-    CourseDefaultChatsEnum.introductions => RoomDefaults.defaultPowerLevels(
-      userID,
-    ),
-    CourseDefaultChatsEnum.announcements => RoomDefaults.restrictedPowerLevels(
-      userID,
-    ),
+  Map<String, dynamic> powerLevels(String userID) => switch (this) {
+    CourseDefaultChatsEnum.introductions =>
+      RoomDefaults.defaultPowerLevels(userID).content,
+    CourseDefaultChatsEnum.announcements =>
+      RoomDefaults.restrictedPowerLevels(userID).content,
   };
 }

--- a/lib/pangea/course_plans/courses/course_plan_room_extension.dart
+++ b/lib/pangea/course_plans/courses/course_plan_room_extension.dart
@@ -83,6 +83,9 @@ extension CoursePlanRoomExtension on Room {
         visibility: sdk.Visibility.private,
         name: activity.title,
         topic: activity.description,
+        powerLevelContentOverride: RoomDefaults.defaultPowerLevels(
+          client.userID!,
+        ).content,
         initialState: [
           StateEvent(
             type: PangeaEventTypes.activityPlan,
@@ -104,7 +107,6 @@ extension CoursePlanRoomExtension on Room {
                 ),
               }).toJson(),
             ),
-          RoomDefaults.defaultPowerLevels(client.userID!),
           await client.pangeaJoinRules(
             'knock_restricted',
             allow: [
@@ -208,9 +210,9 @@ extension CoursePlanRoomExtension on Room {
         name: name,
         roomAliasName:
             "${type.alias}_${id.localpart}_${DateTime.now().millisecondsSinceEpoch}",
+        powerLevelContentOverride: type.powerLevels(client.userID!),
         initialState: [
           StateEvent(type: EventTypes.RoomAvatar, content: {'url': uploadURL}),
-          type.powerLevels(client.userID!),
           await client.pangeaJoinRules(
             'knock_restricted',
             allow: [

--- a/lib/pangea/spaces/client_spaces_extension.dart
+++ b/lib/pangea/spaces/client_spaces_extension.dart
@@ -19,9 +19,11 @@ extension SpacesClientExtension on Client {
       visibility: visibility,
       name: name.trim(),
       topic: topic?.trim(),
-      powerLevelContentOverride: {'events_default': 100},
+      powerLevelContentOverride: RoomDefaults.defaultSpacePowerLevels(
+        userID!,
+        spaceChild: spaceChild,
+      ).content,
       initialState: [
-        RoomDefaults.defaultSpacePowerLevels(userID!, spaceChild: spaceChild),
         await pangeaJoinRules(
           joinRules.toString().replaceAll('JoinRules.', ''),
         ),


### PR DESCRIPTION
## Summary

- `M_FORBIDDEN: user_level (0) < send_level (50)` errors on `createRoom` were traced to power levels being passed in `initialState` instead of `powerLevelContentOverride`
- When `m.room.power_levels` is in `initialState`, it **fully replaces** Synapse's auto-generated power levels event — and since none of our `RoomDefaults` content included a `users` map, the creator ended up at `users_default: 0`
- Any `createRoom` call that also includes an `invite` list then fails: invite requires level 50, creator has level 0
- Using `powerLevelContentOverride` causes Synapse to **merge** the content with defaults, always giving the creator level 100

## Why now?

This appears to be a behavior change in how Synapse processes `initialState` power levels vs. `powerLevelContentOverride`. The error started appearing on staging today (Sentry [#7347797184](https://pangea-chat.sentry.io/issues/7347797184/)). **Needs testing to confirm the fix resolves it** — the logic is sound based on the Matrix spec and Synapse source, but we haven't been able to reproduce and verify in a dev environment.

## Call sites fixed

| File | Room type |
|---|---|
| `bot_client_extension.dart` | Bot DM creation |
| `chat_details.dart` | Group chat (sub-room) creation |
| `course_plan_room_extension.dart` | Activity session rooms + announcements/intro default chats |
| `client_spaces_extension.dart` | Course space creation |
| `create_room_extension.dart` | Added `powerLevelContentOverride` param to `createPangeaDirectChat` / `createPangeaGroupChat` |

Also removes the dead `{'events_default': 100}` override in `createPangeaSpace` that was being silently overwritten by the `initialState` power levels event.

## Test plan

- [ ] Create a new bot DM — should succeed (was the primary failure case)
- [ ] Create a course space with announcements chat — should succeed (`restrictedPowerLevels` with `events_default: 50` was the most restrictive case)
- [ ] Create a group chat sub-room from a space
- [ ] Launch an activity session room
- [ ] Confirm creator has power level 100 in all created rooms

🤖 Generated with [Claude Code](https://claude.com/claude-code)