### PR TITLE
perf(courses): use CMS-generated image sizes instead of full-size originals

### DIFF
--- a/lib/pangea/course_plans/course_locations/course_location_media_repo.dart
+++ b/lib/pangea/course_plans/course_locations/course_location_media_repo.dart
@@ -84,9 +84,21 @@ class CourseLocationMediaRepo {
     final List<CourseMediaInfo> urls = [];
     for (final uuid in request.uuids) {
       try {
-        final url = _storage.read(uuid) as String?;
-        if (url != null) {
-          urls.add(CourseMediaInfo(uuid: uuid, url: url));
+        final cached = _storage.read(uuid);
+        if (cached != null) {
+          if (cached is String) {
+            // Legacy cache format — just the URL string
+            urls.add(CourseMediaInfo(uuid: uuid, url: cached));
+          } else if (cached is Map) {
+            urls.add(
+              CourseMediaInfo(
+                uuid: uuid,
+                url: cached['url'] as String,
+                thumbnailUrl: cached['thumbnailUrl'] as String?,
+                mediumUrl: cached['mediumUrl'] as String?,
+              ),
+            );
+          }
         }
       } catch (e) {
         // If parsing fails, remove the corrupted cache entry
@@ -99,7 +111,13 @@ class CourseLocationMediaRepo {
   static Future<void> _setCached(CourseLocationMediaResponse response) async {
     final List<Future> futures = [];
     for (final entry in response.mediaUrls) {
-      futures.add(_storage.write(entry.uuid, entry.url));
+      futures.add(
+        _storage.write(entry.uuid, {
+          'url': entry.url,
+          'thumbnailUrl': entry.thumbnailUrl,
+          'mediumUrl': entry.mediumUrl,
+        }),
+      );
     }
     await Future.wait(futures);
   }

--- a/lib/pangea/course_plans/course_locations/course_location_media_response.dart
+++ b/lib/pangea/course_plans/course_locations/course_location_media_response.dart
@@ -14,7 +14,14 @@ class CourseLocationMediaResponse {
     return CourseLocationMediaResponse(
       mediaUrls: cmsCoursePlanTopicLocationMediasResult.docs
           .where((e) => e.url != null)
-          .map((e) => CourseMediaInfo(uuid: e.id, url: e.url!))
+          .map(
+            (e) => CourseMediaInfo(
+              uuid: e.id,
+              url: e.url!,
+              thumbnailUrl: e.sizes?.thumbnail?.url,
+              mediumUrl: e.sizes?.medium?.url,
+            ),
+          )
           .toList(),
     );
   }

--- a/lib/pangea/course_plans/course_media/course_media_info.dart
+++ b/lib/pangea/course_plans/course_media/course_media_info.dart
@@ -1,6 +1,21 @@
 class CourseMediaInfo {
   final String uuid;
   final String url;
+  final String? thumbnailUrl;
+  final String? mediumUrl;
 
-  CourseMediaInfo({required this.uuid, required this.url});
+  CourseMediaInfo({
+    required this.uuid,
+    required this.url,
+    this.thumbnailUrl,
+    this.mediumUrl,
+  });
+
+  /// Returns the best URL for the given display width.
+  /// Uses thumbnail for <=256px, medium for <=512px, original for larger.
+  String urlForWidth(double width) {
+    if (width <= 256 && thumbnailUrl != null) return thumbnailUrl!;
+    if (width <= 512 && mediumUrl != null) return mediumUrl!;
+    return mediumUrl ?? url;
+  }
 }

--- a/lib/pangea/course_plans/course_media/course_media_repo.dart
+++ b/lib/pangea/course_plans/course_media/course_media_repo.dart
@@ -87,8 +87,20 @@ class CourseMediaRepo {
 
     for (final uuid in request.uuids) {
       final cached = _storage.read(uuid);
-      if (cached != null && cached is String) {
-        urls.add(CourseMediaInfo(uuid: uuid, url: cached));
+      if (cached != null) {
+        if (cached is String) {
+          // Legacy cache format — just the URL string
+          urls.add(CourseMediaInfo(uuid: uuid, url: cached));
+        } else if (cached is Map) {
+          urls.add(
+            CourseMediaInfo(
+              uuid: uuid,
+              url: cached['url'] as String,
+              thumbnailUrl: cached['thumbnailUrl'] as String?,
+              mediumUrl: cached['mediumUrl'] as String?,
+            ),
+          );
+        }
       }
     }
 
@@ -98,7 +110,13 @@ class CourseMediaRepo {
   static Future<void> _setCached(CourseMediaResponse response) async {
     final List<Future> futures = [];
     for (final entry in response.mediaUrls) {
-      futures.add(_storage.write(entry.uuid, entry.url));
+      futures.add(
+        _storage.write(entry.uuid, {
+          'url': entry.url,
+          'thumbnailUrl': entry.thumbnailUrl,
+          'mediumUrl': entry.mediumUrl,
+        }),
+      );
     }
     await Future.wait(futures);
   }

--- a/lib/pangea/course_plans/course_media/course_media_response.dart
+++ b/lib/pangea/course_plans/course_media/course_media_response.dart
@@ -13,7 +13,14 @@ class CourseMediaResponse {
     return CourseMediaResponse(
       mediaUrls: response.docs
           .where((e) => e.url != null)
-          .map((e) => CourseMediaInfo(uuid: e.id, url: e.url!))
+          .map(
+            (e) => CourseMediaInfo(
+              uuid: e.id,
+              url: e.url!,
+              thumbnailUrl: e.sizes?.thumbnail?.url,
+              mediumUrl: e.sizes?.medium?.url,
+            ),
+          )
           .toList(),
     );
   }

--- a/lib/pangea/course_plans/course_topics/course_topic_model.dart
+++ b/lib/pangea/course_plans/course_topics/course_topic_model.dart
@@ -53,7 +53,7 @@ class CourseTopicModel {
         ).mediaUrls,
       )
       .expand((e) => e)
-      .map((e) => e.url)
+      .map((e) => e.mediumUrl ?? e.url)
       .toList();
 
   Future<List<String>> fetchLocationMedia() async {
@@ -64,7 +64,8 @@ class CourseTopicModel {
         CourseInfoBatchRequest(batchId: uuid, uuids: location.mediaIds),
       );
 
-      allLocationMedia.addAll(mediaResp.mediaUrls.map((e) => e.url));
+      allLocationMedia
+          .addAll(mediaResp.mediaUrls.map((e) => e.mediumUrl ?? e.url));
     }
     return allLocationMedia;
   }

--- a/lib/pangea/course_plans/courses/course_plan_model.dart
+++ b/lib/pangea/course_plans/courses/course_plan_model.dart
@@ -123,11 +123,14 @@ class CoursePlanModel {
   Future<CourseMediaResponse> fetchMediaUrls() => CourseMediaRepo.get(
     CourseInfoBatchRequest(batchId: uuid, uuids: mediaIds),
   );
-  Uri? get imageUrl => loadedMediaUrls.mediaUrls.isEmpty
-      ? loadedTopics.values
-            .lastWhereOrNull((topic) => topic.imageUrl != null)
-            ?.imageUrl
-      : Uri.tryParse(
-          "${Environment.cmsApi}${loadedMediaUrls.mediaUrls.first.url}",
-        );
+  Uri? get imageUrl {
+    if (loadedMediaUrls.mediaUrls.isEmpty) {
+      return loadedTopics.values
+          .lastWhereOrNull((topic) => topic.imageUrl != null)
+          ?.imageUrl;
+    }
+    final media = loadedMediaUrls.mediaUrls.first;
+    final bestUrl = media.mediumUrl ?? media.url;
+    return Uri.tryParse("${Environment.cmsApi}$bestUrl");
+  }
 }

--- a/lib/pangea/payload_client/models/course_plan/cms_course_plan_topic_location_media.dart
+++ b/lib/pangea/payload_client/models/course_plan/cms_course_plan_topic_location_media.dart
@@ -69,6 +69,7 @@ class CmsCoursePlanTopicLocationMedia {
       height: json['height'],
       focalX: json['focalX']?.toDouble(),
       focalY: json['focalY']?.toDouble(),
+      sizes: json['sizes'] != null ? ImageSizes.fromJson(json['sizes']) : null,
     );
   }
 


### PR DESCRIPTION
## What

Use CMS-generated thumbnail (256px) and medium (512px) image variants for course media instead of full-size originals (1024-4000px).

## Why

Closes #6100

Course images load slowly because the client always fetches full-size originals from CMS (often 2-5MB per image), ignoring the pre-generated sized variants. Example from staging: original is 2.1MB, medium is 699KB (68% smaller), thumbnail is 174KB (92% smaller).

## Testing

- [x] Staging

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)