### PR TITLE
fix(analytics): guard null L2 in analytics timer and downgrade to warning

### DIFF
--- a/lib/pangea/analytics_data/analytics_update_service.dart
+++ b/lib/pangea/analytics_data/analytics_update_service.dart
@@ -4,6 +4,7 @@ import 'dart:developer';
 import 'package:flutter/foundation.dart';
 
 import 'package:matrix/matrix.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'package:fluffychat/pangea/analytics_data/analytics_data_service.dart';
 import 'package:fluffychat/pangea/analytics_data/analytics_update_dispatcher.dart';
@@ -39,6 +40,8 @@ class AnalyticsUpdateService {
         _periodicTimer?.cancel();
         return;
       }
+      // Skip if user hasn't set their L2 yet (e.g., mid-onboarding)
+      if (_l2 == null) return;
       sendLocalAnalyticsToAnalyticsRoom();
     });
   }
@@ -100,6 +103,7 @@ class AnalyticsUpdateService {
         e: "No L2 language set for user",
         m: "Cannot send local analytics to analytics room",
         data: {"l2Override": l2Override},
+        level: SentryLevel.warning,
       );
       return;
     }

--- a/lib/pangea/analytics_details_popup/analytics_details_popup.dart
+++ b/lib/pangea/analytics_details_popup/analytics_details_popup.dart
@@ -6,6 +6,7 @@ import 'package:async/async.dart';
 import 'package:diacritic/diacritic.dart';
 import 'package:go_router/go_router.dart';
 import 'package:material_symbols_icons/symbols.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/analytics_data/analytics_data_service.dart';
@@ -92,6 +93,7 @@ class ConstructAnalyticsViewState extends State<ConstructAnalyticsView> {
         e: "No L2 language set for user",
         m: "Cannot set analytics data",
         data: {"view": widget.view, "construct": widget.construct},
+        level: SentryLevel.warning,
       );
       return;
     }


### PR DESCRIPTION
## What

Guard null L2 in analytics periodic timer and downgrade null-L2 logs from error to warning.

## Why

Fixes CLIENT-AP1 — 27 users hitting "No L2 language set for user" error on every analytics timer tick before their L2 syncs from Matrix. This is a timing issue during session startup / onboarding, not a real bug. Users experience no degraded behavior.

## Testing

Code-level: both call sites return early when L2 is null — no behavior change for users. The timer silently skips instead of logging an error.

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None