### PR TITLE
fix: migrate deploy_web from static AWS keys to OIDC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,9 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   WEB_APP_ENV: ${{ vars.WEB_APP_ENV }}
 
+permissions:
+  contents: write # Creates GitHub releases and uploads release assets
+
 jobs:
   create_release:
     name: "Tagged Release"
@@ -176,6 +179,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_web
     environment: production
+    permissions:
+      contents: read
+      id-token: write
     env:
       WEBAPP_S3_BUCKET: ${{ vars.WEBAPP_S3_BUCKET }}
       CF_DISTRIBUTION_ID: ${{ vars.CF_DISTRIBUTION_ID }}
@@ -189,12 +195,24 @@ jobs:
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN_PROD }}
+          aws-region: us-east-1
       - name: Copy files to the production website with the AWS CLI
         run: |
-          aws s3 sync ./build/web s3://$WEBAPP_S3_BUCKET
+          # Immutable hashed assets — cache for 1 year
+          aws s3 sync ./build/web s3://$WEBAPP_S3_BUCKET \
+            --cache-control "public, max-age=31536000, immutable" \
+            --exclude "index.html" \
+            --exclude "flutter_service_worker.js" \
+            --exclude "version.json" \
+            --exclude "manifest.json"
+          # Mutable entry points — always revalidate
+          for f in index.html flutter_service_worker.js version.json manifest.json; do
+            if [ -f "./build/web/$f" ]; then
+              aws s3 cp "./build/web/$f" "s3://$WEBAPP_S3_BUCKET/$f" \
+                --cache-control "no-cache, must-revalidate"
+            fi
+          done
       - name: AWS CloudFront Invalidation
         run: |
           aws cloudfront create-invalidation --distribution-id $CF_DISTRIBUTION_ID --paths "/*"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: Learn a language while texting your friends.
 # Pangea#
 publish_to: none
 # On version bump also increase the build number for F-Droid
-version: 4.1.18+4
+version: 4.1.18+5
 
 environment:
   sdk: ">=3.10.0 <4.0.0"


### PR DESCRIPTION
## Summary

Migrate `deploy_web` job in the release workflow from expired static AWS access keys to OIDC authentication, matching every other repo.

## Root Cause

The `deploy_web` job used `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` which have expired ("The security token included in the request is invalid"). This has been broken for **every release** — checking the last 10 workflow runs, all show failures.

## Changes

- **OIDC auth**: `role-to-assume: AWS_ROLE_ARN_PROD` with `id-token: write` permission (same pattern as website, choreographer, CMS, sygnal)
- **Cache headers**: Immutable hashed assets get 1-year cache; entry points (index.html, service worker) get no-cache
- **Version bump**: 4.1.18+4 -> 4.1.18+5

## Context

- The OIDC infrastructure already exists in terraform and includes `client` in allowed repos
- `AWS_ROLE_ARN_PROD` secret was added ~10 days ago at repo level
- The equivalent changes were already on `main` but never merged to `production`
- The hotfix from #6110 was manually deployed to S3 + CloudFront while this CI fix was being prepared

Fixes the deploy stage of the release workflow. Closes #6109 deploy component.