### PR TITLE
fix: handle null userL1Code in class link SSO signup flow

### DIFF
--- a/lib/pangea/login/pages/create_pangea_account_page.dart
+++ b/lib/pangea/login/pages/create_pangea_account_page.dart
@@ -91,17 +91,18 @@ class CreatePangeaAccountPageState extends State<CreatePangeaAccountPage> {
         }
       }
 
-      final courseId = room.coursePlan?.uuid;
-      if (courseId == null) {
-        throw Exception('No course plan associated with space $spaceId');
-      }
+      _spaceId = spaceId;
 
+      final courseId = room.coursePlan?.uuid;
+      if (courseId == null) return;
+
+      final userL1 =
+          MatrixState.pangeaController.userController.userL1Code ?? 'en';
       request = GetLocalizedCoursesRequest(
         coursePlanIds: [courseId],
-        l1: MatrixState.pangeaController.userController.userL1Code!,
+        l1: userL1,
       );
       final course = await CoursePlansRepo.get(request);
-      _spaceId = spaceId;
       _courseLangCode = course.targetLanguage;
     } catch (err, s) {
       _courseError = err;
@@ -180,6 +181,7 @@ class CreatePangeaAccountPageState extends State<CreatePangeaAccountPage> {
       // This can happen if a user creates a new account via login => SSO
       if (targetLangCode == null) {
         context.go('/registration');
+        return;
       }
 
       final updateFuture = [


### PR DESCRIPTION
## What

Handle null userL1Code during class link SSO signup to prevent force-unwrap crash.

## Why

Addresses #6110

Fixes CLIENT-AP4. When signing up via Google SSO with a class link, userL1Code can be null before profile setup. The force-unwrap crashes registration.

## Testing

- Verified on localhost with Google SSO + class link flow

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None
