### PR TITLE
fix: avatar Uri serialization and CI rm .env failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,8 +114,8 @@ jobs:
           ruby-version: '3.3'
       - name: Update env files to selected environment
         run: |
-          rm .env
-          rm assets/.env
+          rm -f .env
+          rm -f assets/.env
           echo "$WEB_APP_ENV" >> .env
           cp .env assets/.env
       - name: Apply .env patch

--- a/lib/pangea/login/pages/create_pangea_account_page.dart
+++ b/lib/pangea/login/pages/create_pangea_account_page.dart
@@ -120,7 +120,7 @@ class CreatePangeaAccountPageState extends State<CreatePangeaAccountPage> {
         "${AppConfig.assetsBaseURL}/$selectedAvatarPath",
       );
       await client.setProfileField(client.userID!, 'avatar_url', {
-        'avatar_url': avatarUrl,
+        'avatar_url': avatarUrl.toString(),
       });
     } catch (err, s) {
       ErrorHandler.logError(e: err, s: s, data: {});


### PR DESCRIPTION
## What

Fix avatar Uri serialization crash and CI release workflow failure.

## Why

Addresses #6110

Fixes CLIENT-A44 / CLIENT-AP9. Two issues on production:
1. _setAvatar passes a Uri object to setProfileField which calls jsonEncode, causing JsonUnsupportedObjectError
2. release.yaml fails because rm .env exits code 1 when no .env file exists, blocking all production deploys

## Testing

- Avatar fix verified on localhost with Google SSO signup flow
- rm -f fix verified by checking release.yaml workflow logs

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None — merging to production triggers release.yaml which now auto-deploys with the rm -f fix.
