### PR TITLE
fix(notifications): use check-in type for bot notification analytics

### DIFF
--- a/lib/pangea/notifications/notification_tap_utils.dart
+++ b/lib/pangea/notifications/notification_tap_utils.dart
@@ -83,7 +83,7 @@ class NotificationTapUtil {
     if (targetEventName != null) {
       try {
         final variant = notification[_variantKey] as String?;
-        final notificationType = notification['type'] as String?;
+        final notificationType = notification[_checkInTypeKey] as String?;
         final chatId = notification[_chatIdKey] as String?;
         final groupId = notification[_groupIdKey] as String?;
         final activityId = notification[_botActivityIdKey] as String?;


### PR DESCRIPTION
## What
- use `content_check_in_type` for bot notification analytics `notification_type`
- leave the existing bot notification analytics branch unchanged otherwise

## Why
- Addresses #6257
- fixes the client contract mismatch on top of #6258

## Testing
- `dart analyze lib/pangea/notifications/notification_tap_utils.dart`
- [ ] Staging
- [ ] Production

## Deploy Notes
- None