### PR TITLE
feat(client): show TTS voice display names

### DIFF
--- a/.github/instructions/language-list.instructions.md
+++ b/.github/instructions/language-list.instructions.md
@@ -34,13 +34,15 @@ The `l2` getter on [`LanguageModel`](../../lib/pangea/languages/language_model.d
 
 ## Models
 
-- [`LanguageModel`](../../lib/pangea/languages/language_model.dart) — core model with `langCode`, `displayName`, `l2Support`, `script`, `localeEmoji`, `voices`
+- [`LanguageModel`](../../lib/pangea/languages/language_model.dart) — core model with `langCode`, `displayName`, `l2Support`, `script`, `localeEmoji`, and labeled voice options
 - [`L2SupportEnum`](../../lib/pangea/languages/l2_support_enum.dart) — `na`, `alpha`, `beta`, `full` with localized display strings and badge rendering
 - [`LanguageArc`](../../lib/pangea/languages/language_arc_model.dart) — L1→L2 pair, constructed from user settings
 
 ## Conventions
 
 - Display names are localized via `getDisplayName(context)` using l10n keys, with fallback to CMS `language_name`
+- The CMS `voices` field is hydrated as voice option objects with `short_name` + `display_name`; `LanguageModel.voices` remains a convenience getter that exposes only short names for persisted settings
+- Client hydration must remain backward-compatible with legacy `voices: list[str]` CMS responses until choreographer re-syncs every language row
 - Regional variants show `localeEmoji` in place of parenthesized region: "Portuguese 🇧🇷" instead of "Portuguese (Brazil)"
 - `langCodeShort` strips the territory: `en-US` → `en`
 - RTL detection uses a hardcoded list in `LanguageConstants.rtlLanguageCodes`

--- a/lib/pangea/languages/language_model.dart
+++ b/lib/pangea/languages/language_model.dart
@@ -81,7 +81,7 @@ class LanguageModel {
         json['language_code'] ??
         codeFromNameOrCode(json['language_name'], json['language_flag']);
 
-    final rawVoices = json['voices'];
+    final rawVoices = json['voice_options'] ?? json['voices'];
     final voiceOptions = rawVoices is List
         ? rawVoices.map(VoiceOptionModel.fromJson).toList()
         : <VoiceOptionModel>[];
@@ -99,7 +99,7 @@ class LanguageModel {
             )
           : null,
       localeEmoji: json['locale_emoji'],
-        voiceOptions: voiceOptions,
+      voiceOptions: voiceOptions,
     );
   }
 
@@ -110,7 +110,8 @@ class LanguageModel {
     'l2_support': l2Support.storageString,
     'text_direction': textDirection.name,
     'locale_emoji': localeEmoji,
-    'voices': voiceOptions.map((voice) => voice.toJson()).toList(),
+    'voices': voices,
+    'voice_options': voiceOptions.map((voice) => voice.toJson()).toList(),
   };
 
   bool get l2 => l2Support != L2SupportEnum.na;

--- a/lib/pangea/languages/language_model.dart
+++ b/lib/pangea/languages/language_model.dart
@@ -7,6 +7,48 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/languages/l2_support_enum.dart';
 import 'package:fluffychat/pangea/languages/language_constants.dart';
 
+class VoiceOptionModel {
+  final String shortName;
+  final String displayName;
+
+  const VoiceOptionModel({required this.shortName, required this.displayName});
+
+  factory VoiceOptionModel.fromJson(dynamic json) {
+    if (json is String) {
+      return VoiceOptionModel(
+        shortName: json,
+        displayName: _fallbackVoiceDisplayName(json),
+      );
+    }
+
+    final map = json as Map<String, dynamic>;
+    final shortName = (map['short_name'] ?? map['shortName']) as String;
+    final displayName =
+        (map['display_name'] ?? map['displayName']) as String? ??
+        _fallbackVoiceDisplayName(shortName);
+
+    return VoiceOptionModel(shortName: shortName, displayName: displayName);
+  }
+
+  Map<String, dynamic> toJson() => {
+    'short_name': shortName,
+    'display_name': displayName,
+  };
+
+  static String _fallbackVoiceDisplayName(String shortName) {
+    final parts = shortName.split('-');
+    if (parts.length < 3) return shortName;
+
+    final variant = parts.removeLast();
+    final quality = parts.removeLast().replaceAllMapped(
+      RegExp(r'(\d+)'),
+      (match) => ' ${match.group(1)}',
+    );
+    final locale = parts.join('-').toUpperCase();
+    return '$quality $variant ($locale)';
+  }
+}
+
 class LanguageModel {
   final String langCode;
   final String displayName;
@@ -14,7 +56,7 @@ class LanguageModel {
   final String? localeEmoji;
   final L2SupportEnum l2Support;
   final TextDirection? _textDirection;
-  final List<String> voices;
+  final List<VoiceOptionModel> voiceOptions;
 
   LanguageModel({
     required this.langCode,
@@ -22,14 +64,27 @@ class LanguageModel {
     this.localeEmoji,
     this.script = LanguageKeys.unknownLanguage,
     this.l2Support = L2SupportEnum.na,
-    this.voices = const [],
+    this.voiceOptions = const [],
     TextDirection? textDirection,
   }) : _textDirection = textDirection;
+
+  List<String> get voices => voiceOptions.map((voice) => voice.shortName).toList();
+
+  String? displayVoiceName(String shortName) {
+    return voiceOptions
+        .firstWhereOrNull((voice) => voice.shortName == shortName)
+        ?.displayName;
+  }
 
   factory LanguageModel.fromJson(Map<String, dynamic> json) {
     final String code =
         json['language_code'] ??
         codeFromNameOrCode(json['language_name'], json['language_flag']);
+
+    final rawVoices = json['voices'];
+    final voiceOptions = rawVoices is List
+        ? rawVoices.map(VoiceOptionModel.fromJson).toList()
+        : <VoiceOptionModel>[];
 
     return LanguageModel(
       langCode: code,
@@ -44,7 +99,7 @@ class LanguageModel {
             )
           : null,
       localeEmoji: json['locale_emoji'],
-      voices: json['voices'] != null ? List<String>.from(json['voices']) : [],
+        voiceOptions: voiceOptions,
     );
   }
 
@@ -55,7 +110,7 @@ class LanguageModel {
     'l2_support': l2Support.storageString,
     'text_direction': textDirection.name,
     'locale_emoji': localeEmoji,
-    'voices': voices,
+    'voices': voiceOptions.map((voice) => voice.toJson()).toList(),
   };
 
   bool get l2 => l2Support != L2SupportEnum.na;

--- a/lib/pangea/learning_settings/voice_dropdown.dart
+++ b/lib/pangea/learning_settings/voice_dropdown.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:collection/collection.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
@@ -22,14 +23,14 @@ class VoiceDropdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final voices = (language?.voices ?? <String>[]);
-    final value = this.value != null && voices.contains(this.value)
-        ? this.value
+    final voiceOptions = language?.voiceOptions ?? <VoiceOptionModel>[];
+    final selectedVoice = this.value != null
+        ? voiceOptions.firstWhereOrNull((voice) => voice.shortName == this.value)
         : null;
 
     return DropdownButtonFormField2<String>(
-      customButton: value != null
-          ? CustomDropdownTextButton(text: value)
+      customButton: selectedVoice != null
+          ? CustomDropdownTextButton(text: selectedVoice.displayName)
           : null,
       menuItemStyleData: const MenuItemStyleData(
         padding: EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
@@ -45,11 +46,14 @@ class VoiceDropdown extends StatelessWidget {
           borderRadius: BorderRadius.circular(14.0),
         ),
       ),
-      items: voices.map((voice) {
-        return DropdownMenuItem(value: voice, child: Text(voice));
+      items: voiceOptions.map((voice) {
+        return DropdownMenuItem(
+          value: voice.shortName,
+          child: Text(voice.displayName),
+        );
       }).toList(),
       onChanged: enabled ? onChanged : null,
-      value: voices.contains(value) ? value : null,
+      value: selectedVoice?.shortName,
     );
   }
 }

--- a/test/pangea/language_model_test.dart
+++ b/test/pangea/language_model_test.dart
@@ -14,7 +14,8 @@ void main() {
         'locale_emoji': '🇪🇸',
         'l2_support': 'full',
         'script': 'Latn',
-        'voices': [
+        'voices': ['es-ES-Standard-A', 'es-ES-Wavenet-B'],
+        'voice_options': [
           {
             'short_name': 'es-ES-Standard-A',
             'display_name': 'Elena (Spain)',
@@ -37,6 +38,25 @@ void main() {
       expect(model.script, 'Latn');
       expect(model.voices, ['es-ES-Standard-A', 'es-ES-Wavenet-B']);
       expect(model.displayVoiceName('es-ES-Wavenet-B'), 'Marta (Spain)');
+    });
+
+    test('prefers voice_options over legacy voices for display labels', () {
+      final json = {
+        'language_code': 'es',
+        'language_name': 'Spanish',
+        'voices': ['es-ES-Standard-A'],
+        'voice_options': [
+          {
+            'short_name': 'es-ES-Standard-A',
+            'display_name': 'Elena (Spain)',
+          },
+        ],
+      };
+
+      final model = LanguageModel.fromJson(json);
+
+      expect(model.voices, ['es-ES-Standard-A']);
+      expect(model.displayVoiceName('es-ES-Standard-A'), 'Elena (Spain)');
     });
 
     test('parses minimal fields (only required)', () {
@@ -174,7 +194,8 @@ void main() {
         'l2_support': 'beta',
         'script': 'Jpan',
         'locale_emoji': '🇯🇵',
-        'voices': [
+        'voices': ['ja-JP-Standard-A'],
+        'voice_options': [
           {
             'short_name': 'ja-JP-Standard-A',
             'display_name': 'Hiroshi (Japan)',
@@ -190,7 +211,8 @@ void main() {
       expect(serialized['l2_support'], 'beta');
       expect(serialized['script'], 'Jpan');
       expect(serialized['locale_emoji'], '🇯🇵');
-      expect(serialized['voices'], [
+      expect(serialized['voices'], ['ja-JP-Standard-A']);
+      expect(serialized['voice_options'], [
         {
           'short_name': 'ja-JP-Standard-A',
           'display_name': 'Hiroshi (Japan)',

--- a/test/pangea/language_model_test.dart
+++ b/test/pangea/language_model_test.dart
@@ -14,7 +14,16 @@ void main() {
         'locale_emoji': '🇪🇸',
         'l2_support': 'full',
         'script': 'Latn',
-        'voices': ['es-ES-Standard-A', 'es-ES-Wavenet-B'],
+        'voices': [
+          {
+            'short_name': 'es-ES-Standard-A',
+            'display_name': 'Elena (Spain)',
+          },
+          {
+            'short_name': 'es-ES-Wavenet-B',
+            'display_name': 'Marta (Spain)',
+          },
+        ],
         'createdAt': '2026-01-01T00:00:00.000Z',
         'updatedAt': '2026-01-01T00:00:00.000Z',
       };
@@ -27,6 +36,7 @@ void main() {
       expect(model.l2Support, L2SupportEnum.full);
       expect(model.script, 'Latn');
       expect(model.voices, ['es-ES-Standard-A', 'es-ES-Wavenet-B']);
+      expect(model.displayVoiceName('es-ES-Wavenet-B'), 'Marta (Spain)');
     });
 
     test('parses minimal fields (only required)', () {
@@ -96,6 +106,19 @@ void main() {
       expect(model.voices, isEmpty);
     });
 
+    test('handles legacy string voices', () {
+      final json = {
+        'language_code': 'en',
+        'language_name': 'English',
+        'voices': ['en-US-Neural2-A'],
+      };
+
+      final model = LanguageModel.fromJson(json);
+
+      expect(model.voices, ['en-US-Neural2-A']);
+      expect(model.displayVoiceName('en-US-Neural2-A'), 'Neural 2 A (EN-US)');
+    });
+
     test('handles empty voices list', () {
       final json = {
         'language_code': 'fr',
@@ -151,7 +174,12 @@ void main() {
         'l2_support': 'beta',
         'script': 'Jpan',
         'locale_emoji': '🇯🇵',
-        'voices': ['ja-JP-Standard-A'],
+        'voices': [
+          {
+            'short_name': 'ja-JP-Standard-A',
+            'display_name': 'Hiroshi (Japan)',
+          },
+        ],
       };
 
       final model = LanguageModel.fromJson(original);
@@ -162,7 +190,12 @@ void main() {
       expect(serialized['l2_support'], 'beta');
       expect(serialized['script'], 'Jpan');
       expect(serialized['locale_emoji'], '🇯🇵');
-      expect(serialized['voices'], ['ja-JP-Standard-A']);
+      expect(serialized['voices'], [
+        {
+          'short_name': 'ja-JP-Standard-A',
+          'display_name': 'Hiroshi (Japan)',
+        },
+      ]);
     });
 
     test('serializes default values correctly', () {


### PR DESCRIPTION
## What
Show human-readable TTS voice display names in the settings dropdown while keeping stored short names unchanged.

## Why
Closes #6272
Related backend work: pangeachat/2-step-choreographer#1855

## Testing
- Editor diagnostics passed on the edited Dart files.
- flutter test test/pangea/language_model_test.dart could not run here because the local Flutter SDK is missing flutter_tester.

### Tested on:
- [ ] Staging
- [ ] Production

## Deploy Notes
None