### PR TITLE
fix(course-plans): handle localization error results

### DIFF
--- a/lib/pangea/course_plans/course_activities/course_activity_translation_response.dart
+++ b/lib/pangea/course_plans/course_activities/course_activity_translation_response.dart
@@ -5,10 +5,7 @@ class TranslateActivityResponse {
   final Map<String, ActivityPlanModel> plans;
   final Map<String, LocalizationErrorResult> errors;
 
-  TranslateActivityResponse({
-    required this.plans,
-    this.errors = const {},
-  });
+  TranslateActivityResponse({required this.plans, this.errors = const {}});
 
   factory TranslateActivityResponse.fromJson(Map<String, dynamic> json) {
     final plansEntry = json['plans'] as Map<String, dynamic>;
@@ -24,10 +21,7 @@ class TranslateActivityResponse {
       }
     }
 
-    return TranslateActivityResponse(
-      plans: plans,
-      errors: errors,
-    );
+    return TranslateActivityResponse(plans: plans, errors: errors);
   }
 
   Map<String, dynamic> toJson() => {

--- a/lib/pangea/course_plans/course_activities/course_activity_translation_response.dart
+++ b/lib/pangea/course_plans/course_activities/course_activity_translation_response.dart
@@ -1,16 +1,32 @@
 import 'package:fluffychat/pangea/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/pangea/course_plans/localization_error_result.dart';
 
 class TranslateActivityResponse {
   final Map<String, ActivityPlanModel> plans;
+  final Map<String, LocalizationErrorResult> errors;
 
-  TranslateActivityResponse({required this.plans});
+  TranslateActivityResponse({
+    required this.plans,
+    this.errors = const {},
+  });
 
   factory TranslateActivityResponse.fromJson(Map<String, dynamic> json) {
     final plansEntry = json['plans'] as Map<String, dynamic>;
+    final Map<String, ActivityPlanModel> plans = {};
+    final Map<String, LocalizationErrorResult> errors = {};
+
+    for (final entry in plansEntry.entries) {
+      final value = entry.value as Map<String, dynamic>;
+      if (LocalizationErrorResult.isError(value)) {
+        errors[entry.key] = LocalizationErrorResult.fromJson(value);
+      } else {
+        plans[entry.key] = ActivityPlanModel.fromJson(value);
+      }
+    }
+
     return TranslateActivityResponse(
-      plans: plansEntry.map((key, value) {
-        return MapEntry(key, ActivityPlanModel.fromJson(value));
-      }),
+      plans: plans,
+      errors: errors,
     );
   }
 

--- a/lib/pangea/course_plans/course_topics/course_topic_translation_response.dart
+++ b/lib/pangea/course_plans/course_topics/course_topic_translation_response.dart
@@ -5,10 +5,7 @@ class TranslateTopicResponse {
   final Map<String, CourseTopicModel> topics;
   final Map<String, LocalizationErrorResult> errors;
 
-  TranslateTopicResponse({
-    required this.topics,
-    this.errors = const {},
-  });
+  TranslateTopicResponse({required this.topics, this.errors = const {}});
 
   factory TranslateTopicResponse.fromJson(Map<String, dynamic> json) {
     final topicsEntry = json['topics'] as Map<String, dynamic>;
@@ -24,10 +21,7 @@ class TranslateTopicResponse {
       }
     }
 
-    return TranslateTopicResponse(
-      topics: topics,
-      errors: errors,
-    );
+    return TranslateTopicResponse(topics: topics, errors: errors);
   }
 
   Map<String, dynamic> toJson() => {

--- a/lib/pangea/course_plans/course_topics/course_topic_translation_response.dart
+++ b/lib/pangea/course_plans/course_topics/course_topic_translation_response.dart
@@ -1,16 +1,32 @@
 import 'package:fluffychat/pangea/course_plans/course_topics/course_topic_model.dart';
+import 'package:fluffychat/pangea/course_plans/localization_error_result.dart';
 
 class TranslateTopicResponse {
   final Map<String, CourseTopicModel> topics;
+  final Map<String, LocalizationErrorResult> errors;
 
-  TranslateTopicResponse({required this.topics});
+  TranslateTopicResponse({
+    required this.topics,
+    this.errors = const {},
+  });
 
   factory TranslateTopicResponse.fromJson(Map<String, dynamic> json) {
     final topicsEntry = json['topics'] as Map<String, dynamic>;
+    final Map<String, CourseTopicModel> topics = {};
+    final Map<String, LocalizationErrorResult> errors = {};
+
+    for (final entry in topicsEntry.entries) {
+      final value = entry.value as Map<String, dynamic>;
+      if (LocalizationErrorResult.isError(value)) {
+        errors[entry.key] = LocalizationErrorResult.fromJson(value);
+      } else {
+        topics[entry.key] = CourseTopicModel.fromJson(value);
+      }
+    }
+
     return TranslateTopicResponse(
-      topics: topicsEntry.map(
-        (key, value) => MapEntry(key, CourseTopicModel.fromJson(value)),
-      ),
+      topics: topics,
+      errors: errors,
     );
   }
 

--- a/lib/pangea/course_plans/courses/course_plans_repo.dart
+++ b/lib/pangea/course_plans/courses/course_plans_repo.dart
@@ -16,15 +16,21 @@ import 'package:fluffychat/pangea/course_plans/courses/course_filter.dart';
 import 'package:fluffychat/pangea/course_plans/courses/course_plan_model.dart';
 import 'package:fluffychat/pangea/course_plans/courses/get_localized_courses_request.dart';
 import 'package:fluffychat/pangea/course_plans/courses/get_localized_courses_response.dart';
+import 'package:fluffychat/pangea/course_plans/localization_error_result.dart';
 import 'package:fluffychat/pangea/payload_client/payload_client.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 class MissingCourseTranslationException implements Exception {
   final GetLocalizedCoursesResponse response;
+  final LocalizationErrorResult? localizationError;
 
-  const MissingCourseTranslationException({required this.response});
+  const MissingCourseTranslationException({
+    required this.response,
+    this.localizationError,
+  });
 
-  String get errorMessage => "Course plan not found after translation";
+  String get errorMessage =>
+      localizationError?.error ?? "Course plan not found after translation";
 }
 
 class CoursePlansRepo {
@@ -69,6 +75,13 @@ class CoursePlansRepo {
       final translation = await _fetch(request);
       final coursePlan = translation.coursePlans[uuid];
       if (coursePlan == null) {
+        final error = translation.errors[uuid];
+        if (error != null) {
+          throw MissingCourseTranslationException(
+            response: translation,
+            localizationError: error,
+          );
+        }
         throw MissingCourseTranslationException(response: translation);
       }
 

--- a/lib/pangea/course_plans/courses/get_localized_courses_response.dart
+++ b/lib/pangea/course_plans/courses/get_localized_courses_response.dart
@@ -1,20 +1,34 @@
 import 'package:fluffychat/pangea/course_plans/courses/course_plan_model.dart';
+import 'package:fluffychat/pangea/course_plans/localization_error_result.dart';
 
 class GetLocalizedCoursesResponse {
   final Map<String, CoursePlanModel> coursePlans;
+  final Map<String, LocalizationErrorResult> errors;
   final bool hasNextPage;
 
   GetLocalizedCoursesResponse({
     required this.coursePlans,
+    this.errors = const {},
     this.hasNextPage = false,
   });
 
   factory GetLocalizedCoursesResponse.fromJson(Map<String, dynamic> json) {
     final plansEntry = json['course_plans'] as Map<String, dynamic>;
+    final Map<String, CoursePlanModel> coursePlans = {};
+    final Map<String, LocalizationErrorResult> errors = {};
+
+    for (final entry in plansEntry.entries) {
+      final value = entry.value as Map<String, dynamic>;
+      if (LocalizationErrorResult.isError(value)) {
+        errors[entry.key] = LocalizationErrorResult.fromJson(value);
+      } else {
+        coursePlans[entry.key] = CoursePlanModel.fromJson(value);
+      }
+    }
+
     return GetLocalizedCoursesResponse(
-      coursePlans: plansEntry.map(
-        (key, value) => MapEntry(key, CoursePlanModel.fromJson(value)),
-      ),
+      coursePlans: coursePlans,
+      errors: errors,
     );
   }
 

--- a/lib/pangea/course_plans/localization_error_result.dart
+++ b/lib/pangea/course_plans/localization_error_result.dart
@@ -1,0 +1,27 @@
+/// Error result returned by localization endpoints for individual IDs
+/// that could not be localized (e.g., not found, internal server error).
+class LocalizationErrorResult {
+  final String errorCode;
+  final String error;
+
+  const LocalizationErrorResult({
+    required this.errorCode,
+    required this.error,
+  });
+
+  factory LocalizationErrorResult.fromJson(Map<String, dynamic> json) {
+    return LocalizationErrorResult(
+      errorCode: json['errorCode'] as String,
+      error: json['error'] as String,
+    );
+  }
+
+  /// Returns true if the JSON map represents a localization error
+  /// (has an 'errorCode' field) rather than a success result.
+  static bool isError(Map<String, dynamic> json) {
+    return json.containsKey('errorCode');
+  }
+
+  bool get isNotFound => errorCode == 'not-found';
+  bool get isInternalServerError => errorCode == 'internal-server-error';
+}

--- a/lib/pangea/course_plans/localization_error_result.dart
+++ b/lib/pangea/course_plans/localization_error_result.dart
@@ -4,10 +4,7 @@ class LocalizationErrorResult {
   final String errorCode;
   final String error;
 
-  const LocalizationErrorResult({
-    required this.errorCode,
-    required this.error,
-  });
+  const LocalizationErrorResult({required this.errorCode, required this.error});
 
   factory LocalizationErrorResult.fromJson(Map<String, dynamic> json) {
     return LocalizationErrorResult(

--- a/lib/pangea/course_settings/course_settings.dart
+++ b/lib/pangea/course_settings/course_settings.dart
@@ -12,6 +12,7 @@ import 'package:fluffychat/pages/chat_details/chat_details.dart';
 import 'package:fluffychat/pangea/common/widgets/url_image_widget.dart';
 import 'package:fluffychat/pangea/course_creation/course_info_chip_widget.dart';
 import 'package:fluffychat/pangea/course_plans/courses/course_plan_room_extension.dart';
+import 'package:fluffychat/pangea/course_plans/courses/course_plans_repo.dart';
 import 'package:fluffychat/pangea/course_settings/pin_clipper.dart';
 import 'package:fluffychat/pangea/course_settings/topic_activities_list.dart';
 import 'package:fluffychat/pangea/course_settings/topic_participant_list.dart';
@@ -70,85 +71,28 @@ class CourseSettingsState extends State<CourseSettings> {
       );
     }
 
-    if (controller.course == null || controller.courseError != null) {
-      if (controller.courseError != null) {
-        return Center(
-          child: Column(
-            spacing: 50.0,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                L10n.of(context).courseLoadingError,
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodyLarge,
-              ),
-              if (room.canChangeStateEvent(PangeaEventTypes.coursePlan))
-                ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Theme.of(
-                      context,
-                    ).colorScheme.primaryContainer,
-                    foregroundColor: Theme.of(
-                      context,
-                    ).colorScheme.onPrimaryContainer,
-                  ),
-                  onPressed: () => context.go(
-                    "/rooms/spaces/${controller.roomId}/addcourse",
-                  ),
-                  child: Row(
-                    spacing: 8.0,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const Icon(Icons.map_outlined),
-                      Text(L10n.of(context).changeCourse),
-                    ],
-                  ),
-                ),
-            ],
-          ),
+    if (controller.courseError != null) {
+      final error = controller.courseError!;
+      if (error is MissingCourseTranslationException &&
+          error.localizationError?.isNotFound == true) {
+        return _CourseLoadError(
+          error: L10n.of(context).noCourseFound,
+          buttonText: L10n.of(context).addCoursePlan,
+          room: room,
+        );
+      } else {
+        return _CourseLoadError(
+          error: L10n.of(context).courseLoadingError,
+          buttonText: L10n.of(context).changeCourse,
+          room: room,
         );
       }
+    }
 
-      return room.canChangeStateEvent(PangeaEventTypes.coursePlan)
-          ? Column(
-              spacing: 50.0,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  L10n.of(context).noCourseFound,
-                  textAlign: TextAlign.center,
-                  style: Theme.of(context).textTheme.bodyLarge,
-                ),
-                ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Theme.of(
-                      context,
-                    ).colorScheme.primaryContainer,
-                    foregroundColor: Theme.of(
-                      context,
-                    ).colorScheme.onPrimaryContainer,
-                  ),
-                  onPressed: () => context.go(
-                    "/rooms/spaces/${controller.roomId}/addcourse",
-                  ),
-                  child: Row(
-                    spacing: 8.0,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      const Icon(Icons.map_outlined),
-                      Text(L10n.of(context).addCoursePlan),
-                    ],
-                  ),
-                ),
-              ],
-            )
-          : Center(
-              child: Text(
-                L10n.of(context).noCourseFound,
-                textAlign: TextAlign.center,
-                style: Theme.of(context).textTheme.bodyLarge,
-              ),
-            );
+    if (controller.loadingCourse ||
+        controller.loadingTopics ||
+        controller.course == null) {
+      return const Center(child: CircularProgressIndicator.adaptive());
     }
 
     final theme = Theme.of(context);
@@ -156,10 +100,6 @@ class CourseSettingsState extends State<CourseSettings> {
     final double titleFontSize = isColumnMode ? 24.0 : 12.0;
     final double descFontSize = isColumnMode ? 12.0 : 8.0;
     final double iconSize = isColumnMode ? 16.0 : 12.0;
-
-    if (controller.loadingTopics) {
-      return const Center(child: CircularProgressIndicator.adaptive());
-    }
 
     final activeTopicId = controller.currentTopicId(
       Matrix.of(context).client.userID!,
@@ -316,6 +256,50 @@ class CourseSettingsState extends State<CourseSettings> {
             );
           }),
           const SizedBox(height: 16.0),
+        ],
+      ),
+    );
+  }
+}
+
+class _CourseLoadError extends StatelessWidget {
+  final String error;
+  final String buttonText;
+  final Room room;
+
+  const _CourseLoadError({
+    required this.error,
+    required this.buttonText,
+    required this.room,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        spacing: 50.0,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            error,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
+          if (room.canChangeStateEvent(PangeaEventTypes.coursePlan))
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+                foregroundColor: Theme.of(
+                  context,
+                ).colorScheme.onPrimaryContainer,
+              ),
+              onPressed: () => context.go("/rooms/spaces/${room.id}/addcourse"),
+              child: Row(
+                spacing: 8.0,
+                mainAxisSize: MainAxisSize.min,
+                children: [const Icon(Icons.map_outlined), Text(buttonText)],
+              ),
+            ),
         ],
       ),
     );


### PR DESCRIPTION
## What

Parse mixed localization success/error maps and preserve per-ID localization errors for course loads.

## Why

Closes #6308

Addresses pangeachat/2-step-choreographer#1898 and pangeachat/client#6262

## Testing

VS Code diagnostics clean for the touched Dart files.

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None