### PR TITLE
fix: don't show activity end button to user without an activity role

### DIFF
--- a/lib/pangea/activity_sessions/activity_session_chat/activity_stats_menu.dart
+++ b/lib/pangea/activity_sessions/activity_session_chat/activity_stats_menu.dart
@@ -61,8 +61,8 @@ class ActivityStatsMenu extends StatelessWidget {
     final isColumnMode = FluffyThemes.isColumnMode(context);
 
     // Completion status variables
-    final bool userComplete =
-        controller.room.hasPickedRole && controller.room.hasCompletedRole;
+    final hasRole = controller.room.hasPickedRole;
+    final hasCompletedRole = controller.room.hasCompletedRole;
 
     final bool activityComplete = controller.room.isActivityFinished;
     bool shouldShowEndForAll = true;
@@ -162,7 +162,8 @@ class ActivityStatsMenu extends StatelessWidget {
                         ),
                       ],
                     ),
-                    if (!userComplete &&
+                    if (hasRole &&
+                        !hasCompletedRole &&
                         (shouldShowImDone || shouldShowEndForAll)) ...[
                       Text(
                         L10n.of(context).activityDropdownDesc,


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS