### PR TITLE
chore: hide block option in user dialog for bot and support accounts,…

### DIFF
--- a/lib/pangea/chat_list/widgets/dm_list_tile.dart
+++ b/lib/pangea/chat_list/widgets/dm_list_tile.dart
@@ -5,8 +5,10 @@ import 'package:material_symbols_icons/symbols.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/bot/utils/bot_name.dart';
 import 'package:fluffychat/pangea/bot/widgets/bot_face_svg.dart';
 import 'package:fluffychat/pangea/chat_settings/utils/bot_client_extension.dart';
+import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/instructions/instructions_enum.dart';
 import 'package:fluffychat/pangea/support/support_client_extension.dart';
 import 'package:fluffychat/widgets/avatar.dart';
@@ -26,10 +28,13 @@ class DMListTileState extends State<DMListTile> {
 
   @override
   Widget build(BuildContext context) {
+    final blockedUsers = Matrix.of(context).client.ignoredUsers;
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (!Matrix.of(context).client.hasBotDM && widget.visible)
+        if (!Matrix.of(context).client.hasBotDM &&
+            widget.visible &&
+            !blockedUsers.contains(BotName.byEnvironment))
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 1),
             child: Material(
@@ -64,7 +69,8 @@ class DMListTileState extends State<DMListTile> {
           ),
         if (!Matrix.of(context).client.hasSupportDM &&
             !InstructionsEnum.dismissSupportChat.isToggledOff &&
-            widget.visible)
+            widget.visible &&
+            !blockedUsers.contains(Environment.supportUserId))
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 1),
             child: Material(

--- a/lib/widgets/adaptive_dialogs/user_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/user_dialog.dart
@@ -7,7 +7,9 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/analytics_misc/level_display_name.dart';
+import 'package:fluffychat/pangea/bot/utils/bot_name.dart';
 import 'package:fluffychat/pangea/chat/extensions/create_room_extension.dart';
+import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/user/about_me_display.dart';
 import 'package:fluffychat/utils/date_time_extension.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
@@ -204,25 +206,29 @@ class UserDialog extends StatelessWidget {
                   : L10n.of(context).sendAMessage,
             ),
           ),
-          AdaptiveDialogAction(
-            bigButtons: true,
-            borderRadius: AdaptiveDialogAction.centerRadius,
-            onPressed: () {
-              final router = GoRouter.of(context);
-              Navigator.of(context).pop();
-              router.go(
-                '/rooms/settings/security/ignorelist',
-                extra: profile.userId,
-              );
-            },
-            child: Text(
-              // #Pangea
-              // L10n.of(context).ignoreUser,
-              L10n.of(context).block,
-              // Pangea#
-              style: TextStyle(color: theme.colorScheme.error),
+          // #Pangea
+          if (profile.userId != BotName.byEnvironment &&
+              profile.userId != Environment.supportUserId)
+            // Pangea#
+            AdaptiveDialogAction(
+              bigButtons: true,
+              borderRadius: AdaptiveDialogAction.centerRadius,
+              onPressed: () {
+                final router = GoRouter.of(context);
+                Navigator.of(context).pop();
+                router.go(
+                  '/rooms/settings/security/ignorelist',
+                  extra: profile.userId,
+                );
+              },
+              child: Text(
+                // #Pangea
+                // L10n.of(context).ignoreUser,
+                L10n.of(context).block,
+                // Pangea#
+                style: TextStyle(color: theme.colorScheme.error),
+              ),
             ),
-          ),
         ],
         AdaptiveDialogAction(
           bigButtons: true,


### PR DESCRIPTION
… hide start DM buttons for blocked bot / support accounts

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS