### PR TITLE
fix(ci): set no-cache for font assets in S3 deploy

### DIFF
--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -83,7 +83,11 @@ jobs:
             --exclude "index.html" \
             --exclude "flutter_service_worker.js" \
             --exclude "version.json" \
-            --exclude "manifest.json"
+            --exclude "manifest.json" \
+            --exclude "assets/fonts/*"
+          # Font files — stable filenames, must revalidate each session
+          aws s3 sync ./build/web/assets/fonts s3://$WEBAPP_S3_BUCKET/assets/fonts \
+            --cache-control "no-cache, must-revalidate"
           # Mutable entry points — always revalidate
           for f in index.html flutter_service_worker.js version.json manifest.json; do
             if [ -f "./build/web/$f" ]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -205,7 +205,11 @@ jobs:
             --exclude "index.html" \
             --exclude "flutter_service_worker.js" \
             --exclude "version.json" \
-            --exclude "manifest.json"
+            --exclude "manifest.json" \
+            --exclude "assets/fonts/*"
+          # Font files — stable filenames, must revalidate each session
+          aws s3 sync ./build/web/assets/fonts s3://$WEBAPP_S3_BUCKET/assets/fonts \
+            --cache-control "no-cache, must-revalidate"
           # Mutable entry points — always revalidate
           for f in index.html flutter_service_worker.js version.json manifest.json; do
             if [ -f "./build/web/$f" ]; then


### PR DESCRIPTION
## What

Exclude `assets/fonts/*` from immutable caching and upload them with `no-cache, must-revalidate` instead.

## Why

Closes #6391

Font files have stable filenames across builds. The `immutable` directive prevented browsers from ever re-fetching them, so users were stuck with stale icon fonts (e.g. missing MaterialIcons added after January 2024). See also pangeachat/devops#93.

## Testing

CI-only change — verified by inspecting response headers on staging after next deploy.

### Tested on:

- [ ] Staging
- [ ] Production

## Deploy Notes

None