### PR TITLE
fix: don't reset tutorial event in chat controller until tutorial seq…

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -730,8 +730,10 @@ class ChatController extends State<ChatPageWithRoom>
     final tutorialSeq = TutorialModel.chatTutorialSequence;
     if (orchestrator.hasCompletedTutorialSequence(tutorialSeq)) return;
 
+    final success = orchestrator.enqueueTutorialSequence(tutorialSeq);
+    if (!success) return;
+
     _tutorialEvent = event;
-    orchestrator.enqueueTutorialSequence(tutorialSeq);
 
     // After filtering to only unseen tutorials, the first queued tutorial may
     // not be readingAssistance (e.g. the user completed the first two stages

--- a/lib/pangea/onboarding/tutorial_overlay_orchestrator.dart
+++ b/lib/pangea/onboarding/tutorial_overlay_orchestrator.dart
@@ -74,24 +74,25 @@ class TutorialOverlayOrchestrator {
   ) => tutorialSequence.tutorials.where((t) => !t.hasBeenSeen).toList();
 
   /// Adds a single tutorial sequence to the end of the queue.
-  void enqueueTutorialSequence(TutorialSequenceModel tutorialSequence) {
+  bool enqueueTutorialSequence(TutorialSequenceModel tutorialSequence) {
     if (_sequence != null) {
       Logs().w(
         "Trying to enqueue tutorial sequence while previous sequence is still active",
       );
-      return;
+      return false;
     }
 
     final unseenTutorials = unseenTutorialsInSequence(tutorialSequence);
     if (unseenTutorials.isEmpty) {
       Logs().i("All tutorials in sequence have already been seen, skipping");
-      return;
+      return false;
     }
 
     Logs().w("Enqueuing tutorial sequence with tutorials $unseenTutorials");
 
     _sequence = TutorialSequenceModel(tutorials: unseenTutorials);
     _index = 0;
+    return true;
   }
 
   void launchTutorial({


### PR DESCRIPTION
…uence is queued successfully

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS