### PR TITLE
fix(tokens): translate STT offsets from code-points to graphemes

### DIFF
--- a/lib/pangea/tokens/grapheme_offset_index.dart
+++ b/lib/pangea/tokens/grapheme_offset_index.dart
@@ -1,0 +1,77 @@
+import 'package:characters/characters.dart';
+
+/// Maps Unicode code-point offsets (the unit used by backend tokenizers — see
+/// `2-step-choreographer/app/handlers/tokens/token_schema.py`, which computes
+/// offsets via Python `len()`) to grapheme-cluster indices (the unit used by
+/// Dart's [String.characters], which is what renderers slice by).
+///
+/// The two units disagree whenever a grapheme cluster contains more than one
+/// code point: Indic scripts with matras ("ਕਿ" = 2 cp, 1 grapheme), Vietnamese
+/// tone marks, ZWJ emoji sequences, and flag / skin-tone emoji.
+///
+/// Constructed once per transcript (O(n) in grapheme count). Lookups are
+/// O(log n) via binary search.
+class GraphemeOffsetIndex {
+  /// `_starts[i]` is the code-point index at which grapheme cluster `i`
+  /// begins. Sorted ascending; `_starts.length` equals the grapheme count.
+  final List<int> _starts;
+  final int _codepointCount;
+
+  GraphemeOffsetIndex._(this._starts, this._codepointCount);
+
+  factory GraphemeOffsetIndex.fromText(String text) {
+    final List<int> starts = [];
+    int cp = 0;
+    for (final g in text.characters) {
+      starts.add(cp);
+      cp += g.runes.length;
+    }
+    return GraphemeOffsetIndex._(starts, cp);
+  }
+
+  int get graphemeCount => _starts.length;
+  int get codepointCount => _codepointCount;
+
+  /// Returns the grapheme-cluster index that contains code-point position
+  /// [codepoint]. If [codepoint] falls inside a multi-codepoint grapheme,
+  /// returns that grapheme's index.
+  ///
+  /// Values `<= 0` clamp to `0`; values `>= codepointCount` clamp to
+  /// `graphemeCount` (one past the last grapheme), matching the
+  /// half-open-range convention used by [String.characters] slicing.
+  int graphemeStartOfCodepoint(int codepoint) {
+    if (codepoint <= 0) return 0;
+    if (codepoint >= _codepointCount) return _starts.length;
+    // Largest i with _starts[i] <= codepoint.
+    int lo = 0, hi = _starts.length - 1;
+    while (lo < hi) {
+      final int mid = (lo + hi + 1) >> 1;
+      if (_starts[mid] <= codepoint) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return lo;
+  }
+
+  /// Returns the exclusive grapheme-cluster end for a code-point range that
+  /// ends at [codepoint]. An end that falls inside a grapheme rounds up to
+  /// include that grapheme — so partial graphemes are never silently
+  /// truncated when translating a range.
+  int graphemeEndOfCodepoint(int codepoint) {
+    if (codepoint <= 0) return 0;
+    if (codepoint >= _codepointCount) return _starts.length;
+    // Smallest i with _starts[i] >= codepoint.
+    int lo = 0, hi = _starts.length;
+    while (lo < hi) {
+      final int mid = (lo + hi) >> 1;
+      if (_starts[mid] < codepoint) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    return lo;
+  }
+}

--- a/lib/pangea/tokens/stt_transcript_tokens.dart
+++ b/lib/pangea/tokens/stt_transcript_tokens.dart
@@ -48,46 +48,49 @@ class SttTranscriptTokens extends StatelessWidget {
       textScaler: TextScaler.noScaling,
       text: TextSpan(
         style: style ?? DefaultTextStyle.of(context).style,
-        children: TokensUtil.instance.getGlobalTokenPositions(tokens).map((
-          tokenPosition,
-        ) {
-          final text = messageCharacters
-              .skip(tokenPosition.startIndex)
-              .take(tokenPosition.endIndex - tokenPosition.startIndex)
-              .toString();
+        children: TokensUtil.instance
+            .getGlobalTokenPositions(tokens, transcript: model.transcript.text)
+            .map((tokenPosition) {
+              final text = messageCharacters
+                  .skip(tokenPosition.startIndex)
+                  .take(tokenPosition.endIndex - tokenPosition.startIndex)
+                  .toString();
 
-          if (tokenPosition.token == null) {
-            return TextSpan(
-              text: text,
-              style: style ?? DefaultTextStyle.of(context).style,
-            );
-          }
+              if (tokenPosition.token == null) {
+                return TextSpan(
+                  text: text,
+                  style: style ?? DefaultTextStyle.of(context).style,
+                );
+              }
 
-          final token = tokenPosition.token!;
-          final selected = isSelected?.call(token) ?? false;
+              final token = tokenPosition.token!;
+              final selected = isSelected?.call(token) ?? false;
 
-          return WidgetSpan(
-            child: HoverBuilder(
-              builder: (context, hovered) => MouseRegion(
-                cursor: SystemMouseCursors.click,
-                child: GestureDetector(
-                  behavior: HitTestBehavior.translucent,
-                  onTap: onClick != null ? () => onClick?.call(token) : null,
-                  child: UnderlineText(
-                    text: text,
-                    style: style ?? DefaultTextStyle.of(context).style,
-                    underlineColor: TokenRenderingUtil.underlineColor(
-                      Theme.of(context).colorScheme.primary.withAlpha(200),
-                      selected: selected,
-                      hovered: hovered,
-                      isNew: newTokens.any((t) => t == token.text),
+              return WidgetSpan(
+                child: HoverBuilder(
+                  builder: (context, hovered) => MouseRegion(
+                    cursor: SystemMouseCursors.click,
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.translucent,
+                      onTap: onClick != null
+                          ? () => onClick?.call(token)
+                          : null,
+                      child: UnderlineText(
+                        text: text,
+                        style: style ?? DefaultTextStyle.of(context).style,
+                        underlineColor: TokenRenderingUtil.underlineColor(
+                          Theme.of(context).colorScheme.primary.withAlpha(200),
+                          selected: selected,
+                          hovered: hovered,
+                          isNew: newTokens.any((t) => t == token.text),
+                        ),
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ),
-          );
-        }).toList(),
+              );
+            })
+            .toList(),
       ),
     );
   }

--- a/lib/pangea/tokens/tokens_util.dart
+++ b/lib/pangea/tokens/tokens_util.dart
@@ -1,9 +1,9 @@
-import 'package:characters/characters.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/pangea/events/event_wrappers/pangea_message_event.dart';
 import 'package:fluffychat/pangea/events/models/pangea_token_model.dart';
 import 'package:fluffychat/pangea/events/models/pangea_token_text_model.dart';
+import 'package:fluffychat/pangea/tokens/grapheme_offset_index.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 class _TokenPositionCacheItem {
@@ -261,7 +261,7 @@ class TokensUtil {
     required String transcript,
   }) {
     final List<TokenPosition> tokenPositions = [];
-    final _GraphemeIndex index = _GraphemeIndex.fromText(transcript);
+    final GraphemeOffsetIndex index = GraphemeOffsetIndex.fromText(transcript);
 
     // Pre-translate each token's code-point range into grapheme indices.
     final int n = tokens.length;
@@ -339,66 +339,5 @@ class TokensUtil {
     }
 
     return tokenPositions;
-  }
-}
-
-/// Maps code-point offsets (the unit used by backend tokenizers) to
-/// grapheme-cluster offsets (the unit used by Dart's `String.characters`).
-///
-/// Built once per transcript; subsequent lookups are O(log n).
-class _GraphemeIndex {
-  /// `_starts[i]` is the code-point index at which grapheme cluster `i`
-  /// begins. Sorted ascending; length equals the grapheme count.
-  final List<int> _starts;
-  final int _codepointCount;
-
-  _GraphemeIndex._(this._starts, this._codepointCount);
-
-  factory _GraphemeIndex.fromText(String text) {
-    final List<int> starts = [];
-    int cp = 0;
-    for (final g in text.characters) {
-      starts.add(cp);
-      cp += g.runes.length;
-    }
-    return _GraphemeIndex._(starts, cp);
-  }
-
-  int get graphemeCount => _starts.length;
-
-  /// Grapheme index containing code-point position `cp`. If `cp` falls inside
-  /// a multi-codepoint grapheme, returns that grapheme's index.
-  int graphemeStartOfCodepoint(int cp) {
-    if (cp <= 0) return 0;
-    if (cp >= _codepointCount) return _starts.length;
-    // Largest i with _starts[i] <= cp.
-    int lo = 0, hi = _starts.length - 1;
-    while (lo < hi) {
-      final int mid = (lo + hi + 1) >> 1;
-      if (_starts[mid] <= cp) {
-        lo = mid;
-      } else {
-        hi = mid - 1;
-      }
-    }
-    return lo;
-  }
-
-  /// Grapheme index (exclusive end) for a range that ends at code-point `cp`.
-  /// An end that falls inside a grapheme rounds up to include that grapheme.
-  int graphemeEndOfCodepoint(int cp) {
-    if (cp <= 0) return 0;
-    if (cp >= _codepointCount) return _starts.length;
-    // Smallest i with _starts[i] >= cp.
-    int lo = 0, hi = _starts.length;
-    while (lo < hi) {
-      final int mid = (lo + hi) >> 1;
-      if (_starts[mid] < cp) {
-        lo = mid + 1;
-      } else {
-        hi = mid;
-      }
-    }
-    return lo;
   }
 }

--- a/lib/pangea/tokens/tokens_util.dart
+++ b/lib/pangea/tokens/tokens_util.dart
@@ -1,3 +1,4 @@
+import 'package:characters/characters.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/pangea/events/event_wrappers/pangea_message_event.dart';
@@ -246,29 +247,59 @@ class TokensUtil {
     return positions;
   }
 
-  /// Given a list of tokens, reconstructs an original message, including gaps for non-token elements.
-  List<TokenPosition> getGlobalTokenPositions(List<PangeaToken> tokens) {
+  /// Given a list of tokens and the original transcript, reconstructs the
+  /// message as a sequence of positions — one per token, plus gap positions
+  /// for any non-token text in between (e.g. whitespace).
+  ///
+  /// Backend tokenizers (spaCy, LLM, Google, Whisper) produce `token.text.offset`
+  /// in **Unicode code-point units** (Python `len()` semantics). The returned
+  /// `TokenPosition` indices are in **Dart grapheme-cluster units**, matching
+  /// `String.characters` — which is what the renderer slices by. These units
+  /// differ for Indic scripts with matras, many emoji, and combining marks.
+  List<TokenPosition> getGlobalTokenPositions(
+    List<PangeaToken> tokens, {
+    required String transcript,
+  }) {
     final List<TokenPosition> tokenPositions = [];
+    final _GraphemeIndex index = _GraphemeIndex.fromText(transcript);
+
+    // Pre-translate each token's code-point range into grapheme indices.
+    final int n = tokens.length;
+    final List<int> gStart = List.filled(n, 0);
+    final List<int> gEnd = List.filled(n, 0);
+    for (var i = 0; i < n; i++) {
+      final t = tokens[i];
+      final int cpStart = t.text.offset;
+      // `content.runes.length` is the code-point length (matches the backend's
+      // `len()` semantics); we intentionally ignore `t.text.length` here
+      // because `PangeaTokenText.fromJson` stores it as a grapheme count and
+      // mixing units is the root of issue #1963.
+      final int cpEnd = cpStart + t.text.content.runes.length;
+      gStart[i] = index.graphemeStartOfCodepoint(cpStart);
+      gEnd[i] = index.graphemeEndOfCodepoint(cpEnd);
+    }
+
     int tokenPointer = 0;
     int globalPointer = 0;
 
-    while (tokenPointer < tokens.length) {
+    while (tokenPointer < n) {
       int endIndex = tokenPointer;
       PangeaToken token = tokens[tokenPointer];
 
-      if (token.text.offset > globalPointer) {
-        // If the token starts after the current global pointer, we need to
-        // create a new token position for the gap
+      if (gStart[tokenPointer] > globalPointer) {
+        // Gap between the previous token and this one (usually whitespace).
         tokenPositions.add(
-          TokenPosition(startIndex: globalPointer, endIndex: token.text.offset),
+          TokenPosition(
+            startIndex: globalPointer,
+            endIndex: gStart[tokenPointer],
+          ),
         );
-
-        globalPointer = token.text.offset;
+        globalPointer = gStart[tokenPointer];
       }
 
-      // move the end index if the next token is right next to the current token
-      // and either the current token is punctuation or the next token is punctuation
-      while (endIndex < tokens.length - 1) {
+      // Merge this token with an adjacent punctuation token if either side is
+      // PUNCT and there is no gap between them in grapheme space.
+      while (endIndex < n - 1) {
         final PangeaToken currentToken = tokens[endIndex];
         final PangeaToken nextToken = tokens[endIndex + 1];
 
@@ -279,8 +310,7 @@ class TokensUtil {
             nextToken.pos == 'PUNCT' &&
             nextToken.text.content.trim().isNotEmpty;
 
-        if (currentToken.text.offset + currentToken.text.length !=
-            nextToken.text.offset) {
+        if (gEnd[endIndex] != gStart[endIndex + 1]) {
           break;
         }
 
@@ -290,7 +320,6 @@ class TokensUtil {
           if (token.pos == 'PUNCT' && !nextIsPunct) {
             token = nextToken;
           }
-
           endIndex++;
         } else {
           break;
@@ -300,17 +329,76 @@ class TokensUtil {
       tokenPositions.add(
         TokenPosition(
           token: token,
-          startIndex: tokens[tokenPointer].text.offset,
-          endIndex: tokens[endIndex].text.offset + tokens[endIndex].text.length,
+          startIndex: gStart[tokenPointer],
+          endIndex: gEnd[endIndex],
         ),
       );
 
-      // Move to the next token
       tokenPointer = tokenPointer + (endIndex - tokenPointer) + 1;
-      globalPointer =
-          tokens[endIndex].text.offset + tokens[endIndex].text.length;
+      globalPointer = gEnd[endIndex];
     }
 
     return tokenPositions;
+  }
+}
+
+/// Maps code-point offsets (the unit used by backend tokenizers) to
+/// grapheme-cluster offsets (the unit used by Dart's `String.characters`).
+///
+/// Built once per transcript; subsequent lookups are O(log n).
+class _GraphemeIndex {
+  /// `_starts[i]` is the code-point index at which grapheme cluster `i`
+  /// begins. Sorted ascending; length equals the grapheme count.
+  final List<int> _starts;
+  final int _codepointCount;
+
+  _GraphemeIndex._(this._starts, this._codepointCount);
+
+  factory _GraphemeIndex.fromText(String text) {
+    final List<int> starts = [];
+    int cp = 0;
+    for (final g in text.characters) {
+      starts.add(cp);
+      cp += g.runes.length;
+    }
+    return _GraphemeIndex._(starts, cp);
+  }
+
+  int get graphemeCount => _starts.length;
+
+  /// Grapheme index containing code-point position `cp`. If `cp` falls inside
+  /// a multi-codepoint grapheme, returns that grapheme's index.
+  int graphemeStartOfCodepoint(int cp) {
+    if (cp <= 0) return 0;
+    if (cp >= _codepointCount) return _starts.length;
+    // Largest i with _starts[i] <= cp.
+    int lo = 0, hi = _starts.length - 1;
+    while (lo < hi) {
+      final int mid = (lo + hi + 1) >> 1;
+      if (_starts[mid] <= cp) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return lo;
+  }
+
+  /// Grapheme index (exclusive end) for a range that ends at code-point `cp`.
+  /// An end that falls inside a grapheme rounds up to include that grapheme.
+  int graphemeEndOfCodepoint(int cp) {
+    if (cp <= 0) return 0;
+    if (cp >= _codepointCount) return _starts.length;
+    // Smallest i with _starts[i] >= cp.
+    int lo = 0, hi = _starts.length;
+    while (lo < hi) {
+      final int mid = (lo + hi) >> 1;
+      if (_starts[mid] < cp) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    return lo;
   }
 }

--- a/test/pangea/grapheme_offset_index_test.dart
+++ b/test/pangea/grapheme_offset_index_test.dart
@@ -1,0 +1,269 @@
+import 'package:characters/characters.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/tokens/grapheme_offset_index.dart';
+
+/// Exhaustive unit tests for [GraphemeOffsetIndex].
+///
+/// The map converts **code-point offsets** (Python `len()` / Dart `runes`
+/// semantics — what backend tokenizers emit) into **grapheme-cluster
+/// indices** (what Dart's `String.characters` slices by). Bugs in this
+/// translation are the root of issue #1963, so each scripting category that
+/// stresses the distinction has its own test.
+void main() {
+  group('GraphemeOffsetIndex.fromText — structural properties', () {
+    test('empty string has zero graphemes and zero code points', () {
+      final index = GraphemeOffsetIndex.fromText('');
+      expect(index.graphemeCount, 0);
+      expect(index.codepointCount, 0);
+      expect(index.graphemeStartOfCodepoint(0), 0);
+      expect(index.graphemeEndOfCodepoint(0), 0);
+    });
+
+    test('ASCII: grapheme count equals code point count equals length', () {
+      const text = 'hello world';
+      final index = GraphemeOffsetIndex.fromText(text);
+      expect(index.graphemeCount, text.length);
+      expect(index.codepointCount, text.length);
+      expect(index.graphemeCount, text.characters.length);
+    });
+
+    test('CJK ideographs: 1 codepoint == 1 grapheme (no matras)', () {
+      const text = '你好世界'; // 4 Han characters
+      final index = GraphemeOffsetIndex.fromText(text);
+      expect(index.graphemeCount, 4);
+      expect(index.codepointCount, 4);
+    });
+
+    test('Punjabi (Gurmukhi): matras collapse code points into graphemes', () {
+      // "ਕਿਰਪਾ" = 5 code points; graphemes: [ਕਿ, ਰ, ਪਾ] = 3
+      const text = 'ਕਿਰਪਾ';
+      final index = GraphemeOffsetIndex.fromText(text);
+      expect(index.codepointCount, 5);
+      expect(index.graphemeCount, 3);
+      expect(index.graphemeCount, text.characters.length);
+    });
+
+    test('Devanagari (Hindi): virama + consonant form conjunct graphemes', () {
+      // "नमस्ते" - the virama ् creates conjuncts; exact count depends on ICU
+      // rules, so we assert against the authoritative `characters` iterator.
+      const text = 'नमस्ते';
+      final index = GraphemeOffsetIndex.fromText(text);
+      expect(index.codepointCount, text.runes.length);
+      expect(index.graphemeCount, text.characters.length);
+      expect(index.graphemeCount, lessThan(index.codepointCount));
+    });
+
+    test('Tamil: vowel signs attach to consonants', () {
+      const text = 'வணக்கம்'; // "hello"
+      final index = GraphemeOffsetIndex.fromText(text);
+      expect(index.codepointCount, text.runes.length);
+      expect(index.graphemeCount, text.characters.length);
+      expect(index.graphemeCount, lessThan(index.codepointCount));
+    });
+
+    test('Vietnamese: combining diacritics', () {
+      // Using decomposed form to guarantee multi-codepoint graphemes.
+      // "tiếng" with the composed ế = t + i + ế + n + g or decomposed variant
+      const text =
+          'tiếng'; // may be precomposed (1cp per grapheme) depending on source
+      final index = GraphemeOffsetIndex.fromText(text);
+      expect(index.codepointCount, text.runes.length);
+      expect(index.graphemeCount, text.characters.length);
+    });
+
+    test('Supplementary-plane emoji: 1 code point = 1 grapheme', () {
+      const text = '😄'; // U+1F604 — 1 code point, 2 UTF-16 units, 1 grapheme
+      final index = GraphemeOffsetIndex.fromText(text);
+      expect(index.graphemeCount, 1);
+      expect(index.codepointCount, 1);
+    });
+
+    test('ZWJ family emoji collapses multiple code points into 1 grapheme', () {
+      // 👨‍👩‍👧 = 👨 + ZWJ + 👩 + ZWJ + 👧 = 5 code points, 1 grapheme
+      const text = '👨‍👩‍👧';
+      final index = GraphemeOffsetIndex.fromText(text);
+      expect(index.codepointCount, 5);
+      expect(index.graphemeCount, 1);
+    });
+
+    test('Skin-tone modifier: base + modifier = 1 grapheme', () {
+      const text =
+          '👍🏽'; // thumbs up + medium skin tone = 2 code points, 1 grapheme
+      final index = GraphemeOffsetIndex.fromText(text);
+      expect(index.codepointCount, 2);
+      expect(index.graphemeCount, 1);
+    });
+
+    test('Flag emoji: two regional indicators = 1 grapheme', () {
+      const text = '🇺🇸'; // U+1F1FA + U+1F1F8
+      final index = GraphemeOffsetIndex.fromText(text);
+      expect(index.codepointCount, 2);
+      expect(index.graphemeCount, 1);
+    });
+
+    test('Mixed scripts: sum of per-segment counts', () {
+      const text = 'hi ਕਿਰਪਾ 😄 नमस्ते';
+      final index = GraphemeOffsetIndex.fromText(text);
+      expect(index.codepointCount, text.runes.length);
+      expect(index.graphemeCount, text.characters.length);
+    });
+  });
+
+  group('GraphemeOffsetIndex.graphemeStartOfCodepoint', () {
+    test('clamps negative input to 0', () {
+      final index = GraphemeOffsetIndex.fromText('hello');
+      expect(index.graphemeStartOfCodepoint(-1), 0);
+      expect(index.graphemeStartOfCodepoint(-100), 0);
+    });
+
+    test('clamps input >= codepointCount to graphemeCount', () {
+      final index = GraphemeOffsetIndex.fromText('hello');
+      expect(index.graphemeStartOfCodepoint(5), 5);
+      expect(index.graphemeStartOfCodepoint(100), 5);
+    });
+
+    test('ASCII: grapheme start equals code point', () {
+      final index = GraphemeOffsetIndex.fromText('hello');
+      for (var i = 0; i <= 5; i++) {
+        expect(index.graphemeStartOfCodepoint(i), i);
+      }
+    });
+
+    test(
+      'Punjabi: code points inside a matra cluster map to cluster start',
+      () {
+        // "ਕਿਰਪਾ" — graphemes: ਕਿ (cp 0-1), ਰ (cp 2), ਪਾ (cp 3-4)
+        final index = GraphemeOffsetIndex.fromText('ਕਿਰਪਾ');
+        expect(index.graphemeStartOfCodepoint(0), 0); // ਕ → grapheme 0 (ਕਿ)
+        expect(index.graphemeStartOfCodepoint(1), 0); // ਿ → grapheme 0 (ਕਿ)
+        expect(index.graphemeStartOfCodepoint(2), 1); // ਰ → grapheme 1
+        expect(index.graphemeStartOfCodepoint(3), 2); // ਪ → grapheme 2 (ਪਾ)
+        expect(index.graphemeStartOfCodepoint(4), 2); // ਾ → grapheme 2 (ਪਾ)
+      },
+    );
+
+    test(
+      'ZWJ sequence: all interior code points map to the single grapheme',
+      () {
+        const text = '👨‍👩‍👧';
+        final index = GraphemeOffsetIndex.fromText(text);
+        for (var cp = 0; cp < 5; cp++) {
+          expect(index.graphemeStartOfCodepoint(cp), 0);
+        }
+        expect(index.graphemeStartOfCodepoint(5), 1); // past end
+      },
+    );
+  });
+
+  group('GraphemeOffsetIndex.graphemeEndOfCodepoint', () {
+    test('clamps negative input to 0', () {
+      final index = GraphemeOffsetIndex.fromText('hello');
+      expect(index.graphemeEndOfCodepoint(-1), 0);
+    });
+
+    test('clamps input >= codepointCount to graphemeCount', () {
+      final index = GraphemeOffsetIndex.fromText('hello');
+      expect(index.graphemeEndOfCodepoint(5), 5);
+      expect(index.graphemeEndOfCodepoint(100), 5);
+    });
+
+    test('end at 0 is always 0 (empty range)', () {
+      final index = GraphemeOffsetIndex.fromText('ਕਿਰਪਾ');
+      expect(index.graphemeEndOfCodepoint(0), 0);
+    });
+
+    test('end at a grapheme boundary returns that grapheme index exactly', () {
+      // "ਕਿਰਪਾ" — grapheme starts: [0, 2, 3]
+      final index = GraphemeOffsetIndex.fromText('ਕਿਰਪਾ');
+      expect(index.graphemeEndOfCodepoint(2), 1); // includes ਕਿ only
+      expect(index.graphemeEndOfCodepoint(3), 2); // includes ਕਿ + ਰ
+      expect(index.graphemeEndOfCodepoint(5), 3); // includes all
+    });
+
+    test('end inside a grapheme rounds up (never silently truncates)', () {
+      // "ਕਿਰਪਾ" — cp 1 is inside grapheme 0; ending there should still
+      // include grapheme 0 (rounding up) rather than returning 0.
+      final index = GraphemeOffsetIndex.fromText('ਕਿਰਪਾ');
+      expect(index.graphemeEndOfCodepoint(1), 1);
+      expect(index.graphemeEndOfCodepoint(4), 3); // cp 4 inside ਪਾ
+    });
+
+    test('ZWJ sequence: end anywhere past start of sequence yields 1', () {
+      const text = '👨‍👩‍👧';
+      final index = GraphemeOffsetIndex.fromText(text);
+      for (var cp = 1; cp <= 5; cp++) {
+        expect(index.graphemeEndOfCodepoint(cp), 1);
+      }
+    });
+  });
+
+  group('GraphemeOffsetIndex — invariants over every position', () {
+    // Running the same structural properties across every script keeps us
+    // honest if the underlying `characters` package ever changes.
+    final samples = <String>[
+      '',
+      'hello',
+      '你好世界',
+      'ਕਿਰਪਾ ਕਰਕੇ',
+      'ঠিক আছে',
+      'नमस्ते दुनिया',
+      'வணக்கம்',
+      'tiếng Việt',
+      '😄',
+      '👍🏽',
+      '🇺🇸🇯🇵🇰🇷',
+      '👨‍👩‍👧',
+      'a👨‍👩‍👧b',
+      'hi ਕਿਰਪਾ 😄 नमस्ते',
+    ];
+
+    for (final text in samples) {
+      test('monotonic + range-consistent on: ${_label(text)}', () {
+        final index = GraphemeOffsetIndex.fromText(text);
+
+        expect(index.codepointCount, text.runes.length);
+        expect(index.graphemeCount, text.characters.length);
+
+        // Every code-point position maps to a valid grapheme index.
+        for (var cp = 0; cp <= index.codepointCount; cp++) {
+          final gs = index.graphemeStartOfCodepoint(cp);
+          final ge = index.graphemeEndOfCodepoint(cp);
+          expect(gs, inInclusiveRange(0, index.graphemeCount));
+          expect(ge, inInclusiveRange(0, index.graphemeCount));
+          // start(cp) <= end(cp) — the grapheme containing cp is always at or
+          // before the exclusive end of a range ending at cp.
+          expect(gs, lessThanOrEqualTo(ge));
+        }
+
+        // Monotonicity: start and end are non-decreasing.
+        int prevStart = 0, prevEnd = 0;
+        for (var cp = 0; cp <= index.codepointCount; cp++) {
+          final gs = index.graphemeStartOfCodepoint(cp);
+          final ge = index.graphemeEndOfCodepoint(cp);
+          expect(gs, greaterThanOrEqualTo(prevStart));
+          expect(ge, greaterThanOrEqualTo(prevEnd));
+          prevStart = gs;
+          prevEnd = ge;
+        }
+
+        // Round-trip: every [graphemeStart, graphemeEnd) produces the
+        // expected substring when sliced by `characters`.
+        final chars = text.characters.toList();
+        int cursor = 0;
+        for (var gi = 0; gi < index.graphemeCount; gi++) {
+          // Start of grapheme gi in code points.
+          final startCp = cursor;
+          final endCp = cursor + chars[gi].runes.length;
+          expect(index.graphemeStartOfCodepoint(startCp), gi);
+          expect(index.graphemeEndOfCodepoint(endCp), gi + 1);
+          cursor = endCp;
+        }
+      });
+    }
+  });
+}
+
+String _label(String text) => text.isEmpty
+    ? '<empty>'
+    : (text.length > 20 ? '${text.substring(0, 20)}…' : text);

--- a/test/pangea/stt_transcript_tokens_test.dart
+++ b/test/pangea/stt_transcript_tokens_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fluffychat/pangea/events/models/pangea_token_model.dart';

--- a/test/pangea/stt_transcript_tokens_test.dart
+++ b/test/pangea/stt_transcript_tokens_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/events/models/pangea_token_model.dart';
+import 'package:fluffychat/pangea/events/models/pangea_token_text_model.dart';
+import 'package:fluffychat/pangea/lemmas/lemma.dart';
+import 'package:fluffychat/pangea/speech_to_text/speech_to_text_response_model.dart';
+import 'package:fluffychat/pangea/tokens/stt_transcript_tokens.dart';
+import 'package:fluffychat/pangea/tokens/tokens_util.dart';
+
+/// Widget-level coverage for [SttTranscriptTokens].
+///
+/// The widget has two branches. The non-empty-tokens branch calls
+/// `TokensUtil.getNewTokens` which in turn reads
+/// `MatrixState.pangeaController.matrixState.analyticsDataService` — a
+/// process-global singleton not initialized under `flutter test`. Covering
+/// that branch requires bringing up a fake `MatrixState`, which is out of
+/// scope for this change; it's covered by the TO TEST section on issue
+/// #1963 (which exercises the real app on real payloads).
+///
+/// The empty-tokens branch has no singleton dependency and is tested here
+/// as a smoke test to guard against a regression in the fallback render.
+void main() {
+  testWidgets(
+    'SttTranscriptTokens renders plain Text when there are no STT tokens',
+    (tester) async {
+      final model = SpeechToTextResponseModel.fromJson({
+        'results': [
+          {
+            'transcripts': [
+              {
+                'confidence': 100,
+                'lang_code': 'en',
+                'stt_tokens': <Map<String, dynamic>>[],
+                'transcript': 'hello world',
+                'words_per_hr': null,
+              },
+            ],
+          },
+        ],
+      });
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SttTranscriptTokens(eventId: 'test', model: model),
+          ),
+        ),
+      );
+
+      expect(find.text('hello world'), findsOneWidget);
+    },
+  );
+
+  // ---------------------------------------------------------------------
+  // Rendering-contract integration test.
+  //
+  // Reproduces the exact RichText structure that `SttTranscriptTokens`
+  // builds — TextSpan per gap, WidgetSpan per token, tap handler on the
+  // token's `GestureDetector`. We skip `TokensUtil.getNewTokens` because
+  // that reads the `MatrixState` singleton; everything else matches the
+  // real widget, so any regression in how `getGlobalTokenPositions`
+  // output interacts with `.characters.skip/take` would break this test.
+  // ---------------------------------------------------------------------
+
+  Widget buildTranscript(
+    String transcript,
+    List<PangeaToken> tokens,
+    void Function(PangeaToken) onTap,
+  ) {
+    final positions = TokensUtil.instance.getGlobalTokenPositions(
+      tokens,
+      transcript: transcript,
+    );
+    final chars = transcript.characters;
+
+    return MaterialApp(
+      home: Scaffold(
+        body: RichText(
+          text: TextSpan(
+            style: const TextStyle(color: Colors.black),
+            children: positions.map<InlineSpan>((p) {
+              final text = chars
+                  .skip(p.startIndex)
+                  .take(p.endIndex - p.startIndex)
+                  .toString();
+              if (p.token == null) {
+                return TextSpan(text: text);
+              }
+              final token = p.token!;
+              return WidgetSpan(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTap: () => onTap(token),
+                  child: Text(text),
+                ),
+              );
+            }).toList(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  PangeaToken makeToken({
+    required String content,
+    required int offset,
+    String pos = 'NOUN',
+  }) {
+    return PangeaToken(
+      text: PangeaTokenText.fromJson({'content': content, 'offset': offset}),
+      lemma: Lemma(text: content, saveVocab: false, form: content),
+      pos: pos,
+      morph: const {},
+    );
+  }
+
+  testWidgets(
+    'Punjabi "ਕਰਕੇ" renders as a single fully tappable WidgetSpan (issue #1963)',
+    (tester) async {
+      const transcript = 'ਕਿਰਪਾ ਕਰਕੇ';
+      final tokens = [
+        makeToken(content: 'ਕਿਰਪਾ', offset: 0),
+        makeToken(content: 'ਕਰਕੇ', offset: 6),
+      ];
+      final tapped = <PangeaToken>[];
+
+      await tester.pumpWidget(buildTranscript(transcript, tokens, tapped.add));
+
+      // Both words rendered in full, not truncated to a single character.
+      expect(find.text('ਕਿਰਪਾ'), findsOneWidget);
+      expect(find.text('ਕਰਕੇ'), findsOneWidget);
+
+      // Tap the second word; the correct token fires.
+      await tester.tap(find.text('ਕਰਕੇ'));
+      expect(tapped, hasLength(1));
+      expect(tapped.first.text.content, 'ਕਰਕੇ');
+    },
+  );
+
+  testWidgets('Bangla + emoji: tapping the emoji fires the emoji token', (
+    tester,
+  ) async {
+    const transcript = 'আমি এখানেই আছি 😄';
+    final tokens = [
+      makeToken(content: 'আমি', offset: 0),
+      makeToken(content: 'এখানেই', offset: 4),
+      makeToken(content: 'আছি', offset: 11),
+      makeToken(content: '😄', offset: 15),
+    ];
+    final tapped = <PangeaToken>[];
+
+    await tester.pumpWidget(buildTranscript(transcript, tokens, tapped.add));
+
+    expect(find.text('এখানেই'), findsOneWidget);
+    expect(find.text('😄'), findsOneWidget);
+
+    await tester.tap(find.text('😄'));
+    expect(tapped.single.text.content, '😄');
+  });
+
+  testWidgets('ASCII regression: tapping each word fires the correct token', (
+    tester,
+  ) async {
+    const transcript = 'hello world';
+    final tokens = [
+      makeToken(content: 'hello', offset: 0),
+      makeToken(content: 'world', offset: 6),
+    ];
+    final tapped = <PangeaToken>[];
+
+    await tester.pumpWidget(buildTranscript(transcript, tokens, tapped.add));
+
+    await tester.tap(find.text('hello'));
+    await tester.tap(find.text('world'));
+    expect(tapped.map((t) => t.text.content).toList(), ['hello', 'world']);
+  });
+
+  testWidgets('ZWJ family emoji renders as one tappable unit', (tester) async {
+    const transcript = 'my family 👨‍👩‍👧';
+    final tokens = [
+      makeToken(content: 'my', offset: 0, pos: 'PRON'),
+      makeToken(content: 'family', offset: 3),
+      makeToken(content: '👨‍👩‍👧', offset: 10),
+    ];
+    final tapped = <PangeaToken>[];
+
+    await tester.pumpWidget(buildTranscript(transcript, tokens, tapped.add));
+
+    expect(find.text('👨‍👩‍👧'), findsOneWidget);
+    await tester.tap(find.text('👨‍👩‍👧'));
+    expect(tapped.single.text.content, '👨‍👩‍👧');
+  });
+}

--- a/test/pangea/tokens_util_test.dart
+++ b/test/pangea/tokens_util_test.dart
@@ -1,10 +1,21 @@
-import 'package:flutter/widgets.dart';
+import 'package:characters/characters.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fluffychat/pangea/events/models/pangea_token_model.dart';
 import 'package:fluffychat/pangea/events/models/pangea_token_text_model.dart';
 import 'package:fluffychat/pangea/lemmas/lemma.dart';
 import 'package:fluffychat/pangea/tokens/tokens_util.dart';
+
+/// Exhaustive tests for [TokensUtil.getGlobalTokenPositions], the function
+/// whose mixed-unit indexing caused issue #1963.
+///
+/// The strategy has three layers:
+/// 1. **Reproducers** — the exact payloads from the bug report.
+/// 2. **Script coverage** — one test per language category that has any
+///    multi-codepoint grapheme (Indic matras, Vietnamese diacritics,
+///    ZWJ emoji, skin-tone modifiers, flag emoji, supplementary plane).
+/// 3. **Edge cases + invariants** — algorithmic behavior (gaps, empty input,
+///    punctuation merging, tiling, content recovery).
 
 PangeaToken _token({
   required String content,
@@ -19,78 +30,119 @@ PangeaToken _token({
   );
 }
 
-String _sliceByGraphemes(String text, int startIndex, int endIndex) {
-  return text.characters
+/// Builds a token list from a transcript by finding each word in code-point
+/// space — the same unit the backend emits offsets in. This lets tests for
+/// Hindi/Tamil/etc. stay correct without hardcoding per-script offsets.
+List<PangeaToken> _tokensFor(
+  String transcript,
+  List<({String content, String pos})> words,
+) {
+  final runes = transcript.runes.toList();
+  int cursor = 0;
+  final List<PangeaToken> tokens = [];
+  for (final w in words) {
+    final wRunes = w.content.runes.toList();
+    int found = -1;
+    for (var i = cursor; i <= runes.length - wRunes.length; i++) {
+      bool match = true;
+      for (var j = 0; j < wRunes.length; j++) {
+        if (runes[i + j] != wRunes[j]) {
+          match = false;
+          break;
+        }
+      }
+      if (match) {
+        found = i;
+        break;
+      }
+    }
+    if (found < 0) {
+      throw StateError(
+        '"${w.content}" not found in "$transcript" at/after cp $cursor',
+      );
+    }
+    tokens.add(_token(content: w.content, offset: found, pos: w.pos));
+    cursor = found + wRunes.length;
+  }
+  return tokens;
+}
+
+String _slice(String transcript, int startIndex, int endIndex) {
+  return transcript.characters
       .skip(startIndex)
       .take(endIndex - startIndex)
       .toString();
 }
 
-void main() {
-  group('TokensUtil.getGlobalTokenPositions', () {
-    test('ASCII: hello world — positions match rendered substrings', () {
-      const transcript = 'hello world';
-      final tokens = [
-        _token(content: 'hello', offset: 0),
-        _token(content: 'world', offset: 6),
-      ];
+/// Every input token's content must appear somewhere in one of the emitted
+/// position slices. Punctuation tokens may be absorbed into an adjacent
+/// position rather than keeping their own, so we check substring presence
+/// across all slices rather than requiring each token to be a position's
+/// representative.
+void _expectAllContentPresent(
+  String transcript,
+  List<PangeaToken> tokens,
+  List<TokenPosition> positions,
+) {
+  final allSlices = positions
+      .map((p) => _slice(transcript, p.startIndex, p.endIndex))
+      .toList();
 
-      final positions = TokensUtil.instance.getGlobalTokenPositions(
-        tokens,
-        transcript: transcript,
-      );
-
-      // One gap (" ") + two tokens.
-      final wordSlices = positions
-          .where((p) => p.token != null)
-          .map((p) => _sliceByGraphemes(transcript, p.startIndex, p.endIndex))
-          .toList();
-
-      expect(wordSlices, ['hello', 'world']);
-    });
-
-    test(
-      'Punjabi (issue #1963): "ਕਿਰਪਾ ਕਰਕੇ" — both words fully selectable',
-      () {
-        // From the bug report: token offsets are code-points (Python len()).
-        // "ਕਿਰਪਾ" = 5 code points, 3 grapheme clusters (ਕਿ, ਰ, ਪਾ)
-        // "ਕਰਕੇ"  = 4 code points, 3 grapheme clusters (ਕ, ਰ, ਕੇ)
-        const transcript = 'ਕਿਰਪਾ ਕਰਕੇ';
-        final tokens = [
-          _token(content: 'ਕਿਰਪਾ', offset: 0),
-          _token(content: 'ਕਰਕੇ', offset: 6),
-        ];
-
-        final positions = TokensUtil.instance.getGlobalTokenPositions(
-          tokens,
-          transcript: transcript,
-        );
-
-        final wordSlices = positions
-            .where((p) => p.token != null)
-            .map((p) => _sliceByGraphemes(transcript, p.startIndex, p.endIndex))
-            .toList();
-
-        expect(wordSlices, ['ਕਿਰਪਾ', 'ਕਰਕੇ']);
-      },
+  // Sanity check: for token-bearing positions, the slice always contains the
+  // representative token's content.
+  for (final p in positions) {
+    if (p.token == null) continue;
+    final slice = _slice(transcript, p.startIndex, p.endIndex);
+    expect(
+      slice,
+      contains(p.token!.text.content),
+      reason:
+          'representative token "${p.token!.text.content}" missing from slice "$slice"',
     );
+  }
 
-    test('Bangla with emoji — full words + ZWJ-less emoji all recoverable', () {
-      // From the bug report's second payload:
-      //   "ঠিক আছে, kelrap; আমি এখানেই আছি 😄"
-      // Emoji 😄 is 1 code point (Python len), but 2 UTF-16 code units in
-      // Dart; grapheme count 1. The backend emits offset=32 in code-points.
-      const transcript = 'ঠিক আছে, kelrap; আমি এখানেই আছি 😄';
+  for (final t in tokens) {
+    final found = allSlices.any((s) => s.contains(t.text.content));
+    expect(
+      found,
+      isTrue,
+      reason:
+          'no position slice contains "${t.text.content}"; slices: $allSlices',
+    );
+  }
+}
+
+/// Positions are contiguous, non-overlapping, and cover [0, graphemeCount].
+void _expectTiling(String transcript, List<TokenPosition> positions) {
+  if (positions.isEmpty) return;
+  expect(positions.first.startIndex, 0, reason: 'first position starts at 0');
+  expect(
+    positions.last.endIndex,
+    transcript.characters.length,
+    reason: 'last position ends at graphemeCount',
+  );
+  for (var i = 0; i < positions.length - 1; i++) {
+    expect(
+      positions[i].endIndex,
+      positions[i + 1].startIndex,
+      reason: 'gap or overlap between positions $i and ${i + 1}',
+    );
+  }
+  for (final p in positions) {
+    expect(p.startIndex, lessThanOrEqualTo(p.endIndex));
+  }
+}
+
+void main() {
+  // -------------------------------------------------------------------------
+  // 1. Reproducers — exact inputs from issue #1963.
+  // -------------------------------------------------------------------------
+  group('TokensUtil.getGlobalTokenPositions — issue #1963 reproducers', () {
+    test('Punjabi: "ਕਿਰਪਾ ਕਰਕੇ" — both words fully tappable', () {
+      const transcript = 'ਕਿਰਪਾ ਕਰਕੇ';
       final tokens = [
-        _token(content: 'ঠিক', offset: 0),
-        _token(content: 'আছে', offset: 4),
-        _token(content: ',', offset: 7, pos: 'PUNCT'),
-        _token(content: 'kelrap', offset: 9),
-        _token(content: ';', offset: 15, pos: 'PUNCT'),
-        _token(content: 'আমি', offset: 17),
-        _token(content: 'এখানেই', offset: 21),
-        _token(content: 'আছি', offset: 28),
-        _token(content: '😄', offset: 32),
+        _token(content: 'ਕਿਰਪਾ', offset: 0),
+        _token(content: 'ਕਰਕੇ', offset: 6),
       ];
 
       final positions = TokensUtil.instance.getGlobalTokenPositions(
@@ -100,28 +152,27 @@ void main() {
 
       final wordSlices = positions
           .where((p) => p.token != null)
-          .map((p) => _sliceByGraphemes(transcript, p.startIndex, p.endIndex))
+          .map((p) => _slice(transcript, p.startIndex, p.endIndex))
           .toList();
 
-      // Note: punctuation tokens get merged with adjacent tokens by the
-      // existing algorithm; we just require every non-punct word plus the
-      // emoji to be fully recoverable as a substring.
-      expect(wordSlices, contains('ঠিক'));
-      expect(wordSlices.any((s) => s.contains('আছে')), isTrue);
-      expect(wordSlices.any((s) => s.contains('kelrap')), isTrue);
-      expect(wordSlices, contains('আমি'));
-      expect(wordSlices, contains('এখানেই'));
-      expect(wordSlices.any((s) => s.contains('আছি')), isTrue);
-      expect(wordSlices, contains('😄'));
+      expect(wordSlices, ['ਕਿਰਪਾ', 'ਕਰਕੇ']);
+      _expectTiling(transcript, positions);
     });
 
     test(
-      'token positions tile the transcript without overlap and cover it',
+      'Bangla + supplementary-plane emoji: every word + the emoji tappable',
       () {
-        const transcript = 'ਕਿਰਪਾ ਕਰਕੇ';
+        const transcript = 'ঠিক আছে, kelrap; আমি এখানেই আছি 😄';
         final tokens = [
-          _token(content: 'ਕਿਰਪਾ', offset: 0),
-          _token(content: 'ਕਰਕੇ', offset: 6),
+          _token(content: 'ঠিক', offset: 0),
+          _token(content: 'আছে', offset: 4),
+          _token(content: ',', offset: 7, pos: 'PUNCT'),
+          _token(content: 'kelrap', offset: 9),
+          _token(content: ';', offset: 15, pos: 'PUNCT'),
+          _token(content: 'আমি', offset: 17),
+          _token(content: 'এখানেই', offset: 21),
+          _token(content: 'আছি', offset: 28),
+          _token(content: '😄', offset: 32),
         ];
 
         final positions = TokensUtil.instance.getGlobalTokenPositions(
@@ -129,14 +180,546 @@ void main() {
           transcript: transcript,
         );
 
-        // Adjacency: each position's endIndex == next position's startIndex.
-        for (var i = 0; i < positions.length - 1; i++) {
-          expect(positions[i].endIndex, positions[i + 1].startIndex);
-        }
-        // First starts at 0, last ends at grapheme count.
-        expect(positions.first.startIndex, 0);
-        expect(positions.last.endIndex, transcript.characters.length);
+        _expectAllContentPresent(transcript, tokens, positions);
+        _expectTiling(transcript, positions);
       },
     );
   });
+
+  // -------------------------------------------------------------------------
+  // 2. Script coverage — multi-codepoint graphemes in a variety of scripts.
+  // -------------------------------------------------------------------------
+  group('TokensUtil.getGlobalTokenPositions — script coverage', () {
+    test('ASCII (regression): positions are trivial', () {
+      const transcript = 'hello world';
+      final tokens = _tokensFor(transcript, [
+        (content: 'hello', pos: 'NOUN'),
+        (content: 'world', pos: 'NOUN'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+
+    test('CJK ideographs: no matras, one codepoint per grapheme', () {
+      const transcript = '你好 世界';
+      final tokens = _tokensFor(transcript, [
+        (content: '你好', pos: 'NOUN'),
+        (content: '世界', pos: 'NOUN'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+
+    test('Hindi (Devanagari): virama conjuncts', () {
+      const transcript = 'नमस्ते दुनिया';
+      final tokens = _tokensFor(transcript, [
+        (content: 'नमस्ते', pos: 'NOUN'),
+        (content: 'दुनिया', pos: 'NOUN'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+
+    test('Tamil: consonant + vowel-sign sequences', () {
+      const transcript = 'வணக்கம் உலகம்';
+      final tokens = _tokensFor(transcript, [
+        (content: 'வணக்கம்', pos: 'NOUN'),
+        (content: 'உலகம்', pos: 'NOUN'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+
+    test('Thai: no spaces between words (segmented tokens)', () {
+      // Thai doesn't use spaces, so tokens butt right up against each other.
+      const transcript = 'สวัสดีครับ';
+      final tokens = _tokensFor(transcript, [
+        (content: 'สวัสดี', pos: 'NOUN'),
+        (content: 'ครับ', pos: 'PART'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+
+    test('Arabic (RTL, ligatures)', () {
+      const transcript = 'مرحبا بالعالم';
+      final tokens = _tokensFor(transcript, [
+        (content: 'مرحبا', pos: 'NOUN'),
+        (content: 'بالعالم', pos: 'NOUN'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+
+    test('Mixed scripts in one transcript', () {
+      const transcript = 'hi नमस्ते ਕਿਰਪਾ 😄';
+      final tokens = _tokensFor(transcript, [
+        (content: 'hi', pos: 'INTJ'),
+        (content: 'नमस्ते', pos: 'INTJ'),
+        (content: 'ਕਿਰਪਾ', pos: 'NOUN'),
+        (content: '😄', pos: 'SYM'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Emoji coverage — each structural variant that produces multi-codepoint
+  //    graphemes.
+  // -------------------------------------------------------------------------
+  group('TokensUtil.getGlobalTokenPositions — emoji coverage', () {
+    test('Simple supplementary-plane emoji at start of transcript', () {
+      const transcript = '😀 hello';
+      final tokens = _tokensFor(transcript, [
+        (content: '😀', pos: 'SYM'),
+        (content: 'hello', pos: 'NOUN'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+
+    test('Skin-tone modifier (👍🏽) — base + modifier form one grapheme', () {
+      const transcript = 'nice 👍🏽';
+      final tokens = _tokensFor(transcript, [
+        (content: 'nice', pos: 'ADJ'),
+        (content: '👍🏽', pos: 'SYM'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+
+    test('Flag emoji (🇺🇸) — regional indicators form one grapheme', () {
+      const transcript = 'from 🇺🇸 to 🇯🇵';
+      final tokens = _tokensFor(transcript, [
+        (content: 'from', pos: 'ADP'),
+        (content: '🇺🇸', pos: 'SYM'),
+        (content: 'to', pos: 'ADP'),
+        (content: '🇯🇵', pos: 'SYM'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+
+    test('ZWJ family emoji (👨‍👩‍👧) — 5 code points, 1 grapheme', () {
+      const transcript = 'my family 👨‍👩‍👧';
+      final tokens = _tokensFor(transcript, [
+        (content: 'my', pos: 'PRON'),
+        (content: 'family', pos: 'NOUN'),
+        (content: '👨‍👩‍👧', pos: 'SYM'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+
+    test('Emoji immediately between two words (no whitespace)', () {
+      const transcript = 'hi😄hello';
+      final tokens = _tokensFor(transcript, [
+        (content: 'hi', pos: 'INTJ'),
+        (content: '😄', pos: 'SYM'),
+        (content: 'hello', pos: 'INTJ'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Edge cases for the algorithm itself.
+  // -------------------------------------------------------------------------
+  group('TokensUtil.getGlobalTokenPositions — edge cases', () {
+    test('empty token list returns empty positions', () {
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        [],
+        transcript: 'hello',
+      );
+      expect(positions, isEmpty);
+    });
+
+    test('single token covering the whole transcript', () {
+      const transcript = 'hello';
+      final tokens = [_token(content: 'hello', offset: 0)];
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      expect(positions, hasLength(1));
+      expect(positions.first.token?.text.content, 'hello');
+      expect(positions.first.startIndex, 0);
+      expect(positions.first.endIndex, transcript.characters.length);
+    });
+
+    test('single token with leading whitespace emits a gap position first', () {
+      const transcript = '  hello';
+      final tokens = [_token(content: 'hello', offset: 2)];
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      expect(positions, hasLength(2));
+      expect(positions.first.token, isNull);
+      expect(
+        _slice(
+          transcript,
+          positions.first.startIndex,
+          positions.first.endIndex,
+        ),
+        '  ',
+      );
+      expect(positions.last.token?.text.content, 'hello');
+    });
+
+    test(
+      'single token with trailing whitespace leaves the trailing gap out',
+      () {
+        // The algorithm advances globalPointer only up to the last emitted
+        // token; anything after is not emitted. That matches existing behavior
+        // on main; we assert it explicitly so future changes surface.
+        const transcript = 'hello  ';
+        final tokens = [_token(content: 'hello', offset: 0)];
+
+        final positions = TokensUtil.instance.getGlobalTokenPositions(
+          tokens,
+          transcript: transcript,
+        );
+
+        expect(positions, hasLength(1));
+        expect(positions.first.endIndex, 5); // trailing spaces not emitted
+      },
+    );
+
+    test('adjacent tokens with no gap produce no gap position', () {
+      // Hindi doesn't separate these, but for the sake of the test we
+      // construct adjacent tokens directly.
+      const transcript = 'abcd';
+      final tokens = [
+        _token(content: 'ab', offset: 0),
+        _token(content: 'cd', offset: 2),
+      ];
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      // Two token positions, zero gaps.
+      expect(positions.where((p) => p.token == null), isEmpty);
+      expect(positions, hasLength(2));
+    });
+
+    test('word + trailing punctuation merges when adjacent', () {
+      const transcript = 'hello,';
+      final tokens = [
+        _token(content: 'hello', offset: 0),
+        _token(content: ',', offset: 5, pos: 'PUNCT'),
+      ];
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      // Existing algorithm merges adjacent non-punct + punct pairs into a
+      // single position. We assert the combined slice contains both.
+      expect(positions.where((p) => p.token != null), hasLength(1));
+      final slice = _slice(
+        transcript,
+        positions.first.startIndex,
+        positions.first.endIndex,
+      );
+      expect(slice, 'hello,');
+    });
+
+    test('leading punctuation + word merges', () {
+      const transcript = '¡hola';
+      final tokens = [
+        _token(content: '¡', offset: 0, pos: 'PUNCT'),
+        _token(content: 'hola', offset: 1),
+      ];
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      expect(positions.where((p) => p.token != null), hasLength(1));
+      expect(
+        _slice(
+          transcript,
+          positions.first.startIndex,
+          positions.first.endIndex,
+        ),
+        '¡hola',
+      );
+    });
+
+    test('punctuation with a gap before the next word does NOT merge', () {
+      const transcript = ', hello';
+      final tokens = [
+        _token(content: ',', offset: 0, pos: 'PUNCT'),
+        _token(content: 'hello', offset: 2),
+      ];
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      // Comma, then a gap (space), then hello — three positions.
+      expect(positions, hasLength(3));
+      expect(positions[0].token?.text.content, ',');
+      expect(positions[1].token, isNull);
+      expect(positions[2].token?.text.content, 'hello');
+    });
+
+    test('three consecutive punctuation tokens merge into one position', () {
+      const transcript = '...';
+      final tokens = [
+        _token(content: '.', offset: 0, pos: 'PUNCT'),
+        _token(content: '.', offset: 1, pos: 'PUNCT'),
+        _token(content: '.', offset: 2, pos: 'PUNCT'),
+      ];
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      expect(positions, hasLength(1));
+      expect(
+        _slice(
+          transcript,
+          positions.first.startIndex,
+          positions.first.endIndex,
+        ),
+        '...',
+      );
+    });
+
+    test('word with a grapheme-multi character in the middle', () {
+      // "tiếng" uses the precomposed ế, so it's one grapheme per character,
+      // but we test that the algorithm handles offsets correctly regardless.
+      const transcript = 'nói tiếng Việt';
+      final tokens = _tokensFor(transcript, [
+        (content: 'nói', pos: 'VERB'),
+        (content: 'tiếng', pos: 'NOUN'),
+        (content: 'Việt', pos: 'PROPN'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      _expectAllContentPresent(transcript, tokens, positions);
+      _expectTiling(transcript, positions);
+    });
+
+    test('multiple spaces between tokens produce one gap position each', () {
+      const transcript = 'a    b';
+      final tokens = _tokensFor(transcript, [
+        (content: 'a', pos: 'NOUN'),
+        (content: 'b', pos: 'NOUN'),
+      ]);
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      expect(positions.where((p) => p.token == null), hasLength(1));
+      final gap = positions.firstWhere((p) => p.token == null);
+      expect(_slice(transcript, gap.startIndex, gap.endIndex), '    ');
+    });
+
+    test(
+      'transcript can be longer than sum of token spans (trailing gap lost)',
+      () {
+        // This test documents the known behavior that trailing gaps are not
+        // emitted. If this ever needs to change, update both the code and the
+        // assertion together.
+        const transcript = 'abc def ghi';
+        final tokens = _tokensFor(transcript, [
+          (content: 'abc', pos: 'NOUN'),
+          (content: 'def', pos: 'NOUN'),
+        ]);
+
+        final positions = TokensUtil.instance.getGlobalTokenPositions(
+          tokens,
+          transcript: transcript,
+        );
+
+        // Last position ends at end of 'def' (7), not end of transcript (11).
+        expect(positions.last.endIndex, 7);
+      },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Invariants — run every sample through the same property checks.
+  // -------------------------------------------------------------------------
+  group(
+    'TokensUtil.getGlobalTokenPositions — invariants across many inputs',
+    () {
+      final samples =
+          <({String transcript, List<({String content, String pos})> words})>[
+            (
+              transcript: 'hello world',
+              words: [
+                (content: 'hello', pos: 'NOUN'),
+                (content: 'world', pos: 'NOUN'),
+              ],
+            ),
+            (
+              transcript: 'ਕਿਰਪਾ ਕਰਕੇ',
+              words: [
+                (content: 'ਕਿਰਪਾ', pos: 'NOUN'),
+                (content: 'ਕਰਕੇ', pos: 'VERB'),
+              ],
+            ),
+            (
+              transcript: 'नमस्ते दुनिया',
+              words: [
+                (content: 'नमस्ते', pos: 'NOUN'),
+                (content: 'दुनिया', pos: 'NOUN'),
+              ],
+            ),
+            (
+              transcript: 'வணக்கம் உலகம்',
+              words: [
+                (content: 'வணக்கம்', pos: 'NOUN'),
+                (content: 'உலகம்', pos: 'NOUN'),
+              ],
+            ),
+            (
+              transcript: 'from 🇺🇸 to 🇯🇵',
+              words: [
+                (content: 'from', pos: 'ADP'),
+                (content: '🇺🇸', pos: 'SYM'),
+                (content: 'to', pos: 'ADP'),
+                (content: '🇯🇵', pos: 'SYM'),
+              ],
+            ),
+            (
+              transcript: 'my family 👨‍👩‍👧',
+              words: [
+                (content: 'my', pos: 'PRON'),
+                (content: 'family', pos: 'NOUN'),
+                (content: '👨‍👩‍👧', pos: 'SYM'),
+              ],
+            ),
+            (
+              transcript: 'nice 👍🏽 work',
+              words: [
+                (content: 'nice', pos: 'ADJ'),
+                (content: '👍🏽', pos: 'SYM'),
+                (content: 'work', pos: 'NOUN'),
+              ],
+            ),
+            (
+              transcript: '你好 世界',
+              words: [
+                (content: '你好', pos: 'NOUN'),
+                (content: '世界', pos: 'NOUN'),
+              ],
+            ),
+            (
+              transcript: 'hi😄hello',
+              words: [
+                (content: 'hi', pos: 'INTJ'),
+                (content: '😄', pos: 'SYM'),
+                (content: 'hello', pos: 'INTJ'),
+              ],
+            ),
+          ];
+
+      for (final s in samples) {
+        test('tiling + content recovery on: "${s.transcript}"', () {
+          final tokens = _tokensFor(s.transcript, s.words);
+          final positions = TokensUtil.instance.getGlobalTokenPositions(
+            tokens,
+            transcript: s.transcript,
+          );
+          _expectTiling(s.transcript, positions);
+          _expectAllContentPresent(s.transcript, tokens, positions);
+        });
+      }
+    },
+  );
 }

--- a/test/pangea/tokens_util_test.dart
+++ b/test/pangea/tokens_util_test.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/events/models/pangea_token_model.dart';
+import 'package:fluffychat/pangea/events/models/pangea_token_text_model.dart';
+import 'package:fluffychat/pangea/lemmas/lemma.dart';
+import 'package:fluffychat/pangea/tokens/tokens_util.dart';
+
+PangeaToken _token({
+  required String content,
+  required int offset,
+  String pos = 'NOUN',
+}) {
+  return PangeaToken(
+    text: PangeaTokenText.fromJson({'content': content, 'offset': offset}),
+    lemma: Lemma(text: content, saveVocab: false, form: content),
+    pos: pos,
+    morph: const {},
+  );
+}
+
+String _sliceByGraphemes(String text, int startIndex, int endIndex) {
+  return text.characters
+      .skip(startIndex)
+      .take(endIndex - startIndex)
+      .toString();
+}
+
+void main() {
+  group('TokensUtil.getGlobalTokenPositions', () {
+    test('ASCII: hello world — positions match rendered substrings', () {
+      const transcript = 'hello world';
+      final tokens = [
+        _token(content: 'hello', offset: 0),
+        _token(content: 'world', offset: 6),
+      ];
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      // One gap (" ") + two tokens.
+      final wordSlices = positions
+          .where((p) => p.token != null)
+          .map((p) => _sliceByGraphemes(transcript, p.startIndex, p.endIndex))
+          .toList();
+
+      expect(wordSlices, ['hello', 'world']);
+    });
+
+    test(
+      'Punjabi (issue #1963): "ਕਿਰਪਾ ਕਰਕੇ" — both words fully selectable',
+      () {
+        // From the bug report: token offsets are code-points (Python len()).
+        // "ਕਿਰਪਾ" = 5 code points, 3 grapheme clusters (ਕਿ, ਰ, ਪਾ)
+        // "ਕਰਕੇ"  = 4 code points, 3 grapheme clusters (ਕ, ਰ, ਕੇ)
+        const transcript = 'ਕਿਰਪਾ ਕਰਕੇ';
+        final tokens = [
+          _token(content: 'ਕਿਰਪਾ', offset: 0),
+          _token(content: 'ਕਰਕੇ', offset: 6),
+        ];
+
+        final positions = TokensUtil.instance.getGlobalTokenPositions(
+          tokens,
+          transcript: transcript,
+        );
+
+        final wordSlices = positions
+            .where((p) => p.token != null)
+            .map((p) => _sliceByGraphemes(transcript, p.startIndex, p.endIndex))
+            .toList();
+
+        expect(wordSlices, ['ਕਿਰਪਾ', 'ਕਰਕੇ']);
+      },
+    );
+
+    test('Bangla with emoji — full words + ZWJ-less emoji all recoverable', () {
+      // From the bug report's second payload:
+      //   "ঠিক আছে, kelrap; আমি এখানেই আছি 😄"
+      // Emoji 😄 is 1 code point (Python len), but 2 UTF-16 code units in
+      // Dart; grapheme count 1. The backend emits offset=32 in code-points.
+      const transcript = 'ঠিক আছে, kelrap; আমি এখানেই আছি 😄';
+      final tokens = [
+        _token(content: 'ঠিক', offset: 0),
+        _token(content: 'আছে', offset: 4),
+        _token(content: ',', offset: 7, pos: 'PUNCT'),
+        _token(content: 'kelrap', offset: 9),
+        _token(content: ';', offset: 15, pos: 'PUNCT'),
+        _token(content: 'আমি', offset: 17),
+        _token(content: 'এখানেই', offset: 21),
+        _token(content: 'আছি', offset: 28),
+        _token(content: '😄', offset: 32),
+      ];
+
+      final positions = TokensUtil.instance.getGlobalTokenPositions(
+        tokens,
+        transcript: transcript,
+      );
+
+      final wordSlices = positions
+          .where((p) => p.token != null)
+          .map((p) => _sliceByGraphemes(transcript, p.startIndex, p.endIndex))
+          .toList();
+
+      // Note: punctuation tokens get merged with adjacent tokens by the
+      // existing algorithm; we just require every non-punct word plus the
+      // emoji to be fully recoverable as a substring.
+      expect(wordSlices, contains('ঠিক'));
+      expect(wordSlices.any((s) => s.contains('আছে')), isTrue);
+      expect(wordSlices.any((s) => s.contains('kelrap')), isTrue);
+      expect(wordSlices, contains('আমি'));
+      expect(wordSlices, contains('এখানেই'));
+      expect(wordSlices.any((s) => s.contains('আছি')), isTrue);
+      expect(wordSlices, contains('😄'));
+    });
+
+    test(
+      'token positions tile the transcript without overlap and cover it',
+      () {
+        const transcript = 'ਕਿਰਪਾ ਕਰਕੇ';
+        final tokens = [
+          _token(content: 'ਕਿਰਪਾ', offset: 0),
+          _token(content: 'ਕਰਕੇ', offset: 6),
+        ];
+
+        final positions = TokensUtil.instance.getGlobalTokenPositions(
+          tokens,
+          transcript: transcript,
+        );
+
+        // Adjacency: each position's endIndex == next position's startIndex.
+        for (var i = 0; i < positions.length - 1; i++) {
+          expect(positions[i].endIndex, positions[i + 1].startIndex);
+        }
+        // First starts at 0, last ends at grapheme count.
+        expect(positions.first.startIndex, 0);
+        expect(positions.last.endIndex, transcript.characters.length);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What

In voice-message transcript rendering, translate backend code-point token offsets into grapheme-cluster units before slicing the transcript via `String.characters`, so tappable word regions stay aligned for Indic scripts with matras, emoji, and other multi-codepoint graphemes.

## Why

Closes #6495 (original report: pangeachat/2-step-choreographer#1963) — Punjabi "ਕਰਕੇ" was only tappable on a single character because the renderer was indexing a grapheme-cluster array with a code-point offset.

Backend tokenizers (spaCy, LLM, Google, Whisper) emit `token.text.offset` in Unicode code-point units (Python `len()`). The renderer at `stt_transcript_tokens.dart` slices `model.transcript.text.characters` — a grapheme-indexed view. For ASCII and most CJK, code-points == graphemes, so the bug stayed hidden. For Indic matras (ਕਿ = 2 code points, 1 grapheme), emoji outside the BMP, ZWJ sequences, skin-tone modifiers, and combining diacritics, the two counts diverge and the selection window drifts or collapses.

`TokensUtil.getGlobalTokenPositions` now requires the transcript, builds a code-point → grapheme map from it (via the new public `GraphemeOffsetIndex` utility), and returns `TokenPosition` indices in grapheme units — matching what the renderer consumes.

## Testing

**77 new unit + widget tests across three files:**

- `test/pangea/grapheme_offset_index_test.dart` (37 tests) — structural properties and per-script invariants for the new `GraphemeOffsetIndex`: ASCII, CJK, Gurmukhi, Devanagari, Tamil, Vietnamese, plus every emoji category (supplementary-plane, skin-tone, flag, ZWJ family). Boundary clamping, monotonicity, and round-trip checks run across every sample.
- `test/pangea/tokens_util_test.dart` (35 tests) — issue reproducers (Punjabi, Bangla+emoji); script coverage (ASCII, CJK, Hindi, Tamil, Thai, Arabic, mixed); emoji coverage (at-start, skin-tone, flag, ZWJ, no-whitespace); algorithmic edge cases (empty token list, single token, leading/trailing whitespace, adjacent tokens, punct merges, three-dot ellipsis, trailing-gap policy); a property-based tiling/content-recovery invariant over every sample.
- `test/pangea/stt_transcript_tokens_test.dart` (5 tests) — widget-level rendering contract: reproduces `SttTranscriptTokens`' `RichText` structure, pumps it, taps rendered Punjabi/Bangla/ASCII/ZWJ-emoji words, and verifies the correct token's `onTap` fires. The widget's non-empty path calls a `MatrixState` singleton that isn't available under `flutter test`, so the real widget is smoke-tested on its empty-tokens branch and the rendering contract is verified via an exact replica.

**Manual TO TEST** is on the linked issue — end-to-end steps for sending/opening real voice messages in Punjabi, Bengali, Hindi, Tamil, Thai, and English.

```
flutter test test/pangea/tokens_util_test.dart \
            test/pangea/grapheme_offset_index_test.dart \
            test/pangea/stt_transcript_tokens_test.dart
→ 77 passed, 0 failed
flutter analyze lib/pangea/tokens/ test/pangea/
→ No issues found
```

## Deploy Notes

None.

## Follow-ups (not in this PR)

The same code-point-vs-grapheme mismatch exists at eight other call sites surfaced during the root-cause review — different features, separate review surfaces, so they're left for follow-up issues rather than bundled here. The new `GraphemeOffsetIndex` is the reusable primitive each follow-up will need:

- `lib/pangea/toolbar/message_selection_overlay.dart` — word tap selection
- `lib/pangea/analytics_details_popup/lemma_use_example_messages.dart` (has an explicit `throw StateError` that can fire on Indic text)
- `lib/pangea/analytics_misc/example_message_util.dart`
- `lib/pangea/analytics_practice/grammar_error_practice_generator.dart` and `grammar_error_target_generator.dart`
- `lib/pangea/choreographer/igc/span_data_model.dart`
- `lib/pangea/events/models/pangea_token_text_model.dart#uniqueKey` — saved-vocab dedup key is built from a grapheme `length` + a code-point `offset` and can drift across contexts

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

