### PR TITLE
chore(routes): point lemma dictionary URL at /choreo/lemma_meaning

### DIFF
--- a/lib/pangea/common/network/urls.dart
+++ b/lib/pangea/common/network/urls.dart
@@ -45,7 +45,7 @@ class PApiUrls {
       "${PApiUrls._choreoEndpoint}/practice";
 
   static String lemmaDictionary =
-      "${PApiUrls._choreoEndpoint}/lemma_definition";
+      "${PApiUrls._choreoEndpoint}/lemma_meaning";
   static String morphDictionary = "${PApiUrls._choreoEndpoint}/morph_meaning";
 
   static String activitySummary =


### PR DESCRIPTION
## Summary

One-line URL swap to match the choreo route rename from `lemma_definition` → `lemma_meaning`.

**Companion PRs:**
- Choreo: https://github.com/pangeachat/2-step-choreographer/pull/1972
- CMS: https://github.com/pangeachat/cms/pull/230

## Deploy order

**CMS → choreo → client.** Do not ship this client before the choreo PR deploys. Old clients in-flight during the cutover window are covered by the deprecated compat route at `/choreo/lemma_definition` on the choreo side (stays for one release cycle).

## What changed

`lib/pangea/common/network/urls.dart` — one constant, `lemmaDictionaryUrl`, points at `/choreo/lemma_meaning` instead of `/choreo/lemma_definition`. The client already used the term "meaning" everywhere else in product copy and variable names; this aligns the wire path.

## Test plan

- [ ] Resolve lemma meaning from vocab/dictionary flow; confirm the request hits `/choreo/lemma_meaning` (network tab) and returns expected payload shape.
- [ ] Confirm no other references to `/choreo/lemma_definition` remain (`grep -r "lemma_definition" lib/`).
- [ ] Rollout timing: do not release until choreo deploy is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)