### PR TITLE
chore(sentry): drop tracesSampleRate to 2%

### DIFF
--- a/lib/pangea/common/utils/error_handler.dart
+++ b/lib/pangea/common/utils/error_handler.dart
@@ -25,7 +25,7 @@ class ErrorHandler {
   static Future<void> initialize() async {
     await SentryFlutter.init((options) {
       options.dsn = Environment.sentryDsn;
-      options.tracesSampleRate = 0.1;
+      options.tracesSampleRate = 0.02;
       options.debug = kDebugMode;
       options.environment = kDebugMode
           ? "debug"


### PR DESCRIPTION
Org-wide 2% sampling decision. Flutter SDK init in `lib/pangea/common/utils/error_handler.dart` was at 0.1 — drop to 0.02.

## Test plan
- [x] N/A (config)
- [ ] Run app, trigger a navigation, verify Sentry receives traces at the lower rate