### PR TITLE
fix: don't launch tutorial if dialog is open over target widget

### DIFF
--- a/lib/pangea/onboarding/tutorial_overlay_controller.dart
+++ b/lib/pangea/onboarding/tutorial_overlay_controller.dart
@@ -241,6 +241,14 @@ class TutorialOverlayController {
   bool isTutorialQueued(TutorialEnum tutorial) =>
       _state.tutorialType == tutorial;
 
+  bool _hasModalAbove(BuildContext context) {
+    final navigator = Navigator.of(context, rootNavigator: true);
+    final route = ModalRoute.of(context);
+
+    if (route == null) return false;
+    return !route.isCurrent || navigator.canPop();
+  }
+
   void dispose() {
     _forwardTutorialStreamController.close();
     _backNavigationStreamController.close();
@@ -270,6 +278,13 @@ class TutorialOverlayController {
     if (_state.model.activeTutorial != null) {
       Logs().w(
         "Another tutorial is already active: ${_state.model.activeTutorial!.tutorialType}",
+      );
+      return;
+    }
+
+    if (_hasModalAbove(context)) {
+      Logs().w(
+        "Tutorial ${tutorial.tutorialType} blocked because another route/dialog is on top.",
       );
       return;
     }


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS