### PR TITLE
chore: in saved activity chats, disable reactions via the word card a…

### DIFF
--- a/lib/pangea/toolbar/reading_assistance/select_mode_buttons.dart
+++ b/lib/pangea/toolbar/reading_assistance/select_mode_buttons.dart
@@ -11,6 +11,7 @@ import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pages/chat/chat.dart';
+import 'package:fluffychat/pangea/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/pangea/audio/multi_platform_audio_player.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/common/widgets/pressable_button.dart';
@@ -664,7 +665,9 @@ class _MoreButton extends StatelessWidget {
 
     switch (action) {
       case MessageActions.reply:
-        return events.length == 1 && controller.room.canSendDefaultMessages;
+        return events.length == 1 &&
+            controller.room.canSendDefaultMessages &&
+            !controller.room.hasArchivedActivity;
       case MessageActions.edit:
         return controller.canEditSelectedEvents &&
             !events.first.isActivityMessage &&

--- a/lib/pangea/toolbar/word_card/reading_assistance_content.dart
+++ b/lib/pangea/toolbar/word_card/reading_assistance_content.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:matrix/matrix_api_lite/model/message_types.dart';
 
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/pangea/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/pangea/lemmas/lemma_info_response.dart';
 import 'package:fluffychat/pangea/phonetic_transcription/pt_v2_models.dart';
 import 'package:fluffychat/pangea/token_info_feedback/token_info_feedback_request.dart';
@@ -47,6 +48,8 @@ class ReadingAssistanceContent extends StatelessWidget {
       event: overlayController.event,
       onClose: () => overlayController.updateSelectedSpan(null),
       langCode: overlayController.pangeaMessageEvent.messageDisplayLangCode,
+      enableEmojiSelection:
+          !overlayController.pangeaMessageEvent.room.hasArchivedActivity,
       onFlagTokenInfo:
           (
             LemmaInfoResponse lemmaInfo,


### PR DESCRIPTION
…nd replies via select mode buttons

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS