### PR TITLE
docs: replace IGC text references with writing assistance / WA

### DIFF
--- a/.github/instructions/events-and-tokens.instructions.md
+++ b/.github/instructions/events-and-tokens.instructions.md
@@ -89,7 +89,7 @@ Interpretation matrix:
 
 | `originalSent` | `originalWritten` | Meaning |
 |:-:|:-:|---|
-| ✓ | ✗ | Text went through IGC/IT before sending |
+| ✓ | ✗ | Text went through writing assistance / interactive translation before sending |
 | ✗ | ✗ | Added by another user (e.g., translation) |
 | ✓ | ✓ | User wrote and sent as-is (L1 or perfect L2) |
 | ✗ | ✓ | User's original L1 that was then translated via IT |

--- a/.github/instructions/grammar-analytics.instructions.md
+++ b/.github/instructions/grammar-analytics.instructions.md
@@ -61,7 +61,7 @@ Drill-down for a single tag showing:
 
 ### Grammar practice (`grammar_error_practice_generator.dart`, `morph_category_activity_generator.dart`)
 
-Recent addition: users can practice grammar concepts they've struggled with. `GrammarErrorPracticeGenerator` creates activities from past IGC grammar corrections. `MorphCategoryActivityGenerator` creates practice targeting specific morph categories.
+Recent addition: users can practice grammar concepts they've struggled with. `GrammarErrorPracticeGenerator` creates activities from past writing-assistance grammar corrections. `MorphCategoryActivityGenerator` creates practice targeting specific morph categories.
 
 ## Recent Improvements
 

--- a/.github/instructions/practice-exercises.instructions.md
+++ b/.github/instructions/practice-exercises.instructions.md
@@ -72,7 +72,7 @@ The current scoring only considers **recency** and **content-word status**. It i
 | Tier | Who goes here | Practice priority |
 |---|---|---|
 | **Suppressed** | Lemmas whose most recent chat use is `wa` (without assistance) AND no subsequent incorrect practice | **0** — skip entirely |
-| **Active** | Lemmas encountered through `ta` (IT) or `ga` (IGC), OR lemmas with a recent incorrect practice answer (`incXX`) | **High** — prioritize these |
+| **Active** | Lemmas encountered through `ta` (interactive translation) or `ga` (writing assistance), OR lemmas with a recent incorrect practice answer (`incXX`) | **High** — prioritize these |
 | **Maintenance** | Everything else — correctly practiced but aging | **Normal** — standard recency-based |
 
 **Tier transitions:**
@@ -84,7 +84,7 @@ The current scoring only considers **recency** and **content-word status**. It i
 
 **Within each tier**, the existing scoring formula applies: `daysSinceLastUsed × (isContentWord ? 10 : 7)`. Active-tier words get an additional multiplier (e.g., ×2) so they always appear before maintenance words of similar age.
 
-**Key principle**: Words used through IT and IGC should be practiced **much more** than `wa` words. A `wa` word should only re-enter practice if the user later gets it wrong.
+**Key principle**: Words used through interactive translation and writing assistance should be practiced **much more** than `wa` words. A `wa` word should only re-enter practice if the user later gets it wrong.
 
 **Example scenario:**
 1. User types "gato" correctly without assistance → `wa` → Suppressed. Won't appear in practice.
@@ -92,7 +92,7 @@ The current scoring only considers **recency** and **content-word status**. It i
 3. User practices "mariposa" and gets it wrong → `incLM` → stays Active, priority boosted.
 4. User practices "mariposa" correctly 3 times → Active → Maintenance.
 5. Two weeks pass with no interaction → Maintenance, but high recency score → likely to appear.
-6. User later misspells "gato" and IGC corrects it → `ga` → moves from Suppressed back to Active.
+6. User later misspells "gato" and writing assistance corrects it → `ga` → moves from Suppressed back to Active.
 
 ### ⚠️ Grammar Error Practice: Missing Message Data
 

--- a/.github/instructions/profile.instructions.md
+++ b/.github/instructions/profile.instructions.md
@@ -11,7 +11,7 @@ How profile settings are structured, stored, propagated, and surfaced to other u
 `Profile` (in [user_model.dart](lib/pangea/user/user_model.dart)) is the top-level container. It wraps three sub-models:
 
 - **`UserSettings`** — learning prefs: target/source language, CEFR level, gender, voice, country, about, etc.
-- **`UserToolSettings`** — per-tool on/off toggles (interactive translator, grammar, immersion mode, definitions, auto-IGC, autocorrect, TTS).
+- **`UserToolSettings`** — per-tool on/off toggles (interactive translator, grammar, immersion mode, definitions, auto-WA, autocorrect, TTS).
 - **`InstructionSettings`** — which instructional tooltips the user has dismissed.
 
 A separate **`PublicProfileModel`** (in [public_profile_model.dart](lib/pangea/user/public_profile_model.dart)) holds data visible to other users: analytics level/XP per language, country, and about. It lives on the Matrix user profile (public), not in account data.
@@ -34,7 +34,7 @@ A separate **`PublicProfileModel`** (in [public_profile_model.dart](lib/pangea/u
 ### Full settings UI (opens `SettingsLearning`)
 
 1. **Settings page → Learning** — full-page at `/settings/learning`
-2. **IGC button long-press** — modal dialog from the writing-assistance button in the chat input
+2. **Writing-assistance button long-press** — modal dialog from the writing-assistance button in the chat input
 3. **IT bar gear icon** — modal dialog from the interactive translation bar
 4. **Analytics language indicator** — modal dialog from the language-pair chip (e.g. "EN → ES") on the learning progress widget
 

--- a/.github/instructions/writing-assistance.instructions.md
+++ b/.github/instructions/writing-assistance.instructions.md
@@ -6,7 +6,7 @@ applyTo: "lib/pangea/choreographer/**"
 
 Writing assistance is a friendly, non-judgmental helper that quietly reviews what the user types and offers suggestions. It must never feel like error correction — it's a learning companion.
 
-> **⚠️ IT (Interactive Translation) is deprecated.** Do not add new IT functionality. Translation will become a match type within IGC.
+> **⚠️ IT (Interactive Translation) is deprecated.** Do not add new IT functionality. Translation will become a match type within writing assistance.
 
 ## Design Intent
 
@@ -227,7 +227,7 @@ Choreographer (ChangeNotifier)
 
 | Endpoint                        | Status                                   |
 | ------------------------------- | ---------------------------------------- |
-| `/choreo/grammar_v2`            | ✅ Active — primary IGC endpoint         |
+| `/choreo/grammar_v2`            | ✅ Active — primary writing-assistance endpoint |
 | `/choreo/tokenize`              | ✅ Active — tokenizes final text on send |
 | `/choreo/span_details`          | ❌ Dead code — remove                    |
 | `/choreo/it_initialstep`        | ⚠️ Deprecated — remove with IT           |
@@ -239,7 +239,7 @@ Choreographer (ChangeNotifier)
 
 > **Do not extend. Scheduled for removal.**
 
-The `it/` directory, `ITController`, and all IT-related code (`it_bar.dart`, `it_feedback_card.dart`, `word_data_card.dart`, `choreo_mode_enum.dart`) will be removed. Translation will become a match type within IGC.
+The `it/` directory, `ITController`, and all IT-related code (`it_bar.dart`, `it_feedback_card.dart`, `word_data_card.dart`, `choreo_mode_enum.dart`) will be removed. Translation will become a match type within writing assistance.
 
 ---
 


### PR DESCRIPTION
## What

Replace IGC text mentions across 5 client design docs:

- [`writing-assistance.instructions.md`](.github/instructions/writing-assistance.instructions.md) (3): deprecation banner, primary-endpoint label in the API table, IT-removal note.
- [`grammar-analytics.instructions.md`](.github/instructions/grammar-analytics.instructions.md) (1): "past IGC grammar corrections" → "past writing-assistance grammar corrections".
- [`events-and-tokens.instructions.md`](.github/instructions/events-and-tokens.instructions.md) (1): interpretation-matrix cell now reads "writing assistance / interactive translation".
- [`profile.instructions.md`](.github/instructions/profile.instructions.md) (2): `auto-IGC` → `auto-WA` in the UserToolSettings toggles list; "IGC button long-press" → "Writing-assistance button long-press".
- [`practice-exercises.instructions.md`](.github/instructions/practice-exercises.instructions.md) (3): tier-table cell with `ga` annotation; key-principle bullet; example-scenario step 6.

## Why

IGC is the legacy name for writing assistance. The org-level glossary canonicalizes this in [`pangeachat/.github` PR #43, #44](https://github.com/pangeachat/.github/pulls?q=is%3Apr+IGC). This rolls the rename through the client's design docs so new contributors don't have to translate as they read.

## Out of scope (intentional)

Code identifiers are NOT touched in this PR — they need a separate refactor PR with the code author:

- `lib/pangea/choreographer/igc/` (directory + `igc_controller.dart`, `igc_repo.dart`).
- `IGCController` class, `igcMatch.choices`, `igcMatch.bestChoice` etc. throughout `lib/pangea/`.
- The `ga` (`ConstructUseTypeEnum.ga`) enum value — mirrors the choreographer's enum and renaming requires cross-service coordination.
- Test descriptions in `test/pangea/practice_target_scorer_test.dart` — half text, half code identifiers; left for the test author.

Docs-only — no functional change.

## Testing

N/A — docs-only.

## Deploy Notes

None.