### PR TITLE
docs(playwright): point to choreo mock-mode for Playwright runs

### DIFF
--- a/.github/instructions/playwright-testing.instructions.md
+++ b/.github/instructions/playwright-testing.instructions.md
@@ -106,6 +106,16 @@ Once in a room:
 - **Hash routing** — all Flutter routes use `/#/` prefix. Direct navigation works.
 - **Session is ephemeral** — the Playwright browser doesn't share the user's Chrome session. You must log in each time.
 
+## Bypassing Paid Backend Calls
+
+The choreographer supports a per-request `mock` field. When the client sends `mock: true` on a request, choreo runs the full request path (auth, CMS, metering, audits, retries) but swaps every paid third-party call (OpenAI / Anthropic / Vertex chat, embeddings, image-gen, Google TTS, Whisper / Google STT / Deepgram) for a canned, schema-shaped response. Use this to keep Playwright runs deterministic and free.
+
+- Set `MOCK_LLM_LATENCY_OVERRIDE_S=0` in the Playwright env so each mocked response returns instantly (default profiles add realistic latency for load testing).
+- The flag does **not** auto-propagate. Add `mock=true` on the client's choreo request classes when the Playwright run wants mocked responses.
+- Mocked responses are deterministic but obviously bogus (WA returns one double-spaced edit; image-gen returns `mock.pangea.chat/transparent-1x1.png`). Assert on shape, not content.
+
+Full contract, env knobs, and known intentional skips: see [`testing.instructions.md` in `pangeachat/.github`](https://github.com/pangeachat/.github/blob/main/.github/instructions/testing.instructions.md#mock-mode-reqmocktrue).
+
 ## Limitations
 
 - SSO login (Apple/Google) cannot be automated — use email/password login only.


### PR DESCRIPTION
## Summary

Choreo PR [pangeachat/2-step-choreographer#2233](https://github.com/pangeachat/2-step-choreographer/pull/2233) lands a per-request `mock: true` flag that swaps every paid third-party call (LLMs, TTS, STT, embeddings, image-gen) for a canned response while leaving the rest of the choreo request path intact.

Adds a short pointer in the Playwright instructions so the Playwright + accessibility scaffold (PR #5665) knows the mechanism exists. Full contract lives in [`pangeachat/.github` testing.instructions.md](https://github.com/pangeachat/.github/blob/main/.github/instructions/testing.instructions.md#mock-mode-reqmocktrue).

## Followup (not in this PR)

The `mock` flag is **not yet wired into the client choreo request classes**. The wiring (adding `mock=true` to the right outbound calls so Playwright runs actually exercise mock mode) is a separate, larger change. Worth scoping with the test framework — probably easiest to put it on a Playwright-only env var that all client choreo calls forward through when set, rather than per-call.

## Test plan

- [x] Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)