### PR TITLE
Sync canonical issue templates from pangeachat/workflows

### DIFF
--- a/.github/workflows/sync-issue-templates.yml
+++ b/.github/workflows/sync-issue-templates.yml
@@ -1,0 +1,13 @@
+name: Sync issue templates
+
+on:
+  schedule:
+    - cron: '0 13 * * 1' # weekly Mondays 13:00 UTC
+  workflow_dispatch:
+
+jobs:
+  sync:
+    uses: pangeachat/workflows/.github/workflows/reusable-sync-issue-templates.yaml@a02f9792e74b0a406612be47549e3c3c5194632b # main
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
Adds the org-canonical issue templates and a tiny weekly caller workflow that keeps them aligned with [pangeachat/workflows/.github/ISSUE_TEMPLATE/](https://github.com/pangeachat/workflows/tree/main/.github/ISSUE_TEMPLATE) — the canonical source for public repos. Background: pangeachat/.github is private so its default community-health files don't reach public repos.

The caller is SHA-pinned per [worktree-and-pr-hygiene](https://github.com/pangeachat/.github/blob/main/.github/instructions/worktree-and-pr-hygiene.instructions.md#cross-repo-reusable-workflows). To pick up future canonical edits, the workflow runs weekly (Mondays 13:00 UTC) or on-demand via `workflow_dispatch`.

No client testing needed — issue-template metadata + sync workflow.