### PR TITLE
docs(instructions): switch wykuji example to shared staging_automated_tests

### DIFF
--- a/.github/instructions/matrix-auth.instructions.md
+++ b/.github/instructions/matrix-auth.instructions.md
@@ -8,13 +8,26 @@ How to obtain a Matrix access token for staging API testing (choreo endpoints, S
 
 ## Credentials
 
-Staging test credentials live in `client/.env`:
+The shared staging test account is `staging_automated_tests` on
+`staging.pangea.chat`. Authoritative source is AWS Secrets Manager at
+`/staging/test-user/matrix-credentials` (JSON with `TEST_MATRIX_USERNAME`
+and `TEST_MATRIX_PASSWORD` keys). CI fetches it via OIDC; for local use,
+either pull it down with the AWS CLI or read the mirrored values from
+`2-step-choreographer/.env`.
 
-- `STAGING_TEST_EMAIL` — email address
-- `STAGING_TEST_USER` — full Matrix user ID (e.g. `@wykuji:staging.pangea.chat`)
-- `STAGING_TEST_PASSWORD` — password
+```sh
+# Local fetch from AWS Secrets Manager
+aws secretsmanager get-secret-value \
+  --secret-id /staging/test-user/matrix-credentials \
+  --query SecretString --output text | python3 -m json.tool
+```
 
-Read these values from the file at runtime. **Never hardcode credentials in skills, scripts, or chat output.**
+Expected variable names:
+
+- `TEST_MATRIX_USERNAME` — localpart (e.g. `staging_automated_tests`)
+- `TEST_MATRIX_PASSWORD` — password
+
+**Never hardcode credentials in skills, scripts, or chat output.**
 
 ## Get a Matrix Access Token
 
@@ -23,8 +36,8 @@ curl -s -X POST 'https://matrix.staging.pangea.chat/_matrix/client/v3/login' \
   -H 'Content-Type: application/json' \
   -d '{
     "type": "m.login.password",
-    "identifier": {"type": "m.id.user", "user": "<USERNAME_WITHOUT_@_OR_DOMAIN>"},
-    "password": "<STAGING_TEST_PASSWORD>"
+    "identifier": {"type": "m.id.user", "user": "<TEST_MATRIX_USERNAME>"},
+    "password": "<TEST_MATRIX_PASSWORD>"
   }' | python3 -m json.tool
 ```
 
@@ -33,14 +46,14 @@ The response contains `access_token`, `user_id`, `device_id`, and `home_server`.
 ### Extracting the token programmatically
 
 ```sh
-# Read creds from client/.env
-STAGING_USER=$(grep STAGING_TEST_USER client/.env | sed 's/.*= *"//;s/".*//' | sed 's/@//;s/:.*//')
-STAGING_PASS=$(grep STAGING_TEST_PASSWORD client/.env | sed 's/.*= *"//;s/".*//')
+# Read creds from 2-step-choreographer/.env
+TEST_USER=$(grep ^TEST_MATRIX_USERNAME 2-step-choreographer/.env | sed 's/.*= *"\?//;s/"\?$//')
+TEST_PASS=$(grep ^TEST_MATRIX_PASSWORD 2-step-choreographer/.env | sed 's/.*= *"\?//;s/"\?$//')
 
 # Login and extract token
 MATRIX_TOKEN=$(curl -s -X POST 'https://matrix.staging.pangea.chat/_matrix/client/v3/login' \
   -H 'Content-Type: application/json' \
-  -d "{\"type\":\"m.login.password\",\"identifier\":{\"type\":\"m.id.user\",\"user\":\"$STAGING_USER\"},\"password\":\"$STAGING_PASS\"}" \
+  -d "{\"type\":\"m.login.password\",\"identifier\":{\"type\":\"m.id.user\",\"user\":\"$TEST_USER\"},\"password\":\"$TEST_PASS\"}" \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
 
 echo "$MATRIX_TOKEN"
@@ -50,7 +63,7 @@ echo "$MATRIX_TOKEN"
 
 ### Choreo API
 
-Choreo requires **both** the Matrix token and the API key (from `CHOREO_API_KEY` in `client/.env`):
+Choreo requires **both** the Matrix token and the API key (from `CHOREO_API_KEY` in `client/assets/.env`):
 
 ```sh
 curl -s 'https://api.staging.pangea.chat/choreo/<endpoint>' \

--- a/.github/instructions/playwright-testing.instructions.md
+++ b/.github/instructions/playwright-testing.instructions.md
@@ -40,7 +40,7 @@ Then wait 2–3 seconds and take a snapshot — you should now see Flutter widge
 ### Prerequisites
 
 - Flutter web app running locally (e.g. `flutter run -d chrome` on some port)
-- Staging test credentials from `client/.env` (see [matrix-auth.instructions.md](matrix-auth.instructions.md))
+- Staging test credentials for the shared `staging_automated_tests` account (see [matrix-auth.instructions.md](matrix-auth.instructions.md) for the AWS Secrets Manager / `2-step-choreographer/.env` source)
 
 ### Step-by-Step Login
 
@@ -51,7 +51,7 @@ Then wait 2–3 seconds and take a snapshot — you should now see Flutter widge
 5. **Snapshot** — you should see "Sign in with Apple", "Sign in with Google", "Email" options
 6. **Click "Email"** → navigates to `/home/login/email`
 7. **Snapshot** — you should see "Username or Email" and "Password" text fields, and a "Login" button
-8. **Type** the username (just the localpart, e.g. `wykuji`, not the full `@wykuji:staging.pangea.chat`) into the username field
+8. **Type** the username (just the localpart, e.g. `staging_automated_tests`, not the full `@staging_automated_tests:staging.pangea.chat`) into the username field
 9. **Type** the password into the password field
 10. **Click "Login"** button
 11. **Wait** 5–10 seconds for sync to complete


### PR DESCRIPTION
## Summary

- wykuji is Will's personal staging account, never meant as the canonical staging test user in our docs. Update `matrix-auth.instructions.md` and `playwright-testing.instructions.md` to point at the shared `staging_automated_tests` account, which CI already uses.
- Authoritative source is AWS Secrets Manager at `/staging/test-user/matrix-credentials` (JSON with `TEST_MATRIX_USERNAME` / `TEST_MATRIX_PASSWORD`); for local use, mirrored into `2-step-choreographer/.env` or pull with `aws secretsmanager get-secret-value`.
- Rewrites the credentials section and the programmatic-token-fetch example accordingly; the playwright login walkthrough now shows the new username.

## Companion PRs

- pangeachat/2-step-choreographer#2352 — script changes (release_smoke, smoke_feedback_audit, load)
- pangeachat/.github#114 — release-cms-choreo skill + cross-service-debugging doc

## Test plan

- [ ] Skim both docs after merge; no remaining wykuji references.
- [ ] Re-run the curl examples in `matrix-auth.instructions.md` against staging with the new env vars; token comes back as expected.