### PR TITLE
docs: fix broken instructions-authoring link path

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-Check the relevant `.github/instructions/` doc before and after coding. If it doesn't exist, create it with the user first. Follow [instructions-authoring.instructions.md](../../.github/instructions/instructions-authoring.instructions.md) for doc standards.
+Check the relevant `.github/instructions/` doc before and after coding. If it doesn't exist, create it with the user first. Follow [instructions-authoring.instructions.md](../../.github/.github/instructions/instructions-authoring.instructions.md) for doc standards.
 
 # client - Flutter/Dart Language Learning Chat App
 


### PR DESCRIPTION
## Summary
- `.github/copilot-instructions.md`'s link to `instructions-authoring.instructions.md` used `../../.github/instructions/...` — but the doc lives at the doubled-`.github` path (`../../.github/.github/instructions/...`), per the path note in [pangeachat/.github/copilot-instructions.md](https://github.com/pangeachat/.github/blob/main/copilot-instructions.md).

## Test plan
- [ ] Click the link on the rendered file in GitHub; confirm it resolves.