### PR TITLE
docs: drop check-doc boilerplate from copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,3 @@
-Check the relevant `.github/instructions/` doc before and after coding. If it doesn't exist, create it with the user first. Follow [instructions-authoring.instructions.md](../../.github/instructions/instructions-authoring.instructions.md) for doc standards.
-
 # client - Flutter/Dart Language Learning Chat App
 
 ## Tech Stack


### PR DESCRIPTION
## Summary

Part of a cross-repo doc cleanup (companion to pangeachat/.github#140).

Drops the "Check the relevant .github/instructions/ doc..." boilerplate line. The root `copilot-instructions.md` Iterative Development Lifecycle / "Drive intent with documentation" step now states this rule once with rationale; per-repo duplicates were drifting in wording and adding zero unique signal.

## Supersedes

This deletes the exact line PR #6780 fixes a broken link in. Suggest closing #6780 as superseded once this merges. The link being fixed is going away with the whole sentence.

## Test plan

- [x] `cd .. && python3 .github/scripts/sync-copilot-to-claude.py` runs clean
- [x] `client/CLAUDE.md` regenerates without the boilerplate line