### PR TITLE
6832 show suggested vocab list in activity goal dropdown

### DIFF
--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -10,6 +10,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pages/chat/chat.dart';
+import 'package:fluffychat/pangea/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/pangea/common/widgets/shimmer_background.dart';
 import 'package:fluffychat/pangea/events/event_wrappers/pangea_message_event.dart';
 import 'package:fluffychat/pangea/events/models/pangea_token_model.dart';
@@ -469,6 +470,15 @@ class HtmlMessage extends StatelessWidget {
             !isPracticeMode &&
             isFirstNewToken;
 
+        final vocabLemmas = controller.room.activityPlan?.vocab
+            .map((v) => v.lemma.toLowerCase())
+            .toSet();
+        final isVocabHighlight =
+            pangeaMessageEvent!.ownMessage &&
+            vocabLemmas != null &&
+            token != null &&
+            vocabLemmas.contains(token.lemma.text.toLowerCase());
+
         final tokenWidth = renderer.tokenTextWidthForContainer(
           node.text,
           Theme.of(context).colorScheme.primary.withAlpha(200),
@@ -526,25 +536,39 @@ class HtmlMessage extends StatelessWidget {
                             : null,
                         child: HoverBuilder(
                           builder: (context, hovered) {
+                            final underlineTextWidget = UnderlineText(
+                              text: node.text.trim(),
+                              style: existingStyle,
+                              linkStyle: linkStyle,
+                              textDirection: pangeaMessageEvent?.textDirection,
+                              underlineColor: TokenRenderingUtil.underlineColor(
+                                underlineColor,
+                                selected: selected,
+                                highlighted: highlighted,
+                                isNew: isNew,
+                                practiceMode: isPracticeMode,
+                                hovered: hovered,
+                              ),
+                            );
                             return ShimmerBackground(
                               enabled: showShimmer,
                               borderRadius: BorderRadius.circular(4.0),
-                              child: UnderlineText(
-                                text: node.text.trim(),
-                                style: existingStyle,
-                                linkStyle: linkStyle,
-                                textDirection:
-                                    pangeaMessageEvent?.textDirection,
-                                underlineColor:
-                                    TokenRenderingUtil.underlineColor(
-                                      underlineColor,
-                                      selected: selected,
-                                      highlighted: highlighted,
-                                      isNew: isNew,
-                                      practiceMode: isPracticeMode,
-                                      hovered: hovered,
-                                    ),
-                              ),
+                              child: isVocabHighlight
+                                  ? DecoratedBox(
+                                      decoration: BoxDecoration(
+                                        color: AppConfig.goldLight.withAlpha(
+                                          100,
+                                        ),
+                                        borderRadius: BorderRadius.circular(12),
+                                      ),
+                                      child: Padding(
+                                        padding: const EdgeInsets.symmetric(
+                                          horizontal: 4,
+                                        ),
+                                        child: underlineTextWidget,
+                                      ),
+                                    )
+                                  : underlineTextWidget,
                             );
                           },
                         ),

--- a/lib/pangea/activity_orchestrator/activity_stats_menu.dart
+++ b/lib/pangea/activity_orchestrator/activity_stats_menu.dart
@@ -9,8 +9,10 @@ import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/activity_orchestrator/goal_status_widget.dart';
 import 'package:fluffychat/pangea/activity_orchestrator/orchestrator_room_extension.dart';
+import 'package:fluffychat/pangea/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/pangea/activity_sessions/activity_session_chat/activity_vocab_widget.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_session_constants.dart';
 import 'package:fluffychat/pangea/bot/utils/bot_name.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
@@ -79,6 +81,7 @@ class ActivityStatsMenu extends StatelessWidget {
     final isColumnMode = FluffyThemes.isColumnMode(context);
 
     final goals = room.ownRole?.allGoals ?? [];
+    final ActivityPlanModel? activity = room.activityPlan;
 
     // TODO ORCHESTRATOR: show active goal instead of first goal
     final currentGoal = goals.firstOrNull;
@@ -199,15 +202,25 @@ class ActivityStatsMenu extends StatelessWidget {
                     if (remainingGoals.isNotEmpty)
                       Column(
                         spacing: 16.0,
-                        children: [
-                          ...remainingGoals.map(
-                            (g) => GoalStatusWidget(
-                              goal: g,
-                              complete: room.isGoalCompleted(g.id),
-                            ),
-                          ),
-                        ],
+                        children: remainingGoals
+                            .map(
+                              (g) => GoalStatusWidget(
+                                goal: g,
+                                complete: room.isGoalCompleted(g.id),
+                              ),
+                            )
+                            .toList(),
                       ),
+                    if (activity != null) const Divider(height: 1),
+                    ActivityVocabWidget(
+                      key: ValueKey(
+                        "activity-stats-menu-${activity!.activityId}",
+                      ),
+                      vocab: activity.vocab,
+                      langCode: activity.req.targetLanguage,
+                      targetId: "activity-stats-menu-vocab",
+                      activityLangCode: activity.req.targetLanguage,
+                    ),
                     if (!_activityComplete &&
                         room.hasCompletedRole &&
                         room.hasPickedRole)

--- a/lib/pangea/activity_sessions/activity_session_chat/activity_summary_widget.dart
+++ b/lib/pangea/activity_sessions/activity_session_chat/activity_summary_widget.dart
@@ -108,7 +108,6 @@ class ActivitySummary extends StatelessWidget {
                       vocab: activity.vocab,
                       langCode: activity.req.targetLanguage,
                       targetId: "activity-summary-vocab",
-                      usedVocab: usedVocab,
                       activityLangCode: activity.req.targetLanguage,
                     ),
                   ],

--- a/lib/pangea/activity_sessions/activity_session_chat/activity_vocab_widget.dart
+++ b/lib/pangea/activity_sessions/activity_session_chat/activity_vocab_widget.dart
@@ -23,7 +23,6 @@ class ActivityVocabWidget extends StatelessWidget {
   final String langCode;
   final String targetId;
   final String activityLangCode;
-  final ValueNotifier<Set<String>>? usedVocab;
 
   const ActivityVocabWidget({
     super.key,
@@ -31,7 +30,6 @@ class ActivityVocabWidget extends StatelessWidget {
     required this.langCode,
     required this.targetId,
     required this.activityLangCode,
-    this.usedVocab,
   });
 
   @override
@@ -49,24 +47,12 @@ class ActivityVocabWidget extends StatelessWidget {
             style: Theme.of(context).textTheme.bodyMedium,
           ),
         ),
-        usedVocab == null
-            ? _VocabChips(
-                vocab: vocab,
-                targetId: targetId,
-                langCode: langCode,
-                usedVocab: const {},
-                activityLangCode: activityLangCode,
-              )
-            : ValueListenableBuilder(
-                valueListenable: usedVocab!,
-                builder: (context, used, _) => _VocabChips(
-                  vocab: vocab,
-                  targetId: targetId,
-                  langCode: langCode,
-                  usedVocab: used,
-                  activityLangCode: activityLangCode,
-                ),
-              ),
+        _VocabChips(
+          vocab: vocab,
+          targetId: targetId,
+          langCode: langCode,
+          activityLangCode: activityLangCode,
+        ),
       ],
     );
   }
@@ -77,14 +63,12 @@ class _VocabChips extends StatefulWidget {
   final String targetId;
   final String langCode;
   final String activityLangCode;
-  final Set<String> usedVocab;
 
   const _VocabChips({
     required this.vocab,
     required this.targetId,
     required this.langCode,
     required this.activityLangCode,
-    required this.usedVocab,
   });
 
   @override
@@ -182,7 +166,6 @@ class _VocabChipsState extends State<_VocabChips> with CollectableTokensMixin {
 
           return _VocabChip(
             v: v,
-            isUsed: widget.usedVocab.contains(v.lemma.toLowerCase()),
             isNew: isNew,
             isSelected: _selectedVocab == v,
             onTap: () => _selectVocab(v, isNew: isNew),
@@ -196,7 +179,6 @@ class _VocabChipsState extends State<_VocabChips> with CollectableTokensMixin {
 
 class _VocabChip extends StatelessWidget {
   final Vocab v;
-  final bool isUsed;
   final bool isNew;
   final bool isSelected;
   final VoidCallback onTap;
@@ -204,7 +186,6 @@ class _VocabChip extends StatelessWidget {
 
   const _VocabChip({
     required this.v,
-    required this.isUsed,
     required this.isNew,
     required this.isSelected,
     required this.onTap,
@@ -215,12 +196,7 @@ class _VocabChip extends StatelessWidget {
   Widget build(BuildContext context) {
     final linkAndKey = MatrixState.pAnyState.layerLinkAndKey(target);
 
-    final color = isUsed
-        ? Color.alphaBlend(
-            Theme.of(context).colorScheme.surface.withAlpha(150),
-            AppConfig.gold,
-          )
-        : Theme.of(context).colorScheme.primary.withAlpha(20);
+    final color = Theme.of(context).colorScheme.primary.withAlpha(20);
 
     return CompositedTransformTarget(
       link: linkAndKey.link,


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

Takes highlight out of vocab list, also closes #6831 by highlighting used suggested vocab in messages during activities.

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced vocabulary highlighting in chat messages with shimmer and visual effects
  * Added vocabulary widget display in activity statistics menu when activity plan exists
  * Simplified vocabulary chip color styling for improved visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->