### PR TITLE
chore: make audio match item playback speed match full message speed

### DIFF
--- a/lib/pangea/text_to_speech/tts_controller.dart
+++ b/lib/pangea/text_to_speech/tts_controller.dart
@@ -243,6 +243,7 @@ class TtsController {
     ChatController? chatController,
     VoidCallback? onStart,
     VoidCallback? onStop,
+    double speed = 1.0,
 
     /// When provided, skip device TTS and use choreo with phoneme tags.
     /// If omitted, the PT v2 cache is checked automatically.
@@ -300,6 +301,7 @@ class TtsController {
       onStart: onStart,
       onStop: onStop,
       tid: transactionId,
+      speed: speed,
     );
 
     // Only the active request may clear shared request state.
@@ -323,6 +325,7 @@ class TtsController {
     VoidCallback? onStop,
     String? ttsPhoneme,
     required String tid,
+    double speed = 1.0,
   }) async {
     chatController?.stopMediaStream.add(null);
     MatrixState.pangeaController.matrixState.audioPlayer?.stop();
@@ -364,6 +367,7 @@ class TtsController {
               ? const Duration(seconds: 1)
               : const Duration(seconds: 10),
           tid: tid,
+          speed: speed,
         );
 
         // fallback to device TTS if language is supported but choreo fails (e.g. due to timeout)
@@ -375,6 +379,7 @@ class TtsController {
             [token],
             tid,
             requestId: requestId,
+            speed: speed,
           );
         } else if (!success && !_isCurrentRequestId(requestId)) {
           _log('tryToSpeak: skipped fallback for superseded request', tid);
@@ -390,6 +395,7 @@ class TtsController {
           [token],
           tid,
           requestId: requestId,
+          speed: speed,
         );
       }
     } else if (targetID != null && context != null) {
@@ -405,6 +411,7 @@ class TtsController {
     List<PangeaTokenText> tokens,
     String tid, {
     required int requestId,
+    double speed = 1.0,
   }) async {
     if (!_isCurrentRequestId(requestId)) {
       _log('Skipping device playback for superseded request', tid);
@@ -414,6 +421,7 @@ class TtsController {
     try {
       _log('Speaking from device: $text, langCode: $langCode', tid);
       text = text.toLowerCase();
+      _tts.setSpeechRate(speed);
       await Future(() => (_tts.speak(text)));
       _log('Audio playback from device completed', tid);
       return true;
@@ -433,6 +441,7 @@ class TtsController {
     String? ttsPhoneme,
     Duration timeout = const Duration(seconds: 10),
     required String tid,
+    double speed = 1.0,
   }) async {
     _log('_speakFromChoreo: text="$text" ttsPhoneme=$ttsPhoneme', tid);
     TextToSpeechResponseModel? ttsRes;
@@ -477,6 +486,7 @@ class TtsController {
       }
       requestPlayer = AudioPlayer();
       audioPlayer = requestPlayer;
+      audioPlayer!.setSpeed(speed);
       final player = MultiPlatformAudioPlayer(
         audioPlayer: audioPlayer!,
         bytes: audioContent,

--- a/lib/pangea/toolbar/message_practice/message_audio_card.dart
+++ b/lib/pangea/toolbar/message_practice/message_audio_card.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/pages/chat/events/audio_player.dart';
 import 'package:fluffychat/pangea/analytics_misc/text_loading_shimmer.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/pangea/events/audio_playback_speed_controller.dart';
 import 'package:fluffychat/pangea/events/event_wrappers/pangea_message_event.dart';
 import 'package:fluffychat/pangea/text_to_speech/text_to_speech_response_model.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -17,8 +18,14 @@ import 'package:fluffychat/widgets/matrix.dart';
 class MessageAudioCard extends StatefulWidget {
   final PangeaMessageEvent messageEvent;
   final VoidCallback? onError;
+  final AudioPlaybackSpeedController playbackSpeedController;
 
-  const MessageAudioCard({super.key, required this.messageEvent, this.onError});
+  const MessageAudioCard({
+    super.key,
+    required this.messageEvent,
+    required this.playbackSpeedController,
+    this.onError,
+  });
 
   @override
   MessageAudioCardState createState() => MessageAudioCardState();
@@ -81,6 +88,7 @@ class MessageAudioCardState extends State<MessageAudioCard> {
               linkColor: Theme.of(context).brightness == Brightness.light
                   ? Theme.of(context).colorScheme.primary
                   : Theme.of(context).colorScheme.onPrimary,
+              playbackSpeedController: widget.playbackSpeedController,
             )
           : const SizedBox(),
     );

--- a/lib/pangea/toolbar/message_practice/practice_activity_card.dart
+++ b/lib/pangea/toolbar/message_practice/practice_activity_card.dart
@@ -6,6 +6,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/async_state.dart';
 import 'package:fluffychat/pangea/common/widgets/card_error_widget.dart';
 import 'package:fluffychat/pangea/common/widgets/content_loading_indicator.dart';
+import 'package:fluffychat/pangea/events/audio_playback_speed_controller.dart';
 import 'package:fluffychat/pangea/events/models/pangea_token_model.dart';
 import 'package:fluffychat/pangea/practice_exercises/practice_exercise_model.dart';
 import 'package:fluffychat/pangea/practice_exercises/practice_target.dart';
@@ -40,6 +41,8 @@ class PracticeActivityCardState extends State<PracticeActivityCard> {
   final ValueNotifier<AsyncState<PracticeExerciseModel>> _activityState =
       ValueNotifier(const AsyncState.loading());
 
+  final _playbackSpeedController = AudioPlaybackSpeedController();
+
   @override
   void initState() {
     super.initState();
@@ -58,6 +61,7 @@ class PracticeActivityCardState extends State<PracticeActivityCard> {
   @override
   void dispose() {
     _activityState.dispose();
+    _playbackSpeedController.dispose();
     super.dispose();
   }
 
@@ -113,6 +117,7 @@ class PracticeActivityCardState extends State<PracticeActivityCard> {
                 MatchPracticeExerciseModel() => MatchActivityCard(
                   currentActivity: state.value as MatchPracticeExerciseModel,
                   controller: widget.controller,
+                  playbackSpeedController: _playbackSpeedController,
                 ),
               },
               _ => const SizedBox.shrink(),

--- a/lib/pangea/toolbar/message_practice/practice_match_card.dart
+++ b/lib/pangea/toolbar/message_practice/practice_match_card.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/pangea/common/widgets/choice_animation.dart';
+import 'package:fluffychat/pangea/events/audio_playback_speed_controller.dart';
 import 'package:fluffychat/pangea/practice_exercises/practice_exercise_choice.dart';
 import 'package:fluffychat/pangea/practice_exercises/practice_exercise_model.dart';
 import 'package:fluffychat/pangea/toolbar/message_practice/message_audio_card.dart';
@@ -14,11 +15,13 @@ import 'package:fluffychat/pangea/toolbar/message_practice/practice_match_item.d
 class MatchActivityCard extends StatelessWidget {
   final MatchPracticeExerciseModel currentActivity;
   final PracticeController controller;
+  final AudioPlaybackSpeedController playbackSpeedController;
 
   const MatchActivityCard({
     super.key,
     required this.currentActivity,
     required this.controller,
+    required this.playbackSpeedController,
   });
 
   Widget choiceDisplayContent(
@@ -66,7 +69,10 @@ class MatchActivityCard extends StatelessWidget {
       spacing: 4.0,
       children: [
         if (mode == MessagePracticeMode.listening)
-          MessageAudioCard(messageEvent: controller.pangeaMessageEvent),
+          MessageAudioCard(
+            messageEvent: controller.pangeaMessageEvent,
+            playbackSpeedController: playbackSpeedController,
+          ),
         Wrap(
           alignment: WrapAlignment.center,
           spacing: 4.0,
@@ -96,6 +102,7 @@ class MatchActivityCard extends StatelessWidget {
                     : null,
                 controller: controller,
                 shimmer: controller.showChoiceShimmer,
+                playbackSpeedController: playbackSpeedController,
               ),
             );
           }).toList(),

--- a/lib/pangea/toolbar/message_practice/practice_match_item.dart
+++ b/lib/pangea/toolbar/message_practice/practice_match_item.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/common/widgets/shimmer_background.dart';
+import 'package:fluffychat/pangea/events/audio_playback_speed_controller.dart';
 import 'package:fluffychat/pangea/events/models/pangea_token_model.dart';
 import 'package:fluffychat/pangea/practice_exercises/practice_exercise_choice.dart';
 import 'package:fluffychat/pangea/text_to_speech/tts_controller.dart';
@@ -21,6 +22,7 @@ class PracticeMatchItem extends StatefulWidget {
   final bool? isCorrect;
   final bool isSelected;
   final bool shimmer;
+  final AudioPlaybackSpeedController playbackSpeedController;
 
   const PracticeMatchItem({
     super.key,
@@ -32,6 +34,7 @@ class PracticeMatchItem extends StatefulWidget {
     this.audioContent,
     required this.controller,
     this.shimmer = false,
+    required this.playbackSpeedController,
   });
 
   @override
@@ -76,6 +79,7 @@ class PracticeMatchItemState extends State<PracticeMatchItem> {
             langCode: l2,
             pos: widget.token?.pos,
             morph: widget.token?.morph.map((k, v) => MapEntry(k.name, v)),
+            speed: widget.playbackSpeedController.playbackSpeed.value,
           );
         }
       } catch (e, s) {


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio playback speed control is now available across the application. Users can adjust the playback speed for practice exercises and message audio. The speech rate can be customized to individual preferences, allowing users to control how fast or slow audio content is played back during language practice sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->