### PR TITLE
feat(tts): select known-good device voice before backend fallback

### DIFF
--- a/lib/pangea/text_to_speech/tts_controller.dart
+++ b/lib/pangea/text_to_speech/tts_controller.dart
@@ -19,6 +19,7 @@ import 'package:fluffychat/pangea/languages/language_constants.dart';
 import 'package:fluffychat/pangea/phonetic_transcription/pt_v2_disambiguation.dart';
 import 'package:fluffychat/pangea/phonetic_transcription/pt_v2_repo.dart';
 import 'package:fluffychat/pangea/text_to_speech/text_to_speech_repo.dart';
+import 'package:fluffychat/pangea/text_to_speech/tts_routing.dart';
 import 'package:fluffychat/pangea/text_to_speech/text_to_speech_request_model.dart';
 import 'package:fluffychat/pangea/text_to_speech/text_to_speech_response_model.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
@@ -67,6 +68,12 @@ class _AudioRequest {
 
 class TtsController {
   static List<String> _availableLangCodes = [];
+
+  /// Full voice list from flutter_tts `getVoices`. On native each entry carries
+  /// a `quality` field; on web only `name` + `locale` (the engine drops quality
+  /// and localService). Used to select a known-good device voice before falling
+  /// back to backend TTS. See word-text-to-speech.instructions.md.
+  static List<Map<String, String>> _voices = [];
 
   static final _tts = flutter_tts.FlutterTts();
   static final StreamController<bool> loadingChoreoStream =
@@ -125,15 +132,21 @@ class TtsController {
 
   static Future<void> _setAvailableBaseLanguages() async {
     final voices = (await _tts.getVoices) as List?;
-    _availableLangCodes = (voices ?? [])
+    _voices = (voices ?? []).map<Map<String, String>>((v) {
+      final voice = <String, String>{};
+      (v as Map).forEach((key, value) {
+        voice[key.toString()] = value?.toString() ?? '';
+      });
+      return voice;
+    }).toList();
+    _availableLangCodes = _voices
         .map((v) {
           // on iOS / web, the codes are in 'locale', but on Android, they are in 'name'
-          final nameCode = v['name'];
-          final localeCode = v['locale'];
+          final nameCode = v['name'] ?? '';
+          final localeCode = v['locale'] ?? '';
           return localeCode.contains("-") ? localeCode : nameCode;
         })
         .toSet()
-        .cast<String>()
         .toList();
   }
 
@@ -279,7 +292,10 @@ class TtsController {
     final prevOnStop = _onStop;
     _onStop = onStop;
 
-    if (_availableLangCodes.isEmpty) {
+    // On web, network voices (e.g. "Google Deutsch") load asynchronously and may
+    // be absent from the initial list, so refresh each call. See
+    // word-text-to-speech.instructions.md.
+    if (_availableLangCodes.isEmpty || kIsWeb) {
       await setAvailableLanguages();
     }
 
@@ -346,7 +362,30 @@ class TtsController {
         length: text.length,
       );
 
-      final langSupported = _isLangFullySupported(langCode);
+      final selection = TtsRouting.selectVoice(
+        _voices,
+        langCode,
+        isWeb: kIsWeb,
+      );
+      final isSubscribed =
+          MatrixState.pangeaController.subscriptionController.isSubscribed ==
+          true;
+
+      // Routing gate (see word-text-to-speech.instructions.md): a phoneme
+      // override needs backend; else device when it has a known-good voice;
+      // else backend. Backend is Pro-only, so unsubscribed users stay on device.
+      final useBackend = TtsRouting.useBackend(
+        hasPhoneme: ttsPhoneme != null,
+        selection: selection,
+        isSubscribed: isSubscribed,
+      );
+      _log(
+        'tryToSpeak: route=${useBackend ? "backend" : "device"} '
+        'knownGood=${selection.isKnownGood} hasVoice=${selection.hasVoice} '
+        'voice=${selection.voice?['name']} subscribed=$isSubscribed '
+        'phoneme=$ttsPhoneme',
+        tid,
+      );
 
       onStart?.call();
 
@@ -355,24 +394,24 @@ class TtsController {
         return;
       }
 
-      // When tts_phoneme is provided, skip device TTS and use choreo with phoneme tags.
-      if (ttsPhoneme != null || !langSupported) {
+      if (useBackend) {
         final success = await _speakFromChoreo(
           text,
           langCode,
           [token],
           requestId: requestId,
           ttsPhoneme: ttsPhoneme,
-          timeout: langSupported
+          timeout: selection.hasVoice
               ? const Duration(seconds: 1)
               : const Duration(seconds: 10),
           tid: tid,
           speed: speed,
         );
 
-        // fallback to device TTS if language is supported but choreo fails (e.g. due to timeout)
-        if (!success && langSupported && _isCurrentRequestId(requestId)) {
-          _log('tryToSpeak: speaking from device on choreo failure', tid);
+        // Fall back to a device voice if backend fails (e.g. timeout) and the
+        // device has something to play.
+        if (!success && selection.hasVoice && _isCurrentRequestId(requestId)) {
+          _log('tryToSpeak: speaking from device on backend failure', tid);
           await _speakFromDevice(
             text,
             langCode,
@@ -380,15 +419,12 @@ class TtsController {
             tid,
             requestId: requestId,
             speed: speed,
+            voice: selection.voice,
           );
         } else if (!success && !_isCurrentRequestId(requestId)) {
           _log('tryToSpeak: skipped fallback for superseded request', tid);
         }
       } else {
-        _log(
-          'tryToSpeak: speaking from device, language fully supported, no phoneme provided',
-          tid,
-        );
         await _speakFromDevice(
           text,
           langCode,
@@ -396,6 +432,7 @@ class TtsController {
           tid,
           requestId: requestId,
           speed: speed,
+          voice: selection.voice,
         );
       }
     } else if (targetID != null && context != null) {
@@ -412,6 +449,10 @@ class TtsController {
     String tid, {
     required int requestId,
     double speed = 1.0,
+
+    /// The device voice to use, as `{name, locale}`. When omitted, the engine's
+    /// default voice for the language (set via `_setSpeakingLanguage`) is used.
+    Map<String, String>? voice,
   }) async {
     if (!_isCurrentRequestId(requestId)) {
       _log('Skipping device playback for superseded request', tid);
@@ -419,7 +460,13 @@ class TtsController {
     }
 
     try {
-      _log('Speaking from device: $text, langCode: $langCode', tid);
+      _log(
+        'Speaking from device: $text, langCode: $langCode, voice: ${voice?['name']}',
+        tid,
+      );
+      if (voice != null && (voice['name']?.isNotEmpty ?? false)) {
+        await _tts.setVoice(voice);
+      }
       text = text.toLowerCase();
       _tts.setSpeechRate(speed);
       await Future(() => (_tts.speak(text)));
@@ -529,16 +576,4 @@ class TtsController {
     }
   }
 
-  static bool _isLangFullySupported(String langCode) {
-    if (_availableLangCodes.contains(langCode)) {
-      return true;
-    }
-
-    final langCodeShort = langCode.split("-").first;
-    if (langCodeShort.isEmpty) {
-      return false;
-    }
-
-    return _availableLangCodes.any((lang) => lang.startsWith(langCodeShort));
-  }
 }

--- a/lib/pangea/text_to_speech/tts_routing.dart
+++ b/lib/pangea/text_to_speech/tts_routing.dart
@@ -1,0 +1,140 @@
+import 'package:collection/collection.dart';
+
+/// Result of choosing the best device voice for a language.
+///
+/// [voice] is the `{name, locale}` to pass to `flutter_tts.setVoice`, or null
+/// when the device offers no voice for the language. [isKnownGood] means the
+/// voice clears the quality bar so we can skip backend TTS. [hasVoice] is false
+/// only when there is no device voice at all.
+class TtsVoiceSelection {
+  final Map<String, String>? voice;
+  final bool isKnownGood;
+  final bool hasVoice;
+
+  const TtsVoiceSelection({
+    required this.voice,
+    required this.isKnownGood,
+    required this.hasVoice,
+  });
+}
+
+/// Pure device-vs-backend routing logic for word-level TTS, with no dependency
+/// on `flutter_tts`, the network, or app state, so it is unit-testable.
+///
+/// See client/.github/instructions/word-text-to-speech.instructions.md for the
+/// design (known-good-voice gate, web name patterns, native quality field).
+class TtsRouting {
+  /// Web-only: voice-name markers that reliably indicate a high-quality voice.
+  /// flutter_tts surfaces only the name on web (it drops `quality`,
+  /// `localService`, and `voiceURI`), so the name is the sole signal. Broad
+  /// vendor conventions, matched case-insensitively as substrings.
+  static const List<String> webGoodVoiceNamePatterns = [
+    'google', // Chrome network voices, e.g. "Google Deutsch"
+    'online (natural)', // Edge neural voices
+    '(enhanced)', // downloaded Apple voices
+    '(premium)',
+  ];
+
+  /// Web-only: specific voice names to never treat as good even if they match a
+  /// pattern above. Empty for now; add field-reported bad voices here.
+  static const List<String> webExcludedVoiceNames = [];
+
+  /// Native quality rank at/above which a device voice is "known-good" and we
+  /// skip backend. iOS `enhanced`/`premium` and Android `high`/`very high`.
+  static const int nativeGoodQualityRank = 4;
+
+  /// Pick the best device voice for [langCode] from [voices] (the shape returned
+  /// by `flutter_tts.getVoices`). [isWeb] selects the signal: name patterns on
+  /// web, the `quality` field on native.
+  static TtsVoiceSelection selectVoice(
+    List<Map<String, String>> voices,
+    String langCode, {
+    required bool isWeb,
+  }) {
+    final target = langCode.toLowerCase();
+    final short = target.split('-').first;
+    final candidates = voices.where((v) {
+      final loc = (v['locale'] ?? '').toLowerCase();
+      return loc == target || (short.isNotEmpty && loc.startsWith(short));
+    }).toList();
+
+    if (candidates.isEmpty) {
+      return const TtsVoiceSelection(
+        voice: null,
+        isKnownGood: false,
+        hasVoice: false,
+      );
+    }
+
+    Map<String, String> key(Map<String, String> v) => {
+      'name': v['name'] ?? '',
+      'locale': v['locale'] ?? '',
+    };
+
+    if (isWeb) {
+      final good = candidates.firstWhereOrNull(
+        (v) => isGoodWebVoiceName(v['name'] ?? ''),
+      );
+      return TtsVoiceSelection(
+        voice: key(good ?? candidates.first),
+        isKnownGood: good != null,
+        hasVoice: true,
+      );
+    }
+
+    candidates.sort(
+      (a, b) => qualityRank(b['quality']).compareTo(qualityRank(a['quality'])),
+    );
+    final best = candidates.first;
+    return TtsVoiceSelection(
+      voice: key(best),
+      isKnownGood: qualityRank(best['quality']) >= nativeGoodQualityRank,
+      hasVoice: true,
+    );
+  }
+
+  /// Whether the request should go to backend TTS rather than the device.
+  ///
+  /// A phoneme override needs backend (device can't render phonemes); otherwise
+  /// the device is used when it offers a known-good voice. Backend TTS is
+  /// Pro-only, so unsubscribed users always stay on device regardless.
+  static bool useBackend({
+    required bool hasPhoneme,
+    required TtsVoiceSelection selection,
+    required bool isSubscribed,
+  }) {
+    if (hasPhoneme) return isSubscribed;
+    if (!selection.hasVoice) return isSubscribed;
+    if (selection.isKnownGood) return false;
+    return isSubscribed;
+  }
+
+  static bool isGoodWebVoiceName(String name) {
+    final lower = name.toLowerCase();
+    if (webExcludedVoiceNames.any((n) => n.toLowerCase() == lower)) {
+      return false;
+    }
+    return webGoodVoiceNamePatterns.any(lower.contains);
+  }
+
+  static int qualityRank(String? quality) {
+    switch ((quality ?? '').toLowerCase()) {
+      case 'premium': // iOS
+      case 'very high': // Android
+        return 5;
+      case 'enhanced': // iOS
+      case 'high': // Android
+        return 4;
+      case 'normal': // Android
+        return 3;
+      case 'default': // iOS
+        return 2;
+      case 'low': // Android
+        return 1;
+      case 'very low': // Android
+        return 0;
+      default:
+        return 2;
+    }
+  }
+}

--- a/test/pangea/text_to_speech/tts_routing_test.dart
+++ b/test/pangea/text_to_speech/tts_routing_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/text_to_speech/tts_routing.dart';
+
+// Unit tests for the pure device-vs-backend routing logic.
+// Design: client/.github/instructions/word-text-to-speech.instructions.md
+
+Map<String, String> _voice(String name, String locale, {String? quality}) {
+  final voice = {'name': name, 'locale': locale};
+  if (quality != null) voice['quality'] = quality;
+  return voice;
+}
+
+void main() {
+  group('qualityRank', () {
+    test('iOS tiers', () {
+      expect(TtsRouting.qualityRank('premium'), 5);
+      expect(TtsRouting.qualityRank('enhanced'), 4);
+      expect(TtsRouting.qualityRank('default'), 2);
+    });
+
+    test('Android tiers (note the spaces)', () {
+      expect(TtsRouting.qualityRank('very high'), 5);
+      expect(TtsRouting.qualityRank('high'), 4);
+      expect(TtsRouting.qualityRank('normal'), 3);
+      expect(TtsRouting.qualityRank('low'), 1);
+      expect(TtsRouting.qualityRank('very low'), 0);
+    });
+
+    test('case-insensitive and unknown/null default to mid', () {
+      expect(TtsRouting.qualityRank('ENHANCED'), 4);
+      expect(TtsRouting.qualityRank(null), 2);
+      expect(TtsRouting.qualityRank(''), 2);
+      expect(TtsRouting.qualityRank('something-weird'), 2);
+    });
+
+    test('good threshold is enhanced/high and above', () {
+      expect(TtsRouting.qualityRank('enhanced'), greaterThanOrEqualTo(TtsRouting.nativeGoodQualityRank));
+      expect(TtsRouting.qualityRank('high'), greaterThanOrEqualTo(TtsRouting.nativeGoodQualityRank));
+      expect(TtsRouting.qualityRank('normal'), lessThan(TtsRouting.nativeGoodQualityRank));
+      expect(TtsRouting.qualityRank('default'), lessThan(TtsRouting.nativeGoodQualityRank));
+    });
+  });
+
+  group('isGoodWebVoiceName', () {
+    test('matches known-good vendor markers', () {
+      expect(TtsRouting.isGoodWebVoiceName('Google Deutsch'), isTrue);
+      expect(TtsRouting.isGoodWebVoiceName('Microsoft Seraphina Online (Natural)'), isTrue);
+      expect(TtsRouting.isGoodWebVoiceName('Anna (Enhanced)'), isTrue);
+      expect(TtsRouting.isGoodWebVoiceName('Anna (Premium)'), isTrue);
+    });
+
+    test('rejects flat / novelty voices', () {
+      expect(TtsRouting.isGoodWebVoiceName('Anna'), isFalse);
+      expect(TtsRouting.isGoodWebVoiceName('Helena'), isFalse);
+      expect(TtsRouting.isGoodWebVoiceName('Grandpa (German (Germany))'), isFalse);
+    });
+
+    test('is case-insensitive', () {
+      expect(TtsRouting.isGoodWebVoiceName('GOOGLE DEUTSCH'), isTrue);
+    });
+  });
+
+  group('selectVoice — web (name patterns)', () {
+    final germanVoices = [
+      _voice('Anna', 'de-DE'),
+      _voice('Helena', 'de-DE'),
+      _voice('Google Deutsch', 'de-DE'),
+    ];
+
+    test('picks the good-named voice over flat ones', () {
+      final s = TtsRouting.selectVoice(germanVoices, 'de-DE', isWeb: true);
+      expect(s.hasVoice, isTrue);
+      expect(s.isKnownGood, isTrue);
+      expect(s.voice?['name'], 'Google Deutsch');
+    });
+
+    test('only flat voices: hasVoice but not known-good, falls to first candidate', () {
+      final s = TtsRouting.selectVoice(
+        [_voice('Anna', 'de-DE'), _voice('Helena', 'de-DE')],
+        'de-DE',
+        isWeb: true,
+      );
+      expect(s.hasVoice, isTrue);
+      expect(s.isKnownGood, isFalse);
+      expect(s.voice?['name'], 'Anna');
+    });
+
+    test('no voice for the language', () {
+      final s = TtsRouting.selectVoice(germanVoices, 'el-GR', isWeb: true);
+      expect(s.hasVoice, isFalse);
+      expect(s.isKnownGood, isFalse);
+      expect(s.voice, isNull);
+    });
+
+    test('matches by base-language prefix and bare code', () {
+      expect(TtsRouting.selectVoice(germanVoices, 'de', isWeb: true).isKnownGood, isTrue);
+      expect(TtsRouting.selectVoice(germanVoices, 'DE-de', isWeb: true).hasVoice, isTrue);
+    });
+
+    test('web ignores the quality field entirely', () {
+      // A high-quality flat-named voice is still not "good" on web.
+      final s = TtsRouting.selectVoice(
+        [_voice('Anna', 'de-DE', quality: 'very high')],
+        'de-DE',
+        isWeb: true,
+      );
+      expect(s.isKnownGood, isFalse);
+    });
+  });
+
+  group('selectVoice — native (quality field)', () {
+    test('picks highest-quality voice and marks it good', () {
+      final s = TtsRouting.selectVoice(
+        [
+          _voice('Anna', 'de-DE', quality: 'default'),
+          _voice('Markus', 'de-DE', quality: 'enhanced'),
+        ],
+        'de-DE',
+        isWeb: false,
+      );
+      expect(s.voice?['name'], 'Markus');
+      expect(s.isKnownGood, isTrue);
+    });
+
+    test('only low-tier voices: has voice but not good', () {
+      final s = TtsRouting.selectVoice(
+        [
+          _voice('Anna', 'de-DE', quality: 'default'),
+          _voice('Eddy', 'de-DE', quality: 'low'),
+        ],
+        'de-DE',
+        isWeb: false,
+      );
+      expect(s.hasVoice, isTrue);
+      expect(s.isKnownGood, isFalse);
+      expect(s.voice?['name'], 'Anna'); // 'default'(2) outranks 'low'(1)
+    });
+
+    test('native ignores the name patterns', () {
+      // A Google-named voice with no/low quality is not auto-good on native.
+      final s = TtsRouting.selectVoice(
+        [_voice('Google Deutsch', 'de-DE', quality: 'low')],
+        'de-DE',
+        isWeb: false,
+      );
+      expect(s.isKnownGood, isFalse);
+    });
+  });
+
+  group('useBackend', () {
+    const good = TtsVoiceSelection(
+      voice: {'name': 'Google Deutsch', 'locale': 'de-DE'},
+      isKnownGood: true,
+      hasVoice: true,
+    );
+    const flat = TtsVoiceSelection(
+      voice: {'name': 'Anna', 'locale': 'de-DE'},
+      isKnownGood: false,
+      hasVoice: true,
+    );
+    const none = TtsVoiceSelection(voice: null, isKnownGood: false, hasVoice: false);
+
+    test('known-good device voice → device, regardless of subscription', () {
+      expect(TtsRouting.useBackend(hasPhoneme: false, selection: good, isSubscribed: true), isFalse);
+      expect(TtsRouting.useBackend(hasPhoneme: false, selection: good, isSubscribed: false), isFalse);
+    });
+
+    test('flat device voice → backend only if subscribed', () {
+      expect(TtsRouting.useBackend(hasPhoneme: false, selection: flat, isSubscribed: true), isTrue);
+      expect(TtsRouting.useBackend(hasPhoneme: false, selection: flat, isSubscribed: false), isFalse);
+    });
+
+    test('no device voice → backend only if subscribed', () {
+      expect(TtsRouting.useBackend(hasPhoneme: false, selection: none, isSubscribed: true), isTrue);
+      expect(TtsRouting.useBackend(hasPhoneme: false, selection: none, isSubscribed: false), isFalse);
+    });
+
+    test('phoneme override → backend if subscribed, even with a good device voice', () {
+      expect(TtsRouting.useBackend(hasPhoneme: true, selection: good, isSubscribed: true), isTrue);
+      // free user cannot use backend, so a phoneme request falls through to device
+      expect(TtsRouting.useBackend(hasPhoneme: true, selection: good, isSubscribed: false), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What
Word-level TTS now picks the best device voice and uses it, falling back to backend (Google Cloud) TTS only when the device has no good voice — instead of letting the engine play its (often flat) default.

- New pure, unit-tested [`TtsRouting`](lib/pangea/text_to_speech/tts_routing.dart): voice selection + device-vs-backend gate.
- [`TtsController`](lib/pangea/text_to_speech/tts_controller.dart) now captures the full voice list, selects via `TtsRouting`, and **explicitly `setVoice`s** the chosen voice.

## Why
Closes #6871. Root cause (confirmed by ear): the app called `setLanguage` and let the engine pick its default voice, so German played a flat Apple voice even though Chrome's good `Google Deutsch` was installed but unselected.

Gate (see design doc PR #6883):
- **Native (iOS/Android):** `getVoices` `quality` field — good = iOS `enhanced`/`premium`, Android `high`/`very high`.
- **Web (Chrome/Safari/Edge):** no quality field, so infer from the voice name (`google`, `online (natural)`, `(enhanced)`, `(premium)`); patterns hardcoded client-side, safe fallback to backend on a miss.
- **Phoneme overrides** → backend (device can't render phonemes).
- **Pro:** backend is entitlement-gated, so voice selection helps everyone (incl. free users); only the backend fallback is Pro. Unsubscribed users stay on device (no 401).
- Pure client change — no choreographer/CMS work, no per-language matrix.

Related: design doc in #6883.

## Testing
- **Unit:** new `test/pangea/text_to_speech/tts_routing_test.dart` (19 tests) — quality-rank mapping, web name-pattern matching, voice selection (web/native, prefix matching, no-voice), and the full routing gate. All pass.
- **Full suite:** `flutter test` has 54 pre-existing failures in unrelated files (e.g. `tutorial_state_test`); confirmed identical on clean `main` with this change stashed. Nothing in this change is referenced by them.
- **Manual (web):** served locally, opened in Chrome with `Google Deutsch` present; tapping a German word logs `route=device … voice=Google Deutsch` and sounds correct (the A/B difference is large).
- **Integration (mock backend):** not added. The client has no mock-backend harness for TTS, `integration_test/` isn't in CI, and the Playwright tier runs against staging and can't introspect device-vs-backend. The decision logic is fully unit-covered and the controller wiring is manually verified on web, so a bespoke mock harness would be low-ROI and fragile. Flagging rather than silently skipping.
- **Native quality-field path:** built but not device-tested (only web verified).

## Deploy Notes
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced voice selection across iOS, Android, and web platforms with improved quality ranking.
  * Intelligent routing between device and backend text-to-speech playback based on voice availability and subscription status.
  * Added automatic fallback from backend to device playback when needed.

* **Tests**
  * Added comprehensive test coverage for voice selection and routing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->