### PR TITLE
chore: add input field length limits

### DIFF
--- a/lib/pages/chat_details/chat_details.dart
+++ b/lib/pages/chat_details/chat_details.dart
@@ -134,6 +134,7 @@ class ChatDetailsController extends State<ChatDetails>
       title: room.isSpace
           ? L10n.of(context).changeTheNameOfTheClass
           : L10n.of(context).changeTheNameOfTheChat,
+      maxLength: 64,
       // Pangea#
       okLabel: L10n.of(context).ok,
       cancelLabel: L10n.of(context).cancel,

--- a/lib/pages/settings_3pid/settings_3pid.dart
+++ b/lib/pages/settings_3pid/settings_3pid.dart
@@ -28,6 +28,9 @@ class Settings3PidController extends State<Settings3Pid> {
       cancelLabel: L10n.of(context).cancel,
       hintText: L10n.of(context).enterAnEmailAddress,
       keyboardType: TextInputType.emailAddress,
+      // #Pangea
+      maxLength: 254,
+      // Pangea#
     );
     if (input == null) return;
     final clientSecret = DateTime.now().millisecondsSinceEpoch.toString();

--- a/lib/pages/settings_password/settings_password_view.dart
+++ b/lib/pages/settings_password/settings_password_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pages/settings_password/settings_password.dart';
@@ -60,6 +61,9 @@ class SettingsPasswordView extends StatelessWidget {
                     labelText: L10n.of(context).repeatPassword,
                     errorText: controller.newPassword2Error,
                   ),
+                  // #Pangea
+                  inputFormatters: [LengthLimitingTextInputFormatter(128)],
+                  // Pangea#
                 ),
                 const SizedBox(height: 32),
                 SizedBox(

--- a/lib/pages/settings_security/settings_security.dart
+++ b/lib/pages/settings_security/settings_security.dart
@@ -98,6 +98,9 @@ class SettingsSecurityController extends State<SettingsSecurity> {
       isDestructive: true,
       okLabel: L10n.of(context).delete,
       cancelLabel: L10n.of(context).cancel,
+      // #Pangea
+      maxLength: 128,
+      // Pangea#
     );
     if (mxid == null || mxid.isEmpty || mxid != supposedMxid) {
       return;

--- a/lib/pangea/course_creation/public_course_preview_view.dart
+++ b/lib/pangea/course_creation/public_course_preview_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:matrix/matrix.dart';
 
@@ -216,6 +217,9 @@ class PublicCoursePreviewView extends StatelessWidget {
                                   hintText: L10n.of(context).enterCodeToJoin,
                                 ),
                                 onSubmitted: controller.joinWithCode,
+                                inputFormatters: [
+                                  LengthLimitingTextInputFormatter(10),
+                                ],
                               ),
                               Row(
                                 spacing: 8.0,

--- a/lib/pangea/course_plans/course_code_page.dart
+++ b/lib/pangea/course_plans/course_code_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
@@ -98,6 +99,7 @@ class CourseCodePageState extends State<CourseCodePage> {
                         hintText: L10n.of(context).courseCodeHint,
                       ),
                       onFieldSubmitted: (_) => _submit(),
+                      inputFormatters: [LengthLimitingTextInputFormatter(10)],
                     ),
                     ElevatedButton(
                       onPressed: _code.isNotEmpty ? _submit : null,

--- a/lib/pangea/login/pages/pangea_login_view.dart
+++ b/lib/pangea/login/pages/pangea_login_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pages/login/login.dart';
@@ -59,6 +60,9 @@ class PasswordLoginView extends StatelessWidget {
                           controller: controller.usernameController,
                           onTapOutside: (_) =>
                               FocusManager.instance.primaryFocus?.unfocus(),
+                          inputFormatters: [
+                            LengthLimitingTextInputFormatter(128),
+                          ],
                         ),
                         Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
@@ -95,6 +99,9 @@ class PasswordLoginView extends StatelessWidget {
                               ),
                               onTapOutside: (_) =>
                                   FocusManager.instance.primaryFocus?.unfocus(),
+                              inputFormatters: [
+                                LengthLimitingTextInputFormatter(128),
+                              ],
                             ),
                             TextButton(
                               onPressed:

--- a/lib/pangea/login/pages/signup_with_email_view.dart
+++ b/lib/pangea/login/pages/signup_with_email_view.dart
@@ -1,6 +1,7 @@
 // Flutter imports:
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'signup.dart';
@@ -51,6 +52,7 @@ class SignupWithEmailView extends StatelessWidget {
                     controller: controller.usernameController,
                     onTapOutside: (_) =>
                         FocusManager.instance.primaryFocus?.unfocus(),
+                    inputFormatters: [LengthLimitingTextInputFormatter(128)],
                   ),
                   TextFormField(
                     textInputAction: TextInputAction.next,
@@ -62,6 +64,7 @@ class SignupWithEmailView extends StatelessWidget {
                     ),
                     onTapOutside: (_) =>
                         FocusManager.instance.primaryFocus?.unfocus(),
+                    inputFormatters: [LengthLimitingTextInputFormatter(254)],
                   ),
                   TextFormField(
                     textInputAction: TextInputAction.done,
@@ -86,6 +89,7 @@ class SignupWithEmailView extends StatelessWidget {
                     ),
                     onTapOutside: (_) =>
                         FocusManager.instance.primaryFocus?.unfocus(),
+                    inputFormatters: [LengthLimitingTextInputFormatter(128)],
                   ),
                   ElevatedButton(
                     onPressed: controller.enableSignUp

--- a/lib/pangea/onboarding/onboarding_step_views/course_code_step_view.dart
+++ b/lib/pangea/onboarding/onboarding_step_views/course_code_step_view.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/bot/widgets/bot_face_svg.dart';
@@ -83,6 +84,7 @@ class CourseCodeStepViewState extends State<CourseCodeStepView> {
                   ? Icon(Icons.error, color: theme.colorScheme.error)
                   : null,
             ),
+            inputFormatters: [LengthLimitingTextInputFormatter(10)],
           ),
         ],
       ),

--- a/lib/pangea/onboarding/onboarding_step_views/custom_course_step_view.dart
+++ b/lib/pangea/onboarding/onboarding_step_views/custom_course_step_view.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/onboarding/onboarding_steps/custom_course_onboarding_step.dart';
@@ -99,10 +100,12 @@ class CustomCourseStepViewState extends State<CustomCourseStepView> {
           TextField(
             controller: _nameController,
             decoration: InputDecoration(hintText: L10n.of(context).name),
+            inputFormatters: [LengthLimitingTextInputFormatter(254)],
           ),
           TextField(
             controller: _institutionController,
             decoration: InputDecoration(hintText: L10n.of(context).institution),
+            inputFormatters: [LengthLimitingTextInputFormatter(254)],
           ),
           TextField(
             controller: _goalsController,

--- a/lib/utils/uia_request_manager.dart
+++ b/lib/utils/uia_request_manager.dart
@@ -40,6 +40,9 @@ extension UiaRequestManager on MatrixState {
                 maxLines: 1,
                 obscureText: true,
                 hintText: '******',
+                // #Pangea
+                maxLength: 128,
+                // Pangea#
               ));
           if (input == null || input.isEmpty) {
             return uiaRequest.cancel();


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented character limits on text input fields across the application to improve data consistency and prevent excessively long entries in chat names, passwords, usernames, emails, course codes, and institution fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->