### PR TITLE
chore: remove divider and vocab display from activity dropdown menu

### DIFF
--- a/lib/pangea/activity_orchestrator/activity_stats_menu.dart
+++ b/lib/pangea/activity_orchestrator/activity_stats_menu.dart
@@ -9,10 +9,8 @@ import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/activity_orchestrator/goal_status_widget.dart';
 import 'package:fluffychat/pangea/activity_orchestrator/orchestrator_room_extension.dart';
-import 'package:fluffychat/pangea/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_room_extension.dart';
-import 'package:fluffychat/pangea/activity_sessions/activity_session_chat/activity_vocab_widget.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_session_constants.dart';
 import 'package:fluffychat/pangea/bot/utils/bot_name.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
@@ -91,7 +89,6 @@ class ActivityStatsMenu extends StatelessWidget {
     final isColumnMode = FluffyThemes.isColumnMode(context);
 
     final goals = room.ownRole?.allGoals ?? [];
-    final ActivityPlanModel? activity = room.activityPlan;
 
     // TODO ORCHESTRATOR: show active goal instead of first goal
     final currentGoal = goals.firstOrNull;
@@ -221,16 +218,6 @@ class ActivityStatsMenu extends StatelessWidget {
                             )
                             .toList(),
                       ),
-                    if (activity != null) const Divider(height: 1),
-                    ActivityVocabWidget(
-                      key: ValueKey(
-                        "activity-stats-menu-${activity!.activityId}",
-                      ),
-                      vocab: activity.vocab,
-                      langCode: activity.req.targetLanguage,
-                      targetId: "activity-stats-menu-vocab",
-                      activityLangCode: activity.req.targetLanguage,
-                    ),
                     if (_showWaitNotDone)
                       ElevatedButton(
                         onPressed: room.continueActivity,


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated activity stats menu to display current and remaining goals instead of activity vocabulary information, providing clearer focus on goal tracking during activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->