### PR TITLE
chore: Use activity titles in saved activity list

### DIFF
--- a/lib/pangea/analytics_page/activity_archive.dart
+++ b/lib/pangea/analytics_page/activity_archive.dart
@@ -134,7 +134,10 @@ class AnalyticsActivityItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final objective = room.activityPlan?.learningObjective ?? '';
+    final activity = room.activityPlan;
+    final title = activity?.title ?? '';
+    final objective = activity?.learningObjective ?? '';
+
     final cefrLevel = room.activitySummaryByL1?.summary?.participants
         .firstWhereOrNull((p) => p.participantId == room.client.userID)
         ?.cefrLevel;
@@ -161,11 +164,20 @@ class AnalyticsActivityItem extends StatelessWidget {
               ),
             ),
           ),
-          title: Text(
-            objective,
-            maxLines: 3,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(fontSize: 12.0),
+          title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
+          subtitle: Row(
+            crossAxisAlignment: .start,
+            mainAxisAlignment: .center,
+            children: [
+              Expanded(
+                child: Text(
+                  objective,
+                  style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
           ),
           trailing: cefrLevel != null
               ? Padding(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated activity item display in analytics archive: activity titles now appear with single-line truncation, while learning objectives are shown as styled subtitles with multi-line support (up to 2 lines).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->