### PR TITLE
set "Open" color to primary

### DIFF
--- a/lib/pangea/activity_sessions/activity_participant_indicator.dart
+++ b/lib/pangea/activity_sessions/activity_participant_indicator.dart
@@ -122,9 +122,9 @@ class ActivityParticipantIndicator extends StatelessWidget {
                                 (Theme.of(context).brightness ==
                                     Brightness.light
                                 ? (userId?.localpart?.darkColor ??
-                                      name.darkColor)
+                                      theme.colorScheme.primary)
                                 : (userId?.localpart?.lightColorText ??
-                                      name.lightColorText)),
+                                      theme.colorScheme.primary)),
                           ),
                           textAlign: TextAlign.center,
                           maxLines: 1,


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text color logic in the activity participant indicator to use the theme's primary color scheme instead of custom colors for better consistency with app theming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->