### PR TITLE
fix: prevent user from setting avatar with invalid file type

### DIFF
--- a/lib/pages/settings/settings.dart
+++ b/lib/pages/settings/settings.dart
@@ -4,7 +4,9 @@ import 'package:collection/collection.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:matrix/matrix.dart';
+import 'package:mime/mime.dart';
 
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/authentication/p_logout.dart';
 import 'package:fluffychat/utils/file_selector.dart';
@@ -156,6 +158,19 @@ class SettingsController extends State<Settings> {
         name: pickedFile.name,
       );
     }
+    // #Pangea
+    final resp = await showFutureLoadingDialog(
+      context: context,
+      future: () async {
+        final bytes = file.bytes;
+        final mimeType = lookupMimeType(file.name, headerBytes: bytes);
+        if (!AppConfig.allowedMimeTypes.contains(mimeType)) {
+          throw L10n.of(context).invalidInput;
+        }
+      },
+    );
+    if (resp.isError) return;
+    // Pangea#
     final success = await showFutureLoadingDialog(
       context: context,
       future: () => matrix.client.setAvatar(file),

--- a/lib/pangea/user/user_home_page.dart
+++ b/lib/pangea/user/user_home_page.dart
@@ -4,7 +4,9 @@ import 'package:collection/collection.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:matrix/matrix.dart';
+import 'package:mime/mime.dart';
 
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pages/settings/settings.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -119,6 +121,19 @@ class _UserHomePageState extends State<UserHomePage> {
         name: pickedFile.name,
       );
     }
+
+    final resp = await showFutureLoadingDialog(
+      context: context,
+      future: () async {
+        final bytes = file.bytes;
+        final mimeType = lookupMimeType(file.name, headerBytes: bytes);
+        if (!AppConfig.allowedMimeTypes.contains(mimeType)) {
+          throw L10n.of(context).invalidInput;
+        }
+      },
+    );
+    if (resp.isError) return;
+
     final success = await showFutureLoadingDialog(
       context: context,
       future: () => matrix.client.setAvatar(file),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS