### PR TITLE
6678 make activity target stand out more and feel like conversation prompts

### DIFF
--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -3604,7 +3604,6 @@
     "inactive": "غير نشط",
     "confirmRole": "تأكيد الدور",
     "openRoleLabel": "مفتوح",
-    "joinedTheActivity": "👋 {username} انضم كـ {role}",
     "finishedTheActivity": "🎯 {username} أنهى هذا النشاط",
     "activitySummaryError": "ملخصات النشاط غير متوفرة",
     "requestSummaries": "طلب الملخصات",
@@ -6758,17 +6757,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_be.arb
+++ b/lib/l10n/intl_be.arb
@@ -3839,7 +3839,6 @@
     "inactive": "Неактыўны",
     "confirmRole": "Пацвердзіць ролю",
     "openRoleLabel": "АДКРЫТА",
-    "joinedTheActivity": "👋 {username} далучыўся як {role}",
     "finishedTheActivity": "🎯 {username} завяршыў гэтую дзейнасць",
     "activitySummaryError": "Зводкі дзейнасці недаступныя",
     "requestSummaries": "Запытаць зводкі",
@@ -6656,17 +6655,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_bn.arb
+++ b/lib/l10n/intl_bn.arb
@@ -3287,7 +3287,6 @@
     "inactive": "অচল",
     "confirmRole": "ভূমিকা নিশ্চিত করুন",
     "openRoleLabel": "খোলা",
-    "joinedTheActivity": "👋 {username} {role} হিসেবে যোগ দিয়েছেন",
     "finishedTheActivity": "🎯 {username} এই কার্যক্রম শেষ করেছেন",
     "activitySummaryError": "কার্যক্রমের সারাংশ উপলব্ধ নয়",
     "requestSummaries": "সারাংশের জন্য অনুরোধ করুন",
@@ -7133,17 +7132,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_bo.arb
+++ b/lib/l10n/intl_bo.arb
@@ -3119,7 +3119,6 @@
     "inactive": "མིན་ལུས་",
     "confirmRole": "ལས་ཀ་རྟག་པ་འབད།",
     "openRoleLabel": "གཙོ་བོ",
-    "joinedTheActivity": "👋 {username} ལས་སྤྱོད་འདི་ལ་ལོག་འགྱོ། {role}",
     "finishedTheActivity": "🎯 {username} འདི་ལ་སྤྱོད་འདུག",
     "activitySummaryError": "ལས་ཀ་རྒྱབ་སྤྱོད་འབད་མི་ཚུལ།",
     "requestSummaries": "ལོག་ལ་དབྱར་བ་འདི་ལ་བཀོད་རོགས།",
@@ -6500,17 +6499,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_ca.arb
+++ b/lib/l10n/intl_ca.arb
@@ -3690,7 +3690,6 @@
     "inactive": "Inactiu",
     "confirmRole": "Confirma el rol",
     "openRoleLabel": "OBERT",
-    "joinedTheActivity": "👋 {username} s'ha unit com a {role}",
     "finishedTheActivity": "🎯 {username} ha finalitzat aquesta activitat",
     "activitySummaryError": "Resum d'activitats no disponible",
     "requestSummaries": "Sol·licitar resums",
@@ -6569,17 +6568,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -3378,7 +3378,6 @@
     "inactive": "Neaktivní",
     "confirmRole": "Potvrdit roli",
     "openRoleLabel": "Otevřeno",
-    "joinedTheActivity": "👋 {username} se připojil jako {role}",
     "finishedTheActivity": "🎯 {username} ukončil tuto aktivitu",
     "activitySummaryError": "Souhrny aktivit nejsou k dispozici",
     "requestSummaries": "Požádat o souhrny",
@@ -6986,17 +6985,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_da.arb
+++ b/lib/l10n/intl_da.arb
@@ -1383,7 +1383,6 @@
     "inactive": "Inaktiv",
     "confirmRole": "Bekræft rolle",
     "openRoleLabel": "ÅBEN",
-    "joinedTheActivity": "👋 {username} deltog som {role}",
     "finishedTheActivity": "🎯 {username} afsluttede denne aktivitet",
     "activitySummaryError": "Aktivitetsoversigter er ikke tilgængelige",
     "requestSummaries": "Anmod om oversigter",
@@ -7512,17 +7511,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -3881,7 +3881,6 @@
     "inactive": "Inaktiv",
     "confirmRole": "Rolle bestätigen",
     "openRoleLabel": "OFFEN",
-    "joinedTheActivity": "👋 {username} ist als {role} beigetreten",
     "finishedTheActivity": "🎯 {username} hat diese Aktivität beendet",
     "activitySummaryError": "Aktivitätszusammenfassungen nicht verfügbar",
     "requestSummaries": "Zusammenfassungen anfordern",
@@ -6688,17 +6687,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_el.arb
+++ b/lib/l10n/intl_el.arb
@@ -3677,7 +3677,6 @@
     "inactive": "Ανενεργό",
     "confirmRole": "Επιβεβαίωση ρόλου",
     "openRoleLabel": "ΑΝΟΙΧΤΟ",
-    "joinedTheActivity": "👋 {username} συμμετείχε ως {role}",
     "finishedTheActivity": "🎯 {username} ολοκλήρωσε αυτήν τη δραστηριότητα",
     "activitySummaryError": "Οι περιλήψεις δραστηριοτήτων δεν είναι διαθέσιμες",
     "requestSummaries": "Αιτήματα περιλήψεων",
@@ -7467,17 +7466,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -4066,18 +4066,6 @@
     "inactive": "Inactive",
     "confirmRole": "Confirm role",
     "openRoleLabel": "OPEN",
-    "joinedTheActivity": "👋 {username} joined as {role}",
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
-    },
     "finishedTheActivity": "🎯 {username} wrapped up this activity",
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_eo.arb
+++ b/lib/l10n/intl_eo.arb
@@ -2966,7 +2966,6 @@
     "inactive": "Nekonata",
     "confirmRole": "Konfirmu rolon",
     "openRoleLabel": "Malfermita",
-    "joinedTheActivity": "👋 {username} aliĝis kiel {role}",
     "finishedTheActivity": "🎯 {username} finis ĉi tiun agadon",
     "activitySummaryError": "Aktivitatresumoj ne disponeblas",
     "requestSummaries": "Petaj resumoj",
@@ -7537,17 +7536,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -4389,7 +4389,6 @@
     "inactive": "Inactivo",
     "confirmRole": "Confirmar rol",
     "openRoleLabel": "ABIERTO",
-    "joinedTheActivity": "👋 {username} se unió como {role}",
     "finishedTheActivity": "🎯 {username} finalizó esta actividad",
     "activitySummaryError": "Resúmenes de actividades no disponibles",
     "requestSummaries": "Solicitar resúmenes",
@@ -4588,17 +4587,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_et.arb
+++ b/lib/l10n/intl_et.arb
@@ -6519,7 +6519,6 @@
     "inactive": "Mitteaktiivne",
     "confirmRole": "Kinnita roll",
     "openRoleLabel": "AVATUD",
-    "joinedTheActivity": "👋 {username} liitus rolliga {role}",
     "finishedTheActivity": "🎯 {username} lõpetas selle tegevuse",
     "activitySummaryError": "Tegevuste kokkuvõtteid pole saadaval",
     "requestSummaries": "Paluda kokkuvõtteid",
@@ -6667,17 +6666,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_eu.arb
+++ b/lib/l10n/intl_eu.arb
@@ -3849,7 +3849,6 @@
     "inactive": "Erlaxia",
     "confirmRole": "Berretsi rola",
     "openRoleLabel": "IREKIA",
-    "joinedTheActivity": "👋 {username} {role} bezala batu da",
     "finishedTheActivity": "🎯 {username} jarduera hau amaitu du",
     "activitySummaryError": "Jarduera laburpenak ez daude eskuragarri",
     "requestSummaries": "Eskatu laburpenak",
@@ -6656,17 +6655,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_fa.arb
+++ b/lib/l10n/intl_fa.arb
@@ -3723,7 +3723,6 @@
     "inactive": "غیرفعال",
     "confirmRole": "تایید نقش",
     "openRoleLabel": "باز",
-    "joinedTheActivity": "👋 {username} به عنوان {role} پیوست",
     "finishedTheActivity": "🎯 {username} این فعالیت را پایان داد",
     "activitySummaryError": "خلاصه فعالیت‌ها در دسترس نیست",
     "requestSummaries": "درخواست خلاصه‌ها",
@@ -6535,17 +6534,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_fi.arb
+++ b/lib/l10n/intl_fi.arb
@@ -3819,7 +3819,6 @@
     "inactive": "Ei aktiivinen",
     "confirmRole": "Vahvista rooli",
     "openRoleLabel": "AVOIN",
-    "joinedTheActivity": "👋 {username} liittyi roolilla {role}",
     "finishedTheActivity": "🎯 {username} saatteli aktiviteetin päätökseen",
     "activitySummaryError": "Aktiviteettien yhteenvetoja ei saatavilla",
     "requestSummaries": "Pyydä yhteenvetoja",
@@ -6636,17 +6635,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_fil.arb
+++ b/lib/l10n/intl_fil.arb
@@ -2151,7 +2151,6 @@
     "inactive": "Hindi Aktibo",
     "confirmRole": "Kumpirmahin ang papel",
     "openRoleLabel": "BUKAS",
-    "joinedTheActivity": "👋 {username} ay sumali bilang {role}",
     "finishedTheActivity": "🎯 {username} ay nagtapos sa gawaing ito",
     "activitySummaryError": "Hindi magagamit ang mga buod ng gawain",
     "requestSummaries": "Humiling ng mga buod",
@@ -7449,17 +7448,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -3604,7 +3604,6 @@
     "inactive": "Inactif",
     "confirmRole": "Confirmer le rôle",
     "openRoleLabel": "OUVERT",
-    "joinedTheActivity": "👋 {username} a rejoint en tant que {role}",
     "finishedTheActivity": "🎯 {username} a terminé cette activité",
     "activitySummaryError": "Résumé des activités indisponible",
     "requestSummaries": "Demander des résumés",
@@ -6830,17 +6829,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_ga.arb
+++ b/lib/l10n/intl_ga.arb
@@ -3854,7 +3854,6 @@
     "inactive": "Neamhghníomhach",
     "confirmRole": "Deimhnigh ról",
     "openRoleLabel": "OSCAIL",
-    "joinedTheActivity": "👋 {username} d'fháiltigh isteach mar {role}",
     "finishedTheActivity": "🎯 {username} chríochnaigh an gníomhaíocht seo",
     "activitySummaryError": "Ní féidir achoimrigh gníomhaíochta a fháil",
     "requestSummaries": "Iarr achoimrigh",
@@ -6663,17 +6662,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_gl.arb
+++ b/lib/l10n/intl_gl.arb
@@ -3849,7 +3849,6 @@
     "inactive": "Inactivo",
     "confirmRole": "Confirmar rol",
     "openRoleLabel": "ABERTO",
-    "joinedTheActivity": "👋 {username} uniuse como {role}",
     "finishedTheActivity": "🎯 {username} rematou esta actividade",
     "activitySummaryError": "Resúmenes de actividade non dispoñibles",
     "requestSummaries": "Solicitar resúmenes",
@@ -6656,17 +6655,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_he.arb
+++ b/lib/l10n/intl_he.arb
@@ -2474,7 +2474,6 @@
     "inactive": "לא פעיל",
     "confirmRole": "אשר תפקיד",
     "openRoleLabel": "פתוח",
-    "joinedTheActivity": "👋 {username} הצטרף כ-{role}",
     "finishedTheActivity": "🎯 {username} סיים את הפעילות הזו",
     "activitySummaryError": "סיכומי הפעילות אינם זמינים",
     "requestSummaries": "בקש סיכומים",
@@ -7497,17 +7496,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_hi.arb
+++ b/lib/l10n/intl_hi.arb
@@ -3283,7 +3283,6 @@
     "inactive": "निष्क्रिय",
     "confirmRole": "भूमिका की पुष्टि करें",
     "openRoleLabel": "खुली",
-    "joinedTheActivity": "👋 {username} ने {role} के रूप में भाग लिया",
     "finishedTheActivity": "🎯 {username} ने इस गतिविधि को पूरा किया",
     "activitySummaryError": "गतिविधि सारांश उपलब्ध नहीं है",
     "requestSummaries": "सारांश अनुरोध करें",
@@ -7137,17 +7136,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_hr.arb
+++ b/lib/l10n/intl_hr.arb
@@ -3498,7 +3498,6 @@
     "inactive": "Neaktivno",
     "confirmRole": "Potvrdi ulogu",
     "openRoleLabel": "OTVORENO",
-    "joinedTheActivity": "👋 {username} pridružio se kao {role}",
     "finishedTheActivity": "🎯 {username} završio ovu aktivnost",
     "activitySummaryError": "Sažeci aktivnosti nisu dostupni",
     "requestSummaries": "Zatraži sažetke",
@@ -6902,17 +6901,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_hu.arb
+++ b/lib/l10n/intl_hu.arb
@@ -3718,7 +3718,6 @@
     "inactive": "Inaktív",
     "confirmRole": "Szerep megerősítése",
     "openRoleLabel": "NYITOTT",
-    "joinedTheActivity": "👋 {username} csatlakozott {role} szerepben",
     "finishedTheActivity": "🎯 {username} befejezte ezt a tevékenységet",
     "activitySummaryError": "A tevékenység összegzések nem elérhetők",
     "requestSummaries": "Összegzések kérés",
@@ -6545,17 +6544,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_ia.arb
+++ b/lib/l10n/intl_ia.arb
@@ -1411,7 +1411,6 @@
     "inactive": "Inactiv",
     "confirmRole": "Confirma le rolo",
     "openRoleLabel": "APERTE",
-    "joinedTheActivity": "👋 {username} s'aciapava como {role}",
     "finishedTheActivity": "🎯 {username} ha completate iste activitate",
     "activitySummaryError": "Summarios de activitate non disponibile",
     "requestSummaries": "Requerer summarios",
@@ -7528,17 +7527,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -3733,7 +3733,6 @@
     "inactive": "Tidak aktif",
     "confirmRole": "Konfirmasi peran",
     "openRoleLabel": "TERBUKA",
-    "joinedTheActivity": "👋 {username} bergabung sebagai {role}",
     "finishedTheActivity": "🎯 {username} menyelesaikan aktivitas ini",
     "activitySummaryError": "Ringkasan aktivitas tidak tersedia",
     "requestSummaries": "Minta ringkasan",
@@ -6545,17 +6544,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_ie.arb
+++ b/lib/l10n/intl_ie.arb
@@ -3283,7 +3283,6 @@
     "inactive": "Inactiv",
     "confirmRole": "Confirma le role",
     "openRoleLabel": "APERTE",
-    "joinedTheActivity": "👋 {username} s'atactivava como {role}",
     "finishedTheActivity": "🎯 {username} ha finita iste activitate",
     "activitySummaryError": "Summarios de activitate non disponibile",
     "requestSummaries": "Requerer summarios",
@@ -7137,17 +7136,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -3737,7 +3737,6 @@
     "inactive": "Inattivo",
     "confirmRole": "Conferma ruolo",
     "openRoleLabel": "APERTO",
-    "joinedTheActivity": "👋 {username} si è unito come {role}",
     "finishedTheActivity": "🎯 {username} ha concluso questa attività",
     "activitySummaryError": "Riepiloghi dell'attività non disponibili",
     "requestSummaries": "Richiedi riepiloghi",
@@ -6549,17 +6548,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -3135,7 +3135,6 @@
     "inactive": "非アクティブ",
     "confirmRole": "役割を確認",
     "openRoleLabel": "開く",
-    "joinedTheActivity": "👋 {username} が {role} として参加しました",
     "finishedTheActivity": "🏆 {username} がこの活動を終了しました",
     "activitySummaryError": "活動の概要を利用できません",
     "requestSummaries": "概要をリクエスト",
@@ -7286,17 +7285,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_ka.arb
+++ b/lib/l10n/intl_ka.arb
@@ -2004,7 +2004,6 @@
     "inactive": "არაქტიული",
     "confirmRole": "დადასტურება როლი",
     "openRoleLabel": "ღია",
-    "joinedTheActivity": "👋 {username} შეუერთდა როგორც {role}",
     "finishedTheActivity": "🎯 {username} დასრულდა ეს აქტივობა",
     "activitySummaryError": "აქტივობის მიმოხილვები ხელმისაწვდომი არაა",
     "requestSummaries": "მოთხოვნა მიმოხილვებისთვის",
@@ -7486,17 +7485,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -3668,7 +3668,6 @@
     "inactive": "비활성",
     "confirmRole": "역할 확인",
     "openRoleLabel": "오픈",
-    "joinedTheActivity": "👋 {username}님이 {role}로 참여하셨습니다",
     "finishedTheActivity": "🎯 {username}님이 이 활동을 마무리하셨습니다",
     "activitySummaryError": "활동 요약을 사용할 수 없습니다",
     "requestSummaries": "요약 요청",
@@ -6635,17 +6634,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_lt.arb
+++ b/lib/l10n/intl_lt.arb
@@ -3151,7 +3151,6 @@
     "inactive": "Nekeičiama",
     "confirmRole": "Patvirtinti vaidmenį",
     "openRoleLabel": "ATVIRAS",
-    "joinedTheActivity": "👋 {username} prisijungė kaip {role}",
     "finishedTheActivity": "🎯 {username} užbaigė šią veiklą",
     "activitySummaryError": "Veiklos santraukų nėra",
     "requestSummaries": "Prašyti santraukų",
@@ -7304,17 +7303,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_lv.arb
+++ b/lib/l10n/intl_lv.arb
@@ -3839,7 +3839,6 @@
     "inactive": "Neaktīvs",
     "confirmRole": "Apstiprināt lomu",
     "openRoleLabel": "ATVĒRTS",
-    "joinedTheActivity": "👋 {username} pievienojās kā {role}",
     "finishedTheActivity": "🎯 {username} pabeidza šo aktivitāti",
     "activitySummaryError": "Aktivitātes kopsavilkumi nav pieejami",
     "requestSummaries": "Pieprasīt kopsavilkumus",
@@ -6656,17 +6655,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_nb.arb
+++ b/lib/l10n/intl_nb.arb
@@ -3712,7 +3712,6 @@
     "inactive": "Inaktiv",
     "confirmRole": "Bekreft rolle",
     "openRoleLabel": "ÅPEN",
-    "joinedTheActivity": "👋 {username} ble med som {role}",
     "finishedTheActivity": "🎯 {username} avsluttet denne aktiviteten",
     "activitySummaryError": "Aktivitetsoppsummeringer er utilgjengelige",
     "requestSummaries": "Be om oppsummeringer",
@@ -6711,17 +6710,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -3848,7 +3848,6 @@
     "inactive": "Inactief",
     "confirmRole": "Bevestig rol",
     "openRoleLabel": "OPEN",
-    "joinedTheActivity": "👋 {username} heeft deelgenomen als {role}",
     "finishedTheActivity": "🎯 {username} heeft deze activiteit afgerond",
     "activitySummaryError": "Samenvattingen van activiteiten niet beschikbaar",
     "requestSummaries": "Vraag samenvattingen aan",
@@ -6656,17 +6655,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -3726,7 +3726,6 @@
     "inactive": "Nieaktywne",
     "confirmRole": "Potwierdź rolę",
     "openRoleLabel": "OTWARTA",
-    "joinedTheActivity": "👋 {username} dołączył jako {role}",
     "finishedTheActivity": "🎯 {username} zakończył tę aktywność",
     "activitySummaryError": "Podsumowania aktywności niedostępne",
     "requestSummaries": "Żądaj podsumowań",
@@ -6537,17 +6536,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -3691,7 +3691,6 @@
     "inactive": "Inativo",
     "confirmRole": "Confirmar papel",
     "openRoleLabel": "ABERTO",
-    "joinedTheActivity": "👋 {username} entrou como {role}",
     "finishedTheActivity": "🎯 {username} concluiu esta atividade",
     "activitySummaryError": "Resumos de atividades indisponíveis",
     "requestSummaries": "Solicitar resumos",
@@ -7536,17 +7535,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_pt_BR.arb
+++ b/lib/l10n/intl_pt_BR.arb
@@ -3848,7 +3848,6 @@
     "inactive": "Inativo",
     "confirmRole": "Confirmar papel",
     "openRoleLabel": "ABERTO",
-    "joinedTheActivity": "👋 {username} entrou como {role}",
     "finishedTheActivity": "🎯 {username} encerrou esta atividade",
     "activitySummaryError": "Resumos de atividades indisponíveis",
     "requestSummaries": "Solicitar resumos",
@@ -6668,17 +6667,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_pt_PT.arb
+++ b/lib/l10n/intl_pt_PT.arb
@@ -2670,7 +2670,6 @@
     "inactive": "Inativo",
     "confirmRole": "Confirmar papel",
     "openRoleLabel": "ABERTO",
-    "joinedTheActivity": "👋 {username} entrou como {role}",
     "finishedTheActivity": "🎯 {username} concluiu esta atividade",
     "activitySummaryError": "Resumos de atividades indisponíveis",
     "requestSummaries": "Solicitar resumos",
@@ -7506,17 +7505,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_ro.arb
+++ b/lib/l10n/intl_ro.arb
@@ -3211,7 +3211,6 @@
     "inactive": "Inactiv",
     "confirmRole": "Confirmă rolul",
     "openRoleLabel": "DESCHIS",
-    "joinedTheActivity": "👋 {username} s-a alăturat ca {role}",
     "finishedTheActivity": "🎯 {username} a încheiat această activitate",
     "activitySummaryError": "Rezumatul activităților indisponibil",
     "requestSummaries": "Solicită rezumate",
@@ -7243,17 +7242,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -4492,7 +4492,6 @@
     "inactive": "Неактивно",
     "confirmRole": "Подтвердить роль",
     "openRoleLabel": "ОТКРЫТАЯ",
-    "joinedTheActivity": "👋 {username} присоединился как {role}",
     "finishedTheActivity": "🎯 {username} завершил эту активность",
     "archiveToAnalytics": "Добавить в мои завершённые активности",
     "activitySummaryError": "Сводки по активности недоступны",
@@ -7532,17 +7531,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -2513,7 +2513,6 @@
     "inactive": "Neaktívne",
     "confirmRole": "Potvrdiť rolu",
     "openRoleLabel": "OTVORENÁ",
-    "joinedTheActivity": "👋 {username} sa pripojil ako {role}",
     "finishedTheActivity": "🎯 {username} ukončil túto aktivitu",
     "activitySummaryError": "Prehľady aktivít nie sú dostupné",
     "requestSummaries": "Požiadať o prehľady",
@@ -7534,17 +7533,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_sl.arb
+++ b/lib/l10n/intl_sl.arb
@@ -1868,7 +1868,6 @@
     "inactive": "Neaktivno",
     "confirmRole": "Potrdi vlogo",
     "openRoleLabel": "ODPRTO",
-    "joinedTheActivity": "👋 {username} se je pridružil kot {role}",
     "finishedTheActivity": "🎯 {username} je zaključil to dejavnost",
     "activitySummaryError": "Povzetki dejavnosti niso na voljo",
     "requestSummaries": "Zahtevaj povzetke",
@@ -7534,17 +7533,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_sr.arb
+++ b/lib/l10n/intl_sr.arb
@@ -2883,7 +2883,6 @@
     "inactive": "Neaktivno",
     "confirmRole": "Potvrdi ulogu",
     "openRoleLabel": "OTVORENO",
-    "joinedTheActivity": "👋 {username} se pridružio kao {role}",
     "finishedTheActivity": "🎯 {username} završio ovu aktivnost",
     "activitySummaryError": "Sažeci aktivnosti nisu dostupni",
     "requestSummaries": "Zatraži sažetke",
@@ -7541,17 +7540,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_sv.arb
+++ b/lib/l10n/intl_sv.arb
@@ -3410,7 +3410,6 @@
     "inactive": "Inaktiv",
     "confirmRole": "Bekräfta roll",
     "openRoleLabel": "ÖPPEN",
-    "joinedTheActivity": "👋 {username} gick med som {role}",
     "finishedTheActivity": "🎯 {username} avslutade denna aktivitet",
     "activitySummaryError": "Sammanfattningar av aktivitet är otillgängliga",
     "requestSummaries": "Begär sammanfattningar",
@@ -7005,17 +7004,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_ta.arb
+++ b/lib/l10n/intl_ta.arb
@@ -3724,7 +3724,6 @@
     "inactive": "செயலற்றது",
     "confirmRole": "பங்கு உறுதிப்படுத்தவும்",
     "openRoleLabel": "திறந்தது",
-    "joinedTheActivity": "👋 {username} {role} ஆக சேர்ந்தார்",
     "finishedTheActivity": "🎯 {username} இந்த செயல்பாட்டை முடித்தார்",
     "activitySummaryError": "செயல்பாட்டு சுருக்கங்கள் கிடைக்கவில்லை",
     "requestSummaries": "சுருக்கங்களை கோரவும்",
@@ -6544,17 +6543,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_te.arb
+++ b/lib/l10n/intl_te.arb
@@ -1373,7 +1373,6 @@
     "inactive": "చురుకైనది కాదు",
     "confirmRole": "పాత్రను నిర్ధారించండి",
     "openRoleLabel": "తెరవుట",
-    "joinedTheActivity": "👋 {username} పాత్రగా చేరారు",
     "finishedTheActivity": "🎯 {username} ఈ కార్యకలాపాన్ని ముగించారు",
     "activitySummaryError": "కార్యకలాప సారాంశాలు అందుబాటులో లేవు",
     "requestSummaries": "సారాంశాలను అభ్యర్థించండి",
@@ -7542,14 +7541,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -3283,7 +3283,6 @@
     "inactive": "ไม่ทำงาน",
     "confirmRole": "ยืนยันบทบาท",
     "openRoleLabel": "เปิด",
-    "joinedTheActivity": "👋 {username} เข้าร่วมเป็น {role}",
     "finishedTheActivity": "🎯 {username} สรุปกิจกรรมนี้",
     "activitySummaryError": "ไม่สามารถดูสรุปกิจกรรมได้",
     "requestSummaries": "ขอสรุปข้อมูล",
@@ -7137,17 +7136,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -3623,7 +3623,6 @@
     "inactive": "Pasif",
     "confirmRole": "Rolü onayla",
     "openRoleLabel": "AÇIK",
-    "joinedTheActivity": "👋 {username} {role} olarak katıldı",
     "finishedTheActivity": "🎯 {username} bu etkinliği tamamladı",
     "activitySummaryError": "Etkinlik özetleri kullanılamıyor",
     "requestSummaries": "Özetleri talep et",
@@ -6749,17 +6748,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -3849,7 +3849,6 @@
     "inactive": "Неактивний",
     "confirmRole": "Підтвердити роль",
     "openRoleLabel": "ВІДКРИТА",
-    "joinedTheActivity": "👋 {username} приєднався як {role}",
     "finishedTheActivity": "🎯 {username} завершив цю активність",
     "activitySummaryError": "Зведення активностей недоступне",
     "requestSummaries": "Запитати зведення",
@@ -6656,17 +6655,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_uz.arb
+++ b/lib/l10n/intl_uz.arb
@@ -3856,7 +3856,6 @@
     "inactive": "Faol emas",
     "confirmRole": "Rolni tasdiqlash",
     "openRoleLabel": "OCHIQ",
-    "joinedTheActivity": "👋 {username} {role} sifatida qo'shildi",
     "finishedTheActivity": "🎯 {username} bu faoliyatni yakunladi",
     "activitySummaryError": "Faoliyatlar haqida ma'lumotlar mavjud emas",
     "requestSummaries": "So'rovlar xulosasi",
@@ -7069,17 +7068,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -3230,7 +3230,6 @@
     "inactive": "Không hoạt động",
     "confirmRole": "Xác nhận vai trò",
     "openRoleLabel": "MỞ",
-    "joinedTheActivity": "👋 {username} đã tham gia với vai trò {role}",
     "finishedTheActivity": "🎯 {username} đã kết thúc hoạt động này",
     "activitySummaryError": "Không thể lấy tóm tắt hoạt động",
     "requestSummaries": "Yêu cầu tóm tắt",
@@ -3473,17 +3472,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_yue.arb
+++ b/lib/l10n/intl_yue.arb
@@ -1300,7 +1300,6 @@
     "inactive": "未啟用",
     "confirmRole": "確認角色",
     "openRoleLabel": "開放",
-    "joinedTheActivity": "👋 {username} 以 {role} 身份加入",
     "finishedTheActivity": "🎯 {username} 完成了此活動",
     "activitySummaryError": "活動摘要暫時無法取得",
     "requestSummaries": "請求摘要",
@@ -7176,17 +7175,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -3849,7 +3849,6 @@
     "inactive": "不活跃",
     "confirmRole": "确认角色",
     "openRoleLabel": "开放",
-    "joinedTheActivity": "👋 {username} 作为 {role} 加入",
     "finishedTheActivity": "🎯 {username} 完成了此次活动",
     "activitySummaryError": "无法获取活动总结",
     "requestSummaries": "请求总结",
@@ -6656,17 +6655,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/l10n/intl_zh_Hant.arb
+++ b/lib/l10n/intl_zh_Hant.arb
@@ -3705,7 +3705,6 @@
     "inactive": "未激活",
     "confirmRole": "確認角色",
     "openRoleLabel": "開放",
-    "joinedTheActivity": "👋 {username} 以 {role} 身份加入",
     "finishedTheActivity": "🎯 {username} 完成了此活動",
     "activitySummaryError": "無法取得活動摘要",
     "requestSummaries": "請求摘要",
@@ -6560,17 +6559,6 @@
     "@openRoleLabel": {
         "type": "String",
         "placeholders": {}
-    },
-    "@joinedTheActivity": {
-        "type": "String",
-        "placeholders": {
-            "username": {
-                "type": "String"
-            },
-            "role": {
-                "type": "String"
-            }
-        }
     },
     "@finishedTheActivity": {
         "type": "String",

--- a/lib/pangea/activity_sessions/activity_role_model.dart
+++ b/lib/pangea/activity_sessions/activity_role_model.dart
@@ -21,15 +21,11 @@ class ActivityRoleModel {
   bool get isArchived => archivedAt != null;
 
   String? stateEventMessage(String displayName, L10n l10n) {
-    if (isArchived) {
-      return null;
-    }
-
     if (isFinished) {
       return l10n.finishedTheActivity(displayName);
+    } else {
+      return null;
     }
-
-    return l10n.joinedTheActivity(displayName, role ?? l10n.participant);
   }
 
   factory ActivityRoleModel.fromJson(Map<String, dynamic> json) {

--- a/lib/pangea/activity_sessions/activity_session_chat/activity_summary_widget.dart
+++ b/lib/pangea/activity_sessions/activity_session_chat/activity_summary_widget.dart
@@ -89,7 +89,7 @@ class ActivitySummary extends StatelessWidget {
             ),
             Container(
               decoration: BoxDecoration(
-                color: theme.colorScheme.surface.withAlpha(128),
+                color: theme.colorScheme.surface.withAlpha(180),
                 borderRadius: BorderRadius.circular(12.0),
               ),
               padding: const EdgeInsets.all(16.0),
@@ -97,7 +97,10 @@ class ActivitySummary extends StatelessWidget {
                 crossAxisAlignment: .start,
                 spacing: 16.0,
                 children: [
-                  Text(activity.description, style: theme.textTheme.bodyMedium),
+                  Text(
+                    activity.description,
+                    style: TextStyle(fontSize: AppConfig.messageFontSize),
+                  ),
                   const Divider(height: 1),
                   ActivityVocabWidget(
                     key: ValueKey("activity-summary-${activity.activityId}"),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added role-related UI labels: "Inactive", "Confirm role", and "OPEN".

* **Improvements**
  * Activity messaging now prioritizes finished-state notifications.
  * Activity summary card styling updated with stronger background opacity and adjusted text sizing.

* **Other**
  * Removed the previous "joined the activity" join notification across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->