### PR TITLE
chore: remove leave option from chat context menu for invited rooms

### DIFF
--- a/lib/pangea/chat_settings/widgets/chat_context_menu_action.dart
+++ b/lib/pangea/chat_settings/widgets/chat_context_menu_action.dart
@@ -153,7 +153,8 @@ void chatContextMenuAction(
             ],
           ),
         ),
-      if (!room.isActivitySession || !room.isActivityStarted)
+      if (room.membership == Membership.join &&
+          (!room.isActivitySession || !room.isActivityStarted))
         PopupMenuItem(
           value: ChatContextAction.leave,
           child: Row(
@@ -165,7 +166,7 @@ void chatContextMenuAction(
               ),
               const SizedBox(width: 12),
               Text(
-                room.membership == Membership.invite ? l10n.delete : l10n.leave,
+                l10n.leave,
                 style: TextStyle(color: theme.colorScheme.onErrorContainer),
               ),
             ],


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "leave" action in chat menus now displays consistently and only appears when appropriate for the current chat state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->