### PR TITLE
chore: allow toggling of activity dropdown menu for completed activities

### DIFF
--- a/lib/pangea/activity_orchestrator/activity_stats_menu.dart
+++ b/lib/pangea/activity_orchestrator/activity_stats_menu.dart
@@ -117,7 +117,7 @@ class ActivityStatsMenu extends StatelessWidget {
                 children: [
                   if (currentGoal != null)
                     InkWell(
-                      onTap: _activityComplete ? null : _toggleVisibility,
+                      onTap: _toggleVisibility,
                       child: Container(
                         padding: EdgeInsets.symmetric(horizontal: 12.0),
                         height: 55.0,


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Goal header dropdown can now be toggled regardless of activity completion status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->