### PR TITLE
fix: normalize tts audio speed based on audio player speed range

### DIFF
--- a/lib/pangea/text_to_speech/tts_controller.dart
+++ b/lib/pangea/text_to_speech/tts_controller.dart
@@ -468,7 +468,14 @@ class TtsController {
         await _tts.setVoice(voice);
       }
       text = text.toLowerCase();
-      _tts.setSpeechRate(speed);
+
+      try {
+        final speedRange = await _tts.getSpeechRateValidRange;
+        _tts.setSpeechRate(speed * speedRange.normal);
+      } catch (e, s) {
+        error_handler.ErrorHandler.logError(e: e, s: s, data: {'text': text});
+      }
+
       await Future(() => (_tts.speak(text)));
       _log('Audio playback from device completed', tid);
       return true;


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech speech rate handling to properly scale playback speed based on device capabilities, with enhanced error handling for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->