### PR TITLE
chore: allow overlay message bubble's width to expand in emoji mode

### DIFF
--- a/lib/pangea/toolbar/layout/over_message_overlay.dart
+++ b/lib/pangea/toolbar/layout/over_message_overlay.dart
@@ -53,7 +53,7 @@ class OverMessageOverlay extends StatelessWidget {
                               .overlayController
                               .selectModeController
                               .isShowingExtraContent
-                          ? max(controller.originalMessageSize.width, 150)
+                          ? null
                           : controller.originalMessageSize.width,
                       overlayController: controller.widget.overlayController,
                       chatController: controller.widget.chatController,

--- a/lib/pangea/toolbar/reading_assistance/select_mode_controller.dart
+++ b/lib/pangea/toolbar/reading_assistance/select_mode_controller.dart
@@ -170,6 +170,7 @@ class SelectModeController with LemmaEmojiSetter {
           _translationLoader.value is AsyncLoaded<String>) ||
       (selectedMode.value == SelectMode.speechTranslation &&
           _sttTranslationLoader.isLoaded) ||
+      (selectedMode.value == SelectMode.emoji) ||
       _transcriptLoader.isLoaded ||
       _transcriptLoader.isError;
 


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message overlay layout behavior when using emoji selection and other content modes. Message width calculations now properly adapt based on the active mode to prevent layout overflow issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->