### PR TITLE
fix: change html message clip behavior to hide line under text on ove…

### DIFF
--- a/lib/pages/chat/events/html_message.dart
+++ b/lib/pages/chat/events/html_message.dart
@@ -1102,7 +1102,7 @@ class HtmlMessage extends StatelessWidget {
         ),
         style: TextStyle(fontSize: fontSize, color: textColor),
         maxLines: limitHeight ? 64 : null,
-        overflow: TextOverflow.fade,
+        overflow: TextOverflow.clip,
         selectionColor: textColor.withAlpha(128),
       ),
     );


### PR DESCRIPTION
…rflow

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated how HTML-rendered content displays when exceeding available space; overflowing text is now clipped instead of gradually faded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->