### PR TITLE
chore: show language flags in level display name

### DIFF
--- a/lib/pangea/analytics_misc/level_display_name.dart
+++ b/lib/pangea/analytics_misc/level_display_name.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:flutter_svg/svg.dart';
+
 import 'package:fluffychat/widgets/matrix.dart';
 
 class LevelDisplayName extends StatelessWidget {
@@ -24,6 +26,10 @@ class LevelDisplayName extends StatelessWidget {
         ),
         builder: (context, snapshot) {
           final analytics = snapshot.data?.analytics;
+          final base = analytics?.baseLanguage;
+          final target = analytics?.targetLanguage;
+          final level = analytics?.level;
+
           return Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
@@ -40,19 +46,22 @@ class LevelDisplayName extends StatelessWidget {
                 const SizedBox()
               else
                 Row(
+                  spacing: 4.0,
                   children: [
-                    if (snapshot.data?.countryEmoji != null)
-                      Padding(
-                        padding: const EdgeInsets.only(right: 4.0),
-                        child: Text(
-                          snapshot.data!.countryEmoji!,
-                          style: textStyle ?? const TextStyle(fontSize: 16.0),
+                    if (base != null && target != null) ...[
+                      SvgPicture.network(
+                        base.svgUrl.toString(),
+                        errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                        placeholderBuilder: (_) => Center(
+                          child: const CircularProgressIndicator(
+                            strokeWidth: 0.5,
+                          ),
                         ),
+                        width: iconSize ?? 12.0,
+                        height: iconSize ?? 12.0,
                       ),
-                    if (analytics?.baseLanguage != null &&
-                        analytics?.targetLanguage != null)
                       Text(
-                        analytics!.baseLanguage!.langCodeShort.toUpperCase(),
+                        base.langCodeShort.toUpperCase(),
                         style:
                             textStyle ??
                             TextStyle(
@@ -60,15 +69,25 @@ class LevelDisplayName extends StatelessWidget {
                               color: Theme.of(context).colorScheme.primary,
                             ),
                       ),
-                    if (analytics?.baseLanguage != null &&
-                        analytics?.targetLanguage != null)
                       Icon(
                         Icons.chevron_right_outlined,
                         size: iconSize ?? 16.0,
                       ),
-                    if (analytics?.targetLanguage != null)
+                    ],
+                    if (target != null) ...[
+                      SvgPicture.network(
+                        target.svgUrl.toString(),
+                        errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                        placeholderBuilder: (_) => Center(
+                          child: const CircularProgressIndicator(
+                            strokeWidth: 0.5,
+                          ),
+                        ),
+                        width: iconSize ?? 12.0,
+                        height: iconSize ?? 12.0,
+                      ),
                       Text(
-                        analytics!.targetLanguage!.langCodeShort.toUpperCase(),
+                        target.langCodeShort.toUpperCase(),
                         style:
                             textStyle ??
                             TextStyle(
@@ -76,11 +95,12 @@ class LevelDisplayName extends StatelessWidget {
                               color: Theme.of(context).colorScheme.primary,
                             ),
                       ),
+                    ],
                     const SizedBox(width: 4.0),
-                    if (analytics?.level != null) Text("⭐", style: textStyle),
-                    if (analytics?.level != null)
+                    if (level != null) ...[
+                      Text("⭐", style: textStyle),
                       Text(
-                        "${analytics!.level!}",
+                        "$level",
                         style:
                             textStyle ??
                             TextStyle(
@@ -88,6 +108,7 @@ class LevelDisplayName extends StatelessWidget {
                               color: Theme.of(context).colorScheme.primary,
                             ),
                       ),
+                    ],
                   ],
                 ),
             ],


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated language level display to show SVG icons for languages with improved visual layout, including language codes, progression indicators, and proficiency levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->