### PR TITLE
fix: put top-of-chat padding within chat scroll view

### DIFF
--- a/lib/pages/chat/chat_event_list.dart
+++ b/lib/pages/chat/chat_event_list.dart
@@ -115,6 +115,10 @@ class ChatEventList extends StatelessWidget {
 
               // Request history button or progress indicator:
               // #Pangea
+              if (i == events.length + 3) {
+                return SizedBox(height: 50);
+              }
+
               // if (i == events.length + 1) {
               if (i == events.length + 2) {
                 // Pangea#
@@ -260,7 +264,7 @@ class ChatEventList extends StatelessWidget {
             },
             // #Pangea
             // childCount: events.length + 2,
-            childCount: events.length + 3,
+            childCount: events.length + 4,
             // Pangea#
             findChildIndexCallback: (key) =>
                 controller.findChildIndexCallback(key, thisEventsKeyMap),

--- a/lib/pages/chat/chat_view.dart
+++ b/lib/pages/chat/chat_view.dart
@@ -470,8 +470,6 @@ class ChatView extends StatelessWidget {
                           //     child: ChatEventList(controller: controller),
                           //   ),
                           // ),
-                          if (controller.room.showActivityChatUI)
-                            SizedBox(height: 50),
                           Expanded(
                             child: Stack(
                               children: [


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing consistency in the chat event list display
  * Refined vertical spacing in the chat timeline area for better layout alignment and visual presentation
  * Adjusted spacing behavior in the chat interface for enhanced readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->