### PR TITLE
chore: hide flags in level display name when not enough space to show

### DIFF
--- a/lib/pangea/analytics_misc/level_display_name.dart
+++ b/lib/pangea/analytics_misc/level_display_name.dart
@@ -8,11 +8,13 @@ class LevelDisplayName extends StatelessWidget {
   final String userId;
   final TextStyle? textStyle;
   final double? iconSize;
+  final bool showFlags;
 
   const LevelDisplayName({
     required this.userId,
     this.textStyle,
     this.iconSize,
+    this.showFlags = true,
     super.key,
   });
 
@@ -46,20 +48,22 @@ class LevelDisplayName extends StatelessWidget {
                 const SizedBox()
               else
                 Row(
-                  spacing: 4.0,
                   children: [
                     if (base != null && target != null) ...[
-                      SvgPicture.network(
-                        base.svgUrl.toString(),
-                        errorBuilder: (_, _, _) => const SizedBox.shrink(),
-                        placeholderBuilder: (_) => Center(
-                          child: const CircularProgressIndicator(
-                            strokeWidth: 0.5,
+                      if (showFlags) ...[
+                        SvgPicture.network(
+                          base.svgUrl.toString(),
+                          errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                          placeholderBuilder: (_) => Center(
+                            child: const CircularProgressIndicator(
+                              strokeWidth: 0.5,
+                            ),
                           ),
+                          width: iconSize ?? 12.0,
+                          height: iconSize ?? 12.0,
                         ),
-                        width: iconSize ?? 12.0,
-                        height: iconSize ?? 12.0,
-                      ),
+                        SizedBox(width: 4.0),
+                      ],
                       Text(
                         base.langCodeShort.toUpperCase(),
                         style:
@@ -75,17 +79,20 @@ class LevelDisplayName extends StatelessWidget {
                       ),
                     ],
                     if (target != null) ...[
-                      SvgPicture.network(
-                        target.svgUrl.toString(),
-                        errorBuilder: (_, _, _) => const SizedBox.shrink(),
-                        placeholderBuilder: (_) => Center(
-                          child: const CircularProgressIndicator(
-                            strokeWidth: 0.5,
+                      if (showFlags) ...[
+                        SvgPicture.network(
+                          target.svgUrl.toString(),
+                          errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                          placeholderBuilder: (_) => Center(
+                            child: const CircularProgressIndicator(
+                              strokeWidth: 0.5,
+                            ),
                           ),
+                          width: iconSize ?? 12.0,
+                          height: iconSize ?? 12.0,
                         ),
-                        width: iconSize ?? 12.0,
-                        height: iconSize ?? 12.0,
-                      ),
+                        SizedBox(width: 4.0),
+                      ],
                       Text(
                         target.langCodeShort.toUpperCase(),
                         style:

--- a/lib/pangea/chat_settings/pages/room_participants_widget.dart
+++ b/lib/pangea/chat_settings/pages/room_participants_widget.dart
@@ -201,6 +201,7 @@ class RoomParticipantsSection extends StatelessWidget {
                         child: LevelDisplayName(
                           userId: user.id,
                           textStyle: theme.textTheme.labelSmall,
+                          showFlags: false,
                         ),
                       ),
                       Container(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated level display to conditionally render flag icons, improving UI flexibility in different contexts.
  * Refined room participants view to hide level flags for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->