### PR TITLE
chore: set max lines for about me display and set current about me va…

### DIFF
--- a/lib/pangea/user/about_me_display.dart
+++ b/lib/pangea/user/about_me_display.dart
@@ -29,6 +29,8 @@ class AboutMeDisplay extends StatelessWidget {
                 child: Text(
                   snapshot.data!.about!,
                   style: TextStyle(fontSize: textSize),
+                  maxLines: 10,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
       ),

--- a/lib/pangea/user/user_home_page.dart
+++ b/lib/pangea/user/user_home_page.dart
@@ -43,10 +43,13 @@ class _UserHomePageState extends State<UserHomePage> {
   @override
   void initState() {
     super.initState();
+
     _viewModel = LearningSettingsViewModel(
       MatrixState.pangeaController.userController.profile,
       onUpdateProfile: _updateProfile,
     );
+
+    _aboutTextController.text = _viewModel.about ?? '';
   }
 
   @override


### PR DESCRIPTION
…lue on init user home page

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * About me field now properly displays long text with line limiting and ellipsis truncation.
  * Fixed about me field initialization in user profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->