### PR TITLE
fix: handle pending analytics access requests

### DIFF
--- a/lib/pages/chat_list/chat_list.dart
+++ b/lib/pages/chat_list/chat_list.dart
@@ -13,6 +13,8 @@ import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pages/chat_list/chat_list_view.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_session_preview/activity_session_preview_client_extension.dart';
+import 'package:fluffychat/pangea/analytics_access/access_notice_extension.dart';
+import 'package:fluffychat/pangea/analytics_access/join_room_analytics_access_extension.dart';
 import 'package:fluffychat/pangea/analytics_access/join_room_analytics_consent_handler.dart';
 import 'package:fluffychat/pangea/chat/extensions/create_room_extension.dart';
 import 'package:fluffychat/pangea/chat_list/utils/app_version_util.dart';
@@ -577,6 +579,7 @@ class ChatListController extends State<ChatList>
     final client = Matrix.of(context).client;
     _joinCachedSpaceCode(client);
     _startDMWithCachedUserId(client);
+    _handlePendingCourseAnalyticsAccessRequests(client);
 
     // listen for room join events and leave room if over capacity
     // _roomCapacitySubscription?.cancel();
@@ -1136,6 +1139,24 @@ class ChatListController extends State<ChatList>
     final roomId = resp.result;
     if (roomId != null) {
       context.go('/rooms/$roomId');
+    }
+  }
+
+  Future<void> _handlePendingCourseAnalyticsAccessRequests(
+    Client client,
+  ) async {
+    final pending = client.pendingAccessNoticeCourseIds;
+    for (final courseId in pending) {
+      final course = client.getRoomById(courseId);
+      if (course == null || !course.isSpace) continue;
+      final handler = JoinRoomAnalyticsConsentHandler(
+        JoinResponse(
+          roomId: course.id,
+          shouldShowNotice: course.shouldShowAnalyticsAccessNotice,
+        ),
+        course,
+      );
+      await handler.handle(context);
     }
   }
   // Pangea#

--- a/lib/pangea/analytics_access/access_notice_extension.dart
+++ b/lib/pangea/analytics_access/access_notice_extension.dart
@@ -4,23 +4,38 @@ import 'package:fluffychat/pangea/analytics_access/access_notice_model.dart';
 import 'package:fluffychat/pangea/events/constants/pangea_event_types.dart';
 
 extension AccessNoticeExtension on Client {
-  bool sawAccessNotice(String courseId) =>
-      _accessNoticeSettings.noticesShown[courseId] == true;
-
-  AccessNoticeModel get _accessNoticeSettings {
+  AccessNoticeModel get accessNoticeSettings {
     final data = accountData[PangeaEventTypes.accessNoticeShown];
     if (data != null) {
       return AccessNoticeModel.fromJson(data.content);
     }
-    return const AccessNoticeModel(noticesShown: {});
+    return const AccessNoticeModel(noticesAccepted: {});
   }
 
-  Future<void> setSawAccessNotice(String courseId) async {
-    final prevModel = _accessNoticeSettings;
-    final updatedAccessShown = Map<String, bool>.from(prevModel.noticesShown);
-    updatedAccessShown[courseId] = true;
+  List<String> get pendingAccessNoticeCourseIds => accessNoticeSettings
+      .noticesAccepted
+      .entries
+      .where((e) => e.value == false)
+      .map((e) => e.key)
+      .toList();
+
+  bool acceptedAccessNotice(String courseId) =>
+      accessNoticeSettings.noticesAccepted[courseId] == true;
+
+  Future<void> setAccessNoticePending(String courseId) =>
+      _setAcceptedAccessNotice(courseId, false);
+
+  Future<void> setAccessNoticeAccepted(String courseId) =>
+      _setAcceptedAccessNotice(courseId, true);
+
+  Future<void> _setAcceptedAccessNotice(String courseId, bool value) async {
+    final prevModel = accessNoticeSettings;
+    final updatedAccessShown = Map<String, bool>.from(
+      prevModel.noticesAccepted,
+    );
+    updatedAccessShown[courseId] = value;
     await _setAccessNoticeSettings(
-      prevModel.copyWith(noticesShown: updatedAccessShown),
+      prevModel.copyWith(noticesAccepted: updatedAccessShown),
     );
   }
 

--- a/lib/pangea/analytics_access/access_notice_model.dart
+++ b/lib/pangea/analytics_access/access_notice_model.dart
@@ -1,19 +1,21 @@
 class AccessNoticeModel {
-  final Map<String, bool> noticesShown;
+  final Map<String, bool> noticesAccepted;
 
-  const AccessNoticeModel({required this.noticesShown});
+  const AccessNoticeModel({required this.noticesAccepted});
 
-  Map<String, dynamic> toJson() => {"notices_shown": noticesShown};
+  Map<String, dynamic> toJson() => {"notices_accepted": noticesAccepted};
 
   static AccessNoticeModel fromJson(Map<String, dynamic> json) {
     return AccessNoticeModel(
-      noticesShown: json["notices_shown"] != null
-          ? Map<String, bool>.from(json["notices_shown"])
+      noticesAccepted: json["notices_accepted"] != null
+          ? Map<String, bool>.from(json["notices_accepted"])
           : {},
     );
   }
 
-  AccessNoticeModel copyWith({Map<String, bool>? noticesShown}) {
-    return AccessNoticeModel(noticesShown: noticesShown ?? this.noticesShown);
+  AccessNoticeModel copyWith({Map<String, bool>? noticesAccepted}) {
+    return AccessNoticeModel(
+      noticesAccepted: noticesAccepted ?? this.noticesAccepted,
+    );
   }
 }

--- a/lib/pangea/analytics_access/join_room_analytics_access_extension.dart
+++ b/lib/pangea/analytics_access/join_room_analytics_access_extension.dart
@@ -202,7 +202,7 @@ extension JoinRoomAnalyticsAccessClientExtension on Client {
 
 extension JoinRoomAnalyticsAccessRoomExtension on Room {
   bool get shouldShowAnalyticsAccessNotice =>
-      requireAnalyticsAccess && !client.sawAccessNotice(id);
+      requireAnalyticsAccess && !client.acceptedAccessNotice(id);
 
   Future<JoinResponse?> joinWithAccessCheck() async {
     await join();

--- a/lib/pangea/analytics_access/join_room_analytics_consent_handler.dart
+++ b/lib/pangea/analytics_access/join_room_analytics_consent_handler.dart
@@ -16,14 +16,21 @@ class JoinRoomAnalyticsConsentHandler {
   /// Show the user access consent dialog (if not already shown for this course),
   /// leaves room and return null if rejected, grants access and return roomId if accepted
   Future<String?> handle(BuildContext context) async {
+    final roomId = room.id;
+    final client = room.client;
+
+    if (!client.acceptedAccessNotice(roomId)) {
+      await client.setAccessNoticePending(roomId);
+    }
+
     final acceptedAccessRequest = await _showNotice(context);
     if (!acceptedAccessRequest) {
       return null;
     }
 
-    await room.client.setSawAccessNotice(room.id);
+    await client.setAccessNoticeAccepted(roomId);
     await _grantAccess();
-    return room.id;
+    return roomId;
   }
 
   /// Returns false if user was shown the dialog and rejected it, meaning they left the room

--- a/lib/pangea/join_codes/space_code_controller.dart
+++ b/lib/pangea/join_codes/space_code_controller.dart
@@ -146,7 +146,10 @@ class SpaceCodeController {
       for (final roomId in alreadyJoined) {
         final room = client.getRoomById(roomId);
         if (room?.membership == Membership.join) {
-          return JoinResponse(roomId: roomId, shouldShowNotice: false);
+          return JoinResponse(
+            roomId: roomId,
+            shouldShowNotice: room!.shouldShowAnalyticsAccessNotice,
+          );
         } else if (room != null) {
           roomIdToJoin = roomId;
         }


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics access notices now properly track acceptance status instead of just viewing history
  * Pending analytics access notices are now correctly handled during course and space joins
  * Improved consent state persistence and consistency in analytics notice display logic
  * Enhanced handling of analytics access requests across multiple join scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->