### PR TITLE
feat(orchestrator): per-role goal awards in star UI and end-activity gating

### DIFF
--- a/lib/pangea/activity_orchestrator/orchestrator_awarded_goals.dart
+++ b/lib/pangea/activity_orchestrator/orchestrator_awarded_goals.dart
@@ -1,11 +1,43 @@
+/// Per-role cumulative goal awards from orchestrator outputs.
+///
+/// Goals are fulfilled and awarded per role; a goal shared across roles
+/// completes independently for each role. `awards` maps role id to that
+/// role's awarded goal ids.
+///
+/// Reads both state shapes: the current per-role
+/// `{"awards": {role_id: [goal_ids]}}` and the pre-per-role flat
+/// `{"goal_ids": [...]}`. A flat id counts as completed for any role that
+/// declares the goal (callers only ask about ids from a role's own goals
+/// list), matching the bot's expansion semantics.
 class OrchestratorAwardedGoals {
-  final List<String> goalIds;
-  const OrchestratorAwardedGoals({required this.goalIds});
+  final Map<String, List<String>> awards;
+  final List<String> legacyFlatGoalIds;
 
-  bool isGoalCompleted(String id) => goalIds.contains(id);
+  const OrchestratorAwardedGoals({
+    this.awards = const {},
+    this.legacyFlatGoalIds = const [],
+  });
 
-  static OrchestratorAwardedGoals fromJson(Map<String, dynamic> json) =>
-      OrchestratorAwardedGoals(goalIds: List<String>.from(json["goal_ids"]));
+  bool isGoalCompletedForRole(String roleId, String goalId) =>
+      (awards[roleId]?.contains(goalId) ?? false) ||
+      legacyFlatGoalIds.contains(goalId);
 
-  Map<String, dynamic> toJson() => {"goal_ids": goalIds};
+  static OrchestratorAwardedGoals fromJson(Map<String, dynamic> json) {
+    if (json["awards"] == null && json["goal_ids"] != null) {
+      return OrchestratorAwardedGoals(
+        legacyFlatGoalIds: List<String>.from(json["goal_ids"]),
+      );
+    }
+    return OrchestratorAwardedGoals(
+      awards: Map<String, dynamic>.from(json["awards"] ?? {}).map(
+        (roleId, goalIds) => MapEntry(roleId, List<String>.from(goalIds)),
+      ),
+      legacyFlatGoalIds: List<String>.from(json["legacy_flat_goal_ids"] ?? []),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    "awards": awards,
+    "legacy_flat_goal_ids": legacyFlatGoalIds,
+  };
 }

--- a/lib/pangea/activity_orchestrator/orchestrator_awarded_goals.dart
+++ b/lib/pangea/activity_orchestrator/orchestrator_awarded_goals.dart
@@ -29,9 +29,9 @@ class OrchestratorAwardedGoals {
       );
     }
     return OrchestratorAwardedGoals(
-      awards: Map<String, dynamic>.from(json["awards"] ?? {}).map(
-        (roleId, goalIds) => MapEntry(roleId, List<String>.from(goalIds)),
-      ),
+      awards: Map<String, dynamic>.from(
+        json["awards"] ?? {},
+      ).map((roleId, goalIds) => MapEntry(roleId, List<String>.from(goalIds))),
       legacyFlatGoalIds: List<String>.from(json["legacy_flat_goal_ids"] ?? []),
     );
   }

--- a/lib/pangea/activity_orchestrator/orchestrator_output.dart
+++ b/lib/pangea/activity_orchestrator/orchestrator_output.dart
@@ -1,9 +1,10 @@
 import 'package:fluffychat/pangea/activity_orchestrator/orchestrator_flag.dart';
+import 'package:fluffychat/pangea/activity_orchestrator/orchestrator_role_goal_completion.dart';
 import 'package:fluffychat/pangea/activity_orchestrator/orchestrator_role_suggestions.dart';
 
 class OrchestratorOutput {
   final String basedOnEventId;
-  final List<String> goalCompletion;
+  final List<OrchestratorRoleGoalCompletion> goalCompletion;
   final List<OrchestratorRoleSuggestions> suggestions;
   final OrchestratorFlag? flag;
 
@@ -20,7 +21,16 @@ class OrchestratorOutput {
   static OrchestratorOutput fromJson(Map<String, dynamic> json) =>
       OrchestratorOutput(
         basedOnEventId: json["based_on_event_id"],
-        goalCompletion: List<String>.from(json["goal_completion"]),
+        // An old bot may still broadcast flat string ids; those cannot
+        // be attributed to a role and are ignored rather than thrown on.
+        goalCompletion: List.from(json["goal_completion"] ?? [])
+            .whereType<Map>()
+            .map(
+              (b) => OrchestratorRoleGoalCompletion.fromJson(
+                Map<String, dynamic>.from(b),
+              ),
+            )
+            .toList(),
         suggestions: List.from(json["suggestions"])
             .map(
               (s) => OrchestratorRoleSuggestions.fromJson(
@@ -35,7 +45,7 @@ class OrchestratorOutput {
 
   Map<String, dynamic> toJson() => {
     "based_on_event_id": basedOnEventId,
-    "goal_completion": goalCompletion,
+    "goal_completion": goalCompletion.map((b) => b.toJson()).toList(),
     "suggestions": suggestions.map((s) => s.toJson()).toList(),
     "flag": flag?.toJson(),
   };

--- a/lib/pangea/activity_orchestrator/orchestrator_output.dart
+++ b/lib/pangea/activity_orchestrator/orchestrator_output.dart
@@ -18,30 +18,31 @@ class OrchestratorOutput {
   List<OrchestratorRoleSuggestions> suggestionsByRoleId(String roleId) =>
       suggestions.where((s) => s.roleId == roleId).toList();
 
-  static OrchestratorOutput fromJson(Map<String, dynamic> json) =>
-      OrchestratorOutput(
-        basedOnEventId: json["based_on_event_id"],
-        // An old bot may still broadcast flat string ids; those cannot
-        // be attributed to a role and are ignored rather than thrown on.
-        goalCompletion: List.from(json["goal_completion"] ?? [])
-            .whereType<Map>()
-            .map(
-              (b) => OrchestratorRoleGoalCompletion.fromJson(
-                Map<String, dynamic>.from(b),
-              ),
-            )
-            .toList(),
-        suggestions: List.from(json["suggestions"])
-            .map(
-              (s) => OrchestratorRoleSuggestions.fromJson(
-                Map<String, dynamic>.from(s),
-              ),
-            )
-            .toList(),
-        flag: json["flag"] != null
-            ? OrchestratorFlag.fromJson(Map<String, dynamic>.from(json["flag"]))
-            : null,
-      );
+  static OrchestratorOutput fromJson(
+    Map<String, dynamic> json,
+  ) => OrchestratorOutput(
+    basedOnEventId: json["based_on_event_id"],
+    // An old bot may still broadcast flat string ids; those cannot
+    // be attributed to a role and are ignored rather than thrown on.
+    goalCompletion: List.from(json["goal_completion"] ?? [])
+        .whereType<Map>()
+        .map(
+          (b) => OrchestratorRoleGoalCompletion.fromJson(
+            Map<String, dynamic>.from(b),
+          ),
+        )
+        .toList(),
+    suggestions: List.from(json["suggestions"])
+        .map(
+          (s) => OrchestratorRoleSuggestions.fromJson(
+            Map<String, dynamic>.from(s),
+          ),
+        )
+        .toList(),
+    flag: json["flag"] != null
+        ? OrchestratorFlag.fromJson(Map<String, dynamic>.from(json["flag"]))
+        : null,
+  );
 
   Map<String, dynamic> toJson() => {
     "based_on_event_id": basedOnEventId,

--- a/lib/pangea/activity_orchestrator/orchestrator_role_goal_completion.dart
+++ b/lib/pangea/activity_orchestrator/orchestrator_role_goal_completion.dart
@@ -1,0 +1,21 @@
+/// Cumulative completed goal ids for one role from an orchestrator output.
+///
+/// Goals are fulfilled and awarded per role; a goal shared across roles
+/// completes independently for each role.
+class OrchestratorRoleGoalCompletion {
+  final String roleId;
+  final List<String> goalIds;
+
+  const OrchestratorRoleGoalCompletion({
+    required this.roleId,
+    required this.goalIds,
+  });
+
+  static OrchestratorRoleGoalCompletion fromJson(Map<String, dynamic> json) =>
+      OrchestratorRoleGoalCompletion(
+        roleId: json["role_id"],
+        goalIds: List<String>.from(json["goal_ids"] ?? []),
+      );
+
+  Map<String, dynamic> toJson() => {"role_id": roleId, "goal_ids": goalIds};
+}

--- a/lib/pangea/activity_orchestrator/orchestrator_room_extension.dart
+++ b/lib/pangea/activity_orchestrator/orchestrator_room_extension.dart
@@ -5,32 +5,34 @@ import 'package:fluffychat/pangea/activity_orchestrator/orchestrator_awarded_goa
 import 'package:fluffychat/pangea/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_room_extension.dart';
-import 'package:fluffychat/pangea/bot/utils/bot_name.dart';
 import 'package:fluffychat/pangea/events/constants/pangea_event_types.dart';
 
 extension OrchestratorRoomExtension on Room {
   OrchestratorAwardedGoals get orchestratorAwardedGoals {
     final state = getState(PangeaEventTypes.orchestratorAwardedGoals);
-    if (state == null) return OrchestratorAwardedGoals(goalIds: []);
+    if (state == null) return const OrchestratorAwardedGoals();
     try {
       return OrchestratorAwardedGoals.fromJson(state.content);
     } catch (_) {
-      return OrchestratorAwardedGoals(goalIds: []);
+      return const OrchestratorAwardedGoals();
     }
   }
 
   ActivityRoleGoal? get currentGoal {
+    final ownRole = this.ownRole;
     final goals = ownRole?.allGoals;
-    if (goals == null || goals.isEmpty) return null;
+    if (ownRole == null || goals == null || goals.isEmpty) return null;
 
-    final awardedGoals = orchestratorAwardedGoals.goalIds;
-    return goals.firstWhereOrNull((g) => !awardedGoals.contains(g.id));
+    final awarded = orchestratorAwardedGoals;
+    return goals.firstWhereOrNull(
+      (g) => !awarded.isGoalCompletedForRole(ownRole.id, g.id),
+    );
   }
 
   bool isOwnGoalCompleted(String id) {
     final ownRole = this.ownRole;
     if (ownRole == null) return false;
-    return orchestratorAwardedGoals.isGoalCompleted(id);
+    return orchestratorAwardedGoals.isGoalCompletedForRole(ownRole.id, id);
   }
 
   bool get hasCompletedOwnGoals {
@@ -43,8 +45,8 @@ extension OrchestratorRoomExtension on Room {
     final role = activityPlan?.roles[roleId];
     if (role == null) return false;
     final goals = role.allGoals;
-    final completedGoals = orchestratorAwardedGoals.goalIds;
-    return goals.every((g) => completedGoals.contains(g.id));
+    final awarded = orchestratorAwardedGoals;
+    return goals.every((g) => awarded.isGoalCompletedForRole(roleId, g.id));
   }
 
   List<ActivityRoleGoal> get ownCompletedGoals {
@@ -52,21 +54,19 @@ extension OrchestratorRoomExtension on Room {
     if (ownRole == null) return [];
 
     final ownGoals = ownRole.allGoals;
-    final awardedGoals = orchestratorAwardedGoals.goalIds;
-    return ownGoals.where((g) => awardedGoals.contains(g.id)).toList();
+    final awarded = orchestratorAwardedGoals;
+    return ownGoals
+        .where((g) => awarded.isGoalCompletedForRole(ownRole.id, g.id))
+        .toList();
   }
 
+  // Every occupant earns their own role's goals — the bot included — so
+  // there is no bot exemption here anymore.
   bool get haveAllRolesCompletedAllGoals {
     final roles = activityPlan?.roles;
     final assignedRoles = activityRoles?.roles;
     if (roles == null || assignedRoles == null) return false;
 
-    final completedRoles = roles.values.where((r) {
-      final assignedRole = assignedRoles[r.id];
-      return hasCompletedGoalsByRoleId(r.id) ||
-          assignedRole?.userId == BotName.byEnvironment;
-    });
-
-    return completedRoles.length >= roles.length;
+    return roles.values.every((r) => hasCompletedGoalsByRoleId(r.id));
   }
 }

--- a/test/pangea/orchestrator_awarded_goals_test.dart
+++ b/test/pangea/orchestrator_awarded_goals_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/activity_orchestrator/orchestrator_awarded_goals.dart';
+import 'package:fluffychat/pangea/activity_orchestrator/orchestrator_output.dart';
+
+void main() {
+  group('OrchestratorAwardedGoals', () {
+    test('parses per-role awards shape', () {
+      final goals = OrchestratorAwardedGoals.fromJson({
+        'awards': {
+          'guest': ['order_dish', 'propose_toast'],
+          'host': ['welcome_guest'],
+        },
+      });
+
+      expect(goals.isGoalCompletedForRole('guest', 'order_dish'), isTrue);
+      expect(goals.isGoalCompletedForRole('host', 'welcome_guest'), isTrue);
+      // A shared goal completes independently per role: guest earning
+      // propose_toast does not credit the host.
+      expect(goals.isGoalCompletedForRole('host', 'propose_toast'), isFalse);
+      expect(goals.isGoalCompletedForRole('ghost', 'order_dish'), isFalse);
+    });
+
+    test('parses pre-per-role flat shape as legacy ids for any role', () {
+      // Old rooms carry {"goal_ids": [...]}; a flat id counts for any
+      // role that declares the goal (callers only ask about ids from a
+      // role's own goals list), matching the bot's expansion semantics.
+      final goals = OrchestratorAwardedGoals.fromJson({
+        'goal_ids': ['propose_toast'],
+      });
+
+      expect(goals.awards, isEmpty);
+      expect(goals.isGoalCompletedForRole('guest', 'propose_toast'), isTrue);
+      expect(goals.isGoalCompletedForRole('host', 'propose_toast'), isTrue);
+      expect(goals.isGoalCompletedForRole('guest', 'order_dish'), isFalse);
+    });
+
+    test('round-trips per-role shape through json', () {
+      final goals = OrchestratorAwardedGoals.fromJson({
+        'awards': {
+          'guest': ['order_dish'],
+        },
+      });
+      final reparsed = OrchestratorAwardedGoals.fromJson(goals.toJson());
+      expect(reparsed.isGoalCompletedForRole('guest', 'order_dish'), isTrue);
+      expect(reparsed.isGoalCompletedForRole('host', 'order_dish'), isFalse);
+    });
+  });
+
+  group('OrchestratorOutput goal_completion', () {
+    test('parses per-role buckets', () {
+      final output = OrchestratorOutput.fromJson({
+        'based_on_event_id': r'$evt',
+        'goal_completion': [
+          {
+            'role_id': 'guest',
+            'goal_ids': ['order_dish'],
+          },
+        ],
+        'suggestions': [],
+        'flag': null,
+      });
+
+      expect(output.goalCompletion, hasLength(1));
+      expect(output.goalCompletion.first.roleId, 'guest');
+      expect(output.goalCompletion.first.goalIds, ['order_dish']);
+    });
+
+    test('tolerates the old flat shape during rollout', () {
+      // An old bot may still broadcast flat string ids; they cannot be
+      // attributed to a role, so they are ignored rather than throwing
+      // (a throw would break suggestion display for the whole event).
+      final output = OrchestratorOutput.fromJson({
+        'based_on_event_id': r'$evt',
+        'goal_completion': ['order_dish'],
+        'suggestions': [
+          {
+            'role_id': 'guest',
+            'suggestions': [
+              {'text': 'Hola', 'type': 'best'},
+            ],
+          },
+        ],
+        'flag': null,
+      });
+
+      expect(output.goalCompletion, isEmpty);
+      expect(output.suggestionsByRoleId('guest'), hasLength(1));
+    });
+  });
+}


### PR DESCRIPTION
## What

Client reads per-role orchestrator goal awards: `pangea.orchestrator_awarded_goals` parses the new `{awards: {role_id: [goal_ids]}}` shape (old flat `goal_ids` still readable; flat ids count for any declaring role so existing rooms' stars survive), star/goal checks in the room extension are scoped to the role's own bucket, and `pangea.orchestrator_output` parses per-role `goal_completion` while tolerating an old bot's flat broadcast during rollout.

## Why

Addresses pangeachat/pangea-bot#1358.

Goals are shared across roles and awarded per role — under the old flat reads, a partner completing a shared goal lit up your star too. Behavior change to note: `haveAllRolesCompletedAllGoals` drops its bot exemption, since the bot's role now earns its own goals (per pangeachat/2-step-choreographer#2576 and pangeachat/pangea-bot#1364).

## Testing

- New unit tests (written red-first): per-role independence of shared goals, flat-shape compat for both the state event and output broadcasts, JSON round-trip.
- Full client unit suite: 571 tests pass. `flutter analyze` clean on touched files.
- All UI consumers (stats menu, goal stars, chat goal notifier, suggestion chooser) use unchanged extension/controller signatures — no widget changes.

## Deploy Notes

pangeachat/.github#182 — tolerant of both shapes, so it can release before or after the bot; per-role stars behave correctly once pangea-bot#1364 is live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Goal tracking is now role-aware: each role has its own awarded goals while legacy flat goal lists remain supported.
* **Behavior Change**
  * Completion checks and current-goal selection operate per role; all roles must complete their goals (previous exception removed).
* **Tests**
  * Added unit tests verifying per-role parsing, legacy compatibility, and round-trip JSON behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->