### PR TITLE
fix(config): respect explicit scheme in SYNAPSE_URL homeserver URI

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -11,12 +11,12 @@ abstract class AppConfig {
 
   /// SYNAPSE_URL may carry an explicit scheme (local dev uses
   /// http://localhost:8008); only default to https when it has none.
-  static Uri get defaultHomeserverUri => Uri.parse(
-        defaultHomeserver.startsWith('http://') ||
-                defaultHomeserver.startsWith('https://')
-            ? defaultHomeserver
-            : 'https://$defaultHomeserver',
-      );
+  static Uri get defaultHomeserverUri {
+    final url = defaultHomeserver;
+    final hasScheme = url.startsWith('http://') || url.startsWith('https://');
+    return Uri.parse(hasScheme ? url : 'https://$url');
+  }
+
   // Pangea#
   // Const and final configuration values (immutable)
   // #Pangea

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -8,6 +8,15 @@ import 'package:fluffychat/pangea/common/config/environment.dart';
 abstract class AppConfig {
   // #Pangea
   static String get defaultHomeserver => Environment.synapseURL;
+
+  /// SYNAPSE_URL may carry an explicit scheme (local dev uses
+  /// http://localhost:8008); only default to https when it has none.
+  static Uri get defaultHomeserverUri => Uri.parse(
+        defaultHomeserver.startsWith('http://') ||
+                defaultHomeserver.startsWith('https://')
+            ? defaultHomeserver
+            : 'https://$defaultHomeserver',
+      );
   // Pangea#
   // Const and final configuration values (immutable)
   // #Pangea

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -92,17 +92,13 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
   Client get client {
     if (_activeClient < 0 || _activeClient >= widget.clients.length) {
       // #Pangea
-      currentBundle!.first!.homeserver = Uri.parse(
-        "https://${AppConfig.defaultHomeserver}",
-      );
+      currentBundle!.first!.homeserver = AppConfig.defaultHomeserverUri;
       // Pangea#
       return currentBundle!.first!;
     }
 
     // #Pangea
-    widget.clients[_activeClient].homeserver = Uri.parse(
-      "https://${AppConfig.defaultHomeserver}",
-    );
+    widget.clients[_activeClient].homeserver = AppConfig.defaultHomeserverUri;
     // Pangea#
     return widget.clients[_activeClient];
   }
@@ -234,7 +230,7 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
                 // Pangea#
               });
     // #Pangea
-    candidate.homeserver = Uri.parse("https://${AppConfig.defaultHomeserver}");
+    candidate.homeserver = AppConfig.defaultHomeserverUri;
 
     // This listener is not set for the new login client until the user is logged in,
     // but if the user tries to sign up without this listener set, the signup UIA request


### PR DESCRIPTION
## What

`AppConfig.defaultHomeserverUri` respects an explicit scheme in `SYNAPSE_URL` (local dev: `http://localhost:8008`) and defaults to `https://` when schemeless; the three `matrix.dart` call sites use it instead of hardcoding `https://`.

## Why

Closes #6977. Surfaced while testing the orchestrator changes against a local homeserver.

Staging/prod are unaffected: deployed builds get `SYNAPSE_URL` from the `WEB_APP_ENV` secret, whose values are schemeless (the old unconditional `https://$host` prepend would have broken on anything else), and schemeless values take the identical `https://` path in the new getter.

## Testing

- Full client unit suite: 566 tests pass. `flutter analyze` and `dart format` clean on touched files.
- Manual: the change originates from Will's local-dev setup, where the web client connects to a local `http://` homeserver; schemeless staging values produce the same URI as before by construction.

## Deploy Notes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized homeserver URL handling across the app by introducing a canonical URI representation and using it when creating or selecting clients, ensuring explicit schemes (http/https) are preserved and secure defaults applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->