### PR TITLE
fix: filter non-joined room members from topic participant lists

### DIFF
--- a/lib/pangea/room_summaries/room_summaries_model.dart
+++ b/lib/pangea/room_summaries/room_summaries_model.dart
@@ -80,7 +80,11 @@ class CourseInfoSummariesModel extends RoomSummariesModel {
   ) {
     final Map<String, List<User>> topicUserMap = {};
     for (final user in users) {
-      if (user.id == BotName.byEnvironment) continue;
+      if (user.id == BotName.byEnvironment ||
+          user.membership != Membership.join) {
+        continue;
+      }
+
       final topicId = currentTopicIdByUser(user.id, course);
       if (topicId != null) {
         topicUserMap.putIfAbsent(topicId, () => []).add(user);


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user filtering to exclude members who haven't officially joined, ensuring accurate per-topic user mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->