### PR TITLE
chore: style open and happening now sessions like finished sessions

### DIFF
--- a/lib/pangea/activity_sessions/activity_session_start/activity_session_bottom_content.dart
+++ b/lib/pangea/activity_sessions/activity_session_start/activity_session_bottom_content.dart
@@ -9,12 +9,10 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_session_start/activity_session_state_controller.dart';
 import 'package:fluffychat/pangea/activity_sessions/activity_session_start/not_started_session_controller.dart';
 import 'package:fluffychat/pangea/analytics_misc/construct_type_enum.dart';
-import 'package:fluffychat/pangea/course_chats/open_roles_indicator.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/pangea/room_summaries/activity_summary_status_enum.dart';
 import 'package:fluffychat/pangea/room_summaries/room_summary_extension.dart';
 import 'package:fluffychat/widgets/avatar.dart';
-import 'package:fluffychat/widgets/member_actions_popup_menu_button.dart';
 
 class ActivitySessionBottomContent extends StatelessWidget {
   final ActivitySessionStateController controller;
@@ -102,23 +100,13 @@ class _ActivitySummaryStatusSection extends StatelessWidget {
               ),
             ),
           ),
-          if (status == ActivitySummaryStatus.completed)
-            ...roomSummaries.entries.map((e) {
-              return _ActivitySessionDetailsTile(
-                roomSummary: e.value,
-                course: course,
-                onTap: () => onTap(e.key),
-              );
-            })
-          else
-            ...roomSummaries.entries.map((e) {
-              return _ActivitySessionListTile(
-                roomSummary: e.value,
-                status: status,
-                course: course,
-                onTap: () => onTap(e.key),
-              );
-            }),
+          ...roomSummaries.entries.map((e) {
+            return _ActivitySessionDetailsTile(
+              roomSummary: e.value,
+              course: course,
+              onTap: () => onTap(e.key),
+            );
+          }),
         ],
       ),
     );
@@ -335,49 +323,6 @@ class _ActivitySessionDetailsTile extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _ActivitySessionListTile extends StatelessWidget {
-  final RoomSummaryResponse roomSummary;
-  final ActivitySummaryStatus status;
-
-  final Room course;
-  final VoidCallback onTap;
-
-  const _ActivitySessionListTile({
-    required this.roomSummary,
-    required this.status,
-    required this.course,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final activityPlan = roomSummary.activityPlan;
-
-    // If activity is completed, show all roles, even for users who have left the
-    // room (like the bot). Otherwise, show only joined users with roles
-    final activityRoles = status == ActivitySummaryStatus.completed
-        ? (roomSummary.activityRoles?.roles ?? {})
-        : roomSummary.joinedUsersWithRoles;
-
-    return ListTile(
-      title: OpenRolesIndicator(
-        roles: (activityPlan?.roles.values ?? [])
-            .sorted((a, b) => a.id.compareTo(b.id))
-            .toList(),
-        assignedRoles: activityRoles.values.toList(),
-        size: 40.0,
-        spacing: 8.0,
-        space: course,
-        onUserTap: (user, context) {
-          showMemberActionsPopupMenu(context: context, user: user);
-        },
-      ),
-      trailing: course.isRoomAdmin ? const Icon(Icons.arrow_forward) : null,
-      onTap: onTap,
     );
   }
 }


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual consistency of activity session details by implementing a unified display format across all activity status conditions, replacing the previous mixed-format approach with a standardized, cohesive presentation that significantly improves the overall user interface experience.

* **Refactor**
  * Restructured internal component implementations to eliminate duplicate rendering logic and improve code maintainability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->