### PR TITLE
fix: don't show divider in chat context menu if no buttons below divider

### DIFF
--- a/lib/pangea/chat_settings/widgets/chat_context_menu_action.dart
+++ b/lib/pangea/chat_settings/widgets/chat_context_menu_action.dart
@@ -16,6 +16,31 @@ import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 
+extension on ChatContextAction {
+  bool enabled({required Room room, required Room? space}) {
+    switch (this) {
+      case ChatContextAction.open:
+        return true;
+      case ChatContextAction.goToSpace:
+        return space != null;
+      case ChatContextAction.favorite:
+      case ChatContextAction.markUnread:
+        return room.membership == Membership.join && !room.isActivitySession;
+      case ChatContextAction.mute:
+        return room.membership == Membership.join;
+      case ChatContextAction.leave:
+        return room.membership == Membership.join &&
+            (!room.isActivitySession || !room.isActivityStarted);
+      case ChatContextAction.delete:
+        return room.isRoomAdmin && !room.isDirectChat;
+      case ChatContextAction.endActivity:
+        return room.isActiveInActivity && room.isActivityStarted;
+      default:
+        return false;
+    }
+  }
+}
+
 void chatContextMenuAction(
   Room room,
   BuildContext context,
@@ -42,43 +67,47 @@ void chatContextMenuAction(
   );
 
   final displayname = room.getLocalizedDisplayname(MatrixLocals(l10n));
+  final enabledCount = ChatContextAction.values
+      .where((v) => v.enabled(room: room, space: space))
+      .length;
 
   final action = await showMenu<ChatContextAction>(
     context: context,
     position: position,
     items: [
-      PopupMenuItem(
-        value: ChatContextAction.open,
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          spacing: 12.0,
-          children: [
-            Avatar(
-              mxContent: room.avatar,
-              name: displayname,
-              userId: room.directChatMatrixID,
-            ),
-            ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 128),
-              child: Text(
-                displayname,
-                style: TextStyle(color: theme.colorScheme.onSurface),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
+      if (ChatContextAction.open.enabled(room: room, space: space))
+        PopupMenuItem(
+          value: ChatContextAction.open,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            spacing: 12.0,
+            children: [
+              Avatar(
+                mxContent: room.avatar,
+                name: displayname,
+                userId: room.directChatMatrixID,
               ),
-            ),
-          ],
+              ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 128),
+                child: Text(
+                  displayname,
+                  style: TextStyle(color: theme.colorScheme.onSurface),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
         ),
-      ),
-      const PopupMenuDivider(),
-      if (space != null)
+      if (enabledCount > 1) const PopupMenuDivider(),
+      if (ChatContextAction.goToSpace.enabled(room: room, space: space))
         PopupMenuItem(
           value: ChatContextAction.goToSpace,
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
               Avatar(
-                mxContent: space.avatar,
+                mxContent: space!.avatar,
                 size: Avatar.defaultSize / 2,
                 name: space.getLocalizedDisplayname(),
                 userId: space.directChatMatrixID,
@@ -90,7 +119,7 @@ void chatContextMenuAction(
             ],
           ),
         ),
-      if (room.membership == Membership.join) ...[
+      if (ChatContextAction.mute.enabled(room: room, space: space))
         PopupMenuItem(
           value: ChatContextAction.mute,
           child: Row(
@@ -110,38 +139,35 @@ void chatContextMenuAction(
             ],
           ),
         ),
-        if (!room.isActivitySession)
-          PopupMenuItem(
-            value: ChatContextAction.markUnread,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  room.markedUnread
-                      ? Icons.mark_as_unread
-                      : Icons.mark_as_unread_outlined,
-                ),
-                const SizedBox(width: 12),
-                Text(room.markedUnread ? l10n.markAsRead : l10n.markAsUnread),
-              ],
-            ),
+      if (ChatContextAction.markUnread.enabled(room: room, space: space))
+        PopupMenuItem(
+          value: ChatContextAction.markUnread,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                room.markedUnread
+                    ? Icons.mark_as_unread
+                    : Icons.mark_as_unread_outlined,
+              ),
+              const SizedBox(width: 12),
+              Text(room.markedUnread ? l10n.markAsRead : l10n.markAsUnread),
+            ],
           ),
-        if (!room.isActivitySession)
-          PopupMenuItem(
-            value: ChatContextAction.favorite,
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(
-                  room.isFavourite ? Icons.push_pin : Icons.push_pin_outlined,
-                ),
-                const SizedBox(width: 12),
-                Text(room.isFavourite ? l10n.unpin : l10n.pin),
-              ],
-            ),
+        ),
+      if (ChatContextAction.favorite.enabled(room: room, space: space))
+        PopupMenuItem(
+          value: ChatContextAction.favorite,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(room.isFavourite ? Icons.push_pin : Icons.push_pin_outlined),
+              const SizedBox(width: 12),
+              Text(room.isFavourite ? l10n.unpin : l10n.pin),
+            ],
           ),
-      ],
-      if (room.isActiveInActivity && room.isActivityStarted)
+        ),
+      if (ChatContextAction.endActivity.enabled(room: room, space: space))
         PopupMenuItem(
           value: ChatContextAction.endActivity,
           child: Row(
@@ -153,8 +179,7 @@ void chatContextMenuAction(
             ],
           ),
         ),
-      if (room.membership == Membership.join &&
-          (!room.isActivitySession || !room.isActivityStarted))
+      if (ChatContextAction.leave.enabled(room: room, space: space))
         PopupMenuItem(
           value: ChatContextAction.leave,
           child: Row(
@@ -172,7 +197,7 @@ void chatContextMenuAction(
             ],
           ),
         ),
-      if (room.isRoomAdmin && !room.isDirectChat)
+      if (ChatContextAction.delete.enabled(room: room, space: space))
         PopupMenuItem(
           value: ChatContextAction.delete,
           child: Row(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced chat context menu to conditionally display available actions based on context, affecting mark unread, favorite, mute, leave, delete, and end activity options.
  * Menu divider now only appears when multiple actions are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->