### PR TITLE
fix: set active goal on join activity with role

### DIFF
--- a/lib/pages/chat/chat.dart
+++ b/lib/pages/chat/chat.dart
@@ -65,6 +65,7 @@ import 'package:fluffychat/pangea/common/utils/overlay.dart';
 import 'package:fluffychat/pangea/common/widgets/transparent_backdrop.dart';
 import 'package:fluffychat/pangea/constructs/construct_identifier.dart';
 import 'package:fluffychat/pangea/events/constants/message_constants.dart';
+import 'package:fluffychat/pangea/events/constants/pangea_event_types.dart';
 import 'package:fluffychat/pangea/events/event_wrappers/pangea_message_event.dart';
 import 'package:fluffychat/pangea/events/extensions/pangea_event_extension.dart';
 import 'package:fluffychat/pangea/events/models/pangea_token_model.dart';
@@ -224,6 +225,8 @@ class ChatController extends State<ChatPageWithRoom>
   StreamSubscription? _goBackTutorialSubscription;
 
   StreamSubscription? _goalCompletionSubscription;
+  StreamSubscription? _activityRolesSubscription;
+
   late final ValueNotifier<ActivityRoleGoal?> activeGoalNotifier;
 
   /// The event used to start the reading-assistance tutorial. Stored so the
@@ -787,6 +790,11 @@ class ChatController extends State<ChatPageWithRoom>
     }
   }
 
+  void _activityRolesListener() {
+    if (activeGoalNotifier.value != null || room.currentGoal == null) return;
+    activeGoalNotifier.value = room.currentGoal;
+  }
+
   Future<void> _goalCompletionListener(Set<ActivityRoleGoal> goals) async {
     if (goals.isEmpty) return;
 
@@ -887,6 +895,15 @@ class ChatController extends State<ChatPageWithRoom>
         .goalCompletionStream
         .stream
         .listen(_goalCompletionListener);
+
+    _activityRolesSubscription?.cancel();
+    _activityRolesSubscription = room.client.onRoomState.stream
+        .where(
+          (event) =>
+              event.roomId == room.id &&
+              event.state.type == PangeaEventTypes.activityRole,
+        )
+        .listen((_) => _activityRolesListener());
 
     tutorialOverlayController = TutorialOverlayController(
       TutorialSequences.chatTutorialSequence,
@@ -1183,6 +1200,7 @@ class ChatController extends State<ChatPageWithRoom>
     _forwardTutorialSubscription?.cancel();
     _goBackTutorialSubscription?.cancel();
     _goalCompletionSubscription?.cancel();
+    _activityRolesSubscription?.cancel();
     tutorialOverlayController.dispose();
     activeGoalNotifier.dispose();
     //Pangea#


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat now automatically updates the active goal based on room activity role changes, ensuring your current task stays synchronized across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->