### PR TITLE
chore: Match Open sessions spacing to finished sessions

### DIFF
--- a/lib/pangea/activity_sessions/activity_session_start/activity_session_bottom_content.dart
+++ b/lib/pangea/activity_sessions/activity_session_start/activity_session_bottom_content.dart
@@ -88,7 +88,7 @@ class _ActivitySummaryStatusSection extends StatelessWidget {
         vertical: 16.0,
       ),
       child: Column(
-        spacing: status == ActivitySummaryStatus.completed ? 12.0 : 0,
+        spacing: 12.0,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated spacing consistency in the activity session display to ensure uniform visual presentation across all session statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->