### PR TITLE
fix: don't show duplicate skip button in course code onboarding step

### DIFF
--- a/lib/pangea/onboarding/onboarding_step_views/course_code_step_view.dart
+++ b/lib/pangea/onboarding/onboarding_step_views/course_code_step_view.dart
@@ -174,11 +174,19 @@ class CourseCodeStepViewState extends State<CourseCodeStepView> {
         ),
         //     Column(
         Column(
-          spacing: 12.0,
           children: [
-            TextButton(
-              onPressed: widget.skip,
-              child: Text(L10n.of(context).courseCodeStepSkip),
+            ValueListenableBuilder(
+              valueListenable: _showCodeInput,
+              builder: (context, showInput, _) {
+                if (!showInput) return SizedBox();
+                return Padding(
+                  padding: EdgeInsetsGeometry.only(bottom: 12.0),
+                  child: TextButton(
+                    onPressed: widget.skip,
+                    child: Text(L10n.of(context).courseCodeStepSkip),
+                  ),
+                );
+              },
             ),
             ElevatedButton(
               onPressed: _step.enableGoForward ? widget.forward : null,


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skip button visibility in the course code step—the button now appears only when the code input field is displayed, providing a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->