### PR TITLE
fix: don't restrict visibility of forward and report message options

### DIFF
--- a/lib/pangea/toolbar/reading_assistance/select_mode_buttons.dart
+++ b/lib/pangea/toolbar/reading_assistance/select_mode_buttons.dart
@@ -718,6 +718,7 @@ class _MoreButton extends StatelessWidget {
         return controller.canPinSelectedEvents && isPinned;
       case MessageActions.forward:
       case MessageActions.report:
+        return events.length == 1;
       case MessageActions.info:
         return events.length == 1 &&
             MatrixState.pangeaController.userController.showDeveloperOptions;


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed forward and report actions to properly enable when a single message is selected in the reading assistance toolbar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->