### PR TITLE
fix: when getting event by construct use, pass parent event for edite…

### DIFF
--- a/lib/pangea/analytics_misc/client_analytics_extension.dart
+++ b/lib/pangea/analytics_misc/client_analytics_extension.dart
@@ -250,7 +250,7 @@ extension AnalyticsClientExtension on Client {
     }
 
     try {
-      final event = await room.getEventById(use.metadata.eventId!);
+      Event? event = await room.getEventById(use.metadata.eventId!);
       if (event == null) {
         ErrorHandler.logError(
           e: "Event not found for construct use",
@@ -258,6 +258,15 @@ extension AnalyticsClientExtension on Client {
           data: use.toJson(),
         );
         return null;
+      }
+
+      if (event.relationshipType == RelationshipTypes.edit) {
+        final parentId = event.relationshipEventId;
+        if (parentId != null) {
+          final parentEvent = await room.getEventById(parentId);
+          if (parentEvent == null) return null;
+          event = parentEvent;
+        }
       }
 
       final timeline = await room.getTimeline();

--- a/lib/pangea/events/event_wrappers/pangea_message_event.dart
+++ b/lib/pangea/events/event_wrappers/pangea_message_event.dart
@@ -84,14 +84,7 @@ class PangeaMessageEvent {
   String? get _l1Code =>
       MatrixState.pangeaController.userController.userL1?.langCode;
 
-  Event? _latestEditCache;
-  Event get _latestEdit => _latestEditCache ??=
-      _event
-          .aggregatedEvents(timeline, RelationshipTypes.edit)
-          //sort by event.originServerTs to get the most recent first
-          .sorted((a, b) => b.originServerTs.compareTo(a.originServerTs))
-          .firstOrNull ??
-      _event;
+  Event get _latestEdit => _event.getDisplayEvent(timeline);
 
   // get audio events that are related to this event
   Set<Event> get ttsEvents => _latestEdit
@@ -286,7 +279,6 @@ class PangeaMessageEvent {
       : TextDirection.ltr;
 
   void updateLatestEdit() {
-    _latestEditCache = null;
     _representations = null;
   }
 


### PR DESCRIPTION
…d events

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event retrieval to properly resolve edited events to their original event source.
  * Improved latest edit tracking for more accurate event display representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->