### PR TITLE
Goal dropdown spacing

### DIFF
--- a/lib/pangea/activity_orchestrator/activity_stats_menu.dart
+++ b/lib/pangea/activity_orchestrator/activity_stats_menu.dart
@@ -256,7 +256,7 @@ class ActivityStatsMenu extends StatelessWidget {
                           : 0,
                     ),
                     child: Column(
-                      spacing: 16.0,
+                      spacing: 12.0,
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         if (remainingGoals.isNotEmpty)

--- a/lib/pangea/activity_orchestrator/activity_stats_menu.dart
+++ b/lib/pangea/activity_orchestrator/activity_stats_menu.dart
@@ -247,14 +247,20 @@ class ActivityStatsMenu extends StatelessWidget {
                   child: Container(
                     width: double.infinity,
                     color: theme.colorScheme.surface,
-                    padding: const EdgeInsets.fromLTRB(12.0, 12.0, 12.0, 24.0),
+                    padding: EdgeInsets.fromLTRB(
+                      12.0,
+                      remainingGoals.isEmpty ? 12.0 : 0.0,
+                      12.0,
+                      _showWaitNotDone || _showEndForMe || _showEndForAll
+                          ? 16.0
+                          : 0,
+                    ),
                     child: Column(
                       spacing: 16.0,
                       mainAxisSize: MainAxisSize.min,
                       children: [
                         if (remainingGoals.isNotEmpty)
                           Column(
-                            spacing: 16.0,
                             children: remainingGoals
                                 .map(
                                   (g) => GoalStatusWidget(

--- a/lib/pangea/activity_orchestrator/goal_status_widget.dart
+++ b/lib/pangea/activity_orchestrator/goal_status_widget.dart
@@ -41,19 +41,22 @@ class GoalStatusWidget extends StatelessWidget {
       );
     }
 
-    return Row(
-      spacing: 12.0,
-      children: [
-        icon,
-        Flexible(
-          child: Text(
-            goal.description,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+    return SizedBox(
+      height: 55.0,
+      child: Row(
+        spacing: 12.0,
+        children: [
+          icon,
+          Flexible(
+            child: Text(
+              goal.description,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
- Make goal height consistent, regardless of line length
- Remove extra spacing between goals in list
- Make spacing consistent between buttons and goal list (or buttons and singular goal)
- Only add bottom padding if 1+ button is shown

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Dynamically adjusted padding in activity stats menu based on visible action buttons.
  * Fixed goal status widget height for consistent layout presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->