### PR TITLE
fix: cache morph category lookups

### DIFF
--- a/lib/pangea/analytics_details_popup/lemma_usage_dots.dart
+++ b/lib/pangea/analytics_details_popup/lemma_usage_dots.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pangea/analytics_misc/construct_use_model.dart';
-import 'package:fluffychat/pangea/analytics_misc/construct_use_type_enum.dart';
 import 'package:fluffychat/pangea/analytics_misc/constructs_model.dart';
 import 'package:fluffychat/pangea/analytics_misc/learning_skills_enum.dart';
 import 'package:fluffychat/pangea/constructs/construct_level_enum.dart';

--- a/lib/pangea/analytics_misc/construct_use_type_enum.dart
+++ b/lib/pangea/analytics_misc/construct_use_type_enum.dart
@@ -97,11 +97,14 @@ enum ConstructUseTypeEnum {
 
   // grammar error activity
   corGE,
-  incGE,
-}
+  incGE;
 
-extension ConstructUseTypeExtension on ConstructUseTypeEnum {
-  String get string => toString().split('.').last;
+  static ConstructUseTypeEnum fromString(String value) {
+    return ConstructUseTypeEnum.values.firstWhere(
+      (e) => e.name == value,
+      orElse: () => ConstructUseTypeEnum.nan,
+    );
+  }
 
   String description(BuildContext context) {
     switch (this) {
@@ -525,14 +528,5 @@ extension ConstructUseTypeExtension on ConstructUseTypeEnum {
       default:
         return false;
     }
-  }
-}
-
-class ConstructUseTypeUtil {
-  static ConstructUseTypeEnum fromString(String value) {
-    return ConstructUseTypeEnum.values.firstWhere(
-      (e) => e.string == value,
-      orElse: () => ConstructUseTypeEnum.nan,
-    );
   }
 }

--- a/lib/pangea/analytics_misc/constructs_model.dart
+++ b/lib/pangea/analytics_misc/constructs_model.dart
@@ -3,8 +3,6 @@ import 'dart:developer';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import 'package:matrix/matrix.dart';
-
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/pangea/analytics_misc/construct_use_type_enum.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -101,11 +99,11 @@ class OneConstructUse {
   factory OneConstructUse.fromJson(Map<String, dynamic> json) {
     debugger(when: kDebugMode && json['constructType'] == null);
 
-    final ConstructTypeEnum constructType = json['constructType'] != null
+    final constructType = json['constructType'] != null
         ? ConstructTypeEnum.fromString(json['constructType'])
         : ConstructTypeEnum.vocab;
 
-    final useType = ConstructUseTypeUtil.fromString(json['useType']);
+    final useType = ConstructUseTypeEnum.fromString(json['useType']);
 
     return OneConstructUse(
       useType: useType,
@@ -124,7 +122,7 @@ class OneConstructUse {
   }
 
   Map<String, dynamic> toJson() => {
-    'useType': useType.string,
+    'useType': useType.name,
     'chatId': metadata.roomId,
     'timeStamp': metadata.timeStamp.toIso8601String(),
     'form': form,
@@ -168,46 +166,23 @@ class OneConstructUse {
     ConstructTypeEnum constructType,
   ) {
     final categoryEntry = json['cat'] ?? json['categories'];
-
-    if (constructType == ConstructTypeEnum.vocab) {
-      final String? category = categoryEntry is String
-          ? categoryEntry
-          : categoryEntry is List && categoryEntry.isNotEmpty
-          ? categoryEntry.first
-          : null;
-      return category ?? "Other";
-    }
-
-    final morphs = GrammarConstructsProvider.getFeaturesAndTags();
-
-    if (categoryEntry == null) {
-      return morphs.guessMorphCategory(json["lemma"]);
-    }
-
-    if ((categoryEntry is List)) {
-      if (categoryEntry.isEmpty) {
-        return morphs.guessMorphCategory(json["lemma"]);
-      }
-      return categoryEntry.first;
-    } else if (categoryEntry is String) {
+    if (categoryEntry is String) {
       return categoryEntry;
     }
 
-    debugPrint(
-      "Category entry is not a list or string -${json['cat'] ?? json['categories']}-",
-    );
-    return morphs.guessMorphCategory(json["lemma"]);
-  }
+    if (constructType == ConstructTypeEnum.vocab) {
+      final category = categoryEntry is List ? categoryEntry.firstOrNull : null;
+      return category ?? "Other";
+    }
 
-  Room? getRoom(Client client) {
-    if (metadata.roomId == null) return null;
-    return client.getRoomById(metadata.roomId!);
-  }
+    final lemma = json["lemma"];
+    final morphs = GrammarConstructsProvider.getFeaturesAndTags();
 
-  Future<Event?> getEvent(Client client) async {
-    final Room? room = getRoom(client);
-    if (room == null || metadata.eventId == null) return null;
-    return room.getEventById(metadata.eventId!);
+    if (categoryEntry is List && categoryEntry.isNotEmpty) {
+      return categoryEntry.first;
+    }
+
+    return morphs.guessMorphCategory(lemma);
   }
 
   Color pointValueColor(BuildContext context) {
@@ -215,45 +190,21 @@ class OneConstructUse {
     return xp > 0 ? AppConfig.gold : Colors.red;
   }
 
-  ConstructIdentifier get identifier {
-    final id = ConstructIdentifier(
-      lemma: lemma,
-      type: constructType,
-      category: category,
-    );
-
-    if (metadata.timeStamp.isAfter(DateTime(2026, 3, 16)) &&
-        constructType == ConstructTypeEnum.morph &&
-        MorphFeaturesEnum.fromString(category) == MorphFeaturesEnum.Unknown) {
-      ErrorHandler.logError(
-        e: Exception("Morph feature not found"),
-        data: {
-          "category": category,
-          "lemma": lemma,
-          "type": constructType,
-          "metadata": metadata.toJson(),
-        },
-      );
-    }
-
-    return id;
-  }
+  ConstructIdentifier get identifier => ConstructIdentifier(
+    lemma: lemma,
+    type: constructType,
+    category: category,
+  );
 }
 
 class ConstructUseMetaData {
-  String? eventId;
-  String? roomId;
-  DateTime timeStamp;
+  final String? eventId;
+  final String? roomId;
+  final DateTime timeStamp;
 
   ConstructUseMetaData({
     required this.roomId,
     required this.timeStamp,
     this.eventId,
   });
-
-  Map<String, dynamic> toJson() => {
-    'eventID': eventId,
-    'roomID': roomId,
-    'timestamp': timeStamp.toIso8601String(),
-  };
 }

--- a/lib/pangea/analytics_summary/level_analytics_details_content.dart
+++ b/lib/pangea/analytics_summary/level_analytics_details_content.dart
@@ -5,7 +5,6 @@ import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/analytics_data/derived_analytics_data_model.dart';
 import 'package:fluffychat/pangea/analytics_misc/construct_type_enum.dart';
-import 'package:fluffychat/pangea/analytics_misc/construct_use_type_enum.dart';
 import 'package:fluffychat/pangea/analytics_misc/constructs_model.dart';
 import 'package:fluffychat/pangea/analytics_summary/learning_progress_indicators.dart';
 import 'package:fluffychat/pangea/analytics_summary/progress_indicators_enum.dart';

--- a/lib/pangea/morphs/morph_features_and_tags.dart
+++ b/lib/pangea/morphs/morph_features_and_tags.dart
@@ -1,6 +1,5 @@
 import 'package:collection/collection.dart';
 
-import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/morphs/default_grammar_constructs_response.dart';
 import 'package:fluffychat/pangea/morphs/grammar_constructs_response.dart';
 
@@ -97,17 +96,21 @@ class MorphFeaturesAndTags {
   }
 
   String guessMorphCategory(String morphLemma) {
-    for (final featureTags in _features) {
-      if (featureTags.tags.any((t) => t.value == morphLemma)) {
-        return featureTags.feature.value;
-      }
-    }
-    ErrorHandler.logError(
-      m: "Morph construct lemma $morphLemma not found in morph categories and labels",
-      data: {"morphLemma": morphLemma},
-    );
-    return "Other";
+    final cached = _morphCategoriesCache[morphLemma];
+    if (cached != null) return cached;
+
+    final guess =
+        _features
+            .firstWhereOrNull((f) => f.tags.any((t) => t.value == morphLemma))
+            ?.feature
+            .value ??
+        "Other";
+
+    _morphCategoriesCache[morphLemma] = guess;
+    return guess;
   }
+
+  static final Map<String, String> _morphCategoriesCache = {};
 }
 
 class MorphFeatureTags {

--- a/lib/pangea/practice_exercises/practice_exercise_model.dart
+++ b/lib/pangea/practice_exercises/practice_exercise_model.dart
@@ -1,6 +1,5 @@
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-import 'package:fluffychat/pangea/analytics_misc/construct_use_type_enum.dart';
 import 'package:fluffychat/pangea/analytics_misc/constructs_model.dart';
 import 'package:fluffychat/pangea/analytics_practice/analytics_practice_session_model.dart';
 import 'package:fluffychat/pangea/common/constants/model_keys.dart';

--- a/lib/pangea/toolbar/message_practice/practice_controller.dart
+++ b/lib/pangea/toolbar/message_practice/practice_controller.dart
@@ -4,7 +4,6 @@ import 'package:async/async.dart';
 import 'package:collection/collection.dart';
 
 import 'package:fluffychat/pangea/analytics_misc/construct_type_enum.dart';
-import 'package:fluffychat/pangea/analytics_misc/construct_use_type_enum.dart';
 import 'package:fluffychat/pangea/analytics_misc/constructs_model.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/events/event_wrappers/pangea_message_event.dart';


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated enum parsing logic for construct types.
  * Added performance caching to morphology category identification.
  * Updated data model serialization handling.
  * Streamlined internal utilities and code organization.

* **Chores**
  * Removed unused imports and deprecated utility classes across analytics modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->