### PR TITLE
docs: resolve instruction-doc contradictions (audit)

### DIFF
--- a/.github/instructions/practice-exercises.instructions.md
+++ b/.github/instructions/practice-exercises.instructions.md
@@ -133,7 +133,7 @@ Each activity type maps to specific [`ConstructUseTypeEnum`](../../lib/pangea/an
 1. [`AnalyticsPracticeSessionRepo.get(type, language)`](../../lib/pangea/analytics_practice/analytics_practice_session_repo.dart) builds a session:
    - **Vocab**: fetches the user's weakest lemmas (by spaced-repetition score), splits ~50/50 between `lemmaAudio` (needs example messages with audio) and `lemmaMeaning` targets
    - **Grammar**: fetches recent grammar errors first (`grammarError` targets), then fills remaining slots with weak morph features (`grammarCategory` targets)
-   - Session size: 10 exercises + 5 error buffer (constants in [`AnalyticsPracticeConstants`](../../lib/pangea/analytics_practice/analytics_practice_constants.dart))
+   - Session size: 10 exercises shown, plus a 5-item error buffer (15 targets generated — `targetsToGenerate`; constants in [`AnalyticsPracticeConstants`](../../lib/pangea/analytics_practice/analytics_practice_constants.dart)). The "~10" entry-point sessions above are this same 10 shown.
 2. [`AnalyticsPracticeState`](../../lib/pangea/analytics_practice/analytics_practice_page.dart) manages the session UI — progress bar, timer, activity queue, hints
 3. For each target, a [`MessageActivityRequest`](../../lib/pangea/practice_activities/message_activity_request.dart) is sent to the appropriate generator
 4. The generator returns a [`PracticeActivityModel`](../../lib/pangea/practice_activities/practice_activity_model.dart) subclass with choices and answers

--- a/.github/instructions/practice-exercises.instructions.md
+++ b/.github/instructions/practice-exercises.instructions.md
@@ -71,12 +71,12 @@ The current scoring only considers **recency** and **content-word status**. It i
 
 | Tier | Who goes here | Practice priority |
 |---|---|---|
-| **Suppressed** | Lemmas whose most recent chat use is `wa` (without assistance) AND no subsequent incorrect practice | **0** — skip entirely |
-| **Active** | Lemmas encountered through `ta` (interactive translation) or `ga` (writing assistance), OR lemmas with a recent incorrect practice answer (`incXX`) | **High** — prioritize these |
+| **Suppressed** | Lemmas whose most recent chat use is `wa` (writing assistance ran, message correct) or `unk` (no writing assistance run) AND no subsequent incorrect practice | **0** — skip entirely |
+| **Active** | Lemmas encountered through `ta` (interactive translation) or `ga` (grammar correction / IGC), OR lemmas with a recent incorrect practice answer (`incXX`) | **High** — prioritize these |
 | **Maintenance** | Everything else — correctly practiced but aging | **Normal** — standard recency-based |
 
 **Tier transitions:**
-- A `wa` use → moves to Suppressed (user knows this word)
+- A `wa` or `unk` use → moves to Suppressed (user produced the word correctly, no help needed)
 - A `ta` or `ga` use → moves to Active (user needed help)
 - An incorrect practice answer → moves to Active (user struggled)
 - N consecutive correct practice answers → Active → Maintenance (learning is sticking)
@@ -84,15 +84,15 @@ The current scoring only considers **recency** and **content-word status**. It i
 
 **Within each tier**, the existing scoring formula applies: `daysSinceLastUsed × (isContentWord ? 10 : 7)`. Active-tier words get an additional multiplier (e.g., ×2) so they always appear before maintenance words of similar age.
 
-**Key principle**: Words used through interactive translation and writing assistance should be practiced **much more** than `wa` words. A `wa` word should only re-enter practice if the user later gets it wrong.
+**Key principle**: Words the user needed help with (interactive translation or grammar correction) should be practiced **much more** than words they already produce correctly (`wa`/`unk`). Such a word should only re-enter practice if the user later gets it wrong.
 
 **Example scenario:**
-1. User types "gato" correctly without assistance → `wa` → Suppressed. Won't appear in practice.
+1. User types "gato" correctly with no correction needed → `unk` (or `wa` if writing assistance ran and passed) → Suppressed. Won't appear in practice.
 2. User uses IT to translate "mariposa" → `ta` → Active. High priority for practice.
 3. User practices "mariposa" and gets it wrong → `incLM` → stays Active, priority boosted.
 4. User practices "mariposa" correctly 3 times → Active → Maintenance.
 5. Two weeks pass with no interaction → Maintenance, but high recency score → likely to appear.
-6. User later misspells "gato" and writing assistance corrects it → `ga` → moves from Suppressed back to Active.
+6. User later misspells "gato" and it's corrected during grammar checking → `ga` → moves from Suppressed back to Active.
 
 ### ⚠️ Grammar Error Practice: Missing Message Data
 

--- a/.github/instructions/toolbar-reading-assistance.instructions.md
+++ b/.github/instructions/toolbar-reading-assistance.instructions.md
@@ -46,7 +46,7 @@ The toolbar offers several assistance modes. Which ones appear depends on the me
 | ---------------------- | -------------------------------------------------------------------------------- | ---------------------------------------- |
 | **Audio**              | Full sentence TTS with word-by-word highlighting (like a karaoke bar)            | Text messages in user's L2               |
 | **Translate**          | Full L1 translation appears below the message                                    | Text messages in L2 or unknown languages |
-| **Practice**           | Transitions to practice mode (see conversation-activities doc)                           | Text messages in user's L2               |
+| **Practice**           | Transitions to practice mode (see [practice-exercises.instructions.md](practice-exercises.instructions.md))                           | Text messages in user's L2               |
 | **Emoji**              | Emoji picker appears for each word — user can assign personal emoji associations | Text messages in user's L2               |
 | **Speech Translation** | Shows STT transcript + translation for audio messages                            | Audio messages not in user's L1          |
 | **Regenerate**         | Re-tokenizes the message (for when tokenization looks wrong)                     | Optional, when enabled                   |

--- a/lib/pangea/analytics_misc/construct_use_type_enum.dart
+++ b/lib/pangea/analytics_misc/construct_use_type_enum.dart
@@ -8,7 +8,8 @@ import 'package:fluffychat/pangea/analytics_misc/learning_skills_enum.dart';
 import 'package:fluffychat/pangea/practice_exercises/practice_exercise_type_enum.dart';
 
 enum ConstructUseTypeEnum {
-  /// produced in chat by user, igc was run, and we've judged it to be a correct use
+  /// writing assistance ran and the user's message was correct
+  /// (produced in chat by the user, igc ran, and we judged it a correct use)
   wa,
 
   /// produced during IGC


### PR DESCRIPTION
Client-side part of the cross-repo instruction-doc audit.

## Changes
- **toolbar-reading-assistance:** Practice mode now links to `practice-exercises`, not `conversation-activities` (Practice = a practice exercise, not a conversation activity).
- **`wa` use-type:** reworded the `ConstructUseTypeEnum.wa` doc-comment to lead with "writing assistance ran and the user's message was correct" (meaning unchanged). Fixed the "Use-Type-Aware Spaced Repetition" design note, which had labeled `wa` as "without assistance" and `ga` as "writing assistance" using outdated meanings — corrected to match the enum (`wa` = WA ran + correct, `unk` = no WA, `ga` = grammar correction/IGC). Design intent unchanged.
- **practice-exercises:** clarified session sizing (10 shown + 5-item error buffer = 15 targets generated) so "~10" and "10 + 5" read consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rtnynar2bPb4m9JQVBZwrU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rtnynar2bPb4m9JQVBZwrU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced spaced repetition priority model with a three-tier system and refined use-type mapping
  * Clarified that standalone practice sessions display 10 exercises plus a 5-item error buffer (15 targets total)
  * Updated Practice mode documentation references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->