### PR TITLE
ci: pin Node 22 in e2e workflow to fix Playwright install hang

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -74,13 +74,23 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: lts/*
+          # Pin to Node 22 LTS. node-version: lts/* now resolves to the Node 24
+          # line, and Node 24.16.0+ has a stream-destruction regression
+          # (nodejs/node#63495) that deadlocks Playwright 1.58.2's bundled yauzl
+          # while extracting the browser archive: the download reaches 100%, then
+          # the unzip never settles and this step hangs to the job timeout
+          # (microsoft/playwright#41000). Node 22 predates the regression.
+          # Durable fix: bump @playwright/test to >=1.60.0, then drop this pin.
+          node-version: "22"
 
       - name: Install dependencies
         run: npm ci
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
+        # Fail fast instead of silently burning the 30-min job budget if a
+        # browser install ever hangs again (normally finishes in seconds).
+        timeout-minutes: 10
 
       - name: Determine test mode
         id: mode


### PR DESCRIPTION
## Problem

The **E2E Tests (Staging)** job has been cancelled at its 30 minute job timeout on every run, on every branch (main included), since roughly mid June. The `Install Playwright browsers` step (`npx playwright install --with-deps chromium`) downloads Chrome for Testing to 100%, then emits no output for about 25 minutes until the job is killed. Because e2e is a non required check and the step had no step level timeout, it silently burned the full job clock and went unnoticed.

## Root cause

`actions/setup-node@v5` uses `node-version: lts/*`, which now resolves to the Node 24 line on `ubuntu-latest`. Node 24.16.0+ introduced a stream destruction regression ([nodejs/node#63495](https://github.com/nodejs/node/issues/63495)) that deadlocks the `yauzl`/extract-zip bundled in Playwright 1.58.2 while it extracts the browser archive: the download completes, then the unzip never settles and the event loop parks forever ([microsoft/playwright#41000](https://github.com/microsoft/playwright/issues/41000), fixed upstream in Playwright v1.60.0). The same Playwright 1.58.2 and Chrome 145 ran green about six days before the break, when the runner's Node was on the 22 line; the only changed variable was the runner's Node version. The stall is in extraction, not download, so download phase levers (connection timeouts, `--no-shell`, retries) do not address it.

## Fix

Two edits to `.github/workflows/e2e-tests.yml`:

1. Pin `node-version: "22"` (was `lts/*`). Node 22 LTS predates the regression, so Playwright 1.58.2's extraction settles normally.
2. Add `timeout-minutes: 10` to the install step as fail fast defense in depth (it normally finishes in seconds), so a future install hang fails the step instead of silently eating the 30 minute job.

The install command itself is unchanged.

## Durable follow up (separate, optional)

Bump `@playwright/test` to `^1.60.0` (vendors the `yauzl` fix), refresh `package-lock.json`, then remove the Node pin so CI tracks current LTS. Keep the step timeout permanently.

## Verify

Opening this PR triggers e2e (the workflow watches its own path) in smoke mode. The `Install Playwright browsers` step should now complete in well under a minute instead of timing out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. This PR contains internal CI/CD infrastructure updates to the automated testing workflow, including Node.js version pinning and timeout improvements. End users are not affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->