### PR TITLE
fix: course-plan outline cache + activity-start progression lock (QA)

### DIFF
--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -182,10 +182,51 @@ class QuestRepo {
     ];
   }
 
+  /// Process-lifetime cache of resolved outlines, keyed by quest id, so
+  /// switching back to a course's plan doesn't re-spin. In-memory (not
+  /// GetStorage) because [QuestOutline] carries session-scoped media CDN URLs —
+  /// same reasoning as `ActivityPlanRepo`'s in-memory resolve cache.
+  static final Map<String, QuestOutline> _outlineCache = {};
+  static final Map<String, Future<QuestOutline>> _outlineInflight = {};
+
   /// The full outline: quest + objective groups (LOs in order, each with its
-  /// matching activities). Three reads — the quest, then the LO-text batch and
-  /// the activities query in parallel.
-  static Future<QuestOutline> outline(String questId) async {
+  /// matching activities). Cached per quest id; concurrent calls for the same
+  /// quest share one in-flight read. Pass [forceRefresh] to bypass the cache.
+  static Future<QuestOutline> outline(
+    String questId, {
+    bool forceRefresh = false,
+  }) {
+    if (!forceRefresh) {
+      final cached = _outlineCache[questId];
+      if (cached != null) return Future.value(cached);
+      final inflight = _outlineInflight[questId];
+      if (inflight != null) return inflight;
+    }
+    final future = _buildOutline(questId)
+        .then((outline) {
+          _outlineCache[questId] = outline;
+          return outline;
+        })
+        .whenComplete(() => _outlineInflight.remove(questId));
+    _outlineInflight[questId] = future;
+    return future;
+  }
+
+  /// Drop the cached outline for [questId] (e.g. after a course edit).
+  static void invalidateOutline(String questId) {
+    _outlineCache.remove(questId);
+    _outlineInflight.remove(questId);
+  }
+
+  /// Drop all cached outlines (e.g. on logout / account switch).
+  static void clearOutlineCache() {
+    _outlineCache.clear();
+    _outlineInflight.clear();
+  }
+
+  /// Build a fresh outline — three reads (the quest, then the LO-text batch and
+  /// the activities query in parallel). Uncached; callers use [outline].
+  static Future<QuestOutline> _buildOutline(String questId) async {
     final quest = await QuestRepo.quest(questId);
 
     // LO text and activities both depend only on the quest — run in parallel.

--- a/lib/features/quests/user_stars.dart
+++ b/lib/features/quests/user_stars.dart
@@ -1,0 +1,26 @@
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
+
+/// The learner's earned stars per activity, from their own session rooms: stars
+/// = goals the learner has collected in a role they hold, kept as the best
+/// across multiple sessions of the same activity.
+///
+/// This is the same computation `world_map._deriveActivitySignals` feeds into
+/// the progression gate; kept here so other surfaces (e.g. the activity start
+/// page) gate identically — the gate is "resolved once" (quests.instructions.md).
+Map<String, int> userStarsByActivity(Client client) {
+  final stars = <String, int>{};
+  for (final room in client.rooms) {
+    final activityId = room.activityId;
+    if (activityId == null) continue;
+    if (room.ownRole == null) continue;
+    final collected = room.ownCompletedGoals.length;
+    if (collected > (stars[activityId] ?? 0)) {
+      stars[activityId] = collected;
+    }
+  }
+  return stars;
+}

--- a/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
@@ -156,6 +156,22 @@ class _NotStartedSessionCTAButtons extends StatelessWidget {
   Widget build(BuildContext context) {
     final hasActiveSession = controller.canJoinExistingSession;
 
+    // Gated by course progression (same gate the world map applies to pins):
+    // Start is disabled and shows the unlock reason. Reuses the locked-card
+    // wording in world_map_large_card.dart.
+    if (controller.isLocked) {
+      return Column(
+        spacing: 16.0,
+        children: [
+          const Text(
+            'Finish the previous mission to unlock',
+            textAlign: TextAlign.center,
+          ),
+          _CTAButton(L10n.of(context).start, null),
+        ],
+      );
+    }
+
     return FutureBuilder(
       future: controller.neededCourseParticipants,
       builder: (context, snapshot) {

--- a/lib/routes/chat/activity_sessions/not_started_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/not_started_session_controller.dart
@@ -12,6 +12,9 @@ import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
 import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
+import 'package:fluffychat/features/quests/lo_progression.dart';
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/features/quests/user_stars.dart';
 import 'package:fluffychat/features/room_summaries/activity_sessions_status_model.dart';
 import 'package:fluffychat/features/room_summaries/room_summaries_model.dart';
 import 'package:fluffychat/l10n/l10n.dart';
@@ -50,10 +53,17 @@ class NotStartedSessionController extends State<NotStartedSession>
     implements ActivitySessionStateController {
   final _goalsHandler = GoalsSubscriptionHandler();
 
+  /// Whether this activity is gated behind earlier-mission progression.
+  /// Resolved async in [didChangeDependencies]; fail-open (false) for standalone
+  /// activities and any resolution failure, matching the world-map gate.
+  bool _isLocked = false;
+  bool get isLocked => _isLocked;
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     _goalsHandler.init(widget.course?.id, context, setState, () => mounted);
+    _resolveLock();
   }
 
   @override
@@ -150,7 +160,53 @@ class NotStartedSessionController extends State<NotStartedSession>
     NavigationUtil.goToSpaceRoute(joinedActivityRoomId!, [], context);
   }
 
+  /// Resolve whether this activity is locked by the launching course's
+  /// progression gate — the same gate the world map applies to pins
+  /// (quests.instructions.md). Fail-open: a standalone activity, an already-open
+  /// joinable session, a missing course plan, or any error reads unlocked.
+  Future<void> _resolveLock() async {
+    final course = widget.course;
+    if (course == null) return;
+    // An open joinable session means the activity is reachable regardless of the
+    // gate (mirrors the map: a joinable pin is never shown locked).
+    if (canJoinExistingSession) return;
+    final uuid = course.coursePlan?.uuid;
+    if (uuid == null) return;
+    final client = Matrix.of(context).client;
+    try {
+      final outline = await QuestRepo.outline(uuid);
+      final courseLo = CourseLoOutline(
+        orderedLoIds: outline.quest.learningObjectiveIds,
+        activityIdsByLo: {
+          for (final group in outline.groups)
+            group.objective.id: group.activities
+                .map((a) => a.activityId)
+                .toSet(),
+        },
+        starsToUnlock:
+            course.teacherMode.starsToUnlockObjective ??
+            kDefaultStarsToUnlockObjective,
+      );
+      final gate = buildLoGate(
+        outlines: [courseLo],
+        starsByActivity: userStarsByActivity(client),
+      );
+      final loRefs = courseLo.activityIdsByLo.entries
+          .where((e) => e.value.contains(widget.activityId))
+          .map((e) => e.key);
+      final locked = gate.isPinLocked(loRefs);
+      if (mounted && locked != _isLocked) {
+        setState(() => _isLocked = locked);
+      }
+    } catch (_) {
+      // Fail open on any error.
+    }
+  }
+
   void startNewActivity() {
+    // Gated by course progression — Start is disabled, but guard here too so a
+    // `?launch` deep link can't bypass the lock.
+    if (_isLocked) return;
     widget.scrollController.jumpTo(0);
     final course = widget.course;
     // With a course, launch scoped to it; otherwise launch the activity


### PR DESCRIPTION
Two client fixes from the world-redesign staging QA pass.

## 1. Course Plan re-spins on every course switch
`QuestRepo.outline` had no cache, so switching between courses re-fetched and re-spun the plan each time. Added a process-lifetime in-memory cache keyed by quest id, plus in-flight dedup (the same pattern `ActivityPlanRepo` already uses). In-memory rather than GetStorage because the outline carries session-scoped media CDN URLs. Switching back to a course now renders instantly with no spinner and no refetch. Exposes `invalidateOutline` / `clearOutlineCache` for future course-edit flows.

## 2. A locked activity was launchable from its start page
The progression gate already locks the map pins, but the activity start page never consulted it, so a gated activity opened with an enabled Start (the gate that `quests.instructions.md` line 26 specifies for this surface was never wired in). The start page now resolves the same gate (`buildLoGate` / `isPinLocked`) from the launching course's outline and the learner's stars, disables Start with the unlock reason when locked, and guards `startNewActivity` so a `?launch` deep link cannot bypass it. Fail-open throughout: a standalone activity, an open joinable session, a missing or fragmented course plan, or any resolution error all read unlocked, matching the world-map gate. Factors the per-room star scan into `lib/features/quests/user_stars.dart` so the map and start page resolve stars once.

Not included: the empty-Course-Plan issue (Missions render but no activity cards). That is a backend Learning-Objective fragmentation data problem (the quest Mission ids and the activities' refs point at disjoint LO rows). The client join is correct by design and is what the gate relies on, so loosening it would re-introduce v1 fragmentation and corrupt the lock gate. The backend canonicalization handles it.

## Verification
flutter analyze: no issues. Relevant tests pass (lo_progression, quest_activity_card). The lock reuses the already-unit-tested gate and is fail-open in every uncertain path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activities now display as locked when prerequisites haven't been completed, with on-screen guidance prompting you to complete previous missions first.

* **Performance**
  * Enhanced caching of quest data and activity session information for improved app responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->