### PR TITLE
ci: enable ENABLE_SEMANTICS on staging web deploys (not prod)

### DIFF
--- a/.github/skills/run-flutter-web-local/SKILL.md
+++ b/.github/skills/run-flutter-web-local/SKILL.md
@@ -116,7 +116,7 @@ Source of truth for the staging values is the deployed client itself: `curl -s h
 
 ### Driving the app by semantics (Chrome extension)
 
-The app renders to `<canvas>`, so the Chrome extension can only operate it by role+name once Flutter's accessibility semantics tree is on — otherwise it falls back to screenshots and positional clicks. Add `ENABLE_SEMANTICS=true` to `client/.env` and clean-restart to force the tree on from startup. Off by default (semantics has a perf cost). See [`playwright-testing.instructions.md`](../../instructions/playwright-testing.instructions.md) for the full contract.
+The app renders to `<canvas>`, so the Chrome extension can only operate it by role+name once Flutter's accessibility semantics tree is on — otherwise it falls back to screenshots and positional clicks. Add `ENABLE_SEMANTICS=true` to `client/.env` and clean-restart to force the tree on from startup. Off by default locally (semantics has a perf cost). **Staging** deploys force it on (`main_deploy.yaml` stamps `ENABLE_SEMANTICS=true` into the served `/.env`), so `app.staging.pangea.chat` is driveable by role+name too; **production** leaves it off (on-demand per assistive-tech user). See [`playwright-testing.instructions.md`](../../instructions/playwright-testing.instructions.md) for the full contract.
 
 ## Login
 

--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -81,6 +81,10 @@ jobs:
         run: |
           touch build/web/.env
           echo "$WEB_APP_ENV" >> build/web/.env
+          # Staging only: force the Flutter accessibility (semantics) tree on so
+          # automated and assistive-tech testing can read the canvas. NOT set on
+          # production (release.yaml), where semantics stays on-demand per user.
+          echo "ENABLE_SEMANTICS=true" >> build/web/.env
           touch build/web/assets/envs.json
           echo "$ENV_OVERRIDES" >> build/web/assets/envs.json
           mkdir -p build/web/.well-known


### PR DESCRIPTION
Forces Flutter's accessibility (semantics) tree on for the deployed **staging** web app, so `app.staging.pangea.chat` can be driven and read by role+name (automated agents and assistive tech), instead of falling back to screenshots and positional clicks on the opaque canvas.

## What changed
`.github/workflows/main_deploy.yaml` (the staging web deploy) appends `ENABLE_SEMANTICS=true` to the `/.env` it stamps at the web root. The client reads this at startup (`main.dart` calls `ensureSemantics()` when `ENABLE_SEMANTICS == "true"`), so the tree builds from first paint.

## Scope
- **Staging only.** Production (`release.yaml`) is untouched, so prod keeps semantics off / on-demand per assistive-tech user (it carries a small perf cost we do not want forced on real users).
- **Local** is unchanged: it stays opt-in via `client/.env` per the run-flutter-web-local skill (this PR just documents the staging behavior there).
- `integrate.yaml` and `manual.yml` are not web deploys (CI and Play Store respectively), so they need no change.

## Effect
Merging this triggers a staging redeploy; afterwards `curl https://app.staging.pangea.chat/.env` shows `ENABLE_SEMANTICS=true` and the app exposes its semantics tree.