### PR TITLE
fix(nav): course navigation GoException on full room id (What now? chooser + 2 siblings)

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_finished_status_message.dart
+++ b/lib/routes/chat/activity_sessions/activity_finished_status_message.dart
@@ -8,6 +8,7 @@ import 'package:fluffychat/features/activity_sessions/activity_room_extension.da
 import 'package:fluffychat/features/activity_sessions/activity_summary_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_summary_room_extension.dart';
 import 'package:fluffychat/features/languages/p_language_store.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/subscription/widgets/subscription_paywall.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -26,7 +27,13 @@ class ActivityFinishedStatusMessage extends StatelessWidget {
     // A standalone activity has no course to return to — go home instead.
     final course = controller.room.courseParent;
     context.go(
-      course != null ? "/rooms/spaces/${course.id}/details?tab=course" : "/",
+      course != null
+          ? WorkspaceNav.openCourseFilter(
+              GoRouterState.of(context).uri,
+              course.id,
+              tab: 'course',
+            )
+          : "/",
     );
   }
 

--- a/lib/routes/chat_list/course_chats_view.dart
+++ b/lib/routes/chat_list/course_chats_view.dart
@@ -7,6 +7,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/spaces/knocking_users_indicator.dart';
 import 'package:fluffychat/routes/chat/chat_details/chat_context_menu_action.dart';
@@ -129,8 +130,12 @@ class CourseChatsView extends StatelessWidget {
                           title: Text(L10n.of(context).whatNow),
                           subtitle: Text(L10n.of(context).chooseNextActivity),
                           trailing: const Icon(Icons.arrow_forward),
-                          onTap: () => context.pushReplacement(
-                            "/rooms/spaces/${room.id}/details?tab=course",
+                          onTap: () => context.go(
+                            WorkspaceNav.openCourseFilter(
+                              GoRouterState.of(context).uri,
+                              room.id,
+                              tab: 'course',
+                            ),
                           ),
                         )
                       : const SizedBox();

--- a/lib/routes/courses/own/selected_course_page.dart
+++ b/lib/routes/courses/own/selected_course_page.dart
@@ -8,6 +8,7 @@ import 'package:matrix/matrix.dart' as sdk;
 import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_model.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/spaces/client_spaces_extension.dart';
 import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
@@ -119,7 +120,13 @@ class SelectedCourseController extends State<SelectedCourse>
     }
 
     if (!mounted) return;
-    context.go("/rooms/spaces/${space.id}/details?tab=course");
+    context.go(
+      WorkspaceNav.openCourseFilter(
+        GoRouterState.of(context).uri,
+        space.id,
+        tab: 'course',
+      ),
+    );
   }
 
   @override


### PR DESCRIPTION
Found by the staging QA agents: tapping the course "What now? — Choose your next activity!" chooser throws a full Page Not Found:

`GoException: no routes for location: /courses/!BGzOPxsWYbIyDfzGjb%3Astaging.pangea.chat/details?tab=course`

## Root cause
Three places navigated to a course with the **legacy** route `"/rooms/spaces/${room.id}/details?tab=course"`, passing the **full** Matrix room id (`!localpart:host`). The world_v2 legacy redirect rewrites that toward `/courses/<id>/details`, but the `/courses/:spaceid` route expects the **bare localpart**, so the host-bearing id matches no route and GoRouter throws.

## Fix
Use the token-native `WorkspaceNav.openCourseFilter(uri, id, tab: 'course')` (already the working pattern in `goToCourse`), which runs the id through `shortRoomId` and builds the correct `?m=course:<bare>&left=course` URL. Fixed all three call sites:
- `course_chats_view.dart` — the "What now?" chooser (the reported break).
- `activity_finished_status_message.dart` — return-to-course on activity archive (same pattern, same latent break).
- `selected_course_page.dart` — open course after create/select (same pattern).

This also unblocks verifying the activity-start lock gate (#7045), which the agents could not reach because this chooser was the path to a locked activity.

## Verification
`flutter analyze` clean (full project); navigation test suite passes (panel/route/workspace_nav/legacy_redirects/navigation_util).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal navigation logic across multiple screens to use a centralized navigation helper, standardizing course filter routing patterns throughout the app. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->