### PR TITLE
ci: serve staging /.env no-cache so config changes propagate every deploy

### DIFF
--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -108,6 +108,7 @@ jobs:
           aws s3 sync ./build/web s3://$WEBAPP_S3_BUCKET \
             --cache-control "public, max-age=31536000, immutable" \
             --exclude "index.html" \
+            --exclude ".env" \
             --exclude "main.dart.js" \
             --exclude "*.part.js" \
             --exclude "flutter.js" \
@@ -138,11 +139,12 @@ jobs:
             --cache-control "no-cache, must-revalidate"
 
           # =========================
-          # 4. FLUTTER RUNTIME ENTRY FILES
+          # 4. FLUTTER RUNTIME ENTRY FILES + .env (config must propagate every deploy)
           # Must always stay fresh
           # =========================
           RUNTIME_FILES=(
             "index.html"
+            ".env"
             "main.dart.js"
             "flutter.js"
             "flutter_bootstrap.js"


### PR DESCRIPTION
The staging deploy synced `build/web/.env` as part of the immutable bucket sync (`cache-control: public, max-age=31536000, immutable`), so browsers cache `/.env` for a year. The web client fetches `/.env` at startup for its runtime config, so **env/config changes do not reach existing sessions** — they keep serving the cached file. This is why the just-enabled `ENABLE_SEMANTICS=true` (and any future env change: API URLs, keys, flags) did not take effect on staging without a hard reload.

## Fix
Treat `/.env` like `index.html`: exclude it from the immutable sync and re-upload it with `no-cache, must-revalidate`, so the browser revalidates it every load and config propagates on every deploy.

## Scope
Staging only (`main_deploy.yaml`). Production (`release.yaml`) has the same pattern and the same latent bug; left out of this PR deliberately (separate, more sensitive deploy), flagged for a follow-up.

## Note
Existing sessions that already cached the old immutable `/.env` will still serve it until a hard reload or cache expiry; this fix corrects it for all loads after the next staging deploy.