### PR TITLE
fix(onboarding): land course signup on the course route, not the dead /rooms/spaces path

### DIFF
--- a/lib/routes/onboarding/onboarding_steps/joined_course_onboarding_step.dart
+++ b/lib/routes/onboarding/onboarding_steps/joined_course_onboarding_step.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/routes/onboarding/onboarding_steps/onboarding_step.dart';
 
 class JoinedCourseOnboardingStep extends OnboardingStep {
@@ -11,7 +12,12 @@ class JoinedCourseOnboardingStep extends OnboardingStep {
   String get stepDestination {
     final roomId = state.joinedRoomId;
     if (roomId == null) return "/rooms";
-    return "/rooms/spaces/$roomId";
+    // world_v2: a joined course is `/courses/<bareLocalpart>` (PRoutes.course),
+    // not the retired `/rooms/spaces/:spaceid` shape. Passing the FULL room id
+    // through the legacy redirect mis-parses it (the same break as the course
+    // chooser fix) and dead-ends onboarding. PRoutes.course bares the id so the
+    // redirect resolves to the course workspace.
+    return PRoutes.course(roomId);
   }
 
   @override


### PR DESCRIPTION
After signing up via a course invite, onboarding navigated to `/rooms/spaces/<full room id>` (JoinedCourseOnboardingStep.stepDestination) — a retired world_v1 shape. The legacy redirect rewrites it but keeps the FULL room id (`!abc:server`), which carries the server name into `?m=course:` and mis-parses (the same break as the course chooser fix #7047), dead-ending onboarding on a blank/exception route. Fix: use `PRoutes.course(roomId)`, which bares the id to `/courses/<localpart>` and resolves to the valid `?m=course:<id>&left=course` workspace. Verified locally: legacy_redirects_test passes and covers the `/courses/!s` resolution the fix produces.