### PR TITLE
docs/cleanup: fix misleading world-redesign docstrings and onboarding docs

### DIFF
--- a/.github/instructions/codebase-organization.instructions.md
+++ b/.github/instructions/codebase-organization.instructions.md
@@ -11,7 +11,7 @@ This client began as a fork of [krille-chan/fluffychat](https://github.com/krill
 
 | Dir | Role | Examples |
 | --- | --- | --- |
-| `lib/routes/` | Pages and on-screen UI, organized by nav section (GoRouter destinations). Screens, views, controllers, and route-local widgets live here. `chat/` also houses `choreographer/` and `events/`. | [`routes/courses/find_course_page.dart`](../../lib/routes/courses/find_course_page.dart), [`routes/world/activity_map_page.dart`](../../lib/routes/world/activity_map_page.dart), [`routes/chat/events/constants/pangea_event_types.dart`](../../lib/routes/chat/events/constants/pangea_event_types.dart) |
+| `lib/routes/` | Pages and on-screen UI, organized by nav section (GoRouter destinations). Screens, views, controllers, and route-local widgets live here. `chat/` also houses `choreographer/` and `events/`. | [`routes/courses/find_course_page.dart`](../../lib/routes/courses/find_course_page.dart), [`routes/world/world_map.dart`](../../lib/routes/world/world_map.dart), [`routes/chat/events/constants/pangea_event_types.dart`](../../lib/routes/chat/events/constants/pangea_event_types.dart) |
 | `lib/features/` | Per-domain data and logic: models, repos, Matrix Room/Client `*_extension.dart`, services, constants, enums. Mostly data, with a few in-domain UI primitives (see split rule). | [`features/course_plans/courses/course_plans_repo.dart`](../../lib/features/course_plans/courses/course_plans_repo.dart), [`features/languages/language_repo.dart`](../../lib/features/languages/language_repo.dart), [`features/navigation/route_paths.dart`](../../lib/features/navigation/route_paths.dart) |
 | `lib/pangea/` | Shared Pangea infra and common widgets used across features: network layer, `PangeaController`, common widgets, cross-cutting Matrix extensions, plus a few shared-infra domains (lemmas, morphs). | [`pangea/common/network/urls.dart`](../../lib/pangea/common/network/urls.dart), [`pangea/common/controllers/pangea_controller.dart`](../../lib/pangea/common/controllers/pangea_controller.dart), [`pangea/extensions/pangea_room_extension.dart`](../../lib/pangea/extensions/pangea_room_extension.dart) |
 | `lib/widgets/` | FluffyChat base plus general app chrome not tied to one route: root state, nav rail, mobile bottom nav, avatar, dialogs, layouts. Many carry `// #Pangea` edits. | [`widgets/matrix.dart`](../../lib/widgets/matrix.dart) (`MatrixState` root state), [`widgets/navigation_rail.dart`](../../lib/widgets/navigation_rail.dart), [`widgets/avatar.dart`](../../lib/widgets/avatar.dart) |
@@ -20,7 +20,7 @@ This client began as a fork of [krille-chan/fluffychat](https://github.com/krill
 
 ## The features ↔ routes Split
 
-The dominant pattern: domain **data/logic** goes in `lib/features/<domain>/`; on-screen **UI** goes in `lib/routes/<nav_section>/`. Course plans illustrate it: data in [`features/course_plans/courses/`](../../lib/features/course_plans/courses/) (repo, model, room extension), screens in [`routes/courses/`](../../lib/routes/courses/) (`find_course_page.dart`, `add_course_hub_view.dart`).
+The dominant pattern: domain **data/logic** goes in `lib/features/<domain>/`; on-screen **UI** goes in `lib/routes/<nav_section>/`. Course plans illustrate it: data in [`features/course_plans/courses/`](../../lib/features/course_plans/courses/) (repo, model, room extension), screens in [`routes/courses/`](../../lib/routes/courses/) (`find_course_page.dart`, `add_course_options.dart`).
 
 The rule is real but imperfectly enforced. A few feature dirs hold UI today (`features/subscription/widgets/`, `features/bot/widgets/`, `features/tutorials/*_widget.dart`). Keep new **full-screen pages** in `lib/routes/`. A widget may stay in a feature dir only if it is a small in-domain primitive reused across multiple routes; anything that is a screen belongs in `lib/routes/` so the nav taxonomy stays the place to find UI.
 
@@ -53,7 +53,6 @@ Shared-widget tie-breaker: a reusable Pangea-branded widget could plausibly land
 
 ## Known Cruft (Being Cleaned Up)
 
-- **`lib/pages_v2/`** is a stale empty scaffold (zero `.dart` files). New pages go in `lib/routes/`, not here.
 - **`lib/pangea/design_system/`** (and `tokens/`) hold no source. The "design tokens" home is not real code yet; do not route shared widgets there.
 
 ## Future Work

--- a/lib/features/navigation/legacy_redirects.dart
+++ b/lib/features/navigation/legacy_redirects.dart
@@ -329,8 +329,4 @@ abstract class LegacyRedirects {
     // Never redirect to the location we are already at.
     return shortened == uri.toString() ? null : shortened;
   }
-
-  /// Guard: bare `/rooms` maps to the chats list.
-  // (Handled by the `[] => const ['chats']` arm above.)
-  static String get chatsHome => PRoutes.chats;
 }

--- a/lib/features/navigation/panel_registry.dart
+++ b/lib/features/navigation/panel_registry.dart
@@ -77,7 +77,8 @@ class PanelDef {
   ///    `session`, `practice`). A `session` is in BOTH (it's a live chat AND a
   ///    detail).
   /// Roots (a list/menu/summary/course card) declare no group; they are replaced
-  /// via [WorkspaceNav.openMaster], not by sibling exclusivity.
+  /// by the master-opening helpers (e.g. [WorkspaceNav.setSection]), not by
+  /// sibling exclusivity.
   final Set<String> siblingGroups;
 
   /// Whether this panel hosts deeper pages in its own token param (a *push*):

--- a/lib/features/quests/user_stars.dart
+++ b/lib/features/quests/user_stars.dart
@@ -8,9 +8,13 @@ import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orche
 /// = goals the learner has collected in a role they hold, kept as the best
 /// across multiple sessions of the same activity.
 ///
-/// This is the same computation `world_map._deriveActivitySignals` feeds into
-/// the progression gate; kept here so other surfaces (e.g. the activity start
-/// page) gate identically — the gate is "resolved once" (quests.instructions.md).
+/// Used by the activity start page (`not_started_session_controller`) to feed the
+/// progression gate. NOTE: the world map does NOT call this helper — it derives
+/// the same per-activity star counts independently in
+/// `world_map._deriveActivitySignals` and `_userCompletion`. So the two are
+/// parallel implementations of the one rule (quests.instructions.md), not a
+/// single shared source; keep them in sync, or route the map through this
+/// function, until they're unified.
 Map<String, int> userStarsByActivity(Client client) {
   final stars = <String, int>{};
   for (final room in client.rooms) {


### PR DESCRIPTION
Addresses the section A cleanup items (actively-misleading comments/docs) from the world-redesign audit in #7056. Text and accuracy only, no behavior changes.

## Changes

1. `lib/features/quests/user_stars.dart`: the docstring claimed this was the single shared star computation the world map also feeds into ("the gate is resolved once"). It is not. `world_map.dart` never imports it and still computes per-activity stars inline (`_deriveActivitySignals`, `_userCompletion`); only `not_started_session_controller` calls it. Rewrote the docstring to describe the parallel-implementation reality and flag the duplication to keep in sync.
2. `lib/features/navigation/panel_registry.dart`: a docstring referenced `[WorkspaceNav.openMaster]`, which does not exist. Pointed it at the real master-opening helper, `[WorkspaceNav.setSection]`.
3. `lib/features/navigation/legacy_redirects.dart`: removed the dead `chatsHome` getter (zero callers; its own comment noted the work is already done by an arm above). `PRoutes` is still used elsewhere in the file, so no import was orphaned.
4. `.github/instructions/codebase-organization.instructions.md`: fixed two example links pointing at files that do not exist (`routes/world/activity_map_page.dart` to `world_map.dart`, and `add_course_hub_view.dart` to `add_course_options.dart`), and dropped the note documenting the empty `lib/pages_v2/` scaffold.
5. Deleted the empty `lib/pages_v2/` scaffold (5 directories, zero `.dart` files). Git did not track these empty dirs, so they do not appear in the diff.

## Verification

`flutter analyze` on the changed Dart files: no issues found. Grep confirms no remaining references to the removed symbols or files. This PR does not close #7056, which still tracks the larger structural follow-ups (sections B and C: the `world_map.dart` decomposition, duplicated reducers, query-string helpers, and i18n).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated codebase organization guides and inline documentation for consistency and clarity.

* **Refactor**
  * Removed legacy navigation code and streamlined documentation across internal modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->