### PR TITLE
fix(world): rebuild the joined-objective cache when courses change, surface outline failures

### DIFF
--- a/lib/routes/world/joined_objective_cache.dart
+++ b/lib/routes/world/joined_objective_cache.dart
@@ -26,12 +26,17 @@ class JoinedObjectiveCache {
   /// Rebuild from the joined courses' quest outlines. [outlineOf] resolves a
   /// course-plan uuid to its outline (defaults to the v3 quest read layer);
   /// [starsToUnlockOf] supplies the per-course teacher override (defaults to the
-  /// standard threshold). A course that fails to resolve is skipped rather than
-  /// failing the whole set, so one bad course can't blank the banding or gate.
+  /// standard threshold). A course that fails to resolve is skipped (rather than
+  /// failing the whole set) and reported to [onError] — it must NOT be swallowed
+  /// silently: a dropped course contributes no objective ids, and a fully empty
+  /// cache blanks relevance banding and fail-opens the progression gate with no
+  /// visible signal. [onError] is injectable so the rebuild stays unit-testable
+  /// without Matrix, the network, or Sentry.
   Future<void> rebuild(
     List<String> courseUuids, {
     Future<CourseLoOutline> Function(String uuid)? outlineOf,
     int Function(String uuid)? starsToUnlockOf,
+    void Function(String uuid, Object error, StackTrace stack)? onError,
   }) async {
     final resolve = outlineOf ?? _outlineFromQuest;
     final next = <CourseLoOutline>[];
@@ -47,8 +52,11 @@ class JoinedObjectiveCache {
                   starsToUnlockOf?.call(uuid) ?? kDefaultStarsToUnlockObjective,
             ),
           );
-        } catch (_) {
-          // Skip a course that won't resolve; the rest still band and gate.
+        } catch (e, s) {
+          // Skip a course that won't resolve; the rest still band and gate. But
+          // report it — a silently-empty cache is exactly how banding and the
+          // gate go dark unnoticed.
+          onError?.call(uuid, e, s);
         }
       }),
     );

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -15,6 +15,7 @@ import 'package:fluffychat/features/quests/lo_progression.dart';
 import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
 import 'package:fluffychat/features/quests/repo/activity_map_repo.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
 import 'package:fluffychat/routes/world/joined_objective_cache.dart';
 import 'package:fluffychat/routes/world/map_context.dart';
@@ -144,8 +145,19 @@ class WorldMapController extends State<WorldMap>
   Map<String, MapCompletionFilter> _completion = {};
 
   /// Learning-objective ids across the learner's joined courses, for relevance
-  /// banding. Rebuilt async on course join/leave.
+  /// banding. Rebuilt async on course join/leave (see [_maybeRebuildObjectiveCache]).
   final JoinedObjectiveCache _objectiveCache = JoinedObjectiveCache();
+
+  /// The joined-course uuids [_objectiveCache] was last (re)built from. The
+  /// initial build happens on client-set, but the joined-course rooms (or their
+  /// outlines) may not be ready yet; tracking the set lets the sync listener
+  /// rebuild when it changes — or when a prior build resolved nothing — instead
+  /// of the banding + gate staying blank for the whole session.
+  Set<String> _objectiveCacheUuids = const {};
+
+  /// Guards against overlapping objective-cache rebuilds (and stops a
+  /// persistently-failing course from rebuilding on every single sync).
+  bool _objectiveCacheRebuilding = false;
 
   /// Activity ids with a recently-pinged open session (best-effort, scanned from
   /// joined course-space messages). Folded into [_signals].
@@ -220,9 +232,12 @@ class WorldMapController extends State<WorldMap>
     if (_client != client) {
       _client = client;
       _recomputeProgress();
-      // The objective set and pinged scan do network/timeline work, so they run
-      // once on client set (not every sync). Joining a course mid-session
-      // refreshes them on the next remount — acceptable staleness for now.
+      // First build of the objective cache. It can come back empty if the
+      // joined-course rooms / their outlines aren't ready yet — the sync listener
+      // below rebuilds it when the joined-course set changes (or a prior build
+      // resolved nothing), so banding + the gate recover within the session
+      // instead of staying blank until a remount (which never happens for this
+      // persistent map). The pinged scan does one-shot timeline work.
       _rebuildObjectiveCache(client);
       _recomputePinged(client);
       _syncSub?.cancel();
@@ -230,7 +245,9 @@ class WorldMapController extends State<WorldMap>
           .where((s) => s.hasRoomUpdate)
           .rateLimit(const Duration(seconds: 2))
           .listen((_) {
-            if (mounted) _recomputeProgress();
+            if (!mounted) return;
+            _recomputeProgress();
+            _maybeRebuildObjectiveCache(client);
           });
     }
     // Personalized default: my CEFR band (at/below my level). Applied once the
@@ -265,30 +282,68 @@ class WorldMapController extends State<WorldMap>
     });
   }
 
+  /// The learner's joined course spaces (a space they belong to that carries a
+  /// course plan) — the source set for the objective cache + relevance banding.
+  List<Room> _joinedCourseRooms(Client client) => client.rooms
+      .where(
+        (r) =>
+            r.isSpace &&
+            r.membership == Membership.join &&
+            r.coursePlan != null,
+      )
+      .toList();
+
   /// Rebuild the joined-course outlines (a few quest reads), reading each
   /// course's teacher override for the stars-to-unlock threshold, then re-rank.
+  /// Guarded so overlapping syncs don't stack rebuilds. A course whose outline
+  /// fails to resolve is logged (not silently dropped): an empty cache means no
+  /// relevance banding and a fail-open gate, which is otherwise invisible.
   Future<void> _rebuildObjectiveCache(Client client) async {
-    final courseRooms = client.rooms
-        .where(
-          (r) =>
-              r.isSpace &&
-              r.membership == Membership.join &&
-              r.coursePlan != null,
-        )
-        .toList();
-    final uuids = courseRooms.map((r) => r.coursePlan!.uuid).toList();
-    final thresholds = <String, int>{
-      for (final r in courseRooms)
-        r.coursePlan!.uuid:
-            r.teacherMode.starsToUnlockObjective ??
-            kDefaultStarsToUnlockObjective,
-    };
-    await _objectiveCache.rebuild(
-      uuids,
-      starsToUnlockOf: (uuid) =>
-          thresholds[uuid] ?? kDefaultStarsToUnlockObjective,
-    );
-    if (mounted) setState(() {}); // re-rank with the loaded outlines
+    if (_objectiveCacheRebuilding) return;
+    _objectiveCacheRebuilding = true;
+    try {
+      final courseRooms = _joinedCourseRooms(client);
+      final uuids = courseRooms.map((r) => r.coursePlan!.uuid).toList();
+      final thresholds = <String, int>{
+        for (final r in courseRooms)
+          r.coursePlan!.uuid:
+              r.teacherMode.starsToUnlockObjective ??
+              kDefaultStarsToUnlockObjective,
+      };
+      await _objectiveCache.rebuild(
+        uuids,
+        starsToUnlockOf: (uuid) =>
+            thresholds[uuid] ?? kDefaultStarsToUnlockObjective,
+        onError: (uuid, e, s) => ErrorHandler.logError(
+          e: e,
+          s: s,
+          m: 'JoinedObjectiveCache: course outline failed to resolve',
+          data: {'courseUuid': uuid},
+        ),
+      );
+      _objectiveCacheUuids = uuids.toSet();
+      if (mounted) setState(() {}); // re-rank with the loaded outlines
+    } finally {
+      _objectiveCacheRebuilding = false;
+    }
+  }
+
+  /// Rebuild the objective cache when the joined-course set has changed since the
+  /// last build, or when it resolved nothing while courses exist (the rooms or
+  /// their outlines weren't ready at the initial build, or a read transiently
+  /// failed). Idempotent for an unchanged, already-populated set, so it's safe on
+  /// every sync; the in-flight guard keeps a persistently-failing course from
+  /// rebuilding more than once at a time, and it self-heals once the data is fixed.
+  void _maybeRebuildObjectiveCache(Client client) {
+    if (_objectiveCacheRebuilding) return;
+    final uuids = _joinedCourseRooms(
+      client,
+    ).map((r) => r.coursePlan!.uuid).toSet();
+    final setChanged =
+        uuids.length != _objectiveCacheUuids.length ||
+        !uuids.containsAll(_objectiveCacheUuids);
+    final emptyButHasCourses = _objectiveCache.ids.isEmpty && uuids.isNotEmpty;
+    if (setChanged || emptyButHasCourses) _rebuildObjectiveCache(client);
   }
 
   /// Best-effort pinged detection: scan joined course spaces' recent messages

--- a/test/pangea/joined_objective_cache_test.dart
+++ b/test/pangea/joined_objective_cache_test.dart
@@ -52,18 +52,26 @@ void main() {
       );
     });
 
-    test('skips a course that fails to resolve, keeping the rest', () async {
-      final cache = JoinedObjectiveCache();
-      await cache.rebuild(
-        ['ok', 'bad'],
-        outlineOf: (u) async {
-          if (u == 'bad') throw Exception('boom');
-          return _outline(['lo-a']);
-        },
-      );
-      expect(cache.ids, {'lo-a'});
-      expect(cache.outlines.length, 1);
-    });
+    test(
+      'skips a course that fails to resolve, reporting it via onError',
+      () async {
+        final cache = JoinedObjectiveCache();
+        final failed = <String>[];
+        await cache.rebuild(
+          ['ok', 'bad'],
+          outlineOf: (u) async {
+            if (u == 'bad') throw Exception('boom');
+            return _outline(['lo-a']);
+          },
+          onError: (uuid, e, s) => failed.add(uuid),
+        );
+        expect(cache.ids, {'lo-a'});
+        expect(cache.outlines.length, 1);
+        // The failure is surfaced, not swallowed (a silently-empty cache is the
+        // exact failure mode this guards against).
+        expect(failed, ['bad']);
+      },
+    );
 
     test('is empty with no joined courses', () async {
       final cache = JoinedObjectiveCache();


### PR DESCRIPTION
## Problem

The world map's joined-objective cache (`JoinedObjectiveCache`) drives two things: relevance **banding** (an activity is "band-3 / in one of my joined courses" → eligible for a large featured pin) and the **progression gate** (which Missions/activities are locked). It was built **once**, when the map controller's client was first set, and **never rebuilt** afterward (the sync listener only recomputed progress). Two ways that goes wrong, both silent:

1. If the joined-course rooms — or their quest outlines — aren't available at that one build moment, the cache comes back **empty and stays empty for the whole session** (the persistent world map never remounts). With no objective ids, banding never tags anything band-3 (so large featured cards never appear) and the gate fail-opens (nothing locks).
2. A course whose outline throws was **silently swallowed** (`catch (_)`), so a degraded/empty cache had no signal at all.

This is the client half of the "world map shows no large featured cards" investigation. The data-side half — activity `learningObjectiveRefs` not matching quests'/Missions' objective ids — is tracked in choreographer **#2607**.

## Fix

- **Rebuild on change, not once.** The sync listener now calls `_maybeRebuildObjectiveCache`, which rebuilds when the joined-course set has changed since the last build, or when the cache resolved nothing while courses exist (rooms/outlines not ready at first build, or a transient read failure). It's idempotent for an unchanged, populated set, an in-flight guard prevents stacked rebuilds, and it self-heals once the data is available — so banding + the gate recover within the session instead of staying blank until a remount that never happens.
- **Surface failures.** `JoinedObjectiveCache.rebuild` takes an injectable `onError`; the controller wires it to `ErrorHandler.logError` (Sentry). A course that fails to resolve is still skipped (the rest still band and gate), but it's no longer invisible.

## Scope

This is **robustness only**. If the root cause is a genuine LO-id mismatch in the data (choreographer #2607), this fix won't make cards appear — the ids still have to line up. What it does guarantee: the cache won't stay empty due to a build-timing race, and any outline failure is now reported instead of swallowed.

## Verification

- `flutter analyze lib/ test/` clean; `dart format` + import-sorter pass.
- Unit tests green, including a new assertion that a failing course is reported via `onError` rather than swallowed (`test/pangea/joined_objective_cache_test.dart`), plus the surrounding world/quest suites.
- `JoinedObjectiveCache` stays pure/injectable (no Matrix/Sentry import) — `onError` is supplied by the controller, mirroring the existing `outlineOf` / `starsToUnlockOf` injection.

Behavioral confirmation (cache recovers, large cards + locking return for in-course activities) needs a logged-in session and, where the cause is data, the #2607 id fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Errors that occur during course outline resolution are now properly reported and logged instead of being silently ignored, improving system diagnostics.
  * Objective cache now rebuilds intelligently when course availability changes, ensuring course progression data stays current.
  * Enhanced error handling and logging provides better visibility into cache synchronization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->