### PR TITLE
fix(navigation): repair the /rooms dead route and move internal nav to tokens (#7067)

### DIFF
--- a/.github/instructions/routing.instructions.md
+++ b/.github/instructions/routing.instructions.md
@@ -52,6 +52,29 @@ Internal navigation only ever emits token URLs. This single-source rule is why a
 shared link reopens exactly what the sender saw, and why closing a panel is just
 dropping its token: there is no second, path-driven copy to leave standing.
 
+### Navigate by token, never by path
+
+Internal navigation MUST go through the `WorkspaceNav` token helpers (or the
+token-producing `PRoutes` builders) — `setSection`, `openSettings`,
+`openCourseFilter`, `openCoursePage[For]`, `openConstructDetail`, `closeLeft`,
+`PRoutes.chatsList`, `PRoutes.world`, etc. **Do NOT `context.go`/`push` to a
+section/room/course PATH** (`/chats`, `/rooms/settings/...`, `/courses/:id/...`).
+Those paths exist ONLY as **legacy redirect shims** for inbound links we don't
+control (push, `matrix.to`, old bookmarks), which `LegacyRedirects` rewrites to
+tokens before anything renders. A `/…` literal inside a `.go(...)` is a smell: the
+redirect would just bounce it to a token — a wasted hop, and exactly how the
+dead-`/chats` bug (#7067) happened.
+
+The only legitimate path destinations, all declared in `routes.dart`: the
+deliberately-upstream `/rooms/:roomid` room shape (kept verbatim for push /
+`matrix.to`); the pre-login + utility routes (`/home`, `/onboarding`,
+`/registration`, `/logs`, `/configs`); the route-driven Completer flows that can't
+ride a token URL (`/courses/own/:courseid[/invite]`, `/courses/:spaceid/addcourse/:courseId`);
+the public-course preview; and the first-class `/:activityId`. Everything else is a
+token. `PRoutes`'s `chats`/`analytics`/`settings`/`profile`/`rooms` constants are
+**legacy section paths** — redirect sources and `sectionFor` identities, never
+navigation targets.
+
 ### The map is the backdrop
 
 One map stays mounted for the whole app and never remounts, always full width

--- a/lib/features/course_plans/new_course_page.dart
+++ b/lib/features/course_plans/new_course_page.dart
@@ -12,7 +12,9 @@ import 'package:fluffychat/features/course_plans/courses/course_plan_client_exte
 import 'package:fluffychat/features/course_plans/courses/course_plan_model.dart';
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/languages/p_language_store.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/route_paths.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/quests/repo/quest_plans_repo.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -233,7 +235,14 @@ class NewCoursePageState extends State<NewCoursePage> {
       );
     } else if (action == 1) {
       if (existingRoom.isSpace) {
-        context.go('/rooms/spaces/${existingRoom.id}');
+        // world_v2: token nav to the existing course card (sets the map filter +
+        // course panel), not the legacy /rooms/spaces path.
+        context.go(
+          WorkspaceNav.openCourseFilter(
+            GoRouterState.of(context).uri,
+            existingRoom.id,
+          ),
+        );
       } else {
         ErrorHandler.logError(
           e: "Existing course room is not a space",
@@ -259,7 +268,16 @@ class NewCoursePageState extends State<NewCoursePage> {
                 // Accessible name (world_v2 testability contract: every
                 // IconButton needs a tooltip → semantics label).
                 tooltip: MaterialLocalizations.of(context).backButtonTooltip,
-                onPressed: () => context.go('/courses'),
+                // world_v2: the add-course hub is the `addcourse` left token over
+                // the world map, not a `/courses` route.
+                onPressed: () => context.go(
+                  WorkspaceNav.setSection(
+                    GoRouterState.of(context).uri,
+                    PRoutes.world,
+                    const PanelToken('addcourse'),
+                    keepRoom: false,
+                  ),
+                ),
               )
             : widget.embeddedCloseButton,
         title: Text(

--- a/lib/features/course_plans/new_course_page.dart
+++ b/lib/features/course_plans/new_course_page.dart
@@ -12,6 +12,7 @@ import 'package:fluffychat/features/course_plans/courses/course_plan_client_exte
 import 'package:fluffychat/features/course_plans/courses/course_plan_model.dart';
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/languages/p_language_store.dart';
+import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/quests/repo/quest_plans_repo.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -331,7 +332,8 @@ class NewCoursePageState extends State<NewCoursePage> {
                                         style: theme.textTheme.bodyLarge,
                                       ),
                                       ElevatedButton(
-                                        onPressed: () => context.go('/rooms'),
+                                        onPressed: () =>
+                                            context.go(PRoutes.chatsList),
                                         style: ElevatedButton.styleFrom(
                                           backgroundColor: theme
                                               .colorScheme

--- a/lib/features/navigation/app_section.dart
+++ b/lib/features/navigation/app_section.dart
@@ -23,8 +23,9 @@ enum AppSection {
     selectedIcon: Icons.public,
   ),
 
-  /// Chats — the chat list. Root: `/chats`. Matrix rooms (`/rooms/...`)
-  /// belong to this surface too.
+  /// Chats — the chat list. Legacy root `/chats` (redirected to the `chats`
+  /// token; the live location is `PRoutes.chatsList`). Matrix rooms
+  /// (`/rooms/...`) belong to this surface too.
   chats(
     rootPath: PRoutes.chats,
     icon: Icons.forum_outlined,

--- a/lib/features/navigation/legacy_redirects.dart
+++ b/lib/features/navigation/legacy_redirects.dart
@@ -159,11 +159,13 @@ abstract class LegacyRedirects {
       return _toRoomToken(uri, rest.first, rest.sublist(1));
     }
 
-    final List<String>? target = switch (rest) {
-      // `/rooms` — the old chats root. Chats now live at `/chats`; the
-      // world map is `/`.
-      [] => const ['chats'],
+    // Bare `/rooms` was the old chats home. world_v2 has no `/chats` route — the
+    // chat list is the `chats` left token over the world map — so map it straight
+    // there in one hop. The earlier `/rooms` → `/chats` → `/?left=chats` chain
+    // briefly emitted the dead `/chats` literal (the bug in #7067).
+    if (rest.isEmpty) return _toRootWithLeftToken(uri, 'chats');
 
+    final List<String>? target = switch (rest) {
       // Renamed sections.
       ['user_home', ...final tail] => ['profile', ...tail],
       ['analytics', ...final tail] => ['analytics', ...tail],

--- a/lib/features/navigation/route_paths.dart
+++ b/lib/features/navigation/route_paths.dart
@@ -2,9 +2,15 @@ import 'package:fluffychat/features/navigation/room_id_url.dart';
 
 /// Canonical route paths for Pangea-owned surfaces (world_v2).
 ///
-/// All navigation goes through these constants and builders — never
-/// hardcode a path string at a callsite. Fork-owned surfaces (Matrix
-/// rooms) intentionally keep their upstream `/rooms/:roomid` shape so
+/// world_v2 navigation is **token-driven**: internal navigation goes through the
+/// `WorkspaceNav` token helpers (and the token locations/builders here —
+/// [world], [chatsList], [course], [room], [worldObject], [activity]). The bare
+/// **section-path** constants ([chats], [analytics], [courses], [settings],
+/// [profile], [rooms]) are NOT navigation targets — they are legacy redirect
+/// sources + `route_facts.sectionFor` identities that `LegacyRedirects` rewrites
+/// to tokens before render. Never `context.go` a section path; see the
+/// "Navigate by token, never by path" rule in `routing.instructions.md`.
+/// Fork-owned Matrix rooms keep their upstream `/rooms/:roomid` shape so
 /// push-notification and matrix.to deep-link handling stay untouched.
 ///
 /// Design doc: `.github/vision/world_v2.md` (workspace root repo).
@@ -28,20 +34,25 @@ abstract class PRoutes {
   /// and the bare `/rooms` legacy paths redirect here.
   static const String chatsList = '/?left=chats';
 
-  /// Learning analytics section root.
+  /// Legacy analytics section path (redirect source / `sectionFor` identity, not
+  /// a nav target). Analytics is token-driven: `right=analytics:<tab>` etc.
   static const String analytics = '/analytics';
 
-  /// Courses section root (find/browse). A specific joined course lives
-  /// at [course].
+  /// Legacy courses section path (redirect source / `sectionFor` identity). The
+  /// bare hub is the `addcourse` left token; a joined course is [course]'s
+  /// `?m=course:` filter. This base constant is not a direct nav target.
   static const String courses = '/courses';
 
-  /// Settings section root.
+  /// Legacy settings section path (redirect source / `sectionFor` identity, not a
+  /// nav target). Settings is token-driven: `WorkspaceNav.openSettings`.
   static const String settings = '/settings';
 
-  /// Profile section root (formerly user_home).
+  /// Legacy profile section path (formerly user_home; redirect source /
+  /// `sectionFor` identity, not a nav target). Profile is the `settings` token.
   static const String profile = '/profile';
 
-  /// Matrix rooms root — upstream-shaped on purpose.
+  /// Matrix rooms root — upstream-shaped on purpose. Bare `/rooms` redirects to
+  /// [chatsList]; `/rooms/:roomid` is the deliberately-kept room shape ([room]).
   static const String rooms = '/rooms';
 
   // ---- builders -------------------------------------------------------

--- a/lib/features/navigation/route_paths.dart
+++ b/lib/features/navigation/route_paths.dart
@@ -15,9 +15,18 @@ abstract class PRoutes {
   /// World home — the app opens onto the map. World section root.
   static const String world = '/';
 
-  /// Chats section root — the chat list. The world map (`/`) and chats
-  /// are distinct sections in world_v2.
+  /// Legacy chats section path. world_v2 has **no live `/chats` route** — the
+  /// chat list is the `chats` left token over the world map ([chatsList]) — so
+  /// the router redirects `/chats` (and the bare `/rooms` home) there. Kept only
+  /// as the section's legacy-path identity (sibling to [analytics] / [settings],
+  /// matched by `route_facts.sectionFor`); do NOT navigate to it. To open the
+  /// chat list, use [chatsList].
   static const String chats = '/chats';
+
+  /// The chat list as a live world_v2 location: the world map with the chats
+  /// panel open (`/?left=chats`). The canonical "go to chats" target; [chats]
+  /// and the bare `/rooms` legacy paths redirect here.
+  static const String chatsList = '/?left=chats';
 
   /// Learning analytics section root.
   static const String analytics = '/analytics';

--- a/lib/features/navigation/workspace_nav.dart
+++ b/lib/features/navigation/workspace_nav.dart
@@ -240,6 +240,15 @@ abstract class WorkspaceNav {
   static String openCoursePage(Uri current, String page) =>
       openDetail(current, PanelToken('coursepage', page));
 
+  /// Open course [spaceId]'s management [page] (invite / edit / …) from
+  /// ANYWHERE: set the `?m=course:<id>` scope + `course` card, then the
+  /// `coursepage:<page>` detail beside it. Same shape as [openCoursePage] on the
+  /// already-scoped course — use this when the target course may not be the
+  /// current filter (e.g. inviting knocking users from a space tile, or from an
+  /// activity session). See `routing.instructions.md`.
+  static String openCoursePageFor(Uri current, String spaceId, String page) =>
+      openCoursePage(Uri.parse(openCourseFilter(current, spaceId)), page);
+
   /// Replace the whole `left` list (e.g. tapping a top-level section: Chats,
   /// the avatar/profile). The `right` list and other query params are preserved.
   static String setLeft(Uri current, List<PanelToken> tokens) =>

--- a/lib/features/subscription/widgets/subscription_snackbar.dart
+++ b/lib/features/subscription/widgets/subscription_snackbar.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
 
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 
 void showSubscribedSnackbar(BuildContext context) {
@@ -22,7 +23,12 @@ void showSubscribedSnackbar(BuildContext context) {
           text: L10n.of(context).clickToManageSubscription,
           style: TextStyle(color: Theme.of(context).colorScheme.inversePrimary),
           recognizer: TapGestureRecognizer()
-            ..onTap = () => context.go('/rooms/settings/subscription'),
+            ..onTap = () => context.go(
+              WorkspaceNav.openSettings(
+                GoRouterState.of(context).uri,
+                page: 'subscription',
+              ),
+            ),
         ),
       ],
     ),

--- a/lib/pangea/spaces/knocking_users_indicator.dart
+++ b/lib/pangea/spaces/knocking_users_indicator.dart
@@ -7,6 +7,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
@@ -109,9 +110,18 @@ class KnockingUsersIndicatorState extends State<KnockingUsersIndicator> {
                       ),
                     ],
                   ),
-                  onTap: () => context.push(
-                    "/rooms/spaces/${widget.room.id}/details/invite?filter=knock",
-                  ),
+                  onTap: () {
+                    // world_v2: token nav to the course's invite page scoped to
+                    // this space, carrying the knock filter the panel reads once.
+                    final loc = WorkspaceNav.openCoursePageFor(
+                      GoRouterState.of(context).uri,
+                      widget.room.id,
+                      'invite',
+                    );
+                    context.go(
+                      '$loc${loc.contains('?') ? '&' : '?'}filter=knock',
+                    );
+                  },
                 ),
               ),
             ),

--- a/lib/routes/chat/activity_sessions/not_started_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/not_started_session_controller.dart
@@ -228,7 +228,14 @@ class NotStartedSessionController extends State<NotStartedSession>
   void inviteToCourse() {
     final course = widget.course;
     if (course == null) return;
-    context.push("/rooms/spaces/${course.id}/invite");
+    // world_v2: token nav to the course's invite page (no stacked route push).
+    context.go(
+      WorkspaceNav.openCoursePageFor(
+        GoRouterState.of(context).uri,
+        course.id,
+        'invite',
+      ),
+    );
   }
 
   Future<void> joinExistingSession() async {

--- a/lib/routes/chat/chat_details/chat_context_menu_action.dart
+++ b/lib/routes/chat/chat_details/chat_context_menu_action.dart
@@ -227,7 +227,14 @@ void chatContextMenuAction(
       onChatTap.call();
       return;
     case ChatContextAction.goToSpace:
-      outerContext.go("/rooms/spaces/${space!.id}/details");
+      // world_v2: token nav to the course card (sets ?m=course:<id>&left=course),
+      // not the legacy /rooms/spaces path.
+      outerContext.go(
+        WorkspaceNav.openCourseFilter(
+          GoRouterState.of(outerContext).uri,
+          space!.id,
+        ),
+      );
       return;
     case ChatContextAction.favorite:
       await showFutureLoadingDialog(

--- a/lib/routes/chat/chat_details/chat_context_menu_action.dart
+++ b/lib/routes/chat/chat_details/chat_context_menu_action.dart
@@ -5,6 +5,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
@@ -290,7 +291,7 @@ void chatContextMenuAction(
 
       if (!resp.isError) {
         isSpace
-            ? context.go('/rooms')
+            ? context.go(PRoutes.chatsList)
             : NavigationUtil.goToSpaceRoute(null, [], outerContext);
       }
 

--- a/lib/routes/chat/chat_details/delete_space_dialog.dart
+++ b/lib/routes/chat/chat_details/delete_space_dialog.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/chat_details/delete_room_extension.dart';
@@ -50,7 +51,7 @@ class DeleteSpaceDialog extends StatefulWidget {
     );
 
     if (!result.isError) {
-      context.go("/rooms");
+      context.go(PRoutes.chatsList);
     }
   }
 

--- a/lib/routes/chat/chat_details/space_details_content.dart
+++ b/lib/routes/chat/chat_details/space_details_content.dart
@@ -15,6 +15,7 @@ import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dar
 import 'package:fluffychat/features/join_codes/join_rule_extension.dart';
 import 'package:fluffychat/features/join_codes/share_room_button.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
 import 'package:fluffychat/l10n/l10n.dart';
@@ -296,7 +297,7 @@ class SpaceDetailsContent extends StatelessWidget {
             future: room.leaveSpace,
           );
           if (!resp.isError) {
-            context.go("/rooms");
+            context.go(PRoutes.chatsList);
           }
         },
         enabled: room.membership == Membership.join,

--- a/lib/routes/onboarding/onboarding_steps/joined_course_onboarding_step.dart
+++ b/lib/routes/onboarding/onboarding_steps/joined_course_onboarding_step.dart
@@ -12,7 +12,7 @@ class JoinedCourseOnboardingStep extends OnboardingStep {
   @override
   String get stepDestination {
     final roomId = state.joinedRoomId;
-    if (roomId == null) return "/rooms";
+    if (roomId == null) return PRoutes.chatsList;
     // world_v2: a joined course is `/courses/<bareLocalpart>` (PRoutes.course),
     // not the retired `/rooms/spaces/:spaceid` shape. Passing the FULL room id
     // through the legacy redirect mis-parses it (the same break as the course

--- a/lib/routes/onboarding/onboarding_steps/onboarding_step.dart
+++ b/lib/routes/onboarding/onboarding_steps/onboarding_step.dart
@@ -1,5 +1,6 @@
 import 'package:matrix/matrix.dart';
 
+import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/onboarding/onboarding_state_controller.dart';
 
@@ -18,7 +19,7 @@ abstract class OnboardingStep {
 
   bool get customView => false;
 
-  String get stepDestination => "/rooms";
+  String get stepDestination => PRoutes.chatsList;
 
   String nextStepText(L10n l10n) => l10n.next;
 

--- a/lib/routes/settings/settings_notifications/settings_notifications.dart
+++ b/lib/routes/settings/settings_notifications/settings_notifications.dart
@@ -7,6 +7,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/setting_keys.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/notifications/notifications_client_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -256,7 +257,12 @@ class SettingsNotificationsController extends State<SettingsNotifications> {
                 child: InkWell(
                   onTap: () {
                     messenger!.hideCurrentSnackBar();
-                    context.go("/rooms/settings/security/3pid");
+                    context.go(
+                      WorkspaceNav.openSettings(
+                        GoRouterState.of(context).uri,
+                        page: 'security/3pid',
+                      ),
+                    );
                   },
                   child: Text(
                     L10n.of(context).clickToAddEmail,

--- a/lib/widgets/chat_settings_popup_menu.dart
+++ b/lib/widgets/chat_settings_popup_menu.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
@@ -76,7 +77,7 @@ class ChatSettingsPopupMenuState extends State<ChatSettingsPopupMenu> {
                   future: () => widget.room.leave(),
                 );
                 if (result.error == null) {
-                  router.go('/rooms');
+                  router.go(PRoutes.chatsList);
                 }
 
                 break;

--- a/test/pangea/navigation/legacy_redirects_test.dart
+++ b/test/pangea/navigation/legacy_redirects_test.dart
@@ -7,8 +7,10 @@ void main() {
       LegacyRedirects.resolve(Uri.parse(location));
 
   group('LegacyRedirects', () {
-    test('old chats root maps to the chats list', () {
-      expect(resolve('/rooms'), '/chats');
+    test('old chats root maps straight to the chats list (one hop)', () {
+      // #7067: /rooms previously resolved to the dead `/chats` literal and only
+      // then re-redirected; it now lands on the chats token directly.
+      expect(resolve('/rooms'), '/?left=chats');
     });
 
     test('sections are lifted to first-class roots', () {

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -626,6 +626,37 @@ void main() {
       expect(parseOpenPanels(u(loc)).left.single, const PanelToken('course'));
       expect(activeSpaceIdFor(u(loc)), '!s');
     });
+
+    test(
+      'openCoursePageFor opens a management page from ANYWHERE — setting the '
+      'target space scope even from the bare map or a different course',
+      () {
+        // From the bare world map (no course scope at all).
+        var loc = WorkspaceNav.openCoursePageFor(u('/'), '!target', 'invite');
+        expect(activeSpaceIdFor(u(loc)), '!target');
+        expect(parseOpenPanels(u(loc)).left.map((t) => t.type).toList(), [
+          'course',
+          'coursepage',
+        ]);
+        expect(
+          parseOpenPanels(u(loc)).left.last,
+          const PanelToken('coursepage', 'invite'),
+        );
+        // From a DIFFERENT course — the scope is replaced with the target's.
+        loc = WorkspaceNav.openCoursePageFor(
+          u('/?m=course:!other&left=course'),
+          '!target',
+          'edit',
+        );
+        expect(activeSpaceIdFor(u(loc)), '!target');
+        expect(
+          parseOpenPanels(
+            u(loc),
+          ).left.where((t) => t.type == 'coursepage').single,
+          const PanelToken('coursepage', 'edit'),
+        );
+      },
+    );
   });
 
   group('openPractice (takes over the analytics surface)', () {


### PR DESCRIPTION
Closes #7067.

## The bug

End-of-onboarding (and several other call sites) navigated to bare `/rooms` — the old chats home. world_v2's legacy redirect rewrote bare `/rooms` to the literal `/chats`, which has **no GoRoute** (sections became `?left=` tokens), so the intermediate hop surfaced the dead `/chats` route.

## Fix

- **Collapsed the redirect to one hop:** bare `/rooms` now maps straight to `/?left=chats` (the chats panel over the world map). No dead intermediate.
- **Added `PRoutes.chatsList = '/?left=chats'`** as the canonical "go to chats" target and repointed every bare-`/rooms` caller to it (onboarding `stepDestination` + `JoinedCourseOnboardingStep`, `new_course_page`, `space_details_content`, `delete_space_dialog`, `chat_context_menu_action`, `chat_settings_popup_menu`).
- **Clarified `/chats`** as a legacy redirect source / `sectionFor` identity (not a nav target); the inbound `/chats` → `/?left=chats` shim stays for old links.

## Path-route deprecation cleanup (follow-up to review feedback)

The dead route was a symptom of a deprecated pattern — navigating by path instead of by token. world_v2 navigation is token-driven; paths exist only as legacy redirect shims for inbound links (push, `matrix.to`, bookmarks). This makes that rule explicit and cleans up the internal leftovers:

- **Documented the rule.** Added a scannable "Navigate by token, never by path" section to `routing.instructions.md` (with the legitimate path exceptions), and reframed `PRoutes` so the `chats`/`analytics`/`settings`/`profile`/`rooms` constants are clearly **legacy section paths** (redirect sources / `sectionFor` identities), distinct from the token locations/builders used for navigation.
- **Converted the internal-UI path-navs to `WorkspaceNav` tokens:** settings links (`subscription_snackbar`, `settings_notifications`) → `openSettings`; course navs (`chat_context_menu_action`, `new_course_page`) → `openCourseFilter` / `setSection(addcourse)`; and the two `.push` course-invite sites (`knocking_users_indicator`, `not_started_session_controller`) via a new `WorkspaceNav.openCoursePageFor(uri, spaceId, page)` helper that sets the target course scope from anywhere (unit-tested).
- **Deliberately kept** (the documented exceptions): the upstream `/rooms/:roomid` room shape (push / `matrix.to`), the route-driven Completer flows in `new_course_page`, pre-login/utility routes, and the inbound legacy redirects themselves.

## Verification

- `flutter analyze lib/ test/` clean; format + import-sorter pass.
- `test/pangea/navigation/` green, incl. the updated `legacy_redirects_test` (bare `/rooms` → `/?left=chats` in one hop) and a new `openCoursePageFor` test (sets the target scope from the bare map and from a different course).
- Note: `onboarding_step_transition_test.dart` has 8 failures that are **pre-existing on `main`** (from #7071's free-trial onboarding; they reproduce with these changes stashed) — unrelated to this PR, flagged separately.

Behavioral confirmation needs a fresh onboarding session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Navigation throughout the app is now faster and more direct, with fewer redirect steps.
  * Enhanced access to subscription management and course-related settings pages.
  * Streamlined routing behavior across all in-app navigation features for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->