### PR TITLE
fix(nav): close token panels via token fallback instead of dead-end pop (#7076)

### DIFF
--- a/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
+++ b/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
@@ -14,6 +14,7 @@ import 'package:fluffychat/features/analytics/construct_type_enum.dart';
 import 'package:fluffychat/features/analytics/construct_use_model.dart';
 import 'package:fluffychat/features/analytics_data/analytics_data_service.dart';
 import 'package:fluffychat/features/languages/language_model.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -28,6 +29,7 @@ import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
 import 'package:fluffychat/routes/chat/events/phonetic_transcription/pt_v2_models.dart';
 import 'package:fluffychat/routes/chat/events/token_info_feedback/show_token_feedback_dialog.dart';
 import 'package:fluffychat/routes/chat/events/token_info_feedback/token_info_feedback_request.dart';
+import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/analytics_summary/learning_progress_indicators.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
@@ -122,6 +124,20 @@ class ConstructAnalyticsViewState extends State<ConstructAnalyticsView> {
     }
   }
 
+  /// Close this construct detail. As a dialog it pops; as the world_v2 right-
+  /// column token there is nothing to pop to, so fall back to the analytics
+  /// summary for this construct type instead of dead-ending on the loading page
+  /// (#7076).
+  void _close() => NavigationUtil.popOrGo(
+    context,
+    WorkspaceNav.setRight(GoRouterState.of(context).uri, [
+      PanelToken(
+        'analytics',
+        widget.view == ConstructTypeEnum.vocab ? 'vocab' : 'grammar',
+      ),
+    ]),
+  );
+
   void _onBlockConstruct(AnalyticsStreamUpdate update) {
     final blocked = update.blockedConstructs;
     if (blocked == null) return;
@@ -132,7 +148,7 @@ class ConstructAnalyticsViewState extends State<ConstructAnalyticsView> {
       }
 
       if (blocked.contains(widget.construct)) {
-        Navigator.of(context).pop();
+        _close();
       }
     }
   }
@@ -264,7 +280,7 @@ class ConstructAnalyticsViewState extends State<ConstructAnalyticsView> {
           ? AppBar(
               leading: IconButton(
                 tooltip: L10n.of(context).close,
-                onPressed: Navigator.of(context).pop,
+                onPressed: _close,
                 icon: Icon(Icons.close),
               ),
             )

--- a/lib/routes/analytics/construct_analytics/construct_analytics_details/vocab_analytics_details_view.dart
+++ b/lib/routes/analytics/construct_analytics/construct_analytics_details/vocab_analytics_details_view.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 
 import 'package:collection/collection.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:fluffychat/features/analytics/construct_identifier.dart';
 import 'package:fluffychat/features/analytics/construct_level_enum.dart';
 import 'package:fluffychat/features/analytics/construct_use_model.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/lemmas/lemma.dart';
 import 'package:fluffychat/pangea/lemmas/lemma_info_response.dart';
@@ -16,6 +19,7 @@ import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
 import 'package:fluffychat/routes/chat/events/models/pangea_token_text_model.dart';
 import 'package:fluffychat/routes/chat/events/phonetic_transcription/pt_v2_models.dart';
 import 'package:fluffychat/routes/chat/toolbar/word_card/word_zoom_widget.dart';
+import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -90,7 +94,12 @@ class VocabDetailsView extends StatelessWidget {
                       MatrixState.pangeaController.userController.userL2Code!,
                   construct: constructId,
                   pos: constructId.category,
-                  onClose: Navigator.of(context).pop,
+                  onClose: () => NavigationUtil.popOrGo(
+                    context,
+                    WorkspaceNav.setRight(GoRouterState.of(context).uri, const [
+                      PanelToken('analytics', 'vocab'),
+                    ]),
+                  ),
                   onFlagTokenInfo:
                       (
                         LemmaInfoResponse lemmaInfo,

--- a/lib/routes/settings/settings_learning/settings_learning.dart
+++ b/lib/routes/settings/settings_learning/settings_learning.dart
@@ -2,9 +2,13 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import 'package:go_router/go_router.dart';
+
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/settings/settings_learning/learning_settings_view_model.dart';
 import 'package:fluffychat/routes/settings/settings_learning/settings_learning_view.dart';
+import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -84,11 +88,20 @@ class SettingsLearningController extends State<SettingsLearning> {
     super.dispose();
   }
 
+  /// Close the learning-settings surface. As a dialog it pops; as the world_v2
+  /// settings panel there is nothing on the stack to pop to, so it navigates back
+  /// to the settings menu via its token instead of dead-ending on the loading
+  /// page (#7076).
+  void _closeSettings() => NavigationUtil.popOrGo(
+    context,
+    WorkspaceNav.settingsBack(GoRouterState.of(context).uri, 'learning'),
+  );
+
   // if the settings have been changed, show a dialog the user wants to exit without saving
   // if the settings have not been changed, just close the settings page
   Future<void> onSettingsClose() async {
     if (!viewModel.haveSettingsChanged) {
-      Navigator.of(context).pop();
+      _closeSettings();
       return;
     }
 
@@ -99,7 +112,7 @@ class SettingsLearningController extends State<SettingsLearning> {
       context: context,
     );
 
-    resp == OkCancelResult.ok ? await submit() : Navigator.of(context).pop();
+    resp == OkCancelResult.ok ? await submit() : _closeSettings();
   }
 
   // Saves settings without navigating. Returns true if save succeeded.
@@ -130,7 +143,7 @@ class SettingsLearningController extends State<SettingsLearning> {
 
   Future<void> submit() async {
     if (await _saveChanges(context)) {
-      Navigator.of(context).pop();
+      _closeSettings();
     }
   }
 

--- a/lib/utils/navigation_util.dart
+++ b/lib/utils/navigation_util.dart
@@ -14,6 +14,21 @@ import 'package:fluffychat/features/navigation/workspace_nav.dart';
 /// `/rooms/...` or `/courses/...` render paths anymore; inbound legacy paths are
 /// rewritten to tokens by `legacy_redirects`. See `routing.instructions.md`.
 class NavigationUtil {
+  /// Close the current surface without dead-ending. A real pushed route or
+  /// dialog pops normally; but a world_v2 token panel (a settings page, an
+  /// analytics detail) has nothing on the navigator stack to pop to, so a bare
+  /// `Navigator.pop()` falls out of the shell to the initial route and renders
+  /// the loading page (#7076). When there is nothing to pop, navigate to
+  /// [fallback] — a token location — instead. See `routing.instructions.md`.
+  static void popOrGo(BuildContext context, String fallback) {
+    final navigator = Navigator.of(context);
+    if (navigator.canPop()) {
+      navigator.pop();
+    } else {
+      GoRouter.of(context).go(fallback);
+    }
+  }
+
   static void goToSpaceRoute(
     String? goalRoomID,
     List<String> goalSubroute,


### PR DESCRIPTION
## Problem

Closes #7076. In world_v2 the sections are tokens over the world map (`/`), not pushed routes. Several "close" / "back" / "X" controls inside token panels still called `Navigator.of(context).pop()`. A token panel has nothing on the navigator stack to pop to, so the pop falls out of the shell to the initial route and the web app lands back on the initial loading page.

Reproductions in the issue:
1. Save learning settings.
2. Delete a construct in the construct details panel.
3. Close the vocab analytics detail via the X in the word card.

## Fix

New helper `NavigationUtil.popOrGo(context, fallback)`: a real pushed route or dialog still pops normally (`canPop()`), but when there is nothing to pop it navigates to a token location instead of dead-ending.

Applied at the affected token-panel close points:
- `settings_learning` close / cancel / submit go back to the settings menu token.
- `analytics_details_popup` construct-block close and the morph-detail X go back to the matching analytics summary token.
- `vocab_analytics_details_view` word-card X goes back to the vocab analytics summary token.

Genuine dialogs that return a value (report message, feedback dialogs, token-info feedback, push-rule dialog) are left on `pop` since they have a route to pop and rely on the returned value.

## Verification

- `dart format` + `import_sorter` clean.
- `flutter analyze` on the touched files: no issues.
- `flutter test test/pangea/navigation/`: 134 passing.
