### PR TITLE
fix(courses): course-detail back returns to plan list/card instead of blank page (#7090)

### DIFF
--- a/lib/routes/courses/own/selected_course_page.dart
+++ b/lib/routes/courses/own/selected_course_page.dart
@@ -8,6 +8,8 @@ import 'package:matrix/matrix.dart' as sdk;
 import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_model.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/spaces/client_spaces_extension.dart';
@@ -44,6 +46,32 @@ class SelectedCourseController extends State<SelectedCourse>
     super.didUpdateWidget(oldWidget);
     if (oldWidget.courseId != widget.courseId) {
       loadCourse(widget.courseId);
+    }
+  }
+
+  /// world_v2: the course detail is route-driven (`/courses/own/:courseid` and
+  /// `/courses/:spaceid/addcourse/:courseId`) because the launch/add Completer
+  /// can't ride a token URL, so the parent `/courses…` segments render a blank
+  /// `EmptyPage`. A plain `Navigator.pop()` surfaces that blank page (#7090).
+  /// Navigate back to where the detail was opened from instead: the start-my-own
+  /// plan list (`addcourse:own` over the world map) for launch, or the target
+  /// course card for add-to-space.
+  void back() {
+    final uri = GoRouterState.of(context).uri;
+    switch (widget.mode) {
+      case SelectedCourseMode.launch:
+        context.go(
+          WorkspaceNav.setSection(
+            uri,
+            PRoutes.world,
+            const PanelToken('addcourse', 'own'),
+            keepRoom: false,
+          ),
+        );
+      case SelectedCourseMode.addToSpace:
+        context.go(
+          WorkspaceNav.openCourseFilter(uri, widget.spaceId!, tab: 'course'),
+        );
     }
   }
 

--- a/lib/routes/courses/own/selected_course_view.dart
+++ b/lib/routes/courses/own/selected_course_view.dart
@@ -42,7 +42,17 @@ class SelectedCourseView extends StatelessWidget {
           );
 
     return Scaffold(
-      appBar: AppBar(title: Text(controller.title)),
+      appBar: AppBar(
+        // world_v2: explicit token-based back. The auto-implied back would pop
+        // to the route-driven parent's blank EmptyPage (#7090); controller.back
+        // returns to the plan list / course card instead.
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+          onPressed: controller.back,
+        ),
+        title: Text(controller.title),
+      ),
       body: SafeArea(
         child: Container(
           alignment: Alignment.topCenter,

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -512,6 +512,25 @@ void main() {
       expect(lists.left, [const PanelToken('chats')]); // section replaced left
       expect(lists.right, [const PanelToken('analytics', 'vocab')]); // kept
     });
+
+    test('back from the route-driven course detail lands on the plan list '
+        '(#7090)', () {
+      // The course detail is route-driven (`/courses/own/:courseid`), so its
+      // parent segments render a blank EmptyPage. Its back navigates to the
+      // start-my-own plan list token over the world map rather than popping to
+      // that blank parent — even though the current URL is the legacy path.
+      final planList = WorkspaceNav.setSection(
+        u('/courses/own/abc-123'),
+        '/',
+        const PanelToken('addcourse', 'own'),
+        keepRoom: false,
+      );
+      expect(u(planList).path, '/');
+      expect(parseOpenPanels(u(planList)).left, [
+        const PanelToken('addcourse', 'own'),
+      ]);
+      expect(parseOpenPanels(u(planList)).right, isEmpty);
+    });
   });
 
   group('openDetail (generic, registry-driven exclusive groups)', () {


### PR DESCRIPTION
## Problem

Closes #7090. Start my own course, open a course plan, press back: you land on a blank page instead of the plan list.

The course detail (`SelectedCourse`) is route-driven under `/courses/own/:courseid` (launch) and `/courses/:spaceid/addcourse/:courseId` (add-to-space), because the launch/add flow uses a `Completer` that can't ride a token URL. Those parent route segments render a blank `EmptyPage` placeholder (they normally redirect to a token before rendering). The detail's `AppBar` had no explicit `leading`, so Flutter auto-implied a back button that pops to that blank parent. `popOrGo` does not help here: the navigator can pop, it just pops to the blank page.

## Fix

Give the detail an explicit token-based back (`SelectedCourseController.back`), mode-aware:
- launch: back to the start-my-own plan list, the `addcourse:own` left token over the world map.
- add-to-space: back to the target course card (`?m=course:<id>&left=course`).

`AppBar.leading` is now an explicit back IconButton (with the standard back tooltip for the accessibility contract) wired to `controller.back`.

## Verification

- New regression test in `workspace_nav_test.dart`: back from the legacy course-detail path resolves to `addcourse:own` over the world map with no stale path or query.
- `dart format` + `import_sorter` clean.
- `flutter analyze` on the touched files: no issues.
- `flutter test test/pangea/navigation/`: 135 passing.
