### PR TITLE
fix(analytics): keep spinner up until vocab+grammar data loads, not just service init (#7078)

### DIFF
--- a/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
+++ b/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
@@ -67,6 +67,14 @@ class ConstructAnalyticsViewState extends State<ConstructAnalyticsView> {
 
   List<ConstructUses>? vocab;
 
+  /// True until the first vocab+grammar fetch (`_setAnalyticsData`) completes.
+  /// `analyticsService.isInitializing` only covers the underlying service sync;
+  /// the per-type aggregation runs after that, so without this flag the panel
+  /// renders an empty list before the data lands and looks like "no data"
+  /// rather than "loading" (#7078). Stays false across later stream-driven
+  /// refreshes so they update in place instead of flashing a spinner.
+  bool loadingAnalytics = true;
+
   bool isSearching = false;
   FocusNode searchFocusNode = FocusNode();
   ConstructLevelEnum? selectedConstructLevel;
@@ -110,10 +118,16 @@ class ConstructAnalyticsViewState extends State<ConstructAnalyticsView> {
         data: {"view": widget.view, "construct": widget.construct},
         level: SentryLevel.warning,
       );
+      if (mounted && loadingAnalytics) {
+        setState(() => loadingAnalytics = false);
+      }
       return;
     }
     final future = <Future>[_setMorphs(), _setVocab(l2.langCodeShort)];
     await Future.wait(future);
+    if (mounted && loadingAnalytics) {
+      setState(() => loadingAnalytics = false);
+    }
   }
 
   void _onConstructUpdate(AnalyticsStreamUpdate update) {
@@ -294,7 +308,7 @@ class ConstructAnalyticsViewState extends State<ConstructAnalyticsView> {
               if (widget.construct == null && !widget.embedded)
                 LearningProgressIndicators(selected: widget.view.indicator),
               Expanded(
-                child: analyticsService.isInitializing
+                child: analyticsService.isInitializing || loadingAnalytics
                     ? Center(child: CircularProgressIndicator.adaptive())
                     : widget.view == ConstructTypeEnum.morph
                     ? widget.construct == null


### PR DESCRIPTION
## Problem

Closes #7078. The analytics panel gives no way to tell whether it is still loading or genuinely has no data.

The panel only shows a spinner while `analyticsService.isInitializing`. The per-type vocab/grammar aggregation runs after that, in the view controller (`_setAnalyticsData` → `_setVocab` / `_setMorphs`). So once the service finishes initializing, the panel renders with the lists not yet populated, and an empty list reads as "no data" while it is actually still fetching.

## Fix

Add a controller flag `loadingAnalytics` (true until the first `_setAnalyticsData` completes, including the no-target-language early return) and keep the spinner up while `isInitializing || loadingAnalytics`. The flag stays false across later stream-driven refreshes, so a refresh updates the lists in place instead of flashing a spinner over data that is already on screen.

## Verification

- `dart format` + `import_sorter` clean.
- `flutter analyze` on the touched file: no issues.

Note: there is no isolated test harness for this view (it depends on the live analytics service + grammar provider), so this is covered by analysis rather than a new unit test.

Follow-up (not in scope): the grammar tab has no distinct empty-state instruction (vocab has `analyticsVocabListEmpty`); adding one would need a new enum + l10n key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced loading state handling in the analytics popup to eliminate visual flashing of empty content during data operations. The loading indicator now displays consistently until all required analytics data finishes loading, providing clearer feedback throughout the data aggregation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->