### PR TITLE
fix(courses): close edit panel back to course card after save instead of dead-end pop (#7096)

### DIFF
--- a/lib/routes/chat/chat_details/edit_course/edit_course.dart
+++ b/lib/routes/chat/chat_details/edit_course/edit_course.dart
@@ -2,13 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:file_picker/file_picker.dart';
+import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/course_plans/map_clipper.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/settings/settings.dart';
 import 'package:fluffychat/utils/file_selector.dart';
+import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
 import 'package:fluffychat/widgets/avatar.dart';
@@ -113,8 +117,18 @@ class EditCourseController extends State<EditCourse> {
       );
     }
 
-    if (!resp.isError) {
-      Navigator.of(context).pop();
+    if (!resp.isError && mounted) {
+      // world_v2: this is the `coursepage:edit` token panel, not a route. A bare
+      // Navigator.pop() has nothing to pop to in the shell and falls out to a
+      // blank page (#7096/#7076); close the edit panel back to the course card,
+      // which then shows the saved title/description.
+      NavigationUtil.popOrGo(
+        context,
+        WorkspaceNav.closeLeft(
+          GoRouterState.of(context).uri,
+          const PanelToken('coursepage', 'edit'),
+        ),
+      );
     }
   }
 


### PR DESCRIPTION
## Problem

Closes #7096. Editing a course's description and clicking Save changes saves the value, but the Editing page is left on an empty bar instead of returning to the course (the saved text does not show).

The Editing page (`EditCourse`) is a world_v2 token panel (`coursepage:edit`), not a route. After a successful save it called a bare `Navigator.pop()`, which in the token shell has nothing to pop to and falls out of the shell to a blank surface (the same dead-end class as #7076) rather than closing the edit panel.

## Fix

On a successful save, close the edit panel back to the course card via a token navigation (`closeLeft` of the `coursepage:edit` token), guarded by `NavigationUtil.popOrGo`. The course card then renders the saved title/description.

## Verification

- `closeLeft` (the token transition used here) is covered in `workspace_nav_test.dart`.
- `dart format` + `import_sorter` clean.
- `flutter analyze` on the touched file: no issues.

Note: `EditCourse` depends on the live Matrix client (room state), so there is no isolated widget-test harness for it; the navigation change is covered by analysis plus the existing `closeLeft` tests.
