### PR TITLE
fix(courses): post-create invite nav uses tokens, not single-pass legacy paths (#7082)

### DIFF
--- a/lib/routes/courses/own/invite/course_invite_page.dart
+++ b/lib/routes/courses/own/invite/course_invite_page.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
@@ -261,7 +262,17 @@ class CourseInvitePageController extends State<CourseInvitePage>
                           future: getSpaceId,
                         );
                         if (mounted && !resp.isError) {
-                          context.go("/rooms/spaces/${resp.result}/invite");
+                          // world_v2: token nav, not the legacy /rooms/spaces
+                          // path. go_router runs the legacy redirect once, but
+                          // that path needs two passes to reach its token form,
+                          // so it stranded on a blank /courses/:id page (#7082).
+                          context.go(
+                            WorkspaceNav.openCoursePageFor(
+                              GoRouterState.of(context).uri,
+                              resp.result!,
+                              'invite',
+                            ),
+                          );
                         }
                       },
                       style: ElevatedButton.styleFrom(
@@ -284,7 +295,14 @@ class CourseInvitePageController extends State<CourseInvitePage>
                           future: getSpaceId,
                         );
                         if (mounted && !resp.isError) {
-                          context.go("/rooms/spaces/${resp.result}");
+                          // world_v2: token nav to the course card (see #7082).
+                          context.go(
+                            WorkspaceNav.openCourseFilter(
+                              GoRouterState.of(context).uri,
+                              resp.result!,
+                              tab: 'course',
+                            ),
+                          );
                         }
                       },
                       style: ElevatedButton.styleFrom(


### PR DESCRIPTION
## Problem

Closes #7082. Creating a course and then leaving the invite page lands on a blank panel (the "Play with AI for now" button) or a "Page Not Found" / GoException (the "Invite your friends" button).

The invite page navigated with raw legacy paths: `/rooms/spaces/<id>` and `/rooms/spaces/<id>/invite`. go_router runs the top-level legacy redirect **at most once per navigation**, but those paths need two passes to reach their token form (`/rooms/spaces/<id>` → `/courses/<id>` → `/?m=course:<id>&left=course`). So pass 1's output is treated as final: `/courses/<id>` matches a route whose pageBuilder is `const EmptyPage()` (the blank panel), and `/courses/<id>/invite` has no route (the GoException).

## Fix

Navigate with the token helpers the rest of the post-creation flow already uses (one hop, no reliance on the redirect):
- "Play with AI for now" → `WorkspaceNav.openCourseFilter(uri, spaceId, tab: 'course')`
- "Invite your friends" → `WorkspaceNav.openCoursePageFor(uri, spaceId, 'invite')`

## Verification

Local Chrome test against a freshly rebuilt dev server (staging backends):
- "Play with AI for now" → `#/?m=course:!<id>&left=course:course` → renders the course card (title, Chats/Course Plan/Participants tabs). No blank panel.
- "Invite your friends" → `#/?m=course:!<id>&left=course,coursepage:invite` → renders the course card + the invite page. No GoException.

`dart format` + `import_sorter` clean; `flutter analyze` on the touched file: no issues.

Out of scope (filed separately): the invite page throws "No course creation completer provided" if reached without the live creation completer (e.g. a reload or back-nav onto `/courses/own/:id/invite`); several other `/rooms/spaces/<id>/details` internal navs share the single-pass-redirect mechanism.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation**
  * Improved routing consistency for course invitation flows
  * Updated navigation for "Invite your friends" and "Play with AI" actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->