### PR TITLE
fix(layout): collapse lowest-priority panel across columns on overlap (left<->right parity) (#7088)

### DIFF
--- a/lib/widgets/layouts/panel_allocator.dart
+++ b/lib/widgets/layouts/panel_allocator.dart
@@ -208,19 +208,31 @@ abstract class PanelAllocator {
       return (math.max(0, l - 1) + math.max(0, r - 1)) * panelGap;
     }
 
-    // Fold a **parent** behind its **child** until the rest fit at their
-    // reasonable min (the comfort floor). A fold neither peeks to a stripe nor
-    // reserves width — the parent is simply not drawn, its content one back-step
-    // away on the child that keeps the column (the detail keeps the column; its
-    // master is a pop behind, reached by closing the detail). Only a parent whose
-    // child is also visible in the SAME column is foldable: folding is
-    // per-column, and a folded panel is reached by closing its child, so a panel
-    // with no same-column child to keep the column never folds — it compresses
-    // toward its hard min instead. A child is never folded, so a live `room` (the
-    // chat list's detail) keeps its session, and a lone right panel (the
-    // analytics summary) is never sacrificed to left-column overflow. The map is
-    // the backdrop, not a panel, so it isn't sized here — it shows wherever the
-    // panels leave room. See `routing.instructions.md`.
+    // Relieve width pressure until the survivors fit their reasonable min (the
+    // comfort floor), or — failing that — at least their hard min so the two
+    // columns never overlap. Two tiers:
+    //
+    // Tier 1 — **fold a parent behind its same-column child**: the parent is
+    // simply not drawn (no stripe, no reserved width), its content one back-step
+    // away on the child that keeps the column (reached by closing the detail).
+    // Per-column, lowest-priority master first. A child is never folded, so a
+    // live `room` (the chat list's detail) keeps its session.
+    //
+    // Tier 2 — **collapse for left↔right parity** (#7088): when no same-column
+    // parent-fold is available AND the survivors' hard mins would overflow (the
+    // columns would otherwise overlap), collapse the lowest-priority panel across
+    // BOTH columns — but never the just-opened ([focusHint]) panel, so opening a
+    // panel is never a visible no-op. A collapsed panel is hidden entirely
+    // (reopened from the cluster, not a back-step). So a lone right summary (the
+    // analytics list) now yields to a higher-priority left panel instead of being
+    // overlapped, and symmetrically a low-priority left panel yields to the
+    // right. Tier 2 fires only on real overlap, so layouts that merely compress
+    // toward their mins are unchanged. The map is the backdrop, not a panel, so
+    // it isn't sized here. See `routing.instructions.md`.
+    final focusEntry =
+        (focusHint != null && focusHint >= 0 && focusHint < all.length)
+        ? all[focusHint]
+        : null;
     final folded = <_Entry>{};
     while (true) {
       final vis = all.where((e) => !folded.contains(e)).toList();
@@ -228,6 +240,7 @@ abstract class PanelAllocator {
       final needReasonable =
           vis.fold(0.0, (s, e) => s + e.def.reasonableMin) + gapsFor(vis);
       if (needReasonable <= content) break;
+      // Tier 1: fold a parent behind its same-column child.
       final foldable = vis
           .where(
             (parent) => vis.any(
@@ -237,11 +250,22 @@ abstract class PanelAllocator {
             ),
           )
           .toList();
-      if (foldable.isEmpty) break;
-      // Among independent master/detail pairs all under pressure, fold the
-      // lowest-priority master first (a cross-tree tiebreak).
-      foldable.sort((a, b) => a.def.priority.compareTo(b.def.priority));
-      folded.add(foldable.first);
+      if (foldable.isNotEmpty) {
+        // Among independent master/detail pairs all under pressure, fold the
+        // lowest-priority master first (a cross-tree tiebreak).
+        foldable.sort((a, b) => a.def.priority.compareTo(b.def.priority));
+        folded.add(foldable.first);
+        continue;
+      }
+      // Tier 2: no parent-fold left. Only collapse when the hard mins would
+      // actually overflow (panels would overlap); otherwise let them compress.
+      final needMin =
+          vis.fold(0.0, (s, e) => s + e.def.minWidth) + gapsFor(vis);
+      if (needMin <= content) break;
+      final collapsible = vis.where((e) => e != focusEntry).toList();
+      if (collapsible.isEmpty) break;
+      collapsible.sort((a, b) => a.def.priority.compareTo(b.def.priority));
+      folded.add(collapsible.first);
     }
 
     // Size the surviving panels: ideals if they fit, else compress toward their

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -452,8 +452,9 @@ class _ShellLayout {
     // is idempotent for an unchanged token set, so a width change never
     // reshuffles panes or adds history. Ephemeral view state, deliberately OUTSIDE
     // the URL (a shared link / refresh has no recency and the allocator falls back
-    // to the tree's leaf rule). Only consulted in narrow mode. See
-    // `routing.instructions.md`.
+    // to the tree's leaf rule). Consulted in narrow mode (which pane to seat) and
+    // in column mode (the just-opened pane is protected from a left↔right parity
+    // collapse, #7088). See `routing.instructions.md`.
     final paneIds = [
       for (final t in leftTokens) t.encode(),
       for (final t in rightTokens) t.encode(),
@@ -462,7 +463,7 @@ class _ShellLayout {
     for (final id in paneIds) {
       if (!_paneRecency.contains(id)) _paneRecency.add(id);
     }
-    final focusHint = (!isColumnMode && _paneRecency.isNotEmpty)
+    final focusHint = _paneRecency.isNotEmpty
         ? paneIds.indexOf(_paneRecency.last)
         : null;
 

--- a/test/pangea/navigation/panel_allocator_test.dart
+++ b/test/pangea/navigation/panel_allocator_test.dart
@@ -125,6 +125,93 @@ void main() {
     );
   });
 
+  group('left↔right parity collapse (#7088)', () {
+    test(
+      'a lone right summary yields (collapses) instead of being overlapped',
+      () {
+        // course + room (independent left panels) + the analytics summary can't
+        // all honor their hard mins in this column-mode budget, and analytics
+        // has no same-column child to fold behind. It is the lowest priority
+        // (analytics 40 < course 60 < room 80), so it collapses to make room
+        // rather than being overlapped by the left column.
+        final l = run(
+          viewport: 1200,
+          left: ['course', 'room'],
+          right: ['analytics'],
+        );
+        expect(l.right.single.vis, PanelVis.hidden); // analytics yields
+        expect(l.left[0].vis, PanelVis.full); // course
+        expect(l.left[1].vis, PanelVis.full); // room
+        expectNoOverlap(l);
+      },
+    );
+
+    test('the collapse is symmetric across columns (parity)', () {
+      const lo = PanelDef(
+        type: 'lo',
+        column: PanelColumn.left,
+        minWidth: 360,
+        idealWidth: 720,
+        priority: 20,
+      );
+      const hi = PanelDef(
+        type: 'hi',
+        column: PanelColumn.left,
+        minWidth: 360,
+        idealWidth: 720,
+        priority: 80,
+      );
+      // Two independent panels, one per column, on a budget too tight for both
+      // hard mins: the LOWER-priority one collapses regardless of its column.
+      final rightLo = PanelAllocator.allocate(
+        viewport: 850,
+        isColumnMode: true,
+        left: [hi],
+        right: [lo],
+      );
+      expect(rightLo.right.single.vis, PanelVis.hidden); // lo (right) yields
+      expect(rightLo.left.single.vis, PanelVis.full); // hi (left) stays
+
+      final leftLo = PanelAllocator.allocate(
+        viewport: 850,
+        isColumnMode: true,
+        left: [lo],
+        right: [hi],
+      );
+      expect(leftLo.left.single.vis, PanelVis.hidden); // lo (left) yields
+      expect(leftLo.right.single.vis, PanelVis.full); // hi (right) stays
+    });
+
+    test('the just-opened (focus) panel is never the one collapsed', () {
+      const lo = PanelDef(
+        type: 'lo',
+        column: PanelColumn.left,
+        minWidth: 360,
+        idealWidth: 720,
+        priority: 20,
+      );
+      const hi = PanelDef(
+        type: 'hi',
+        column: PanelColumn.left,
+        minWidth: 360,
+        idealWidth: 720,
+        priority: 80,
+      );
+      // all = [hi(left,0), lo(right,1)]; the user just opened lo (focusHint=1).
+      // Even though lo is the lower priority, it must survive — the higher-
+      // priority hi yields, so opening lo is not a visible no-op.
+      final l = PanelAllocator.allocate(
+        viewport: 850,
+        isColumnMode: true,
+        left: [hi],
+        right: [lo],
+        focusHint: 1,
+      );
+      expect(l.right.single.vis, PanelVis.full); // lo kept (focused)
+      expect(l.left.single.vis, PanelVis.hidden); // hi yields despite priority
+    });
+  });
+
   group('non-overlap holds across viewports', () {
     test('chat + summary never overlap from tight to wide', () {
       for (final viewport in [900.0, 1100.0, 1334.0, 1600.0, 1920.0]) {


### PR DESCRIPTION
## Problem

Closes #7088. On a narrow web window, opening another panel could overlap the analytics panel, covering text and inputs.

The panel allocator's fold step only folds a parent behind its same-column child. A lone right panel (the analytics summary) has no child, so it was never folded; when left panels opened and the budget got tight, they compressed to their hard min and, past a point, overflowed and drew on top of the analytics column.

## Fix

Generalize the collapse rule with left↔right parity. The allocator's relief loop now has two tiers:
- Tier 1 (unchanged): fold a parent behind its same-column child (a back-step).
- Tier 2 (new): when no same-column parent-fold is available and the survivors' hard mins would overflow (overlap imminent), collapse the lowest-priority panel across **both** columns — never the just-opened (`focusHint`) panel, so opening a panel is never a visible no-op. A collapsed panel is hidden and reopened from the cluster (not a back-step).

So the analytics summary now yields to a higher-priority left panel under width pressure instead of being overlapped, and symmetrically a low-priority left panel yields to the right. Tier 2 only fires on real overlap, so layouts that merely compress are unchanged. The shell now also provides `focusHint` in column mode (it was narrow-mode only) so the just-opened panel is protected from a parity collapse.

## Verification

- Unit: 21 `panel_allocator_test` cases pass, including three new ones (lone-right summary yields instead of overlapping; collapse is symmetric across columns; the focused panel is never the one collapsed) and the existing no-overlap-across-viewports invariants. Full navigation suite (138) green.
- Local Chrome (fresh build, staging): wide → both panels side by side; narrowing → analytics collapses at ~910px with no overlap (token retained, reopenable); opening a panel at a tight width keeps the just-opened one (the older yields); re-widening restores both. No console errors.

`dart format` + `import_sorter` clean; `flutter analyze` on the touched files: no issues.
