### PR TITLE
Remove create button on new course list, click tile to select

### DIFF
--- a/lib/features/course_plans/new_course_page.dart
+++ b/lib/features/course_plans/new_course_page.dart
@@ -418,9 +418,7 @@ class NewCoursePageState extends State<NewCoursePage> {
                                 vertical: 4.0,
                               ),
                               child: InkWell(
-                                onTap: () => MapContextController.set(
-                                  CourseMapContext(course.uuid),
-                                ),
+                                onTap: () => _onSelect(course),
                                 borderRadius: BorderRadius.circular(12.0),
                                 child: Container(
                                   padding: const EdgeInsets.all(12.0),
@@ -471,19 +469,6 @@ class NewCoursePageState extends State<NewCoursePage> {
                                             ),
                                           ],
                                         ),
-                                      ),
-                                      FilledButton(
-                                        onPressed: () => _onSelect(course),
-                                        style: FilledButton.styleFrom(
-                                          backgroundColor: theme
-                                              .colorScheme
-                                              .primaryContainer,
-                                          foregroundColor: theme
-                                              .colorScheme
-                                              .onPrimaryContainer,
-                                          visualDensity: VisualDensity.compact,
-                                        ),
-                                        child: Text(L10n.of(context).create),
                                       ),
                                     ],
                                   ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified course selection interaction by consolidating the create button functionality into the course card tap action. The separate create button has been removed, and tapping the course card now directly initiates the selection flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->