### PR TITLE
fix(world-map): add zoom-out/World control + hide green cluster hull (#7086, #7068)

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -610,6 +610,20 @@ class WorldMapController extends State<WorldMap>
     setState(() => _promotedActivityId = null);
   }
 
+  /// Glide back to the whole-world view (the initial camera). Pins, clusters,
+  /// and search only ever zoom the camera IN, so this is the one explicit
+  /// "zoom out to everything" affordance (#7086). Camera-only: the course scope
+  /// and open panels are untouched.
+  void resetToWorld() => _animateCameraTo(const LatLng(20, 0), 3.0);
+
+  /// Step the zoom by [delta] levels around the current center, clamped to the
+  /// map's range — backs the on-map +/- buttons, since a tap/search only ever
+  /// zooms IN (#7086).
+  void zoomBy(double delta) => _animateCameraTo(
+    mapController.camera.center,
+    (mapController.camera.zoom + delta).clamp(3.0, 18.0).toDouble(),
+  );
+
   /// Resolve a [MapFocus] to a map coordinate, or null if not resolvable yet.
   /// Exhaustive over the sealed [MapFocus]: adding a focus kind makes this a
   /// compile error until its arm is added — that is the extension seam.

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -95,6 +95,48 @@ class _PinRender {
   });
 }
 
+/// The on-map zoom controls (#7086): a small bottom-right stack with a World
+/// reset (the one obvious "zoom out to everything", since pins/clusters/search
+/// only ever zoom the camera IN) and +/- zoom steps. Camera-only — it never
+/// changes the open panels or the course scope.
+class _MapZoomControls extends StatelessWidget {
+  final WorldMapController controller;
+
+  const _MapZoomControls({required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context);
+    final theme = Theme.of(context);
+    return Material(
+      elevation: 2.0,
+      color: theme.colorScheme.surface,
+      borderRadius: BorderRadius.circular(8.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.public),
+            tooltip: l10n.world,
+            onPressed: controller.resetToWorld,
+          ),
+          Divider(height: 1.0, color: theme.colorScheme.outlineVariant),
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: l10n.zoomIn,
+            onPressed: () => controller.zoomBy(1),
+          ),
+          IconButton(
+            icon: const Icon(Icons.remove),
+            tooltip: l10n.zoomOut,
+            onPressed: () => controller.zoomBy(-1),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 /// The stateless render of the persistent world map, driven by its
 /// [WorldMapController]. It reads the controller's cached signals / stars /
 /// pins, applies the per-frame progression gate + relevance ranking to pick each
@@ -171,6 +213,11 @@ class WorldMapView extends StatelessWidget {
         // unclustered in the layer above so they're always visible.
         MarkerClusterLayerWidget(
           options: MarkerClusterLayerOptions(
+            // No convex-hull "zoom polygon" on cluster tap: the package default
+            // draws a bright-green (0xFF00FF00) hull with a yellow border during
+            // the zoom animation, which flashed between areas while loading
+            // (#7068). The map uses a smooth camera glide, not the hull metaphor.
+            showPolygon: false,
             maxClusterRadius: 48,
             size: const Size(40, 40),
             padding: const EdgeInsets.all(50),
@@ -204,8 +251,26 @@ class WorldMapView extends StatelessWidget {
       ],
     );
 
-    // World gets the search + filter overlay; a course shows its plain map.
-    if (!controller.isWorld) return map;
+    // The on-map zoom-out / World control (#7086): pins, clusters, and search
+    // only zoom the camera IN, so this is the way back out. Bottom-right, clear
+    // of the right column and above the attribution; shown on both the world map
+    // and a course map.
+    final controls = Positioned(
+      right: controller.widget.rightOverlayWidth + 12,
+      bottom: 28,
+      child: _MapZoomControls(controller: controller),
+    );
+
+    // A course shows its plain map (plus the controls); the world map adds the
+    // search + filter overlay.
+    if (!controller.isWorld) {
+      return Stack(
+        children: [
+          Positioned.fill(child: map),
+          controls,
+        ],
+      );
+    }
     final l2 = MatrixState.pangeaController.userController.userL2Code;
     return Stack(
       children: [
@@ -231,6 +296,7 @@ class WorldMapView extends StatelessWidget {
             emptyInView: !controller.loadingPins && render.visible.isEmpty,
           ),
         ),
+        controls,
       ],
     );
   }


### PR DESCRIPTION
## Problem

Two world-map chrome issues:
- Closes #7086: after a pin/cluster/search tap zooms the camera in, there is no clear on-map way to zoom back out.
- Closes #7068: tapping a cluster flashed bright-green convex-hull polygons/triangles between the pins during the zoom animation.

## Fix

- #7086: add `WorldMapController.resetToWorld()` (glide to the whole-world view) and `zoomBy(delta)` (step the zoom, clamped to [3,18]), both reusing the existing `_animateCameraTo` glide. Add a small bottom-right `_MapZoomControls` Material stack — a World reset (globe), zoom in (+), zoom out (−) — with `l10n.world` / `l10n.zoomIn` / `l10n.zoomOut` tooltips (so each exposes a semantics label). It is added to both the world-map and course-map branches.
- #7068: set `showPolygon: false` on `MarkerClusterLayerOptions` — the `flutter_map_marker_cluster` default draws a bright-green (`0xFF00FF00`) hull with a yellow border on cluster tap; the map uses a smooth camera glide, not the hull metaphor.

## Verification

Local Chrome (fresh build, staging): the control renders bottom-right clear of the edge/attribution; the World reset glides back to the whole-world view; +/− move the camera; no green polygon appears at any point during a cluster-tap zoom; the three buttons expose "World" / "Zoom in" / "Zoom out" semantics labels.

`dart format` + `import_sorter` clean; `flutter analyze` on the touched files: no issues. (No unit tests exist for the map view.)

Follow-up (filed separately): rapid repeated +/− clicks under-advance because `zoomBy` re-reads the live (mid-glide) camera zoom each call; a target-accumulating / integer-snapping zoom step would make the buttons feel crisper. The World reset and single clicks work correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive zoom controls in the bottom-right corner of the world map, allowing users to zoom in, zoom out, and reset the view to display the entire world
  * Improved cluster pin visualization by removing animated polygon overlays that previously appeared during cluster interactions, resulting in a cleaner map interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->