### PR TITLE
fix(courses): invite-page robustness + convert stranding legacy course navs to tokens (#7100)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "pangea-web",
+      "runtimeExecutable": "flutter",
+      "runtimeArgs": [
+        "run",
+        "-d",
+        "web-server",
+        "--web-port",
+        "8090",
+        "--web-hostname",
+        "0.0.0.0"
+      ],
+      "port": 8090
+    }
+  ]
+}

--- a/lib/features/course_plans/new_course_page.dart
+++ b/lib/features/course_plans/new_course_page.dart
@@ -13,6 +13,7 @@ import 'package:fluffychat/features/course_plans/courses/course_plan_model.dart'
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/languages/p_language_store.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/quests/repo/quest_plans_repo.dart';
@@ -186,7 +187,7 @@ class NewCoursePageState extends State<NewCoursePage> {
     if (existingRoom == null || widget.spaceId != null) {
       context.go(
         widget.spaceId != null
-            ? '/rooms/spaces/${widget.spaceId}/addcourse/${course.uuid}'
+            ? '/courses/${shortRoomId(widget.spaceId!)}/addcourse/${course.uuid}'
             : '/${widget.route}/course/own/${course.uuid}',
       );
       return;
@@ -230,7 +231,7 @@ class NewCoursePageState extends State<NewCoursePage> {
     if (action == 0) {
       context.go(
         widget.spaceId != null
-            ? '/rooms/spaces/${widget.spaceId}/addcourse/${course.uuid}'
+            ? '/courses/${shortRoomId(widget.spaceId!)}/addcourse/${course.uuid}'
             : '/${widget.route}/course/own/${course.uuid}',
       );
     } else if (action == 1) {

--- a/lib/routes/analytics/activities/activity_archive.dart
+++ b/lib/routes/analytics/activities/activity_archive.dart
@@ -12,6 +12,9 @@ import 'package:fluffychat/features/analytics/saved_analytics_extension.dart';
 import 'package:fluffychat/features/analytics_data/analytics_init_error_indicator.dart';
 import 'package:fluffychat/features/instructions/instructions_enum.dart';
 import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/route_paths.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/analytics_navigation_util.dart';
 import 'package:fluffychat/widgets/analytics_summary/learning_progress_indicators.dart';
@@ -82,8 +85,14 @@ class ActivityArchive extends StatelessWidget {
                                             style: ElevatedButton.styleFrom(
                                               padding: EdgeInsets.zero,
                                             ),
-                                            onPressed: () =>
-                                                context.go("/rooms/course"),
+                                            onPressed: () => context.go(
+                                              WorkspaceNav.setSection(
+                                                GoRouterState.of(context).uri,
+                                                PRoutes.world,
+                                                const PanelToken('addcourse'),
+                                                keepRoom: false,
+                                              ),
+                                            ),
                                             child: Row(
                                               mainAxisAlignment:
                                                   MainAxisAlignment.center,

--- a/lib/routes/chat_list/chat_list.dart
+++ b/lib/routes/chat_list/chat_list.dart
@@ -36,6 +36,7 @@ import 'package:fluffychat/routes/invite_user/user_invite_link_repo.dart';
 import 'package:fluffychat/utils/chat_list_handle_space_tap.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
+import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/show_scaffold_dialog.dart';
 import 'package:fluffychat/utils/show_update_snackbar.dart';
@@ -472,7 +473,9 @@ class ChatListController extends State<ChatList>
   void editSpace(BuildContext context, String spaceId) async {
     await Matrix.of(context).client.getRoomById(spaceId)!.postLoad();
     if (mounted) {
-      context.push('/rooms/$spaceId/details');
+      context.go(
+        WorkspaceNav.openCourseFilter(GoRouterState.of(context).uri, spaceId),
+      );
     }
   }
 
@@ -693,7 +696,12 @@ class ChatListController extends State<ChatList>
       final joinedRoomId = await handler.handle(context);
       if (joinedRoomId == null) continue;
 
-      context.go("/rooms/spaces/$joinedRoomId/details");
+      context.go(
+        WorkspaceNav.openCourseFilter(
+          GoRouterState.of(context).uri,
+          joinedRoomId,
+        ),
+      );
     }
   }
 
@@ -744,7 +752,12 @@ class ChatListController extends State<ChatList>
         final joinedRoomId = await handler.handle(context);
         if (joinedRoomId == null) continue;
 
-        context.go("/rooms/spaces/$joinedRoomId/details");
+        context.go(
+          WorkspaceNav.openCourseFilter(
+            GoRouterState.of(context).uri,
+            joinedRoomId,
+          ),
+        );
       }
     }
   }
@@ -1166,8 +1179,13 @@ class ChatListController extends State<ChatList>
     if (joinedRoomId == null) return;
 
     room.isSpace
-        ? context.go('/rooms/spaces/$joinedRoomId/details')
-        : context.go('/rooms/$joinedRoomId');
+        ? context.go(
+            WorkspaceNav.openCourseFilter(
+              GoRouterState.of(context).uri,
+              joinedRoomId,
+            ),
+          )
+        : NavigationUtil.goToSpaceRoute(joinedRoomId, const [], context);
   }
 
   Future<void> _startDMWithCachedUserId(Client client) async {
@@ -1182,7 +1200,7 @@ class ChatListController extends State<ChatList>
     if (!mounted) return;
     final roomId = resp.result;
     if (roomId != null) {
-      context.go('/rooms/$roomId');
+      NavigationUtil.goToSpaceRoute(roomId, const [], context);
     }
   }
 

--- a/lib/routes/chat_list/course_chats_page.dart
+++ b/lib/routes/chat_list/course_chats_page.dart
@@ -485,7 +485,9 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
     }
 
     if (room.isSpace) {
-      context.go("/rooms/spaces/${room.id}/details");
+      context.go(
+        WorkspaceNav.openCourseFilter(GoRouterState.of(context).uri, room.id),
+      );
       return;
     }
 
@@ -545,7 +547,7 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
       throw Exception("Failed to join room");
     }
 
-    context.go("/rooms/spaces/${widget.roomId}/$roomId");
+    NavigationUtil.goToSpaceRoute(roomId, const [], context);
   }
 
   bool _includeSpaceChild(Room space, SpaceRoomsChunk$2 hierarchyMember) {
@@ -695,7 +697,7 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
       GoogleAnalytics.addParent(roomId, classCode);
     }
 
-    context.go('/rooms/spaces/${widget.roomId}/$roomId');
+    NavigationUtil.goToSpaceRoute(roomId, const [], context);
   }
 
   @override

--- a/lib/routes/chat_list/room_invite_dialog.dart
+++ b/lib/routes/chat_list/room_invite_dialog.dart
@@ -5,9 +5,11 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/analytics_access/join_room_analytics_consent_handler.dart';
 import 'package:fluffychat/features/join_codes/knocked_rooms_extension.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
+import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 
@@ -38,11 +40,14 @@ class RoomInviteDialog extends StatelessWidget {
         final joinedRoomId = await handler.handle(context);
         if (joinedRoomId == null) return;
 
-        context.go(
-          room.isSpace
-              ? "/rooms/spaces/$joinedRoomId/details"
-              : "/rooms/$joinedRoomId",
-        );
+        room.isSpace
+            ? context.go(
+                WorkspaceNav.openCourseFilter(
+                  GoRouterState.of(context).uri,
+                  joinedRoomId,
+                ),
+              )
+            : NavigationUtil.goToSpaceRoute(joinedRoomId, const [], context);
         return;
       case CourseInviteAction.decline:
         await room.leave();

--- a/lib/routes/courses/find_course_page.dart
+++ b/lib/routes/courses/find_course_page.dart
@@ -9,6 +9,9 @@ import 'package:matrix/matrix.dart' hide Result;
 import 'package:fluffychat/features/bot/widgets/bot_face_svg.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_model.dart';
 import 'package:fluffychat/features/languages/language_model.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/route_paths.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/quests/repo/quest_plans_repo.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -287,12 +290,20 @@ class FindCoursePageState extends State<FindCoursePage> {
   }
 
   void startNewCourse() {
-    String route = "/rooms/course/own";
+    // world_v2: open the start-my-own list as an `addcourse:own` left panel over
+    // the map. setSection already emits a `?left=…` query, so the lang/showAll
+    // filter rides alongside with `&`.
+    String route = WorkspaceNav.setSection(
+      GoRouterState.of(context).uri,
+      PRoutes.world,
+      const PanelToken('addcourse', 'own'),
+      keepRoom: false,
+    );
     final targetLanguage = targetLanguageFilter.value?.langCode;
     if (targetLanguage != null) {
-      route += "?lang=${Uri.encodeComponent(targetLanguage)}";
+      route += "&lang=${Uri.encodeComponent(targetLanguage)}";
     } else {
-      route += "?showAll=true";
+      route += "&showAll=true";
     }
     context.go(route);
   }

--- a/lib/routes/courses/own/invite/course_invite_page.dart
+++ b/lib/routes/courses/own/invite/course_invite_page.dart
@@ -9,7 +9,10 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
+import 'package:fluffychat/features/course_plans/courses/course_plan_client_extension.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -39,6 +42,29 @@ class CourseInvitePageController extends State<CourseInvitePage>
   void initState() {
     super.initState();
     loadCourse(widget.courseId);
+    // The invite route is single-use: the creation completer only rides in
+    // state.extra during the live wizard. On a reload / browser-back onto
+    // /courses/own/:courseid/invite the completer is null; if there is also no
+    // already-created space for this plan, the page is a dead end (both buttons
+    // would error), so redirect to the start-my-own list instead of stranding.
+    // (When a space DOES exist, getSpaceId resolves it and the page works.)
+    if (widget.courseCreationCompleter == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final existing = Matrix.of(
+          context,
+        ).client.getRoomByCourseId(widget.courseId);
+        if (existing != null) return;
+        context.go(
+          WorkspaceNav.setSection(
+            GoRouterState.of(context).uri,
+            PRoutes.world,
+            const PanelToken('addcourse', 'own'),
+            keepRoom: false,
+          ),
+        );
+      });
+    }
   }
 
   @override
@@ -50,10 +76,21 @@ class CourseInvitePageController extends State<CourseInvitePage>
   }
 
   Future<String> getSpaceId() async {
-    if (widget.courseCreationCompleter == null) {
-      throw Exception("No course creation completer provided");
+    final completer = widget.courseCreationCompleter;
+    if (completer == null) {
+      // No live creation completer (reload / back). The route param is the
+      // course PLAN uuid; the created space carries it in its coursePlan state
+      // event, so resolve the already-created space rather than throwing. A
+      // room matched this way already has that state, so no sync wait is needed.
+      // (initState redirects away when no such room exists; this throw is a
+      // belt-and-suspenders for that race.)
+      final room = Matrix.of(context).client.getRoomByCourseId(widget.courseId);
+      if (room == null) {
+        throw Exception("No course room for plan ${widget.courseId}");
+      }
+      return room.id;
     }
-    final spaceId = await widget.courseCreationCompleter!.future;
+    final spaceId = await completer.future;
     final room = Matrix.of(context).client.getRoomById(spaceId);
     if (room == null || room.coursePlan == null) {
       await Matrix.of(context).client.onRoomState.stream

--- a/lib/routes/courses/preview/public_course_preview.dart
+++ b/lib/routes/courses/preview/public_course_preview.dart
@@ -10,10 +10,12 @@ import 'package:fluffychat/features/analytics_access/join_room_analytics_consent
 import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
 import 'package:fluffychat/features/join_codes/knocked_rooms_extension.dart';
 import 'package:fluffychat/features/join_codes/space_code_controller.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/courses/preview/public_course_preview_view.dart';
+import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -134,8 +136,13 @@ class PublicCoursePreviewController extends State<PublicCoursePreview>
     if (joinedRoomId == null) return;
 
     room.isSpace
-        ? context.go('/rooms/spaces/$joinedRoomId/details')
-        : context.go('/rooms/$joinedRoomId');
+        ? context.go(
+            WorkspaceNav.openCourseFilter(
+              GoRouterState.of(context).uri,
+              joinedRoomId,
+            ),
+          )
+        : NavigationUtil.goToSpaceRoute(joinedRoomId, const [], context);
   }
 
   Future<void> joinCourse() async {
@@ -149,7 +156,9 @@ class PublicCoursePreviewController extends State<PublicCoursePreview>
     final r = client.getRoomById(roomID!);
     if (r != null && r.membership == Membership.join) {
       if (mounted) {
-        context.go("/rooms/spaces/${r.id}/details");
+        context.go(
+          WorkspaceNav.openCourseFilter(GoRouterState.of(context).uri, r.id),
+        );
       }
       return;
     }
@@ -195,7 +204,12 @@ class PublicCoursePreviewController extends State<PublicCoursePreview>
       throw Exception("Failed to fetch roomID");
     }
 
-    context.go("/rooms/spaces/$joinedRoomId/details");
+    context.go(
+      WorkspaceNav.openCourseFilter(
+        GoRouterState.of(context).uri,
+        joinedRoomId,
+      ),
+    );
   }
 
   @override

--- a/lib/routes/courses/private/course_code_page.dart
+++ b/lib/routes/courses/private/course_code_page.dart
@@ -7,8 +7,10 @@ import 'package:go_router/go_router.dart';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/features/analytics_access/join_room_analytics_consent_handler.dart';
 import 'package:fluffychat/features/join_codes/space_code_controller.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/spaces/space_constants.dart';
+import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -58,8 +60,13 @@ class CourseCodePageState extends State<CourseCodePage> {
     if (joinedRoomId == null) return;
 
     room.isSpace
-        ? context.go('/rooms/spaces/$joinedRoomId/details')
-        : context.go('/rooms/$joinedRoomId');
+        ? context.go(
+            WorkspaceNav.openCourseFilter(
+              GoRouterState.of(context).uri,
+              joinedRoomId,
+            ),
+          )
+        : NavigationUtil.goToSpaceRoute(joinedRoomId, const [], context);
   }
 
   @override

--- a/lib/widgets/public_room_bottom_sheet.dart
+++ b/lib/widgets/public_room_bottom_sheet.dart
@@ -8,6 +8,7 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/features/analytics_access/join_room_analytics_access_extension.dart';
 import 'package:fluffychat/features/join_codes/knocked_rooms_extension.dart';
 import 'package:fluffychat/features/join_codes/space_code_controller.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_rooms_chunk_extension.dart';
 import 'package:fluffychat/utils/adaptive_bottom_sheet.dart';
@@ -42,7 +43,9 @@ class PublicRoomBottomSheet extends StatefulWidget {
     );
 
     if (room != null && room.membership == Membership.join) {
-      context.go("/rooms/spaces/${room.id}/details");
+      context.go(
+        WorkspaceNav.openCourseFilter(GoRouterState.of(context).uri, room.id),
+      );
       return null;
     }
 


### PR DESCRIPTION
## Summary

Two #7082 follow-ups in the world_v2 course-navigation area.

**Part 1 — invite page is no longer single-use.** `CourseInvitePage.getSpaceId` treated the live creation completer (passed via `state.extra` during the creation wizard) as the only source of the space id and threw on any reload / browser-back. It now resolves the already-created space via `client.getRoomByCourseId(courseId)` (the route param is the course plan uuid; the created space carries it in its `coursePlan` state event), and `initState` redirects to the start-my-own list when no such space exists — so revisiting the invite route no longer crashes with "Oops, something went wrong".

**Part 2 — convert stranding legacy `/rooms/spaces/<id>` course navs to tokens (closes #7100).** go_router runs the top-level legacy redirect only once, but `/rooms/spaces/<id>...` needs two passes, so these stranded on a blank `/courses/:id` `EmptyPage`. Converted the internal navigations to `WorkspaceNav.openCourseFilter` (course card) / `NavigationUtil.goToSpaceRoute` (room), and the route-driven add-to-space path to the canonical `/courses/:spaceid/addcourse/:courseId` (one pass), and the add-course CTAs to `setSection(addcourse[:own])`. Sites: course_chats_page, chat_list, room_invite_dialog, course_code_page, public_course_preview, public_room_bottom_sheet, activity_archive, new_course_page, find_course_page. Single-pass-safe `PRoutes.course()` navs and bare non-space room navs were left as-is.

## Verification

- `dart format` + `import_sorter` clean; `flutter analyze` across all 10 touched files: no issues.
- `flutter test test/pangea/navigation/`: 138 passing.
- Full diff reviewed; conversions are uniform and use helpers (`openCourseFilter` / `goToSpaceRoute`) already verified in Chrome to render the course card in #7082.
- Local Chrome confirmation was blocked by a flaky local debug-build mount issue in the test env (not a code defect — the changes run only in handlers / a route initState, not at boot). QA to confirm on staging.

Closes #7100.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Course creation and invitation flows now properly handle navigation edge cases like page reloads and back navigation.

* **Refactor**
  * Standardized navigation throughout course and space flows to use consistent, typed routing helpers instead of hardcoded path strings, improving reliability and maintainability.

* **Chores**
  * Added Flutter web debug launch configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->