### PR TITLE
fix(world-map): accumulate +/- zoom steps so rapid clicks advance full levels (#7086 follow-up)

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -618,11 +618,18 @@ class WorldMapController extends State<WorldMap>
 
   /// Step the zoom by [delta] levels around the current center, clamped to the
   /// map's range — backs the on-map +/- buttons, since a tap/search only ever
-  /// zooms IN (#7086).
-  void zoomBy(double delta) => _animateCameraTo(
-    mapController.camera.center,
-    (mapController.camera.zoom + delta).clamp(3.0, 18.0).toDouble(),
-  );
+  /// zooms IN (#7086). Accumulates toward the in-flight glide target (not the
+  /// mid-glide live zoom), so rapid clicks each advance a full level instead of
+  /// under-shooting, and snaps to integer levels so the steps land crisply.
+  void zoomBy(double delta) {
+    final base = (_camAnim?.isAnimating ?? false)
+        ? _camTargetZoom
+        : mapController.camera.zoom;
+    _animateCameraTo(
+      mapController.camera.center,
+      (base + delta).clamp(3.0, 18.0).roundToDouble(),
+    );
+  }
 
   /// Resolve a [MapFocus] to a map coordinate, or null if not resolvable yet.
   /// Exhaustive over the sealed [MapFocus]: adding a focus kind makes this a


### PR DESCRIPTION
## Summary

Follow-up polish to the #7086 on-map zoom control. `WorldMapController.zoomBy` computed its target from `mapController.camera.zoom` — the **live, mid-glide** zoom — so rapid +/- clicks during the ~600ms glide each re-read a zoom that hadn't reached the prior target and under-advanced (~0.15 level per click).

It now accumulates toward the **in-flight glide target** (`_camTargetZoom` while `_camAnim` is animating, else the settled camera zoom) and snaps to integer levels (`roundToDouble`), so each rapid click steps a full level. Reusing `_camTargetZoom` (rather than a new pending field) keeps it correct after `resetToWorld`/`flyTo`/cluster-tap, which all set that target.

## Verification

Local Chrome (against the local backend): 3 rapid "−" clicks widened the map bounding-box latitude span 7.88× ≈ 3.0 full zoom levels out (old behavior would have moved ~0.45); the World reset glides to the whole-world view; "+" steps one clean full level. Integer snap confirmed across steps. `dart format` + `import_sorter` clean; `flutter analyze`: no issues.

Refs #7086.
