### PR TITLE
fix(nav): opening Settings closes open analytics panels (right-column exclusivity) (#7109)

### DIFF
--- a/lib/features/navigation/workspace_nav.dart
+++ b/lib/features/navigation/workspace_nav.dart
@@ -386,16 +386,35 @@ abstract class WorkspaceNav {
     return pushPage(current, type, parent.isEmpty ? null : parent);
   }
 
+  /// The analytics-family right panels: the analytics summary, its vocab/grammar
+  /// details, and the practice/activity-review surfaces. Opening Settings drops
+  /// these so the right column shows one feature at a time — mirroring how
+  /// opening analytics replaces the right column and drops Settings (#7109).
+  static const Set<String> _analyticsRightPanels = {
+    'analytics',
+    'vocab',
+    'grammar',
+    'practice',
+    'review',
+  };
+
   /// Open the settings/profile MENU as the right-column master (page null/empty),
   /// or a settings PAGE as its detail beside the menu. A page blooms at the front
   /// of the right group with the `settings` menu master kept (or seated) behind
   /// it — so they coexist when width allows and fold to a push when not. A
-  /// `/`-path page is a leaf (its own back pops it). See `routing.instructions.md`.
+  /// `/`-path page is a leaf (its own back pops it). Opening Settings also drops
+  /// any open analytics-family panel so the two don't clutter the right column
+  /// together (#7109). See `routing.instructions.md`.
   static String openSettings(Uri current, {String? page}) {
     if (page == null || page.isEmpty) {
       return _mutate(current, 'right', (tokens) {
         final next = tokens
-            .where((t) => t.type != 'settings' && t.type != 'settingspage')
+            .where(
+              (t) =>
+                  t.type != 'settings' &&
+                  t.type != 'settingspage' &&
+                  !_analyticsRightPanels.contains(t.type),
+            )
             .toList();
         next.add(const PanelToken('settings'));
         return next;
@@ -403,7 +422,13 @@ abstract class WorkspaceNav {
     }
     final detail = PanelToken('settingspage', page);
     return _mutate(current, 'right', (tokens) {
-      final next = tokens.where((t) => t.type != 'settingspage').toList();
+      final next = tokens
+          .where(
+            (t) =>
+                t.type != 'settingspage' &&
+                !_analyticsRightPanels.contains(t.type),
+          )
+          .toList();
       next.insert(0, detail);
       if (!next.any((t) => t.type == 'settings')) {
         next.add(const PanelToken('settings'));

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -391,11 +391,25 @@ void main() {
   });
 
   group('openSettings / settingsBack (the right-column settings panel)', () {
-    test('opens the menu as a right token, keeping other right panels', () {
+    test('opens the menu and drops the open analytics panel (#7109)', () {
       final loc = WorkspaceNav.openSettings(u('/?right=analytics:vocab'));
       final right = parseOpenPanels(u(loc)).right;
       expect(right.any((t) => t.type == 'settings' && t.param == null), isTrue);
-      expect(right.any((t) => t.type == 'analytics'), isTrue);
+      // Opening Settings closes the analytics panel — symmetric with opening
+      // analytics replacing the right column — so they don't clutter it (#7109).
+      expect(right.any((t) => t.type == 'analytics'), isFalse);
+    });
+
+    test('opening a settings page drops open vocab/grammar/analytics '
+        'details (#7109)', () {
+      final loc = WorkspaceNav.openSettings(
+        u('/?right=vocab:abc,grammar:def,analytics:vocab'),
+        page: 'learning',
+      );
+      final right = parseOpenPanels(u(loc)).right;
+      // Only the settings page + its menu master remain; the analytics family
+      // is gone.
+      expect(right.map((t) => t.type), ['settingspage', 'settings']);
     });
 
     test('opening a page seats it as a detail BESIDE the menu master', () {
@@ -442,18 +456,22 @@ void main() {
     });
 
     test('closeSettings drops the menu AND its page, keeps the rest', () {
-      var loc = WorkspaceNav.openRight(
-        u('/'),
-        const PanelToken('analytics', 'vocab'),
+      // Analytics can no longer coexist with settings (opening settings drops
+      // it, #7109), so "the rest" is a left panel. closeSettings clears the
+      // right settings panel and leaves the left column intact.
+      var loc = WorkspaceNav.openSettings(
+        u('/?left=room:!a'),
+        page: 'learning',
       );
-      loc = WorkspaceNav.openSettings(u(loc), page: 'learning');
       loc = WorkspaceNav.closeSettings(u(loc));
-      final right = parseOpenPanels(u(loc)).right;
+      final panels = parseOpenPanels(u(loc));
       expect(
-        right.any((t) => t.type == 'settings' || t.type == 'settingspage'),
+        panels.right.any(
+          (t) => t.type == 'settings' || t.type == 'settingspage',
+        ),
         isFalse,
       );
-      expect(right.single, const PanelToken('analytics', 'vocab'));
+      expect(panels.left.single, const PanelToken('room', '!a'));
     });
   });
 


### PR DESCRIPTION
## Problem

Closes #7109. Opening Vocab / Grammar / Activity-Stars closes an open Settings panel, but opening Settings did NOT close those analytics panels — so the right column ended up cluttered with both.

The asymmetry: opening analytics uses `setRight([analytics:tab])`, which replaces the whole right column (dropping settings); but `WorkspaceNav.openSettings` only de-duped settings tokens and appended `settings`, leaving any open analytics-family panel in place.

## Fix

`openSettings` now also drops the analytics-family right panels (`analytics`, `vocab`, `grammar`, `practice`, `review`) when seating the settings menu/page — making the two mutually exclusive in the right column, symmetric with analytics-open. Both entry points (avatar Settings and the flag/language settings) route through `openSettings`, so both are covered.

## Verification

- Unit: 139 navigation tests pass, including a new case (opening Settings drops an open analytics panel) and a page-detail case (opening a settings page drops open vocab/grammar/analytics details); the `closeSettings` test was updated to the new exclusivity (it now keeps a left panel as "the rest").
- Local Chrome (local backend, @learner): Vocab open → tap avatar Settings → Vocab closes (`#/?right=settings`); Grammar open → tap the language flag → Grammar closes (`#/?right=settingspage:learning,settings`, no analytics token).

`dart format` + `import_sorter` clean; `flutter analyze`: no issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed settings panel behavior to ensure analytics panels close when settings are opened, displaying settings content exclusively in the right column.

* **Tests**
  * Updated navigation tests to verify correct interaction between settings and analytics panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->