### PR TITLE
fix(nav): Stars activity closes the course card (#7106); closing course keeps the running activity (#7111)

### DIFF
--- a/lib/features/navigation/workspace_nav.dart
+++ b/lib/features/navigation/workspace_nav.dart
@@ -128,11 +128,29 @@ abstract class WorkspaceNav {
   static String openExclusiveLeftRoom(Uri current, PanelToken token) =>
       openDetail(current, token);
 
-  /// A completed-activity `session` review is a left detail in BOTH `liveView`
-  /// and `detail`, so opening it drops any other room/session AND any
-  /// vocab/grammar detail (one detail across columns).
+  /// A completed-activity `session` review (opened from the Stars archive) is a
+  /// left detail in BOTH `liveView` and `detail`, so opening it drops any other
+  /// room/session AND any vocab/grammar detail (one detail across columns). It
+  /// ALSO drops the open `course` card and its `coursepage` so the review isn't
+  /// rendered behind a still-open course window (#7106) — the Stars archive is
+  /// this helper's only caller, and a live in-course session opens via
+  /// [openExclusiveLeftRoom] (+ [openCourseFilter]) instead, so the course is
+  /// only dropped on the Stars path. (Not a shared sibling group: that would
+  /// evict the course on every room/vocab/grammar/practice open too.)
   static String openExclusiveSession(Uri current, PanelToken token) =>
-      openDetail(current, token);
+      _mutateBoth(current, (left) {
+        final next = left
+            .where(
+              (t) =>
+                  t != token &&
+                  !_areSiblings(token, t) &&
+                  t.type != 'course' &&
+                  t.type != 'coursepage',
+            )
+            .toList();
+        next.add(token);
+        return next;
+      }, (right) => right.where((t) => !_areSiblings(token, t)).toList());
 
   /// Open a vocab/grammar construct detail (the `detail` group): drops the other
   /// construct detail and any `session`, seats the detail at the front of the
@@ -340,11 +358,20 @@ abstract class WorkspaceNav {
               !(dropDependentCoursePage && t.type == 'coursepage'),
         )
         .toList();
+    // Preserve unrelated one-shot query the way closeLeft/_mutate already do —
+    // recompute only m/left/right and carry the rest forward. Critically this
+    // keeps `?activity=`/`?launch=`/`?roomid=` (a launching or running activity
+    // renders as the center canvas, independent of the course card), so closing
+    // the course no longer unmounts/aborts the activity (#7111). The map filter
+    // (`?m=`) is re-added below, so drop it from the carried set to avoid a dupe.
+    final rest = WorkspaceQuery.parts(current.query);
+    WorkspaceQuery.removeKeys(rest, {'m', 'left', 'right'});
     final parts = <String>[
       ?_mapFilter(current),
       if (left.isNotEmpty) 'left=${left.map((t) => t.encode()).join(',')}',
       if (lists.right.isNotEmpty)
         'right=${lists.right.map((t) => t.encode()).join(',')}',
+      ...rest,
     ];
     return WorkspaceQuery.location(PRoutes.world, parts);
   }

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -284,6 +284,20 @@ void main() {
       );
       expect(left.single, const PanelToken('session', '!s'));
     });
+
+    test('opening a session from Stars closes the open course card (#7106)', () {
+      // A saved activity opened from the Stars archive takes over the left
+      // column: the open course card closes (so the review isn't rendered behind
+      // it) while the map scope is kept.
+      final loc = WorkspaceNav.openExclusiveSession(
+        u('/?m=course:!s&left=course'),
+        const PanelToken('session', '!a'),
+      );
+      final left = parseOpenPanels(u(loc)).left;
+      expect(left.any((t) => t.type == 'course'), isFalse); // card closed
+      expect(left.singleWhere((t) => t.type == 'session').param, '!a');
+      expect(loc.contains('m=course'), isTrue); // map scope preserved
+    });
   });
 
   group('setLeft / clearLeft', () {
@@ -354,6 +368,23 @@ void main() {
         const PanelToken('chats'),
       );
       expect(loc, '/');
+    });
+
+    test('closing the course keeps a launching activity overlay (#7111)', () {
+      // A launching/running activity lives in the ?activity= overlay (the center
+      // canvas, independent of the course card); closing the course must not
+      // drop it.
+      final loc = WorkspaceNav.closeSection(
+        u('/?m=course:!s&left=course&activity=act-1&launch=true'),
+        const PanelToken('course'),
+      );
+      expect(loc.contains('activity=act-1'), isTrue); // overlay preserved
+      expect(loc.contains('launch=true'), isTrue);
+      expect(loc.contains('m=course'), isTrue); // scope kept
+      expect(
+        parseOpenPanels(u(loc)).left.any((t) => t.type == 'course'),
+        isFalse,
+      ); // card gone
     });
   });
 


### PR DESCRIPTION
## Summary

Two related course/activity panel-behavior fixes.

**#7106 — a saved activity from the Stars archive now closes the open course card.** `openExclusiveSession` (the Stars archive's only caller) previously only dropped same-sibling-group panels, so an open `course` card (no shared group) survived and the activity rendered behind it. It now also drops the left `course`/`coursepage` while keeping the map scope, so the activity opens in front. Live in-course sessions use `openExclusiveLeftRoom`, not this path, so the course is only dropped on the Stars path.

**#7111 — closing the course no longer aborts a launching/running activity.** A launching activity lives entirely in the `?activity=`/`?launch=` URL overlay (rendered as the center canvas, independent of the course card). The course card's X uses `closeSection`, which rebuilt the URL keeping only the map filter + panel lists — dropping `?activity=`/`?launch=` and unmounting the activity mid-launch. `closeSection` now preserves unrelated one-shot query (like `closeLeft`/`_mutate` already do), so closing the course keeps the activity alive and gives it the room.

## Verification

- Unit: 141 navigation tests pass, including two new cases (opening a session drops the course card; `closeSection` keeps `?activity=`/`?launch=`).
- Local Chrome (local backend, @learner): #7106 — opened a course, opened a saved activity from Stars → course card closed, session opened in front (`left=course` → `left=session:...`). #7111 — course card + launching activity co-present, clicked the course X → `?activity=...&launch=true` and `m=course:...` persisted, the activity panel stayed mounted.

`dart format` + `import_sorter` clean; `flutter analyze`: no issues.

Closes #7106. Closes #7111.
