### PR TITLE
fix(nav): course participants-tab invite/permissions opened a blank panel (#7099)

### DIFF
--- a/lib/utils/navigation_util.dart
+++ b/lib/utils/navigation_util.dart
@@ -46,11 +46,12 @@ class NavigationUtil {
     // the card.
     if (goalRoomID == null) {
       if (activeSpaceId != null) {
+        final coursePage = coursePageFor(sub);
         context.go(
-          sub.isEmpty
+          coursePage.isEmpty
               ? WorkspaceNav.openCourse(uri, const PanelToken('course'))
               : _appendQuery(
-                  WorkspaceNav.openCoursePage(uri, sub),
+                  WorkspaceNav.openCoursePage(uri, coursePage),
                   queryParams,
                 ),
           extra: extra,
@@ -65,12 +66,18 @@ class NavigationUtil {
     }
 
     // The active course SPACE itself: re-show its card, or open a management
-    // page (invite / edit / …) as a `coursepage` detail beside the card.
+    // page (invite / edit / …) as a `coursepage` detail beside the card. The
+    // shared chat-details UI addresses these with a room-style `details/<page>`
+    // subroute, so normalize to the course's bare page (see coursePageFor).
     if (activeSpaceId != null && goalRoomID == activeSpaceId) {
+      final coursePage = coursePageFor(sub);
       context.go(
-        sub.isEmpty
+        coursePage.isEmpty
             ? WorkspaceNav.openCourse(uri, const PanelToken('course'))
-            : _appendQuery(WorkspaceNav.openCoursePage(uri, sub), queryParams),
+            : _appendQuery(
+                WorkspaceNav.openCoursePage(uri, coursePage),
+                queryParams,
+              ),
         extra: extra,
       );
       return;
@@ -151,5 +158,22 @@ class NavigationUtil {
         )
         .join('&');
     return '$loc${loc.contains('?') ? '&' : '?'}$q';
+  }
+
+  /// Normalizes a room-style chat-details subroute to its course `coursepage`.
+  ///
+  /// The chat-details UI is shared between rooms and the course space and
+  /// addresses management screens with a room-style `details/<page>` path (e.g.
+  /// the participants tab invites via `['details', 'invite']`). A course has no
+  /// `details` coursepage — that role is the card itself — so `details` maps to
+  /// `''` (show the card) and `details/<page>` to the bare `<page>` coursepage.
+  /// Any other subroute is already a bare coursepage and passes through.
+  /// Without this, `details/invite` became the unhandled token
+  /// `coursepage:details/invite`, rendering an empty, un-closable panel (#7099).
+  @visibleForTesting
+  static String coursePageFor(String sub) {
+    if (sub == 'details') return '';
+    if (sub.startsWith('details/')) return sub.substring('details/'.length);
+    return sub;
   }
 }

--- a/test/pangea/navigation/navigation_util_test.dart
+++ b/test/pangea/navigation/navigation_util_test.dart
@@ -92,4 +92,48 @@ void main() {
       ]);
     });
   });
+
+  /// Guards #7099: the chat-details UI (participants tab, button row) addresses
+  /// course-space management screens with a room-style `details/<page>`
+  /// subroute, but a course has no `details` coursepage. Before the fix this
+  /// produced the unhandled token `coursepage:details/invite`, which the left
+  /// panel rendered as an empty, un-closable `SizedBox.shrink()`.
+  /// [NavigationUtil.coursePageFor] normalizes the subroute so the coursepage
+  /// is one the renderer actually handles.
+  group('coursePageFor (room-style subroute → course page)', () {
+    test('details/<page> drops the room-only `details` segment', () {
+      expect(NavigationUtil.coursePageFor('details/invite'), 'invite');
+      expect(
+        NavigationUtil.coursePageFor('details/permissions'),
+        'permissions',
+      );
+    });
+
+    test('bare `details` maps to the card (empty page)', () {
+      expect(NavigationUtil.coursePageFor('details'), '');
+    });
+
+    test('an already-bare course page passes through unchanged', () {
+      expect(NavigationUtil.coursePageFor('invite'), 'invite');
+      expect(NavigationUtil.coursePageFor('edit'), 'edit');
+      expect(NavigationUtil.coursePageFor(''), '');
+    });
+
+    test(
+      'end to end: a participants-tab invite seats a renderable coursepage',
+      () {
+        // The participants tab calls goToSpaceRoute(space, ['details','invite']);
+        // through the course-space branch that is openCoursePage(.., 'invite').
+        final loc = WorkspaceNav.openCoursePage(
+          u('/?m=course:!s&left=course'),
+          NavigationUtil.coursePageFor('details/invite'),
+        );
+        final coursepage = parseOpenPanels(
+          u(loc),
+        ).left.where((t) => t.type == 'coursepage').single;
+        // The renderable token — NOT the blank `coursepage:details/invite`.
+        expect(coursepage, const PanelToken('coursepage', 'invite'));
+      },
+    );
+  });
 }


### PR DESCRIPTION
Fixes #7099.

## Symptom
Inviting from a course's Participants tab opened a blank, un-closable panel (no X). The user could only dismiss the whole course card or hit browser-back.

## Root cause
The chat-details UI (participants tab, button row) is shared between rooms and the course space. It addresses management screens with a room-style `details/<page>` subroute, e.g. the participants-tab invite calls `goToSpaceRoute(space, ['details', 'invite'])`. For a real room this is correct (`room:<id>/details/invite`). But when the target is the course space itself, `goToSpaceRoute` fed `'details/invite'` straight into `openCoursePage`, producing the token `coursepage:details/invite`. A course has no `details` coursepage, so the renderer fell through to `SizedBox.shrink()`: the blank panel.

The "Permisos" button (`['details', 'permissions']`) had the same defect (`coursepage:details/permissions`).

## Fix
Normalize the room-style subroute to the course's bare page in one place, `NavigationUtil.coursePageFor`:
- `details` maps to the card (a course has no separate details screen; the card is it),
- `details/<page>` maps to the bare `<page>` coursepage,
- an already-bare page passes through.

Applied in both `goToSpaceRoute` branches that open a coursepage (the null-target-with-active-course branch and the course-space branch). The room path is untouched, so `room:<id>/details/invite` still works as before.

## Tests
- 4 new regression tests in `navigation_util_test.dart` covering the normalization and an end-to-end check that the participants invite seats the renderable `coursepage:invite` token, not the blank `coursepage:details/invite`. 11/11 pass.
- `flutter analyze`, `dart format`, and `import_sorter` clean.

## Verified locally
Local Chrome on a fresh build of this branch:
- Participants tab invite renders the full invite UI (search, Participantes/Mis contactos/Público filters, contact list, working X); token is `coursepage:invite`.
- "Permisos" renders the real permissions page; token is `coursepage:permissions`.
- The pre-existing "More menu invite" path still works.

QA can verify on staging once merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed navigation to course pages when accessed from chat and invite contexts.

* **Tests**
  * Added tests for course page navigation routing to ensure correct path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->