### PR TITLE
docs(accessibility): per-surface audit coverage, decoupled from functional tests

### DIFF
--- a/.github/instructions/accessibility.instructions.md
+++ b/.github/instructions/accessibility.instructions.md
@@ -1,35 +1,33 @@
 ---
-applyTo: "lib/pangea/**,lib/pages/**,lib/widgets/**"
-description: "Accessibility design intent for the client — what audit-ready means, why a canvas app needs explicit naming, and what automated tests do and don't cover."
+applyTo: "lib/pangea/**,lib/routes/**,lib/widgets/**,e2e/**"
+description: "Accessibility design intent and audit-coverage strategy for the client — canvas-as-authoring, what axe can and cannot prove, and per-surface auditing decoupled from functional tests."
 ---
 
 # Accessibility — Design Intent
 
-We build for screen-reader, keyboard, and low-vision users as a first-class requirement, not a retrofit. Institutional buyers and the WL360 research studies treat accessibility as a procurement gate, so "audit-ready" (WCAG 2.1 AA) is a product target, not a nice-to-have.
+We build for screen-reader, keyboard, and low-vision users as a first-class requirement, not a retrofit. Institutional buyers and the WL360 studies treat accessibility as a procurement gate, so **audit-ready (WCAG 2.1 AA)** is a product target.
 
 ## The one fact that shapes everything
 
-The app renders to a single opaque `<canvas>`. Unlike a normal web page, **nothing is accessible by default** — a button, a field, an image is invisible to assistive tech until we explicitly give it a name. Accessibility here is an act of authoring, performed element by element as the UI is built, not a setting we switch on later. The mechanical per-widget naming rules live in [playwright-testing.instructions.md § Widget testability](playwright-testing.instructions.md#widget-testability--non-negotiable); honor them as you build, because the same omission that breaks a test breaks a real screen-reader user.
+The app renders to a single opaque `<canvas>`. Nothing reaches assistive tech until we explicitly author a name and role for it, element by element as the UI is built — accessibility is an act of authoring, not a setting switched on later. The per-widget rules live in [playwright-testing.instructions.md § Widget testability](playwright-testing.instructions.md). The omission that hides an element from a test hides it from a real screen-reader user in the same way.
 
 ## What "audit-ready" means
 
-An auditor checks three independent things. All three must hold; passing one does not imply the others.
+Three independent checks; all must hold.
 
-- **Operable by screen reader** — every interactive element announces what it is and what it does; images are either described or marked decorative; reading order makes sense.
-- **Operable by keyboard alone** — every action is reachable and triggerable without a mouse, focus is always visible, and focus never gets trapped.
-- **Usable by low vision** — sufficient color contrast, text that survives zoom/resize, and nothing conveyed by color alone.
+- **Screen reader** — every interactive element announces what it is and does; images are described or marked decorative; reading order makes sense.
+- **Keyboard alone** — every action is reachable and triggerable without a mouse; focus is always visible and never trapped.
+- **Low vision** — sufficient contrast, text survives zoom/resize, nothing conveyed by color alone.
 
-## Don't mistake green tests for audit-ready
+## Automated auditing proves only part
 
-Our automated axe suite is a **regression guard for flows we've already labeled**, not a conformance measure. It runs against the semantics overlay only, so by design it cannot see:
+We run axe-core (WCAG 2.1 AA) against the semantics overlay. Two decisions shape coverage:
 
-- **Color contrast and visual layout** — pixels inside the canvas are opaque to it.
-- **Real keyboard operability and focus visibility** — presence of a name is not proof the app is operable.
-- **Actual screen-reader behavior** — a named element is not proof VoiceOver/TalkBack/NVDA announce it correctly.
-- **Mobile** — iOS/Android, where most users are, are out of scope until Patrol lands.
+- **A11y auditing is decoupled from functional tests and covers more surfaces.** We don't script a click-through per surface. Because the URL is the workspace, an audit deep-links straight to a surface, so a surface gets accessibility coverage whether or not it has a functional spec.
+- **A surface that never rendered passes vacuously.** axe over an empty or un-woken semantics tree reports zero violations — a false pass, not conformance. An audit must confirm its surface is actually present in the tree (the map must be woken first) before its result counts; an audit that cannot reach its surface fails rather than silently passing.
 
-These gaps close only through **manual passes**: a real screen reader, keyboard-only navigation, and a contrast/zoom review. Treat the automated suite as ~a quarter of the work and the manual passes as the rest.
+axe still cannot judge **color contrast**, **real keyboard operability and focus visibility**, **actual screen-reader output**, or **mobile**. Treat the automated suite as roughly a quarter of the work; the rest closes only through manual passes — a real screen reader, keyboard-only, and a contrast/zoom review. Fix an unnamed control in Dart; never allowlist a violation, which is permanent product debt.
 
 ## Responsibility
 
-Accessibility is owned by whoever builds or changes the UI, in the same change — not deferred to a later test-writing or audit pass. New interactive surfaces ship with names; new flows get a manual screen-reader sanity check. The living coverage backlog is [`e2e/web-and-accessibility-next-steps.md`](../../e2e/web-and-accessibility-next-steps.md).
+Accessibility is owned by whoever builds or changes the UI, in the same change — new surfaces ship with names, new flows get a manual screen-reader sanity check. Living backlog: [`e2e/web-and-accessibility-next-steps.md`](../../e2e/web-and-accessibility-next-steps.md).


### PR DESCRIPTION
Folds the accessibility audit-coverage strategy into the existing `accessibility.instructions.md` (the single home for a11y design), per instructions-authoring. No code change.

What changed:
- Two new design decisions in the "Automated auditing proves only part" section: (1) a11y auditing is decoupled from functional Playwright tests and covers more surfaces (deep-link per surface); (2) a surface that never rendered passes vacuously, so an audit must confirm its surface is present in the tree before the result counts, and fails rather than silently passing.
- Restated the "fix the unnamed control in Dart, never allowlist" rule.
- Fixed stale frontmatter: `applyTo` pointed at `lib/pages/**` (removed in the world redesign), now `lib/routes/**` plus `e2e/**`; tightened the description.
- Trimmed to 434 words to stay within the instruction-doc budget.

Implementation (per-surface audits, fixture readiness gate, trigger-map remap) and the test-infra staleness cleanup are tracked separately, not in this doc.
