### PR TITLE
fix(nav): navigating within one popup no longer swaps/evicts the other (#7104)

### DIFF
--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -64,6 +64,96 @@ GlobalKey _roomKeyFor(String roomId) => _leftRoomKeys.putIfAbsent(
 /// [_ShellLayout.resolve]. See `routing.instructions.md`.
 final List<String> _paneRecency = <String>[];
 
+/// The stable recency identity of an open panel — its *family instance*, not its
+/// current page. Navigating WITHIN a panel changes the token string but must NOT
+/// change which panel is the recency focus (a within-panel move is a push on the
+/// panel's own stack, not a fresh open; see `routing.instructions.md`), so the
+/// key deliberately ignores the parts of the token that a within-panel
+/// navigation rewrites:
+///
+///  - The family is the **root of the navigation tree** ([PanelDef.parent]
+///    chain): a `settingspage` detail keys as its `settings` master, a
+///    `vocab`/`grammar` construct as its `analytics` summary, a `coursepage` as
+///    its `course` card — so opening/paging a detail off a master keeps the
+///    master's recency slot instead of demoting an unrelated open popup.
+///  - The instance is the family root's **identity**: a `room`/`session` is
+///    keyed by its bare room id (the `<id>/subpage` push is stripped, mirroring
+///    the URL parser's dedup), so two different rooms stay distinct while a
+///    room → members push keeps one slot. A singleton family (settings,
+///    analytics, course — whose live identity is the `?m=` filter, not the tab
+///    param) keys on the root type alone, so a tab/page switch reuses its slot.
+///
+/// This is the one fix point for #7104 ("open tabs switching places"): the
+/// allocator's Tier-2 collapse and narrow-mode focus both read the recency-derived
+/// `focusHint`, so keying recency on stable identity stops a within-panel
+/// navigation from stealing focus and evicting the other column's popup.
+String _recencyKey(PanelToken token) {
+  // Walk to the navigation-tree root so a detail inherits its master's slot.
+  var def = PanelRegistry.defFor(token.type);
+  var rootType = token.type;
+  // Bounded by the registry depth (two generations today); guard against a
+  // malformed cyclic/self parent just in case.
+  final seen = <String>{rootType};
+  while (def?.parent != null && seen.add(def!.parent!)) {
+    rootType = def.parent!;
+    def = PanelRegistry.defFor(rootType);
+  }
+  // A room/session instance is its bare room id; the rest is a pushed sub-page.
+  // A `room` keeps its OWN type as the root (its parent `chats` is the list, a
+  // separate panel), so this branch is reached with the original type.
+  if (token.type == 'room' || token.type == 'session') {
+    final bareId = (token.param ?? '').split('/').first;
+    return '${token.type}:$bareId';
+  }
+  // Every other family (settings/analytics/course/chats/addcourse/practice/
+  // review) is a singleton per column: key on the root type, so paging or
+  // tab-switching within it reuses the one slot.
+  return rootType;
+}
+
+/// Sync the back-stack [recency] against the currently open [allTokens] (merged
+/// `[left…, right…]`, the allocator's entry order) and return the allocator
+/// `focusHint` index, or null when nothing is open.
+///
+/// Recency is keyed on STABLE panel identity ([_recencyKey]) — the panel-family
+/// instance, not the per-page token string — so navigating WITHIN a panel (a
+/// settings menu → page, a room → members, a course tab switch, a vocab detail
+/// off the analytics summary) reuses the panel's existing slot instead of
+/// jumping to most-recent. Without this, navigating inside one popup stole the
+/// back-stack top from an unrelated open popup, and the column-mode Tier-2
+/// collapse then evicted that OTHER popup — so the two appeared to swap columns
+/// (#7104). A genuinely new panel (a different room, the first detail of a
+/// family) still mints a new key and is promoted as the user expects.
+///
+/// The recency-top key can match more than one open pane (a master and its
+/// detail share a key, e.g. `course` + `coursepage`, `settings` + `settingspage`);
+/// resolve to the **leaf** — the pane no other open pane names as parent — so the
+/// just-opened detail wins focus over its master regardless of list order (a left
+/// detail appends after its master; a right detail front-inserts). This mirrors
+/// the allocator's own leaf rule. Mutates [recency] in place. Pure and
+/// allocator-free so it is unit-tested directly. See `routing.instructions.md`.
+@visibleForTesting
+int? recencyFocusHint(List<PanelToken> allTokens, List<String> recency) {
+  final paneKeys = [for (final t in allTokens) _recencyKey(t)];
+  recency.removeWhere((id) => !paneKeys.contains(id));
+  for (final id in paneKeys) {
+    if (!recency.contains(id)) recency.add(id);
+  }
+  if (recency.isEmpty) return null;
+  final topKey = recency.last;
+  final matches = <int>[
+    for (var i = 0; i < paneKeys.length; i++)
+      if (paneKeys[i] == topKey) i,
+  ];
+  if (matches.isEmpty) return null;
+  return matches.firstWhere(
+    (i) => !allTokens.any(
+      (t) => PanelRegistry.defFor(t.type)?.parent == allTokens[i].type,
+    ),
+    orElse: () => matches.last,
+  );
+}
+
 /// The world_v2 workspace shell: a single persistent [WorldMap] with the open
 /// panels overlaid. Not "two columns" — it owns the map backdrop, the nav rail,
 /// the top-right cluster, the center canvas/detail, AND both panel columns. Every
@@ -446,26 +536,24 @@ class _ShellLayout {
     ];
 
     // Narrow focus = the most-recently-opened panel (back-stack top). Sync the
-    // recency list against the open tokens: append newly-opened ids (in list
-    // order), prune closed ones; the merged [left…, right…] id order matches the
+    // recency list against the open panels: append newly-opened keys (in list
+    // order), prune closed ones; the merged [left…, right…] order matches the
     // allocator's entry order, so the focus index maps straight through. The sync
-    // is idempotent for an unchanged token set, so a width change never
+    // is idempotent for an unchanged panel set, so a width change never
     // reshuffles panes or adds history. Ephemeral view state, deliberately OUTSIDE
     // the URL (a shared link / refresh has no recency and the allocator falls back
     // to the tree's leaf rule). Consulted in narrow mode (which pane to seat) and
     // in column mode (the just-opened pane is protected from a left↔right parity
     // collapse, #7088). See `routing.instructions.md`.
-    final paneIds = [
-      for (final t in leftTokens) t.encode(),
-      for (final t in rightTokens) t.encode(),
-    ];
-    _paneRecency.removeWhere((id) => !paneIds.contains(id));
-    for (final id in paneIds) {
-      if (!_paneRecency.contains(id)) _paneRecency.add(id);
-    }
-    final focusHint = _paneRecency.isNotEmpty
-        ? paneIds.indexOf(_paneRecency.last)
-        : null;
+    //
+    // The whole rule — STABLE-identity keying ([_recencyKey]) plus leaf
+    // resolution of the recency-top key — lives in [recencyFocusHint], extracted
+    // so it is unit-tested against real allocator input (#7104). It mutates
+    // [_paneRecency] in place (the shared back-stack) and returns the focus index.
+    final focusHint = recencyFocusHint([
+      ...leftTokens,
+      ...rightTokens,
+    ], _paneRecency);
 
     final layout = PanelAllocator.allocate(
       viewport: viewport,

--- a/test/pangea/navigation/swap_probe_test.dart
+++ b/test/pangea/navigation/swap_probe_test.dart
@@ -1,0 +1,272 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/navigation/panel_registry.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
+import 'package:fluffychat/widgets/layouts/panel_allocator.dart';
+import 'package:fluffychat/widgets/layouts/workspace_shell.dart';
+
+/// Regression coverage for #7104 ("open tabs switching places"): with two popups
+/// open in two columns, navigating WITHIN one popup (Settings → Subscription)
+/// must NOT make the OTHER popup change columns / disappear.
+///
+/// Cause: the narrow/collapse focus signal (`focusHint`) was keyed on the
+/// per-page token string, so a within-panel navigation minted a "new" token id
+/// that the recency sync promoted to the back-stack top, stealing focus from the
+/// unrelated popup; the column-mode Tier-2 parity collapse then evicted that other
+/// popup. The fix keys recency on STABLE panel identity (the navigation-tree
+/// family root) and resolves a shared key to the leaf pane.
+///
+/// Drives the REAL production focus rule ([recencyFocusHint] in
+/// `workspace_shell.dart`) over real nav-helper URLs → parser → allocator, so
+/// there is no mirrored logic to drift out of lock-step.
+void main() {
+  PanelDef d(String t) => PanelRegistry.defFor(t)!;
+
+  // The production back-stack the shell mutates per build; reset per test.
+  final paneRecency = <String>[];
+  int? focusHintFor(List<PanelToken> all) => recencyFocusHint(all, paneRecency);
+
+  WorkspaceLayout layoutOf(Uri u, double vp, {required bool columnMode}) {
+    final lists = parseOpenPanels(u);
+    final fh = focusHintFor([...lists.left, ...lists.right]);
+    return PanelAllocator.allocate(
+      viewport: vp,
+      isColumnMode: columnMode,
+      railWidth: columnMode ? 105.0 : PanelAllocator.defaultRailWidth,
+      left: [for (final t in lists.left) d(t.type)],
+      right: [for (final t in lists.right) d(t.type)],
+      focusHint: fh,
+    );
+  }
+
+  PanelVis visOf(WorkspaceLayout l, Uri u, String type) {
+    final lists = parseOpenPanels(u);
+    final li = lists.left.indexWhere((t) => t.type == type);
+    if (li >= 0) return l.left[li].vis;
+    final ri = lists.right.indexWhere((t) => t.type == type);
+    if (ri >= 0) return l.right[ri].vis;
+    return PanelVis.hidden;
+  }
+
+  double? leftOf(WorkspaceLayout l, Uri u, String type) {
+    final lists = parseOpenPanels(u);
+    final li = lists.left.indexWhere((t) => t.type == type);
+    if (li >= 0) return l.left[li].left;
+    final ri = lists.right.indexWhere((t) => t.type == type);
+    if (ri >= 0) return l.right[ri].left;
+    return null;
+  }
+
+  setUp(paneRecency.clear);
+
+  // The type of the pane the recency rule currently focuses, replaying each
+  // build in order (recency accumulates per build, like the live shell).
+  String focusType(Uri u) {
+    final all = [...parseOpenPanels(u).left, ...parseOpenPanels(u).right];
+    return all[focusHintFor(all)!].type;
+  }
+
+  group('#7104 — navigating within a popup keeps the other popup put', () {
+    test('a push inside a NON-focused popup does not steal focus from the '
+        'most-recent popup (the core regression)', () {
+      // Open a room (left), THEN an analytics summary (right): analytics is the
+      // most-recently opened, so it holds focus. A push WITHIN the room
+      // (room → members) must NOT steal focus to the room. Before the fix the
+      // per-page token id changed, promoting the room to the back-stack top, and
+      // the tight-band Tier-2 collapse then evicted the analytics popup — the
+      // visible "swap". This case fails on the pre-fix (token-string) keying and
+      // passes on the stable-identity keying.
+      var u = Uri.parse(
+        WorkspaceNav.openLeft(Uri.parse('/'), const PanelToken('room', '!abc')),
+      );
+      expect(focusType(u), 'room');
+      u = Uri.parse(
+        WorkspaceNav.setRight(u, [const PanelToken('analytics', 'vocab')]),
+      );
+      expect(focusType(u), 'analytics');
+      u = Uri.parse(WorkspaceNav.pushPage(u, 'room', '!abc/members'));
+      expect(
+        focusType(u),
+        'analytics',
+        reason:
+            'a push inside the non-focused room must not steal focus (#7104)',
+      );
+    });
+
+    test('tight band: navigating the non-focused popup does not evict the focused '
+        'popup (the visible symptom)', () {
+      // The Tier-2 parity-collapse band (#7088): with two opposite-column
+      // popups whose hard-mins overflow, only the focused one stays full. Open
+      // settings, THEN a course — the course is most-recent, so it holds focus
+      // and (protected from the collapse) stays full while settings yields.
+      const vp = 900.0;
+      var u = Uri.parse(WorkspaceNav.openSettings(Uri.parse('/')));
+      layoutOf(u, vp, columnMode: true); // build 1: settings (right)
+      u = Uri.parse(WorkspaceNav.openCourseFilter(u, '!space:server'));
+      final before = layoutOf(u, vp, columnMode: true); // build 2: course focus
+      expect(
+        visOf(before, u, 'course'),
+        PanelVis.full,
+        reason: 'the most-recent (course) popup holds focus and stays full',
+      );
+      // Guard that we are genuinely in the collapse band (else the assertion
+      // below is trivially true): the non-focused settings popup is the one
+      // that yields. course (priority 60) > settingspage (55), so course can
+      // ONLY be evicted by focus protecting the other popup — exactly the
+      // pre-fix focus-steal this test pins.
+      expect(
+        visOf(before, u, 'settings'),
+        PanelVis.hidden,
+        reason: 'the band must force a collapse for this test to discriminate',
+      );
+
+      // Navigate WITHIN settings (the NON-focused popup) → subscription. Before
+      // the fix this stole focus to settings and the collapse evicted course
+      // (course flipped full→hidden — the "swap"). The focused popup must stay.
+      u = Uri.parse(WorkspaceNav.openSettings(u, page: 'subscription'));
+      final after = layoutOf(u, vp, columnMode: true);
+      expect(
+        visOf(after, u, 'course'),
+        PanelVis.full,
+        reason:
+            'a nav inside the other popup must not evict the focused course (#7104)',
+      );
+      expect(visOf(after, u, 'settingspage'), PanelVis.hidden);
+    });
+
+    test('wide column mode: left room stays at the same x across the nav', () {
+      const vp = 1600.0;
+      var u = Uri.parse(
+        WorkspaceNav.openLeft(Uri.parse('/'), const PanelToken('room', '!abc')),
+      );
+      u = Uri.parse(WorkspaceNav.openSettings(u)); // open settings (right)
+      final before = layoutOf(u, vp, columnMode: true);
+      final roomXBefore = leftOf(before, u, 'room');
+      expect(visOf(before, u, 'room'), PanelVis.full);
+
+      // Navigate WITHIN settings → subscription (the other popup must not move).
+      u = Uri.parse(WorkspaceNav.openSettings(u, page: 'subscription'));
+      final after = layoutOf(u, vp, columnMode: true);
+      expect(visOf(after, u, 'room'), PanelVis.full, reason: 'room must stay');
+      expect(
+        leftOf(after, u, 'room'),
+        roomXBefore,
+        reason: 'room must not shift columns/position (#7104)',
+      );
+      expect(visOf(after, u, 'settingspage'), PanelVis.full);
+    });
+
+    test(
+      'within-panel navigation never changes focusHint (settings family)',
+      () {
+        int? fhOf(Uri u) {
+          final ls = parseOpenPanels(u);
+          return focusHintFor([...ls.left, ...ls.right]);
+        }
+
+        var u = Uri.parse(
+          WorkspaceNav.openLeft(
+            Uri.parse('/'),
+            const PanelToken('room', '!abc'),
+          ),
+        );
+        u = Uri.parse(WorkspaceNav.openSettings(u));
+        final fhSettings = fhOf(u);
+        u = Uri.parse(WorkspaceNav.openSettings(u, page: 'subscription'));
+        final fhSubscription = fhOf(u);
+        u = Uri.parse(WorkspaceNav.openSettings(u, page: 'learning'));
+        final fhLearning = fhOf(u);
+        expect(fhSubscription, fhSettings);
+        expect(fhLearning, fhSettings);
+      },
+    );
+
+    test('within-panel navigation never changes focusHint (room push)', () {
+      int? fhOf(Uri u) {
+        final ls = parseOpenPanels(u);
+        return focusHintFor([...ls.left, ...ls.right]);
+      }
+
+      var u = Uri.parse(WorkspaceNav.openSettings(Uri.parse('/')));
+      u = Uri.parse(WorkspaceNav.openLeft(u, const PanelToken('room', '!abc')));
+      final fhRoom = fhOf(u);
+      u = Uri.parse(WorkspaceNav.pushPage(u, 'room', '!abc/members'));
+      final fhMembers = fhOf(u);
+      expect(fhMembers, fhRoom);
+    });
+  });
+
+  group('#7104 fix must not regress narrow-mode detail-show', () {
+    test('opening a settings page shows the page over the menu (narrow)', () {
+      var u = Uri.parse(WorkspaceNav.openSettings(Uri.parse('/')));
+      u = Uri.parse(WorkspaceNav.openSettings(u, page: 'subscription'));
+      final l = layoutOf(u, 400, columnMode: false);
+      expect(visOf(l, u, 'settingspage'), PanelVis.full);
+      expect(visOf(l, u, 'settings'), PanelVis.hidden);
+    });
+
+    test('opening a construct detail shows it over the summary (narrow)', () {
+      var u = Uri.parse(
+        WorkspaceNav.setRight(Uri.parse('/'), [
+          const PanelToken('analytics', 'vocab'),
+        ]),
+      );
+      u = Uri.parse(
+        WorkspaceNav.openConstructDetail(
+          u,
+          const PanelToken('vocab', 'hablar'),
+          'vocab',
+        ),
+      );
+      final l = layoutOf(u, 400, columnMode: false);
+      expect(visOf(l, u, 'vocab'), PanelVis.full);
+      expect(visOf(l, u, 'analytics'), PanelVis.hidden);
+    });
+
+    test(
+      'opening a course page shows the page over the card (narrow, left detail '
+      'appended after master — leaf resolution)',
+      () {
+        // A course needs its `?m=course:<id>` filter for the parser to keep the
+        // `course`/`coursepage` tokens (the card's identity rides the filter).
+        var u = Uri.parse(
+          WorkspaceNav.openCourseFilter(Uri.parse('/'), '!space:server'),
+        );
+        u = Uri.parse(WorkspaceNav.openCoursePage(u, 'invite'));
+        final l = layoutOf(u, 400, columnMode: false);
+        // coursepage is appended AFTER course in the left list; the leaf rule
+        // must still seat the page, not the card.
+        expect(visOf(l, u, 'coursepage'), PanelVis.full);
+        expect(visOf(l, u, 'course'), PanelVis.hidden);
+      },
+    );
+
+    test('a genuinely new panel is still promoted (narrow)', () {
+      // Replay every URL transition so recency builds as it does per-build in the
+      // real shell (each build syncs once).
+      var u = Uri.parse(
+        WorkspaceNav.openLeft(Uri.parse('/'), const PanelToken('room', '!abc')),
+      );
+      layoutOf(u, 400, columnMode: false); // build 1: room
+      u = Uri.parse(WorkspaceNav.openSettings(u));
+      final l = layoutOf(u, 400, columnMode: false); // build 2: + settings
+      expect(visOf(l, u, 'settings'), PanelVis.full);
+      expect(visOf(l, u, 'room'), PanelVis.hidden);
+    });
+
+    test('switching to a different room is promoted (distinct identity)', () {
+      var u = Uri.parse(WorkspaceNav.openSettings(Uri.parse('/')));
+      layoutOf(u, 400, columnMode: false); // build 1: settings
+      u = Uri.parse(WorkspaceNav.openLeft(u, const PanelToken('room', '!abc')));
+      layoutOf(u, 400, columnMode: false); // build 2: + room abc
+      u = Uri.parse(
+        WorkspaceNav.openExclusiveLeftRoom(u, const PanelToken('room', '!xyz')),
+      );
+      final l = layoutOf(u, 400, columnMode: false); // build 3: swap to xyz
+      expect(visOf(l, u, 'room'), PanelVis.full); // the !xyz room
+      expect(visOf(l, u, 'settings'), PanelVis.hidden);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #7104.

## Symptom
With two popups open in two columns, navigating to a different page WITHIN one popup (e.g. Settings then Manage Subscription) made that popup appear to swap columns with the other, and the popup you were looking at could disappear.

## Root cause
The panel allocator never moves panels between columns; `?left=`/`?right=` order is the source of truth and a panel's column is static. The visible "swap" is the #7088 column-mode Tier-2 parity collapse hiding the other column's popup, driven by a stale `focusHint`.

`focusHint` derives from the back-stack recency list, which was keyed on `PanelToken.encode()` (type:param). Because that embeds the page param, navigating WITHIN a panel (a settings menu to a settings page, a room to its members, a course tab switch, a vocab detail off the analytics summary) minted a brand-new id. The recency sync pruned the old id and appended the new one, so the just-navigated panel became the back-stack top, stealing focus from an unrelated open popup. In the tight two-column band (roughly 860 to 1000px, where the two columns' hard mins overflow), the allocator protects the focused panel from the parity collapse and instead collapses the lowest-priority panel across both columns, which was now the OTHER popup. That eviction reads as a column swap.

## Fix
Re-key the ephemeral recency on STABLE panel-family identity instead of the per-page token string. The allocator, the URL encode/parse layer, and the registry are all untouched.

- `_recencyKey(token)` walks the `PanelDef.parent` chain to the navigation-tree root, so a detail inherits its master's slot (`settingspage` to `settings`, `vocab`/`grammar` to `analytics`, `coursepage` to `course`). A `room`/`session` keys on its bare room id (the `/subpage` push is stripped, mirroring the URL parser's dedup), so distinct rooms stay distinct while a within-room push keeps one slot.
- The recency-top key can match a coexisting master and detail, so `focusHint` resolves to the leaf among them (the pane no open pane names as parent), matching the allocator's own leaf rule.
- This is extracted into `recencyFocusHint(allTokens, recency)` (the recency sync plus leaf resolution) so the exact focus rule is unit-tested against real allocator input rather than mirrored.

A genuinely new panel (a different room, the first detail of a family) still mints a new key and is promoted as before.

## Tests
`test/pangea/navigation/swap_probe_test.dart` drives the real `recencyFocusHint` over real nav-helper URLs through the parser and the allocator (no mirrored logic):
- a push inside a NON-focused popup does not steal focus from the most-recent popup (this case fails on the old token-string keying and passes on the new keying);
- at the tight collapse band (vp 900), navigating the non-focused popup does not evict the focused one (course priority 60 > settingspage 55, so course can only stay full via focus protection; the test guards that the collapse is actually firing);
- narrow-mode detail-show is preserved (settings page over menu, construct over summary, coursepage over card, a new panel still promoted, a different room promoted by distinct identity).

Full `test/pangea/navigation/` suite passes (155 tests, including all 21 allocator tests). `flutter analyze`, `dart format`, and `import_sorter` are clean.

## Local verification
Fresh local build of this branch confirmed the fix compiles and runs as @learner; the regression suite above runs against the exact production focus logic at the viewports the bug needs. The end-to-end visual click-through in the tight band could not be exercised because the local test browser's viewport is locked at 1728px (above the 860 to 1000px band where the symptom appears) and the OS-resize fallback was unavailable. The collapse-band behavior is instead pinned by the unit test above; QA can confirm the visual behavior on staging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where navigating within a popup would steal focus from other open popups in both column and narrow layout modes.

* **Tests**
  * Added regression test coverage for popup navigation and focus behavior across different workspace layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->