### PR TITLE
fix(a11y): name the mobile course-sheet grab handle for assistive tech

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -496,6 +496,7 @@
     "clearArchive": "Clear archive",
     "@clearArchive": {},
     "joinTheCourseToPlay": "Join a course that includes this activity to play it.",
+    "resizeCoursePanel": "Resize course panel",
     "close": "Close",
     "@close": {
         "type": "String",

--- a/lib/widgets/layouts/mobile_course_sheet.dart
+++ b/lib/widgets/layouts/mobile_course_sheet.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:fluffychat/l10n/l10n.dart';
+
 /// Mobile course view: the persistent world map shows through underneath, and
 /// the course detail rides in a draggable bottom sheet over it (the Maps-style
 /// "map + expandable panel" pattern). Two rest positions:
@@ -97,23 +99,33 @@ class _MobileCourseSheetState extends State<MobileCourseSheet> {
           clipBehavior: Clip.antiAlias,
           child: Column(
             children: [
-              // Grab handle: drag to resize, tap to toggle peek/full.
-              GestureDetector(
-                behavior: HitTestBehavior.opaque,
+              // Grab handle: drag to resize, tap to toggle peek/full. Exposed to
+              // assistive tech as a single named button that runs the toggle
+              // (the drag is pointer-only); without this the bare GestureDetector
+              // is an unnamed actionable element (axe `aria-command-name`).
+              Semantics(
+                button: true,
+                label: L10n.of(context).resizeCoursePanel,
                 onTap: _toggle,
-                onVerticalDragUpdate: _onDrag,
-                onVerticalDragEnd: _onDragEnd,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 10.0),
-                  child: Center(
-                    child: Container(
-                      width: 36.0,
-                      height: 4.0,
-                      decoration: BoxDecoration(
-                        color: theme.colorScheme.onSurfaceVariant.withValues(
-                          alpha: 0.4,
+                child: ExcludeSemantics(
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: _toggle,
+                    onVerticalDragUpdate: _onDrag,
+                    onVerticalDragEnd: _onDragEnd,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 10.0),
+                      child: Center(
+                        child: Container(
+                          width: 36.0,
+                          height: 4.0,
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.onSurfaceVariant.withValues(
+                              alpha: 0.4,
+                            ),
+                            borderRadius: BorderRadius.circular(2.0),
+                          ),
                         ),
-                        borderRadius: BorderRadius.circular(2.0),
                       ),
                     ),
                   ),


### PR DESCRIPTION
Names the mobile course-panel grab handle for assistive technology.

On narrow screens the course detail opens in a draggable bottom sheet whose grab handle (tap to toggle peek/full, drag to resize) was a bare `GestureDetector` with no accessible name, so a screen reader saw an unnamed actionable element. A June 2026 axe sweep of the course panel flagged this (`aria-command-name`).

Fix: wrap the handle in `Semantics(button: true, label: ..., onTap: _toggle)` over an `ExcludeSemantics` GestureDetector, so assistive tech gets a single named "Resize course panel" button that runs the toggle while pointer users keep the full drag and tap. Adds the `resizeCoursePanel` l10n key.

Verification: `flutter gen-l10n` regenerates the key; `flutter analyze` clean. The desktop course panel does not use this sheet and is unaffected.

Part of the axe-coverage work tracked in #7126.
