### PR TITLE
fix(nav): attach the sheet controller so the narrow course handle resizes (#7102)

### DIFF
--- a/lib/widgets/layouts/mobile_course_sheet.dart
+++ b/lib/widgets/layouts/mobile_course_sheet.dart
@@ -97,33 +97,44 @@ class _MobileCourseSheetState extends State<MobileCourseSheet> {
           elevation: 8.0,
           borderRadius: const BorderRadius.vertical(top: Radius.circular(20.0)),
           clipBehavior: Clip.antiAlias,
-          child: Column(
-            children: [
+          // The content must be a scroll view bound to the sheet's
+          // [scrollController]: a DraggableScrollableController only ATTACHES
+          // once a scrollable consumes that controller. A plain Column never
+          // attaches it, so `isAttached` stays false and every animateTo/jumpTo
+          // silently no-ops — the handle looked live but did nothing (#7102).
+          // Scrolling is disabled here on purpose: the handle drives resize and
+          // the course detail scrolls on its own controllers, so this outer view
+          // must only serve to attach the controller, never scroll-to-resize.
+          child: CustomScrollView(
+            controller: scrollController,
+            physics: const NeverScrollableScrollPhysics(),
+            slivers: [
               // Grab handle: drag to resize, tap to toggle peek/full. Exposed to
               // assistive tech as a single named button that runs the toggle
               // (the drag is pointer-only); without this the bare GestureDetector
-              // is an unnamed actionable element (axe `aria-command-name`).
-              Semantics(
-                button: true,
-                label: L10n.of(context).resizeCoursePanel,
-                onTap: _toggle,
-                child: ExcludeSemantics(
-                  child: GestureDetector(
-                    behavior: HitTestBehavior.opaque,
-                    onTap: _toggle,
-                    onVerticalDragUpdate: _onDrag,
-                    onVerticalDragEnd: _onDragEnd,
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 10.0),
-                      child: Center(
-                        child: Container(
-                          width: 36.0,
-                          height: 4.0,
-                          decoration: BoxDecoration(
-                            color: theme.colorScheme.onSurfaceVariant.withValues(
-                              alpha: 0.4,
+              // is an unnamed actionable element (axe `aria-command-name`, #7128).
+              SliverToBoxAdapter(
+                child: Semantics(
+                  button: true,
+                  label: L10n.of(context).resizeCoursePanel,
+                  onTap: _toggle,
+                  child: ExcludeSemantics(
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.opaque,
+                      onTap: _toggle,
+                      onVerticalDragUpdate: _onDrag,
+                      onVerticalDragEnd: _onDragEnd,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 10.0),
+                        child: Center(
+                          child: Container(
+                            width: 36.0,
+                            height: 4.0,
+                            decoration: BoxDecoration(
+                              color: theme.colorScheme.onSurfaceVariant
+                                  .withValues(alpha: 0.4),
+                              borderRadius: BorderRadius.circular(2.0),
                             ),
-                            borderRadius: BorderRadius.circular(2.0),
                           ),
                         ),
                       ),
@@ -131,7 +142,10 @@ class _MobileCourseSheetState extends State<MobileCourseSheet> {
                   ),
                 ),
               ),
-              Expanded(
+              // The course detail fills the rest of the sheet (as the old
+              // Expanded did) and scrolls internally on its own controllers.
+              SliverFillRemaining(
+                hasScrollBody: true,
                 child: Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16.0),
                   child: widget.child,

--- a/test/pangea/navigation/mobile_course_sheet_test.dart
+++ b/test/pangea/navigation/mobile_course_sheet_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/widgets/layouts/mobile_course_sheet.dart';
+
+/// Regression coverage for #7102 ("Can't expand course page on narrow screen"):
+/// the grab handle's drag/tap must actually resize the bottom sheet.
+///
+/// Root cause: a `DraggableScrollableController` only ATTACHES once a scrollable
+/// consumes the `scrollController` the sheet's builder provides. The builder
+/// returned a plain `Column` that ignored it, so `isAttached` stayed false and
+/// every `animateTo`/`jumpTo` from the handle gestures silently no-opped — the
+/// handle rendered but did nothing. The fix binds the content to that controller
+/// (a non-scrolling `CustomScrollView`), so the handle drives resize as intended.
+///
+/// The handle's y is the sheet's top edge: a bigger sheet means a lower y.
+void main() {
+  Future<void> pumpSheet(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(400, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: const Scaffold(body: MobileCourseSheet(child: SizedBox.expand())),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('drag up on the handle expands the sheet (peek → full)', (
+    tester,
+  ) async {
+    await pumpSheet(tester);
+    final handle = find.byType(GestureDetector);
+    expect(handle, findsOneWidget);
+    final peekY = tester.getTopLeft(handle).dy;
+    await tester.drag(handle, const Offset(0, -400));
+    await tester.pumpAndSettle();
+    expect(
+      tester.getTopLeft(handle).dy,
+      lessThan(peekY),
+      reason: 'dragging the handle up must grow the sheet (#7102)',
+    );
+  });
+
+  testWidgets('drag down on the handle collapses the sheet (full → peek)', (
+    tester,
+  ) async {
+    await pumpSheet(tester);
+    final handle = find.byType(GestureDetector);
+    await tester.tap(handle); // expand to full first
+    await tester.pumpAndSettle();
+    final fullY = tester.getTopLeft(handle).dy;
+    await tester.drag(handle, const Offset(0, 400));
+    await tester.pumpAndSettle();
+    expect(
+      tester.getTopLeft(handle).dy,
+      greaterThan(fullY),
+      reason: 'dragging the handle down must shrink the sheet (#7102)',
+    );
+  });
+
+  testWidgets('tap on the handle toggles peek ↔ full', (tester) async {
+    await pumpSheet(tester);
+    final handle = find.byType(GestureDetector);
+    final peekY = tester.getTopLeft(handle).dy;
+    await tester.tap(handle);
+    await tester.pumpAndSettle();
+    final fullY = tester.getTopLeft(handle).dy;
+    expect(fullY, lessThan(peekY), reason: 'tap expands to full');
+    await tester.tap(handle);
+    await tester.pumpAndSettle();
+    expect(
+      tester.getTopLeft(handle).dy,
+      greaterThan(fullY),
+      reason: 'tapping again collapses back to peek',
+    );
+  });
+}


### PR DESCRIPTION
Fixes #7102.

## Symptom
On a narrow screen, selecting a course shows a draggable bottom sheet with a grab handle, but the handle does nothing: you can't drag to expand the course page or tap to toggle it.

## Root cause
`MobileCourseSheet` drives the sheet from the grab handle (drag to resize, tap to toggle) by calling `animateTo`/`jumpTo` on a `DraggableScrollableController`. A `DraggableScrollableController` only attaches once a scrollable actually consumes the `scrollController` the sheet's builder hands you. The builder returned a plain `Column` that never used it, so the controller stayed unattached, `isAttached` was always false, and every handle gesture hit the `if (!_controller.isAttached) return;` guard and silently no-opped. The handle rendered but was inert.

Confirmed with a widget probe: the handle's drag and tap callbacks fired correctly (real deltas), but `isAttached` was false in both, and the sheet's top edge never moved.

## Fix
Bind the sheet content to the provided `scrollController` so the controller attaches: the builder now returns a `CustomScrollView` (controller wired) with the handle as a `SliverToBoxAdapter` and the course detail as a `SliverFillRemaining` (same "handle on top, detail fills the rest" layout the old `Column` + `Expanded` produced). Scrolling on this outer view is disabled (`NeverScrollableScrollPhysics`) on purpose: the handle drives resize and the course detail scrolls on its own controllers, so the outer view only serves to attach the controller, never to scroll-to-resize. No behavior change to the handle gestures themselves.

## Tests
New `test/pangea/navigation/mobile_course_sheet_test.dart` pumps the sheet at a narrow 400x800 surface and drives the real handle gestures, measuring the sheet's top edge:
- drag up expands (peek to full);
- drag down collapses (full to peek);
- tap toggles peek and full.
All three fail on the pre-fix code (the sheet never moves) and pass after. Full `test/pangea/navigation/` suite passes (158 tests). `flutter analyze`, `dart format`, and `import_sorter` are clean.

## Local verification
Verified via the widget test above, which simulates the actual drag/tap at a narrow viewport and asserts the sheet resizes (a deterministic interaction test, and a permanent regression guard). The local test browser's viewport is locked at 1728px, above the narrow breakpoint where this sheet appears, so the in-browser narrow click-through could not be exercised; QA can confirm on staging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile course sheet resizing behavior on narrow screens to provide reliable responsiveness. The sheet now responds smoothly to user interactions—dragging the handle to resize and tapping to toggle between peek and full-screen states. Enhanced scroll handling and animation support improve the overall mobile experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->