### PR TITLE
fix(e2e): auth setup waits for world_v2 post-login, not the retired #/rooms

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -47,9 +47,14 @@ test("authenticate", async ({ page }) => {
   await expect(loginButton).toBeEnabled();
   await loginButton.click();
 
-  // Wait for chat list to load (URL should contain /rooms)
-  // Login involves a Matrix server round-trip, so give it ample time
-  await expect(page).toHaveURL("#/rooms", { timeout: 120000 });
+  // Login involves a Matrix server round-trip, so give it ample time. On
+  // world_v2 a successful login lands on the world map (PRoutes.world = '/'),
+  // not the retired v1 '#/rooms'. Wait until the app leaves the login flow,
+  // which means the Matrix session is established.
+  await expect(page).not.toHaveURL(/\/login/, { timeout: 120000 });
+  // Let the post-login navigation and the IndexedDB session write settle before
+  // capturing storage state.
+  await page.waitForTimeout(3000);
 
   // Save authentication state (indexedDB: true captures Flutter/Matrix
   // session tokens stored in IndexedDB, not just cookies + localStorage)


### PR DESCRIPTION
Fixes the e2e auth setup so authenticated specs (and the accessibility suite) can log in on world_v2.

`auth.setup.ts` waited for the retired v1 URL `#/rooms` after login; world_v2 lands on the world map (`PRoutes.world = '/'`), so setup timed out and every authenticated spec was skipped. It now waits for the app to leave the login flow (which means the Matrix session is established and persisted) and settles before capturing storage state.

## Verification
A `workflow_dispatch` smoke run on this branch (real Secrets Manager creds via OIDC) ran the `setup` project and it **passed** (`1 passed`): auth.setup now logs in and saves state on world_v2. The same run's `login-logout` functional spec still fails on its own identical `#/rooms` staleness (line 59) plus a world_v2 logout-path change; that and the other functional specs' world_v2 rework are tracked in #7126.

Unblocks the authenticated per-surface axe audits in #7126.
