### PR TITLE
fix(nav): one close control on the activity loading header, not a redundant back+X (#7115)

### DIFF
--- a/lib/routes/world/activity_detail_panel.dart
+++ b/lib/routes/world/activity_detail_panel.dart
@@ -146,33 +146,25 @@ class _ActivityDetailPanelState extends State<ActivityDetailPanel> {
       );
     }
 
-    // While resolving, a minimal back/close row over a spinner.
+    // While resolving, a minimal close row over a spinner. ONE control only,
+    // matching the loaded start view's rule (activity_sessions_start_view.dart):
+    // a back-arrow when the activity is still course-scoped (`?m=course:` over
+    // `?activity=`), so it returns toward the course; an X otherwise (a map pin /
+    // standalone), so it dismisses to the map. Rendering both ← and X here was a
+    // redundant pair that did the same thing in the pin case (#7115).
+    final uri = GoRouter.of(context).routeInformationProvider.value.uri;
+    final embedded = uri.queryParameters['activity'] != null;
+    final courseScoped =
+        uri.queryParameters['m']?.startsWith('course:') ?? false;
+    final showBack = embedded && courseScoped;
     return Scaffold(
       body: SafeArea(
         child: Column(
           children: [
-            Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 4.0,
-                vertical: 4.0,
-              ),
-              child: Row(
-                children: [
-                  IconButton(
-                    tooltip: MaterialLocalizations.of(
-                      context,
-                    ).backButtonTooltip,
-                    icon: const Icon(Icons.arrow_back),
-                    onPressed: _back,
-                  ),
-                  const Spacer(),
-                  IconButton(
-                    tooltip: L10n.of(context).close,
-                    icon: const Icon(Icons.close),
-                    onPressed: _close,
-                  ),
-                ],
-              ),
+            ActivityLoadingHeader(
+              showBack: showBack,
+              onBack: _back,
+              onClose: _close,
             ),
             const Expanded(
               child: Center(child: CircularProgressIndicator.adaptive()),
@@ -182,4 +174,42 @@ class _ActivityDetailPanelState extends State<ActivityDetailPanel> {
       ),
     );
   }
+}
+
+/// The single close control shown over the activity-resolve spinner. Exactly ONE
+/// control, mirroring the loaded start view's rule (activity_sessions_start_view
+/// and routing.instructions.md → one close affordance per panel): a back-arrow
+/// when [showBack] (the activity is still course-scoped, so it returns toward the
+/// course), an X otherwise (a map pin / standalone, so it dismisses to the map).
+/// Rendering both ← and X here was a redundant pair doing the same thing (#7115).
+class ActivityLoadingHeader extends StatelessWidget {
+  final bool showBack;
+  final VoidCallback onBack;
+  final VoidCallback onClose;
+
+  const ActivityLoadingHeader({
+    super.key,
+    required this.showBack,
+    required this.onBack,
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) => Padding(
+    padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 4.0),
+    child: Align(
+      alignment: Alignment.centerLeft,
+      child: showBack
+          ? IconButton(
+              tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+              icon: const Icon(Icons.arrow_back),
+              onPressed: onBack,
+            )
+          : IconButton(
+              tooltip: L10n.of(context).close,
+              icon: const Icon(Icons.close),
+              onPressed: onClose,
+            ),
+    ),
+  );
 }

--- a/test/pangea/navigation/activity_loading_header_test.dart
+++ b/test/pangea/navigation/activity_loading_header_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/activity_detail_panel.dart';
+
+/// Regression coverage for #7115 ("Redundant back and X buttons on activity
+/// page"): the activity-resolve loading header must show exactly ONE close
+/// control — a back-arrow when course-scoped, an X otherwise — never both. The
+/// old header rendered ← and X together, and both did the same thing in the map/
+/// pin case.
+void main() {
+  Future<void> pumpHeader(WidgetTester tester, {required bool showBack}) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: ActivityLoadingHeader(
+            showBack: showBack,
+            onBack: () {},
+            onClose: () {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('course-scoped: shows ONLY a back arrow, not an X', (
+    tester,
+  ) async {
+    await pumpHeader(tester, showBack: true);
+    expect(find.byIcon(Icons.arrow_back), findsOneWidget);
+    expect(find.byIcon(Icons.close), findsNothing);
+  });
+
+  testWidgets('pin / standalone: shows ONLY a close X, not a back arrow', (
+    tester,
+  ) async {
+    await pumpHeader(tester, showBack: false);
+    expect(find.byIcon(Icons.close), findsOneWidget);
+    expect(find.byIcon(Icons.arrow_back), findsNothing);
+  });
+
+  testWidgets('never renders both controls at once (the #7115 redundancy)', (
+    tester,
+  ) async {
+    for (final showBack in [true, false]) {
+      await pumpHeader(tester, showBack: showBack);
+      final controls = find.byType(IconButton).evaluate().length;
+      expect(controls, 1, reason: 'exactly one close control, never a pair');
+    }
+  });
+}


### PR DESCRIPTION
Fixes #7115.

## Symptom
Opening an activity shows both a back arrow and an X. The back arrow just closes the page the same way the X does, so they are redundant.

## Root cause
The redundant pair is in `ActivityDetailPanel`'s loading header (the brief activity-resolve spinner state, also where a stalled CMS read leaves the panel). That header rendered a `Row` with a leading back arrow (`_back`) AND a trailing X (`_close`). In the common map/pin entry there is no navigator history to pop, so `_back` falls through to `_close`: two controls, one behavior.

The loaded start view (`ActivitySessionStartView`) already shows a single leading control. An earlier cleanup removed the redundant trailing X there but missed this loading header.

Reproduced locally on the standalone `/<activityId>` route: both `Atrás` (←, top-left) and `Cerrar` (X, top-right) appeared, and clicking either went straight to the world map.

## Fix
The loading header now shows exactly ONE control, mirroring the loaded view's rule (one close affordance per panel, see `routing.instructions.md`): a back arrow when the activity is still course-scoped (`?m=course:` over `?activity=`), so it returns toward the course; an X otherwise (a map pin or the standalone route), so it dismisses to the map. The `embedded`/`courseScoped` discriminator is the same one the loaded view uses.

The header is extracted into a small `ActivityLoadingHeader` widget so the single-control rule is unit-tested directly.

## Tests
New `test/pangea/navigation/activity_loading_header_test.dart`:
- course-scoped shows only a back arrow (no X);
- pin/standalone shows only an X (no back arrow);
- never renders both controls at once (the #7115 redundancy).
`flutter analyze`, `dart format`, and `import_sorter` are clean.

## Local verification
Verified via the widget test above, which asserts exactly one control (the correct one) renders and never a pair. The behavior of the surviving control is unchanged from before; QA can confirm visually on staging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed activity loading overlay to display only the appropriate navigation control based on context—a back button for embedded course activities or a close button for others. Eliminates duplicate control display during loading.

* **Tests**
  * Added test coverage for activity loading overlay control behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->