### PR TITLE
fix(a11y): un-nest chat-list dismiss button; add authenticated world_v2 axe audits

### DIFF
--- a/e2e/scripts/a11y.spec.ts
+++ b/e2e/scripts/a11y.spec.ts
@@ -10,11 +10,9 @@ import { expect, test } from "../fixtures";
  * coverage. Scoped to the semantics overlay (<flt-semantics-host>)
  * since Flutter's <canvas> is opaque to axe.
  *
- * Triggers:
- * - lib/pangea/login/**
- * - lib/pages/login/**
- * - lib/pangea/chat_list/**
- * - lib/pages/chat_list/**
+ * Triggers (world_v2): see e2e/trigger-map.json for the authoritative globs.
+ * - lib/routes/world/**, lib/features/navigation/**, lib/widgets/layouts/**
+ * - lib/routes/chat_list/**, lib/routes/home/login/**
  * - e2e/scripts/a11y.spec.ts
  */
 
@@ -29,6 +27,23 @@ async function auditPage(page: import("@playwright/test").Page) {
     .analyze();
 
   return results.violations;
+}
+
+/**
+ * Reach an authenticated world_v2 surface and prove it rendered before auditing.
+ * The home is a canvas map; flutter_map defers its semantics tree until a pointer
+ * event, so we wake it, then wait for a surface-specific control. Auditing before
+ * the surface is in the tree would report zero violations vacuously.
+ */
+async function gotoSurface(
+  page: import("@playwright/test").Page,
+  hash: string,
+  sentinel: import("@playwright/test").Locator,
+) {
+  await page.goto(hash);
+  await page.mouse.move(640, 400);
+  await page.mouse.wheel(0, -500);
+  await expect(sentinel).toBeVisible({ timeout: 90_000 });
 }
 
 test.describe("Accessibility (axe-core)", () => {
@@ -63,22 +78,30 @@ test.describe("Accessibility (axe-core)", () => {
     });
   });
 
-  test.describe("Authenticated pages", () => {
-    // Debug mode needs extra time to restore IndexedDB session + sync Matrix
+  test.describe("Authenticated world_v2 surfaces", () => {
+    // Re-attach the saved auth state; the parent describe forces logged-out.
+    test.use({
+      storageState: path.join(__dirname, "..", ".auth", "user.json"),
+    });
+    // Login + IndexedDB session restore + Matrix sync need extra time.
     test.setTimeout(120_000);
 
-    test("chat list has no a11y violations", async ({ page }) => {
-      try {
-        // Auth fixture loads saved state → lands on /rooms or /home
-        await expect(page.getByRole("button", { name: intl.home })).toBeVisible({
-          timeout: 90000,
-        });
-      } catch (error) {
-        // If button was not found, the language might not be english
-        console.error('Locator timeout exceeded:', error.message);
-        console.log('Check that the account L1 is english.')
-      }
+    test("world map has no a11y violations", async ({ page }) => {
+      await gotoSurface(
+        page,
+        "/#/",
+        page.getByRole("textbox", { name: intl.mapSearchHint }),
+      );
+      const violations = await auditPage(page);
+      expect(violations, formatViolations(violations)).toHaveLength(0);
+    });
 
+    test("chat list has no a11y violations", async ({ page }) => {
+      await gotoSurface(
+        page,
+        "/#/?left=chats",
+        page.getByRole("button", { name: intl.chatWithSupport }).first(),
+      );
       const violations = await auditPage(page);
       expect(violations, formatViolations(violations)).toHaveLength(0);
     });

--- a/e2e/trigger-map.json
+++ b/e2e/trigger-map.json
@@ -54,10 +54,11 @@
   },
   "a11y": {
     "globs": [
-      "lib/pangea/login/**",
-      "lib/pages/login/**",
-      "lib/pangea/chat_list/**",
-      "lib/pages/chat_list/**",
+      "lib/routes/world/**",
+      "lib/features/navigation/**",
+      "lib/widgets/layouts/**",
+      "lib/routes/chat_list/**",
+      "lib/routes/home/**",
       "e2e/scripts/a11y.spec.ts"
     ],
     "web": "e2e/scripts/a11y.spec.ts",

--- a/lib/routes/chat_list/dm_list_tile.dart
+++ b/lib/routes/chat_list/dm_list_tile.dart
@@ -76,43 +76,53 @@ class DMListTileState extends State<DMListTile> {
             child: Material(
               borderRadius: BorderRadius.circular(AppConfig.borderRadius),
               clipBehavior: Clip.hardEdge,
-              child: ListTile(
-                contentPadding: EdgeInsets.only(left: 16, right: 16),
-                leading: Container(
-                  alignment: Alignment.center,
-                  height: Avatar.defaultSize,
-                  width: Avatar.defaultSize,
-                  child: const Icon(
-                    Symbols.chat_add_on,
-                    size: Avatar.defaultSize - 16,
+              // The dismiss button sits beside the tappable tile, not inside it.
+              // A focusable control nested inside another focusable control is an
+              // axe `nested-interactive` violation and a screen-reader trap.
+              child: Row(
+                children: [
+                  Expanded(
+                    child: ListTile(
+                      contentPadding: EdgeInsets.only(left: 16, right: 16),
+                      leading: Container(
+                        alignment: Alignment.center,
+                        height: Avatar.defaultSize,
+                        width: Avatar.defaultSize,
+                        child: const Icon(
+                          Symbols.chat_add_on,
+                          size: Avatar.defaultSize - 16,
+                        ),
+                      ),
+                      title: Text(L10n.of(context).chatWithSupport),
+                      subtitle: Text(L10n.of(context).supportSubtitle),
+                      onTap: _loading
+                          ? null
+                          : () async {
+                              setState(() => _loading = true);
+                              try {
+                                final resp =
+                                    await showFutureLoadingDialog<String>(
+                                      context: context,
+                                      future: Matrix.of(
+                                        context,
+                                      ).client.startChatWithSupport,
+                                    );
+                                if (!mounted) return;
+                                if (resp.isError) return;
+                                context.go('/rooms/${resp.result}');
+                              } finally {
+                                if (mounted) setState(() => _loading = false);
+                              }
+                            },
+                    ),
                   ),
-                ),
-                trailing: IconButton(
-                  tooltip: L10n.of(context).dismiss,
-                  icon: const Icon(Icons.close),
-                  onPressed: () =>
-                      InstructionsEnum.dismissSupportChat.setToggledOff(true),
-                ),
-                title: Text(L10n.of(context).chatWithSupport),
-                subtitle: Text(L10n.of(context).supportSubtitle),
-                onTap: _loading
-                    ? null
-                    : () async {
-                        setState(() => _loading = true);
-                        try {
-                          final resp = await showFutureLoadingDialog<String>(
-                            context: context,
-                            future: Matrix.of(
-                              context,
-                            ).client.startChatWithSupport,
-                          );
-                          if (!mounted) return;
-                          if (resp.isError) return;
-                          context.go('/rooms/${resp.result}');
-                        } finally {
-                          if (mounted) setState(() => _loading = false);
-                        }
-                      },
+                  IconButton(
+                    tooltip: L10n.of(context).dismiss,
+                    icon: const Icon(Icons.close),
+                    onPressed: () =>
+                        InstructionsEnum.dismissSupportChat.setToggledOff(true),
+                  ),
+                ],
               ),
             ),
           ),


### PR DESCRIPTION
Improves axe scores on the redesigned surfaces and adds authenticated WCAG 2.1 AA coverage for them.

## Fix
The chat-list "Chat with Support" tile was a tappable `ListTile` (`onTap`) whose trailing **Dismiss** `IconButton` was nested inside it: a focusable control inside another focusable control, which axe flags as `nested-interactive` (serious) and which traps screen-reader focus. The Dismiss button is now a sibling of the tile in a `Row`, same layout, no nesting.

## New authenticated axe audits
Added world_v2 surface audits to `a11y.spec.ts` with a readiness gate (wake the canvas map, then wait for a surface-specific control before auditing, so a not-yet-rendered surface cannot pass vacuously):
- **world map** — verified green against staging.
- **chat list** — guards the `nested-interactive` above.

Refreshed the stale `a11y` trigger-map globs (they pointed at the removed `lib/pages` / `lib/pangea/chat_list` tree) to the live `lib/routes/world`, `lib/features/navigation`, `lib/widgets/layouts`, `lib/routes/chat_list`, `lib/routes/home`.

## Verification (local, against staging, real creds)
`auth.setup` + landing + login + **world map** all pass. The **chat list** audit currently fails against staging with exactly the `nested-interactive` this PR removes; because the e2e suite targets deployed staging, that audit turns green on the post-merge deploy. `flutter analyze` clean on the changed widget.

Part of #7126.
