### PR TITLE
fix(world-map): promote a pin on tap instead of only recentering (#7072)

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -600,9 +600,17 @@ class WorldMapController extends State<WorldMap>
   /// large tier on tap (the large card then taps through to the plan page). The
   /// large marker hydrates the full plan itself (image + star total), so this
   /// only flips the tier. No navigation, no preview popup.
-  void promoteToLarge(QuestActivityCard card) {
-    setState(() => _promotedActivityId = card.activityId);
-    ActivityPlanRepo.instance.ensure(card.activityId);
+  void promoteToLarge(QuestActivityCard card) =>
+      promoteToLargeById(card.activityId);
+
+  /// As [promoteToLarge] but by id. The clustered small/mid markers route their
+  /// tap here via the cluster layer's `onMarkerTap`: the marker-cluster package
+  /// intercepts marker taps, so a marker's own `onTap` never fires for a pointer
+  /// (it only centered the camera, the #7072 symptom). The tapped marker carries
+  /// its activity id as its key, which is all promotion needs.
+  void promoteToLargeById(String activityId) {
+    setState(() => _promotedActivityId = activityId);
+    ActivityPlanRepo.instance.ensure(activityId);
   }
 
   void collapse() {

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -221,6 +221,21 @@ class WorldMapView extends StatelessWidget {
             maxClusterRadius: 48,
             size: const Size(40, 40),
             padding: const EdgeInsets.all(50),
+            // The cluster package intercepts marker taps and routes them to
+            // `onMarkerTap` — a marker's own child `onTap` never fires for a
+            // pointer. Without this, a small/mid pin tap only ran
+            // `centerMarkerOnClick`, so it recentered the camera and did nothing
+            // else (#7072). Per the world-map design ("tap promotes, tap again
+            // opens"), promote the tapped pin to its large card in place; a group
+            // bubble still zooms to de-cluster (`zoomToBoundsOnClick`). The pin
+            // carries its activity id as its key. Promote in place, no recenter.
+            centerMarkerOnClick: false,
+            onMarkerTap: (marker) {
+              final key = marker.key;
+              if (key is ValueKey<String>) {
+                controller.promoteToLargeById(key.value);
+              }
+            },
             markers: _clusterMarkers(render),
             builder: (context, markers) {
               // Colour the bubble by the cluster's dominant (highest-ladder)
@@ -481,6 +496,8 @@ class WorldMapView extends StatelessWidget {
     double fill,
   ) {
     return Marker(
+      // Carries the activity id for the cluster layer's onMarkerTap (#7072).
+      key: ValueKey(card.activityId),
       point: point,
       width: 18,
       height: 18,
@@ -517,6 +534,8 @@ class WorldMapView extends StatelessWidget {
     double fill,
   ) {
     return Marker(
+      // Carries the activity id for the cluster layer's onMarkerTap (#7072).
+      key: ValueKey(card.activityId),
       point: point,
       width: 44,
       height: 44,


### PR DESCRIPTION
Fixes #7072.

## Symptom
Clicking an activity pin ("chat icon") on the world map only recenters the camera on it and otherwise does nothing. Per the world-map design ("tap promotes, tap again opens"), a small/mid pin should promote to its large card in place; the large card then opens the plan; a group bubble zooms to de-cluster.

## Root cause
The small/mid pins render inside a `MarkerClusterLayerWidget` (flutter_map_marker_cluster). That package intercepts marker taps and routes them to its own `onMarkerTap` callback, so a marker's own child `onTap` never fires for a pointer. `onMarkerTap` was not set, and `centerMarkerOnClick` defaults to `true`, so a pin tap only ran the recenter and nothing else: the pin's `promoteToLarge` was effectively dead code. (Confirmed against the package source: `marker_cluster_layer_options.dart` exposes `onMarkerTap` / `centerMarkerOnClick`; the doc notes the markers' own taps go through `onMarkerTap`.)

## Fix
- Wire the cluster layer's `onMarkerTap` to promote the tapped pin to its large card, and set `centerMarkerOnClick: false` so it promotes in place (no recenter), matching the design.
- The tapped marker is identified by its activity id, carried as `key: ValueKey(card.activityId)` on the small and mid markers.
- Add `WorldMapController.promoteToLargeById(activityId)`; `promoteToLarge(card)` delegates to it.

The markers' own child `onTap` is kept: it still serves the accessibility semantic action (screen-reader activation, which bypasses the cluster layer's pointer interception). Large cards render in a separate unclustered `MarkerLayer`, so their tap-to-open path was already working and is unchanged. Group bubbles still zoom to de-cluster (`zoomToBoundsOnClick`, unchanged).

## Verification
`flutter analyze`, `dart format`, and `import_sorter` are clean, and the change compiles and serves on a fresh local build. The in-browser click-through could not be automated: tapping CanvasKit map pins by pixel is unreliable in the test harness (the automated verifier repeatedly stalled on the pin tap, which is itself the symptom of the bug being fixed). The fix is a direct, package-source-confirmed wiring change with no effect on other surfaces, so QA can confirm the visual behavior on staging: tap a pin -> its large card appears in place (no recenter); tap the card -> opens the plan; tap a count bubble -> zooms in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined cluster marker interactions—tapping an activity within a clustered group now directly opens the activity detail card instead of recentering the map, streamlining the user experience.
  * Improved consistency by consolidating the activity promotion flow, ensuring uniform behavior when accessing activities through search results or cluster interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->