### PR TITLE
fix(a11y): name the settings avatar camera button; add settings axe audit

### DIFF
--- a/e2e/scripts/a11y.spec.ts
+++ b/e2e/scripts/a11y.spec.ts
@@ -105,6 +105,16 @@ test.describe("Accessibility (axe-core)", () => {
       const violations = await auditPage(page);
       expect(violations, formatViolations(violations)).toHaveLength(0);
     });
+
+    test("settings panel has no a11y violations", async ({ page }) => {
+      await gotoSurface(
+        page,
+        "/#/?right=settings",
+        page.getByRole("button", { name: intl.learningSettings }).first(),
+      );
+      const violations = await auditPage(page);
+      expect(violations, formatViolations(violations)).toHaveLength(0);
+    });
   });
 });
 

--- a/e2e/trigger-map.json
+++ b/e2e/trigger-map.json
@@ -59,6 +59,7 @@
       "lib/widgets/layouts/**",
       "lib/routes/chat_list/**",
       "lib/routes/home/**",
+      "lib/routes/settings/**",
       "e2e/scripts/a11y.spec.ts"
     ],
     "web": "e2e/scripts/a11y.spec.ts",

--- a/lib/routes/settings/settings_view.dart
+++ b/lib/routes/settings/settings_view.dart
@@ -115,6 +115,10 @@ class SettingsView extends StatelessWidget {
                                       right: 0,
                                       child: FloatingActionButton.small(
                                         elevation: 2,
+                                        // Names the icon-only button for assistive
+                                        // tech (otherwise an unnamed control / axe
+                                        // `aria-command-name`).
+                                        tooltip: L10n.of(context).changeYourAvatar,
                                         onPressed: controller.setAvatarAction,
                                         heroTag: null,
                                         child: const Icon(


### PR DESCRIPTION
Continues the axe-coverage work (#7126).

## Fix
The settings profile header's avatar "change picture" control is a `FloatingActionButton.small` with an icon and no `tooltip`, so it had no accessible name (axe `aria-command-name`, serious). Added `tooltip: L10n.of(context).changeYourAvatar` (existing string), which Flutter exposes as the button's name.

## New audit
Added an authenticated **settings panel** axe audit to `a11y.spec.ts` (readiness gate: wake the map, wait for the "Learning settings" item), and added `lib/routes/settings/**` to the `a11y` trigger-map globs.

## Verification (local, against staging, real creds)
landing + login + world map + chat list all pass; the settings audit currently fails against staging with exactly the `aria-command-name` this PR removes (the unnamed 40×40 avatar button). Because the suite targets deployed staging, the settings audit turns green on the post-merge deploy. `flutter analyze` clean. Also confirmed #7132 is now green on deployed staging (chat list = 0 violations).
