### PR TITLE
fix(nav): password-change close no longer strands on the loading page (#7076)

### DIFF
--- a/lib/routes/settings/settings_security/settings_password/settings_password.dart
+++ b/lib/routes/settings/settings_security/settings_password/settings_password.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
 
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/settings/settings_security/settings_password/settings_password_view.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
+import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 class SettingsPassword extends StatefulWidget {
@@ -61,7 +63,20 @@ class SettingsPasswordController extends State<SettingsPassword> {
       scaffoldMessenger.showSnackBar(
         SnackBar(content: Text(L10n.of(context).passwordHasBeenChanged)),
       );
-      if (mounted) context.pop();
+      // world_v2: this is the `settingspage:security/password` token panel, not
+      // a route. A bare context.pop() has nothing on the navigator stack to pop
+      // to and falls out of the shell to the blank loading page (#7076); fall
+      // back to the Security page (the parent). As a real pushed route popOrGo
+      // still pops normally.
+      if (mounted) {
+        NavigationUtil.popOrGo(
+          context,
+          WorkspaceNav.settingsBack(
+            GoRouterState.of(context).uri,
+            'security/password',
+          ),
+        );
+      }
     } catch (e) {
       setState(() {
         newPassword2Error = e.toLocalizedString(


### PR DESCRIPTION
Fixes #7076.

## Context
This was reopened with four reported areas where closing via `pop()` stranded on the blank initial loading page. I mapped every `pop()` / `Navigator.pop` / `context.pop` across the world_v2 token-panel surfaces (settings, analytics, courses, chat-details, profile, world, widgets) to find what still strands.

## Findings
The four reported areas are already fixed on `main` (by #7096 and the earlier `popOrGo` conversions), and I re-verified each:
- **Learning settings save** — `settings_learning.dart` already uses `popOrGo(settingsBack('learning'))`.
- **Construct delete** — deleting a construct already closes its detail: `blockConstructs` streams an update to `analytics_details_popup._onBlockConstruct`, which calls `_close()` (`popOrGo(setRight([analytics:<type>]))`) when the open detail is the deleted one. So the deleted construct's own detail is dismissed, not stranded.
- **Vocab detail X (word card)** — already `popOrGo(setRight([analytics:vocab]))`.
- **Edit-course save** — already `popOrGo(closeLeft(coursepage:edit))` (the #7096 fix); the only save exit, no path strands.

The one genuinely remaining strand the sweep found is a fifth case not in the original list:

## Root cause (this fix)
The change-password page renders as the `settingspage:security/password` token panel (`settings_panel.dart:64`). On a successful change it called a bare `if (mounted) context.pop()` with no `canPop` guard and is not a dialog, so as a token panel it had nothing on the navigator stack and fell out of the shell to the blank loading page.

## Fix
Replace the bare `context.pop()` with `NavigationUtil.popOrGo(context, WorkspaceNav.settingsBack(uri, 'security/password'))`, mirroring `settings_learning.dart`. `settingsBack` resolves a `a/b` leaf to its parent page, so the password page closes back to the Security page; as a real pushed route `popOrGo` still pops normally.

## Tests
The close destination is already covered by `workspace_nav_test.dart` ("settingsBack: a leaf pops to its parent page"), which asserts `settingsBack('security/password')` resolves to the `security` page. `flutter analyze`, `dart format`, and `import_sorter` are clean.

The change-password flow itself can't be exercised end to end without account credentials, so this relies on the unit-tested `settingsBack` destination plus the established `popOrGo` pattern used by the other (now-verified) settings/analytics/course close paths. QA can confirm on staging by deep-linking the password panel and changing a password.
