### PR TITLE
fix(courses): collapse course modules that have no activities (#7114)

### DIFF
--- a/lib/routes/courses/course_objectives/course_objectives_view.dart
+++ b/lib/routes/courses/course_objectives/course_objectives_view.dart
@@ -12,6 +12,17 @@ import 'package:fluffychat/features/quests/repo/quest_repo.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/chat/chat_details/activity_suggestion_card.dart';
 
+/// The objective groups that should render: those with at least one activity.
+/// An activity-less objective would otherwise show a header over a fixed-height
+/// activity-card row that is all empty space, so it is dropped (#7114). Null
+/// (still loading / no data) maps to an empty list.
+@visibleForTesting
+List<QuestObjectiveGroup> objectiveGroupsWithActivities(
+  List<QuestObjectiveGroup>? groups,
+) => (groups ?? const <QuestObjectiveGroup>[])
+    .where((g) => g.activities.isNotEmpty)
+    .toList();
+
 /// The Activities / Course-plan tab of a selected course (world_v2): the
 /// course's learning objectives, each with the activities that satisfy it.
 /// Objectives are the unlockable unit; activities are interchangeable
@@ -120,7 +131,10 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
         if (snapshot.connectionState != ConnectionState.done) {
           return const Center(child: CircularProgressIndicator.adaptive());
         }
-        final groups = snapshot.data ?? const [];
+        // Activity-less objectives are dropped (see [objectiveGroupsWithActivities],
+        // #7114). Filtering before the empty check means an outline that is ALL
+        // activity-less still falls through to the "no activities" message.
+        final groups = objectiveGroupsWithActivities(snapshot.data);
         if (groups.isEmpty) {
           return Center(
             child: Padding(

--- a/test/pangea/courses/course_objectives_filter_test.dart
+++ b/test/pangea/courses/course_objectives_filter_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_media_enum.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_request.dart';
+import 'package:fluffychat/features/quests/models/learning_objective_model.dart';
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/routes/courses/course_objectives/course_objectives_view.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+
+/// Regression coverage for #7114 ("Remove extra space for course modules
+/// without activities"): an objective/module with no activities must be dropped
+/// from the course-objectives list, not rendered as a header over an empty
+/// fixed-height activity-card row.
+void main() {
+  ActivityPlanModel plan(String id) => ActivityPlanModel(
+    req: ActivityPlanRequest(
+      topic: '',
+      mode: '',
+      objective: '',
+      media: MediaEnum.nan,
+      cefrLevel: LanguageLevelTypeEnum.a2,
+      languageOfInstructions: 'en',
+      targetLanguage: 'es',
+      numberOfParticipants: 2,
+    ),
+    title: '',
+    learningObjective: '',
+    instructions: '',
+    vocab: const [],
+    activityId: id,
+  );
+
+  QuestObjectiveGroup objGroup(String id, {required bool withActivities}) =>
+      QuestObjectiveGroup(
+        objective: LearningObjective(id: id, objective: 'obj-$id'),
+        activities: withActivities
+            ? [QuestActivity(activityId: 'a-$id', plan: plan('a-$id'))]
+            : const [],
+      );
+
+  group('objectiveGroupsWithActivities (#7114)', () {
+    test('drops activity-less objectives, keeps the rest in order', () {
+      final result = objectiveGroupsWithActivities([
+        objGroup('1', withActivities: true),
+        objGroup('2', withActivities: false),
+        objGroup('3', withActivities: true),
+      ]);
+      expect(result.map((g) => g.objective.id).toList(), ['1', '3']);
+    });
+
+    test('null (still loading / no data) yields an empty list', () {
+      expect(objectiveGroupsWithActivities(null), isEmpty);
+    });
+
+    test('an all-empty outline yields empty (falls through to the '
+        '"no activities" message)', () {
+      expect(
+        objectiveGroupsWithActivities([objGroup('1', withActivities: false)]),
+        isEmpty,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #7114.

## Symptom
In a course's objectives/modules list, a module with no activities still reserved the full activity-card row height, leaving a block of empty space under its header.

## Root cause
`course_objectives_view.dart` renders each objective group as a header plus a fixed-height (`cardHeight`, 200-280px) horizontal row of its activity cards. A group whose `activities` list is empty still rendered that fixed-height row, so it showed as empty space.

## Fix
Filter objective groups to those with at least one activity before rendering, via a small `objectiveGroupsWithActivities` helper. Filtering happens before the existing empty check, so an outline that is entirely activity-less still falls through to the "no activities" message; populated modules render unchanged; activity-less ones collapse out.

## Tests
New `test/pangea/courses/course_objectives_filter_test.dart` covers the helper: activity-less objectives are dropped while the rest keep their order, null (loading) yields empty, and an all-empty outline yields empty. `flutter analyze`, `dart format`, and `import_sorter` are clean.

The list itself can't be rendered locally for a visual check (course-plan content reads 403 against the staging CMS from the local stack), so the behavior is guarded by the unit test above; QA can confirm the visual on staging with a course that has activity-less modules.
