### PR TITLE
fix(a11y): name the profile avatar camera button; add profile axe audit

### DIFF
--- a/e2e/scripts/a11y.spec.ts
+++ b/e2e/scripts/a11y.spec.ts
@@ -115,6 +115,17 @@ test.describe("Accessibility (axe-core)", () => {
       const violations = await auditPage(page);
       expect(violations, formatViolations(violations)).toHaveLength(0);
     });
+
+    test("profile page has no a11y violations", async ({ page }) => {
+      await gotoSurface(
+        page,
+        "/#/?right=settingspage:profile,settings",
+        // The profile shows the account's Matrix id; the CI account is fixed.
+        page.getByRole("button", { name: /staging_automated_tests/ }).first(),
+      );
+      const violations = await auditPage(page);
+      expect(violations, formatViolations(violations)).toHaveLength(0);
+    });
   });
 });
 

--- a/e2e/trigger-map.json
+++ b/e2e/trigger-map.json
@@ -60,6 +60,7 @@
       "lib/routes/chat_list/**",
       "lib/routes/home/**",
       "lib/routes/settings/**",
+      "lib/routes/profile/**",
       "e2e/scripts/a11y.spec.ts"
     ],
     "web": "e2e/scripts/a11y.spec.ts",

--- a/lib/routes/profile/user_home_page.dart
+++ b/lib/routes/profile/user_home_page.dart
@@ -256,6 +256,9 @@ class _UserHomePageState extends State<UserHomePage> {
                               right: 0,
                               child: FloatingActionButton.small(
                                 elevation: 2,
+                                // Names the icon-only button for assistive tech
+                                // (otherwise axe `aria-command-name`).
+                                tooltip: L10n.of(context).changeYourAvatar,
                                 onPressed: _setAvatarAction,
                                 heroTag: null,
                                 child: const Icon(Icons.camera_alt_outlined),


### PR DESCRIPTION
Continues the axe-coverage work (#7126).

## Fix
The profile page's avatar "change picture" control (`user_home_page.dart`) is a `FloatingActionButton.small` with no `tooltip`, so it had no accessible name (axe `aria-command-name`, serious) — the same pattern fixed for the settings header in #7134. Added `tooltip: L10n.of(context).changeYourAvatar`.

## New audit
Added an authenticated **profile page** axe audit to `a11y.spec.ts` and `lib/routes/profile/**` to the `a11y` trigger-map globs.

## Verification (local, against staging, real creds)
landing + login + world map + chat list + settings all pass; the profile audit currently fails against staging with exactly the `aria-command-name` this PR removes (the unnamed avatar button), and turns green on the post-merge deploy. `flutter analyze` clean.

Found in the same sweep, still open (next iterations): settings "Change your style" page (4 unnamed buttons + an unlabeled slider), settings devices page (nested-interactive), settings notifications page (image without alt).
