### PR TITLE
fix(analytics): shimmer the main-view cluster while analytics load instead of showing zeros (#7078)

### DIFF
--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
+import 'package:shimmer/shimmer.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
@@ -123,6 +124,15 @@ class _WorldUserClusterState extends State<WorldUserCluster> {
                 return StreamBuilder(
                   stream: dispatcher.activityAnalyticsStream.stream,
                   builder: (context, _) {
+                    // While the analytics database is still loading, shimmer the
+                    // whole cluster rather than flash zeros — this distinguishes
+                    // "loading" from a loaded-but-empty learner (#7078). The
+                    // construct/activity update streams above (and the derivedData
+                    // future below) rebuild this when init completes, flipping
+                    // isInitializing false. See analytics-system.instructions.md.
+                    if (service.isInitializing) {
+                      return WorldUserClusterShimmer(showFlag: l2 != null);
+                    }
                     final vocab = service.numConstructs(
                       ConstructTypeEnum.vocab,
                     );
@@ -218,6 +228,50 @@ class _WorldUserClusterState extends State<WorldUserCluster> {
             child: _LanguageFlag(language: l2, onTap: _openLearningSettings),
           ),
       ],
+    );
+  }
+}
+
+/// The cluster's loading state (#7078): a shimmer skeleton in the cluster's
+/// shape — the avatar circle, the powerups pill, and (when an L2 is set) the
+/// language flag — shown while the analytics database is still loading, so the
+/// main view reads as "loading" instead of flashing zeros. [showFlag] mirrors
+/// the live cluster, which only draws the flag when an L2 is set, so the
+/// skeleton footprint matches and the layout does not jump on load.
+@visibleForTesting
+class WorldUserClusterShimmer extends StatelessWidget {
+  final bool showFlag;
+
+  const WorldUserClusterShimmer({super.key, required this.showFlag});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final base = scheme.surfaceContainerHighest;
+    Widget box(double w, double h, double radius) => Container(
+      width: w,
+      height: h,
+      decoration: BoxDecoration(
+        color: base,
+        borderRadius: BorderRadius.circular(radius),
+      ),
+    );
+    return Shimmer.fromColors(
+      baseColor: base,
+      highlightColor: scheme.surface,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          box(56, 56, 28), // avatar circle
+          const SizedBox(height: 8),
+          box(72, 200, 28), // powerups pill (3 trackers + level medal)
+          if (showFlag)
+            Padding(
+              padding: const EdgeInsets.only(top: 20),
+              child: box(52, 36, 6), // language flag
+            ),
+        ],
+      ),
     );
   }
 }

--- a/test/pangea/world/world_user_cluster_shimmer_test.dart
+++ b/test/pangea/world/world_user_cluster_shimmer_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shimmer/shimmer.dart';
+
+import 'package:fluffychat/routes/world/world_user_cluster.dart';
+
+/// #7078: while the analytics database is loading, the main-view cluster shows a
+/// full-widget shimmer skeleton instead of flashing zeros. The skeleton mirrors
+/// the live cluster's shape (avatar, powerups pill, optional language flag).
+void main() {
+  // The shimmer animates forever (Shimmer.fromColors default loop), so pump a
+  // single frame — pumpAndSettle would never return.
+  Future<void> pumpShimmer(WidgetTester tester, {required bool showFlag}) =>
+      tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(child: WorldUserClusterShimmer(showFlag: showFlag)),
+          ),
+        ),
+      );
+
+  testWidgets('renders a single continuous shimmer over the skeleton', (
+    tester,
+  ) async {
+    await pumpShimmer(tester, showFlag: true);
+    expect(find.byType(Shimmer), findsOneWidget);
+  });
+
+  testWidgets('showing the language flag adds exactly one skeleton box', (
+    tester,
+  ) async {
+    await pumpShimmer(tester, showFlag: false);
+    final withoutFlag = find.byType(Container).evaluate().length;
+    await pumpShimmer(tester, showFlag: true);
+    final withFlag = find.byType(Container).evaluate().length;
+    expect(
+      withFlag,
+      withoutFlag + 1,
+      reason: 'the flag adds one skeleton box vs avatar + pill alone',
+    );
+  });
+}


### PR DESCRIPTION
Fixes #7078.

## Symptom
The main-view cluster (top-right: vocab / grammar / star totals, level, XP ring) showed zeros while the analytics database was still loading, so there was no way to tell "loading" from a genuinely empty learner. (#7097 already fixed the analytics *panel* spinner; this is the main-view indicator Gabby clarified the ticket was about.)

## Fix
While `analyticsDataService.isInitializing` is true, the cluster now renders a full-widget shimmer skeleton in its own shape (avatar circle, powerups pill, and the language flag when an L2 is set) instead of the real counts. `showFlag` mirrors the live cluster so the skeleton footprint matches and the layout does not jump on load. Once the analytics database finishes initializing it swaps to the real counts.

The pre-world UI used per-number spinners; a single continuous shimmer over the whole widget reads more cleanly.

## Why the transition is reliable
The gate sits inside the cluster's existing construct/activity update `StreamBuilder`s. The analytics service's init `finally` block calls `initCompleter.complete()` (flipping `isInitializing` false) and then immediately `sendEmptyAnalyticsUpdate()` + `sendActivityAnalyticsUpdate(null)` — the exact streams those builders listen to — so init-completion always triggers a rebuild that swaps shimmer to real. `reinitialize()` resets the completer and re-emits, so the shimmer correctly re-arms (e.g., on an L2 switch). A warm cluster (already initialized) shows the real counts immediately, no shimmer.

## Tests
New `test/pangea/world/world_user_cluster_shimmer_test.dart` covers `WorldUserClusterShimmer`: it renders a single `Shimmer` over the skeleton, and showing the flag adds exactly one skeleton box. `flutter analyze`, `dart format`, and `import_sorter` are clean.

The on-screen loading window is brief (the local analytics init is fast and cached), so catching the live shimmer in automation is racy; the swap logic is proven by the service's post-init stream emissions above, and QA can confirm the visual on staging with a cold load.
