### PR TITLE
fix(profile): wrap the about-me text so a long bio stays within its box (#7117)

### DIFF
--- a/lib/widgets/users/about_me_display.dart
+++ b/lib/widgets/users/about_me_display.dart
@@ -22,23 +22,44 @@ class AboutMeDisplay extends StatelessWidget {
         future: MatrixState.pangeaController.userController.getPublicProfile(
           userId,
         ),
-        builder: (context, snapshot) => snapshot.data?.about == null
-            ? const SizedBox.shrink()
-            : Container(
-                padding: const EdgeInsets.symmetric(vertical: 8.0),
-                constraints: BoxConstraints(maxHeight: 100),
-                child: SingleChildScrollView(
-                  child: Row(
-                    children: [
-                      Text(
-                        snapshot.data!.about!,
-                        style: TextStyle(fontSize: textSize),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ],
-                  ),
-                ),
-              ),
+        builder: (context, snapshot) {
+          final about = snapshot.data?.about;
+          return about == null
+              ? const SizedBox.shrink()
+              : AboutMeText(about: about, textSize: textSize);
+        },
+      ),
+    );
+  }
+}
+
+/// The about-me body: a vertically scrollable block of WRAPPING text. It wraps
+/// at the width of the surrounding box (an ancestor `ConstrainedBox(maxWidth:)`)
+/// and scrolls within [maxHeight]. Previously the text sat inside a `Row`, which
+/// gave it unbounded width so a long bio never wrapped and spilled out of the
+/// box — and the `overflow: ellipsis` could not trigger inside an unbounded Row
+/// (#7117). It is a shared widget, so this fixes both the mini profile popup and
+/// the larger profile.
+@visibleForTesting
+class AboutMeText extends StatelessWidget {
+  final String about;
+  final double textSize;
+  final double maxHeight;
+
+  const AboutMeText({
+    super.key,
+    required this.about,
+    required this.textSize,
+    this.maxHeight = 100.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      constraints: BoxConstraints(maxHeight: maxHeight),
+      child: SingleChildScrollView(
+        child: Text(about, style: TextStyle(fontSize: textSize)),
       ),
     );
   }

--- a/test/pangea/users/about_me_text_test.dart
+++ b/test/pangea/users/about_me_text_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/widgets/users/about_me_display.dart';
+
+/// Regression coverage for #7117 ("About me goes out of Profile Box"): a long
+/// about-me must wrap within the profile box and scroll, not overflow it. The
+/// old layout put the text in a Row (unbounded width), so a long bio rendered as
+/// one wide line that spilled out of the box.
+void main() {
+  testWidgets('a long about wraps within a narrow box without overflowing', (
+    tester,
+  ) async {
+    final longAbout = List.generate(80, (i) => 'word$i').join(' ');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 200),
+              child: AboutMeText(about: longAbout, textSize: 12),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // No RenderFlex overflow (the old Row overflowed on a long bio).
+    expect(tester.takeException(), isNull);
+    final text = find.text(longAbout);
+    expect(text, findsOneWidget);
+    // Wrapped: the text lays out within the box width rather than one long line.
+    expect(tester.getSize(text).width, lessThanOrEqualTo(200.0));
+  });
+
+  testWidgets('a short about renders without scrolling issues', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 200),
+              child: AboutMeText(about: 'hi', textSize: 12),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    expect(find.text('hi'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Fixes #7117.

## Symptom
When you open a user's profile (the mini popup from their icon, and the larger profile), a long "about me" overflowed past the box instead of staying inside it.

## Root cause
`AboutMeDisplay` put the about text inside a `Row`, which gives its child unbounded width. So a long bio laid out as one wide single line and spilled out of the `maxWidth` box, and the `overflow: TextOverflow.ellipsis` could never trigger (it only applies when the Text is width-constrained, which it was not inside the Row).

## Fix
Drop the `Row` (and the dead ellipsis) so the text sits directly in the `SingleChildScrollView`: it now wraps at the surrounding box width and scrolls vertically within the `maxHeight`. The body is extracted into a small `AboutMeText` widget so the wrapping behavior is unit-tested. It is a shared widget, so this fixes both the mini profile popup and the larger profile.

## Tests
New `test/pangea/users/about_me_text_test.dart`: a long about wraps within a narrow box without a RenderFlex overflow (the text lays out within `maxWidth`, not one long line), and a short about renders cleanly. `flutter analyze`, `dart format`, and `import_sorter` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved about-me text display to properly wrap and scroll instead of truncating with ellipsis, ensuring longer bios are fully visible and readable.

* **Tests**
  * Added regression tests for about-me text display functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->