### PR TITLE
fix(a11y): exclude the decorative style-preview toolbar from semantics

### DIFF
--- a/lib/routes/settings/settings_style/settings_style_view.dart
+++ b/lib/routes/settings/settings_style/settings_style_view.dart
@@ -205,7 +205,10 @@ class SettingsStyleView extends StatelessWidget {
                               ),
                             ),
                           // #Pangea
-                          StyleExampleMessage(),
+                          // Decorative style preview; its toolbar buttons are
+                          // disabled demos, so keep the whole preview out of the
+                          // semantics tree (axe `aria-command-name` otherwise).
+                          ExcludeSemantics(child: StyleExampleMessage()),
                           // Column(
                           //   mainAxisSize: .min,
                           //   children: [


### PR DESCRIPTION
Continues the axe-coverage work (#7126), verified on a local profile build.

## Fix
The "Change your style" page renders a decorative preview of a chat message that includes a demo toolbar of four **disabled** buttons (`onPressed: null`). Those four had no accessible name (axe `aria-command-name` ×4), so a screen reader would announce four unnamed disabled buttons. Wrapped the preview in `ExcludeSemantics` so it stays out of the assistive-tech tree (it is a visual style preview, not operable content).

## Verification
Run against a **local profile build** (`localhost:8091`, staging backends, real creds): the style page's four `aria-command-name` violations are gone; world map / chat list / settings / profile remain green. `flutter analyze` clean.

## Known limitation (deferred)
The page's font-size `Slider` triggers a critical axe `label` violation: Flutter web renders the slider as `<input type=range>` and does not expose an `aria-label` from any wrapping `Semantics` (tried `Semantics(label:)`, `MergeSemantics`, and an explicit `Semantics(slider:true,label:)` over `ExcludeSemantics(Slider)` — none attach a name to the input). That is a Flutter-web framework limitation, so the committed style-page audit is deferred until it can be resolved. Tracked in #7126.
