### PR TITLE
fix(layout): panels respect the top safe-area inset so close/back clears the top bar (#7143)

### DIFF
--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -210,8 +210,8 @@ class WorkspaceShell extends StatelessWidget {
             if (l.mobileCourseIndex != null) _mobileCourseSheet(l),
             if (l.isMobileActivity) _mobileActivitySheet(l),
             _navRailLayer(l),
-            ..._leftPanelLayers(l),
-            ..._rightPanelLayers(l),
+            ..._leftPanelLayers(context, l),
+            ..._rightPanelLayers(context, l),
             if ((l.mapVisible && l.allocation.clusterVisible) ||
                 l.isMobileCourse ||
                 l.isMobileActivity)
@@ -299,7 +299,7 @@ class WorkspaceShell extends StatelessWidget {
   /// Keyed by token so opening/closing a sibling panel doesn't shift indices and
   /// remount this one; a `room` panel additionally carries a roomId GlobalKey so
   /// its ChatController repositions rather than remounts when the slot moves.
-  List<Widget> _leftPanelLayers(_ShellLayout l) => [
+  List<Widget> _leftPanelLayers(BuildContext context, _ShellLayout l) => [
     for (var i = 0; i < l.leftTokens.length; i++)
       // Skip a narrow course card — it renders in the bottom sheet above, not as
       // a full-screen left panel (no double-render).
@@ -307,7 +307,12 @@ class WorkspaceShell extends StatelessWidget {
           l.allocation.left[i].vis != PanelVis.hidden)
         Positioned(
           key: ValueKey(l.leftTokens[i].encode()),
-          top: 0,
+          // Respect the top safe-area inset so the panel's close/back control
+          // isn't cut off under the system top bar (#7143). PanelCard's own 12px
+          // top margin equals the cluster's chromeMargin, so this aligns the
+          // panel content with the safe-area-respecting top-right cluster. No-op
+          // where there is no top inset (desktop/web).
+          top: MediaQuery.viewPaddingOf(context).top,
           bottom: 0,
           left: l.allocation.left[i].left,
           width: l.allocation.left[i].width,
@@ -324,7 +329,7 @@ class WorkspaceShell extends StatelessWidget {
   /// slot. The slots tile and never overlap by construction; a folded slot is
   /// `hidden` (not drawn), its content one back-step away on the higher-priority
   /// sibling that stayed.
-  List<Widget> _rightPanelLayers(_ShellLayout l) => [
+  List<Widget> _rightPanelLayers(BuildContext context, _ShellLayout l) => [
     for (var i = 0; i < l.rightTokens.length; i++)
       if (l.allocation.right[i].vis != PanelVis.hidden)
         Positioned(
@@ -333,7 +338,9 @@ class WorkspaceShell extends StatelessWidget {
           // position — otherwise its stateful content (analytics, a detail) would
           // remount and re-fetch.
           key: ValueKey(l.rightTokens[i].encode()),
-          top: 0,
+          // Respect the top safe-area inset so the close/back control clears the
+          // system top bar (#7143); aligns with the cluster (see _leftPanelLayers).
+          top: MediaQuery.viewPaddingOf(context).top,
           bottom: 0,
           left: l.allocation.right[i].left,
           width: l.allocation.right[i].width,


### PR DESCRIPTION
Fixes #7143.

## Symptom
Across all panels (Activities, Grammar, Vocab, Level, Settings, Chats, Word Cards), the X / Back close control at the top of the panel was hard to click — it sat jammed against the system top bar.

## Root cause
The shell positions the left/right panel layers at `Positioned(top: 0, ...)` — flush at the viewport top, ignoring the top safe-area inset. The top-right user cluster already respects it (`top: chromeMargin + MediaQuery.viewPaddingOf(context).top`), so on a device with a status bar / notch the panels (and their close controls, the shared `PanelHeader.leading`) ended up under the system top bar while the cluster cleared it.

A visual repro on desktop web confirmed the control is *not* occluded there (no chrome over it) — it sits at y=16 with the inset being 0 — which is why this manifests where there IS a top inset (mobile / PWA / notch), matching the reporter's narrow screenshot.

## Fix
Both panel layers now use the same expression as the cluster: `top: MediaQuery.viewPaddingOf(context).top`. Because `PanelCard` already adds a 12px top margin equal to the cluster's `chromeMargin`, this aligns the panel content exactly with the cluster's safe-area-respecting top. Geometry is shared, so this one change fixes every panel and column at once. `_leftPanelLayers`/`_rightPanelLayers` now take the build `context` (like `_clusterLayer`).

## Verification
- Desktop/web: `viewPaddingOf.top == 0`, so `top` stays `0` — provably identical to before (no regression). `flutter analyze`, `dart format`, `import_sorter` clean.
- The control clearing the top bar only manifests where there's a non-zero top inset, which the locked desktop test viewport can't simulate, so QA should confirm on a device/narrow build with a status bar. The fix mirrors the cluster's already-shipped safe-area handling.
- No automated test: the change is in the shell's private layer methods; a full-shell widget test is disproportionate for a 2-line safe-area mirror of proven code.

Note: the repro also saw the top-right cluster overlapping the panel's *trailing* (right) header corner — that's a separate concern from this leading close control and is out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed positioning of left and right panel close/back controls to properly account for system top safe-area spacing, preventing overlap with the system status bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->