### PR TITLE
fix(layout): settings menu and page fold to a single window (#7145)

### DIFF
--- a/lib/features/navigation/panel_registry.dart
+++ b/lib/features/navigation/panel_registry.dart
@@ -95,6 +95,14 @@ class PanelDef {
   /// panel (same pattern to follow). See `routing.instructions.md`.
   final bool mapContent;
 
+  /// When this panel opens as a DETAIL, its same-column master always folds
+  /// behind it so the two read as ONE window — the detail with a back that
+  /// reveals the master — regardless of width, instead of coexisting side by
+  /// side when there's room. Set on the settings page so it behaves like the
+  /// narrow layout everywhere (#7145). Distinct from width-driven folding, which
+  /// only kicks in under width pressure; this folds the master unconditionally.
+  final bool foldsParentAlways;
+
   const PanelDef({
     required this.column,
     required this.minWidth,
@@ -107,6 +115,7 @@ class PanelDef {
     this.siblingGroups = const {},
     this.pushable = false,
     this.mapContent = false,
+    this.foldsParentAlways = false,
   });
 
   /// The comfort floor the fold trigger uses: an explicit [reasonableMinWidth],
@@ -241,6 +250,10 @@ abstract class PanelRegistry {
       priority: 55,
       siblingGroups: {'settingsdetail'},
       pushable: true,
+      // The settings menu + page are ONE window: the menu always folds behind
+      // the page (a back reveals it), like narrow, instead of opening a second
+      // side panel when there's room (#7145).
+      foldsParentAlways: true,
     ),
     // The analytics summary — a right-column root master. Its details are a
     // `vocab`/`grammar` construct detail and (cross-column) a `session` review.

--- a/lib/widgets/layouts/panel_allocator.dart
+++ b/lib/widgets/layouts/panel_allocator.dart
@@ -234,6 +234,22 @@ abstract class PanelAllocator {
         ? all[focusHint]
         : null;
     final folded = <_Entry>{};
+    // Always-single-window details (the settings page) fold their same-column
+    // master UNCONDITIONALLY — before any width-driven folding — so the menu +
+    // page read as one window (the page with a back that reveals the menu), like
+    // the narrow layout, instead of opening a redundant second side panel when
+    // there's room (#7145). Width-driven folding below then proceeds over the
+    // remainder. Scoped per def flag, so analytics/course master+detail pairs
+    // still coexist when width allows.
+    for (final detail in all) {
+      if (!detail.def.foldsParentAlways) continue;
+      for (final parent in all) {
+        if (parent.column == detail.column &&
+            parent.def.type == detail.def.parent) {
+          folded.add(parent);
+        }
+      }
+    }
     while (true) {
       final vis = all.where((e) => !folded.contains(e)).toList();
       if (vis.length <= 1) break;

--- a/test/pangea/navigation/panel_allocator_test.dart
+++ b/test/pangea/navigation/panel_allocator_test.dart
@@ -125,6 +125,39 @@ void main() {
     );
   });
 
+  group('always-single-window details fold their master unconditionally '
+      '(#7145)', () {
+    test('the settings page always folds the menu behind it — one window, '
+        'even when both would fit', () {
+      // openSettings seats the page in front of the menu: [settingspage,
+      // settings]. The page is flagged foldsParentAlways, so the menu folds
+      // behind it BEFORE any width pressure — even on a wide viewport where
+      // both reasonable-mins fit. The result reads as one window (the page)
+      // with a back that reveals the menu, like the narrow layout, never a
+      // redundant second side tab.
+      final l = run(viewport: 1920, right: ['settingspage', 'settings']);
+      expect(l.right[0].vis, PanelVis.full); // settingspage holds the column
+      expect(l.right[1].vis, PanelVis.hidden); // settings menu folds behind it
+      expect(l.right[1].width, 0); // folded slots carry no width
+      // The surviving page is folded-over its master → its close is a `←` back.
+      expect(l.right[0].foldedOver, isTrue);
+      expectNoOverlap(l);
+    });
+
+    test('an ordinary master/detail pair (analytics + vocab) still coexists '
+        'when width allows — the fold is scoped to flagged details', () {
+      // Same wide viewport: vocab is analytics's detail but NOT
+      // foldsParentAlways, so with room for both reasonable-mins they tile
+      // side by side and neither is folded-over (closing either reveals the
+      // map, not a master).
+      final l = run(viewport: 1920, right: ['vocab', 'analytics']);
+      expect(l.right[0].vis, PanelVis.full); // vocab
+      expect(l.right[1].vis, PanelVis.full); // analytics
+      expect(l.right.every((s) => !s.foldedOver), isTrue);
+      expectNoOverlap(l);
+    });
+  });
+
   group('left↔right parity collapse (#7088)', () {
     test(
       'a lone right summary yields (collapses) instead of being overlapped',


### PR DESCRIPTION
Closes #7145.

## Problem

Opening a settings page (Edit Profile, Learning Settings, etc.) on a wide screen seated the settings menu and the page as two side-by-side tabs in the right column. The user wanted the page to behave like it does on a narrow screen: open in the same window every time, with a back that returns to the menu, not a redundant second tab.

## Fix

The settings page now folds its menu behind it unconditionally, before any width-driven folding, so the two always read as one window. This is the same single-window behavior the narrow layout already produced under width pressure, now applied at every width.

- `panel_registry.dart`: new `foldsParentAlways` flag on `PanelDef`, set true on `settingspage`.
- `panel_allocator.dart`: a pre-fold pass folds a flagged detail's same-column master before the width-pressure loop. The existing `foldedOver` logic then gives the surviving page a back arrow that reveals the folded menu.

The flag is scoped per def, so ordinary master/detail pairs (analytics + a vocab/grammar detail) still coexist side by side when width allows.

## Verification

- Unit tests in `panel_allocator_test.dart`: settings always folds to one window with the page folded-over (back arrow), even at a wide viewport where both would fit; and a non-flagged analytics + vocab pair still coexists at the same wide viewport (proving the fold is settings-specific).
- Full navigation suite: 163 passing.
- Manually verified in the running client at a wide viewport: opening a settings page shows one window with a back arrow; the back returns to the menu in a single click.

## TO TEST
- [ ] Open Settings
- [ ] Open a settings page (Edit Profile, Learning Settings, Style, etc.)
- [ ] Confirm it opens in the same window as the menu, not as a second side tab
- [ ] Click the back arrow and confirm it returns to the settings menu in one click