### PR TITLE
fix(nav): Edit Profile back returns to the settings menu in one click (#7147)

### DIFF
--- a/lib/features/navigation/legacy_redirects.dart
+++ b/lib/features/navigation/legacy_redirects.dart
@@ -18,15 +18,16 @@ abstract class LegacyRedirects {
     // world_v2: the profile + settings tree is a right-column panel, not a
     // route. Rewrite any /settings or /profile location to the canonical
     // `settings` token so deep links, bookmarks, and the retired route-driven
-    // render all land on the panel. The token param is the sub-page (a
-    // profile/* path keeps its `profile/` prefix so `/profile/edit` is
-    // distinguishable). See `routing.instructions.md`.
+    // render all land on the panel. The token param is the sub-page. The
+    // profile editor collapses to the single-segment `profile` page: a legacy
+    // `/profile/edit` link opens the same editor, so it must not become a
+    // nested `profile/edit` leaf whose back arrow pops to an identical-looking
+    // `profile` page first, needing two clicks (#7147). See
+    // `routing.instructions.md`.
     if (segments.isNotEmpty &&
         (segments.first == 'settings' || segments.first == 'profile')) {
       final sub = segments.first == 'profile'
-          ? (segments.length > 1
-                ? 'profile/${segments.sublist(1).join('/')}'
-                : '')
+          ? (segments.length > 1 ? 'profile' : '')
           : segments.sublist(1).join('/');
       // world_v2 master/detail: the menu is the `settings` master; a sub-page
       // opens beside it as a `settingspage` detail (front of the right group,

--- a/lib/routes/settings/settings_view.dart
+++ b/lib/routes/settings/settings_view.dart
@@ -208,17 +208,21 @@ class SettingsView extends StatelessWidget {
                     //   ),
                     // Divider(color: theme.dividerColor),
                     // world_v2: the Avatar surface merges profile + settings;
-                    // the full profile editor lives at /profile/edit.
+                    // the profile editor is the single-segment `profile` page.
+                    // It is not a nested `profile/edit` leaf — `profile` and
+                    // `profile/edit` render the same editor, so the extra
+                    // segment only made the back arrow pop to an identical-
+                    // looking page first, needing a second click (#7147).
                     ListTile(
                       leading: const Icon(Icons.account_circle_outlined),
                       title: Text(L10n.of(context).editProfile),
-                      tileColor: activeRoute.startsWith('/profile/edit')
+                      tileColor: activeRoute.startsWith('/profile')
                           ? theme.colorScheme.surfaceContainerHigh
                           : null,
                       onTap: () => context.go(
                         WorkspaceNav.openSettings(
                           GoRouterState.of(context).uri,
-                          page: 'profile/edit',
+                          page: 'profile',
                         ),
                       ),
                     ),

--- a/test/pangea/navigation/legacy_redirects_test.dart
+++ b/test/pangea/navigation/legacy_redirects_test.dart
@@ -34,10 +34,10 @@ void main() {
         '/?right=settingspage:security%2Fpassword,settings',
       );
       expect(resolve('/profile'), '/?right=settings');
-      expect(
-        resolve('/profile/edit'),
-        '/?right=settingspage:profile%2Fedit,settings',
-      );
+      // The profile editor collapses to the single-segment `profile` page, so a
+      // legacy `/profile/edit` link opens the editor with a one-click back to
+      // the menu, not a nested `profile/edit` leaf (#7147).
+      expect(resolve('/profile/edit'), '/?right=settingspage:profile,settings');
     });
 
     test('find/create course flows keep literal names', () {

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -465,6 +465,33 @@ void main() {
       ); // menu still there
     });
 
+    test('the profile editor is a single-segment leaf, so its back returns to '
+        'the menu in one step — not via a phantom profile parent (#7147)', () {
+      // The Settings menu opens the editor as `profile`, NOT `profile/edit`.
+      // Both render the same editor, so a nested `profile/edit` leaf made the
+      // back arrow popPage to an identical-looking `profile` page first,
+      // forcing a second click. A single-segment param has no `/`, so the
+      // panel treats its back as a plain close that reveals the menu in one
+      // step.
+      final opened = WorkspaceNav.openSettings(u('/'), page: 'profile');
+      final page = parseOpenPanels(
+        u(opened),
+      ).right.firstWhere((t) => t.type == 'settingspage');
+      expect(page.param, 'profile'); // single segment, not 'profile/edit'
+      expect(
+        page.param!.contains('/'),
+        isFalse,
+      ); // back is a close, not popPage
+      // One close drops the page and lands on the menu.
+      final back = WorkspaceNav.closeRight(
+        u(opened),
+        const PanelToken('settingspage', 'profile'),
+      );
+      final right = parseOpenPanels(u(back)).right;
+      expect(right.any((t) => t.type == 'settingspage'), isFalse); // page gone
+      expect(right.single.type, 'settings'); // menu remains, one step
+    });
+
     test('settingsBack: a leaf pops to its parent page; a top-level page '
         'returns to the menu (drops the page detail)', () {
       final toSecurity = WorkspaceNav.settingsBack(


### PR DESCRIPTION
Closes #7147.

## Problem

Settings, then Edit Profile, then the back arrow needed two clicks to return to the settings menu. The first click appeared to do nothing.

## Cause

The Edit Profile menu row opened the editor as the page `profile/edit`. A page id with a slash is treated as a pushed sub-page, so the back arrow pops one segment: `profile/edit` to `profile`. But `profile` and `profile/edit` render the exact same editor (`UserHomePage`, constructed with no arguments either way), so the first back was a visual no-op and a second click was needed to actually drop the page and reveal the menu.

This is unlike a real nested page such as `security/password`, where the parent `security` is a distinct sub-menu and popping to it is meaningful.

## Fix

Address the profile editor as the single-segment page `profile` (there is no separate `profile` view vs `profile/edit` editor, they are the same screen). With no slash, the back arrow is a plain close that drops the page and reveals the menu in one step.

- `settings_view.dart`: the Edit Profile row opens `page: 'profile'`.
- `legacy_redirects.dart`: a legacy `/profile/edit` deep link collapses to the single-segment `profile` page too, so external links get the same one-click back.

The generic push/pop logic is unchanged, so real nested pages (`security/password` to `security` to menu) still step back one level as before.

## Verification

- `workspace_nav_test.dart`: opening the editor yields a single-segment `profile` token whose back is a one-step close to the menu, not a pop to a phantom parent.
- `legacy_redirects_test.dart`: `/profile/edit` resolves to `settingspage:profile,settings`.
- Full navigation suite: 63 passing.
- Manually verified in the running client: opening the profile editor and clicking back once lands on the settings menu.

## TO TEST
- [ ] Open Settings
- [ ] Click Edit Profile
- [ ] Click the back button and confirm it takes you back to Settings in a single click

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed navigation flow for the profile editor within settings to return to the settings menu with a single back-click instead of multiple steps
* Corrected legacy path resolution for profile editing URLs to eliminate redundant navigation segments and simplify the navigation structure
* Updated settings view to properly recognize the profile editor as a single navigation level

<!-- end of auto-generated comment: release notes by coderabbit.ai -->