### PR TITLE
fix(nav): preserve the selected analytics construct across a page refresh (#7079)

### DIFF
--- a/lib/features/navigation/route_facts.dart
+++ b/lib/features/navigation/route_facts.dart
@@ -115,6 +115,50 @@ AppSection sectionFor(Uri uri) {
   return AppSection.world;
 }
 
+/// Split a URL token list on its *top-level* commas only — commas inside a
+/// `{...}` JSON param (an encoded construct) are NOT list delimiters.
+///
+/// A construct param is wrapped in braces and its commas are percent-encoded
+/// (`%2C`) by [PanelToken.encode], so the in-app form has no literal commas
+/// inside a param. But on a cold boot / refresh the browser normalizes the URL
+/// fragment in `window.location`, decoding the param's `%2C` back to literal
+/// commas (it keeps `%22` for the quotes). Re-parsing that through `Uri` then
+/// re-encodes the brace chars — which are not query-legal — to `%7B`/`%7D`,
+/// while the commas (valid sub-delims) stay literal. A naive `split(',')` would
+/// shatter the construct token mid-JSON, the param would fail to `jsonDecode`,
+/// and the selected construct would be lost, the detail panel falling back to
+/// the summary grid (#7079). Tracking brace depth keeps the param whole.
+///
+/// Braces appear as `%7B`/`%7D` in `uri.query` on both paths (and the literal
+/// `{`/`}` forms are matched too, for safety), so this parses both identically.
+List<String> splitTopLevelTokens(String list) {
+  final out = <String>[];
+  var depth = 0;
+  var start = 0;
+  for (var i = 0; i < list.length; i++) {
+    final c = list[i];
+    if (c == '{') {
+      depth++;
+    } else if (c == '}') {
+      if (depth > 0) depth--;
+    } else if (c == '%' && i + 3 <= list.length) {
+      final hex = list.substring(i + 1, i + 3).toUpperCase();
+      if (hex == '7B') {
+        depth++;
+        i += 2;
+      } else if (hex == '7D') {
+        if (depth > 0) depth--;
+        i += 2;
+      }
+    } else if (c == ',' && depth == 0) {
+      out.add(list.substring(start, i));
+      start = i + 1;
+    }
+  }
+  out.add(list.substring(start));
+  return out;
+}
+
 /// The map-filter values from `?m=` — a comma list of typed tokens (today only
 /// `course:<spaceid>`) that scope the persistent world map. Read raw (not the
 /// percent-decoded `queryParameters`) and PanelToken-parsed, mirroring
@@ -132,7 +176,7 @@ List<PanelToken> mapFiltersFor(Uri uri) {
   }
   if (encoded == null || encoded.isEmpty) return const [];
   final tokens = <PanelToken>[];
-  for (final element in encoded.split(',')) {
+  for (final element in splitTopLevelTokens(encoded)) {
     final token = PanelToken.parse(element);
     if (token != null) tokens.add(token);
   }
@@ -258,7 +302,7 @@ List<PanelToken> _parsePanelList(Uri uri, String key) {
   final seen = <String>{};
   final usedGroups = <String>{};
   final tokens = <PanelToken>[];
-  for (final element in encodedList.split(',')) {
+  for (final element in splitTopLevelTokens(encodedList)) {
     final token = PanelToken.parse(element);
     if (token == null) continue;
     final def = PanelRegistry.defFor(token.type);

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -24,6 +24,26 @@ void main() {
       expect(parseOpenPanels(u(loc)).right.single, token);
     });
 
+    test('a browser-normalized construct param (literal commas inside braces) '
+        'survives the cold-boot parse — selection not shattered (#7079)', () {
+      // On a refresh/cold boot the browser normalizes the fragment in
+      // window.location, decoding the encoded construct param's %2C back to
+      // literal commas inside literal braces (it keeps %22 for the quotes). A
+      // naive comma split would shatter the token mid-JSON, jsonDecode would
+      // fail, and the construct detail would fall back to the summary grid.
+      // Brace-aware splitting keeps the param whole.
+      final uri = u(
+        '/?right=vocab:{%22lemma%22:%22campus%22,%22type%22:%22vocab%22,'
+        '%22cat%22:%22noun%22},analytics:vocab',
+      );
+      final right = parseOpenPanels(uri).right;
+      expect(right.map((t) => t.type), ['vocab', 'analytics']);
+      expect(
+        right.first.param,
+        '{"lemma":"campus","type":"vocab","cat":"noun"}',
+      );
+    });
+
     test('atStart blooms a detail to the left of an existing summary', () {
       var loc = WorkspaceNav.openRight(
         u('/chats'),


### PR DESCRIPTION
Closes #7079.

## Problem

Selecting a vocabulary or grammar construct in Analytics opens its detail panel and writes the selection into the URL (`right=vocab:{...},analytics:vocab`). On a page refresh the construct was lost: the detail panel fell back to the full summary grid, so you ended up with two identical grids side by side instead of the construct you had open.

## Cause

A construct param is a JSON blob whose commas are percent-encoded (`%2C`) when the token is written, so the in-app URL has no literal commas inside the param and the comma-split that separates list tokens works fine.

But on a refresh the browser normalizes the fragment in `window.location`, decoding the param's `%2C` back to literal commas. Re-parsing that location through `Uri` then re-encodes the brace characters to `%7B`/`%7D` (braces are not legal in a query) while the commas, which are legal, stay literal. The list parser's naive `split(',')` then cut the construct token apart mid-JSON, the param failed to decode, and the detail rendered as if no construct were selected.

## Fix

Split the `left=`/`right=` (and `m=`) token lists on top-level commas only, tracking brace depth so commas inside a `{...}` construct param are not treated as delimiters. Braces appear as `%7B`/`%7D` in the parsed query on both the in-app and refreshed paths, so both now parse identically. This is a no-op for tokens without a JSON param.

## Verification

- `workspace_nav_test.dart`: a browser-normalized construct URL (literal commas inside encoded braces) parses to the intact `vocab` construct plus the analytics summary; the existing in-app round-trip test still passes.
- Full navigation suite: 165 passing.
- Manually verified in the running client: open a construct, refresh the page, and the construct detail is still there (no longer collapses to a second summary grid).

## TO TEST
- [ ] Open Analytics and select a vocabulary or grammar construct
- [ ] Refresh the page
- [ ] Confirm the selected construct detail is still open (not replaced by a second summary grid)