### PR TITLE
fix(activity): closing an errored activity chat drops only the room, not the chat list (#7156)

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -3,7 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/room_id_url.dart';
+import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/route_paths.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/navigation/workspace_query.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/widgets/error_indicator.dart';
@@ -14,6 +18,29 @@ import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_
 import 'package:fluffychat/routes/chat/activity_sessions/activity_summary_widget.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
+
+/// The location that closes a non-embedded activity plan opened as a room/
+/// session token (the chat list / a left panel): it drops ONLY that token, so
+/// the rest of the workspace — notably the chat list — survives. Closing an
+/// activity (e.g. one stuck on an "activity not found" error) must not also
+/// clear the chat list (#7156). Returns null when no such token is open — the
+/// standalone `/<activityId>` route — so the caller pops or falls back to home.
+@visibleForTesting
+String? activityRoomCloseLocation(Uri uri, String? roomId) {
+  if (roomId == null || roomId.isEmpty) return null;
+  final localpart = shortRoomId(roomId);
+  bool matches(PanelToken t) =>
+      (t.type == 'room' || t.type == 'session') &&
+      (t.param ?? '').split('/').first == localpart;
+  final panels = parseOpenPanels(uri);
+  for (final t in panels.left) {
+    if (matches(t)) return WorkspaceNav.closeLeft(uri, t);
+  }
+  for (final t in panels.right) {
+    if (matches(t)) return WorkspaceNav.closeRight(uri, t);
+  }
+  return null;
+}
 
 class ActivitySessionStartView extends StatelessWidget {
   final ActivitySessionStartState controller;
@@ -112,15 +139,27 @@ class ActivitySessionStartView extends StatelessWidget {
                           context,
                         ).go(overlayDropped(reopenCard: false)),
                       )
-                    // Standalone `/<activityId>` route: this page is the
-                    // bottom of the stack; popping would leave an empty
-                    // navigator, so fall back to the home map.
+                    // Opened as a room/session token (the chat list / a left
+                    // panel): drop ONLY that token so the rest of the workspace
+                    // — notably the chat list — survives (#7156). The standalone
+                    // `/<activityId>` route has no such token: it is the bottom
+                    // of the stack, so pop, or fall back to the home map.
                     : IconButton(
                         tooltip: L10n.of(context).close,
                         icon: const Icon(Icons.close),
-                        onPressed: () => Navigator.of(context).canPop()
-                            ? Navigator.of(context).pop()
-                            : GoRouter.of(context).go(PRoutes.world),
+                        onPressed: () {
+                          final close = activityRoomCloseLocation(
+                            uri,
+                            controller.widget.roomId,
+                          );
+                          if (close != null) {
+                            GoRouter.of(context).go(close);
+                          } else if (Navigator.of(context).canPop()) {
+                            Navigator.of(context).pop();
+                          } else {
+                            GoRouter.of(context).go(PRoutes.world);
+                          }
+                        },
                       ),
                 // Pangea#
               ),

--- a/test/pangea/navigation/activity_room_close_test.dart
+++ b/test/pangea/navigation/activity_room_close_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_sessions_start_view.dart';
+
+void main() {
+  Uri u(String s) => Uri.parse(s);
+
+  group('activityRoomCloseLocation (#7156)', () {
+    test('closing a room-token activity drops only the room, keeping the '
+        'chat list', () {
+      final loc = activityRoomCloseLocation(
+        u('/?left=chats,room:!abc'),
+        '!abc',
+      );
+      expect(loc, isNotNull);
+      final left = parseOpenPanels(u(loc!)).left;
+      expect(left.any((t) => t.type == 'chats'), isTrue); // chat list survives
+      expect(left.any((t) => t.type == 'room'), isFalse); // room dropped
+    });
+
+    test('other open panels survive (e.g. an analytics summary)', () {
+      final loc = activityRoomCloseLocation(
+        u('/?left=chats,room:!abc&right=analytics:vocab'),
+        '!abc',
+      );
+      final panels = parseOpenPanels(u(loc!));
+      expect(panels.left.map((t) => t.type), ['chats']);
+      expect(panels.right.any((t) => t.type == 'analytics'), isTrue);
+    });
+
+    test('the standalone /<activityId> route has no room token, so it returns '
+        'null (caller pops or falls back to home)', () {
+      expect(activityRoomCloseLocation(u('/abc123'), '!abc'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #7156.

## Problem

Opening a chat that is an activity session whose activity can no longer be found shows an "Activity not found" error. Closing that error closed the **chat list** too, instead of just the chat.

## Cause

An activity-session room opened from the chat list rides the URL as a `room:` token (e.g. `?left=chats,room:!id`) and renders the activity start view. That view's close control had three cases: embedded over a course (`?activity=`), an embedded map-pin entry, and a standalone `/<activityId>` route. A `room:` token entry matched none of them and fell through to the standalone branch, whose fallback is `go(PRoutes.world)` — which clears the whole workspace, including the chat list.

## Fix

For the non-embedded case, drop only the room/session token from the current URL (via `closeLeft`/`closeRight`), so the rest of the workspace — the chat list and any other open panels — survives. Only the true standalone `/<activityId>` route (no such token present) still pops or falls back to the home map.

The logic is extracted as `activityRoomCloseLocation(uri, roomId)` and unit-tested.

## Verification

- `activity_room_close_test.dart`: a room-token activity closes to just-the-room (chat list and other panels survive); a standalone route returns null (caller pops/home).
- Full navigation suite: 168 passing.
- Manually verified in the running client: open an activity chat that errors, close it, and the chat list stays open.

## TO TEST
- [ ] Open the chat list
- [ ] Select a chat that can no longer be found (activity-not-found error)
- [ ] Close the error chat and confirm the chat list stays open