### PR TITLE
fix: reset cefr filters on widen search

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -180,5 +180,11 @@ abstract class AppConfig {
     "image/gif",
     "image/png",
   };
+
+  static const Color green = Color(0xFF34A853);
+  static const Color purple = Color(0xFF7B61FF);
+  static const Color gray = Color(0xFFB4B2A9);
+  static const Color grayText = Color(0xFF5F5E5A);
+  static const Color completedGreen = Color(0xFF3B6D11);
   // Pangea#
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -4915,5 +4915,6 @@
     "sevenDaysFree": "7 DAYS FREE",
     "manageTrialInSettings": "Manage your trial anytime in\nSubscription Settings",
     "noCreditCardRequired": "No credit card required.",
-    "proFeatures": "PRO"
+    "proFeatures": "PRO",
+    "widenSearch": "Widen search"
 }

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -170,7 +170,7 @@ class WorldMapController extends State<WorldMap>
 
   /// Size of the featured (joinable) pool, recorded by [WorldMapView] each build;
   /// the rotation tick only advances when it exceeds [largeBudget].
-  int largePoolSize = 0;
+  int _largePoolSize = 0;
 
   /// How many large featured cards show at once (desktop).
   static const int largeBudget = 3;
@@ -211,7 +211,7 @@ class WorldMapController extends State<WorldMap>
     // Rotate the large featured slots when more joinable activities qualify than
     // the budget, so each gets airtime (world-map.instructions.md).
     _rotationTimer = Timer.periodic(const Duration(seconds: 5), (_) {
-      if (mounted && largePoolSize > largeBudget) {
+      if (mounted && _largePoolSize > largeBudget) {
         setState(() => _largeRotationIndex++);
       }
     });
@@ -281,6 +281,8 @@ class WorldMapController extends State<WorldMap>
       _completion = completion;
     });
   }
+
+  void setLargePoolSize(int update) => _largePoolSize = update;
 
   /// The learner's joined course spaces (a space they belong to that carries a
   /// course plan) — the source set for the objective cache + relevance banding.
@@ -561,15 +563,18 @@ class WorldMapController extends State<WorldMap>
     });
   }
 
-  void resetFilters() {
-    final wasWidened = !_l2Only;
+  void resetFilters({bool l2Only = true}) {
+    final toggleL2Only = _l2Only != l2Only;
     setState(() {
       _query = '';
       _completionFilter.clear();
       _cefrFilter = {..._defaultCefr};
-      _l2Only = true;
+      _l2Only = l2Only;
     });
-    if (wasWidened) loadWorldPins(); // L2 narrowed again → re-fetch
+
+    if (toggleL2Only) {
+      loadWorldPins(); // L2 narrowed again → re-fetch
+    }
   }
 
   /// Fly to a search result and open its preview (the Maps-style result tap).

--- a/lib/routes/world/world_map_client_extension.dart
+++ b/lib/routes/world/world_map_client_extension.dart
@@ -1,0 +1,19 @@
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+
+extension WorldMapClientExtension on Client {
+  Room? bestJoinableActivityInstance(String activityId) {
+    Room? best;
+    for (final r in rooms) {
+      if (r.activityId != activityId) continue;
+      if (!(r.numRemainingRoles > 0 && r.ownRoleState == null)) continue;
+      final ms = r.lastEvent?.originServerTs.millisecondsSinceEpoch ?? 0;
+      final bestMs =
+          best?.lastEvent?.originServerTs.millisecondsSinceEpoch ?? 0;
+      if (best == null || ms > bestMs) best = r;
+    }
+    return best;
+  }
+}

--- a/lib/routes/world/world_map_cluster_bubble.dart
+++ b/lib/routes/world/world_map_cluster_bubble.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+
+/// The clustered-pins bubble (Google-Maps grouping), coloured by the cluster's
+/// dominant state so a cluster with an open session reads green.
+class WorldMapClusterBubble extends StatelessWidget {
+  final int count;
+  final ActivityPinState dominant;
+
+  const WorldMapClusterBubble({
+    super.key,
+    required this.count,
+    required this.dominant,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: dominant.color,
+        shape: BoxShape.circle,
+        border: Border.all(color: Colors.white, width: 2),
+        boxShadow: const [BoxShadow(blurRadius: 4, color: Colors.black38)],
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        '$count',
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+          fontSize: 13,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/world/world_map_large_card.dart
+++ b/lib/routes/world/world_map_large_card.dart
@@ -46,23 +46,6 @@ class WorldMapLargeCard extends StatelessWidget {
     this.openSlots = 0,
   });
 
-  static const Color _green = Color(0xFF34A853);
-  static const Color _purple = Color(0xFF7B61FF);
-  static const Color _gray = Color(0xFFB4B2A9);
-  static const Color _grayText = Color(0xFF5F5E5A);
-  static const Color _completedGreen = Color(0xFF3B6D11);
-
-  Color get _accent {
-    switch (state) {
-      case ActivityPinState.joinable:
-        return _green;
-      case ActivityPinState.locked:
-        return _gray;
-      case ActivityPinState.unlocked:
-        return _purple;
-    }
-  }
-
   /// The most-goal role's goal count stands in for the activity's star total: a
   /// learner plays one role, and the richest role bounds the progress bar.
   int get _starsTotal {
@@ -97,7 +80,7 @@ class WorldMapLargeCard extends StatelessWidget {
           padding: const EdgeInsets.all(10),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: _accent, width: 2),
+            border: Border.all(color: state.accent, width: 2),
           ),
           child: Column(
             mainAxisSize: MainAxisSize.min,
@@ -147,7 +130,7 @@ class WorldMapLargeCard extends StatelessWidget {
                 style: TextStyle(
                   fontWeight: FontWeight.bold,
                   fontSize: 13,
-                  color: locked ? _grayText : null,
+                  color: locked ? AppConfig.grayText : null,
                 ),
               ),
               const SizedBox(height: 4),
@@ -182,7 +165,7 @@ class WorldMapLargeCard extends StatelessWidget {
       alignment: Alignment.center,
       children: [
         Opacity(opacity: 0.5, child: image),
-        const Icon(Icons.lock, size: 20, color: _grayText),
+        const Icon(Icons.lock, size: 20, color: AppConfig.grayText),
       ],
     );
   }
@@ -199,8 +182,8 @@ class WorldMapLargeCard extends StatelessWidget {
   }) {
     final l10n = L10n.of(context);
     final Color fg = completed
-        ? _completedGreen
-        : (locked ? _grayText : _accent);
+        ? AppConfig.completedGreen
+        : (locked ? AppConfig.grayText : state.accent);
     final IconData icon = completed
         ? Icons.check_circle_outline
         : (pinged ? Icons.back_hand : Icons.chat_bubble_outline);
@@ -276,12 +259,12 @@ class WorldMapLargeCard extends StatelessWidget {
   Widget _lockedRequirement(BuildContext context) {
     return Row(
       children: [
-        const Icon(Icons.lock, size: 13, color: _grayText),
+        const Icon(Icons.lock, size: 13, color: AppConfig.grayText),
         const SizedBox(width: 6),
         Expanded(
           child: Text(
             L10n.of(context).lockedMissionRequirement,
-            style: const TextStyle(fontSize: 11, color: _grayText),
+            style: const TextStyle(fontSize: 11, color: AppConfig.grayText),
           ),
         ),
       ],
@@ -297,14 +280,14 @@ class WorldMapLargeCard extends StatelessWidget {
         _actionPill(
           Icons.refresh,
           l10n.playAgain,
-          _purple,
+          AppConfig.purple,
           const Color(0xFFCECBF6),
         ),
         const SizedBox(width: 6),
         _actionPill(
           Icons.visibility_outlined,
           l10n.reviewActivity,
-          _grayText,
+          AppConfig.grayText,
           const Color(0xFFD3D1C7),
         ),
       ],

--- a/lib/routes/world/world_map_ranking.dart
+++ b/lib/routes/world/world_map_ranking.dart
@@ -1,3 +1,6 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
 import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
 
@@ -6,10 +9,55 @@ import 'package:fluffychat/routes/settings/settings_learning/language_level_type
 /// world-map.instructions.md). Completion is no longer a state — it renders as a
 /// progress fill carried by [PinSignals.completionFraction], orthogonal to the
 /// colour, so finished work stays visible without hiding the next thing to do.
-enum ActivityPinState { locked, unlocked, joinable }
+enum ActivityPinState {
+  locked,
+  unlocked,
+  joinable;
+
+  /// The colour a pin reads as for its [ActivityPinState] (see
+  /// world-map.instructions.md): locked gray, unlocked purple, joinable green.
+  /// Completion is not a colour — it renders as the inner gold fill in [_stateDot].
+  Color get color {
+    switch (this) {
+      case ActivityPinState.joinable:
+        return const Color(0xFF34A853); // green — an open session to join
+      case ActivityPinState.unlocked:
+        return const Color(0xFF7B61FF); // purple — available, not started
+      case ActivityPinState.locked:
+        return Colors.grey;
+    }
+  }
+
+  Color get accent {
+    switch (this) {
+      case ActivityPinState.joinable:
+        return AppConfig.green;
+      case ActivityPinState.locked:
+        return AppConfig.gray;
+      case ActivityPinState.unlocked:
+        return AppConfig.purple;
+    }
+  }
+}
 
 /// The visual weight a pin renders at, assigned by the ranking + state gate.
-enum PinTier { small, mid, large }
+enum PinTier {
+  small,
+  mid,
+  large;
+
+  double dotHeight(ActivityPinState state) => switch (this) {
+    PinTier.small => 18.0,
+    PinTier.mid => 44.0,
+    PinTier.large => state == ActivityPinState.joinable ? 184.0 : 150.0,
+  };
+
+  double get dotWidth => switch (this) {
+    PinTier.small => 18.0,
+    PinTier.mid => 44.0,
+    PinTier.large => 260.0,
+  };
+}
 
 /// Live signals for one activity, derived from Matrix room state (not on the
 /// pin card): its resolved [state], a 0..1 [completionFraction] (stars earned

--- a/lib/routes/world/world_map_room_extension.dart
+++ b/lib/routes/world/world_map_room_extension.dart
@@ -1,0 +1,15 @@
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/bot/utils/bot_name.dart';
+import 'package:fluffychat/routes/world/world_map_large_card.dart';
+
+extension WorldMapRoomExtension on Room {
+  List<LargeCardParticipant> get largeCardParticipants => getParticipants()
+      .where(
+        (u) => u.membership == Membership.join && u.id != BotName.byEnvironment,
+      )
+      .map<LargeCardParticipant>(
+        (u) => (avatar: u.avatarUrl, name: u.calcDisplayname()),
+      )
+      .toList();
+}

--- a/lib/routes/world/world_map_search_overlay.dart
+++ b/lib/routes/world/world_map_search_overlay.dart
@@ -22,6 +22,7 @@ class WorldMapSearchOverlay extends StatefulWidget {
   final bool l2Only;
   final String? l2Label;
   final VoidCallback onToggleL2;
+  final VoidCallback onWidenSearch;
 
   /// CEFR band: [selectedCefr] is the active level set (default = at/below the
   /// user's level); toggling a chip adds/removes a level.
@@ -52,6 +53,7 @@ class WorldMapSearchOverlay extends StatefulWidget {
     required this.l2Only,
     required this.l2Label,
     required this.onToggleL2,
+    required this.onWidenSearch,
     required this.selectedCefr,
     required this.onToggleCefr,
     required this.selectedCompletion,
@@ -244,8 +246,8 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
                   if (widget.l2Only && widget.l2Label != null)
                     FilledButton.tonalIcon(
                       icon: const Icon(Icons.translate, size: 16),
-                      label: Text(l10n.mapFilterAllLanguages),
-                      onPressed: widget.onToggleL2,
+                      label: Text(l10n.widenSearch),
+                      onPressed: widget.onWidenSearch,
                     ),
                 ],
               ),

--- a/lib/routes/world/world_map_signals.dart
+++ b/lib/routes/world/world_map_signals.dart
@@ -2,11 +2,9 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
-import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/features/quests/user_stars.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
 import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
-import 'package:fluffychat/routes/world/world_map_large_card.dart';
 import 'package:fluffychat/routes/world/world_map_ranking.dart';
 import 'package:fluffychat/routes/world/world_map_search_overlay.dart';
 
@@ -183,36 +181,6 @@ Map<String, MapCompletionFilter> reduceCompletion(
     }
   }
   return m;
-}
-
-/// The newest open joinable session for [activityId]: its joined non-bot
-/// participants (for the avatar stack) and its open-role count (the "?" slots).
-/// Empty when no such session is in the user's reachable rooms. A Matrix reducer
-/// (reads participants), so it lives beside the other room derivations rather
-/// than in the stateless view.
-({List<LargeCardParticipant> participants, int openSlots}) joinableInfo(
-  Client client,
-  String activityId,
-) {
-  Room? best;
-  for (final r in client.rooms) {
-    if (r.activityId != activityId) continue;
-    if (!(r.numRemainingRoles > 0 && r.ownRoleState == null)) continue;
-    final ms = r.lastEvent?.originServerTs.millisecondsSinceEpoch ?? 0;
-    final bestMs = best?.lastEvent?.originServerTs.millisecondsSinceEpoch ?? 0;
-    if (best == null || ms > bestMs) best = r;
-  }
-  if (best == null) return (participants: const [], openSlots: 0);
-  final participants = best
-      .getParticipants()
-      .where(
-        (u) => u.membership == Membership.join && u.id != BotName.byEnvironment,
-      )
-      .map<LargeCardParticipant>(
-        (u) => (avatar: u.avatarUrl, name: u.calcDisplayname()),
-      )
-      .toList();
-  return (participants: participants, openSlots: best.numRemainingRoles);
 }
 
 /// CEFR levels at or below [level] — the personalized default band (attainable

--- a/lib/routes/world/world_map_state_dot.dart
+++ b/lib/routes/world/world_map_state_dot.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+
+class WorldMapDot extends StatelessWidget {
+  final QuestActivityCard card;
+  final ActivityPinState state;
+  final PinTier tier;
+  final VoidCallback onTap;
+  final bool pinged;
+  final double fill;
+
+  const WorldMapDot({
+    super.key,
+    required this.card,
+    required this.state,
+    required this.tier,
+    required this.onTap,
+    required this.pinged,
+    this.fill = 0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: card.title,
+      // Semantics below names the pin; exclude the Tooltip so the title isn't
+      // announced twice ("<title> <title>").
+      excludeFromSemantics: true,
+      child: Semantics(
+        button: true,
+        label: card.title,
+        excludeSemantics: true,
+        child: GestureDetector(
+          onTap: onTap,
+          child: tier == PinTier.mid
+              ? _MediumDotContent(state: state, pinged: pinged, fill: fill)
+              : _SmallDotContent(state: state, fill: fill),
+        ),
+      ),
+    );
+  }
+}
+
+class _SmallDotContent extends StatelessWidget {
+  final ActivityPinState state;
+  final double fill;
+
+  const _SmallDotContent({required this.state, this.fill = 0});
+
+  @override
+  Widget build(BuildContext context) => _WorldMapStateDot(
+    state: state,
+    diameter: 18,
+    borderWidth: 1.5,
+    fill: fill,
+  );
+}
+
+class _MediumDotContent extends StatelessWidget {
+  final ActivityPinState state;
+  final bool pinged;
+  final double fill;
+
+  const _MediumDotContent({
+    required this.state,
+    required this.pinged,
+    this.fill = 0,
+  });
+
+  @override
+  Widget build(BuildContext context) => Stack(
+    clipBehavior: Clip.none,
+    alignment: Alignment.center,
+    children: [
+      _WorldMapStateDot(
+        state: state,
+        diameter: 36,
+        borderWidth: 2,
+        fill: fill,
+        glyph: const Icon(
+          Icons.chat_bubble_outline,
+          size: 18,
+          color: Colors.white,
+        ),
+      ),
+      if (pinged)
+        Positioned(
+          top: -2,
+          right: -2,
+          child: Container(
+            padding: const EdgeInsets.all(2),
+            decoration: const BoxDecoration(
+              color: Colors.white,
+              shape: BoxShape.circle,
+            ),
+            child: const Icon(
+              Icons.back_hand,
+              size: 12,
+              color: Color(0xFF34A853),
+            ),
+          ),
+        ),
+    ],
+  );
+}
+
+/// The state-coloured pin body with the progress fill: an outer [state]-coloured
+/// disc, an inner gold disc whose radius scales with [fill] (0..1 — stars earned
+/// toward the activity's total), and an optional [glyph] on top. The fill is
+/// linear in radius (`r = innerRadius·fill`), so a full activity reads as a solid
+/// gold centre while a fresh one shows none. Design: world-map.instructions.md.
+class _WorldMapStateDot extends StatelessWidget {
+  final ActivityPinState state;
+  final double diameter;
+  final double borderWidth;
+  final double fill;
+  final Widget? glyph;
+
+  const _WorldMapStateDot({
+    required this.state,
+    required this.diameter,
+    required this.borderWidth,
+    this.fill = 0,
+    this.glyph,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final inner = (diameter - 2 * borderWidth) * fill.clamp(0.0, 1.0);
+    return Container(
+      width: diameter,
+      height: diameter,
+      decoration: BoxDecoration(
+        color: state.color,
+        shape: BoxShape.circle,
+        border: Border.all(color: Colors.white, width: borderWidth),
+        boxShadow: const [BoxShadow(blurRadius: 3, color: Colors.black38)],
+      ),
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          if (inner > 0)
+            Container(
+              width: inner,
+              height: inner,
+              decoration: const BoxDecoration(
+                color: AppConfig.gold,
+                shape: BoxShape.circle,
+              ),
+            ),
+          ?glyph,
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -6,135 +6,65 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_map_marker_cluster/flutter_map_marker_cluster.dart';
 import 'package:latlong2/latlong.dart';
 
-import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/quests/lo_progression.dart';
 import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/world/world_map.dart';
+import 'package:fluffychat/routes/world/world_map_client_extension.dart';
+import 'package:fluffychat/routes/world/world_map_cluster_bubble.dart';
 import 'package:fluffychat/routes/world/world_map_large_card.dart';
 import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_room_extension.dart';
 import 'package:fluffychat/routes/world/world_map_search_overlay.dart';
-import 'package:fluffychat/routes/world/world_map_signals.dart';
+import 'package:fluffychat/routes/world/world_map_state_dot.dart';
 import 'package:fluffychat/widgets/matrix.dart';
-
-/// The colour a pin reads as for its [ActivityPinState] (see
-/// world-map.instructions.md): locked gray, unlocked purple, joinable green.
-/// Completion is not a colour — it renders as the inner gold fill in [_stateDot].
-Color _stateColor(ActivityPinState state) {
-  switch (state) {
-    case ActivityPinState.joinable:
-      return const Color(0xFF34A853); // green — an open session to join
-    case ActivityPinState.unlocked:
-      return const Color(0xFF7B61FF); // purple — available, not started
-    case ActivityPinState.locked:
-      return Colors.grey;
-  }
-}
-
-/// The state-coloured pin body with the progress fill: an outer [state]-coloured
-/// disc, an inner gold disc whose radius scales with [fill] (0..1 — stars earned
-/// toward the activity's total), and an optional [glyph] on top. The fill is
-/// linear in radius (`r = innerRadius·fill`), so a full activity reads as a solid
-/// gold centre while a fresh one shows none. Design: world-map.instructions.md.
-Widget _stateDot({
-  required ActivityPinState state,
-  required double diameter,
-  required double borderWidth,
-  double fill = 0,
-  Widget? glyph,
-}) {
-  final inner = (diameter - 2 * borderWidth) * fill.clamp(0.0, 1.0);
-  return Container(
-    width: diameter,
-    height: diameter,
-    decoration: BoxDecoration(
-      color: _stateColor(state),
-      shape: BoxShape.circle,
-      border: Border.all(color: Colors.white, width: borderWidth),
-      boxShadow: const [BoxShadow(blurRadius: 3, color: Colors.black38)],
-    ),
-    child: Stack(
-      alignment: Alignment.center,
-      children: [
-        if (inner > 0)
-          Container(
-            width: inner,
-            height: inner,
-            decoration: const BoxDecoration(
-              color: AppConfig.gold,
-              shape: BoxShape.circle,
-            ),
-          ),
-        ?glyph,
-      ],
-    ),
-  );
-}
 
 /// The per-frame pin draw model resolved by [WorldMapView._resolvePinRender]:
 /// the visible set and, for each pin id, its tier / colour-state / pinged-badge /
 /// progress-fill, plus the cluster dominant-state lookup. Lets the build method
 /// read as composition (resolve the model, then lay out the marker layers).
-class _PinRender {
+class _PinRenderer {
   final List<QuestActivityCard> visible;
-  final PinTier Function(String id) tierOf;
-  final ActivityPinState Function(String id) stateOf;
-  final bool Function(String id) pingedOf;
-  final double Function(String id) fillOf;
-  final Map<LatLng, ActivityPinState> clusterStateByPoint;
+  final Map<String, double> activityIdToFill;
+  final Map<String, ActivityPinState> activityIdToState;
+  final Map<String, bool> activityIdToPingStatus;
+  final Map<String, PinTier> activityIdToTier;
 
-  const _PinRender({
+  const _PinRenderer({
     required this.visible,
-    required this.tierOf,
-    required this.stateOf,
-    required this.pingedOf,
-    required this.fillOf,
-    required this.clusterStateByPoint,
+    required this.activityIdToFill,
+    required this.activityIdToState,
+    required this.activityIdToPingStatus,
+    required this.activityIdToTier,
   });
-}
 
-/// The on-map zoom controls (#7086): a small bottom-right stack with a World
-/// reset (the one obvious "zoom out to everything", since pins/clusters/search
-/// only ever zoom the camera IN) and +/- zoom steps. Camera-only — it never
-/// changes the open panels or the course scope.
-class _MapZoomControls extends StatelessWidget {
-  final WorldMapController controller;
+  List<QuestActivityCard> get largeCards => visible
+      .where((c) => c.point != null && tierOf(c.activityId) == PinTier.large)
+      .toList();
 
-  const _MapZoomControls({required this.controller});
+  List<QuestActivityCard> get nonLargeCards => visible
+      .where((c) => c.point != null && tierOf(c.activityId) != PinTier.large)
+      .toList();
 
-  @override
-  Widget build(BuildContext context) {
-    final l10n = L10n.of(context);
-    final theme = Theme.of(context);
-    return Material(
-      elevation: 2.0,
-      color: theme.colorScheme.surface,
-      borderRadius: BorderRadius.circular(8.0),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          IconButton(
-            icon: const Icon(Icons.public),
-            tooltip: l10n.world,
-            onPressed: controller.resetToWorld,
-          ),
-          Divider(height: 1.0, color: theme.colorScheme.outlineVariant),
-          IconButton(
-            icon: const Icon(Icons.add),
-            tooltip: l10n.zoomIn,
-            onPressed: () => controller.zoomBy(1),
-          ),
-          IconButton(
-            icon: const Icon(Icons.remove),
-            tooltip: l10n.zoomOut,
-            onPressed: () => controller.zoomBy(-1),
-          ),
-        ],
-      ),
-    );
-  }
+  Map<LatLng, ActivityPinState> get clusterStateByPoint =>
+      <LatLng, ActivityPinState>{
+        for (final c in visible)
+          if (c.point != null) c.point!: stateOf(c.activityId),
+      };
+
+  // The progress fill renders only on unlocked pins (the unlocked→finished
+  // gradation); joinable and locked carry no fill.
+  double fillOf(String id) => activityIdToFill[id] ?? 0;
+
+  ActivityPinState stateOf(String id) =>
+      activityIdToState[id] ?? ActivityPinState.unlocked;
+
+  bool pingedOf(String id) => activityIdToPingStatus[id] ?? false;
+
+  PinTier tierOf(String id) => activityIdToTier[id] ?? PinTier.small;
 }
 
 /// The stateless render of the persistent world map, driven by its
@@ -149,6 +79,211 @@ class WorldMapView extends StatelessWidget {
 
   const WorldMapView(this.controller, {super.key});
 
+  /// Resolve the per-frame pin draw model: the visible set, and for each pin its
+  /// tier / colour-state / pinged / fill, plus the cluster dominant-state lookup.
+  /// Applies the progression gate (a pin whose objectives are all locked reads
+  /// locked, unless it already has an open joinable session) and the relevance
+  /// ranking that assigns tiers, both rebuilt each frame from the controller's
+  /// cached signals + stars so a star award re-gates next build. Records the
+  /// featured-pool size on the controller for its rotation timer. See
+  /// world-map.instructions.md.
+  _PinRenderer _resolvePinRender(BuildContext context) {
+    final visible = controller.visiblePins;
+    final signals = _getSignals(visible);
+    final ranking = _getRankings(visible: visible, signals: signals);
+
+    final largePool = ranking.largePool;
+    final largeWindow = _getLargeWindow(context: context, largePool: largePool);
+
+    // Record the pool size so the controller's rotation timer knows whether
+    // there are more featured candidates than the budget (and should rotate).
+    controller.setLargePoolSize(largePool.length);
+
+    return _createPinRenderer(
+      visible: visible,
+      signals: signals,
+      largeWindow: largeWindow,
+      largeIds: largePool.toSet(),
+      mediumIds: ranking.midIds,
+    );
+  }
+
+  Map<String, PinSignals> _getSignals(List<QuestActivityCard> visible) {
+    final gate = buildLoGate(
+      outlines: controller.objectiveCache.outlines,
+      starsByActivity: controller.userStars,
+    );
+
+    final signals = <String, PinSignals>{};
+    for (final card in visible) {
+      final base = controller.signals[card.activityId] ?? const PinSignals();
+      signals[card.activityId] =
+          (base.state != ActivityPinState.joinable &&
+              gate.isPinLocked(card.learningObjectiveRefs))
+          ? PinSignals(
+              state: ActivityPinState.locked,
+              completionFraction: base.completionFraction,
+              pinged: base.pinged,
+              recency: base.recency,
+            )
+          : base;
+    }
+    return signals;
+  }
+
+  RankingResult _getRankings({
+    required List<QuestActivityCard> visible,
+    required Map<String, PinSignals> signals,
+  }) {
+    // Rank only the in-view pins (camera bounds when available) so promotion
+    // reflects what the learner is looking at.
+    List<QuestActivityCard> inView = visible;
+    try {
+      final bounds = controller.mapController.camera.visibleBounds;
+      inView = visible
+          .where((c) => c.point != null && bounds.contains(c.point!))
+          .toList();
+    } catch (_) {
+      // Camera not ready; rank the full filtered set.
+    }
+
+    final user = MatrixState.pangeaController.userController;
+    return rankPins(
+      inViewPins: inView,
+      userL2: user.userL2Code,
+      userCefr: user.userCefrLevel,
+      joinedObjectiveIds: controller.objectiveCache.ids,
+      signals: signals,
+    );
+  }
+
+  Set<String> _getLargeWindow({
+    required BuildContext context,
+    required List<String> largePool,
+  }) {
+    // Auto-featured large cards render only where there is horizontal room
+    // (desktop / column mode); a promoted card renders at any width.
+    final desktop = FluffyThemes.isColumnMode(context);
+
+    // The large featured cards (desktop only): a rotating window over the
+    // joinable pool; pool members not currently featured render at mid weight.
+    final largeWindow = <String>{};
+    if (desktop && largePool.isNotEmpty) {
+      final n = min(WorldMapController.largeBudget, largePool.length);
+      for (int i = 0; i < n; i++) {
+        largeWindow.add(
+          largePool[(controller.largeRotationIndex + i) % largePool.length],
+        );
+      }
+    }
+
+    return largeWindow;
+  }
+
+  _PinRenderer _createPinRenderer({
+    required List<QuestActivityCard> visible,
+    required Map<String, PinSignals> signals,
+    required Set<String> largeWindow,
+    required Set<String> largeIds,
+    required Set<String> mediumIds,
+  }) {
+    final activityIds = visible.map((c) => c.activityId).toSet();
+
+    final Map<String, PinTier> tiers = {};
+    final Map<String, ActivityPinState> states = {};
+    final Map<String, bool> pings = {};
+    final Map<String, double> fills = {};
+
+    for (final id in activityIds) {
+      tiers[id] =
+          id == controller.promotedActivityId || largeWindow.contains(id)
+          ? PinTier.large
+          : largeIds.contains(id) || mediumIds.contains(id)
+          ? PinTier.mid
+          : PinTier.small;
+
+      final signal = signals[id];
+      states[id] = signal?.state ?? ActivityPinState.unlocked;
+      pings[id] = signal?.pinged ?? false;
+      fills[id] = signal == null || signal.state == ActivityPinState.unlocked
+          ? 0
+          : signal.completionFraction;
+    }
+
+    return _PinRenderer(
+      visible: visible,
+      activityIdToFill: fills,
+      activityIdToPingStatus: pings,
+      activityIdToState: states,
+      activityIdToTier: tiers,
+    );
+  }
+
+  /// The clustered small/mid pins (large cards render unclustered above). Skips
+  /// pins with no point and any promoted-to-large pin.
+  List<Marker> _clusterMarkers(_PinRenderer render) =>
+      render.nonLargeCards.map((card) {
+        final state = render.stateOf(card.activityId);
+        final tier = render.tierOf(card.activityId);
+
+        return Marker(
+          key: ValueKey(card.activityId),
+          point: card.point!,
+          width: tier.dotWidth,
+          height: tier.dotHeight(state),
+          child: WorldMapDot(
+            card: card,
+            state: state,
+            tier: tier,
+            onTap: () => controller.promoteToLarge(card),
+            pinged: render.pingedOf(card.activityId),
+            fill: render.fillOf(card.activityId),
+          ),
+        );
+      }).toList();
+
+  /// The 1–3 large featured cards (desktop) plus any tap-promoted card, rendered
+  /// unclustered so they're always visible.
+  List<Marker> _largeMarkers(_PinRenderer render) => render.largeCards.map((
+    card,
+  ) {
+    // Hydrate the full plan for this featured card (no-op once cached); the
+    // repo listener rebuilds the map when it lands.
+    ActivityPlanRepo.instance.ensure(card.activityId);
+    final plan = ActivityPlanRepo.instance.cachedPlan(card.activityId);
+
+    final joinableActivity = controller.client?.bestJoinableActivityInstance(
+      card.activityId,
+    );
+
+    final state = render.stateOf(card.activityId);
+    final tier = PinTier.large;
+
+    return Marker(
+      point: card.point!,
+      width: tier.dotWidth,
+      // The inner Align lets the card hug its own content (each state is a
+      // different height: locked has no star row, completed adds an action row,
+      // joinable adds the avatar row). Height here is only a ceiling so the
+      // tallest variant isn't clipped; shorter cards don't stretch to fill it.
+      height: tier.dotHeight(state),
+      alignment: Alignment.topCenter,
+      child: Align(
+        alignment: Alignment.topCenter,
+        child: WorldMapLargeCard(
+          card: card,
+          state: state,
+          pinged: render.pingedOf(card.activityId),
+          plan: plan,
+          starsEarned: controller.userStars[card.activityId] ?? 0,
+          participants: joinableActivity?.largeCardParticipants ?? [],
+          openSlots: joinableActivity?.numRemainingRoles ?? 0,
+          onTap: () => controller.openActivity(card),
+        ),
+      ),
+    );
+  }).toList();
+
   @override
   Widget build(BuildContext context) {
     // world-map-tiles Phase 1: free hosted tiles switched by app theme —
@@ -159,6 +294,7 @@ class WorldMapView extends StatelessWidget {
     // Resolve which pins to draw and each one's tier/state/pinged/fill once per
     // frame, then lay out the layers from it.
     final render = _resolvePinRender(context);
+    final clusterStateByPoint = render.clusterStateByPoint;
 
     final map = FlutterMap(
       mapController: controller.mapController,
@@ -242,14 +378,17 @@ class WorldMapView extends StatelessWidget {
               // state.
               var dominant = ActivityPinState.locked;
               for (final m in markers) {
-                final s = render.clusterStateByPoint[m.point];
+                final s = clusterStateByPoint[m.point];
                 if (s != null && s.index > dominant.index) dominant = s;
               }
               return Semantics(
                 button: true,
                 label: '${markers.length} ${L10n.of(context).activities}',
                 excludeSemantics: true,
-                child: _clusterBubble(context, markers.length, dominant),
+                child: WorldMapClusterBubble(
+                  count: markers.length,
+                  dominant: dominant,
+                ),
               );
             },
           ),
@@ -300,6 +439,7 @@ class WorldMapView extends StatelessWidget {
             l2Only: controller.l2Only,
             l2Label: l2?.toUpperCase(),
             onToggleL2: controller.toggleL2,
+            onWidenSearch: () => controller.resetFilters(l2Only: false),
             selectedCefr: controller.cefrFilter,
             onToggleCefr: controller.toggleCefr,
             selectedCompletion: controller.completionFilter,
@@ -315,321 +455,45 @@ class WorldMapView extends StatelessWidget {
       ],
     );
   }
+}
 
-  /// Resolve the per-frame pin draw model: the visible set, and for each pin its
-  /// tier / colour-state / pinged / fill, plus the cluster dominant-state lookup.
-  /// Applies the progression gate (a pin whose objectives are all locked reads
-  /// locked, unless it already has an open joinable session) and the relevance
-  /// ranking that assigns tiers, both rebuilt each frame from the controller's
-  /// cached signals + stars so a star award re-gates next build. Records the
-  /// featured-pool size on the controller for its rotation timer. See
-  /// world-map.instructions.md.
-  _PinRender _resolvePinRender(BuildContext context) {
-    final visible = controller.visiblePins;
-    // Auto-featured large cards render only where there is horizontal room
-    // (desktop / column mode); a promoted card renders at any width.
-    final desktop = FluffyThemes.isColumnMode(context);
+/// The on-map zoom controls (#7086): a small bottom-right stack with a World
+/// reset (the one obvious "zoom out to everything", since pins/clusters/search
+/// only ever zoom the camera IN) and +/- zoom steps. Camera-only — it never
+/// changes the open panels or the course scope.
+class _MapZoomControls extends StatelessWidget {
+  final WorldMapController controller;
 
-    final gate = buildLoGate(
-      outlines: controller.objectiveCache.outlines,
-      starsByActivity: controller.userStars,
-    );
-    final signals = <String, PinSignals>{};
-    for (final card in visible) {
-      final base = controller.signals[card.activityId] ?? const PinSignals();
-      signals[card.activityId] =
-          (base.state != ActivityPinState.joinable &&
-              gate.isPinLocked(card.learningObjectiveRefs))
-          ? PinSignals(
-              state: ActivityPinState.locked,
-              completionFraction: base.completionFraction,
-              pinged: base.pinged,
-              recency: base.recency,
-            )
-          : base;
-    }
+  const _MapZoomControls({required this.controller});
 
-    // Rank only the in-view pins (camera bounds when available) so promotion
-    // reflects what the learner is looking at.
-    List<QuestActivityCard> inView = visible;
-    try {
-      final bounds = controller.mapController.camera.visibleBounds;
-      inView = visible
-          .where((c) => c.point != null && bounds.contains(c.point!))
-          .toList();
-    } catch (_) {
-      // Camera not ready; rank the full filtered set.
-    }
-    final user = MatrixState.pangeaController.userController;
-    final ranking = rankPins(
-      inViewPins: inView,
-      userL2: user.userL2Code,
-      userCefr: user.userCefrLevel,
-      joinedObjectiveIds: controller.objectiveCache.ids,
-      signals: signals,
-    );
-    // Record the pool size so the controller's rotation timer knows whether
-    // there are more featured candidates than the budget (and should rotate).
-    controller.largePoolSize = ranking.largePool.length;
-    // The large featured cards (desktop only): a rotating window over the
-    // joinable pool; pool members not currently featured render at mid weight.
-    final largeWindow = <String>{};
-    if (desktop && ranking.largePool.isNotEmpty) {
-      final n = min(WorldMapController.largeBudget, ranking.largePool.length);
-      for (var i = 0; i < n; i++) {
-        largeWindow.add(
-          ranking.largePool[(controller.largeRotationIndex + i) %
-              ranking.largePool.length],
-        );
-      }
-    }
-
-    PinTier tierOf(String id) {
-      // A tapped small/mid pin is promoted to its large card in place.
-      if (id == controller.promotedActivityId) return PinTier.large;
-      if (largeWindow.contains(id)) return PinTier.large;
-      if (ranking.largePool.contains(id) || ranking.midIds.contains(id)) {
-        return PinTier.mid;
-      }
-      return PinTier.small;
-    }
-
-    ActivityPinState stateOf(String id) =>
-        signals[id]?.state ?? ActivityPinState.unlocked;
-    bool pingedOf(String id) => signals[id]?.pinged ?? false;
-    // The progress fill renders only on unlocked pins (the unlocked→finished
-    // gradation); joinable and locked carry no fill.
-    double fillOf(String id) {
-      final s = signals[id];
-      if (s == null || s.state != ActivityPinState.unlocked) return 0;
-      return s.completionFraction;
-    }
-
-    return _PinRender(
-      visible: visible,
-      tierOf: tierOf,
-      stateOf: stateOf,
-      pingedOf: pingedOf,
-      fillOf: fillOf,
-      clusterStateByPoint: <LatLng, ActivityPinState>{
-        for (final c in visible)
-          if (c.point != null) c.point!: stateOf(c.activityId),
-      },
-    );
-  }
-
-  /// The clustered small/mid pins (large cards render unclustered above). Skips
-  /// pins with no point and any promoted-to-large pin.
-  List<Marker> _clusterMarkers(_PinRender render) => render.visible
-      .map((card) {
-        final point = card.point;
-        if (point == null) return null;
-        final tier = render.tierOf(card.activityId);
-        if (tier == PinTier.large) return null; // rendered unclustered above
-        final state = render.stateOf(card.activityId);
-        return tier == PinTier.mid
-            ? _midPinMarker(
-                card,
-                point,
-                state,
-                render.pingedOf(card.activityId),
-                render.fillOf(card.activityId),
-              )
-            : _smallDotMarker(
-                card,
-                point,
-                state,
-                render.fillOf(card.activityId),
-              );
-      })
-      .whereType<Marker>()
-      .toList();
-
-  /// The 1–3 large featured cards (desktop) plus any tap-promoted card, rendered
-  /// unclustered so they're always visible.
-  List<Marker> _largeMarkers(_PinRender render) => render.visible
-      .where(
-        (c) => c.point != null && render.tierOf(c.activityId) == PinTier.large,
-      )
-      .map(
-        (card) => _largeCardMarker(
-          card,
-          card.point!,
-          render.stateOf(card.activityId),
-          render.pingedOf(card.activityId),
-        ),
-      )
-      .toList();
-
-  /// The clustered-pins bubble (Google-Maps grouping), coloured by the cluster's
-  /// dominant state so a cluster with an open session reads green.
-  Widget _clusterBubble(
-    BuildContext context,
-    int count,
-    ActivityPinState dominant,
-  ) {
-    return Container(
-      decoration: BoxDecoration(
-        color: _stateColor(dominant),
-        shape: BoxShape.circle,
-        border: Border.all(color: Colors.white, width: 2),
-        boxShadow: const [BoxShadow(blurRadius: 4, color: Colors.black38)],
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        '$count',
-        style: const TextStyle(
-          color: Colors.white,
-          fontWeight: FontWeight.bold,
-          fontSize: 13,
-        ),
-      ),
-    );
-  }
-
-  /// Small tier: a plain state-coloured dot (the long tail), with the gold
-  /// progress fill. No glyph.
-  Marker _smallDotMarker(
-    QuestActivityCard card,
-    LatLng point,
-    ActivityPinState state,
-    double fill,
-  ) {
-    return Marker(
-      // Carries the activity id for the cluster layer's onMarkerTap (#7072).
-      key: ValueKey(card.activityId),
-      point: point,
-      width: 18,
-      height: 18,
-      child: Tooltip(
-        message: card.title,
-        // Semantics below names the pin; exclude the Tooltip so the title isn't
-        // announced twice ("<title> <title>"). See accessibility.instructions.md.
-        excludeFromSemantics: true,
-        child: Semantics(
-          button: true,
-          label: card.title,
-          excludeSemantics: true,
-          child: GestureDetector(
-            onTap: () => controller.promoteToLarge(card),
-            child: _stateDot(
-              state: state,
-              diameter: 18,
-              borderWidth: 1.5,
-              fill: fill,
-            ),
+  @override
+  Widget build(BuildContext context) {
+    final l10n = L10n.of(context);
+    final theme = Theme.of(context);
+    return Material(
+      elevation: 2.0,
+      color: theme.colorScheme.surface,
+      borderRadius: BorderRadius.circular(8.0),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.public),
+            tooltip: l10n.world,
+            onPressed: controller.resetToWorld,
           ),
-        ),
-      ),
-    );
-  }
-
-  /// Mid tier: a state-coloured pin with an activity glyph and the gold progress
-  /// fill, plus a hand badge when the open session has been pinged.
-  Marker _midPinMarker(
-    QuestActivityCard card,
-    LatLng point,
-    ActivityPinState state,
-    bool pinged,
-    double fill,
-  ) {
-    return Marker(
-      // Carries the activity id for the cluster layer's onMarkerTap (#7072).
-      key: ValueKey(card.activityId),
-      point: point,
-      width: 44,
-      height: 44,
-      child: Tooltip(
-        message: card.title,
-        // Semantics below names the pin; exclude the Tooltip so the title isn't
-        // announced twice ("<title> <title>").
-        excludeFromSemantics: true,
-        child: Semantics(
-          button: true,
-          label: card.title,
-          excludeSemantics: true,
-          child: GestureDetector(
-            onTap: () => controller.promoteToLarge(card),
-            child: Stack(
-              clipBehavior: Clip.none,
-              alignment: Alignment.center,
-              children: [
-                _stateDot(
-                  state: state,
-                  diameter: 36,
-                  borderWidth: 2,
-                  fill: fill,
-                  glyph: const Icon(
-                    Icons.chat_bubble_outline,
-                    size: 18,
-                    color: Colors.white,
-                  ),
-                ),
-                if (pinged)
-                  Positioned(
-                    top: -2,
-                    right: -2,
-                    child: Container(
-                      padding: const EdgeInsets.all(2),
-                      decoration: const BoxDecoration(
-                        color: Colors.white,
-                        shape: BoxShape.circle,
-                      ),
-                      child: const Icon(
-                        Icons.back_hand,
-                        size: 12,
-                        color: Color(0xFF34A853),
-                      ),
-                    ),
-                  ),
-              ],
-            ),
+          Divider(height: 1.0, color: theme.colorScheme.outlineVariant),
+          IconButton(
+            icon: const Icon(Icons.add),
+            tooltip: l10n.zoomIn,
+            onPressed: () => controller.zoomBy(1),
           ),
-        ),
-      ),
-    );
-  }
-
-  /// Large tier: the rich featured card (Figma `… Large`). The full plan (image +
-  /// goal total) hydrates on demand for the few featured activities; the
-  /// joinable form also shows the session's participants (via [joinableInfo]).
-  /// See [WorldMapLargeCard] and world-map.instructions.md.
-  Marker _largeCardMarker(
-    QuestActivityCard card,
-    LatLng point,
-    ActivityPinState state,
-    bool pinged,
-  ) {
-    final client = controller.client;
-    // Hydrate the full plan for this featured card (no-op once cached); the
-    // repo listener rebuilds the map when it lands.
-    ActivityPlanRepo.instance.ensure(card.activityId);
-    final plan = ActivityPlanRepo.instance.cachedPlan(card.activityId);
-    final joinable = state == ActivityPinState.joinable;
-    final info = (joinable && client != null)
-        ? joinableInfo(client, card.activityId)
-        : (participants: const <LargeCardParticipant>[], openSlots: 0);
-    return Marker(
-      point: point,
-      width: 260,
-      // The inner Align lets the card hug its own content (each state is a
-      // different height: locked has no star row, completed adds an action row,
-      // joinable adds the avatar row). Height here is only a ceiling so the
-      // tallest variant isn't clipped; shorter cards don't stretch to fill it.
-      height: joinable ? 184 : 150,
-      alignment: Alignment.topCenter,
-      child: Align(
-        alignment: Alignment.topCenter,
-        child: WorldMapLargeCard(
-          card: card,
-          state: state,
-          pinged: pinged,
-          plan: plan,
-          starsEarned: controller.userStars[card.activityId] ?? 0,
-          participants: info.participants,
-          openSlots: info.openSlots,
-          onTap: () => controller.openActivity(card),
-        ),
+          IconButton(
+            icon: const Icon(Icons.remove),
+            tooltip: l10n.zoomOut,
+            onPressed: () => controller.zoomBy(-1),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Widen search" option in the world map search interface to adjust filter scope
  * Improved clustered activity pin visualization on the world map
  * Enhanced world map pin indicators with better visual state representation and styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->