### PR TITLE
fix(activity): activity page resolves to error instead of loading forever when a CMS read stalls (#7085)

### DIFF
--- a/lib/features/course_plans/payload_client/payload_client.dart
+++ b/lib/features/course_plans/payload_client/payload_client.dart
@@ -10,7 +10,21 @@ class PayloadClient {
   final String accessToken;
   final String basePath = "/cms/api";
 
-  PayloadClient({required this.baseUrl, required this.accessToken});
+  /// Optional injected HTTP client (tests pass a MockClient to drive timeouts).
+  /// Null in production so reads use the package's top-level helper — a
+  /// PayloadClient is created per call, so there is no client to leak.
+  final http.Client? _httpClient;
+
+  /// How long a read may take before it is treated as a stalled connection and
+  /// throws. Overridable so a test can assert the bound without a real wait.
+  final Duration readTimeout;
+
+  PayloadClient({
+    required this.baseUrl,
+    required this.accessToken,
+    http.Client? httpClient,
+    this.readTimeout = const Duration(seconds: 30),
+  }) : _httpClient = httpClient;
 
   Map<String, String> get _headers {
     final headers = {
@@ -24,7 +38,15 @@ class PayloadClient {
   /// Generic GET request
   Future<http.Response> _get(String endpoint) async {
     final url = Uri.parse('$baseUrl$endpoint');
-    final response = await http.get(url, headers: _headers);
+    // Bound the read: a stalled connection (opened but never completing) must
+    // throw instead of hanging the caller forever. Un-timed CMS reads here left
+    // activity/course resolvers spinning with no error and no activity (#7085,
+    // #7159, #7080); on timeout the caller's existing error handling takes over.
+    final client = _httpClient;
+    final request = client == null
+        ? http.get(url, headers: _headers)
+        : client.get(url, headers: _headers);
+    final response = await request.timeout(readTimeout);
     return response;
   }
 

--- a/lib/routes/chat/activity_sessions/activity_session_start_page.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_start_page.dart
@@ -127,7 +127,12 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
         loading = true;
         error = null;
       });
-      await Future.wait([_loadSummary(), _loadActivity()]);
+      // Gate `loading` on the bounded activity fetch ALONE, so the page always
+      // resolves to the activity or the not-found error. The room summaries are
+      // non-essential to that render and their fetch can stall, so they load as
+      // a self-catching side-effect (below) that must never wedge the spinner
+      // (#7085, #7159).
+      await _loadActivity();
     } catch (e, s) {
       error = e;
       ErrorHandler.logError(
@@ -144,9 +149,14 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
         setState(() => loading = false);
       }
     }
+    // Refresh summary-derived UI (member counts, role availability) when it
+    // lands; never awaited, so a slow or stalled summary fetch cannot block the
+    // activity-or-error render.
+    if (mounted) unawaited(_loadSummary());
   }
 
   Future<void> _loadSummary() async {
+    if (!mounted) return;
     final Set<String> roomIds = {};
     if (widget.roomId != null) {
       roomIds.add(widget.roomId!);
@@ -160,16 +170,30 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
     }
 
     if (roomIds.isEmpty) return;
-    final roomSummariesResponse = await Matrix.of(context).client
-        .loadRoomSummaries(
-          roomIds.toList(),
-          l1Code: MatrixState.pangeaController.userController.userL1Code,
+    try {
+      final roomSummariesResponse = await Matrix.of(context).client
+          .loadRoomSummaries(
+            roomIds.toList(),
+            l1Code: MatrixState.pangeaController.userController.userL1Code,
+          )
+          .timeout(const Duration(seconds: 30));
+      if (!mounted) return;
+      setState(() {
+        _roomSummariesModel = ActivitySessionSummariesModel(
+          roomSummariesResponse,
+          activityId: widget.activityId,
         );
-
-    _roomSummariesModel = ActivitySessionSummariesModel(
-      roomSummariesResponse,
-      activityId: widget.activityId,
-    );
+      });
+    } catch (e, s) {
+      // Summaries are non-essential (member counts / role availability); a slow
+      // or stalled /room_preview must not block or fail the activity render, so
+      // degrade to the empty model initialized in initState (#7085, #7159).
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"activityId": widget.activityId},
+      );
+    }
   }
 
   Future<void> _loadActivity() async {

--- a/lib/routes/world/activity_detail_panel.dart
+++ b/lib/routes/world/activity_detail_panel.dart
@@ -79,12 +79,19 @@ class _ActivityDetailPanelState extends State<ActivityDetailPanel> {
     }
     // No course selected (e.g. opened from World): find a joined course that
     // includes this activity. Null L2 skips the language filter.
+    //
+    // Bounded: matchingCourseSpaces reads each joined course's quest outline
+    // from the CMS, and those reads are sequential within a course, so a slow
+    // or stalled backend could leave this resolve spinner up far longer than a
+    // user will wait (#7085, #7159). A miss just means the activity opens
+    // unscoped, so cap the whole resolve and fall through on timeout. Mirrors
+    // launch_activity_session's bound on the same call.
     try {
       final spaces = await ActivityCourseResolver.matchingCourseSpaces(
         Matrix.of(context).client,
         widget.activityId,
         null,
-      );
+      ).timeout(const Duration(seconds: 10));
       if (!mounted) return;
       setState(() {
         _parentId = spaces.firstOrNull?.id;

--- a/test/pangea/payload_client_timeout_test.dart
+++ b/test/pangea/payload_client_timeout_test.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 

--- a/test/pangea/payload_client_timeout_test.dart
+++ b/test/pangea/payload_client_timeout_test.dart
@@ -1,0 +1,45 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:fluffychat/features/course_plans/payload_client/payload_client.dart';
+
+void main() {
+  // A stalled CMS read (connection opened but the response never arrives) must
+  // time out and throw, not hang the caller forever. Un-timed reads here left
+  // the activity/course resolvers spinning with no error and no activity
+  // (#7085, #7159, #7080). A tiny readTimeout keeps the test fast.
+  group('PayloadClient bounds a stalled read', () {
+    PayloadClient clientThatNeverResponds() => PayloadClient(
+      baseUrl: 'https://cms.example.test',
+      accessToken: 'token',
+      // Never completes the response — simulates an open-but-stalled connection.
+      httpClient: MockClient((_) => Completer<http.Response>().future),
+      readTimeout: const Duration(milliseconds: 50),
+    );
+
+    test('findById throws TimeoutException instead of hanging', () {
+      expect(
+        clientThatNeverResponds().findById<Map<String, dynamic>>(
+          'quests',
+          'missing',
+          (j) => j,
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+
+    test('find throws TimeoutException instead of hanging', () {
+      expect(
+        clientThatNeverResponds().find<Map<String, dynamic>>(
+          'quests',
+          (j) => j,
+        ),
+        throwsA(isA<TimeoutException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #7085. Also fixes #7159 (same symptom: activities opened from the map stuck loading).

## Problem

Opening an activity from the map loaded indefinitely (an infinite spinner that never resolved to the activity or to the "activity not found" error). The standalone `/<activityId>` route and the in-course `?activity=` overlay both resolved correctly; only the map-pin entry hung.

## Root cause (two un-timed hang vectors on the map path)

A root-cause investigation (parallel readers + an adversarial verifier) found the map entry has two un-bounded waits that the other entries skip:

1. **Outer gate.** A map pin strips the `?m=course:` scope, so `ActivityDetailPanel._resolveParent` runs `ActivityCourseResolver.matchingCourseSpaces`, which `Future.wait`s over per-course `QuestRepo.outline` reads. Each read ends at `PayloadClient._get`, which did `http.get` with **no timeout**. A stalled CMS connection (opened but never completing) leaves that `Future.wait` pending forever, so the panel's resolve-spinner never clears and the start page never even mounts. (Notably `launch_activity_session.dart` already wraps the same call in `.timeout(10s)` — the panel's un-timed call was the inconsistency.)

2. **Inner gate.** Once mounted, `ActivitySessionStartState._load` gated `loading` on `Future.wait([_loadSummary(), _loadActivity()])`. `_loadActivity` is bounded, but `_loadSummary` (`loadRoomSummaries` → `/room_preview`) was un-timed, and the map entry is the only one that populates a non-empty room set, so a stalled summary kept `loading` true forever — the not-found error sat ready on the already-resolved activity branch but never showed.

## Fix

- **Bound CMS reads at the root:** `PayloadClient._get` now `.timeout`s (default 30s; injectable). A stalled read throws instead of hanging, so the resolver's per-course `try/catch` degrades that course gracefully and the page mounts. This also bounds the same hang class behind #7080.
- **Decouple the inner gate:** `_load` now gates `loading` on `_loadActivity()` alone, so the page always resolves to the activity or the not-found error. Summaries load as a self-catching, timed, non-blocking side-effect that refreshes the view when they land — they can never wedge the spinner.

Both working paths are unchanged: standalone still skips summaries (empty room set), in-course still short-circuits the parent resolve, and both still surface `activityNotFound` via the unchanged `_loadActivity` throw.

## Verification

- `payload_client_timeout_test.dart`: a stalled read (a `MockClient` that never responds) makes `find`/`findById` throw `TimeoutException` instead of hanging.
- Analyze / format / import_sorter clean; nav + course/activity unit suites pass.
- Honest limitation: the live stall (an open-but-never-completing connection) cannot be reproduced in the local client, where the CMS returns a fast 403 rather than stalling. I verified locally that the activity paths resolve to the not-found error (the fast-error case), and the timeout behavior is pinned by the unit test and matches the existing `launch_activity_session` precedent.

## TO TEST
- [ ] Open an activity from the map
- [ ] Confirm it resolves to the activity or the "activity not found" error, and never spins indefinitely
- [ ] Confirm the standalone activity link and an in-course activity still open correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network requests now timeout after 30 seconds (configurable) to prevent indefinite hangs
  * Activity loading no longer waits for room summary updates, improving perceived load speed
  * Enhanced error handling for network failures with graceful fallbacks

* **Tests**
  * Added timeout behavior test coverage for network requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->