### PR TITLE
feat(activities): match goal stars on goal_slug + honor pinned version on read

### DIFF
--- a/lib/features/activity_sessions/activity_plan_fetch_request.dart
+++ b/lib/features/activity_sessions/activity_plan_fetch_request.dart
@@ -1,23 +1,31 @@
 import 'package:fluffychat/pangea/common/utils/base_request.dart';
 
 /// Request for a single localized activity plan from the choreographer
-/// (`GET /choreo/v2/activity/{activity_id}?l1=`).
+/// (`GET /choreo/v2/activity/{activity_id}?l1=&version=`).
 ///
-/// Keyed by `(activity_id, l1)`: the plan body is localized per viewer L1, so
-/// two L1-different viewers of the same activity must not collide on cache.
-/// `version` is not sent — the choreo `version` query param is an int Payload
-/// version while the pinned `version_id` is a timestamp; version-pinned reads
-/// are a choreo follow-up, so this reads the latest. See
-/// activities.instructions.md.
+/// Keyed by `(activity_id, l1, version)`: the plan body is localized per viewer
+/// L1, so two L1-different viewers must not collide on cache; and a session
+/// pins a `version` (an opaque content-signature), so the pinned read must not
+/// collide with the latest read. `version` is sent only when pinning; omit it
+/// to read the latest. See activities.instructions.md.
 class ActivityPlanFetchRequest extends BaseRequest {
   final String activityId;
   final String l1;
+  final String? version;
 
-  ActivityPlanFetchRequest({required this.activityId, required this.l1});
+  ActivityPlanFetchRequest({
+    required this.activityId,
+    required this.l1,
+    this.version,
+  });
 
   @override
-  String get storageKey => '${activityId}_$l1';
+  String get storageKey => '${activityId}_${l1}_${version ?? ''}';
 
   @override
-  Map<String, dynamic> toJson() => {'activity_id': activityId, 'l1': l1};
+  Map<String, dynamic> toJson() => {
+    'activity_id': activityId,
+    'l1': l1,
+    if (version != null) 'version': version,
+  };
 }

--- a/lib/features/activity_sessions/activity_plan_fetch_response.dart
+++ b/lib/features/activity_sessions/activity_plan_fetch_response.dart
@@ -14,12 +14,16 @@ class ActivityPlanFetchResponse extends BaseResponse {
   final String? l1;
   final String? versionId;
   final bool usedFallback;
+  // True when the pinned version was unavailable (evicted) and the latest was
+  // served instead. Distinct from [usedFallback] (an L1-translation miss).
+  final bool usedFallbackVersion;
 
   ActivityPlanFetchResponse({
     required this.rawPlan,
     this.l1,
     this.versionId,
     this.usedFallback = false,
+    this.usedFallbackVersion = false,
   });
 
   /// The plan body mapped into the client model (media `upload_id`s unresolved).
@@ -36,6 +40,7 @@ class ActivityPlanFetchResponse extends BaseResponse {
       l1: json['l1'] as String?,
       versionId: json['version_id'] as String?,
       usedFallback: json['used_fallback'] == true,
+      usedFallbackVersion: json['used_fallback_version'] == true,
     );
   }
 
@@ -45,5 +50,6 @@ class ActivityPlanFetchResponse extends BaseResponse {
     'l1': l1,
     'version_id': versionId,
     'used_fallback': usedFallback,
+    'used_fallback_version': usedFallbackVersion,
   };
 }

--- a/lib/features/activity_sessions/activity_plan_model.dart
+++ b/lib/features/activity_sessions/activity_plan_model.dart
@@ -367,22 +367,40 @@ class ActivityRole {
 
 class ActivityRoleGoal {
   final String id;
+  // Content-derived award identity from the choreo plan. The bot awards stars
+  // on this (the Payload `id` re-mints on every edit), so star rendering keys
+  // on it with an `id` fallback during the migration window. Null on
+  // legacy/unmigrated goals.
+  final String? goalSlug;
   final String description;
 
-  const ActivityRoleGoal({required this.id, required this.description});
+  const ActivityRoleGoal({
+    required this.id,
+    required this.description,
+    this.goalSlug,
+  });
 
-  Map<String, dynamic> toJson() => {"id": id, "description": description};
+  Map<String, dynamic> toJson() => {
+    "id": id,
+    if (goalSlug != null) "goal_slug": goalSlug,
+    "description": description,
+  };
 
   factory ActivityRoleGoal.fromJson(Map<String, dynamic> json) =>
-      ActivityRoleGoal(id: json["id"], description: json["description"]);
+      ActivityRoleGoal(
+        id: json["id"],
+        goalSlug: json["goal_slug"] as String?,
+        description: json["description"],
+      );
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is ActivityRoleGoal &&
           id == other.id &&
+          goalSlug == other.goalSlug &&
           description == other.description;
 
   @override
-  int get hashCode => id.hashCode ^ description.hashCode;
+  int get hashCode => id.hashCode ^ goalSlug.hashCode ^ description.hashCode;
 }

--- a/lib/features/activity_sessions/activity_plan_repo.dart
+++ b/lib/features/activity_sessions/activity_plan_repo.dart
@@ -51,17 +51,29 @@ class ActivityPlanRepo
 
   @override
   Future<Response> fetch(Requests req, ActivityPlanFetchRequest request) {
-    final uri = Uri.parse(
-      PApiUrls.activityById(request.activityId),
-    ).replace(queryParameters: {if (request.l1.isNotEmpty) 'l1': request.l1});
+    final uri = Uri.parse(PApiUrls.activityById(request.activityId)).replace(
+      queryParameters: {
+        if (request.l1.isNotEmpty) 'l1': request.l1,
+        // The session's pinned content-signature; omitted for discovery reads,
+        // which want the latest.
+        if (request.version != null) 'version': request.version!,
+      },
+    );
     return req.get(url: uri.toString());
   }
 
   String get _viewerL1 =>
       MatrixState.pangeaController.userController.userL1Code ?? 'en';
 
-  ActivityPlanFetchRequest _request(String activityId, String? l1) =>
-      ActivityPlanFetchRequest(activityId: activityId, l1: l1 ?? _viewerL1);
+  ActivityPlanFetchRequest _request(
+    String activityId,
+    String? l1, {
+    String? version,
+  }) => ActivityPlanFetchRequest(
+    activityId: activityId,
+    l1: l1 ?? _viewerL1,
+    version: version,
+  );
 
   /// The plan for [activityId], localized to [l1] (viewer L1 by default), with
   /// media resolved. Cached (TTL + in-flight dedup); null on fetch failure.
@@ -70,9 +82,10 @@ class ActivityPlanRepo
   Future<ActivityPlanModel?> getPlan(
     String activityId, {
     String? l1,
+    String? version,
     bool forceRefresh = false,
   }) async {
-    final request = _request(activityId, l1);
+    final request = _request(activityId, l1, version: version);
     final result = await get(request, forceRefresh: forceRefresh);
     final response = result.result;
     if (response == null) return null;
@@ -87,8 +100,8 @@ class ActivityPlanRepo
   /// [getPlan] has run, else the raw (TTL-checked) cached plan, else null — in
   /// which case the caller should [ensure]. Drops the resolved entry when the
   /// underlying TTL'd cache has expired so it can't outlive it.
-  ActivityPlanModel? cachedPlan(String activityId, {String? l1}) {
-    final request = _request(activityId, l1);
+  ActivityPlanModel? cachedPlan(String activityId, {String? l1, String? version}) {
+    final request = _request(activityId, l1, version: version);
     final raw = getCached(request);
     if (raw == null) {
       _resolved.remove(request.storageKey);
@@ -109,8 +122,13 @@ class ActivityPlanRepo
   /// does NOT revalidate (one fetch per visible pin would be a fetch storm).
   /// Stale-while-revalidate: [cachedPlan] keeps serving the old plan until the
   /// fresh one lands, so there is no loading flicker.
-  void ensure(String activityId, {String? l1, bool revalidate = false}) {
-    final key = _request(activityId, l1).storageKey;
+  void ensure(
+    String activityId, {
+    String? l1,
+    String? version,
+    bool revalidate = false,
+  }) {
+    final key = _request(activityId, l1, version: version).storageKey;
     if (_hydrating.contains(key)) return;
     final doRevalidate = revalidate && _revalidated.add(key);
     if (!doRevalidate && _resolved.containsKey(key)) return;
@@ -118,6 +136,7 @@ class ActivityPlanRepo
     getPlan(
       activityId,
       l1: l1,
+      version: version,
       forceRefresh: doRevalidate,
     ).whenComplete(() => _hydrating.remove(key));
   }

--- a/lib/features/activity_sessions/activity_room_extension.dart
+++ b/lib/features/activity_sessions/activity_room_extension.dart
@@ -23,12 +23,15 @@ extension ActivityRoomExtension on Room {
     if (stateEvent == null) return null;
     final content = stateEvent.content;
 
-    // Reference shape carries no embedded plan body (no `req`); hydrate it.
+    // Reference shape carries no embedded plan body (no `req`); hydrate it,
+    // pinned to the version this session was started on so an owner edit can't
+    // change the rendered plan mid-session.
     if (content[ActivitySessionConstants.activityPlanRequest] == null) {
       final referenceId = _referencePlanActivityId(content);
       if (referenceId == null) return null;
-      ActivityPlanRepo.instance.ensure(referenceId);
-      return ActivityPlanRepo.instance.cachedPlan(referenceId);
+      final version = content[ActivitySessionConstants.versionId] as String?;
+      ActivityPlanRepo.instance.ensure(referenceId, version: version);
+      return ActivityPlanRepo.instance.cachedPlan(referenceId, version: version);
     }
 
     try {
@@ -42,6 +45,12 @@ extension ActivityRoomExtension on Room {
       return null;
     }
   }
+
+  /// The content-signature this session pinned at creation (from the
+  /// `pangea.activity_plan` state event), or null for a legacy/embedded room.
+  String? get pinnedActivityVersionId =>
+      getState(PangeaEventTypes.activityPlan)?.content[ActivitySessionConstants
+          .versionId] as String?;
 
   /// activity_id of a reference plan: the room-type suffix
   /// (`PangeaRoomTypes.activitySession:<activity_id>`) is authoritative, with

--- a/lib/features/quests/repo/activity_v2_mapper.dart
+++ b/lib/features/quests/repo/activity_v2_mapper.dart
@@ -42,6 +42,9 @@ ActivityPlanModel activityPlanFromV2(Map<String, dynamic> doc) {
             // back to the goal text, which is stable and distinct within a role,
             // so goal-completion keying still works the same way per session.
             id: (g['id'] ?? g['goal'] ?? '') as String,
+            // Content-derived award identity; the bot awards on this so stars
+            // survive owner edits. Null on legacy/unmigrated goals.
+            goalSlug: g['goal_slug'] as String?,
             description: (g['goal'] ?? '') as String,
           ),
         )

--- a/lib/routes/chat/activity_sessions/activity_stats_menu.dart
+++ b/lib/routes/chat/activity_sessions/activity_stats_menu.dart
@@ -179,6 +179,7 @@ class ActivityStatsMenu extends StatelessWidget {
                                       goal: visibleGoal,
                                       complete: room.isOwnGoalCompleted(
                                         visibleGoal.id,
+                                        goalSlug: visibleGoal.goalSlug,
                                       ),
                                       starTarget:
                                           ActivitySessionConstants.goalMenuStarTargetId(
@@ -272,7 +273,10 @@ class ActivityStatsMenu extends StatelessWidget {
                                 .map(
                                   (g) => GoalStatusWidget(
                                     goal: g,
-                                    complete: room.isOwnGoalCompleted(g.id),
+                                    complete: room.isOwnGoalCompleted(
+                                      g.id,
+                                      goalSlug: g.goalSlug,
+                                    ),
                                   ),
                                 )
                                 .toList(),

--- a/lib/routes/chat/activity_sessions/select_role_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/select_role_session_controller.dart
@@ -169,6 +169,10 @@ class SelectRoleSessionController extends State<SelectRoleSession>
   }
 
   Future<void> confirmRoleSelection() async {
+    // Idempotency guard: a fast double-tap (before the loading dialog mounts)
+    // would otherwise create two session rooms with two independent version
+    // pins. The `_confirmed` flag was set here but never read.
+    if (_confirmed) return;
     setState(() => _confirmed = true);
     final activity = widget.activity;
     if (activity == null) {

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -949,7 +949,14 @@ class ChatController extends State<ChatPageWithRoom>
     // so the visible plan never flickers.
     final activitySessionId = room.activityId;
     if (activitySessionId != null) {
-      ActivityPlanRepo.instance.ensure(activitySessionId, revalidate: true);
+      // Revalidate pinned to the session's version: this refreshes the
+      // re-translation of the pinned version (goal text / role names) without
+      // pulling newer canonical content into a live pinned session.
+      ActivityPlanRepo.instance.ensure(
+        activitySessionId,
+        version: room.pinnedActivityVersionId,
+        revalidate: true,
+      );
     }
 
     _goalCompletionSubscription?.cancel();

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_awarded_goals.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_awarded_goals.dart
@@ -18,9 +18,20 @@ class OrchestratorAwardedGoals {
     this.legacyFlatGoalIds = const [],
   });
 
-  bool isGoalCompletedForRole(String roleId, String goalId) =>
-      (awards[roleId]?.contains(goalId) ?? false) ||
-      legacyFlatGoalIds.contains(goalId);
+  /// Whether [roleId] has completed the goal. Matches on [goalSlug] first —
+  /// the bot now awards on the content-derived slug, which survives owner
+  /// edits — then falls back to the Payload [goalId] so awards written before
+  /// the slug cutover still render during the migration window.
+  bool isGoalCompletedForRole(String roleId, String goalId, {String? goalSlug}) {
+    final roleAwards = awards[roleId];
+    if (goalSlug != null &&
+        ((roleAwards?.contains(goalSlug) ?? false) ||
+            legacyFlatGoalIds.contains(goalSlug))) {
+      return true;
+    }
+    return (roleAwards?.contains(goalId) ?? false) ||
+        legacyFlatGoalIds.contains(goalId);
+  }
 
   static OrchestratorAwardedGoals fromJson(Map<String, dynamic> json) {
     if (json["awards"] == null && json["goal_ids"] != null) {

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart
@@ -14,15 +14,16 @@ extension OrchestratorClientExtension on Client {
     if (activityId == null) return {};
     final role = activity?.roles[roleId];
     if (role == null) return {};
-    final roleGoalIds = role.allGoals.map((g) => g.id).toSet();
     final completed = <String>{};
     for (final room in rooms) {
       if (room.activityId != activityId) continue;
       if (room.ownRoleState?.id != roleId) continue;
       final awarded = room.orchestratorAwardedGoals;
-      completed.addAll(
-        roleGoalIds.where((id) => awarded.isGoalCompletedForRole(roleId, id)),
-      );
+      for (final g in role.allGoals) {
+        if (awarded.isGoalCompletedForRole(roleId, g.id, goalSlug: g.goalSlug)) {
+          completed.add(g.id);
+        }
+      }
     }
     return completed;
   }

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart
@@ -26,14 +26,22 @@ extension OrchestratorRoomExtension on Room {
 
     final awarded = orchestratorAwardedGoals;
     return goals.firstWhereOrNull(
-      (g) => !awarded.isGoalCompletedForRole(ownRole.id, g.id),
+      (g) => !awarded.isGoalCompletedForRole(
+        ownRole.id,
+        g.id,
+        goalSlug: g.goalSlug,
+      ),
     );
   }
 
-  bool isOwnGoalCompleted(String id) {
+  bool isOwnGoalCompleted(String id, {String? goalSlug}) {
     final ownRole = this.ownRole;
     if (ownRole == null) return false;
-    return orchestratorAwardedGoals.isGoalCompletedForRole(ownRole.id, id);
+    return orchestratorAwardedGoals.isGoalCompletedForRole(
+      ownRole.id,
+      id,
+      goalSlug: goalSlug,
+    );
   }
 
   bool get hasCompletedOwnGoals {
@@ -47,7 +55,9 @@ extension OrchestratorRoomExtension on Room {
     if (role == null) return false;
     final goals = role.allGoals;
     final awarded = orchestratorAwardedGoals;
-    return goals.every((g) => awarded.isGoalCompletedForRole(roleId, g.id));
+    return goals.every(
+      (g) => awarded.isGoalCompletedForRole(roleId, g.id, goalSlug: g.goalSlug),
+    );
   }
 
   List<ActivityRoleGoal> get ownCompletedGoals {
@@ -57,7 +67,13 @@ extension OrchestratorRoomExtension on Room {
     final ownGoals = ownRole.allGoals;
     final awarded = orchestratorAwardedGoals;
     return ownGoals
-        .where((g) => awarded.isGoalCompletedForRole(ownRole.id, g.id))
+        .where(
+          (g) => awarded.isGoalCompletedForRole(
+            ownRole.id,
+            g.id,
+            goalSlug: g.goalSlug,
+          ),
+        )
         .toList();
   }
 

--- a/test/pangea/orchestrator_awarded_goals_test.dart
+++ b/test/pangea/orchestrator_awarded_goals_test.dart
@@ -45,6 +45,47 @@ void main() {
       expect(reparsed.isGoalCompletedForRole('guest', 'order_dish'), isTrue);
       expect(reparsed.isGoalCompletedForRole('host', 'order_dish'), isFalse);
     });
+
+    test('matches on goal_slug, with legacy id fallback', () {
+      // The bot now awards on the content-derived slug.
+      final slugAwarded = OrchestratorAwardedGoals.fromJson({
+        'awards': {
+          'guest': ['content-slug-1'],
+        },
+      });
+      expect(
+        slugAwarded.isGoalCompletedForRole(
+          'guest',
+          'cms-id-1',
+          goalSlug: 'content-slug-1',
+        ),
+        isTrue,
+      );
+      // A goal whose slug was not awarded is not complete.
+      expect(
+        slugAwarded.isGoalCompletedForRole(
+          'guest',
+          'other-id',
+          goalSlug: 'other-slug',
+        ),
+        isFalse,
+      );
+      // Migration fallback: an award still keyed on the old Payload id renders
+      // when the goal carries a slug the bot hasn't re-awarded yet.
+      final idAwarded = OrchestratorAwardedGoals.fromJson({
+        'awards': {
+          'guest': ['cms-id-1'],
+        },
+      });
+      expect(
+        idAwarded.isGoalCompletedForRole(
+          'guest',
+          'cms-id-1',
+          goalSlug: 'content-slug-1',
+        ),
+        isTrue,
+      );
+    });
   });
 
   group('OrchestratorOutput goal_completion', () {


### PR DESCRIPTION
## What
Match activity goal stars on the content-derived `goal_slug`, and honor the session's pinned version on activity reads.

## Why
Closes #7190. Part of pangeachat/.github#199. Consumes the merged choreo (pangeachat/2-step-choreographer#2568) + bot (pangeachat/pangea-bot#1338) cutover. Without this, once the bot deploys (it awards on `goal_slug`) earned stars stop rendering, and an in-progress session can drift onto edited content.

- **goal_slug**: carried on `ActivityRoleGoal` (from the v2 mapper). `OrchestratorAwardedGoals.isGoalCompletedForRole` matches on `goal_slug` first, falling back to the Payload id so awards written before the cutover still render during the migration window. All star-render call sites thread the goal's slug.
- **Honor the pin**: the reference-shape `room.activityPlan` getter and the on-open revalidate now pass the session's pinned `version_id` (the content-signature) to the read, so a session renders the version it started on; the revalidate refreshes the re-translation of the pinned version, not newer canonical content. Discovery reads (start page, world map) stay unpinned (latest).
- **Fetch model**: request cache key grows to `(activity, l1, version)`; response parses `used_fallback_version` (no longer dropped).
- **Idempotency**: `confirmRoleSelection` now early-returns if already confirmed (the `_confirmed` flag was set but never read), so a double-tap can't create two sessions with divergent pins.

Session creation already pins `version_id` from the lobby fetch, so no change there.

## Testing
- `dart analyze` clean on all 13 changed files.
- `flutter test test/pangea/orchestrator_awarded_goals_test.dart` — 6 passed, including new coverage that awards match on `goal_slug` with the legacy-id fallback.

## Deploy Notes
None. Depends on choreo pangeachat/2-step-choreographer#2568 + bot pangeachat/pangea-bot#1338 (both merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
