### PR TITLE
chore(format): dart format activity plan/room + orchestrator files to unblock CI

### DIFF
--- a/lib/features/activity_sessions/activity_plan_repo.dart
+++ b/lib/features/activity_sessions/activity_plan_repo.dart
@@ -100,7 +100,11 @@ class ActivityPlanRepo
   /// [getPlan] has run, else the raw (TTL-checked) cached plan, else null — in
   /// which case the caller should [ensure]. Drops the resolved entry when the
   /// underlying TTL'd cache has expired so it can't outlive it.
-  ActivityPlanModel? cachedPlan(String activityId, {String? l1, String? version}) {
+  ActivityPlanModel? cachedPlan(
+    String activityId, {
+    String? l1,
+    String? version,
+  }) {
     final request = _request(activityId, l1, version: version);
     final raw = getCached(request);
     if (raw == null) {

--- a/lib/features/activity_sessions/activity_room_extension.dart
+++ b/lib/features/activity_sessions/activity_room_extension.dart
@@ -31,7 +31,10 @@ extension ActivityRoomExtension on Room {
       if (referenceId == null) return null;
       final version = content[ActivitySessionConstants.versionId] as String?;
       ActivityPlanRepo.instance.ensure(referenceId, version: version);
-      return ActivityPlanRepo.instance.cachedPlan(referenceId, version: version);
+      return ActivityPlanRepo.instance.cachedPlan(
+        referenceId,
+        version: version,
+      );
     }
 
     try {
@@ -49,8 +52,10 @@ extension ActivityRoomExtension on Room {
   /// The content-signature this session pinned at creation (from the
   /// `pangea.activity_plan` state event), or null for a legacy/embedded room.
   String? get pinnedActivityVersionId =>
-      getState(PangeaEventTypes.activityPlan)?.content[ActivitySessionConstants
-          .versionId] as String?;
+      getState(
+            PangeaEventTypes.activityPlan,
+          )?.content[ActivitySessionConstants.versionId]
+          as String?;
 
   /// activity_id of a reference plan: the room-type suffix
   /// (`PangeaRoomTypes.activitySession:<activity_id>`) is authoritative, with

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_awarded_goals.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_awarded_goals.dart
@@ -22,7 +22,11 @@ class OrchestratorAwardedGoals {
   /// the bot now awards on the content-derived slug, which survives owner
   /// edits — then falls back to the Payload [goalId] so awards written before
   /// the slug cutover still render during the migration window.
-  bool isGoalCompletedForRole(String roleId, String goalId, {String? goalSlug}) {
+  bool isGoalCompletedForRole(
+    String roleId,
+    String goalId, {
+    String? goalSlug,
+  }) {
     final roleAwards = awards[roleId];
     if (goalSlug != null &&
         ((roleAwards?.contains(goalSlug) ?? false) ||

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart
@@ -20,7 +20,11 @@ extension OrchestratorClientExtension on Client {
       if (room.ownRoleState?.id != roleId) continue;
       final awarded = room.orchestratorAwardedGoals;
       for (final g in role.allGoals) {
-        if (awarded.isGoalCompletedForRole(roleId, g.id, goalSlug: g.goalSlug)) {
+        if (awarded.isGoalCompletedForRole(
+          roleId,
+          g.id,
+          goalSlug: g.goalSlug,
+        )) {
           completed.add(g.id);
         }
       }


### PR DESCRIPTION
`main` is red on the "Check formatting" gate, which blocks `code_tests` (and therefore merges) on every open PR. Four files merged via #7179/#7190/#7191 are not `dart format`-clean: the added `version` parameter pushed several signatures past the line limit, so the formatter wants to wrap them.

This applies `dart format` to just those four files. The diff is whitespace-only (line-wrapping); no logic changes. CI's own format gate flagged these, so this restores it to green.

- `activity_plan_repo.dart`
- `activity_room_extension.dart`
- `activity_orchestrator/orchestrator_awarded_goals.dart`
- `activity_orchestrator/orchestrator_client_extension.dart`