### PR TITLE
feat(analytics): emit version_pin_honored + fallback_cause on activity events

### DIFF
--- a/lib/features/activity_sessions/activity_plan_fetch_response.dart
+++ b/lib/features/activity_sessions/activity_plan_fetch_response.dart
@@ -17,6 +17,9 @@ class ActivityPlanFetchResponse extends BaseResponse {
   // True when the pinned version was unavailable (evicted) and the latest was
   // served instead. Distinct from [usedFallback] (an L1-translation miss).
   final bool usedFallbackVersion;
+  // Why the read degraded (e.g. version_evicted, l1_missing); null on a clean
+  // pin hit. Carried into the model for the `fallback_cause` analytics dimension.
+  final String? fallbackCause;
 
   ActivityPlanFetchResponse({
     required this.rawPlan,
@@ -24,6 +27,7 @@ class ActivityPlanFetchResponse extends BaseResponse {
     this.versionId,
     this.usedFallback = false,
     this.usedFallbackVersion = false,
+    this.fallbackCause,
   });
 
   /// The plan body mapped into the client model (media `upload_id`s unresolved).
@@ -31,6 +35,8 @@ class ActivityPlanFetchResponse extends BaseResponse {
     'res': {'plan': rawPlan},
     'req': {'user_l1': l1},
     'version_id': versionId,
+    'used_fallback_version': usedFallbackVersion,
+    'fallback_cause': fallbackCause,
   });
 
   factory ActivityPlanFetchResponse.fromJson(Map<String, dynamic> json) {
@@ -41,6 +47,7 @@ class ActivityPlanFetchResponse extends BaseResponse {
       versionId: json['version_id'] as String?,
       usedFallback: json['used_fallback'] == true,
       usedFallbackVersion: json['used_fallback_version'] == true,
+      fallbackCause: json['fallback_cause'] as String?,
     );
   }
 
@@ -51,5 +58,6 @@ class ActivityPlanFetchResponse extends BaseResponse {
     'version_id': versionId,
     'used_fallback': usedFallback,
     'used_fallback_version': usedFallbackVersion,
+    'fallback_cause': fallbackCause,
   };
 }

--- a/lib/features/activity_sessions/activity_plan_model.dart
+++ b/lib/features/activity_sessions/activity_plan_model.dart
@@ -208,8 +208,7 @@ class ActivityPlanModel {
       versionId: json[ActivitySessionConstants.versionId] as String?,
       usedFallbackVersion:
           json[ActivitySessionConstants.usedFallbackVersion] == true,
-      fallbackCause:
-          json[ActivitySessionConstants.fallbackCause] as String?,
+      fallbackCause: json[ActivitySessionConstants.fallbackCause] as String?,
       isDeprecatedModel: json["bookmark_id"] != null,
     );
   }

--- a/lib/features/activity_sessions/activity_plan_model.dart
+++ b/lib/features/activity_sessions/activity_plan_model.dart
@@ -25,6 +25,13 @@ class ActivityPlanModel {
   /// for card/lobby reads that don't pin. See activities.instructions.md.
   final String? versionId;
 
+  /// Pin-resolution outcome at the time this plan was last read, parallel to
+  /// [versionId]. True when the pinned version was evicted and the latest was
+  /// served (scoring fails closed); [fallbackCause] says why it degraded. Drive
+  /// the `version_pin_honored` analytics dimension off `!usedFallbackVersion`.
+  final bool usedFallbackVersion;
+  final String? fallbackCause;
+
   final ActivityPlanRequest req;
   final String title;
   final String description;
@@ -56,6 +63,8 @@ class ActivityPlanModel {
     required this.vocab,
     required this.activityId,
     this.versionId,
+    this.usedFallbackVersion = false,
+    this.fallbackCause,
     Map<String, ActivityRole>? roles,
     String? imageURL,
     this.media = const [],
@@ -80,6 +89,8 @@ class ActivityPlanModel {
         vocab: vocab,
         activityId: activityId,
         versionId: versionId,
+        usedFallbackVersion: usedFallbackVersion,
+        fallbackCause: fallbackCause,
         roles: _roles,
         imageURL: _imageURL,
         media: media,
@@ -195,6 +206,10 @@ class ActivityPlanModel {
       roles: roles,
       activityId: activityId,
       versionId: json[ActivitySessionConstants.versionId] as String?,
+      usedFallbackVersion:
+          json[ActivitySessionConstants.usedFallbackVersion] == true,
+      fallbackCause:
+          json[ActivitySessionConstants.fallbackCause] as String?,
       isDeprecatedModel: json["bookmark_id"] != null,
     );
   }
@@ -203,6 +218,8 @@ class ActivityPlanModel {
     return {
       ActivitySessionConstants.activityId: activityId,
       ActivitySessionConstants.versionId: versionId,
+      ActivitySessionConstants.usedFallbackVersion: usedFallbackVersion,
+      ActivitySessionConstants.fallbackCause: fallbackCause,
       ActivitySessionConstants.activityPlanImageURL: _imageURL,
       ActivitySessionConstants.activityPlanMedia: media
           .map((block) => block.toJson())

--- a/lib/features/activity_sessions/activity_session_constants.dart
+++ b/lib/features/activity_sessions/activity_session_constants.dart
@@ -23,6 +23,10 @@ class ActivitySessionConstants {
   /// body is fetched live from CMS — see activities.instructions.md.
   static const String versionId = 'version_id';
   static const String sourceCourseId = 'source_course_id';
+  // Pin-resolution outcome carried alongside the plan for analytics: whether
+  // the pinned version was evicted (latest served instead) and why it degraded.
+  static const String usedFallbackVersion = 'used_fallback_version';
+  static const String fallbackCause = 'fallback_cause';
 
   static const String activityRequestTopic = 'topic';
   static const String activityRequestObjective = 'objective';

--- a/lib/features/quests/repo/activity_v2_mapper.dart
+++ b/lib/features/quests/repo/activity_v2_mapper.dart
@@ -108,6 +108,10 @@ ActivityPlanModel activityPlanFromV2(Map<String, dynamic> doc) {
     // the canonical row's version stamp for direct CMS reads. Either pins the
     // session at launch (activities.instructions.md).
     versionId: (doc['version_id'] ?? doc['updatedAt']) as String?,
+    // Pin-resolution outcome from the fetch (top-level, like version_id).
+    // Absent for direct CMS reads → defaults to "honored".
+    usedFallbackVersion: doc['used_fallback_version'] == true,
+    fallbackCause: doc['fallback_cause'] as String?,
     req: request,
     title: (plan['title'] ?? '') as String,
     description: plan['description'] as String?,

--- a/lib/pangea/common/utils/firebase_analytics.dart
+++ b/lib/pangea/common/utils/firebase_analytics.dart
@@ -220,17 +220,37 @@ class GoogleAnalytics {
     );
   }
 
-  static void startActivity(String activityId, String roomId) {
+  static void startActivity(
+    String activityId,
+    String roomId, {
+    bool? versionPinHonored,
+    String? fallbackCause,
+  }) {
     logEvent(
       'start_activity',
-      parameters: {'activity_id': activityId, 'room_id': roomId},
+      parameters: {
+        'activity_id': activityId,
+        'room_id': roomId,
+        'version_pin_honored': ?versionPinHonored,
+        'fallback_cause': ?fallbackCause,
+      },
     );
   }
 
-  static void completeActivity(String activityId, String roomId) {
+  static void completeActivity(
+    String activityId,
+    String roomId, {
+    bool? versionPinHonored,
+    String? fallbackCause,
+  }) {
     logEvent(
       'complete_activity',
-      parameters: {'activity_id': activityId, 'room_id': roomId},
+      parameters: {
+        'activity_id': activityId,
+        'room_id': roomId,
+        'version_pin_honored': ?versionPinHonored,
+        'fallback_cause': ?fallbackCause,
+      },
     );
   }
 

--- a/lib/routes/chat/activity_sessions/activity_finished_status_message.dart
+++ b/lib/routes/chat/activity_sessions/activity_finished_status_message.dart
@@ -47,6 +47,8 @@ class ActivityFinishedStatusMessage extends StatelessWidget {
       GoogleAnalytics.completeActivity(
         activityPlan.activityId,
         controller.room.id,
+        versionPinHonored: !activityPlan.usedFallbackVersion,
+        fallbackCause: activityPlan.fallbackCause,
       );
 
       final lang = activityPlan.req.targetLanguage.split("-").first;

--- a/lib/routes/chat/activity_sessions/select_role_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/select_role_session_controller.dart
@@ -216,7 +216,12 @@ class SelectRoleSessionController extends State<SelectRoleSession>
       }
     }
 
-    GoogleAnalytics.startActivity(activity.activityId, widget.roomId ?? '');
+    GoogleAnalytics.startActivity(
+      activity.activityId,
+      widget.roomId ?? '',
+      versionPinHonored: !activity.usedFallbackVersion,
+      fallbackCause: activity.fallbackCause,
+    );
   }
 
   Future<void> _joinActivity() async {

--- a/test/pangea/activity_version_pin_fallback_test.dart
+++ b/test/pangea/activity_version_pin_fallback_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_plan_fetch_response.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+
+/// Version-pin fallback threading: the choreo fetch's `used_fallback_version` /
+/// `fallback_cause` must reach the call sites that emit the `version_pin_honored`
+/// analytics dimension, via the response → mapper → model path (and survive the
+/// session-event round-trip read by completeActivity).
+void main() {
+  Map<String, dynamic> rawPlan() => {
+    'activity_id': 'a1',
+    'title': 'Cafe',
+    'description': 'Order coffee.',
+    'learning_objective': 'Greet politely.',
+    'roles': [
+      {'role_id': 'r1', 'name': 'Customer'},
+    ],
+  };
+
+  group('version-pin fallback threading', () {
+    test('fetch response parses fallback fields and carries them to the model', () {
+      final resp = ActivityPlanFetchResponse.fromJson({
+        'plan': rawPlan(),
+        'l1': 'fr',
+        'version_id': 'v1',
+        'used_fallback_version': true,
+        'fallback_cause': 'version_evicted',
+      });
+      expect(resp.usedFallbackVersion, isTrue);
+      expect(resp.fallbackCause, 'version_evicted');
+
+      final plan = resp.plan;
+      expect(plan.usedFallbackVersion, isTrue);
+      expect(plan.fallbackCause, 'version_evicted');
+      // version_pin_honored is derived as !usedFallbackVersion at the call site.
+      expect(!plan.usedFallbackVersion, isFalse);
+    });
+
+    test('clean pin hit defaults to honored with no cause', () {
+      final resp = ActivityPlanFetchResponse.fromJson({
+        'plan': rawPlan(),
+        'version_id': 'v1',
+      });
+      expect(resp.usedFallbackVersion, isFalse);
+      expect(resp.fallbackCause, isNull);
+      expect(resp.plan.usedFallbackVersion, isFalse);
+      expect(resp.plan.fallbackCause, isNull);
+    });
+
+    test('fields survive withMedia and the session-event round-trip', () {
+      final plan = ActivityPlanFetchResponse.fromJson({
+        'plan': rawPlan(),
+        'used_fallback_version': true,
+        'fallback_cause': 'cms_unavailable',
+      }).plan;
+
+      // withMedia must not drop the fields (it rebuilds the model).
+      expect(plan.withMedia(const []).usedFallbackVersion, isTrue);
+      expect(plan.withMedia(const []).fallbackCause, 'cms_unavailable');
+
+      // completeActivity reads room.activityPlan, which for embedded sessions
+      // comes back through fromJson(toJson) — the fields must persist.
+      final restored = ActivityPlanModel.fromJson(plan.toJson());
+      expect(restored.usedFallbackVersion, isTrue);
+      expect(restored.fallbackCause, 'cms_unavailable');
+    });
+  });
+}

--- a/test/pangea/activity_version_pin_fallback_test.dart
+++ b/test/pangea/activity_version_pin_fallback_test.dart
@@ -19,23 +19,26 @@ void main() {
   };
 
   group('version-pin fallback threading', () {
-    test('fetch response parses fallback fields and carries them to the model', () {
-      final resp = ActivityPlanFetchResponse.fromJson({
-        'plan': rawPlan(),
-        'l1': 'fr',
-        'version_id': 'v1',
-        'used_fallback_version': true,
-        'fallback_cause': 'version_evicted',
-      });
-      expect(resp.usedFallbackVersion, isTrue);
-      expect(resp.fallbackCause, 'version_evicted');
+    test(
+      'fetch response parses fallback fields and carries them to the model',
+      () {
+        final resp = ActivityPlanFetchResponse.fromJson({
+          'plan': rawPlan(),
+          'l1': 'fr',
+          'version_id': 'v1',
+          'used_fallback_version': true,
+          'fallback_cause': 'version_evicted',
+        });
+        expect(resp.usedFallbackVersion, isTrue);
+        expect(resp.fallbackCause, 'version_evicted');
 
-      final plan = resp.plan;
-      expect(plan.usedFallbackVersion, isTrue);
-      expect(plan.fallbackCause, 'version_evicted');
-      // version_pin_honored is derived as !usedFallbackVersion at the call site.
-      expect(!plan.usedFallbackVersion, isFalse);
-    });
+        final plan = resp.plan;
+        expect(plan.usedFallbackVersion, isTrue);
+        expect(plan.fallbackCause, 'version_evicted');
+        // version_pin_honored is derived as !usedFallbackVersion at the call site.
+        expect(!plan.usedFallbackVersion, isFalse);
+      },
+    );
 
     test('clean pin hit defaults to honored with no cause', () {
       final resp = ActivityPlanFetchResponse.fromJson({


### PR DESCRIPTION
## What
Emit a `version_pin_honored` dimension (plus `fallback_cause`) on the `start_activity` and `complete_activity` Firebase events, so we can measure how often a session renders its exact pinned version vs. falls back.

Closes #7193. Part of pangeachat/.github#199.

## Why now (not "deploy-gated")
The choreographer already returns `used_fallback_version` / `fallback_cause` on the activity fetch, and `used_fallback_version` was already parsed into the response model (#7190). Firebase GA4 is **open-schema** — custom event params flow through with no backend/schema change first, so there was no real deploy gate. The cross-service audit also flagged this signal as shipped-but-unsurfaced.

## How
Threads the fetch's fallback outcome along the same path `version_id` already travels (response → mapper → model → session event), so both call sites read it off the model:
- `ActivityPlanFetchResponse`: parse `fallback_cause`; pass `used_fallback_version` + `fallback_cause` into the mapper.
- `activity_v2_mapper`: read both top-level (like `version_id`); default to honored/null when absent (direct CMS reads).
- `ActivityPlanModel`: two new fields (`usedFallbackVersion`, `fallbackCause`) carried through `withMedia` and the `toJson`/`fromJson` session-event round-trip + `ActivitySessionConstants`.
- `GoogleAnalytics.startActivity` / `completeActivity`: optional `versionPinHonored` (= `!usedFallbackVersion`) + `fallbackCause`, emitted via Dart 3 null-aware map entries (omitted when null).
- Both call sites pass the values off the resolved plan.

## Testing
- New `test/pangea/activity_version_pin_fallback_test.dart`: response parses the fields and carries them to the model; clean pin hit defaults to honored/null; fields survive `withMedia` and the session-event round-trip. All green.
- `flutter analyze` on all touched files: no issues.

## Notes
- For modern reference-shape sessions, `room.activityPlan` hydrates from the live fetch (via `ActivityPlanRepo.cachedPlan`), so `complete_activity` reflects the actual pin outcome; the event round-trip covers embedded/legacy sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics tracking to monitor activity plan version management behavior and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->