### PR TITLE
fix(a11y): exclude decorative chat-tile + chat-background elements from semantics

### DIFF
--- a/lib/routes/chat/chat_view.dart
+++ b/lib/routes/chat/chat_view.dart
@@ -408,67 +408,75 @@ class ChatView extends StatelessWidget {
                         controller.room.activityPlan!.imageURL != null &&
                         AppConfig.useActivityImageAsChatBackground &&
                         !controller.room.activityPlan!.hasPlayableMedia)
-                      Opacity(
-                        opacity: 0.25,
-                        child: ImageFiltered(
-                          imageFilter: ui.ImageFilter.blur(
-                            sigmaX: accountConfig.wallpaperBlur ?? 0.0,
-                            sigmaY: accountConfig.wallpaperBlur ?? 0.0,
+                      ExcludeSemantics(
+                        // #Pangea: decorative blurred chat background, not content. // Pangea#
+                        child: Opacity(
+                          opacity: 0.25,
+                          child: ImageFiltered(
+                            imageFilter: ui.ImageFilter.blur(
+                              sigmaX: accountConfig.wallpaperBlur ?? 0.0,
+                              sigmaY: accountConfig.wallpaperBlur ?? 0.0,
+                            ),
+                            child:
+                                controller.room.activityPlan!.imageURL!
+                                    .toString()
+                                    .startsWith('mxc')
+                                ? MxcImage(
+                                    uri:
+                                        controller.room.activityPlan!.imageURL!,
+                                    fit: BoxFit.cover,
+                                    height: MediaQuery.sizeOf(context).height,
+                                    width: MediaQuery.sizeOf(context).width,
+                                    cacheKey: controller
+                                        .room
+                                        .activityPlan!
+                                        .imageURL
+                                        .toString(),
+                                    isThumbnail: false,
+                                  )
+                                : Image.network(
+                                    controller.room.activityPlan!.imageURL
+                                        .toString(),
+                                    fit: BoxFit.cover,
+                                    height: MediaQuery.sizeOf(context).height,
+                                    width: MediaQuery.sizeOf(context).width,
+                                    headers:
+                                        controller.room.activityPlan!.imageURL
+                                            .toString()
+                                            .contains(Environment.cmsApi)
+                                        ? {
+                                            'Authorization':
+                                                'Bearer ${MatrixState.pangeaController.userController.accessToken}',
+                                          }
+                                        : null,
+                                    errorBuilder:
+                                        (context, error, stackTrace) =>
+                                            Container(),
+                                  ),
                           ),
-                          child:
-                              controller.room.activityPlan!.imageURL!
-                                  .toString()
-                                  .startsWith('mxc')
-                              ? MxcImage(
-                                  uri: controller.room.activityPlan!.imageURL!,
-                                  fit: BoxFit.cover,
-                                  height: MediaQuery.sizeOf(context).height,
-                                  width: MediaQuery.sizeOf(context).width,
-                                  cacheKey: controller
-                                      .room
-                                      .activityPlan!
-                                      .imageURL
-                                      .toString(),
-                                  isThumbnail: false,
-                                )
-                              : Image.network(
-                                  controller.room.activityPlan!.imageURL
-                                      .toString(),
-                                  fit: BoxFit.cover,
-                                  height: MediaQuery.sizeOf(context).height,
-                                  width: MediaQuery.sizeOf(context).width,
-                                  headers:
-                                      controller.room.activityPlan!.imageURL
-                                          .toString()
-                                          .contains(Environment.cmsApi)
-                                      ? {
-                                          'Authorization':
-                                              'Bearer ${MatrixState.pangeaController.userController.accessToken}',
-                                        }
-                                      : null,
-                                  errorBuilder: (context, error, stackTrace) =>
-                                      Container(),
-                                ),
                         ),
                       )
                     // If not enabled, fall through to default wallpaper logic
                     else if (accountConfig.wallpaperUrl != null)
                       // Pangea#
-                      Opacity(
-                        opacity: accountConfig.wallpaperOpacity ?? 0.5,
-                        child: ImageFiltered(
-                          imageFilter: ui.ImageFilter.blur(
-                            sigmaX: accountConfig.wallpaperBlur ?? 0.0,
-                            sigmaY: accountConfig.wallpaperBlur ?? 0.0,
-                          ),
-                          child: MxcImage(
-                            cacheKey: accountConfig.wallpaperUrl.toString(),
-                            uri: accountConfig.wallpaperUrl,
-                            fit: BoxFit.cover,
-                            height: MediaQuery.sizeOf(context).height,
-                            width: MediaQuery.sizeOf(context).width,
-                            isThumbnail: false,
-                            placeholder: (_) => Container(),
+                      ExcludeSemantics(
+                        // #Pangea: decorative blurred wallpaper, not content. // Pangea#
+                        child: Opacity(
+                          opacity: accountConfig.wallpaperOpacity ?? 0.5,
+                          child: ImageFiltered(
+                            imageFilter: ui.ImageFilter.blur(
+                              sigmaX: accountConfig.wallpaperBlur ?? 0.0,
+                              sigmaY: accountConfig.wallpaperBlur ?? 0.0,
+                            ),
+                            child: MxcImage(
+                              cacheKey: accountConfig.wallpaperUrl.toString(),
+                              uri: accountConfig.wallpaperUrl,
+                              fit: BoxFit.cover,
+                              height: MediaQuery.sizeOf(context).height,
+                              width: MediaQuery.sizeOf(context).width,
+                              isThumbnail: false,
+                              placeholder: (_) => Container(),
+                            ),
                           ),
                         ),
                       ),

--- a/lib/routes/chat_list/chat_list_item.dart
+++ b/lib/routes/chat_list/chat_list_item.dart
@@ -91,111 +91,117 @@ class ChatListItem extends StatelessWidget {
               visualDensity: const VisualDensity(vertical: -0.5),
               contentPadding: const EdgeInsets.symmetric(horizontal: 8),
               onLongPress: () => onLongPress?.call(context),
-              leading: HoverBuilder(
-                builder: (context, hovered) => AnimatedScale(
-                  duration: FluffyThemes.animationDuration,
-                  curve: FluffyThemes.animationCurve,
-                  scale: hovered ? 1.1 : 1.0,
-                  // #Pangea
-                  child: Tooltip(
-                    message: L10n.of(context).moreOptions,
-                    // Pangea#
-                    child: SizedBox(
-                      width: Avatar.defaultSize,
-                      height: Avatar.defaultSize,
-                      child: Stack(
-                        children: [
-                          if (space != null)
+              // #Pangea: the avatar/drop-down affordances are redundant unnamed
+              // menu triggers (they just re-fire onLongPress); keep them out of
+              // the semantics tree so they are not nested unnamed buttons inside
+              // the tappable tile (axe nested-interactive / aria-command-name).
+              leading: ExcludeSemantics(
+                child: HoverBuilder(
+                  builder: (context, hovered) => AnimatedScale(
+                    duration: FluffyThemes.animationDuration,
+                    curve: FluffyThemes.animationCurve,
+                    scale: hovered ? 1.1 : 1.0,
+                    // #Pangea
+                    child: Tooltip(
+                      message: L10n.of(context).moreOptions,
+                      // Pangea#
+                      child: SizedBox(
+                        width: Avatar.defaultSize,
+                        height: Avatar.defaultSize,
+                        child: Stack(
+                          children: [
+                            if (space != null)
+                              Positioned(
+                                top: 0,
+                                left: 0,
+                                child: Avatar(
+                                  border: BorderSide(
+                                    width: 2,
+                                    color:
+                                        backgroundColor ??
+                                        theme.colorScheme.surface,
+                                  ),
+                                  borderRadius: BorderRadius.circular(
+                                    AppConfig.borderRadius / 4,
+                                  ),
+                                  mxContent: space.avatar,
+                                  size: Avatar.defaultSize * 0.75,
+                                  name: space.getLocalizedDisplayname(),
+                                  // #Pangea
+                                  userId: space.directChatMatrixID,
+                                  useRive: true,
+                                  // Pangea#
+                                  onTap: () => onLongPress?.call(context),
+                                ),
+                              ),
                             Positioned(
-                              top: 0,
-                              left: 0,
+                              bottom: 0,
+                              right: 0,
                               child: Avatar(
-                                border: BorderSide(
-                                  width: 2,
-                                  color:
-                                      backgroundColor ??
-                                      theme.colorScheme.surface,
-                                ),
-                                borderRadius: BorderRadius.circular(
-                                  AppConfig.borderRadius / 4,
-                                ),
-                                mxContent: space.avatar,
-                                size: Avatar.defaultSize * 0.75,
-                                name: space.getLocalizedDisplayname(),
+                                border: space == null
+                                    ? room.isSpace
+                                          ? BorderSide(
+                                              width: 1,
+                                              color: theme.dividerColor,
+                                            )
+                                          : null
+                                    : BorderSide(
+                                        width: 2,
+                                        color:
+                                            backgroundColor ??
+                                            theme.colorScheme.surface,
+                                      ),
                                 // #Pangea
-                                userId: space.directChatMatrixID,
-                                useRive: true,
+                                // borderRadius: room.isSpace
+                                //     ? BorderRadius.circular(
+                                //         AppConfig.borderRadius / 4,
+                                //       )
+                                //     : null,
+                                borderRadius:
+                                    borderRadius ??
+                                    (room.isSpace
+                                        ? BorderRadius.circular(
+                                            AppConfig.borderRadius / 4,
+                                          )
+                                        : null),
                                 // Pangea#
+                                mxContent: room.avatar,
+                                size: space != null
+                                    ? Avatar.defaultSize * 0.75
+                                    : Avatar.defaultSize,
+                                name: displayname,
+                                presenceUserId: directChatMatrixId,
+                                presenceBackgroundColor: backgroundColor,
                                 onTap: () => onLongPress?.call(context),
                               ),
                             ),
-                          Positioned(
-                            bottom: 0,
-                            right: 0,
-                            child: Avatar(
-                              border: space == null
-                                  ? room.isSpace
-                                        ? BorderSide(
-                                            width: 1,
-                                            color: theme.dividerColor,
-                                          )
-                                        : null
-                                  : BorderSide(
-                                      width: 2,
-                                      color:
-                                          backgroundColor ??
-                                          theme.colorScheme.surface,
+                            Positioned(
+                              top: 0,
+                              right: 0,
+                              child: GestureDetector(
+                                onTap: () => onLongPress?.call(context),
+                                child: AnimatedScale(
+                                  duration: FluffyThemes.animationDuration,
+                                  curve: FluffyThemes.animationCurve,
+                                  scale: listTileHovered ? 1.0 : 0.0,
+                                  child: Material(
+                                    color: backgroundColor,
+                                    borderRadius: BorderRadius.circular(16),
+                                    child: const Icon(
+                                      Icons.arrow_drop_down_circle_outlined,
+                                      size: 18,
                                     ),
-                              // #Pangea
-                              // borderRadius: room.isSpace
-                              //     ? BorderRadius.circular(
-                              //         AppConfig.borderRadius / 4,
-                              //       )
-                              //     : null,
-                              borderRadius:
-                                  borderRadius ??
-                                  (room.isSpace
-                                      ? BorderRadius.circular(
-                                          AppConfig.borderRadius / 4,
-                                        )
-                                      : null),
-                              // Pangea#
-                              mxContent: room.avatar,
-                              size: space != null
-                                  ? Avatar.defaultSize * 0.75
-                                  : Avatar.defaultSize,
-                              name: displayname,
-                              presenceUserId: directChatMatrixId,
-                              presenceBackgroundColor: backgroundColor,
-                              onTap: () => onLongPress?.call(context),
-                            ),
-                          ),
-                          Positioned(
-                            top: 0,
-                            right: 0,
-                            child: GestureDetector(
-                              onTap: () => onLongPress?.call(context),
-                              child: AnimatedScale(
-                                duration: FluffyThemes.animationDuration,
-                                curve: FluffyThemes.animationCurve,
-                                scale: listTileHovered ? 1.0 : 0.0,
-                                child: Material(
-                                  color: backgroundColor,
-                                  borderRadius: BorderRadius.circular(16),
-                                  child: const Icon(
-                                    Icons.arrow_drop_down_circle_outlined,
-                                    size: 18,
                                   ),
                                 ),
                               ),
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                   ),
                 ),
-              ),
+              ), // Pangea# end ExcludeSemantics
               title: Row(
                 children: <Widget>[
                   Expanded(


### PR DESCRIPTION
Real a11y bugs surfaced by auditing a **course-enrolled** staging account (a populated chat list + an open chat room), which the bare CI test account never exposed. Fixes verified against a local profile build of this branch with that account.

### Fixes
- **`chat_list_item.dart`** — the leading avatar/drop-down affordances are redundant unnamed `onTap`s (they just re-fire `onLongPress`). Wrapped in `ExcludeSemantics` so they're not nested, unnamed buttons inside the tappable tile.
- **`chat_view.dart`** — the decorative blurred chat backgrounds (activity image / wallpaper, `Opacity`→`MxcImage`/`Image.network`) wrapped in `ExcludeSemantics` so they're not unlabeled `role=img` content.

### Verified (rich-account chat-room audit, before → after)
- `aria-command-name`: **14 → 0** ✓
- `role-img-alt`: **1 → 0** ✓
- `nested-interactive`: **4 → 1**

### Known follow-up (not in this PR)
The remaining `nested-interactive` (1) + `no-focusable-content` (4) are the **invite-tile "Decline invitation" button** nested in the tappable `ListTile` — a deeper `ListTile` restructure (same class as #7132), only on invite tiles. Tracked for a follow-up, along with wiring the course-enrolled account into CI as a separate (slow) audit suite.

These changes only *remove* decorative nodes from the semantics tree, so they can't add violations to the existing (bare-account) audits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced accessibility semantics for chat backgrounds and decorative UI elements.
  * Improved accessibility handling for chat list avatars and dropdown controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->