### PR TITLE
fix(settings): consistent settings panel width so pages don't resize on drill-in (#7146)

### DIFF
--- a/lib/features/navigation/panel_registry.dart
+++ b/lib/features/navigation/panel_registry.dart
@@ -246,7 +246,10 @@ abstract class PanelRegistry {
       parent: 'settings',
       minWidth: 360,
       reasonableMinWidth: 440,
-      idealWidth: 600,
+      // Match the `settings` menu width: a page replaces the folded menu in the
+      // same slot (foldsParentAlways), so an unequal ideal made the panel resize
+      // and the close/back icon jump when drilling in or out (#7146).
+      idealWidth: 520,
       priority: 55,
       siblingGroups: {'settingsdetail'},
       pushable: true,

--- a/test/pangea/navigation/panel_allocator_test.dart
+++ b/test/pangea/navigation/panel_allocator_test.dart
@@ -144,6 +144,18 @@ void main() {
       expectNoOverlap(l);
     });
 
+    test('the page holds the column at the same width the menu had — no '
+        'resize or close/back jump when drilling in (#7146)', () {
+      // The page replaces the folded menu in the same slot, so the two must be
+      // the same width. An unequal ideal (520 menu vs 600 page) resized the
+      // panel and shifted the leading close/back icon when opening a sub-page.
+      final menuOnly = run(viewport: 1920, right: ['settings']);
+      final withPage = run(viewport: 1920, right: ['settingspage', 'settings']);
+      expect(withPage.right[0].width, menuOnly.right.single.width);
+      // Guard the defs directly so they can't silently drift apart again.
+      expect(def('settingspage').idealWidth, def('settings').idealWidth);
+    });
+
     test('an ordinary master/detail pair (analytics + vocab) still coexists '
         'when width allows — the fold is scoped to flagged details', () {
       // Same wide viewport: vocab is analytics's detail but NOT


### PR DESCRIPTION
Closes #7146.

## Problem
The settings menu and a settings sub-page had different panel widths (the `settings` menu token at 520, a `settingspage` at 600). Because a sub-page replaces the folded menu in the same slot (`foldsParentAlways`), opening or leaving a page visibly resized the panel and shifted the close/back icon, so the X and back arrows did not line up across pages.

## Fix
Set the `settingspage` ideal width to 520 to match the `settings` menu. The two now occupy the same slot at the same width, so the panel stays put when you drill in or out and the leading close/back icon holds its position.

## Tests
- Added a regression test in `panel_allocator_test.dart` asserting the page holds the column at the same width the menu had, plus a direct guard so the two defs cannot drift apart again.
- `flutter analyze`, `dart format`, `import_sorter`, and the full allocator suite are green.

## Verified in-client (local, logged in)
Clicked through Settings menu, Chat, and Notifications. All three sit at the same left edge, and the close/back icon stays at the same position across the menu and every page.

## Out of scope (follow-up)
Sub-pages still render their own centered page title (a second header row) where the menu shows a left-aligned title in the shared panel header. Unifying that means routing each page title through the panel header and dropping the per-page app bars, which touches the dialog-mode learning page and the 3pid page's app bar actions. Worth a separate polish pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed settings panel width inconsistency that caused visual misalignment when navigating between the settings menu and settings page, ensuring smooth panel transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->