### PR TITLE
fix(analytics): single close X on the vocab word card (#7169)

### DIFF
--- a/lib/routes/analytics/construct_analytics/construct_analytics_details/vocab_analytics_details_view.dart
+++ b/lib/routes/analytics/construct_analytics/construct_analytics_details/vocab_analytics_details_view.dart
@@ -1,13 +1,10 @@
 import 'package:flutter/material.dart';
 
 import 'package:collection/collection.dart';
-import 'package:go_router/go_router.dart';
 
 import 'package:fluffychat/features/analytics/construct_identifier.dart';
 import 'package:fluffychat/features/analytics/construct_level_enum.dart';
 import 'package:fluffychat/features/analytics/construct_use_model.dart';
-import 'package:fluffychat/features/navigation/panel_token.dart';
-import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/lemmas/lemma.dart';
 import 'package:fluffychat/pangea/lemmas/lemma_info_response.dart';
@@ -19,7 +16,6 @@ import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
 import 'package:fluffychat/routes/chat/events/models/pangea_token_text_model.dart';
 import 'package:fluffychat/routes/chat/events/phonetic_transcription/pt_v2_models.dart';
 import 'package:fluffychat/routes/chat/toolbar/word_card/word_zoom_widget.dart';
-import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -94,12 +90,9 @@ class VocabDetailsView extends StatelessWidget {
                       MatrixState.pangeaController.userController.userL2Code!,
                   construct: constructId,
                   pos: constructId.category,
-                  onClose: () => NavigationUtil.popOrGo(
-                    context,
-                    WorkspaceNav.setRight(GoRouterState.of(context).uri, const [
-                      PanelToken('analytics', 'vocab'),
-                    ]),
-                  ),
+                  // No own close button: the panel header already supplies the
+                  // single page X. Passing onClose here drew a redundant second
+                  // X inside the word card (#7169).
                   onFlagTokenInfo:
                       (
                         LemmaInfoResponse lemmaInfo,


### PR DESCRIPTION
Closes #7169.

## Problem
When a word is selected on the vocab analytics page, the word card showed its own close X on top of the panel header's X, so the page had two ways to close it. The card's X is the less intuitive of the two.

## Fix
Stop passing `onClose` to the word card (`WordZoomWidget`) in the vocab detail view. The widget already hides its close button when no `onClose` is given, so the shared panel header X is left as the single, consistent close. The chat toolbar still passes `onClose` where the word card is its own popup, so that X is unchanged.

## Tests
`flutter analyze`, `dart format`, and `import_sorter` are green. The change also let four now-unused imports go.

## Verification note
The local build's vocab list would not populate offline (analytics aggregation needs the backend), so I could not select a word in-client here. The change is small and follows the widget's existing contract (it renders the X only when onClose is non-null), and the grammar detail already shows a single X the same way. I will confirm on staging after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a duplicate close action from the vocabulary analytics details panel, leaving a single consistent “X” close control.
  * Cleaned up navigation-related wiring in the view to match the intended panel behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->