### PR TITLE
fix(world-map): keep on-map zoom controls fixed when a right panel opens (#7166)

### DIFF
--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -356,11 +356,14 @@ class WorldMapView extends StatelessWidget {
     );
 
     // The on-map zoom-out / World control (#7086): pins, clusters, and search
-    // only zoom the camera IN, so this is the way back out. Bottom-right, clear
-    // of the right column and above the attribution; shown on both the world map
-    // and a course map.
+    // only zoom the camera IN, so this is the way back out. Pinned to the
+    // viewport bottom-right and kept there when a right panel opens (#7166): the
+    // 88px cluster gutter reserved beside the right column leaves room, so the
+    // controls no longer slide left with the panel. (rightOverlayWidth still pads
+    // the camera fit in world_map.dart so focal content lands in the uncovered
+    // area; only this on-map chrome stays fixed.) Shown on world and course maps.
     final controls = Positioned(
-      right: controller.widget.rightOverlayWidth + 12,
+      right: 12,
       bottom: 28,
       child: _MapZoomControls(controller: controller),
     );


### PR DESCRIPTION
Closes #7166.

## Problem
The on-map zoom controls (the globe/recenter button stacked with the + and - zoom buttons) jumped left whenever a right-column panel like Settings opened, even though there is ample space on web. The nav rail and top search bar stayed put.

## Root cause
The controls' `Positioned` offset was `right: rightOverlayWidth + 12` in `world_map_view.dart`. `rightOverlayWidth` is the width covered by the right panel column (0 when none is open), so opening Settings grew the offset by the panel width plus the 88px cluster gutter and slid the controls left to sit just inside the panel.

## Fix
Pin the controls to `right: 12`, which is exactly their no-panel position, so they stay at the viewport bottom-right in every state. The 88px cluster gutter reserved to the right of the right column leaves room for the ~48px control stack, so it sits clear of the panel and is never hidden under it. The camera-fit padding in `world_map.dart` still consumes `rightOverlayWidth`, so focal content keeps re-framing into the uncovered area; only the on-map chrome is now fixed.

## Verified in-client (local, logged in)
With Settings open, the zoom controls stay at the viewport bottom-right in the gutter to the right of the panel instead of jumping left. Narrow and mobile layouts are unaffected (the overlay width is already 0 there).

## Notes
Scoped to the right-panel case in the issue. The top-left search overlay intentionally still tracks the left overlay width, since the left column has no equivalent reserved gutter.