### PR TITLE
fix(world-map): disable the on-map +/- buttons at the zoom limits (#7171)

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -90,6 +90,18 @@ class WorldMapController extends State<WorldMap>
     with SingleTickerProviderStateMixin {
   final MapController _ownController = MapController();
 
+  /// The camera zoom range — the single source for FlutterMap's MapOptions, the
+  /// +/- step clamp in [zoomBy], the World reset in [resetToWorld], and the
+  /// on-map control disabled states (#7171). minZoom 3 is the whole world.
+  static const double minZoom = 3.0;
+  static const double maxZoom = 18.0;
+
+  /// Whether a zoom-in / zoom-out step would still change the camera, i.e. the
+  /// on-map + / - button should be enabled. At a limit the matching button is
+  /// disabled so it can't no-op (#7171).
+  static bool canZoomIn(double zoom) => zoom < maxZoom;
+  static bool canZoomOut(double zoom) => zoom > minZoom;
+
   /// The activity pins currently shown — the active context's set (the whole
   /// world, or a selected quest's activities). Thin: id, title, point.
   List<QuestActivityCard> _pins = [];
@@ -678,7 +690,7 @@ class WorldMapController extends State<WorldMap>
   /// and search only ever zoom the camera IN, so this is the one explicit
   /// "zoom out to everything" affordance (#7086). Camera-only: the course scope
   /// and open panels are untouched.
-  void resetToWorld() => _animateCameraTo(const LatLng(20, 0), 3.0);
+  void resetToWorld() => _animateCameraTo(const LatLng(20, 0), minZoom);
 
   /// Step the zoom by [delta] levels around the current center, clamped to the
   /// map's range — backs the on-map +/- buttons, since a tap/search only ever
@@ -691,7 +703,7 @@ class WorldMapController extends State<WorldMap>
         : mapController.camera.zoom;
     _animateCameraTo(
       mapController.camera.center,
-      (base + delta).clamp(3.0, 18.0).roundToDouble(),
+      (base + delta).clamp(minZoom, maxZoom).roundToDouble(),
     );
   }
 

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -258,8 +258,8 @@ class WorldMapView extends StatelessWidget {
         // ±90 band is only ~1024px tall at z2 — that would freeze *all*
         // panning on windows taller than ~1024px (common when maximized).
         // z3 gives a ~2048px band, clearing any realistic viewport.
-        minZoom: 3,
-        maxZoom: 18,
+        minZoom: WorldMapController.minZoom,
+        maxZoom: WorldMapController.maxZoom,
         // Clamp latitude only — leaving longitude free so the user can pan
         // east-west and the world wraps seamlessly ("rotate the world
         // around"). Epsg3857 replicates longitude, so tiles and markers
@@ -419,6 +419,16 @@ class _MapZoomControls extends StatelessWidget {
 
   const _MapZoomControls({required this.controller});
 
+  /// The live camera zoom, or null before the map is laid out (reading the
+  /// camera throws until then) — null leaves both step buttons enabled.
+  double? _currentZoom() {
+    try {
+      return controller.mapController.camera.zoom;
+    } catch (_) {
+      return null;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = L10n.of(context);
@@ -427,26 +437,39 @@ class _MapZoomControls extends StatelessWidget {
       elevation: 2.0,
       color: theme.colorScheme.surface,
       borderRadius: BorderRadius.circular(8.0),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          IconButton(
-            icon: const Icon(Icons.public),
-            tooltip: l10n.world,
-            onPressed: controller.resetToWorld,
-          ),
-          Divider(height: 1.0, color: theme.colorScheme.outlineVariant),
-          IconButton(
-            icon: const Icon(Icons.add),
-            tooltip: l10n.zoomIn,
-            onPressed: () => controller.zoomBy(1),
-          ),
-          IconButton(
-            icon: const Icon(Icons.remove),
-            tooltip: l10n.zoomOut,
-            onPressed: () => controller.zoomBy(-1),
-          ),
-        ],
+      // Re-evaluate the +/- enabled state as the camera zooms (pinch, scroll,
+      // or the glide) so each button greys out at its limit (#7171). Scoped to
+      // this small stack via the map event stream rather than a full-view
+      // rebuild; the World reset stays enabled (it re-centers, not just zooms).
+      child: StreamBuilder(
+        stream: controller.mapController.mapEventStream,
+        builder: (context, _) {
+          final zoom = _currentZoom();
+          final canZoomIn = zoom == null || WorldMapController.canZoomIn(zoom);
+          final canZoomOut =
+              zoom == null || WorldMapController.canZoomOut(zoom);
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.public),
+                tooltip: l10n.world,
+                onPressed: controller.resetToWorld,
+              ),
+              Divider(height: 1.0, color: theme.colorScheme.outlineVariant),
+              IconButton(
+                icon: const Icon(Icons.add),
+                tooltip: l10n.zoomIn,
+                onPressed: canZoomIn ? () => controller.zoomBy(1) : null,
+              ),
+              IconButton(
+                icon: const Icon(Icons.remove),
+                tooltip: l10n.zoomOut,
+                onPressed: canZoomOut ? () => controller.zoomBy(-1) : null,
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/test/pangea/world_map_zoom_test.dart
+++ b/test/pangea/world_map_zoom_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/world/world_map.dart';
+
+void main() {
+  // The on-map +/- buttons must grey out at the camera's zoom limits so a tap
+  // can never no-op (#7171). The limits are the single source shared by
+  // FlutterMap's MapOptions, zoomBy's clamp, and the World reset.
+  group('WorldMapController zoom limits (#7171)', () {
+    test('zoom-in is enabled below max and disabled at max', () {
+      expect(WorldMapController.canZoomIn(WorldMapController.minZoom), isTrue);
+      expect(
+        WorldMapController.canZoomIn(WorldMapController.maxZoom - 0.5),
+        isTrue,
+      );
+      expect(WorldMapController.canZoomIn(WorldMapController.maxZoom), isFalse);
+    });
+
+    test('zoom-out is enabled above min and disabled at min', () {
+      expect(WorldMapController.canZoomOut(WorldMapController.maxZoom), isTrue);
+      expect(
+        WorldMapController.canZoomOut(WorldMapController.minZoom + 0.5),
+        isTrue,
+      );
+      expect(
+        WorldMapController.canZoomOut(WorldMapController.minZoom),
+        isFalse,
+      );
+    });
+
+    test('the zoom range is non-empty (min below max)', () {
+      expect(WorldMapController.minZoom, lessThan(WorldMapController.maxZoom));
+    });
+  });
+}


### PR DESCRIPTION
Closes #7171.

## Problem
The on-map + and - buttons stayed tappable at the camera's zoom limits, so at the whole-world zoom the - button (and at max zoom the + button) did nothing when pressed.

## Fix
Extract the zoom range to named constants on `WorldMapController` (`minZoom` 3, `maxZoom` 18), now the single source shared by FlutterMap's `MapOptions`, `zoomBy`'s clamp, and the World reset. The on-map control stack listens to the map event stream and greys out `+` at max zoom and `-` at min zoom, so a step button can never no-op. The World reset (globe) stays enabled, since it re-centers rather than only zooming.

## Tests
Added `world_map_zoom_test.dart` for the `canZoomIn`/`canZoomOut` boundary logic. `flutter analyze`, `dart format`, and `import_sorter` are green.

## Verified in-client (local, logged in)
At the initial whole-world zoom the `-` button is greyed; clicking `+` zooms in and `-` re-enables; the World reset returns to the whole-world view. The controls update live as the camera zooms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Zoom controls on the world map now update dynamically based on the current zoom level, with clearer limits for zooming in and out.
  * The map reset action now returns to the world view using the updated minimum zoom level.

* **Bug Fixes**
  * Improved consistency of map zoom behavior by applying the same zoom limits across the map view and controls.

* **Tests**
  * Added coverage for world map zoom limits and control enable/disable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->