### PR TITLE
fix(chat): back out of new DM creation returns to the chat list (#7170)

### DIFF
--- a/lib/routes/new_private_chat/new_private_chat_view.dart
+++ b/lib/routes/new_private_chat/new_private_chat_view.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 
+import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/new_private_chat/new_private_chat.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
@@ -26,7 +28,12 @@ class NewPrivateChatView extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         scrolledUnderElevation: 0,
-        leading: const Center(child: BackButton()),
+        // world_v2: this legacy path route is reached via `go` from the
+        // chat-list token, so a plain pop lands on a blank panel. Send back to
+        // the chat list explicitly (#7170).
+        leading: Center(
+          child: BackButton(onPressed: () => context.go(PRoutes.chatsList)),
+        ),
         // #Pangea
         title: Text(L10n.of(context).newDirectMessage),
         // title: Text(L10n.of(context).newChat),


### PR DESCRIPTION
Closes #7170.

## Problem
From All chats, tapping Direct message opens the new-DM page, but pressing its back button landed on an empty popup instead of a functioning page.

## Root cause
The chat list lives at the `left=chats` token over the map. The Direct message FAB navigates with `context.go('/rooms/newprivatechat')`, which leaves the token world, so the `?left=chats` state is gone. The new-DM page's plain back button then popped to whatever preceded the chat list, leaving a blank panel.

## Fix
Point the new-DM page's back button at the canonical chat-list token (`PRoutes.chatsList`, `/?left=chats`) so backing out deterministically returns to the chat list, matching the rest of the token-driven navigation.

## Verified in-client (local, logged in)
All chats > Direct message > back now returns to the chat list (Conversaciones), not an empty popup.