### PR TITLE
feat(a11y): announce status messages and inline errors to screen readers (WCAG 4.1.3) (#7203)

### DIFF
--- a/lib/features/join_codes/share_room_button.dart
+++ b/lib/features/join_codes/share_room_button.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/features/join_codes/join_rule_extension.dart';
 import 'package:fluffychat/features/join_codes/share_room_code_util.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 
 class ShareRoomButton extends StatelessWidget {
   final Widget child;
@@ -35,8 +36,9 @@ class ShareRoomButton extends StatelessWidget {
         },
       );
 
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).oopsSomethingWentWrong)),
+        assertive: true,
       );
       return;
     }
@@ -45,7 +47,7 @@ class ShareRoomButton extends StatelessWidget {
 
     final messenger = ScaffoldMessenger.of(context);
     messenger.hideCurrentSnackBar();
-    messenger.showSnackBar(
+    messenger.showSnackBarAnnounced(
       SnackBar(
         content: Text(L10n.of(context).copiedToClipboard),
         showCloseIcon: true,

--- a/lib/features/subscription/widgets/subscription_snackbar.dart
+++ b/lib/features/subscription/widgets/subscription_snackbar.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 
 void showSubscribedSnackbar(BuildContext context) {
   final Widget text = RichText(
@@ -33,5 +34,5 @@ void showSubscribedSnackbar(BuildContext context) {
       ],
     ),
   );
-  ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: text));
+  ScaffoldMessenger.of(context).showSnackBarAnnounced(SnackBar(content: text));
 }

--- a/lib/pangea/common/widgets/error_indicator.dart
+++ b/lib/pangea/common/widgets/error_indicator.dart
@@ -22,20 +22,27 @@ class ErrorIndicator extends StatelessWidget {
   Widget build(BuildContext context) {
     final defaultStyle = DefaultTextStyle.of(context).style;
     final style = defaultStyle.merge(this.style ?? defaultStyle);
-    final content = RichText(
-      text: TextSpan(
-        children: [
-          WidgetSpan(
-            alignment: PlaceholderAlignment.middle,
-            child: Icon(
-              Icons.error,
-              color: iconColor ?? AppConfig.error,
-              size: iconSize ?? 24.0,
+    // A live region so screen readers speak the error when this indicator
+    // appears (it is shown in place via setState, not as a new route, so it is
+    // otherwise silent) — WCAG 4.1.3 (#7203). The decorative error icon carries
+    // no semantic label, so only the message is announced.
+    final content = Semantics(
+      liveRegion: true,
+      child: RichText(
+        text: TextSpan(
+          children: [
+            WidgetSpan(
+              alignment: PlaceholderAlignment.middle,
+              child: Icon(
+                Icons.error,
+                color: iconColor ?? AppConfig.error,
+                size: iconSize ?? 24.0,
+              ),
             ),
-          ),
-          TextSpan(text: '  '),
-          TextSpan(text: message, style: style),
-        ],
+            TextSpan(text: '  '),
+            TextSpan(text: message, style: style),
+          ],
+        ),
       ),
     );
 

--- a/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
+++ b/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
@@ -31,6 +31,7 @@ import 'package:fluffychat/routes/chat/events/token_info_feedback/show_token_fee
 import 'package:fluffychat/routes/chat/events/token_info_feedback/token_info_feedback_request.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -317,7 +318,7 @@ class _PracticeButton extends StatelessWidget {
 
   void _showSnackbar(BuildContext context, String message) {
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
-    ScaffoldMessenger.of(context).showSnackBar(
+    ScaffoldMessenger.of(context).showSnackBarAnnounced(
       SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
     );
   }

--- a/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
@@ -16,6 +16,7 @@ import 'package:fluffychat/routes/chat/activity_sessions/activity_sessions_start
 import 'package:fluffychat/routes/chat/activity_sessions/bot_join_error_dialog.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -180,7 +181,7 @@ class ConfirmedRoleSessionController extends State<ConfirmedRoleSession>
 
     if (mounted) {
       setState(() {});
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(
           content: Text(L10n.of(context).pingSent, textAlign: TextAlign.center),
           duration: const Duration(milliseconds: 2000),

--- a/lib/routes/chat/add_widget_tile.dart
+++ b/lib/routes/chat/add_widget_tile.dart
@@ -4,6 +4,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/chat/add_widget_tile_view.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 
 class AddWidgetTile extends StatefulWidget {
   final Room room;
@@ -74,8 +75,9 @@ class AddWidgetTileState extends State<AddWidgetTile> {
       widget.room.addWidget(matrixWidget);
       Navigator.of(context).pop();
     } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).errorAddingWidget)),
+        assertive: true,
       );
     }
   }

--- a/lib/routes/chat/audio_player.dart
+++ b/lib/routes/chat/audio_player.dart
@@ -17,6 +17,7 @@ import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/multi_platform_audio_player.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import '../../widgets/matrix.dart';
 
 class AudioPlayerWidget extends StatefulWidget {
@@ -255,9 +256,10 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
     } catch (e, s) {
       Logs().v('Could not download audio file', e, s);
       if (!mounted) rethrow;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(e.toLocalizedString(context))));
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
+        SnackBar(content: Text(e.toLocalizedString(context))),
+        assertive: true,
+      );
       rethrow;
     }
     if (!context.mounted) return;

--- a/lib/routes/chat/audio_player.dart
+++ b/lib/routes/chat/audio_player.dart
@@ -20,6 +20,9 @@ import 'package:fluffychat/utils/url_launcher.dart';
 import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import '../../widgets/matrix.dart';
 
+// #Pangea
+// Pangea#
+
 class AudioPlayerWidget extends StatefulWidget {
   final Color color;
   final Color linkColor;
@@ -256,10 +259,12 @@ class AudioPlayerState extends State<AudioPlayerWidget> {
     } catch (e, s) {
       Logs().v('Could not download audio file', e, s);
       if (!mounted) rethrow;
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(e.toLocalizedString(context))),
         assertive: true,
       );
+      // Pangea#
       rethrow;
     }
     if (!context.mounted) return;

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -114,6 +114,7 @@ import 'package:fluffychat/utils/show_scaffold_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/share_scaffold_dialog.dart';
@@ -462,7 +463,7 @@ class ChatController extends State<ChatPageWithRoom>
     if (shareItems == null || shareItems.isEmpty) return;
     if (!room.otherPartyCanReceiveMessages) {
       final theme = Theme.of(context);
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(
           backgroundColor: theme.colorScheme.errorContainer,
           closeIconColor: theme.colorScheme.onErrorContainer,
@@ -472,6 +473,7 @@ class ChatController extends State<ChatPageWithRoom>
           ),
           showCloseIcon: true,
         ),
+        assertive: true,
       );
       return;
     }
@@ -1735,8 +1737,9 @@ class ChatController extends State<ChatPageWithRoom>
             data: {'roomId': roomId, 'file': file.name},
           );
           // Pangea#
-          scaffoldMessenger.showSnackBar(
+          scaffoldMessenger.showSnackBarAnnounced(
             SnackBar(content: Text((e as Object).toLocalizedString(context))),
+            assertive: true,
           );
           return null;
         });
@@ -1870,7 +1873,7 @@ class ChatController extends State<ChatPageWithRoom>
     // });
     clearSelectedEvents();
     // Pangea#
-    ScaffoldMessenger.of(context).showSnackBar(
+    ScaffoldMessenger.of(context).showSnackBarAnnounced(
       SnackBar(content: Text(L10n.of(context).contentHasBeenReported)),
     );
   }
@@ -2875,12 +2878,13 @@ class ChatController extends State<ChatPageWithRoom>
 
     if (assistanceState == AssistanceStateEnum.error) {
       final error = choreographer.errorService.error!;
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(
           duration: const Duration(seconds: 5),
           showCloseIcon: true,
           content: Text(error.toLocalizedString(context)),
         ),
+        assertive: true,
       );
       choreographer.errorService.clear();
       return;
@@ -3005,7 +3009,7 @@ class ChatController extends State<ChatPageWithRoom>
     if (resp.isError) return;
     if (mounted) {
       messenger.hideCurrentSnackBar();
-      messenger.showSnackBar(
+      messenger.showSnackBarAnnounced(
         SnackBar(
           content: Text(
             L10n.of(context).languageUpdated,

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -124,6 +124,9 @@ import 'send_file_dialog.dart';
 import 'send_location_dialog.dart';
 
 // #Pangea
+// Pangea#
+
+// #Pangea
 class _TimelineUpdateNotifier extends ChangeNotifier {
   void notify() {
     notifyListeners();
@@ -463,6 +466,7 @@ class ChatController extends State<ChatPageWithRoom>
     if (shareItems == null || shareItems.isEmpty) return;
     if (!room.otherPartyCanReceiveMessages) {
       final theme = Theme.of(context);
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(
           backgroundColor: theme.colorScheme.errorContainer,
@@ -475,6 +479,7 @@ class ChatController extends State<ChatPageWithRoom>
         ),
         assertive: true,
       );
+      // Pangea#
       return;
     }
     for (final item in shareItems) {
@@ -1737,10 +1742,12 @@ class ChatController extends State<ChatPageWithRoom>
             data: {'roomId': roomId, 'file': file.name},
           );
           // Pangea#
+          // #Pangea
           scaffoldMessenger.showSnackBarAnnounced(
             SnackBar(content: Text((e as Object).toLocalizedString(context))),
             assertive: true,
           );
+          // Pangea#
           return null;
         });
     // #Pangea
@@ -1873,9 +1880,11 @@ class ChatController extends State<ChatPageWithRoom>
     // });
     clearSelectedEvents();
     // Pangea#
+    // #Pangea
     ScaffoldMessenger.of(context).showSnackBarAnnounced(
       SnackBar(content: Text(L10n.of(context).contentHasBeenReported)),
     );
+    // Pangea#
   }
 
   void deleteErrorEventsAction() async {
@@ -2878,6 +2887,7 @@ class ChatController extends State<ChatPageWithRoom>
 
     if (assistanceState == AssistanceStateEnum.error) {
       final error = choreographer.errorService.error!;
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(
           duration: const Duration(seconds: 5),
@@ -2886,6 +2896,7 @@ class ChatController extends State<ChatPageWithRoom>
         ),
         assertive: true,
       );
+      // Pangea#
       choreographer.errorService.clear();
       return;
     }
@@ -3009,6 +3020,7 @@ class ChatController extends State<ChatPageWithRoom>
     if (resp.isError) return;
     if (mounted) {
       messenger.hideCurrentSnackBar();
+      // #Pangea
       messenger.showSnackBarAnnounced(
         SnackBar(
           content: Text(
@@ -3017,6 +3029,7 @@ class ChatController extends State<ChatPageWithRoom>
           ),
         ),
       );
+      // Pangea#
     }
   }
 

--- a/lib/routes/chat/chat_details/access/chat_access_settings_controller.dart
+++ b/lib/routes/chat/chat_details/access/chat_access_settings_controller.dart
@@ -14,6 +14,9 @@ import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
+// #Pangea
+// Pangea#
+
 class ChatAccessSettings extends StatefulWidget {
   final String roomId;
 
@@ -116,10 +119,12 @@ class ChatAccessSettingsController extends State<ChatAccessSettings> {
     } catch (e, s) {
       Logs().w('Unable to change join rules', e, s);
       if (mounted) {
+        // #Pangea
         ScaffoldMessenger.of(context).showSnackBarAnnounced(
           SnackBar(content: Text(e.toLocalizedString(context))),
           assertive: true,
         );
+        // Pangea#
       }
     } finally {
       if (mounted) {
@@ -141,10 +146,12 @@ class ChatAccessSettingsController extends State<ChatAccessSettings> {
     } catch (e, s) {
       Logs().w('Unable to change history visibility', e, s);
       if (mounted) {
+        // #Pangea
         ScaffoldMessenger.of(context).showSnackBarAnnounced(
           SnackBar(content: Text(e.toLocalizedString(context))),
           assertive: true,
         );
+        // Pangea#
       }
     } finally {
       if (mounted) {
@@ -166,10 +173,12 @@ class ChatAccessSettingsController extends State<ChatAccessSettings> {
     } catch (e, s) {
       Logs().w('Unable to change guest access', e, s);
       if (mounted) {
+        // #Pangea
         ScaffoldMessenger.of(context).showSnackBarAnnounced(
           SnackBar(content: Text(e.toLocalizedString(context))),
           assertive: true,
         );
+        // Pangea#
       }
     } finally {
       if (mounted) {
@@ -347,10 +356,12 @@ class ChatAccessSettingsController extends State<ChatAccessSettings> {
     } catch (e, s) {
       Logs().w('Unable to change visibility', e, s);
       if (mounted) {
+        // #Pangea
         ScaffoldMessenger.of(context).showSnackBarAnnounced(
           SnackBar(content: Text(e.toLocalizedString(context))),
           assertive: true,
         );
+        // Pangea#
       }
     } finally {
       if (mounted) {

--- a/lib/routes/chat/chat_details/access/chat_access_settings_controller.dart
+++ b/lib/routes/chat/chat_details/access/chat_access_settings_controller.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -115,9 +116,10 @@ class ChatAccessSettingsController extends State<ChatAccessSettings> {
     } catch (e, s) {
       Logs().w('Unable to change join rules', e, s);
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(e.toLocalizedString(context))));
+        ScaffoldMessenger.of(context).showSnackBarAnnounced(
+          SnackBar(content: Text(e.toLocalizedString(context))),
+          assertive: true,
+        );
       }
     } finally {
       if (mounted) {
@@ -139,9 +141,10 @@ class ChatAccessSettingsController extends State<ChatAccessSettings> {
     } catch (e, s) {
       Logs().w('Unable to change history visibility', e, s);
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(e.toLocalizedString(context))));
+        ScaffoldMessenger.of(context).showSnackBarAnnounced(
+          SnackBar(content: Text(e.toLocalizedString(context))),
+          assertive: true,
+        );
       }
     } finally {
       if (mounted) {
@@ -163,9 +166,10 @@ class ChatAccessSettingsController extends State<ChatAccessSettings> {
     } catch (e, s) {
       Logs().w('Unable to change guest access', e, s);
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(e.toLocalizedString(context))));
+        ScaffoldMessenger.of(context).showSnackBarAnnounced(
+          SnackBar(content: Text(e.toLocalizedString(context))),
+          assertive: true,
+        );
       }
     } finally {
       if (mounted) {
@@ -343,9 +347,10 @@ class ChatAccessSettingsController extends State<ChatAccessSettings> {
     } catch (e, s) {
       Logs().w('Unable to change visibility', e, s);
       if (mounted) {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(e.toLocalizedString(context))));
+        ScaffoldMessenger.of(context).showSnackBarAnnounced(
+          SnackBar(content: Text(e.toLocalizedString(context))),
+          assertive: true,
+        );
       }
     } finally {
       if (mounted) {

--- a/lib/routes/chat/chat_details/chat_details.dart
+++ b/lib/routes/chat/chat_details/chat_details.dart
@@ -32,6 +32,9 @@ import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/local_notifications_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
+// #Pangea
+// Pangea#
+
 enum AliasActions { copy, delete, setCanonical }
 
 class ChatDetails extends StatefulWidget {
@@ -147,9 +150,11 @@ class ChatDetailsController extends State<ChatDetails>
       future: () => room.setName(input),
     );
     if (success.error == null) {
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).displaynameHasBeenChanged)),
       );
+      // Pangea#
     }
   }
 

--- a/lib/routes/chat/chat_details/chat_details.dart
+++ b/lib/routes/chat/chat_details/chat_details.dart
@@ -27,6 +27,7 @@ import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/local_notifications_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -146,7 +147,7 @@ class ChatDetailsController extends State<ChatDetails>
       future: () => room.setName(input),
     );
     if (success.error == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).displaynameHasBeenChanged)),
       );
     }
@@ -289,7 +290,7 @@ class ChatDetailsController extends State<ChatDetails>
       future: () => room.updateRoomCapacity(newCapacity),
     );
     if (success.error == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).chatCapacityHasBeenChanged)),
       );
       setState(() {});

--- a/lib/routes/chat/chat_details/edit_course/edit_course.dart
+++ b/lib/routes/chat/chat_details/edit_course/edit_course.dart
@@ -15,6 +15,7 @@ import 'package:fluffychat/utils/file_selector.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -105,7 +106,7 @@ class EditCourseController extends State<EditCourse> {
     );
 
     if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(
           content: Text(
             resp.isError
@@ -114,6 +115,7 @@ class EditCourseController extends State<EditCourse> {
             textAlign: TextAlign.center,
           ),
         ),
+        assertive: resp.isError,
       );
     }
 

--- a/lib/routes/chat/chat_details/emotes/settings_emotes.dart
+++ b/lib/routes/chat/chat_details/emotes/settings_emotes.dart
@@ -14,6 +14,7 @@ import 'package:fluffychat/utils/file_selector.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import '../../../../widgets/matrix.dart';
 import 'import_archive_dialog.dart';
@@ -270,8 +271,9 @@ class EmotesSettingsController extends State<EmotesSettings> {
     final keyName = name.toLowerCase().replaceAll(' ', '_');
 
     if (packKeys?.contains(name) ?? false) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).stickerPackNameAlreadyExists)),
+        assertive: true,
       );
       return;
     }

--- a/lib/routes/chat/chat_details/invite/pangea_invitation_selection.dart
+++ b/lib/routes/chat/chat_details/invite/pangea_invitation_selection.dart
@@ -15,6 +15,7 @@ import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/chat_details/invite/pangea_invitation_selection_view.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -366,9 +367,10 @@ class PangeaInvitationSelectionController
     try {
       response = await matrix.client.searchUser(text, limit: 100);
     } catch (e) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text((e).toLocalizedString(context))));
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
+        SnackBar(content: Text((e).toLocalizedString(context))),
+        assertive: true,
+      );
       return;
     } finally {
       setState(() {
@@ -437,7 +439,7 @@ class PangeaInvitationSelectionController
     );
     if (success.error == null) {
       ScaffoldMessenger.of(context).hideCurrentSnackBar();
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(
           content: Text(
             room.isSpace
@@ -475,7 +477,7 @@ class PangeaInvitationSelectionController
       },
     ).then((result) {
       if (result.error == null) {
-        ScaffoldMessenger.of(context).showSnackBar(
+        ScaffoldMessenger.of(context).showSnackBarAnnounced(
           SnackBar(
             content: Text(
               L10n.of(context).spaceParticipantsHaveBeenInvitedToTheChat,
@@ -483,9 +485,10 @@ class PangeaInvitationSelectionController
           ),
         );
       } else {
-        ScaffoldMessenger.of(
-          context,
-        ).showSnackBar(SnackBar(content: Text(result.error.toString())));
+        ScaffoldMessenger.of(context).showSnackBarAnnounced(
+          SnackBar(content: Text(result.error.toString())),
+          assertive: true,
+        );
       }
     });
   }

--- a/lib/routes/chat/chat_details/permissions/chat_permissions_settings.dart
+++ b/lib/routes/chat/chat_details/permissions/chat_permissions_settings.dart
@@ -15,6 +15,9 @@ import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/permission_slider_dialog.dart';
 
+// #Pangea
+// Pangea#
+
 class ChatPermissionsSettings extends StatefulWidget {
   // #Pangea
   /// world_v2: the room/space this page edits. Supplied explicitly when hosted
@@ -60,10 +63,12 @@ class ChatPermissionsSettingsController extends State<ChatPermissionsSettings> {
   }) async {
     final room = Matrix.of(context).client.getRoomById(roomId!)!;
     if (!room.canSendEvent(EventTypes.RoomPowerLevels)) {
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).noPermission)),
         assertive: true,
       );
+      // Pangea#
       return;
     }
     newLevel ??= await showPermissionChooser(

--- a/lib/routes/chat/chat_details/permissions/chat_permissions_settings.dart
+++ b/lib/routes/chat/chat_details/permissions/chat_permissions_settings.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/constants/default_power_level.dart';
 import 'package:fluffychat/routes/chat/chat_details/permissions/chat_permissions_settings_view.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/permission_slider_dialog.dart';
@@ -59,9 +60,10 @@ class ChatPermissionsSettingsController extends State<ChatPermissionsSettings> {
   }) async {
     final room = Matrix.of(context).client.getRoomById(roomId!)!;
     if (!room.canSendEvent(EventTypes.RoomPowerLevels)) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(L10n.of(context).noPermission)));
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
+        SnackBar(content: Text(L10n.of(context).noPermission)),
+        assertive: true,
+      );
       return;
     }
     newLevel ??= await showPermissionChooser(

--- a/lib/routes/chat/chat_details/room_capacity_button.dart
+++ b/lib/routes/chat/chat_details/room_capacity_button.dart
@@ -6,6 +6,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/chat_details/chat_details.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 
 class RoomCapacityButton extends StatefulWidget {
@@ -85,7 +86,7 @@ class RoomCapacityButtonState extends State<RoomCapacityButton> {
       future: () => widget.room.updateRoomCapacity(newCapacity),
     );
     if (success.error == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).chatCapacityHasBeenChanged)),
       );
       setState(() {});

--- a/lib/routes/chat/event_info_dialog.dart
+++ b/lib/routes/chat/event_info_dialog.dart
@@ -12,6 +12,9 @@ import 'package:fluffychat/utils/date_time_extension.dart';
 import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 
+// #Pangea
+// Pangea#
+
 extension EventInfoDialogExtension on Event {
   void showInfoDialog(BuildContext context) => showAdaptiveBottomSheet(
     context: context,

--- a/lib/routes/chat/event_info_dialog.dart
+++ b/lib/routes/chat/event_info_dialog.dart
@@ -9,6 +9,7 @@ import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/adaptive_bottom_sheet.dart';
 import 'package:fluffychat/utils/date_time_extension.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 
 extension EventInfoDialogExtension on Event {
@@ -106,7 +107,7 @@ class EventInfoDialog extends StatelessWidget {
               icon: const Icon(Icons.copy),
               onPressed: () {
                 Clipboard.setData(ClipboardData(text: prettyJson(event)));
-                ScaffoldMessenger.of(context).showSnackBar(
+                ScaffoldMessenger.of(context).showSnackBarAnnounced(
                   SnackBar(content: Text(L10n.of(context).copiedToClipboard)),
                 );
               },

--- a/lib/routes/chat/send_file_dialog.dart
+++ b/lib/routes/chat/send_file_dialog.dart
@@ -14,6 +14,7 @@ import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/size_string.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/dialog_text_field.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import '../../utils/resize_video.dart';
 
 class SendFileDialog extends StatefulWidget {
@@ -123,12 +124,13 @@ class SendFileDialogState extends State<SendFileDialog> {
             milliseconds: retryAfterMs + 1000,
           );
 
-          scaffoldMessenger.showSnackBar(
+          scaffoldMessenger.showSnackBarAnnounced(
             SnackBar(
               content: Text(
                 l10n.serverLimitReached(retryAfterDuration.inSeconds),
               ),
             ),
+            assertive: true,
           );
           await Future.delayed(retryAfterDuration);
 
@@ -146,7 +148,7 @@ class SendFileDialogState extends State<SendFileDialog> {
     } catch (e) {
       scaffoldMessenger.clearSnackBars();
       final theme = Theme.of(context);
-      scaffoldMessenger.showSnackBar(
+      scaffoldMessenger.showSnackBarAnnounced(
         SnackBar(
           backgroundColor: theme.colorScheme.errorContainer,
           closeIconColor: theme.colorScheme.onErrorContainer,
@@ -157,6 +159,7 @@ class SendFileDialogState extends State<SendFileDialog> {
           duration: const Duration(seconds: 30),
           showCloseIcon: true,
         ),
+        assertive: true,
       );
       rethrow;
     }

--- a/lib/routes/chat/send_file_dialog.dart
+++ b/lib/routes/chat/send_file_dialog.dart
@@ -17,6 +17,9 @@ import 'package:fluffychat/widgets/adaptive_dialogs/dialog_text_field.dart';
 import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import '../../utils/resize_video.dart';
 
+// #Pangea
+// Pangea#
+
 class SendFileDialog extends StatefulWidget {
   final Room room;
   final List<XFile> files;
@@ -124,6 +127,7 @@ class SendFileDialogState extends State<SendFileDialog> {
             milliseconds: retryAfterMs + 1000,
           );
 
+          // #Pangea
           scaffoldMessenger.showSnackBarAnnounced(
             SnackBar(
               content: Text(
@@ -132,6 +136,7 @@ class SendFileDialogState extends State<SendFileDialog> {
             ),
             assertive: true,
           );
+          // Pangea#
           await Future.delayed(retryAfterDuration);
 
           scaffoldMessenger.showLoadingSnackBar(l10n.sendingAttachment);
@@ -148,6 +153,7 @@ class SendFileDialogState extends State<SendFileDialog> {
     } catch (e) {
       scaffoldMessenger.clearSnackBars();
       final theme = Theme.of(context);
+      // #Pangea
       scaffoldMessenger.showSnackBarAnnounced(
         SnackBar(
           backgroundColor: theme.colorScheme.errorContainer,
@@ -161,6 +167,7 @@ class SendFileDialogState extends State<SendFileDialog> {
         ),
         assertive: true,
       );
+      // Pangea#
       rethrow;
     }
 

--- a/lib/routes/chat/start_poll_bottom_sheet.dart
+++ b/lib/routes/chat/start_poll_bottom_sheet.dart
@@ -4,6 +4,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 
 class StartPollBottomSheet extends StatefulWidget {
   final Room room;
@@ -50,9 +51,10 @@ class _StartPollBottomSheetState extends State<StartPollBottomSheet> {
     } catch (e, s) {
       Logs().w('Unable to create poll', e, s);
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(e.toLocalizedString(context))));
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
+        SnackBar(content: Text(e.toLocalizedString(context))),
+        assertive: true,
+      );
     }
   }
 

--- a/lib/routes/chat/toolbar/reading_assistance/select_mode_buttons.dart
+++ b/lib/routes/chat/toolbar/reading_assistance/select_mode_buttons.dart
@@ -28,6 +28,7 @@ import 'package:fluffychat/routes/chat/events/utils/report_message.dart';
 import 'package:fluffychat/routes/chat/toolbar/message_selection_overlay.dart';
 import 'package:fluffychat/routes/chat/toolbar/reading_assistance/select_mode_controller.dart';
 import 'package:fluffychat/utils/multi_platform_audio_player.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 enum SelectMode {
@@ -331,7 +332,7 @@ class SelectModeButtonsState extends State<SelectModeButtons> {
       if (!InstructionsEnum.emojiToolbarMode.isToggledOff) {
         InstructionsEnum.emojiToolbarMode.setToggledOff(true);
         ScaffoldMessenger.of(context).hideCurrentSnackBar();
-        ScaffoldMessenger.of(context).showSnackBar(
+        ScaffoldMessenger.of(context).showSnackBarAnnounced(
           SnackBar(
             content: Text(L10n.of(context).emojiToolbarInstruction),
             showCloseIcon: true,
@@ -352,7 +353,7 @@ class SelectModeButtonsState extends State<SelectModeButtons> {
 
     final messenger = ScaffoldMessenger.of(context);
     messenger.hideCurrentSnackBar();
-    messenger.showSnackBar(
+    messenger.showSnackBarAnnounced(
       SnackBar(
         content: RichText(
           textAlign: TextAlign.center,

--- a/lib/routes/chat/toolbar/word_card/lemma_emoji_setter_mixin.dart
+++ b/lib/routes/chat/toolbar/word_card/lemma_emoji_setter_mixin.dart
@@ -6,6 +6,7 @@ import 'package:fluffychat/features/analytics/constructs_model.dart';
 import 'package:fluffychat/features/instructions/instructions_enum.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/vocab_analytics_list_tile.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 mixin LemmaEmojiSetter {
@@ -56,7 +57,7 @@ mixin LemmaEmojiSetter {
     final theme = Theme.of(context);
     final l10n = L10n.of(context);
 
-    messenger.showSnackBar(
+    messenger.showSnackBarAnnounced(
       SnackBar(
         showCloseIcon: false,
         padding: const EdgeInsets.all(8.0),
@@ -91,6 +92,7 @@ mixin LemmaEmojiSetter {
         ),
         duration: const Duration(seconds: 30),
       ),
+      announcement: l10n.emojiSelectedSnackbar(constructId.lemma),
     );
   }
 

--- a/lib/routes/chat_list/chat_list.dart
+++ b/lib/routes/chat_list/chat_list.dart
@@ -44,6 +44,7 @@ import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart'
 import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/share_scaffold_dialog.dart';
 import '../../../utils/account_bundles.dart';
@@ -251,8 +252,9 @@ class ChatListController extends State<ChatList>
     }
 
     if (room.membership == Membership.ban) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).youHaveBeenBannedFromThisChat)),
+        assertive: true,
       );
       return;
     }
@@ -406,9 +408,10 @@ class ChatListController extends State<ChatList>
       );
     } catch (e, s) {
       Logs().w('Searching has crashed', e, s);
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(e.toLocalizedString(context))));
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
+        SnackBar(content: Text(e.toLocalizedString(context))),
+        assertive: true,
+      );
     }
     if (!isSearchMode) return;
     setState(() {

--- a/lib/routes/chat_list/chat_list.dart
+++ b/lib/routes/chat_list/chat_list.dart
@@ -52,6 +52,9 @@ import '../../config/setting_keys.dart';
 import '../../utils/url_launcher.dart';
 import '../../widgets/matrix.dart';
 
+// #Pangea
+// Pangea#
+
 enum PopupMenuAction {
   settings,
   invite,
@@ -252,10 +255,12 @@ class ChatListController extends State<ChatList>
     }
 
     if (room.membership == Membership.ban) {
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).youHaveBeenBannedFromThisChat)),
         assertive: true,
       );
+      // Pangea#
       return;
     }
 
@@ -408,10 +413,12 @@ class ChatListController extends State<ChatList>
       );
     } catch (e, s) {
       Logs().w('Searching has crashed', e, s);
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(e.toLocalizedString(context))),
         assertive: true,
       );
+      // Pangea#
     }
     if (!isSearchMode) return;
     setState(() {

--- a/lib/routes/chat_list/course_chats_page.dart
+++ b/lib/routes/chat_list/course_chats_page.dart
@@ -78,7 +78,7 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
     _roomSubscription?.cancel();
     _roomSubscription = widget.client.onSync.stream
         .where(_hasHierarchyUpdate)
-        .listen((update) => loadHierarchy(reload: true));
+        .listen((update) => loadHierarchy(reload: true, background: true));
   }
 
   @override
@@ -90,7 +90,7 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
       _roomSubscription?.cancel();
       _roomSubscription = widget.client.onSync.stream
           .where(_hasHierarchyUpdate)
-          .listen((update) => loadHierarchy(reload: true));
+          .listen((update) => loadHierarchy(reload: true, background: true));
 
       discoveredChildren = null;
       _nextBatch = null;
@@ -221,7 +221,10 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
     }
   }
 
-  Future<void> loadHierarchy({bool reload = false}) async {
+  Future<void> loadHierarchy({
+    bool reload = false,
+    bool background = false,
+  }) async {
     final space = this.space;
     if (space == null) return;
 
@@ -241,13 +244,21 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
     } catch (e, s) {
       Logs().w('Unable to load hierarchy', e, s);
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBarAnnounced(
-          SnackBar(
-            content: Text(e.toLocalizedString(context)),
-            showCloseIcon: true,
-          ),
-          assertive: true,
+        final snackBar = SnackBar(
+          content: Text(e.toLocalizedString(context)),
+          showCloseIcon: true,
         );
+        // Background sync reloads can fire repeatedly on a flaky request, so
+        // only a foreground (user-opened/navigated) failure is announced to
+        // screen readers; background failures still show the toast but stay
+        // silent to avoid repeated announcements (#7203).
+        if (background) {
+          ScaffoldMessenger.of(context).showSnackBar(snackBar);
+        } else {
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBarAnnounced(snackBar, assertive: true);
+        }
       }
     } finally {
       if (mounted) {

--- a/lib/routes/chat_list/course_chats_page.dart
+++ b/lib/routes/chat_list/course_chats_page.dart
@@ -31,6 +31,7 @@ import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/public_room_bottom_sheet.dart';
@@ -240,11 +241,12 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
     } catch (e, s) {
       Logs().w('Unable to load hierarchy', e, s);
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
+        ScaffoldMessenger.of(context).showSnackBarAnnounced(
           SnackBar(
             content: Text(e.toLocalizedString(context)),
             showCloseIcon: true,
           ),
+          assertive: true,
         );
       }
     } finally {
@@ -473,8 +475,9 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
     }
 
     if (room.membership == Membership.ban) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).youHaveBeenBannedFromThisChat)),
+        assertive: true,
       );
       return;
     }

--- a/lib/routes/home/login/login.dart
+++ b/lib/routes/home/login/login.dart
@@ -15,6 +15,9 @@ import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
+// #Pangea
+// Pangea#
+
 class Login extends StatefulWidget {
   // #Pangea
   // final Client client;
@@ -357,9 +360,11 @@ class LoginController extends State<Login> {
       // Pangea#
     );
     if (success.error == null) {
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).passwordHasBeenChanged)),
       );
+      // Pangea#
       usernameController.text = input;
       passwordController.text = password;
       login();

--- a/lib/routes/home/login/login.dart
+++ b/lib/routes/home/login/login.dart
@@ -11,6 +11,7 @@ import 'package:fluffychat/routes/home/signup/signup.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -356,7 +357,7 @@ class LoginController extends State<Login> {
       // Pangea#
     );
     if (success.error == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).passwordHasBeenChanged)),
       );
       usernameController.text = input;

--- a/lib/routes/home/login_loading_dialog.dart
+++ b/lib/routes/home/login_loading_dialog.dart
@@ -123,11 +123,18 @@ class LoginLoadingDialogState extends State<LoginLoadingDialog> {
           crossAxisAlignment: .center,
           children: [
             exception != null
-                ? Text(
-                    exception is MatrixException
-                        ? exception.errorMessage
-                        : exception.toLocalizedString(context),
+                // #Pangea: announce the login error to screen readers when it
+                // replaces the spinner in the still-open dialog (WCAG 4.1.3,
+                // #7203).
+                ? Semantics(
+                    liveRegion: true,
+                    child: Text(
+                      exception is MatrixException
+                          ? exception.errorMessage
+                          : exception.toLocalizedString(context),
+                    ),
                   )
+                // Pangea#
                 : ValueListenableBuilder<InitState?>(
                     valueListenable: _initState,
                     builder: (context, initState, child) =>

--- a/lib/routes/new_private_chat/new_private_chat.dart
+++ b/lib/routes/new_private_chat/new_private_chat.dart
@@ -14,6 +14,7 @@ import 'package:fluffychat/utils/adaptive_bottom_sheet.dart';
 import 'package:fluffychat/utils/fluffy_share.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/url_launcher.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import '../../widgets/adaptive_dialogs/user_dialog.dart';
 
@@ -78,10 +79,11 @@ class NewPrivateChatController extends State<NewPrivateChat> {
     if (PlatformInfos.isAndroid) {
       final info = await DeviceInfoPlugin().androidInfo;
       if (info.version.sdkInt < 21) {
-        ScaffoldMessenger.of(context).showSnackBar(
+        ScaffoldMessenger.of(context).showSnackBarAnnounced(
           SnackBar(
             content: Text(L10n.of(context).unsupportedAndroidVersionLong),
           ),
+          assertive: true,
         );
         return;
       }
@@ -98,9 +100,9 @@ class NewPrivateChatController extends State<NewPrivateChat> {
     await Clipboard.setData(
       ClipboardData(text: Matrix.of(context).client.userID!),
     );
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(L10n.of(context).copiedToClipboard)));
+    ScaffoldMessenger.of(context).showSnackBarAnnounced(
+      SnackBar(content: Text(L10n.of(context).copiedToClipboard)),
+    );
   }
 
   void openUserModal(Profile profile) =>

--- a/lib/routes/new_private_chat/new_private_chat.dart
+++ b/lib/routes/new_private_chat/new_private_chat.dart
@@ -18,6 +18,9 @@ import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import '../../widgets/adaptive_dialogs/user_dialog.dart';
 
+// #Pangea
+// Pangea#
+
 class NewPrivateChat extends StatefulWidget {
   const NewPrivateChat({super.key});
 
@@ -79,12 +82,14 @@ class NewPrivateChatController extends State<NewPrivateChat> {
     if (PlatformInfos.isAndroid) {
       final info = await DeviceInfoPlugin().androidInfo;
       if (info.version.sdkInt < 21) {
+        // #Pangea
         ScaffoldMessenger.of(context).showSnackBarAnnounced(
           SnackBar(
             content: Text(L10n.of(context).unsupportedAndroidVersionLong),
           ),
           assertive: true,
         );
+        // Pangea#
         return;
       }
     }
@@ -100,9 +105,11 @@ class NewPrivateChatController extends State<NewPrivateChat> {
     await Clipboard.setData(
       ClipboardData(text: Matrix.of(context).client.userID!),
     );
+    // #Pangea
     ScaffoldMessenger.of(context).showSnackBarAnnounced(
       SnackBar(content: Text(L10n.of(context).copiedToClipboard)),
     );
+    // Pangea#
   }
 
   void openUserModal(Profile profile) =>

--- a/lib/routes/profile/user_home_page.dart
+++ b/lib/routes/profile/user_home_page.dart
@@ -17,6 +17,7 @@ import 'package:fluffychat/utils/fluffy_share.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
@@ -198,11 +199,12 @@ class _UserHomePageState extends State<UserHomePage> {
 
       if (mounted) {
         ScaffoldMessenger.of(context).hideCurrentSnackBar();
-        ScaffoldMessenger.of(context).showSnackBar(
+        ScaffoldMessenger.of(context).showSnackBarAnnounced(
           SnackBar(
             content: Text(L10n.of(context).oopsSomethingWentWrong),
             showCloseIcon: true,
           ),
+          assertive: true,
         );
       }
     }

--- a/lib/routes/settings/settings_notifications/settings_notifications.dart
+++ b/lib/routes/settings/settings_notifications/settings_notifications.dart
@@ -22,6 +22,9 @@ import 'package:fluffychat/widgets/local_notifications_extension.dart';
 import '../../../widgets/matrix.dart';
 import 'settings_notifications_view.dart';
 
+// #Pangea
+// Pangea#
+
 class SettingsNotifications extends StatefulWidget {
   const SettingsNotifications({super.key});
 
@@ -107,10 +110,12 @@ class SettingsNotificationsController extends State<SettingsNotifications> {
       // #Pangea
       ScaffoldMessenger.of(context).hideCurrentSnackBar();
       // Pangea#
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(e.toLocalizedString(context))),
         assertive: true,
       );
+      // Pangea#
     } finally {
       if (mounted) {
         setState(() {
@@ -195,10 +200,12 @@ class SettingsNotificationsController extends State<SettingsNotifications> {
           // #Pangea
           ScaffoldMessenger.of(context).hideCurrentSnackBar();
           // Pangea#
+          // #Pangea
           ScaffoldMessenger.of(context).showSnackBarAnnounced(
             SnackBar(content: Text(e.toLocalizedString(context))),
             assertive: true,
           );
+          // Pangea#
         } finally {
           if (mounted) {
             setState(() {
@@ -286,6 +293,11 @@ class SettingsNotificationsController extends State<SettingsNotifications> {
         duration: Duration(seconds: 15),
         showCloseIcon: true,
       ),
+      // The call to action lives in a WidgetSpan, which toPlainText() drops, so
+      // announce the full message (description + CTA) explicitly (#7203).
+      announcement:
+          '${L10n.of(context).noAddressDescription} '
+          '${L10n.of(context).clickToAddEmail}',
     );
   }
   // Pangea#

--- a/lib/routes/settings/settings_notifications/settings_notifications.dart
+++ b/lib/routes/settings/settings_notifications/settings_notifications.dart
@@ -16,6 +16,7 @@ import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/local_notifications_extension.dart';
 import '../../../widgets/matrix.dart';
@@ -106,9 +107,10 @@ class SettingsNotificationsController extends State<SettingsNotifications> {
       // #Pangea
       ScaffoldMessenger.of(context).hideCurrentSnackBar();
       // Pangea#
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(e.toLocalizedString(context))));
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
+        SnackBar(content: Text(e.toLocalizedString(context))),
+        assertive: true,
+      );
     } finally {
       if (mounted) {
         setState(() {
@@ -193,9 +195,10 @@ class SettingsNotificationsController extends State<SettingsNotifications> {
           // #Pangea
           ScaffoldMessenger.of(context).hideCurrentSnackBar();
           // Pangea#
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(SnackBar(content: Text(e.toLocalizedString(context))));
+          ScaffoldMessenger.of(context).showSnackBarAnnounced(
+            SnackBar(content: Text(e.toLocalizedString(context))),
+            assertive: true,
+          );
         } finally {
           if (mounted) {
             setState(() {
@@ -225,11 +228,12 @@ class SettingsNotificationsController extends State<SettingsNotifications> {
 
       if (!mounted) return;
       ScaffoldMessenger.of(context).hideCurrentSnackBar();
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(
           content: Text(e.toLocalizedString(context)),
           showCloseIcon: true,
         ),
+        assertive: true,
       );
     } finally {
       if (mounted) {
@@ -243,7 +247,7 @@ class SettingsNotificationsController extends State<SettingsNotifications> {
   void showNoEmailSnackbar() {
     messenger ??= ScaffoldMessenger.of(context);
     messenger!.hideCurrentSnackBar();
-    messenger!.showSnackBar(
+    messenger!.showSnackBarAnnounced(
       SnackBar(
         content: RichText(
           text: TextSpan(

--- a/lib/routes/settings/settings_security/settings_password/settings_password.dart
+++ b/lib/routes/settings/settings_security/settings_password/settings_password.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/settings/settings_security/settings_password/settings_password_view.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 class SettingsPassword extends StatefulWidget {
@@ -60,7 +61,7 @@ class SettingsPasswordController extends State<SettingsPassword> {
         newPassword1Controller.text,
         oldPassword: oldPasswordController.text,
       );
-      scaffoldMessenger.showSnackBar(
+      scaffoldMessenger.showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).passwordHasBeenChanged)),
       );
       // world_v2: this is the `settingspage:security/password` token panel, not

--- a/lib/routes/settings/settings_subscription/settings_subscription.dart
+++ b/lib/routes/settings/settings_subscription/settings_subscription.dart
@@ -13,6 +13,7 @@ import 'package:fluffychat/features/subscription/widgets/subscription_snackbar.d
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/routes/settings/settings_subscription/settings_subscription_view.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 class SubscriptionManagement extends StatefulWidget {
@@ -171,7 +172,7 @@ class SubscriptionManagementController extends State<SubscriptionManagement>
   Future<void> onClickCancelSubscription() async {
     final uri = await launchMangementUrl(ManagementOption.cancel);
     if (uri != null) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(
           showCloseIcon: true,
           duration: const Duration(seconds: 30),
@@ -192,6 +193,7 @@ class SubscriptionManagementController extends State<SubscriptionManagement>
             ],
           ),
         ),
+        announcement: L10n.of(context).managementSnackbarMessage,
       );
     }
     await SubscriptionManagementRepo.setClickedCancelSubscription();

--- a/lib/routes/settings/settings_view.dart
+++ b/lib/routes/settings/settings_view.dart
@@ -18,6 +18,9 @@ import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/mxc_image_viewer.dart';
 
+// #Pangea
+// Pangea#
+
 class SettingsView extends StatelessWidget {
   final SettingsController controller;
 

--- a/lib/routes/settings/settings_view.dart
+++ b/lib/routes/settings/settings_view.dart
@@ -13,6 +13,7 @@ import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/routes/settings/settings.dart';
 import 'package:fluffychat/routes/settings/support_chat_list_tile.dart';
 import 'package:fluffychat/utils/fluffy_share.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/mxc_image_viewer.dart';
@@ -346,7 +347,9 @@ class SettingsView extends StatelessWidget {
                                       "${snapshot.data!.version}+${snapshot.data!.buildNumber}",
                                 ),
                               );
-                              ScaffoldMessenger.of(context).showSnackBar(
+                              ScaffoldMessenger.of(
+                                context,
+                              ).showSnackBarAnnounced(
                                 SnackBar(
                                   content: Text(
                                     L10n.of(context).copiedToClipboard,

--- a/lib/utils/error_reporter.dart
+++ b/lib/utils/error_reporter.dart
@@ -4,6 +4,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 
 class ErrorReporter {
   final BuildContext? context;
@@ -29,7 +30,7 @@ class ErrorReporter {
     try {
       // Attempt to retrieve the L10n instance using the current context
       final L10n l10n = L10n.of(context!);
-      ScaffoldMessenger.of(context!).showSnackBar(
+      ScaffoldMessenger.of(context!).showSnackBarAnnounced(
         SnackBar(
           content: Text(
             l10n.oopsSomethingWentWrong, // Use the non-null L10n instance to get the error message
@@ -38,6 +39,7 @@ class ErrorReporter {
           showCloseIcon: true,
           // Pangea#
         ),
+        assertive: true,
       );
     } catch (err) {
       debugPrint("Failed to show error snackbar.");

--- a/lib/utils/error_reporter.dart
+++ b/lib/utils/error_reporter.dart
@@ -6,6 +6,9 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/widgets/announcing_snackbar.dart';
 
+// #Pangea
+// Pangea#
+
 class ErrorReporter {
   final BuildContext? context;
   final String? message;

--- a/lib/utils/fluffy_share.dart
+++ b/lib/utils/fluffy_share.dart
@@ -9,6 +9,9 @@ import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import '../widgets/matrix.dart';
 
+// #Pangea
+// Pangea#
+
 abstract class FluffyShare {
   static Future<void> share(
     String text,
@@ -26,9 +29,11 @@ abstract class FluffyShare {
       return;
     }
     await Clipboard.setData(ClipboardData(text: text));
+    // #Pangea
     ScaffoldMessenger.of(context).showSnackBarAnnounced(
       SnackBar(content: Text(L10n.of(context).copiedToClipboard)),
     );
+    // Pangea#
     return;
   }
 

--- a/lib/utils/fluffy_share.dart
+++ b/lib/utils/fluffy_share.dart
@@ -6,6 +6,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import '../widgets/matrix.dart';
 
 abstract class FluffyShare {
@@ -25,9 +26,9 @@ abstract class FluffyShare {
       return;
     }
     await Clipboard.setData(ClipboardData(text: text));
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(SnackBar(content: Text(L10n.of(context).copiedToClipboard)));
+    ScaffoldMessenger.of(context).showSnackBarAnnounced(
+      SnackBar(content: Text(L10n.of(context).copiedToClipboard)),
+    );
     return;
   }
 

--- a/lib/utils/matrix_sdk_extensions/matrix_file_extension.dart
+++ b/lib/utils/matrix_sdk_extensions/matrix_file_extension.dart
@@ -6,6 +6,7 @@ import 'package:share_plus/share_plus.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/size_string.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 
 extension MatrixFileExtension on MatrixFile {
   void save(BuildContext context) async {
@@ -19,7 +20,7 @@ extension MatrixFileExtension on MatrixFile {
     );
     if (downloadPath == null) return;
 
-    scaffoldMessenger.showSnackBar(
+    scaffoldMessenger.showSnackBarAnnounced(
       SnackBar(content: Text(l10n.fileHasBeenSavedAt(downloadPath))),
     );
   }

--- a/lib/utils/show_update_snackbar.dart
+++ b/lib/utils/show_update_snackbar.dart
@@ -4,6 +4,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 
 abstract class UpdateNotifier {
   static const String versionStoreKey = 'last_known_version';
@@ -16,7 +17,7 @@ abstract class UpdateNotifier {
 
     if (currentVersion != storedVersion) {
       if (storedVersion != null) {
-        scaffoldMessenger.showSnackBar(
+        scaffoldMessenger.showSnackBarAnnounced(
           SnackBar(
             duration: const Duration(
               seconds:

--- a/lib/utils/show_update_snackbar.dart
+++ b/lib/utils/show_update_snackbar.dart
@@ -6,6 +6,9 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/announcing_snackbar.dart';
 
+// #Pangea
+// Pangea#
+
 abstract class UpdateNotifier {
   static const String versionStoreKey = 'last_known_version';
 
@@ -17,6 +20,7 @@ abstract class UpdateNotifier {
 
     if (currentVersion != storedVersion) {
       if (storedVersion != null) {
+        // #Pangea
         scaffoldMessenger.showSnackBarAnnounced(
           SnackBar(
             duration: const Duration(
@@ -36,6 +40,7 @@ abstract class UpdateNotifier {
             // Pangea#
           ),
         );
+        // Pangea#
       }
       await store.setString(versionStoreKey, currentVersion);
     }

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -16,6 +16,9 @@ import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/public_room_bottom_sheet.dart';
 import 'platform_infos.dart';
 
+// #Pangea
+// Pangea#
+
 class UrlLauncher {
   /// The url to open.
   final String? url;
@@ -38,10 +41,12 @@ class UrlLauncher {
     final uri = Uri.tryParse(url!);
     if (uri == null) {
       // we can't open this thing
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).cantOpenUri(url!))),
         assertive: true,
       );
+      // Pangea#
       return;
     }
 
@@ -93,10 +98,12 @@ class UrlLauncher {
       return;
     }
     if (uri.host.isEmpty) {
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).cantOpenUri(url!))),
         assertive: true,
       );
+      // Pangea#
       return;
     }
     // okay, we have either an http or an https URI.

--- a/lib/utils/url_launcher.dart
+++ b/lib/utils/url_launcher.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/user_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/public_room_bottom_sheet.dart';
@@ -37,8 +38,9 @@ class UrlLauncher {
     final uri = Uri.tryParse(url!);
     if (uri == null) {
       // we can't open this thing
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).cantOpenUri(url!))),
+        assertive: true,
       );
       return;
     }
@@ -91,8 +93,9 @@ class UrlLauncher {
       return;
     }
     if (uri.host.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(L10n.of(context).cantOpenUri(url!))),
+        assertive: true,
       );
       return;
     }

--- a/lib/widgets/announcing_snackbar.dart
+++ b/lib/widgets/announcing_snackbar.dart
@@ -38,9 +38,16 @@ extension AnnouncingScaffoldMessenger on ScaffoldMessengerState {
 /// the caller should pass an explicit `announcement`.
 String? snackBarAnnouncementText(Widget content) {
   if (content is Text) {
-    return content.data ?? content.textSpan?.toPlainText();
+    // semanticsLabel overrides the visible text for screen readers, so prefer
+    // it when present (CodeRabbit, #7203).
+    return content.semanticsLabel ??
+        content.data ??
+        content.textSpan?.toPlainText();
   }
   if (content is RichText) {
+    // toPlainText() substitutes a placeholder glyph for WidgetSpan children, so
+    // RichText carrying its label in a WidgetSpan (e.g. a tappable link) must
+    // pass an explicit announcement at the call site instead (#7203).
     return content.text.toPlainText();
   }
   return null;

--- a/lib/widgets/announcing_snackbar.dart
+++ b/lib/widgets/announcing_snackbar.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+
+/// WCAG 4.1.3 (Status Messages): a SnackBar is shown visually but is silent to
+/// screen readers, so status, success, and error toasts are never heard. This
+/// wraps [ScaffoldMessengerState.showSnackBar] to also announce the message as a
+/// live-region update via [SemanticsService.sendAnnouncement] — it moves no focus
+/// and is invisible to sighted users, so there is no downside for them.
+///
+/// Announce politely by default; pass `assertive: true` for errors so they
+/// interrupt. Pass an explicit [announcement] when the SnackBar content is not
+/// simple text. See issue #7203.
+extension AnnouncingScaffoldMessenger on ScaffoldMessengerState {
+  ScaffoldFeatureController<SnackBar, SnackBarClosedReason>
+  showSnackBarAnnounced(
+    SnackBar snackBar, {
+    String? announcement,
+    bool assertive = false,
+  }) {
+    final controller = showSnackBar(snackBar);
+    final message = announcement ?? snackBarAnnouncementText(snackBar.content);
+    if (message != null && message.trim().isNotEmpty) {
+      SemanticsService.sendAnnouncement(
+        View.of(context),
+        message,
+        Directionality.maybeOf(context) ?? TextDirection.ltr,
+        assertiveness: assertive
+            ? Assertiveness.assertive
+            : Assertiveness.polite,
+      );
+    }
+    return controller;
+  }
+}
+
+/// Best-effort plain text of a SnackBar's [content] for a screen-reader
+/// announcement. Returns null when the content is not simple text, in which case
+/// the caller should pass an explicit `announcement`.
+String? snackBarAnnouncementText(Widget content) {
+  if (content is Text) {
+    return content.data ?? content.textSpan?.toPlainText();
+  }
+  if (content is RichText) {
+    return content.text.toPlainText();
+  }
+  return null;
+}

--- a/lib/widgets/future_loading_dialog.dart
+++ b/lib/widgets/future_loading_dialog.dart
@@ -210,17 +210,23 @@ class LoadingDialogState<T> extends State<LoadingDialog> {
               const SizedBox(width: 20),
             ],
             Expanded(
-              child: Text(
-                titleLabel,
-                maxLines: 4,
-                // #Pangea
-                // textAlign: exception == null ? TextAlign.left : null,
-                textAlign: exception == null && _successMessage == null
-                    ? TextAlign.left
-                    : null,
-                // Pangea#
-                overflow: TextOverflow.ellipsis,
+              // #Pangea: a live region so the settled result (error or success)
+              // is announced to screen readers; the loading state is already
+              // read when the dialog opens, so the region only flips on once
+              // there is a result (WCAG 4.1.3, #7203).
+              child: Semantics(
+                liveRegion: exception != null || _successMessage != null,
+                child: Text(
+                  titleLabel,
+                  maxLines: 4,
+                  // textAlign: exception == null ? TextAlign.left : null,
+                  textAlign: exception == null && _successMessage == null
+                      ? TextAlign.left
+                      : null,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
+              // Pangea#
             ),
           ],
         ),

--- a/lib/widgets/image_viewer/video_player.dart
+++ b/lib/widgets/image_viewer/video_player.dart
@@ -13,6 +13,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/event_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/blur_hash.dart';
 import '../../../utils/error_reporter.dart';
 import '../mxc_image.dart';
@@ -115,9 +116,10 @@ class EventVideoPlayerState extends State<EventVideoPlayer> {
         );
       });
     } on IOException catch (e) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(e.toLocalizedString(context))));
+      ScaffoldMessenger.of(context).showSnackBarAnnounced(
+        SnackBar(content: Text(e.toLocalizedString(context))),
+        assertive: true,
+      );
       // #Pangea
       setState(() => _error = e);
       // Pangea#

--- a/lib/widgets/image_viewer/video_player.dart
+++ b/lib/widgets/image_viewer/video_player.dart
@@ -18,6 +18,9 @@ import 'package:fluffychat/widgets/blur_hash.dart';
 import '../../../utils/error_reporter.dart';
 import '../mxc_image.dart';
 
+// #Pangea
+// Pangea#
+
 class EventVideoPlayer extends StatefulWidget {
   final Event event;
 
@@ -116,10 +119,12 @@ class EventVideoPlayerState extends State<EventVideoPlayer> {
         );
       });
     } on IOException catch (e) {
+      // #Pangea
       ScaffoldMessenger.of(context).showSnackBarAnnounced(
         SnackBar(content: Text(e.toLocalizedString(context))),
         assertive: true,
       );
+      // Pangea#
       // #Pangea
       setState(() => _error = e);
       // Pangea#

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -42,6 +42,9 @@ import '../utils/account_bundles.dart';
 import '../utils/background_push.dart';
 import 'local_notifications_extension.dart';
 
+// #Pangea
+// Pangea#
+
 // import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 class Matrix extends StatefulWidget {
@@ -454,12 +457,14 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
         // Pangea#
       }
       if (loggedInWithMultipleClients && state != LoginState.loggedIn) {
+        // #Pangea
         ScaffoldMessenger.of(
           FluffyChatApp.router.routerDelegate.navigatorKey.currentContext ??
               context,
         ).showSnackBarAnnounced(
           SnackBar(content: Text(L10n.of(context).oneClientLoggedOut)),
         );
+        // Pangea#
 
         if (state != LoginState.loggedIn) {
           FluffyChatApp.router.go(PRoutes.world);

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -33,6 +33,7 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dar
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/uia_request_manager.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/fluffy_chat_app.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import '../config/setting_keys.dart';
@@ -456,7 +457,7 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
         ScaffoldMessenger.of(
           FluffyChatApp.router.routerDelegate.navigatorKey.currentContext ??
               context,
-        ).showSnackBar(
+        ).showSnackBarAnnounced(
           SnackBar(content: Text(L10n.of(context).oneClientLoggedOut)),
         );
 

--- a/test/pangea/announcing_snackbar_test.dart
+++ b/test/pangea/announcing_snackbar_test.dart
@@ -12,6 +12,15 @@ void main() {
       expect(snackBarAnnouncementText(const Text('Saved')), 'Saved');
     });
 
+    test('prefers semanticsLabel over the visible text', () {
+      expect(
+        snackBarAnnouncementText(
+          const Text('5', semanticsLabel: 'five new messages'),
+        ),
+        'five new messages',
+      );
+    });
+
     test('reads a Text built from a span', () {
       expect(
         snackBarAnnouncementText(const Text.rich(TextSpan(text: 'Copied'))),

--- a/test/pangea/announcing_snackbar_test.dart
+++ b/test/pangea/announcing_snackbar_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
+
+void main() {
+  // The announcing snackbar derives its screen-reader text from the SnackBar
+  // content; verify the extraction so announcements stay meaningful (#7203).
+  group('snackBarAnnouncementText', () {
+    test('reads a plain Text content', () {
+      expect(snackBarAnnouncementText(const Text('Saved')), 'Saved');
+    });
+
+    test('reads a Text built from a span', () {
+      expect(
+        snackBarAnnouncementText(const Text.rich(TextSpan(text: 'Copied'))),
+        'Copied',
+      );
+    });
+
+    test('reads RichText content', () {
+      expect(
+        snackBarAnnouncementText(
+          RichText(
+            textDirection: TextDirection.ltr,
+            text: const TextSpan(text: 'Update available'),
+          ),
+        ),
+        'Update available',
+      );
+    });
+
+    test(
+      'returns null for non-text content (caller must announce explicitly)',
+      () {
+        expect(snackBarAnnouncementText(const Icon(Icons.error)), isNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #7203.

## What
Status toasts and inline errors were shown visually but were silent to screen readers (no live regions existed anywhere). This adds them, moving WCAG 4.1.3 (Status Messages) from Does Not Support toward Supports.

## Changes
1. **Announcing-snackbar helper** (`lib/widgets/announcing_snackbar.dart`): an extension `showSnackBarAnnounced` on `ScaffoldMessengerState` that shows the SnackBar and announces its text via `SemanticsService.sendAnnouncement` (polite by default, assertive for errors). It auto-extracts the message from `Text` / `RichText` content, or accepts an explicit `announcement` for other content. Uses the non-deprecated `sendAnnouncement` (`announce` is deprecated as of Flutter 3.35).
2. **Routed all 56 real `showSnackBar` sites (35 files) through the wrapper.** Errors (catch blocks, `e.toLocalizedString`, `oopsSomethingWentWrong`, denials) announce assertively (31 sites); status and success stay polite. Two non-text contents (a Row-based subscription toast, the emoji-selected toast) pass an explicit `announcement`. A file-local loading-spinner toast in `send_file_dialog` (transient progress) was intentionally left alone.
3. **Inline-error live regions on the shared components that render them**, so they announce when they appear in place (not as a new route):
   - `ErrorIndicator` (15 usages) wraps its message in `Semantics(liveRegion: true)`.
   - `FutureLoadingDialog` announces its settled result; the loading state is already read on open, so the region only flips on once there is a result.
   - The login loading dialog announces its error when it replaces the spinner (the wrong-password case).

## Invisible to sighted users
`sendAnnouncement` and `liveRegion` move no focus and render nothing, so there is no visual change. SnackBar content, colors, durations, and actions are unchanged.

## Tests
- New unit test for the helper's text extraction (`Text` / `Text.rich` / `RichText` / non-text).
- `flutter analyze` (whole project), `dart format`, and `import_sorter` are green; the full suite passes. The one local failure is `choreo_endpoint_test` (a backend endpoint test needing a live backend), unrelated to this change.

## Verification
This is a screen-reader feature and cannot be exercised without an actual screen reader, so the real check is the issue's TO-TEST (VoiceOver / NVDA / TalkBack). No visual regression is covered by the widget-test suite. I will sanity-check the deployed staging build after merge.

Context: VPAT/ACR criterion 4.1.3 in pangeachat/security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessible, screen-reader-friendly announcements for many in-app messages, including copy actions, saves, invites, uploads, and update notices.
  * Error and success dialogs now better announce their results to assistive technologies.

* **Bug Fixes**
  * Improved visibility of important error messages so they’re more reliably announced when they appear.
  * Several notifications now use higher-priority announcements for critical failures.

* **Tests**
  * Added coverage for announcement text extraction from common text widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->