### PR TITLE
fix(activities): remove obsolete 'join a course' button from the empty stars menu (#7173)

### DIFF
--- a/lib/routes/analytics/activities/activity_archive.dart
+++ b/lib/routes/analytics/activities/activity_archive.dart
@@ -12,10 +12,6 @@ import 'package:fluffychat/features/analytics/saved_analytics_extension.dart';
 import 'package:fluffychat/features/analytics_data/analytics_init_error_indicator.dart';
 import 'package:fluffychat/features/instructions/instructions_enum.dart';
 import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dart';
-import 'package:fluffychat/features/navigation/panel_token.dart';
-import 'package:fluffychat/features/navigation/route_paths.dart';
-import 'package:fluffychat/features/navigation/workspace_nav.dart';
-import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/analytics_navigation_util.dart';
 import 'package:fluffychat/widgets/analytics_summary/learning_progress_indicators.dart';
 import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
@@ -80,42 +76,6 @@ class ActivityArchive extends StatelessWidget {
                                         : InstructionsEnum
                                               .activityAnalyticsList,
                                     padding: const EdgeInsets.all(8.0),
-                                    extraContent: archive.isEmpty
-                                        ? ElevatedButton(
-                                            style: ElevatedButton.styleFrom(
-                                              padding: EdgeInsets.zero,
-                                            ),
-                                            onPressed: () => context.go(
-                                              WorkspaceNav.setSection(
-                                                GoRouterState.of(context).uri,
-                                                PRoutes.world,
-                                                const PanelToken('addcourse'),
-                                                keepRoom: false,
-                                              ),
-                                            ),
-                                            child: Row(
-                                              mainAxisAlignment:
-                                                  MainAxisAlignment.center,
-                                              children: [
-                                                Text(
-                                                  L10n.of(
-                                                    context,
-                                                  ).joinCourseForActivities,
-                                                  style:
-                                                      FluffyThemes.isColumnMode(
-                                                        context,
-                                                      )
-                                                      ? Theme.of(
-                                                          context,
-                                                        ).textTheme.titleSmall
-                                                      : Theme.of(
-                                                          context,
-                                                        ).textTheme.bodyMedium,
-                                                ),
-                                              ],
-                                            ),
-                                          )
-                                        : null,
                                   );
                                 }
                                 i--;


### PR DESCRIPTION
Closes #7173.

The empty stars / saved-activities menu showed a 'Join a course to try activities' button that navigated to the add-course flow. Activities are now playable whether or not you are in a course, so that prompt is obsolete (and the button was reported as not working). Removed it.

Changes:
- Dropped the empty-state's `extraContent` button in `activity_archive.dart` and the imports it left unused (`panel_token`, `route_paths`, `workspace_nav`, `l10n`).
- The empty-state message (`noSavedActivitiesYet`) stays. The `joinCourseForActivities` string is now unused but left in place; pruning it across every locale file is out of scope here.

`flutter analyze`, `dart format`, and `import_sorter` are green; the suite passes.

Note: the button only appeared in the empty stars state, which is not reachable on an account that already has saved activities, so this is a code-verified removal. The empty-state path is exercised by the staging E2E suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the analytics activity empty state by removing the extra action button from the inline tooltip.
  * Kept the activity list display unchanged, with only the empty-state experience updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->