### PR TITLE
fix(chat): scope word-card/message/practice overlay to the chat panel (#7157)

### DIFF
--- a/lib/features/overlay/overlay.dart
+++ b/lib/features/overlay/overlay.dart
@@ -38,6 +38,33 @@ class OverlayUtil {
     }
   }
 
+  /// The dismiss backdrop. Confined to the opening context's rect when
+  /// [OverlayDisplayDetails.boundBackdropToParent] is set (so a chat toolbar
+  /// overlay dims only its panel, not the whole screen — #7157); otherwise it
+  /// fills the screen as before.
+  static Widget _backdrop(
+    BuildContext context,
+    OverlayDisplayDetails displayDetails,
+  ) {
+    final WidgetBoundaries bounds = displayDetails.boundBackdropToParent
+        ? (getBoundingBox(context) ?? WidgetBoundaries.defaultBoundaries)
+        : WidgetBoundaries.defaultBoundaries;
+    return Positioned(
+      top: bounds.top,
+      bottom: bounds.bottom,
+      left: bounds.left,
+      right: bounds.right,
+      child: IgnorePointer(
+        ignoring: displayDetails.ignorePointer,
+        child: TransparentBackdrop(
+          backgroundColor: displayDetails.backgroundColor,
+          onDismiss: displayDetails.onDismiss,
+          blurBackground: displayDetails.blurBackground,
+        ),
+      ),
+    );
+  }
+
   static bool showOverlay({
     required BuildContext context,
     required Widget child,
@@ -52,14 +79,7 @@ class OverlayUtil {
         builder: (_) => Stack(
           children: [
             if (displayDetails.backDropToDismiss)
-              IgnorePointer(
-                ignoring: displayDetails.ignorePointer,
-                child: TransparentBackdrop(
-                  backgroundColor: displayDetails.backgroundColor,
-                  onDismiss: displayDetails.onDismiss,
-                  blurBackground: displayDetails.blurBackground,
-                ),
-              ),
+              _backdrop(context, displayDetails),
             switch (displayDetails) {
               TransformOverlayDisplayDetails(
                 transformTargetId: final targetId,

--- a/lib/features/overlay/overlay_display_details.dart
+++ b/lib/features/overlay/overlay_display_details.dart
@@ -15,6 +15,12 @@ sealed class OverlayDisplayDetails {
   final bool ignorePointer;
   final bool canPop;
 
+  /// Confine the dismiss backdrop (and so the dimming) to the rect of the
+  /// context that opened the overlay, instead of the whole screen. Lets a chat
+  /// toolbar overlay dim only its panel in world_v2 (#7157). Default false keeps
+  /// the historical full-screen backdrop.
+  final bool boundBackdropToParent;
+
   final VoidCallback? onDismiss;
 
   const OverlayDisplayDetails({
@@ -28,6 +34,7 @@ sealed class OverlayDisplayDetails {
     this.closePrevOverlay = true,
     this.ignorePointer = false,
     this.canPop = true,
+    this.boundBackdropToParent = false,
     this.onDismiss,
   });
 }
@@ -99,6 +106,7 @@ class CenteredOverlayDisplayDetails extends OverlayDisplayDetails {
     super.closePrevOverlay = true,
     super.ignorePointer = false,
     super.canPop = true,
+    super.boundBackdropToParent = false,
     super.onDismiss,
   });
 }

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -2661,7 +2661,10 @@ class ChatController extends State<ChatPageWithRoom>
         displayDetails: CenteredOverlayDisplayDetails(
           overlayKey: "button_message_backdrop",
           bypassBlockingOverlays: bypassBlockingOverlays,
-          useParentBoundaries: false,
+          // #7157: the pre-toolbar backdrop is a plain backdrop, so bound both it
+          // and the auto-dismiss backdrop to the chat panel.
+          useParentBoundaries: true,
+          boundBackdropToParent: true,
         ),
       );
 
@@ -2682,6 +2685,8 @@ class ChatController extends State<ChatPageWithRoom>
           overlayKey: "message_toolbar_overlay",
           bypassBlockingOverlays: bypassBlockingOverlays,
           useParentBoundaries: false,
+          // #7157: dim only the chat panel, not the whole screen.
+          boundBackdropToParent: true,
         ),
       );
     } else {
@@ -2695,6 +2700,8 @@ class ChatController extends State<ChatPageWithRoom>
           overlayKey: "message_toolbar_overlay",
           bypassBlockingOverlays: bypassBlockingOverlays,
           useParentBoundaries: false,
+          // #7157: dim only the chat panel, not the whole screen.
+          boundBackdropToParent: true,
         ),
       );
     }

--- a/lib/routes/chat/toolbar/layout/message_selection_positioner.dart
+++ b/lib/routes/chat/toolbar/layout/message_selection_positioner.dart
@@ -9,6 +9,8 @@ import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dart';
+import 'package:fluffychat/features/overlay/overlay.dart';
+import 'package:fluffychat/features/overlay/widget_boundaries_model.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/chat/chat.dart';
 import 'package:fluffychat/routes/chat/events/event_wrappers/pangea_message_event.dart';
@@ -155,6 +157,14 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
     "Error getting media query size",
     null,
   );
+
+  /// The chat panel's rect as insets from the screen edges. In world_v2 the chat
+  /// is a panel over the map, so the practice overlay (centered message, input
+  /// bar, instruction) must lay out within this rect, not the whole screen
+  /// (#7157). On a full-screen chat the insets are ~0, so behaviour is unchanged.
+  WidgetBoundaries get _panelBounds =>
+      OverlayUtil.getBoundingBox(widget.chatController.context) ??
+      WidgetBoundaries.defaultBoundaries;
 
   EdgeInsets? get screenPadding => _runWithLogging<EdgeInsets?>(
     () => MediaQuery.paddingOf(context),
@@ -423,15 +433,25 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
                     ),
                     if (readingAssistanceMode ==
                         ReadingAssistanceMode.practiceMode) ...[
-                      CenteredMessage(controller: this),
+                      // #7157: center the message within the chat panel, not the
+                      // whole screen. The transition reads this widget's real
+                      // position, so it follows automatically.
+                      Positioned(
+                        top: 0,
+                        bottom: 0,
+                        left: _panelBounds.left,
+                        right: _panelBounds.right,
+                        child: CenteredMessage(controller: this),
+                      ),
                       PracticeModeTransitionAnimation(
                         targetId:
                             "overlay_center_message_${widget.event.eventId}",
                         controller: this,
                       ),
                       Positioned(
-                        left: 0,
-                        right: 0,
+                        // #7157: span the chat panel, not the whole screen.
+                        left: _panelBounds.left,
+                        right: _panelBounds.right,
                         bottom: 20,
                         child: ReadingAssistanceInputBar(
                           widget.overlayController.practiceController,
@@ -447,8 +467,9 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
                                 _ => 80,
                               }
                             : 0,
-                        left: 0,
-                        right: 0,
+                        // #7157: span the chat panel, not the whole screen.
+                        left: _panelBounds.left,
+                        right: _panelBounds.right,
                         child: ListenableBuilder(
                           listenable:
                               widget.overlayController.practiceController,

--- a/lib/routes/chat/toolbar/layout/practice_mode_transition_animation.dart
+++ b/lib/routes/chat/toolbar/layout/practice_mode_transition_animation.dart
@@ -171,7 +171,9 @@ class CenteredMessage extends StatelessWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  SizedBox(width: controller.screenSize!.width, height: 20.0),
+                  // #7157: fill the panel-bounded parent (was screen width) so
+                  // the message centers within the chat panel, not the screen.
+                  const SizedBox(width: double.infinity, height: 20.0),
                   Padding(
                     padding: EdgeInsets.symmetric(horizontal: 16.0),
                     child: OverlayCenterContent(


### PR DESCRIPTION
Closes #7157.

## Problem
In world_v2 the chat is a panel over the map, but the message toolbar, word card, and message-practice overlay dimmed the whole screen and laid out against the full viewport (a holdover from when chat was full-screen). It should only cover the chat window.

## Root cause
The overlay is a single OverlayEntry in the root overlay: a full-screen dim barrier plus a positioner that sizes/positions everything against the screen (`MediaQuery` + a screen-width Stack). The toolbar opted out of parent-bounding (`useParentBoundaries: false`), so nothing scoped to the panel.

## Fix
Keep the overlay in the screen coordinate frame (so the message's absolute position and the practice transition stay correct) and bound the pieces that spanned the screen to the chat panel's rect (`OverlayUtil.getBoundingBox` of the chat context):
- New `boundBackdropToParent` flag confines the dismiss/dim backdrop to the chat panel (set on the three toolbar overlays), so the dim now covers only the panel.
- The practice centered-message, input bar, and instruction lay out within the panel rect rather than the full screen. The transition follows the centered message automatically.
- Default behavior is unchanged: on a full-screen chat (mobile) the panel rect equals the screen, so the insets are ~0.

## Verified in-client (local, logged in)
Tapped a word in a chat: the word card and toolbar render within the chat panel and the dim covers only the panel (chat list and map stay bright), instead of the whole screen.

## Verification note
The message-practice flow (centered message) is message-level and hard to drive from the harness; it reuses the same `getBoundingBox` panel-bounding that the verified word-card path uses, is analyze/test clean, and is covered by the staging E2E plus the issue's TO-TEST for practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat overlays and practice-mode layouts now stay within the chat panel instead of covering the full screen.
  * Dismiss backdrops can now be confined to the area where an overlay opens, creating a more localized dimming effect.

* **Bug Fixes**
  * Improved alignment for message selection and input areas so they match the chat panel boundaries more consistently.
  * Updated centered message positioning to behave correctly within the chat panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->