### PR TITLE
docs: link agent-browser-qa and run-flutter-web-local from testing guide

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -111,6 +111,7 @@ BASE_URL=https://app.staging.pangea.chat npx playwright test --config e2e/playwr
 
 - **Device testing**: `flutter run` on physical device or emulator for full app flows
 - **Playwright MCP**: Interactive browser exploration of the Flutter web build via Playwright MCP tools. Uses accessibility snapshots (`browser_snapshot`) to interact with Flutter's CanvasKit-rendered UI. Useful for authoring new specs and debugging semantics gaps. See [playwright-testing.instructions.md](playwright-testing.instructions.md) for the MCP interaction guide (login flow, navigation, accessibility enabling, tips)
+- **Agent browser QA**: An AI agent drives the live web client through the Claude-in-Chrome extension (not scripted Playwright, not Playwright MCP) for exploratory bug-finding against local or staging. The canvas semantics-tree wake recipe and round structure live in the [`agent-browser-qa`](../skills/agent-browser-qa/SKILL.md) skill; local env / staging switch via [`run-flutter-web-local`](../skills/run-flutter-web-local/SKILL.md).
 
 ## Future Work
 


### PR DESCRIPTION
## What

Adds an **Agent browser QA** bullet to the Manual Testing section of the client testing guide, pointing at the [`agent-browser-qa`](../skills/agent-browser-qa/SKILL.md) and [`run-flutter-web-local`](../skills/run-flutter-web-local/SKILL.md) skills. Neither was referenced from the testing doc before.

Distinguished from the existing **Playwright MCP** bullet: agent browser QA drives the live client through the Claude-in-Chrome extension (exploratory, not scripted Playwright, not Playwright MCP).

## Why

Companion to the operator-driven runs table added to the cross-repo testing strategy (pangeachat/.github#207), which points here as the canonical home for the client-owned agent-QA mechanism.

Docs-only; no issue per the docs-only exception.