### PR TITLE
fix(ci): remove duplicate environment key blocking all integrate.yaml runs

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -9,7 +9,6 @@ permissions:
 
 jobs:
   code_tests:
-    environment: staging
     runs-on: ubuntu-latest
     environment: staging
     steps:


### PR DESCRIPTION
## Problem

The `code_tests` job in `integrate.yaml` had a duplicate `environment: staging` key. #6981 added it after `runs-on`, then #6807 (Firebase split) added a second copy right after the job name. Duplicate mapping keys make the workflow file invalid, so GitHub ran no jobs and reported "This run likely failed because of a workflow file issue."

The effect was repo-wide: every PR and every push to main had a failing `integrate.yaml` check since #6807 merged, with none of the gates (format, import sort, analyze, test, builds) actually running. Code merged unchecked in that window.

## Fix

1. Remove the duplicate key so the workflow parses and the gates run again.
2. Clean up the format/import-sort debt that slipped in while the gates were off: `firebase_options.dart`, `import_archive_dialog.dart`, and `profile_setup_step_view.dart`. Pure `dart format` + `import_sorter` output, no behavior change.

## Verification

Locally, after these changes: `dart format lib/ test/ --set-exit-if-changed` passes, `dart run import_sorter:main --no-comments --exit-if-changed` passes, `flutter analyze` is clean. CI now runs the gates (this PR is the first to exercise them since #6807).
