### PR TITLE
feat: a11y screen-reader fixes from QA pass (#7185)

### DIFF
--- a/lib/config/firebase_options.dart
+++ b/lib/config/firebase_options.dart
@@ -9,7 +9,6 @@ import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 
-
 class DefaultFirebaseOptions {
   static FirebaseOptions get currentPlatform {
     if (kIsWeb) {

--- a/lib/features/notifications/enable_notifications_dialog.dart
+++ b/lib/features/notifications/enable_notifications_dialog.dart
@@ -25,83 +25,87 @@ class EnableNotificationsDialog extends StatelessWidget {
                 horizontal: 16.0,
                 vertical: 24.0,
               ),
-              child: Column(
-                spacing: 12.0,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  CachedNetworkImage(
-                    imageUrl:
-                        "${AppConfig.assetsBaseURL}/${NotificationsConstants.notifRequestImage}",
-                    errorWidget: (_, _, _) => SizedBox.shrink(),
-                  ),
-                  Text(
-                    l10n.enableNotificationsTitle,
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                      fontWeight: FontWeight.bold,
+              child: Semantics(
+                container: true,
+                child: Column(
+                  spacing: 12.0,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    CachedNetworkImage(
+                      imageUrl:
+                          "${AppConfig.assetsBaseURL}/${NotificationsConstants.notifRequestImage}",
+                      errorWidget: (_, _, _) => SizedBox.shrink(),
                     ),
-                  ),
-                  Text(
-                    l10n.enableNotificationsDesc,
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.bodyLarge,
-                  ),
-                  ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Theme.of(
+                    Text(
+                      l10n.enableNotificationsTitle,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.headlineSmall
+                          ?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                    Text(
+                      l10n.enableNotificationsDesc,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                    ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Theme.of(
+                          context,
+                        ).colorScheme.primaryContainer,
+                        foregroundColor: Theme.of(
+                          context,
+                        ).colorScheme.onPrimaryContainer,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 24,
+                          vertical: 12,
+                        ),
+                      ),
+                      onPressed: () => Navigator.of(
                         context,
-                      ).colorScheme.primaryContainer,
-                      foregroundColor: Theme.of(
-                        context,
-                      ).colorScheme.onPrimaryContainer,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 24,
-                        vertical: 12,
+                      ).pop<OkCancelResult>(OkCancelResult.ok),
+                      child: Wrap(
+                        children: [
+                          Text(
+                            l10n.enableNotifications,
+                            style: Theme.of(context).textTheme.bodyLarge,
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
                       ),
                     ),
-                    onPressed: () => Navigator.of(
-                      context,
-                    ).pop<OkCancelResult>(OkCancelResult.ok),
-                    child: Wrap(
-                      children: [
-                        Text(
-                          l10n.enableNotifications,
-                          style: Theme.of(context).textTheme.bodyLarge,
-                          textAlign: TextAlign.center,
+                    ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Theme.of(
+                          context,
+                        ).colorScheme.surfaceContainerHigh,
+                        foregroundColor: Theme.of(
+                          context,
+                        ).colorScheme.onSurface,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 24,
+                          vertical: 12,
                         ),
-                      ],
-                    ),
-                  ),
-                  ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Theme.of(
+                      ),
+                      onPressed: () => Navigator.of(
                         context,
-                      ).colorScheme.surfaceContainerHigh,
-                      foregroundColor: Theme.of(context).colorScheme.onSurface,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 24,
-                        vertical: 12,
+                      ).pop<OkCancelResult>(OkCancelResult.cancel),
+                      child: Wrap(
+                        children: [
+                          Text(
+                            l10n.skipForNow,
+                            style: Theme.of(context).textTheme.bodyLarge
+                                ?.copyWith(
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurface.withAlpha(180),
+                                ),
+                            textAlign: TextAlign.center,
+                          ),
+                        ],
                       ),
                     ),
-                    onPressed: () => Navigator.of(
-                      context,
-                    ).pop<OkCancelResult>(OkCancelResult.cancel),
-                    child: Wrap(
-                      children: [
-                        Text(
-                          l10n.skipForNow,
-                          style: Theme.of(context).textTheme.bodyLarge
-                              ?.copyWith(
-                                color: Theme.of(
-                                  context,
-                                ).colorScheme.onSurface.withAlpha(180),
-                              ),
-                          textAlign: TextAlign.center,
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
 

--- a/lib/features/notifications/suggest_mobile_dialog.dart
+++ b/lib/features/notifications/suggest_mobile_dialog.dart
@@ -25,54 +25,52 @@ class SuggestMobileDialog extends StatelessWidget {
                 horizontal: 16.0,
                 vertical: 24.0,
               ),
-              child: Column(
-                spacing: 12.0,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  CachedNetworkImage(
-                    imageUrl:
-                        "${AppConfig.assetsBaseURL}/${NotificationsConstants.notifRequestImage}",
-                    errorWidget: (_, _, _) => SizedBox.shrink(),
-                  ),
-                  Text(
-                    l10n.enableNotificationsTitle,
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                      fontWeight: FontWeight.bold,
+              child: Semantics(
+                container: true,
+                child: Column(
+                  spacing: 12.0,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    CachedNetworkImage(
+                      imageUrl:
+                          "${AppConfig.assetsBaseURL}/${NotificationsConstants.notifRequestImage}",
+                      errorWidget: (_, _, _) => SizedBox.shrink(),
                     ),
-                  ),
-                  Text(
-                    l10n.suggestMobileDesc,
-                    textAlign: TextAlign.center,
-                    style: Theme.of(context).textTheme.bodyLarge,
-                  ),
-                  ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Theme.of(
+                    Text(
+                      l10n.enableNotificationsTitle,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.headlineSmall
+                          ?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                    Text(
+                      l10n.suggestMobileDesc,
+                      textAlign: TextAlign.center,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                    ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Theme.of(
+                          context,
+                        ).colorScheme.primaryContainer,
+                        foregroundColor: Theme.of(
+                          context,
+                        ).colorScheme.onPrimaryContainer,
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 24,
+                          vertical: 12,
+                        ),
+                      ),
+                      onPressed: () => Navigator.of(
                         context,
-                      ).colorScheme.primaryContainer,
-                      foregroundColor: Theme.of(
-                        context,
-                      ).colorScheme.onPrimaryContainer,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 24,
-                        vertical: 12,
+                      ).pop<OkCancelResult>(OkCancelResult.cancel),
+                      child: Text(
+                        l10n.gotIt,
+                        style: Theme.of(context).textTheme.bodyLarge,
+                        textAlign: TextAlign.center,
                       ),
                     ),
-                    onPressed: () => Navigator.of(
-                      context,
-                    ).pop<OkCancelResult>(OkCancelResult.cancel),
-                    child: Wrap(
-                      children: [
-                        Text(
-                          l10n.gotIt,
-                          style: Theme.of(context).textTheme.bodyLarge,
-                          textAlign: TextAlign.center,
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -4932,5 +4932,14 @@
                 "type": "String"
             }
         }
-    }
+    },
+    "activityLabel": "Activity: {title}",
+    "@activityLabel": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "resetMapView": "Reset map view"
 }

--- a/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
@@ -44,13 +44,17 @@ class ActivitySessionButtons extends StatelessWidget {
                   spacing: 16.0,
                   children: [
                     if (description != null)
-                      Text(
-                        description,
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
+                      Semantics(
+                        label: description,
+                        enabled: false,
+                        child: Text(
+                          description,
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                          ),
+                          textAlign: TextAlign.center,
                         ),
-                        textAlign: TextAlign.center,
                       ),
                     _SessionCTAButtons(sessionController),
                   ],

--- a/lib/routes/chat_list/chat_list_item.dart
+++ b/lib/routes/chat_list/chat_list_item.dart
@@ -78,6 +78,34 @@ class ChatListItem extends StatelessWidget {
         : room.getState(EventTypes.RoomMember, lastEvent.senderId) == null;
     final space = this.space;
 
+    // #Pangea
+    final String messagePreview =
+        room.isSpace && room.membership == Membership.join
+        ? L10n.of(context).countChats(room.spaceChildCount)
+        : room.membership == Membership.invite
+        ? (room
+                  .getState(EventTypes.RoomMember, room.client.userID!)
+                  ?.content
+                  .tryGet<String>('reason') ??
+              (isDirectChat
+                  ? L10n.of(context).newChatRequest
+                  : L10n.of(context).inviteChat))
+        : lastEvent?.calcLocalizedBodyFallback(
+                MatrixLocals(L10n.of(context)),
+                hideReply: true,
+                hideEdit: true,
+                plaintextBody: true,
+                removeMarkdown: true,
+                withSenderNamePrefix:
+                    (!isDirectChat ||
+                    directChatMatrixId != room.lastEvent?.senderId),
+              ) ??
+              L10n.of(context).noMessagesYet;
+    final String chatSemanticsLabel = unread
+        ? '$displayname, $messagePreview, ${L10n.of(context).unread}'
+        : '$displayname, $messagePreview';
+    // Pangea#
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 1),
       child: Material(
@@ -202,207 +230,227 @@ class ChatListItem extends StatelessWidget {
                   ),
                 ),
               ), // Pangea# end ExcludeSemantics
-              title: Row(
-                children: <Widget>[
-                  Expanded(
-                    child: Text(
-                      displayname,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      softWrap: false,
-                      style: TextStyle(
-                        fontWeight: unread || room.hasNewMessages
-                            ? FontWeight.w500
-                            : null,
-                      ),
-                    ),
-                  ),
-                  if (isMuted)
-                    const Padding(
-                      padding: EdgeInsets.only(left: 4.0),
-                      child: Icon(Icons.notifications_off_outlined, size: 16),
-                    ),
-                  if (room.isFavourite)
-                    Padding(
-                      padding: EdgeInsets.only(
-                        right: hasNotifications ? 4.0 : 0.0,
-                      ),
-                      child: Icon(
-                        Icons.push_pin,
-                        size: 16,
-                        color: theme.colorScheme.primary,
-                      ),
-                    ),
-                  if (!room.isSpace && room.membership != Membership.invite)
-                    Padding(
-                      padding: const EdgeInsets.only(left: 4.0),
-                      child: Text(
-                        room.latestEventReceivedTime.localizedTimeShort(
-                          context,
-                        ),
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: theme.colorScheme.outline,
-                        ),
-                      ),
-                    ),
-                ],
-              ),
-              subtitle: Row(
-                crossAxisAlignment: .start,
-                mainAxisAlignment: .center,
-                children: <Widget>[
-                  if (typingText.isEmpty &&
-                      ownMessage &&
-                      room.lastEvent?.status.isSending == true) ...[
-                    const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                    ),
-                    const SizedBox(width: 4),
-                  ],
-                  AnimatedSize(
-                    clipBehavior: Clip.hardEdge,
-                    duration: FluffyThemes.animationDuration,
-                    curve: FluffyThemes.animationCurve,
-                    child: typingText.isNotEmpty
-                        ? Padding(
-                            padding: const EdgeInsets.only(right: 4.0),
-                            child: Icon(
-                              Icons.edit_outlined,
-                              color: theme.colorScheme.secondary,
-                              size: 16,
-                            ),
-                          )
-                        : room.lastEvent?.relationshipType ==
-                              RelationshipTypes.thread
-                        ? Container(
-                            decoration: BoxDecoration(
-                              border: Border.all(
-                                color: theme.colorScheme.outline,
-                              ),
-                              borderRadius: BorderRadius.circular(
-                                AppConfig.borderRadius,
-                              ),
-                            ),
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8.0,
-                            ),
-                            margin: const EdgeInsets.only(right: 4.0),
-                            child: Row(
-                              mainAxisSize: .min,
-                              children: [
-                                Icon(
-                                  Icons.message_outlined,
-                                  size: 12,
-                                  color: theme.colorScheme.outline,
-                                ),
-                                const SizedBox(width: 4),
-                                Text(
-                                  L10n.of(context).thread,
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    color: theme.colorScheme.outline,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          )
-                        : const SizedBox.shrink(),
-                  ),
-                  Expanded(
-                    child: room.isSpace && room.membership == Membership.join
-                        ? Text(
-                            // #Pangea
-                            // L10n.of(
-                            //   context,
-                            // ).countChats(room.spaceChildren.length),
-                            L10n.of(context).countChats(room.spaceChildCount),
-                            // Pangea#
-                            style: TextStyle(color: theme.colorScheme.outline),
-                          )
-                        : typingText.isNotEmpty
-                        ? Text(
-                            typingText,
-                            style: TextStyle(color: theme.colorScheme.primary),
-                            maxLines: 1,
-                            softWrap: false,
-                          )
-                        // #Pangea
-                        : room.lastEvent != null
-                        ? ChatListItemSubtitle(
-                            room: room,
-                            style: TextStyle(
-                              fontWeight: unread || room.hasNewMessages
-                                  ? FontWeight.bold
-                                  : null,
-                              color: theme.colorScheme.onSurfaceVariant,
-                            ),
-                          )
-                        // Pangea#
-                        : FutureBuilder(
-                            key: ValueKey(
-                              '${lastEvent?.eventId}_${lastEvent?.type}_${lastEvent?.redacted}',
-                            ),
-                            future: needLastEventSender
-                                ? lastEvent.calcLocalizedBody(
-                                    MatrixLocals(L10n.of(context)),
-                                    hideReply: true,
-                                    hideEdit: true,
-                                    plaintextBody: true,
-                                    removeMarkdown: true,
-                                    withSenderNamePrefix:
-                                        (!isDirectChat ||
-                                        directChatMatrixId !=
-                                            room.lastEvent?.senderId),
-                                  )
+              // #Pangea
+              title: Semantics(
+                label: chatSemanticsLabel,
+                child: ExcludeSemantics(
+                  child: Row(
+                    // Pangea#
+                    children: <Widget>[
+                      Expanded(
+                        child: Text(
+                          displayname,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          softWrap: false,
+                          style: TextStyle(
+                            fontWeight: unread || room.hasNewMessages
+                                ? FontWeight.w500
                                 : null,
-                            initialData: lastEvent?.calcLocalizedBodyFallback(
-                              MatrixLocals(L10n.of(context)),
-                              hideReply: true,
-                              hideEdit: true,
-                              plaintextBody: true,
-                              removeMarkdown: true,
-                              withSenderNamePrefix:
-                                  (!isDirectChat ||
-                                  directChatMatrixId !=
-                                      room.lastEvent?.senderId),
+                          ),
+                        ),
+                      ),
+                      if (isMuted)
+                        const Padding(
+                          padding: EdgeInsets.only(left: 4.0),
+                          child: Icon(
+                            Icons.notifications_off_outlined,
+                            size: 16,
+                          ),
+                        ),
+                      if (room.isFavourite)
+                        Padding(
+                          padding: EdgeInsets.only(
+                            right: hasNotifications ? 4.0 : 0.0,
+                          ),
+                          child: Icon(
+                            Icons.push_pin,
+                            size: 16,
+                            color: theme.colorScheme.primary,
+                          ),
+                        ),
+                      if (!room.isSpace && room.membership != Membership.invite)
+                        Padding(
+                          padding: const EdgeInsets.only(left: 4.0),
+                          child: Text(
+                            room.latestEventReceivedTime.localizedTimeShort(
+                              context,
                             ),
-                            builder: (context, snapshot) => Text(
-                              room.membership == Membership.invite
-                                  ? room
-                                            .getState(
-                                              EventTypes.RoomMember,
-                                              room.client.userID!,
-                                            )
-                                            ?.content
-                                            .tryGet<String>('reason') ??
-                                        (isDirectChat
-                                            ? L10n.of(context).newChatRequest
-                                            // #Pangea
-                                            // : L10n.of(context).inviteGroupChat)
-                                            : L10n.of(context).inviteChat)
-                                  // Pangea#
-                                  : snapshot.data ??
-                                        L10n.of(context).noMessagesYet,
-                              softWrap: false,
-                              maxLines: room.notificationCount >= 1 ? 2 : 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: TextStyle(
-                                color: unread || room.hasNewMessages
-                                    ? theme.colorScheme.onSurface
-                                    : theme.colorScheme.outline,
-                                decoration: room.lastEvent?.redacted == true
-                                    ? TextDecoration.lineThrough
-                                    : null,
-                              ),
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: theme.colorScheme.outline,
                             ),
                           ),
+                        ),
+                    ],
                   ),
-                  const SizedBox(width: 8),
-                  UnreadBubble(room: room),
-                ],
+                ),
+              ),
+              // #Pangea
+              subtitle: ExcludeSemantics(
+                child: Row(
+                  // Pangea#
+                  crossAxisAlignment: .start,
+                  mainAxisAlignment: .center,
+                  children: <Widget>[
+                    if (typingText.isEmpty &&
+                        ownMessage &&
+                        room.lastEvent?.status.isSending == true) ...[
+                      const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator.adaptive(
+                          strokeWidth: 2,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                    ],
+                    AnimatedSize(
+                      clipBehavior: Clip.hardEdge,
+                      duration: FluffyThemes.animationDuration,
+                      curve: FluffyThemes.animationCurve,
+                      child: typingText.isNotEmpty
+                          ? Padding(
+                              padding: const EdgeInsets.only(right: 4.0),
+                              child: Icon(
+                                Icons.edit_outlined,
+                                color: theme.colorScheme.secondary,
+                                size: 16,
+                              ),
+                            )
+                          : room.lastEvent?.relationshipType ==
+                                RelationshipTypes.thread
+                          ? Container(
+                              decoration: BoxDecoration(
+                                border: Border.all(
+                                  color: theme.colorScheme.outline,
+                                ),
+                                borderRadius: BorderRadius.circular(
+                                  AppConfig.borderRadius,
+                                ),
+                              ),
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8.0,
+                              ),
+                              margin: const EdgeInsets.only(right: 4.0),
+                              child: Row(
+                                mainAxisSize: .min,
+                                children: [
+                                  Icon(
+                                    Icons.message_outlined,
+                                    size: 12,
+                                    color: theme.colorScheme.outline,
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    L10n.of(context).thread,
+                                    style: TextStyle(
+                                      fontSize: 12,
+                                      color: theme.colorScheme.outline,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            )
+                          : const SizedBox.shrink(),
+                    ),
+                    Expanded(
+                      child: room.isSpace && room.membership == Membership.join
+                          ? Text(
+                              // #Pangea
+                              // L10n.of(
+                              //   context,
+                              // ).countChats(room.spaceChildren.length),
+                              L10n.of(context).countChats(room.spaceChildCount),
+                              // Pangea#
+                              style: TextStyle(
+                                color: theme.colorScheme.outline,
+                              ),
+                            )
+                          : typingText.isNotEmpty
+                          ? Text(
+                              typingText,
+                              style: TextStyle(
+                                color: theme.colorScheme.primary,
+                              ),
+                              maxLines: 1,
+                              softWrap: false,
+                            )
+                          // #Pangea
+                          : room.lastEvent != null
+                          ? ChatListItemSubtitle(
+                              room: room,
+                              style: TextStyle(
+                                fontWeight: unread || room.hasNewMessages
+                                    ? FontWeight.bold
+                                    : null,
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            )
+                          // Pangea#
+                          : FutureBuilder(
+                              key: ValueKey(
+                                '${lastEvent?.eventId}_${lastEvent?.type}_${lastEvent?.redacted}',
+                              ),
+                              future: needLastEventSender
+                                  ? lastEvent.calcLocalizedBody(
+                                      MatrixLocals(L10n.of(context)),
+                                      hideReply: true,
+                                      hideEdit: true,
+                                      plaintextBody: true,
+                                      removeMarkdown: true,
+                                      withSenderNamePrefix:
+                                          (!isDirectChat ||
+                                          directChatMatrixId !=
+                                              room.lastEvent?.senderId),
+                                    )
+                                  : null,
+                              initialData: lastEvent?.calcLocalizedBodyFallback(
+                                MatrixLocals(L10n.of(context)),
+                                hideReply: true,
+                                hideEdit: true,
+                                plaintextBody: true,
+                                removeMarkdown: true,
+                                withSenderNamePrefix:
+                                    (!isDirectChat ||
+                                    directChatMatrixId !=
+                                        room.lastEvent?.senderId),
+                              ),
+                              builder: (context, snapshot) => Text(
+                                room.membership == Membership.invite
+                                    ? room
+                                              .getState(
+                                                EventTypes.RoomMember,
+                                                room.client.userID!,
+                                              )
+                                              ?.content
+                                              .tryGet<String>('reason') ??
+                                          (isDirectChat
+                                              ? L10n.of(context).newChatRequest
+                                              // #Pangea
+                                              // : L10n.of(context).inviteGroupChat)
+                                              : L10n.of(context).inviteChat)
+                                    // Pangea#
+                                    : snapshot.data ??
+                                          L10n.of(context).noMessagesYet,
+                                softWrap: false,
+                                maxLines: room.notificationCount >= 1 ? 2 : 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(
+                                  color: unread || room.hasNewMessages
+                                      ? theme.colorScheme.onSurface
+                                      : theme.colorScheme.outline,
+                                  decoration: room.lastEvent?.redacted == true
+                                      ? TextDecoration.lineThrough
+                                      : null,
+                                ),
+                              ),
+                            ),
+                    ),
+                    const SizedBox(width: 8),
+                    UnreadBubble(room: room),
+                  ],
+                ),
               ),
               onTap: onTap,
               trailing: onForget == null

--- a/lib/routes/courses/course_list_tile.dart
+++ b/lib/routes/courses/course_list_tile.dart
@@ -58,11 +58,13 @@ class CourseListTile extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Avatar(
-                  mxContent: space.avatar,
-                  name: displayname,
-                  size: 44.0,
-                  borderRadius: BorderRadius.circular(10.0),
+                ExcludeSemantics(
+                  child: Avatar(
+                    mxContent: space.avatar,
+                    name: displayname,
+                    size: 44.0,
+                    borderRadius: BorderRadius.circular(10.0),
+                  ),
                 ),
                 const SizedBox(width: 10.0),
                 Expanded(
@@ -70,12 +72,14 @@ class CourseListTile extends StatelessWidget {
                     mainAxisSize: MainAxisSize.min,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        displayname,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.bold,
+                      ExcludeSemantics(
+                        child: Text(
+                          displayname,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ),
                       const SizedBox(height: 8.0),

--- a/lib/routes/home/login_loading_dialog.dart
+++ b/lib/routes/home/login_loading_dialog.dart
@@ -107,54 +107,58 @@ class LoginLoadingDialogState extends State<LoginLoadingDialog> {
   Widget build(BuildContext context) {
     final exception = this.exception;
 
-    return AlertDialog.adaptive(
-      title: exception == null
-          ? null
-          : Icon(
-              Icons.error_outline_outlined,
-              color: Theme.of(context).colorScheme.error,
-              size: 48,
-            ),
-      content: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 256),
-        child: Column(
-          spacing: 12.0,
-          mainAxisSize: .min,
-          crossAxisAlignment: .center,
-          children: [
-            exception != null
-                // #Pangea: announce the login error to screen readers when it
-                // replaces the spinner in the still-open dialog (WCAG 4.1.3,
-                // #7203).
-                ? Semantics(
-                    liveRegion: true,
-                    child: Text(
-                      exception is MatrixException
-                          ? exception.errorMessage
-                          : exception.toLocalizedString(context),
-                    ),
-                  )
-                // Pangea#
-                : ValueListenableBuilder<InitState?>(
-                    valueListenable: _initState,
-                    builder: (context, initState, child) =>
-                        Text(_initStateLabel),
-                  ),
-            if (exception == null) LinearProgressIndicator(),
-          ],
-        ),
-      ),
-      actions: exception == null
-          ? null
-          : [
-              AdaptiveDialogAction(
-                onPressed: () => Navigator.of(
-                  context,
-                ).pop(Result.error(exception, stackTrace)),
-                child: Text(L10n.of(context).close),
+    return Semantics(
+      label: _initStateLabel,
+      container: true,
+      child: AlertDialog.adaptive(
+        title: exception == null
+            ? null
+            : Icon(
+                Icons.error_outline_outlined,
+                color: Theme.of(context).colorScheme.error,
+                size: 48,
               ),
+        content: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 256),
+          child: Column(
+            spacing: 12.0,
+            mainAxisSize: .min,
+            crossAxisAlignment: .center,
+            children: [
+              exception != null
+                  // #Pangea: announce the login error to screen readers when it
+                  // replaces the spinner in the still-open dialog (WCAG 4.1.3,
+                  // #7203).
+                  ? Semantics(
+                      liveRegion: true,
+                      child: Text(
+                        exception is MatrixException
+                            ? exception.errorMessage
+                            : exception.toLocalizedString(context),
+                      ),
+                    )
+                  // Pangea#
+                  : ValueListenableBuilder<InitState?>(
+                      valueListenable: _initState,
+                      builder: (context, initState, child) =>
+                          Text(_initStateLabel),
+                    ),
+              if (exception == null) LinearProgressIndicator(),
             ],
-      // Pangea#
+          ),
+        ),
+        actions: exception == null
+            ? null
+            : [
+                AdaptiveDialogAction(
+                  onPressed: () => Navigator.of(
+                    context,
+                  ).pop(Result.error(exception, stackTrace)),
+                  child: Text(L10n.of(context).close),
+                ),
+              ],
+        // Pangea#
+      ),
     );
   }
 }

--- a/lib/routes/home/login_or_signup_view.dart
+++ b/lib/routes/home/login_or_signup_view.dart
@@ -92,8 +92,7 @@ class _LoginOrSignupViewState extends State<LoginOrSignupView> {
                       spacing: 12.0,
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        Semantics(
-                          label: L10n.of(context).pangeaChatLogo,
+                        ExcludeSemantics(
                           child: PangeaLogoSvg(
                             width: 48.0,
                             forceColor: theme.colorScheme.onSurface,

--- a/lib/routes/world/world_map_large_card.dart
+++ b/lib/routes/world/world_map_large_card.dart
@@ -76,90 +76,96 @@ class WorldMapLargeCard extends StatelessWidget {
 
     return GestureDetector(
       onTap: onTap,
-      child: Material(
-        elevation: 6,
-        borderRadius: BorderRadius.circular(12),
-        color: Theme.of(context).colorScheme.surface,
-        child: Container(
-          width: 260,
-          padding: const EdgeInsets.all(10),
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(12),
-            border: Border.all(color: state.accent, width: 2),
-          ),
-          child: Column(
-            spacing: 8.0,
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _Header(
-                card: card,
-                plan: plan,
-                completed: completed,
-                pinged: pinged,
-                foregroundColor: state.accent,
-              ),
-              total == 0
-                  ? SizedBox(height: 16)
-                  : Row(
-                      children: List.generate(
-                        shown,
-                        (i) => Icon(
-                          i < earned ? Icons.star : Icons.star_border,
-                          size: 16,
-                          color: i < earned
-                              ? AppConfig.gold
-                              : AppConfig.grayText,
-                        ),
-                      ),
-                    ),
-              if (completed)
-                Row(
-                  children: [
-                    _ActionPill(
-                      icon: Icons.refresh,
-                      label: L10n.of(context).playAgain,
-                      foregroundColor: AppConfig.purple,
-                      borderColor: const Color(0xFFCECBF6),
-                    ),
-                    const SizedBox(width: 6),
-                    _ActionPill(
-                      icon: Icons.visibility_outlined,
-                      label: L10n.of(context).reviewActivity,
-                      foregroundColor: AppConfig.grayText,
-                      borderColor: const Color(0xFFD3D1C7),
-                    ),
-                  ],
+      // #Pangea: announce the card as a single "Activity: <title>" button so the
+      // screen reader gets context and the title is not double-read (#7185).
+      child: Semantics(
+        label: L10n.of(context).activityLabel(card.title),
+        button: true,
+        child: Material(
+          elevation: 6,
+          borderRadius: BorderRadius.circular(12),
+          color: Theme.of(context).colorScheme.surface,
+          child: Container(
+            width: 260,
+            padding: const EdgeInsets.all(10),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(12),
+              border: Border.all(color: state.accent, width: 2),
+            ),
+            child: Column(
+              spacing: 8.0,
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _Header(
+                  card: card,
+                  plan: plan,
+                  completed: completed,
+                  pinged: pinged,
+                  foregroundColor: state.accent,
                 ),
-              if (_showParticipants)
-                Row(
-                  children: [
-                    for (final p in participants.take(4)) ...[
-                      Avatar(mxContent: p.avatar, name: p.name, size: 28),
-                      const SizedBox(width: 4),
-                    ],
-                    for (int i = 0; i < openSlots.clamp(0, 4); i++) ...[
-                      Container(
-                        width: 28,
-                        height: 28,
-                        decoration: const BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: Colors.black12,
-                        ),
-                        alignment: Alignment.center,
-                        child: const Text(
-                          '?',
-                          style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                            color: Colors.black45,
+                total == 0
+                    ? SizedBox(height: 16)
+                    : Row(
+                        children: List.generate(
+                          shown,
+                          (i) => Icon(
+                            i < earned ? Icons.star : Icons.star_border,
+                            size: 16,
+                            color: i < earned
+                                ? AppConfig.gold
+                                : AppConfig.grayText,
                           ),
                         ),
                       ),
-                      const SizedBox(width: 4),
+                if (completed)
+                  Row(
+                    children: [
+                      _ActionPill(
+                        icon: Icons.refresh,
+                        label: L10n.of(context).playAgain,
+                        foregroundColor: AppConfig.purple,
+                        borderColor: const Color(0xFFCECBF6),
+                      ),
+                      const SizedBox(width: 6),
+                      _ActionPill(
+                        icon: Icons.visibility_outlined,
+                        label: L10n.of(context).reviewActivity,
+                        foregroundColor: AppConfig.grayText,
+                        borderColor: const Color(0xFFD3D1C7),
+                      ),
                     ],
-                  ],
-                ),
-            ],
+                  ),
+                if (_showParticipants)
+                  Row(
+                    children: [
+                      for (final p in participants.take(4)) ...[
+                        Avatar(mxContent: p.avatar, name: p.name, size: 28),
+                        const SizedBox(width: 4),
+                      ],
+                      for (int i = 0; i < openSlots.clamp(0, 4); i++) ...[
+                        Container(
+                          width: 28,
+                          height: 28,
+                          decoration: const BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: Colors.black12,
+                          ),
+                          alignment: Alignment.center,
+                          child: const Text(
+                            '?',
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              color: Colors.black45,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                      ],
+                    ],
+                  ),
+              ],
+            ),
           ),
         ),
       ),
@@ -218,13 +224,17 @@ class _Header extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                card.title,
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-                style: const TextStyle(
-                  fontWeight: FontWeight.bold,
-                  fontSize: 13,
+              // #Pangea: the title is already in the card's Semantics label, so
+              // exclude the visible text to avoid a double-read (#7185).
+              ExcludeSemantics(
+                child: Text(
+                  card.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 13,
+                  ),
                 ),
               ),
               const SizedBox(height: 4),

--- a/lib/routes/world/world_map_state_dot.dart
+++ b/lib/routes/world/world_map_state_dot.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/world/world_map_ranking.dart';
 
 class WorldMapDot extends StatelessWidget {
@@ -31,7 +32,7 @@ class WorldMapDot extends StatelessWidget {
       excludeFromSemantics: true,
       child: Semantics(
         button: true,
-        label: card.title,
+        label: L10n.of(context).activityLabel(card.title),
         excludeSemantics: true,
         child: GestureDetector(
           onTap: onTap,

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -453,7 +453,7 @@ class _MapZoomControls extends StatelessWidget {
             children: [
               IconButton(
                 icon: const Icon(Icons.public),
-                tooltip: l10n.world,
+                tooltip: l10n.resetMapView,
                 onPressed: controller.resetToWorld,
               ),
               Divider(height: 1.0, color: theme.colorScheme.outlineVariant),

--- a/lib/widgets/navi_rail_item.dart
+++ b/lib/widgets/navi_rail_item.dart
@@ -68,38 +68,45 @@ class NaviRailItem extends StatelessWidget {
               height: height,
               child: Stack(
                 children: [
-                  AnimatedPositioned(
-                    duration: FluffyThemes.animationDuration,
-                    left: expanded ? 0.0 : -expandedSectionWidth,
-                    child: Container(
-                      height: height,
-                      width: naviRailWidth + expandedSectionWidth,
-                      padding: const EdgeInsets.only(right: 16.0),
-                      child: Row(
-                        children: [
-                          SizedBox(width: naviRailWidth),
-                          Expanded(
-                            child: ListTile(
-                              title: Text(
-                                toolTip,
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
-                                style: theme.textTheme.bodyMedium,
-                              ),
-                              onTap: onTap,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(16.0),
-                              ),
-                              contentPadding: const EdgeInsets.symmetric(
-                                horizontal: 8.0,
-                                vertical: 0.0,
+                  // #Pangea
+                  // The expanded ListTile duplicates the label already carried
+                  // by the interactive icon button + its tooltip below, so
+                  // ExcludeSemantics prevents VoiceOver double-reading (#7185).
+                  ExcludeSemantics(
+                    child: AnimatedPositioned(
+                      duration: FluffyThemes.animationDuration,
+                      left: expanded ? 0.0 : -expandedSectionWidth,
+                      child: Container(
+                        height: height,
+                        width: naviRailWidth + expandedSectionWidth,
+                        padding: const EdgeInsets.only(right: 16.0),
+                        child: Row(
+                          children: [
+                            SizedBox(width: naviRailWidth),
+                            Expanded(
+                              child: ListTile(
+                                title: Text(
+                                  toolTip,
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: theme.textTheme.bodyMedium,
+                                ),
+                                onTap: onTap,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(16.0),
+                                ),
+                                contentPadding: const EdgeInsets.symmetric(
+                                  horizontal: 8.0,
+                                  vertical: 0.0,
+                                ),
                               ),
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
                   ),
+                  // Pangea#
                   Container(
                     height: height,
                     width: naviRailWidth,

--- a/lib/widgets/navigation_rail.dart
+++ b/lib/widgets/navigation_rail.dart
@@ -132,12 +132,19 @@ class SpacesNavigationRail extends StatelessWidget {
         position: b.BadgePosition.topEnd(top: -5, end: -7),
         child: ClipPath(
           clipper: MapClipper(),
-          child: Avatar(
-            mxContent: space.avatar,
-            name: displayname,
-            border: BorderSide(width: 1, color: Theme.of(context).dividerColor),
-            borderRadius: BorderRadius.circular(0),
-            size: naviRailWidth - (isColumnMode ? 32.0 : 24.0),
+          // The course name is already announced by NaviRailItem's toolTip, so
+          // exclude the avatar's own name label to avoid a double-read (#7185).
+          child: ExcludeSemantics(
+            child: Avatar(
+              mxContent: space.avatar,
+              name: displayname,
+              border: BorderSide(
+                width: 1,
+                color: Theme.of(context).dividerColor,
+              ),
+              borderRadius: BorderRadius.circular(0),
+              size: naviRailWidth - (isColumnMode ? 32.0 : 24.0),
+            ),
           ),
         ),
       ),
@@ -211,16 +218,26 @@ class SpacesNavigationRail extends StatelessWidget {
                         NaviRailItem(
                           isSelected: isWorld,
                           backgroundColor: Colors.transparent,
-                          icon: PangeaLogoSvg(
-                            width: naviRailWidth - (isColumnMode ? 32.0 : 24.0),
-                            forceColor: Theme.of(
-                              context,
-                            ).colorScheme.onSurfaceVariant,
+                          // #Pangea
+                          // Exclude the logo's semanticsLabel so VoiceOver reads
+                          // only the button tooltip ("world"), not the logo name.
+                          icon: ExcludeSemantics(
+                            child: PangeaLogoSvg(
+                              width:
+                                  naviRailWidth - (isColumnMode ? 32.0 : 24.0),
+                              forceColor: Theme.of(
+                                context,
+                              ).colorScheme.onSurfaceVariant,
+                            ),
                           ),
-                          selectedIcon: PangeaLogoSvg(
-                            width: naviRailWidth - (isColumnMode ? 32.0 : 24.0),
-                            forceColor: Theme.of(context).colorScheme.primary,
+                          selectedIcon: ExcludeSemantics(
+                            child: PangeaLogoSvg(
+                              width:
+                                  naviRailWidth - (isColumnMode ? 32.0 : 24.0),
+                              forceColor: Theme.of(context).colorScheme.primary,
+                            ),
                           ),
+                          // Pangea#
                           onTap: () {
                             collapse();
                             // World is home: clear every panel (both columns)


### PR DESCRIPTION
Addresses screen-reader findings from the manual QA pass in #7185 (Kelrap, dark-mode VoiceOver). This is the first batch: what the screen reader *says* (labels, decorative excludes, and double-read cleanups). Keyboard/focus and structural items follow in a second PR.

## Fixes

**Decorative elements excluded** (were announced as noise):
- Login/signup page Pangea logo (redundant with the wordmark text)
- Nav-rail "world" icon (was reading "Pangea Chat logo" on top of its tooltip)
- World-map card placeholder square

**Missing or unclear labels:**
- Map activity pins and featured cards now announce "Activity: <title>" for context (new `activityLabel` string)
- Map reset button is now "Reset map view" (was "World") (new `resetMapView` string)
- Login loading dialog now announces its current stage

**Double-reads removed** (parent + child both announced):
- Chat list rows now read as a single "name, last message" (plus "Unread" when unread) instead of a run-on of name + timestamp + preview + bubble
- Course tiles (Courses panel) and nav-rail course shortcuts no longer say the title twice (avatar name excluded)
- Featured map cards no longer repeat the title
- "Got it!" notification button (removed a redundant wrapper)

**Other:**
- "Waiting to fill N roles…" status text no longer announced as a clickable button
- "Never miss a chat" notification dialogs now expose their title and description to the screen reader

## Testing

Verified locally on a debug build (`flutter run`, `ENABLE_SEMANTICS=true`) by inspecting the live semantics tree per the `run-flutter-web-local` skill: confirmed the map pins/cards, reset button, nav world icon, nav-rail course items, and chat-list rows announce correctly, and the login-page logo is no longer a separate node. `dart analyze`, `dart format`, `import_sorter`, and the source a11y floor-check all pass.

New localization strings are English-only for now; other locales fall back to English until translated.

## Not in this PR (follow-ups, tracked in #7185)
- Keyboard operability of the world-user cluster (Settings reachability), section headings, and modal focus trapping.
- The double-read pattern is broader than the spots fixed here (e.g. some FABs); a systematic MergeSemantics pass is worth doing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for screen readers by refining semantics handling in notifications, mobile suggestion prompts, chat list items, course tiles, login loading, and navigation rail/world map cards to reduce duplicate announcements.
  * Updated accessibility labels and tooltips, including localized “reset map view” and activity-related announcements.
  * Added new English localization entries for activity labels (with title placeholder) and the map reset action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->