### PR TITLE
feat: a11y Settings reachability + section headings (#7185)

### DIFF
--- a/lib/routes/chat_list/course_chats_view.dart
+++ b/lib/routes/chat_list/course_chats_view.dart
@@ -150,10 +150,15 @@ class CourseChatsView extends StatelessWidget {
                             top: 20.0,
                             bottom: 4.0,
                           ),
-                          child: Text(
-                            L10n.of(context).myActivities,
-                            style: const TextStyle(fontSize: 12.0),
-                            textAlign: TextAlign.center,
+                          // Mark as a heading so screen-reader users can jump
+                          // between sections via the rotor. See issue #7185.
+                          child: Semantics(
+                            header: true,
+                            child: Text(
+                              L10n.of(context).myActivities,
+                              style: const TextStyle(fontSize: 12.0),
+                              textAlign: TextAlign.center,
+                            ),
                           ),
                         );
                 }
@@ -187,10 +192,15 @@ class CourseChatsView extends StatelessWidget {
                             top: 20.0,
                             bottom: 4.0,
                           ),
-                          child: Text(
-                            L10n.of(context).openToJoin,
-                            style: const TextStyle(fontSize: 12.0),
-                            textAlign: TextAlign.center,
+                          // Mark as a heading so screen-reader users can jump
+                          // between sections via the rotor. See issue #7185.
+                          child: Semantics(
+                            header: true,
+                            child: Text(
+                              L10n.of(context).openToJoin,
+                              style: const TextStyle(fontSize: 12.0),
+                              textAlign: TextAlign.center,
+                            ),
                           ),
                         );
                 }

--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -194,6 +194,10 @@ class _Avatar extends StatelessWidget {
           button: true,
           label: label,
           excludeSemantics: true,
+          // Expose the tap on the announced node so screen-reader users can
+          // activate it (e.g. open Settings); GestureDetector alone leaves the
+          // button unactivatable via assistive tech. See issue #7185.
+          onTap: onTap,
           child: GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTap: onTap,
@@ -475,6 +479,8 @@ class _LevelMedal extends StatelessWidget {
             button: true,
             label: label,
             excludeSemantics: true,
+            // Expose the tap on the announced node for assistive tech (#7185).
+            onTap: onTap,
             child: SizedBox(
               width: 38,
               height: 44,
@@ -560,6 +566,8 @@ class _LanguageFlag extends StatelessWidget {
           button: true,
           label: '${language.getDisplayName(l10n)}, ${l10n.learningSettings}',
           excludeSemantics: true,
+          // Expose the tap on the announced node for assistive tech (#7185).
+          onTap: onTap,
           // Opaque so the whole chip is tappable — not just the painted glyphs
           // / flag pixels (a transparent-interior box defers the hit test).
           child: GestureDetector(


### PR DESCRIPTION
Second batch of fixes for the QA screen-reader pass in #7185: how you *operate* the app. Follows #7241 (which covered what the screen reader says).

## Fixes

**Settings reachable by assistive tech (Kelrap: "I can't figure out how to open settings via screen reader").** The world-user cluster controls (account avatar, level medal, language flag) wrapped a `GestureDetector` inside a `Semantics(button: true, ...)`, so the announced node had no tap action and a screen-reader user could not activate it. Added `onTap` to the announced `Semantics` node on all three, so they are now activatable via assistive tech.

**Section headings.** The "My Activities" / "Open to join" section dividers in the course view were plain text. Wrapped them in `Semantics(header: true)` so screen-reader users can jump between sections via the rotor.

## Testing

Verified locally (debug build, `ENABLE_SEMANTICS=true`, driven through the live semantics tree): activating the account button via the accessibility node now opens the Settings panel, confirming the fix. The heading change is a standard `Semantics(header: true)` wrap (its sections render conditionally on activity sessions, which I could not reliably reach in the test account, so it is code-verified rather than live-verified). `dart analyze`, `dart format`, `import_sorter`, and the source a11y floor-check all pass.

## Not in this PR
- **Modal focus trapping** was in scope but is deferred: Flutter dialogs already scope focus via `ModalRoute`, and the canvas focus behavior is murky and hard to verify without risk of regression. It needs its own focused investigation.
- Full physical-keyboard Tab support for these cluster controls (a `FocusableActionDetector` / `InkWell` change) is a further step beyond the screen-reader activation fixed here; tracked with the keyboard pass.
- The systemic double-read pass and the remaining structural items (reading order, focus-ring alignment, auto-focus-on-open) remain on #7185.