### PR TITLE
fix(ci): stop check_duplicates.yaml invalid-workflow failures

### DIFF
--- a/.github/workflows/check_duplicates.yaml
+++ b/.github/workflows/check_duplicates.yaml
@@ -1,6 +1,9 @@
+# Disabled workflow, kept for future re-enablement. Every line must stay
+# commented: a bare uncommented `on:` with no jobs is an invalid workflow and
+# makes GitHub fail the run with "workflow file issue" on every event.
 # name: Check duplicates
 
-on:
+# on:
 #   issues:
 #     types: [opened]
 


### PR DESCRIPTION
## Problem

`check_duplicates.yaml` is a disabled workflow: its `name`, triggers, and `jobs` are all commented out. But the `on:` key was left uncommented with no value and no jobs, which is an invalid workflow file. GitHub flags every event with "This run likely failed because of a workflow file issue," adding noise alongside the (now-fixed) integrate.yaml breakage.

## Fix

Comment out the `on:` line so the entire file is inert, and add a note explaining why every line must stay commented. The workflow code is preserved for future re-enablement. No behavior change beyond stopping the invalid-workflow failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled an automated workflow so it no longer runs on every event.
  * Added guidance in the workflow file to prevent invalid configuration from triggering run failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->