### PR TITLE
fix(ci): retry flaky binaryen download in web build

### DIFF
--- a/scripts/prepare-web.sh
+++ b/scripts/prepare-web.sh
@@ -1,11 +1,30 @@
 #!/bin/sh -ve
 
+# Retry the web build: flutter_rust_bridge_codegen downloads binaryen from
+# GitHub releases, which intermittently flakes (transient network / rate
+# limits) and fails the build even though the asset is available. Retrying the
+# command re-attempts the download.
+retry() {
+  attempt=1
+  while true; do
+    "$@" && return 0
+    status=$?
+    if [ "$attempt" -ge 3 ]; then
+      echo "retry: '$*' failed after $attempt attempts (exit $status)" >&2
+      return "$status"
+    fi
+    echo "retry: '$*' failed (attempt $attempt/3, exit $status), retrying in 15s..." >&2
+    attempt=$((attempt + 1))
+    sleep 15
+  done
+}
+
 version=$(yq ".dependencies.flutter_vodozemac" < pubspec.yaml)
 version=$(expr "$version" : '\^*\(.*\)')
 git clone https://github.com/famedly/dart-vodozemac.git -b ${version} .vodozemac
 cd .vodozemac
 cargo install flutter_rust_bridge_codegen
-flutter_rust_bridge_codegen build-web --dart-root dart --rust-root $(readlink -f rust) --release
+retry flutter_rust_bridge_codegen build-web --dart-root dart --rust-root $(readlink -f rust) --release
 cd ..
 rm -f ./assets/vodozemac/vodozemac_bindings_dart*
 mv .vodozemac/dart/web/pkg/vodozemac_bindings_dart* ./assets/vodozemac/


### PR DESCRIPTION
## Problem

`build_debug_web` fails intermittently at the "Prepare web" step with `failed to download binaryen vNNN` from GitHub releases. The asset is present (the URL returns 200); the failure is a transient network / rate-limit blip during `flutter_rust_bridge_codegen build-web`. Recent runs show a success/failure mix on the same code, so it is flakiness, not a real break.

## Fix

Wrap the `flutter_rust_bridge_codegen build-web` call (where binaryen is downloaded) in a small `retry` helper: up to 3 attempts with a 15s pause. A permanent failure still returns non-zero, so `set -e` fails the build as before. No change to the happy path.

## Verification

`sh -n` passes. The retry helper was unit-tested: returns 0 on first success, recovers on eventual success, and returns non-zero after exhausting retries.
