### PR TITLE
fix: drop redundant tooltips on labeled extended FABs (a11y double-read) (#7185)

### DIFF
--- a/.github/instructions/accessibility.instructions.md
+++ b/.github/instructions/accessibility.instructions.md
@@ -38,7 +38,7 @@ Author these as you build.
 
 **Enforced by the source gate** ([`a11y_floor_check.py`](../../scripts/a11y_floor_check.py)):
 
-- **`IconButton` / `FloatingActionButton`** → `tooltip:` (its accessible name). Reuse an existing `L10n` key where one fits.
+- **`IconButton` / `FloatingActionButton`** → `tooltip:` (its accessible name). Reuse an existing `L10n` key where one fits. Exception: a `FloatingActionButton.extended` already has a visible `label:` that is its name, so do **not** add a tooltip there — it double-reads. (The floor-check accepts `tooltip:` *or* `label:`.)
 - **`Image.*`** → `semanticLabel:` if it conveys information, or `excludeFromSemantics: true` if decorative (placeholder, blurhash, background, redundant logo).
 
 **Not gated, caught by axe or the manual passes** (apply them anyway):

--- a/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
+++ b/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
@@ -328,7 +328,6 @@ class _PracticeButton extends StatelessWidget {
     final analyticsService = Matrix.of(context).analyticsDataService;
     if (analyticsService.isInitializing) {
       return FloatingActionButton.extended(
-        tooltip: L10n.of(context).practice,
         onPressed: () =>
             _showSnackbar(context, L10n.of(context).loadingPleaseWait),
         label: Text(view.practiceButtonText(context)),
@@ -343,7 +342,6 @@ class _PracticeButton extends StatelessWidget {
     final enabled = count >= 10;
 
     return FloatingActionButton.extended(
-      tooltip: L10n.of(context).practice,
       onPressed: enabled
           // world_v2: practice opens as a right-column `practice:<type>` panel
           // that takes over the analytics surface (it is not a route). See

--- a/lib/routes/chat_list/chat_list_view.dart
+++ b/lib/routes/chat_list/chat_list_view.dart
@@ -53,7 +53,6 @@ class ChatListView extends StatelessWidget {
                     !controller.isSearchMode && controller.activeSpaceId == null
                     ? FloatingActionButton.extended(
                         onPressed: () => context.go('/rooms/newprivatechat'),
-                        tooltip: L10n.of(context).directMessage,
                         // #Pangea
                         icon: const Icon(Icons.chat_bubble_outline),
                         // icon: const Icon(Icons.add_outlined),

--- a/lib/widgets/profile_bottom_sheet.dart
+++ b/lib/widgets/profile_bottom_sheet.dart
@@ -101,9 +101,6 @@ class ProfileBottomSheet extends StatelessWidget {
                   padding: const EdgeInsets.all(12),
                   child: FloatingActionButton.extended(
                     onPressed: () => _startDirectChat(context),
-                    // #Pangea
-                    tooltip: L10n.of(context).newChat,
-                    // Pangea#
                     label: Text(L10n.of(context).newChat),
                     icon: const Icon(Icons.send_outlined),
                   ),

--- a/scripts/a11y_floor_check.py
+++ b/scripts/a11y_floor_check.py
@@ -31,8 +31,12 @@ CHECKS = [
         # FloatingActionButton(, .small(, .extended(, etc. NOT `.styleFrom(`
         # (a ButtonStyle builder, not a widget).
         re.compile(r"\b(IconButton|FloatingActionButton)(\.(?!styleFrom)\w+)?\("),
-        ["tooltip:"],
-        "IconButton/FloatingActionButton needs a `tooltip:` (its accessible name).",
+        # `tooltip:` names an icon-only button. A `FloatingActionButton.extended`
+        # carries a visible `label:` which is already its accessible name, so a
+        # tooltip there is redundant (and double-reads); accept either.
+        ["tooltip:", "label:"],
+        "IconButton/FloatingActionButton needs a `tooltip:` (its accessible name), "
+        "or a visible `label:` for an extended FAB.",
     ),
     (
         re.compile(r"\bImage\.(network|asset|file|memory)\("),


### PR DESCRIPTION
Part of #7185 (issue-loop pass). Fixes a screen-reader double-read on extended FABs.

## Problem

A `FloatingActionButton.extended` already carries a visible `label:` that *is* its accessible name. The earlier a11y floor-check back-fill (#7226) added a `tooltip:` to these FABs anyway, so the name was announced twice, e.g. "Mensaje directo Mensaje directo", "New chat New chat", "Practice Practice".

## Fix

- Removed the redundant `tooltip:` from the three labeled extended FABs (direct-message in the chat list, "New chat" in the profile sheet, and the two practice FABs in the analytics popup).
- Refined the source a11y floor-check so a labeled extended FAB satisfies the naming rule via `label:` (not only `tooltip:`), so it does not re-require the duplicate. Verified the refinement still flags a tooltip-less icon-only button.
- Updated the naming-contract note in `accessibility.instructions.md` to document the exception.

## Testing

Verified locally (debug build, `ENABLE_SEMANTICS=true`): the chat-list direct-message FAB now announces "Mensaje directo" once instead of twice. Floor-check, `dart analyze`, and `dart format` pass.