### PR TITLE
fix(navigation): highlight the open room in the chat list (#7208)

### DIFF
--- a/lib/features/navigation/route_facts.dart
+++ b/lib/features/navigation/route_facts.dart
@@ -197,10 +197,25 @@ String? activeSpaceIdFor(Uri uri) {
   return null;
 }
 
-/// The active chat/course room id, if the route addresses one.
+/// The open room id from the world_v2 panel tokens (a `room:` token in the
+/// `left=` / `right=` lists), or null. This is the chat the list highlights as
+/// active (#7208).
+String? activeRoomIdFromPanels(Uri uri) {
+  final panels = parseOpenPanels(uri);
+  for (final token in [...panels.left, ...panels.right]) {
+    if (token.type == 'room' && token.param != null) {
+      return fullRoomId(token.param!);
+    }
+  }
+  return null;
+}
+
+/// The active chat/course room id, if the route addresses one — the legacy
+/// `/rooms/:roomid` path param, or the world_v2 open `room:` panel token.
 String? activeRoomIdFor(GoRouterState state) {
   final roomId = state.pathParameters['roomid'];
-  return roomId == null ? null : fullRoomId(roomId);
+  if (roomId != null) return fullRoomId(roomId);
+  return activeRoomIdFromPanels(state.uri);
 }
 
 /// The activity an open route addresses: the in-course overlay (`?activity=`)

--- a/lib/routes/world/workspace_left_panel.dart
+++ b/lib/routes/world/workspace_left_panel.dart
@@ -88,7 +88,14 @@ class WorkspaceLeftPanel extends StatelessWidget {
         return Column(
           children: [
             _panelHeader(context, isColumnMode, L10n.of(context).chats),
-            Expanded(child: ChatList(activeChat: null, activeSpace: null)),
+            Expanded(
+              child: ChatList(
+                // Highlight the open room in the list (#7208): derive it from
+                // the `room:` panel token, not the legacy path param.
+                activeChat: activeRoomIdFor(GoRouterState.of(context)),
+                activeSpace: null,
+              ),
+            ),
           ],
         );
       case 'room':

--- a/test/pangea/navigation/route_facts_test.dart
+++ b/test/pangea/navigation/route_facts_test.dart
@@ -148,4 +148,22 @@ void main() {
       );
     });
   });
+
+  group('activeRoomIdFromPanels (#7208)', () {
+    String? active(String location) =>
+        activeRoomIdFromPanels(Uri.parse(location));
+
+    test('no open room token yields null', () {
+      expect(active('/?left=chats'), isNull);
+      expect(active('/'), isNull);
+    });
+
+    test('the open room: token (beside the chat list) is the active room', () {
+      expect(active('/?left=chats,room:!abc:server.org'), '!abc:server.org');
+    });
+
+    test('a foreign-homeserver room id is kept intact', () {
+      expect(active('/?left=chats,room:!abc:matrix.org'), '!abc:matrix.org');
+    });
+  });
 }


### PR DESCRIPTION
Closes #7208.

## Problem

In the world_v2 workspace, opening a chat does not highlight it in the chat list. The chat list is rendered with a hardcoded `activeChat: null`, so the active-room highlight never lights up even when a room is open.

## Fix

Derive the active room from the open panel tokens. world_v2 carries the open room as a `room:` token in the `left=` / `right=` lists rather than a path param, so:

- `route_facts.dart`: add `activeRoomIdFromPanels(uri)` (the first `room:` token's id, federation-safe via `fullRoomId`) and have `activeRoomIdFor` fall back to it when there is no `/rooms/:roomid` path param.
- `workspace_left_panel.dart`: feed `activeChat: activeRoomIdFor(GoRouterState.of(context))` into the chat list instead of `null`.

## Verification

- Unit tests added for `activeRoomIdFromPanels` (no room → null; the open `room:` token is the active room; foreign-homeserver ids kept intact). Full `route_facts_test.dart` passes (18/18).
- `flutter analyze`, `dart format`, and `import_sorter` all clean.
- Verified locally: opening a chat adds its `room:` token to the URL and highlights that row in the list (confirmed visually).
