### PR TITLE
chore(dev): sync staging Firebase analytics default into local .env

### DIFF
--- a/scripts/sync-dev-secrets.sh
+++ b/scripts/sync-dev-secrets.sh
@@ -46,6 +46,14 @@ SECRET_MAP=(
   "TEST_MATRIX_PASSWORD=/staging/test-user/matrix-credentials#password"
 )
 
+# Static, non-secret defaults written verbatim (no AWS call). The staging Firebase analytics
+# web config is public — it ships in the web bundle — and is the sensible default for local
+# builds (prod analytics is for prod builds only). Without it, local web analytics is off.
+# See pangeachat/client#7262.
+STATIC_MAP=(
+  "GOOGLE_ANALYTICS_FIREBASE_OPTIONS_BASE64=ewogICAiYXBpS2V5IjoiQUl6YVN5QWpjNmZJWU44UUFHZ1lzMHh2SWlaVUVQdVJLcUFZMi1zIiwKICAgImF1dGhEb21haW4iOiJwYW5nZWEtY2hhdC1zdGFnaW5nLWFuYWx5dGljcy5maXJlYmFzZWFwcC5jb20iLAogICAicHJvamVjdElkIjoicGFuZ2VhLWNoYXQtc3RhZ2luZy1hbmFseXRpY3MiLAogICAic3RvcmFnZUJ1Y2tldCI6InBhbmdlYS1jaGF0LXN0YWdpbmctYW5hbHl0aWNzLmZpcmViYXNlc3RvcmFnZS5hcHAiLAogICAibWVzc2FnaW5nU2VuZGVySWQiOiI1MDE3MDcyMzkwNjgiLAogICAiYXBwSWQiOiIxOjUwMTcwNzIzOTA2ODp3ZWI6ZWFlZWI3Nzk4YjI4NjkzZDkwNDc1OSIsCiAgICJtZWFzdXJlbWVudElkIjoiRy0yTjJHWkxSTVpWIgp9"
+)
+
 fetch_secret() {
   local secret_name="$1"
   local json_key="${2:-}"
@@ -60,7 +68,7 @@ fetch_secret() {
 
 # Track managed keys as space-delimited string (bash 3-compatible — no `declare -A`).
 MANAGED_VARS=""
-for entry in "${SECRET_MAP[@]}"; do
+for entry in "${SECRET_MAP[@]}" "${STATIC_MAP[@]}"; do
   MANAGED_VARS="$MANAGED_VARS ${entry%%=*}"
 done
 
@@ -89,6 +97,11 @@ if [[ -f "$OUT" ]]; then
 fi
 
 printf '# --- Synced by sync-dev-secrets.sh on %s ---\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$TMP_FILE"
+
+# Static values, written verbatim (no AWS call).
+for entry in "${STATIC_MAP[@]}"; do
+  printf '%s\n' "$entry" >> "$TMP_FILE"
+done
 
 for entry in "${SECRET_MAP[@]}"; do
   env_var="${entry%%=*}"


### PR DESCRIPTION
Dev-onboarding companion to #7262, which switches the Firebase/analytics defaults to staging and notes that local web dev now needs `GOOGLE_ANALYTICS_FIREBASE_OPTIONS_BASE64` in `.env` (without it, local web analytics is off). Rather than have every dev paste the blob by hand, the sync script provides it.

## What changed
Adds a `STATIC_MAP` to `scripts/sync-dev-secrets.sh` (mirroring the choreo/cms sibling scripts, which the header already says this one follows) carrying the staging analytics base64. Running `./scripts/sync-dev-secrets.sh` now writes it into `.env` along with the test-user Matrix creds.

## Why static, not Secrets Manager
The value is **public Firebase web config** — it ships in the web bundle and is already in #7262's description in the clear — and it's the same staging value for every dev. So it belongs as a checked-in static default, not an AWS Secrets Manager secret. (`STATIC_MAP` is the same vehicle choreo uses for `MATRIX_URL` / `CMS_URL`.)

Verified with a dry run: the var lands in `.env` and decodes to `projectId: pangea-chat-staging-analytics`.

Note: this means local web runs report analytics to the **staging** project, which is #7262's intent (staging is the default for non-prod builds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the development environment sync process to keep certain non-secret configuration values in sync alongside secret values.
  * Existing environment files now have those managed entries refreshed cleanly during sync, reducing stale or duplicated settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->