### PR TITLE
Add border to learning settings flag button

### DIFF
--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -530,28 +530,20 @@ class _LanguageFlag extends StatelessWidget {
   static const double _w = 52.0;
   static const double _h = 36.0;
   static const double _radius = 6.0;
+  static const double _borderWidth = 2.0;
 
   @override
   Widget build(BuildContext context) {
     final l10n = L10n.of(context);
     final theme = Theme.of(context);
 
-    final codeWidget = Container(
-      width: _w,
-      height: _h,
-      alignment: Alignment.center,
-      decoration: BoxDecoration(
-        color: theme.colorScheme.primary,
-        borderRadius: BorderRadius.circular(_radius),
-      ),
-      child: Text(
-        language.langCodeShort.toUpperCase(),
-        style: TextStyle(
-          color: theme.colorScheme.onPrimary,
-          fontSize: 18,
-          fontWeight: FontWeight.w700,
-          height: 1.0,
-        ),
+    final codeWidget = Text(
+      language.langCodeShort.toUpperCase(),
+      style: TextStyle(
+        color: theme.colorScheme.onPrimary,
+        fontSize: 18,
+        fontWeight: FontWeight.w700,
+        height: 1.0,
       ),
     );
 
@@ -573,20 +565,30 @@ class _LanguageFlag extends StatelessWidget {
           child: GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTap: onTap,
-            child: language.shouldShowFlag
-                ? ClipRRect(
-                    borderRadius: BorderRadius.circular(_radius),
-                    child: SvgPicture.network(
-                      language.svgUrl.toString(),
-                      width: _w,
-                      height: _h,
-                      fit: BoxFit.cover,
-                      errorBuilder: (ctx, _, _) => codeWidget,
-                      placeholderBuilder: (_) =>
-                          const SizedBox(width: _w, height: _h),
-                    ),
-                  )
-                : codeWidget,
+            child: Container(
+              width: _w,
+              height: _h,
+              padding: .all(_borderWidth),
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primary,
+                borderRadius: BorderRadius.circular(_radius + _borderWidth),
+              ),
+              child: language.shouldShowFlag
+                  ? ClipRRect(
+                      borderRadius: BorderRadius.circular(_radius),
+                      child: SvgPicture.network(
+                        language.svgUrl.toString(),
+                        width: _w,
+                        height: _h,
+                        fit: BoxFit.cover,
+                        errorBuilder: (ctx, _, _) => codeWidget,
+                        placeholderBuilder: (_) =>
+                            const SizedBox(width: _w, height: _h),
+                      ),
+                    )
+                  : codeWidget,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the appearance of language chips with better spacing and border handling.
  * Updated the fallback language code display to render more cleanly.
  * Preserved existing flag loading and placeholder behavior while refining the chip layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->