### PR TITLE
fix: filtered activity stars earned by user l2

### DIFF
--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart
@@ -3,6 +3,7 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
 
 extension OrchestratorClientExtension on Client {
@@ -32,12 +33,18 @@ extension OrchestratorClientExtension on Client {
     return completed;
   }
 
-  int get totalStarsEarned {
+  int totalStarsEarned(LanguageModel lang) {
     final byActivity = <String, int>{};
     for (final room in rooms) {
       final activityId = room.activityId;
+      final activityLang = room.activityPlan?.req.targetLanguage;
       final roleId = room.ownRoleState?.id;
-      if (activityId == null || roleId == null) continue;
+      if (activityId == null || roleId == null || activityLang == null) {
+        continue;
+      }
+
+      if (lang.langCodeShort != activityLang.split('-').first) continue;
+
       final earned = room.orchestratorAwardedGoals.awards[roleId]?.length ?? 0;
       if (earned > (byActivity[activityId] ?? 0)) {
         byActivity[activityId] = earned;

--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -115,7 +115,9 @@ class _WorldUserClusterState extends State<WorldUserCluster> {
 
         final vocab = service.numConstructs(ConstructTypeEnum.vocab);
         final grammar = service.numConstructs(ConstructTypeEnum.morph);
-        final earnedActivityStars = client.totalStarsEarned;
+        final earnedActivityStars = l2 != null
+            ? client.totalStarsEarned(l2)
+            : 0;
 
         return FutureBuilder<DerivedAnalyticsDataModel>(
           future: l2 != null


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
