### PR TITLE
fix(routing): open in-course activities via token URL, not the legacy /courses path

### DIFF
--- a/lib/features/navigation/route_paths.dart
+++ b/lib/features/navigation/route_paths.dart
@@ -4,7 +4,9 @@ import 'package:fluffychat/features/navigation/room_id_url.dart';
 ///
 /// world_v2 navigation is **token-driven**: internal navigation goes through the
 /// `WorkspaceNav` token helpers (and the token locations/builders here —
-/// [world], [chatsList], [course], [room], [worldObject], [activity]). The bare
+/// [world], [chatsList], [course], [room], [worldObject]). The in-course
+/// activity overlay is produced token-natively by
+/// `WorkspaceNav.openCourseActivity` (#7267), not by a path builder here. The bare
 /// **section-path** constants ([chats], [analytics], [courses], [settings],
 /// [profile], [rooms]) are NOT navigation targets — they are legacy redirect
 /// sources + `route_facts.sectionFor` identities that `LegacyRedirects` rewrites
@@ -65,24 +67,6 @@ abstract class PRoutes {
 
   /// First-class world object (activity for now) — `/<uuid>`.
   static String worldObject(String id) => '/$id';
-
-  /// Open an activity in its course — the canonical in-course overlay over the
-  /// persistent map (`/courses/:spaceid?activity=:id`). [tab] preserves the
-  /// underlying course tab, [roomId] joins an existing session room, [launch]
-  /// skips the lobby. This is the single producer of the in-course open shape.
-  static String activity(
-    String spaceId,
-    String activityId, {
-    String? roomId,
-    bool launch = false,
-    String? tab,
-  }) {
-    final params = <String>['activity=$activityId'];
-    if (tab != null) params.add('tab=$tab');
-    if (roomId != null) params.add('roomid=${shortRoomId(roomId)}');
-    if (launch) params.add('launch=true');
-    return '${course(spaceId)}?${params.join('&')}';
-  }
 
   /// Open an activity with no course context — the shareable first-class uuid
   /// (`/<uuid>`). [launch] skips the lobby.

--- a/lib/features/navigation/workspace_nav.dart
+++ b/lib/features/navigation/workspace_nav.dart
@@ -267,6 +267,38 @@ abstract class WorkspaceNav {
   static String openCoursePageFor(Uri current, String spaceId, String page) =>
       openCoursePage(Uri.parse(openCourseFilter(current, spaceId)), page);
 
+  /// Open an in-course activity as the immersive `?activity=` overlay over the
+  /// course-scoped map — the token-native producer for "open this activity in
+  /// its course". Sets the `?m=course:<spaceId>` scope and the `activity=<id>`
+  /// overlay on a CLEAN workspace (no `left`/`right` tokens): an activity is an
+  /// immersive task that REPLACES the open panels rather than stacking beside
+  /// them, and the surviving `?m=course:` scope makes the plan the card's child
+  /// (its close is a back-arrow that reopens the card). [launch] skips the lobby
+  /// straight to role selection; [roomId] reopens/rejoins a specific session
+  /// room; [autoplay] autostarts the plan's hero media (muted, block 0).
+  ///
+  /// Replaces the legacy `/courses/:id?activity=` path producer: `context.go`-ing
+  /// that path made `LegacyRedirects` rewrite it back to tokens INCLUDING
+  /// `left=course`, re-opening the course card beside the activity (#7267).
+  /// Inbound `/courses/:id?activity=` external links still map through
+  /// `legacy_redirects` unchanged. See `routing.instructions.md`.
+  static String openCourseActivity(
+    String spaceId,
+    String activityId, {
+    bool launch = false,
+    String? roomId,
+    bool autoplay = false,
+  }) {
+    final parts = <String>[
+      'm=${PanelToken('course', shortRoomId(spaceId)).encode()}',
+      'activity=$activityId',
+      if (roomId != null) 'roomid=${shortRoomId(roomId)}',
+      if (launch) 'launch=true',
+      if (autoplay) 'autoplay=0',
+    ];
+    return WorkspaceQuery.location(PRoutes.world, parts);
+  }
+
   /// Replace the whole `left` list (e.g. tapping a top-level section: Chats,
   /// the avatar/profile). The `right` list and other query params are preserved.
   static String setLeft(Uri current, List<PanelToken> tokens) =>

--- a/lib/features/notifications/notification_tap_utils.dart
+++ b/lib/features/notifications/notification_tap_utils.dart
@@ -7,6 +7,7 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/features/bot/bot_room_extension.dart';
 import 'package:fluffychat/features/bot/bot_target_event_name_enum.dart';
 import 'package:fluffychat/features/navigation/route_paths.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
@@ -131,7 +132,13 @@ class NotificationTapUtil {
         return;
       }
 
-      router.go(PRoutes.activity(roomId, activityId, roomId: sessionRoomId));
+      router.go(
+        WorkspaceNav.openCourseActivity(
+          roomId,
+          activityId,
+          roomId: sessionRoomId,
+        ),
+      );
       return;
     } catch (err, s) {
       ErrorHandler.logError(e: err, s: s, data: {'roomId': sessionRoomId});

--- a/lib/routes/chat/activity_sessions/not_started_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/not_started_session_controller.dart
@@ -157,7 +157,11 @@ class NotStartedSessionController extends State<NotStartedSession>
     // standalone via its first-class route.
     context.go(
       course != null
-          ? PRoutes.activity(course.id, widget.activityId, launch: true)
+          ? WorkspaceNav.openCourseActivity(
+              course.id,
+              widget.activityId,
+              launch: true,
+            )
           : PRoutes.activityStandalone(widget.activityId, launch: true),
     );
   }

--- a/lib/routes/chat_list/course_chats_page.dart
+++ b/lib/routes/chat_list/course_chats_page.dart
@@ -13,7 +13,6 @@ import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dar
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
 import 'package:fluffychat/features/join_codes/join_rule_extension.dart';
 import 'package:fluffychat/features/join_codes/knocked_rooms_extension.dart';
-import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
@@ -541,7 +540,13 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
     );
     final roomId = chunk.chunk.roomId;
     if (!hasRole) {
-      context.go(PRoutes.activity(widget.roomId, activityId, roomId: roomId));
+      context.go(
+        WorkspaceNav.openCourseActivity(
+          widget.roomId,
+          activityId,
+          roomId: roomId,
+        ),
+      );
       return;
     }
 

--- a/lib/routes/courses/course_objectives/course_objectives_view.dart
+++ b/lib/routes/courses/course_objectives/course_objectives_view.dart
@@ -7,7 +7,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
-import 'package:fluffychat/features/navigation/workspace_query.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/chat/chat_details/activity_suggestion_card.dart';
@@ -256,34 +256,18 @@ class _ObjectiveSection extends StatelessWidget {
                       context.go('/${ref.activityId}');
                       return;
                     }
-                    final uri = GoRouter.of(
-                      context,
-                    ).routeInformationProvider.value.uri;
-                    // Rebuild the query from the RAW parts, not
-                    // uri.replace(queryParameters:) — the latter re-encodes the
-                    // already-encoded `m=course:!id` filter (`:`→`%3A`, `!`→`%21`),
-                    // which the raw-query parser then mis-reads, de-scoping the
-                    // map and blanking the course panel. Keep `m=` (course scope)
-                    // verbatim and add the activity. Drop the `left=course` card
-                    // AND the `right=` review surface: an activity is an
-                    // immersive task, so it REPLACES other panels rather than
-                    // stacking on them — backing out returns to the course map,
-                    // never a stale vocab/analytics page. See routing.instructions.md.
-                    final parts = WorkspaceQuery.parts(uri.query);
-                    WorkspaceQuery.removeKeys(parts, {
-                      'left',
-                      'right',
-                      'activity',
-                      'autoplay',
-                    });
-                    parts.add('activity=${ref.activityId}');
-                    // Tapping a video card opens the plan with that video
-                    // autostarting (muted) — see the carousel.
-                    if (ref.plan.heroBlock?.isVideo == true ||
-                        ref.plan.heroBlock?.isYoutube == true) {
-                      parts.add('autoplay=0');
-                    }
-                    context.go(WorkspaceQuery.location('/', parts));
+                    // Immersive in-course open: the token producer drops the
+                    // `left=course` card (and any right panel) and keeps the
+                    // `?m=course:` scope, so the plan takes the card's slot and
+                    // backs out to it. A video hero autostarts (muted).
+                    context.go(
+                      WorkspaceNav.openCourseActivity(
+                        room!.id,
+                        ref.activityId,
+                        autoplay: ref.plan.heroBlock?.isVideo == true ||
+                            ref.plan.heroBlock?.isYoutube == true,
+                      ),
+                    );
                   },
                   child: Stack(
                     children: [

--- a/lib/routes/courses/course_objectives/course_objectives_view.dart
+++ b/lib/routes/courses/course_objectives/course_objectives_view.dart
@@ -264,7 +264,8 @@ class _ObjectiveSection extends StatelessWidget {
                       WorkspaceNav.openCourseActivity(
                         room!.id,
                         ref.activityId,
-                        autoplay: ref.plan.heroBlock?.isVideo == true ||
+                        autoplay:
+                            ref.plan.heroBlock?.isVideo == true ||
                             ref.plan.heroBlock?.isYoutube == true,
                       ),
                     );

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
+import 'package:fluffychat/features/navigation/workspace_query.dart';
 
 void main() {
   Uri u(String s) => Uri.parse(s);
@@ -808,5 +809,55 @@ void main() {
         expect(right.map((t) => t.type).toSet(), {'vocab', 'analytics'});
       },
     );
+  });
+
+  group('openCourseActivity (token-native in-course overlay, #7267)', () {
+    // Bare localpart ids (no `:domain`): shortRoomId only strips the home
+    // server_name, which is unavailable in a unit test (no MatrixState), so a
+    // `!x:server.com` would ride the URL whole. The existing course helpers test
+    // the same way — the id format is orthogonal to what this producer asserts.
+    test('sets the course scope + activity overlay on a clean workspace — no '
+        'left/right panels (the #7267 split)', () {
+      final loc = WorkspaceNav.openCourseActivity('!space', 'act-123');
+      final uri = u(loc);
+      expect(uri.path, '/'); // over the persistent world map
+      // The `m` filter is the course scope, encoded the same as everywhere else.
+      expect(
+        WorkspaceQuery.valueOf(uri.query, 'm'),
+        const PanelToken('course', '!space').encode(),
+      );
+      expect(uri.queryParameters['activity'], 'act-123');
+      // The whole point of the fix: an activity REPLACES the panels, so no
+      // `left=course` card (or any right panel) re-opens beside it.
+      expect(WorkspaceQuery.valueOf(uri.query, 'left'), isNull);
+      expect(WorkspaceQuery.valueOf(uri.query, 'right'), isNull);
+    });
+
+    test('launch:true adds the lobby-skip flag', () {
+      final loc = WorkspaceNav.openCourseActivity(
+        '!space',
+        'act-123',
+        launch: true,
+      );
+      expect(WorkspaceQuery.valueOf(u(loc).query, 'launch'), 'true');
+    });
+
+    test('roomId reopens a specific session room (shortRoomId localpart)', () {
+      final loc = WorkspaceNav.openCourseActivity(
+        '!space',
+        'act-123',
+        roomId: '!sess',
+      );
+      expect(WorkspaceQuery.valueOf(u(loc).query, 'roomid'), '!sess');
+    });
+
+    test('autoplay:true autostarts the hero media at block 0', () {
+      final loc = WorkspaceNav.openCourseActivity(
+        '!space',
+        'act-123',
+        autoplay: true,
+      );
+      expect(WorkspaceQuery.valueOf(u(loc).query, 'autoplay'), '0');
+    });
   });
 }


### PR DESCRIPTION
Closes #7267

## Problem
Launching an activity from a course opened the activity in a new panel on the right while the course panel snapped back to its main view. Gabby flagged the jarring transition when an activity becomes a session.

Root cause: in-course activity navigation went through `PRoutes.activity(spaceId, activityId, ...)`, which builds the legacy path `/courses/:spaceid?activity=...`. `context.go`-ing a `/courses/:spaceid` path makes `LegacyRedirects` rewrite it back into tokens **including `left=course`**, so the course card re-opens beside the activity. The course-list card tap used a separate, correct hand-rolled producer, so the two entry points disagreed.

## Fix
Add one token-native producer, `WorkspaceNav.openCourseActivity(spaceId, activityId, {launch, roomId, autoplay})`, that sets `?m=course:<id>&activity=<id>` on a clean workspace (no `left`/`right`), and repoint every internal in-course activity open to it:
- course Plan-tab card tap (was raw `WorkspaceQuery` surgery)
- Start / launch from the activity plan
- activity push-notification tap
- opening an activity from the course chats page

The legacy `PRoutes.activity` path producer is removed (no other references). `PRoutes.activityStandalone` (the first-class `/<uuid>` no-course shape) is unchanged, and the **inbound** `/courses/:id?activity=` mapping in `legacy_redirects` is left as-is (see follow-ups). This obeys the routing doc's "navigate by token, never `.go` a `/…` path" rule.

## Verification
- `flutter analyze` clean.
- `flutter test test/pangea/navigation/` green (176 pass), including 4 new `openCourseActivity` tests that assert the produced URL keeps the course scope, sets the activity overlay, and carries **no** `left`/`right` token (the #7267 split).

## TO TEST
- [ ] In a joined course, open the **Course / Plan** tab and tap an activity. The activity plan opens in place of the course panel (same left area), map zoomed to the activity; tapping back returns to the course.
- [ ] On that activity plan, tap **Start**. The role-selection / lobby opens in the **same** panel (replacing the plan), **not** as a new panel on the right, and the course panel does **not** reappear beside it.
- [ ] Open an activity from a **course chat list** row — same in-place behavior.
- [ ] Tap an **activity push notification** — the activity opens inside its course in place (no course panel splitting beside it).

## Follow-ups (out of scope here)
- Inbound external `/courses/:id?activity=` links still map to `left=course` + activity in `legacy_redirects` (cross-repo deep-link contract) — worth aligning separately.
- A `launch → logged out` symptom observed once on the local full stack while reproducing this; likely a token/entitlement artifact, to investigate on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In-course activities now open through a more consistent workspace overlay experience.
  * Launch links can include course context, room context, and autoplay behavior when needed.

* **Bug Fixes**
  * Improved navigation handling for activity taps, joins, notifications, and session starts.
  * Preserved the standalone shareable activity route for direct access outside a course.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->