### PR TITLE
fix(run-flutter-web-local): robust fifo holder (no EOF-quit, no orphan pile)

### DIFF
--- a/.github/skills/run-flutter-web-local/SKILL.md
+++ b/.github/skills/run-flutter-web-local/SKILL.md
@@ -64,11 +64,20 @@ The dev server reads stdin from a FIFO so we can send it `r`/`q` from other shel
 
 ```bash
 [ -p /tmp/f8090 ] || mkfifo /tmp/f8090
-( sleep 100000000 > /tmp/f8090 & )   # holder keeps the FIFO open for writing
+# Keep ONE writer holding the fifo open, or flutter's stdin hits EOF and it quits
+# right after serving (you'll see the banner, then nothing listening on 8090). Two rules:
+#   • open it READ-WRITE (`<>`), not write-only — a RW holder never EOFs and never blocks.
+#   • reuse the existing holder via a pidfile. Do NOT guard on `pgrep -f sleep` (stale
+#     holders from old sessions make that match and skip creation), and do NOT spawn a
+#     fresh holder every launch (they pile up as orphaned `sleep` processes).
+HPF=/tmp/f8090.holder
+if ! { [ -f "$HPF" ] && kill -0 "$(cat "$HPF" 2>/dev/null)" 2>/dev/null; }; then
+  ( exec 3<>/tmp/f8090; exec sleep 2147483647 ) & echo $! > "$HPF"
+fi
 # then launch flutter with `< /tmp/f8090`
 ```
 
-Send commands with `printf 'r' > /tmp/f8090` (hot reload) or `printf 'q' > /tmp/f8090` (quit). One holder + one `flutter run` only.
+Send commands with `printf 'r' > /tmp/f8090` (hot reload) or `printf 'q' > /tmp/f8090` (quit). One holder + one `flutter run` only — the pidfile guard above keeps it to one. Orphaned `sleep 100000000` holders from the old write-only pattern are harmless; clear them with `pkill -f 'sleep 100000000'` while no client is running.
 
 ## Recovery from a zombie pile / wedged build
 


### PR DESCRIPTION
## Problem

The fifo-holder step started the client and then it quietly died: banner appears, then nothing is listening on :8090. Root cause: the holder is `( sleep 100000000 > /tmp/f8090 & )`, which

1. **opens the fifo write-only** — fragile; if the holder isn't the active writer when flutter opens stdin, flutter hits EOF and quits right after serving, and
2. **spawns a fresh holder every launch with no reuse guard** — so orphaned `sleep` holders pile up (found 21 on one machine). Worse, that pile tempts a `pgrep -f sleep || create` guard, which then matches a stale holder and skips creating one for the *current* fifo — guaranteeing the EOF-quit.

## Fix

Idempotent, read-write holder keyed by a pidfile:

- `exec 3<>/tmp/f8090` opens **read-write** — never EOFs, never blocks on open.
- A pidfile (`/tmp/f8090.holder`) means a live holder is reused instead of stacking a new one each launch.
- Comment explicitly warns off the two traps (write-only open; `pgrep sleep` guard).

## Testing

Verified in isolation: a reader on the fifo gets no EOF (holder keeps a writer), the guard is idempotent (second run spawns no second holder), and `printf` still delivers `r`/`q`. Then used it to bring the real client up on :8090 cleanly.

Note: orphaned `sleep 100000000` holders from the old pattern are harmless; the skill now says to clear them with `pkill -f 'sleep 100000000'` while no client is running.