### PR TITLE
refactor(auth): stop sending dead choreo api_key header

### DIFF
--- a/lib/features/activity_sessions/activity_feedback_repo.dart
+++ b/lib/features/activity_sessions/activity_feedback_repo.dart
@@ -4,7 +4,6 @@ import 'package:http/http.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_feedback_request.dart';
 import 'package:fluffychat/features/activity_sessions/activity_feedback_response.dart';
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -19,7 +18,6 @@ class ActivityFeedbackRepo {
     ActivityFeedbackRequest request,
   ) async {
     final Requests req = Requests(
-      choreoApiKey: Environment.choreoApiKey,
       accessToken: MatrixState.pangeaController.userController.accessToken,
     );
 

--- a/lib/features/activity_sessions/activity_summary_repo.dart
+++ b/lib/features/activity_sessions/activity_summary_repo.dart
@@ -7,7 +7,6 @@ import 'package:http/http.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_summary_request_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_summary_response_model.dart';
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -70,7 +69,6 @@ class ActivitySummaryRepo {
   ) async {
     try {
       final Requests req = Requests(
-        choreoApiKey: Environment.choreoApiKey,
         accessToken: MatrixState.pangeaController.userController.accessToken,
       );
 

--- a/lib/features/subscription/repo/all_products_repo.dart
+++ b/lib/features/subscription/repo/all_products_repo.dart
@@ -6,7 +6,6 @@ import 'package:http/http.dart';
 
 import 'package:fluffychat/features/subscription/models/subscription_details.dart';
 import 'package:fluffychat/features/subscription/repo/subscription_repo.dart';
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -75,7 +74,6 @@ class AllProductsRepo {
   static Future<Result<List<SubscriptionDetails>>> _fetch() async {
     try {
       final Requests req = Requests(
-        choreoApiKey: Environment.choreoApiKey,
         accessToken: MatrixState.pangeaController.userController.accessToken,
       );
       final Response res = await req.get(url: PApiUrls.rcProductsChoreo);

--- a/lib/features/subscription/repo/billing_portal_repo.dart
+++ b/lib/features/subscription/repo/billing_portal_repo.dart
@@ -4,7 +4,6 @@ import 'package:async/async.dart';
 import 'package:http/http.dart';
 
 import 'package:fluffychat/features/subscription/repo/billing_portal_response.dart';
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -51,7 +50,6 @@ class BillingPortalRepo {
     try {
       final Requests req = Requests(
         accessToken: MatrixState.pangeaController.userController.accessToken,
-        choreoApiKey: Environment.choreoApiKey,
       );
       final Response res = await req.get(url: PApiUrls.billingPortal);
 

--- a/lib/features/subscription/repo/payment_history_repo.dart
+++ b/lib/features/subscription/repo/payment_history_repo.dart
@@ -4,7 +4,6 @@ import 'package:async/async.dart';
 import 'package:http/http.dart';
 
 import 'package:fluffychat/features/subscription/repo/payment_history_response.dart';
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -53,7 +52,6 @@ class PaymentHistoryRepo {
     try {
       final Requests req = Requests(
         accessToken: MatrixState.pangeaController.userController.accessToken,
-        choreoApiKey: Environment.choreoApiKey,
       );
       final Response res = await req.get(url: PApiUrls.paymentHistory);
 

--- a/lib/features/subscription/repo/payment_link_repo.dart
+++ b/lib/features/subscription/repo/payment_link_repo.dart
@@ -4,7 +4,6 @@ import 'package:async/async.dart';
 import 'package:http/http.dart';
 
 import 'package:fluffychat/features/subscription/repo/payment_link_request.dart';
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -31,7 +30,6 @@ class PaymentLinkRepo {
   static Future<Result<String>> _fetch(PaymentLinkRequest request) async {
     try {
       final Requests req = Requests(
-        choreoApiKey: Environment.choreoApiKey,
         accessToken: MatrixState.pangeaController.userController.accessToken,
       );
       final String reqUrl = Uri.encodeFull(

--- a/lib/features/subscription/repo/subscription_app_ids_repo.dart
+++ b/lib/features/subscription/repo/subscription_app_ids_repo.dart
@@ -5,7 +5,6 @@ import 'package:get_storage/get_storage.dart';
 import 'package:http/http.dart';
 
 import 'package:fluffychat/features/subscription/utils/subscription_app_id.dart';
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -72,7 +71,6 @@ class SubscriptionAppIdsRepo {
   static Future<Result<SubscriptionAppIds>> _fetch() async {
     try {
       final Requests req = Requests(
-        choreoApiKey: Environment.choreoApiKey,
         accessToken: MatrixState.pangeaController.userController.accessToken,
       );
       final Response res = await req.get(url: PApiUrls.rcAppsChoreo);

--- a/lib/features/subscription/repo/subscription_repo.dart
+++ b/lib/features/subscription/repo/subscription_repo.dart
@@ -8,7 +8,6 @@ import 'package:http/http.dart' as http;
 
 import 'package:fluffychat/features/subscription/models/subscription_details.dart';
 import 'package:fluffychat/features/subscription/utils/subscription_app_id.dart';
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -18,7 +17,6 @@ class SubscriptionRepo {
   static Future<SubscriptionAppIds?> getAppIds() async {
     try {
       final Requests req = Requests(
-        choreoApiKey: Environment.choreoApiKey,
         accessToken: MatrixState.pangeaController.userController.accessToken,
       );
       final http.Response res = await req.get(url: PApiUrls.rcAppsChoreo);
@@ -40,7 +38,6 @@ class SubscriptionRepo {
   static Future<List<SubscriptionDetails>?> getAllProducts() async {
     try {
       final Requests req = Requests(
-        choreoApiKey: Environment.choreoApiKey,
         accessToken: MatrixState.pangeaController.userController.accessToken,
       );
       final http.Response res = await req.get(url: PApiUrls.rcProductsChoreo);
@@ -62,7 +59,6 @@ class SubscriptionRepo {
   static Future<bool> activateFreeTrial() async {
     try {
       final Requests req = Requests(
-        choreoApiKey: Environment.choreoApiKey,
         accessToken: MatrixState.pangeaController.userController.accessToken,
       );
       final http.Response res = await req.get(url: PApiUrls.rcProductsTrial);
@@ -87,7 +83,6 @@ class SubscriptionRepo {
     List<SubscriptionDetails>? allProducts,
   ) async {
     final Requests req = Requests(
-      choreoApiKey: Environment.choreoApiKey,
       accessToken: MatrixState.pangeaController.userController.accessToken,
     );
 

--- a/lib/features/subscription/repo/validate_promo_code_repo.dart
+++ b/lib/features/subscription/repo/validate_promo_code_repo.dart
@@ -5,7 +5,6 @@ import 'package:http/http.dart';
 
 import 'package:fluffychat/features/subscription/repo/validate_promo_code_request.dart';
 import 'package:fluffychat/features/subscription/repo/validate_promo_code_response.dart';
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -74,7 +73,6 @@ class ValidatePromoCodeRepo {
     try {
       final Requests req = Requests(
         accessToken: MatrixState.pangeaController.userController.accessToken,
-        choreoApiKey: Environment.choreoApiKey,
       );
 
       String requestUrl =

--- a/lib/pangea/common/config/environment.dart
+++ b/lib/pangea/common/config/environment.dart
@@ -99,12 +99,6 @@ class Environment {
       ? 'https://sygnal.staging.pangea.chat/_matrix/push/v1/notify'
       : 'https://sygnal.pangea.chat/_matrix/push/v1/notify';
 
-  static String get choreoApiKey {
-    return appConfigOverride?.choreoApiKey ??
-        dotenv.env['CHOREO_API_KEY'] ??
-        'e6fa9fa97031ba0c852efe78457922f278a2fbc109752fe18e465337699e9873';
-  }
-
   static String get sentryDsn {
     return appConfigOverride?.sentryDsn ??
         dotenv.env["SENTRY_DSN"] ??
@@ -214,7 +208,6 @@ class AppConfigOverride {
   final String? synapseURL;
   final String? homeServer;
   final String? choreoApi;
-  final String? choreoApiKey;
   final String? sentryDsn;
   final String? googleAnalyticsFirebaseOptionsBase64;
   final String? rcGoogleKey;
@@ -229,7 +222,6 @@ class AppConfigOverride {
     this.synapseURL,
     this.homeServer,
     this.choreoApi,
-    this.choreoApiKey,
     this.sentryDsn,
     this.googleAnalyticsFirebaseOptionsBase64,
     this.rcGoogleKey,
@@ -246,7 +238,6 @@ class AppConfigOverride {
       synapseURL: json['synapseURL'] as String?,
       homeServer: json['homeServer'] as String?,
       choreoApi: json['choreoApi'] as String?,
-      choreoApiKey: json['choreoApiKey'] as String?,
       sentryDsn: json['sentryDsn'] as String?,
       googleAnalyticsFirebaseOptionsBase64:
           json['googleAnalyticsFirebaseOptionsBase64'] as String?,
@@ -265,7 +256,6 @@ class AppConfigOverride {
       'synapseURL': synapseURL,
       'homeServer': homeServer,
       'choreoApi': choreoApi,
-      'choreoApiKey': choreoApiKey,
       'sentryDsn': sentryDsn,
       'googleAnalyticsFirebaseOptionsBase64':
           googleAnalyticsFirebaseOptionsBase64,
@@ -284,7 +274,6 @@ class AppConfigOverride {
         synapseURL.hashCode ^
         homeServer.hashCode ^
         choreoApi.hashCode ^
-        choreoApiKey.hashCode ^
         sentryDsn.hashCode ^
         googleAnalyticsFirebaseOptionsBase64.hashCode ^
         rcGoogleKey.hashCode ^
@@ -303,7 +292,6 @@ class AppConfigOverride {
         synapseURL == other.synapseURL &&
         homeServer == other.homeServer &&
         choreoApi == other.choreoApi &&
-        choreoApiKey == other.choreoApiKey &&
         sentryDsn == other.sentryDsn &&
         googleAnalyticsFirebaseOptionsBase64 ==
             other.googleAnalyticsFirebaseOptionsBase64 &&

--- a/lib/pangea/common/network/requests.dart
+++ b/lib/pangea/common/network/requests.dart
@@ -19,9 +19,8 @@ class ChoreoException implements Exception {
 
 class Requests {
   late String? accessToken;
-  late String? choreoApiKey;
 
-  Requests({this.accessToken, this.choreoApiKey});
+  Requests({this.accessToken});
 
   Future<http.Response> post({
     required String url,
@@ -97,9 +96,6 @@ class Requests {
     };
     if (accessToken != null) {
       headers["Authorization"] = 'Bearer ${accessToken!}';
-    }
-    if (choreoApiKey != null) {
-      headers['api_key'] = choreoApiKey!;
     }
     return headers;
   }

--- a/lib/pangea/common/utils/base_repo.dart
+++ b/lib/pangea/common/utils/base_repo.dart
@@ -7,7 +7,6 @@ import 'package:http/http.dart' hide BaseResponse, BaseRequest;
 import 'package:matrix/matrix_api_lite/utils/logs.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/utils/base_request.dart';
 import 'package:fluffychat/pangea/common/utils/base_response.dart';
@@ -119,7 +118,6 @@ abstract class BaseRepo<
     try {
       final Requests req = Requests(
         accessToken: MatrixState.pangeaController.userController.accessToken,
-        choreoApiKey: Environment.choreoApiKey,
       );
 
       final Response res = await fetch(req, request).timeout(timeout);

--- a/lib/routes/chat/events/token_info_feedback/token_info_feedback_repo.dart
+++ b/lib/routes/chat/events/token_info_feedback/token_info_feedback_repo.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:http/http.dart';
 
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/routes/chat/events/token_info_feedback/token_info_feedback_request.dart';
@@ -19,7 +18,6 @@ class TokenInfoFeedbackRepo {
     TokenInfoFeedbackRequest request,
   ) async {
     final Requests req = Requests(
-      choreoApiKey: Environment.choreoApiKey,
       accessToken: MatrixState.pangeaController.userController.accessToken,
     );
 

--- a/lib/routes/chat/toolbar/practice_exercises/practice_generation_repo.dart
+++ b/lib/routes/chat/toolbar/practice_exercises/practice_generation_repo.dart
@@ -9,7 +9,6 @@ import 'package:async/async.dart';
 import 'package:get_storage/get_storage.dart';
 import 'package:http/http.dart';
 
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -94,7 +93,6 @@ class PracticeRepo {
     required MessagePracticeExerciseRequest requestModel,
   }) async {
     final Requests request = Requests(
-      choreoApiKey: Environment.choreoApiKey,
       accessToken: accessToken,
     );
     final Response res = await request.post(

--- a/lib/routes/chat_list/app_version_util.dart
+++ b/lib/routes/chat_list/app_version_util.dart
@@ -12,7 +12,6 @@ import 'package:url_launcher/url_launcher_string.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/constants/local.key.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
@@ -31,7 +30,6 @@ class AppVersionUtil {
     final currentBuildNumber = packageInfo.buildNumber;
 
     final Requests request = Requests(
-      choreoApiKey: Environment.choreoApiKey,
       accessToken: accessToken,
     );
 

--- a/test/pangea/choreo_endpoint_test.dart
+++ b/test/pangea/choreo_endpoint_test.dart
@@ -50,7 +50,6 @@ void main() {
   String userID = "";
   // Resolved in setUpAll from the shared endpoint-test env (the .env layer), so
   // this test points at the same environment as the synapse/cms endpoint tests.
-  late String apiKey;
   late String choreoApi;
 
   setUpAll(() {
@@ -58,7 +57,6 @@ void main() {
       EndpointTestEnv.load();
       assert(EndpointTestEnv.testUsername != null);
       assert(EndpointTestEnv.testPassword != null);
-      apiKey = EndpointTestEnv.choreoApiKey;
       choreoApi = "${EndpointTestEnv.choreoApi}/choreo";
 
       // Send login request
@@ -97,7 +95,6 @@ void main() {
         mock: true,
       ).toJson();
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(
@@ -120,7 +117,6 @@ void main() {
       ).toJson();
 
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(
@@ -150,7 +146,6 @@ void main() {
         ).toJson();
 
         final Requests req = Requests(
-          choreoApiKey: apiKey,
           accessToken: authToken,
         );
         final Response res = await req.post(
@@ -178,7 +173,6 @@ void main() {
       ).toJson();
 
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(
@@ -204,7 +198,6 @@ void main() {
       ).toJson();
 
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(
@@ -231,7 +224,6 @@ void main() {
       ).toJson();
 
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(
@@ -256,7 +248,6 @@ void main() {
       ).toJson();
 
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(
@@ -282,7 +273,6 @@ void main() {
       ).toJson();
 
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(
@@ -322,7 +312,6 @@ void main() {
       ).toJson();
 
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(
@@ -356,7 +345,6 @@ void main() {
       ).toJson();
 
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(
@@ -386,7 +374,6 @@ void main() {
       ).toJson();
 
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(
@@ -409,7 +396,6 @@ void main() {
       ).toJson();
 
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(
@@ -435,7 +421,6 @@ void main() {
       ).toJson();
 
       final Requests req = Requests(
-        choreoApiKey: apiKey,
         accessToken: authToken,
       );
       final Response res = await req.post(

--- a/test/pangea/endpoint_test_env.dart
+++ b/test/pangea/endpoint_test_env.dart
@@ -49,7 +49,6 @@ class EndpointTestEnv {
   /// (works for staging/prod's shared domain; set `CMS_API` explicitly locally).
   static String get cmsApi => dotenv.env['CMS_API'] ?? choreoApi;
 
-  static String get choreoApiKey => _require('CHOREO_API_KEY');
 
   static String? get testUsername => dotenv.env['TEST_MATRIX_USERNAME'];
   static String? get testPassword => dotenv.env['TEST_MATRIX_PASSWORD'];


### PR DESCRIPTION
## What

Stops the client from sending the `api_key` header to the choreographer, and removes the supporting config:

- `Requests` (`requests.dart`): drop the `choreoApiKey` field/constructor param and the `headers['api_key'] = ...` block.
- `Environment` / `AppConfigOverride` (`environment.dart`): remove the `choreoApiKey` getter (incl. a **hardcoded fallback key committed in source**), field, constructor param, fromJson/toJson/hashCode/==.
- Remove the `choreoApiKey: Environment.choreoApiKey` argument from all 13 call sites and their now-dead `environment.dart` imports.
- Tests: drop the `choreoApiKey:` args and the unused `EndpointTestEnv.choreoApiKey` getter.

## Why

The choreographer never validated this header — it was a declared-but-unconsumed `APIKeyHeader` (removed in pangeachat/2-step-choreographer#2646). As a key shipped in the web client (served at `/.env`, and hardcoded in source) it could never be secret anyway. Real auth is the Matrix bearer token + RevenueCat entitlement. Net: removes a misleading dead auth surface and a hardcoded credential constant. No behavior change — the server ignored the header.

## Testing

`flutter analyze` clean (No issues found). No `choreoApiKey`/`api_key` references remain in `lib` or `test`. Pairs with pangeachat/2-step-choreographer#2646 (server-side removal); either order is safe since the server already ignored the value.