### PR TITLE
fix(dialogs): interior taps no longer dismiss column-mode bottom sheets

### DIFF
--- a/lib/utils/adaptive_bottom_sheet.dart
+++ b/lib/utils/adaptive_bottom_sheet.dart
@@ -22,13 +22,22 @@ Future<T?> showAdaptiveBottomSheet<T>({
         child: Container(
           margin: const EdgeInsets.all(16),
           constraints: const BoxConstraints(maxWidth: 480, maxHeight: 720),
-          child: Material(
-            elevation: Theme.of(context).dialogTheme.elevation ?? 4,
-            shadowColor: Theme.of(context).dialogTheme.shadowColor,
-            borderRadius: BorderRadius.circular(AppConfig.borderRadius),
-            color: Theme.of(context).scaffoldBackgroundColor,
-            clipBehavior: Clip.hardEdge,
-            child: builder(context),
+          // Absorb taps anywhere on the popup's rect — including the rounded
+          // corners the Material clips away to transparent — so an interior tap
+          // is a no-op instead of falling through to the dismiss barrier that
+          // sits behind the dialog content (#7261). The transparent surround
+          // outside this box still dismisses.
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () {},
+            child: Material(
+              elevation: Theme.of(context).dialogTheme.elevation ?? 4,
+              shadowColor: Theme.of(context).dialogTheme.shadowColor,
+              borderRadius: BorderRadius.circular(AppConfig.borderRadius),
+              color: Theme.of(context).scaffoldBackgroundColor,
+              clipBehavior: Clip.hardEdge,
+              child: builder(context),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Closes #7261

## Problem
On a wide/column-mode layout, tapping the interior of the **Start poll** popup (anywhere that isn't a button or field) can close it.

Root cause: `showAdaptiveBottomSheet` renders the column-mode popup as `showDialog(barrierDismissible: true, …)` with the content centered inside a rounded `Material`. Flutter's dismiss `ModalBarrier` sits *behind* the content layer, and the content only absorbs a tap where an opaque `RenderBox` is painted. The rounded-corner gaps the `Material` clips away (and any interior region not covered by an opaque surface) are transparent, so a tap there falls through to the barrier and dismisses the popup.

## Fix
Wrap the popup's frame in a `GestureDetector(behavior: HitTestBehavior.opaque, onTap: () {})` so the whole rect absorbs taps (a no-op), while the transparent surround outside it still dismisses. This is the same absorber idiom already used in `word_zoom_widget.dart`.

Because this is the shared `showAdaptiveBottomSheet` helper, the fix also hardens the other column-mode sheets that go through it (join-public-room, event-info, new-private-chat QR).

#7284 (the chat/DM **invite** popup) is a separate presentation (a plain `AlertDialog.adaptive`, not this helper) whose card should already be opaque, so I'm investigating its leak separately rather than bundling a blind fix here.

## TO TEST
- [ ] On web (wide window), open a chat, tap the + menu, choose **Start poll**.
- [ ] Click empty interior areas of the poll popup (gaps, near the rounded corners) — it should **not** close.
- [ ] Click clearly outside the popup (the dimmed surround) — it should still close.
- [ ] Sanity-check another wide-mode sheet (e.g. join a public room from search) closes only on outside taps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed accidental tap-through behavior in the adaptive bottom sheet when using column mode, so taps inside the dialog no longer dismiss it unexpectedly.
  * Improved touch handling across the full sheet area, including visually transparent regions, for a more reliable interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->