### PR TITLE
fix(dialogs): incoming-invite popup no longer closes on interior taps

### DIFF
--- a/lib/routes/chat_list/chat_list.dart
+++ b/lib/routes/chat_list/chat_list.dart
@@ -40,7 +40,7 @@ import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/show_scaffold_dialog.dart';
 import 'package:fluffychat/utils/show_update_snackbar.dart';
-import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
+import 'package:fluffychat/widgets/adaptive_dialogs/invite_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
@@ -154,65 +154,38 @@ class ChatListController extends State<ChatList>
   void onChatTap(Room room) async {
     if (room.membership == Membership.invite) {
       // #Pangea
-      final theme = Theme.of(context);
       final inviteEvent = room.getState(
         EventTypes.RoomMember,
         room.client.userID!,
       );
       final matrixLocals = MatrixLocals(L10n.of(context));
-      final action = await showAdaptiveDialog<InviteAction>(
-        barrierDismissible: true,
-        context: context,
-        builder: (context) => AlertDialog.adaptive(
-          title: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 256),
-            child: Center(
-              child: Text(
-                room.getLocalizedDisplayname(matrixLocals),
-                textAlign: TextAlign.center,
-              ),
-            ),
+      final action = await showInviteDialog<InviteAction>(
+        context,
+        title: room.getLocalizedDisplayname(matrixLocals),
+        message: inviteEvent == null
+            ? L10n.of(context).inviteForMe
+            : inviteEvent.content.tryGet<String>('reason') ??
+                  L10n.of(context).youInvitedBy(
+                    room
+                        .unsafeGetUserFromMemoryOrFallback(inviteEvent.senderId)
+                        .calcDisplayname(i18n: matrixLocals),
+                  ),
+        actions: [
+          InviteDialogAction(
+            label: L10n.of(context).accept,
+            value: InviteAction.accept,
           ),
-          content: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 256, maxHeight: 256),
-            child: Text(
-              inviteEvent == null
-                  ? L10n.of(context).inviteForMe
-                  : inviteEvent.content.tryGet<String>('reason') ??
-                        L10n.of(context).youInvitedBy(
-                          room
-                              .unsafeGetUserFromMemoryOrFallback(
-                                inviteEvent.senderId,
-                              )
-                              .calcDisplayname(i18n: matrixLocals),
-                        ),
-              textAlign: TextAlign.center,
-            ),
+          InviteDialogAction(
+            label: L10n.of(context).decline,
+            value: InviteAction.decline,
+            destructive: true,
           ),
-          actions: [
-            AdaptiveDialogAction(
-              onPressed: () => Navigator.of(context).pop(InviteAction.accept),
-              bigButtons: true,
-              child: Text(L10n.of(context).accept),
-            ),
-            AdaptiveDialogAction(
-              onPressed: () => Navigator.of(context).pop(InviteAction.decline),
-              bigButtons: true,
-              child: Text(
-                L10n.of(context).decline,
-                style: TextStyle(color: theme.colorScheme.error),
-              ),
-            ),
-            AdaptiveDialogAction(
-              onPressed: () => Navigator.of(context).pop(InviteAction.block),
-              bigButtons: true,
-              child: Text(
-                L10n.of(context).block,
-                style: TextStyle(color: theme.colorScheme.error),
-              ),
-            ),
-          ],
-        ),
+          InviteDialogAction(
+            label: L10n.of(context).block,
+            value: InviteAction.block,
+            destructive: true,
+          ),
+        ],
       );
       switch (action) {
         case null:

--- a/lib/routes/chat_list/course_chats_page.dart
+++ b/lib/routes/chat_list/course_chats_page.dart
@@ -29,7 +29,7 @@ import 'package:fluffychat/routes/chat_list/extended_space_rooms_chunk.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
-import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
+import 'package:fluffychat/widgets/adaptive_dialogs/invite_dialog.dart';
 import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -383,66 +383,40 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
           exceptionContext: ExceptionContext.joinRoom,
         );
       } else {
-        final theme = Theme.of(context);
         final inviteEvent = room.getState(
           EventTypes.RoomMember,
           room.client.userID!,
         );
         final matrixLocals = MatrixLocals(L10n.of(context));
-        final action = await showAdaptiveDialog<InviteAction>(
-          barrierDismissible: true,
-          context: context,
-          builder: (context) => AlertDialog.adaptive(
-            title: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 256),
-              child: Center(
-                child: Text(
-                  room.getLocalizedDisplayname(matrixLocals),
-                  textAlign: TextAlign.center,
-                ),
-              ),
+        final action = await showInviteDialog<InviteAction>(
+          context,
+          title: room.getLocalizedDisplayname(matrixLocals),
+          message: inviteEvent == null
+              ? L10n.of(context).inviteForMe
+              : inviteEvent.content.tryGet<String>('reason') ??
+                    L10n.of(context).youInvitedBy(
+                      room
+                          .unsafeGetUserFromMemoryOrFallback(
+                            inviteEvent.senderId,
+                          )
+                          .calcDisplayname(i18n: matrixLocals),
+                    ),
+          actions: [
+            InviteDialogAction(
+              label: L10n.of(context).accept,
+              value: InviteAction.accept,
             ),
-            content: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 256, maxHeight: 256),
-              child: Text(
-                inviteEvent == null
-                    ? L10n.of(context).inviteForMe
-                    : inviteEvent.content.tryGet<String>('reason') ??
-                          L10n.of(context).youInvitedBy(
-                            room
-                                .unsafeGetUserFromMemoryOrFallback(
-                                  inviteEvent.senderId,
-                                )
-                                .calcDisplayname(i18n: matrixLocals),
-                          ),
-                textAlign: TextAlign.center,
-              ),
+            InviteDialogAction(
+              label: L10n.of(context).decline,
+              value: InviteAction.decline,
+              destructive: true,
             ),
-            actions: [
-              AdaptiveDialogAction(
-                onPressed: () => Navigator.of(context).pop(InviteAction.accept),
-                bigButtons: true,
-                child: Text(L10n.of(context).accept),
-              ),
-              AdaptiveDialogAction(
-                onPressed: () =>
-                    Navigator.of(context).pop(InviteAction.decline),
-                bigButtons: true,
-                child: Text(
-                  L10n.of(context).decline,
-                  style: TextStyle(color: theme.colorScheme.error),
-                ),
-              ),
-              AdaptiveDialogAction(
-                onPressed: () => Navigator.of(context).pop(InviteAction.block),
-                bigButtons: true,
-                child: Text(
-                  L10n.of(context).block,
-                  style: TextStyle(color: theme.colorScheme.error),
-                ),
-              ),
-            ],
-          ),
+            InviteDialogAction(
+              label: L10n.of(context).block,
+              value: InviteAction.block,
+              destructive: true,
+            ),
+          ],
         );
         switch (action) {
           case null:

--- a/lib/routes/chat_list/room_invite_dialog.dart
+++ b/lib/routes/chat_list/room_invite_dialog.dart
@@ -10,19 +10,30 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
-import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
+import 'package:fluffychat/widgets/adaptive_dialogs/invite_dialog.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 
 enum CourseInviteAction { accept, decline }
 
-class RoomInviteDialog extends StatelessWidget {
-  final Room room;
-  const RoomInviteDialog({super.key, required this.room});
-
+class RoomInviteDialog {
   static Future<void> show(BuildContext context, Room room) async {
-    final resp = await showDialog<CourseInviteAction>(
-      context: context,
-      builder: (context) => RoomInviteDialog(room: room),
+    final resp = await showInviteDialog<CourseInviteAction>(
+      context,
+      title: L10n.of(context).youreInvited,
+      message: room.isSpace
+          ? L10n.of(context).invitedToSpace(room.name, room.creatorId ?? "???")
+          : L10n.of(context).invitedToChat(room.name, room.creatorId ?? "???"),
+      actions: [
+        InviteDialogAction(
+          label: L10n.of(context).decline,
+          value: CourseInviteAction.decline,
+          destructive: true,
+        ),
+        InviteDialogAction(
+          label: L10n.of(context).accept,
+          value: CourseInviteAction.accept,
+        ),
+      ],
     );
 
     switch (resp) {
@@ -55,49 +66,5 @@ class RoomInviteDialog extends StatelessWidget {
       case null:
         return;
     }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog.adaptive(
-      title: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 256),
-        child: Center(
-          child: Text(
-            L10n.of(context).youreInvited,
-            textAlign: TextAlign.center,
-          ),
-        ),
-      ),
-      content: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 256, maxHeight: 256),
-        child: Text(
-          room.isSpace
-              ? L10n.of(
-                  context,
-                ).invitedToSpace(room.name, room.creatorId ?? "???")
-              : L10n.of(
-                  context,
-                ).invitedToChat(room.name, room.creatorId ?? "???"),
-          textAlign: TextAlign.center,
-        ),
-      ),
-      actions: [
-        AdaptiveDialogAction(
-          onPressed: () =>
-              Navigator.of(context).pop(CourseInviteAction.decline),
-          bigButtons: true,
-          child: Text(
-            L10n.of(context).decline,
-            style: TextStyle(color: Theme.of(context).colorScheme.error),
-          ),
-        ),
-        AdaptiveDialogAction(
-          onPressed: () => Navigator.of(context).pop(CourseInviteAction.accept),
-          bigButtons: true,
-          child: Text(L10n.of(context).accept),
-        ),
-      ],
-    );
   }
 }

--- a/lib/widgets/adaptive_dialogs/invite_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/invite_dialog.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+
+/// One full-width action button in an [showInviteDialog].
+class InviteDialogAction<T> {
+  final String label;
+  final T value;
+  final bool destructive;
+  const InviteDialogAction({
+    required this.label,
+    required this.value,
+    this.destructive = false,
+  });
+}
+
+/// Incoming-invite confirmation popup.
+///
+/// Replaces `AlertDialog.adaptive`, whose Cupertino card is not hit-opaque over
+/// its padding, so a tap on the card interior fell through to the dismiss
+/// barrier and closed the popup (#7284). A plain `Material` card is opaque to
+/// *paint* but not to *hit-testing* (empty card areas with no child don't
+/// absorb taps), so the card is wrapped in an explicit
+/// `GestureDetector(HitTestBehavior.opaque)` that swallows every interior tap as
+/// a no-op. Tapping the dimmed surround outside the card still dismisses
+/// (returns null). Buttons are full-width and stacked.
+Future<T?> showInviteDialog<T>(
+  BuildContext context, {
+  required String title,
+  required String message,
+  required List<InviteDialogAction<T>> actions,
+}) {
+  return showDialog<T>(
+    context: context,
+    barrierDismissible: true,
+    builder: (context) {
+      final theme = Theme.of(context);
+      return Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 320),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () {},
+            child: Material(
+              elevation: theme.dialogTheme.elevation ?? 4,
+              shadowColor: theme.dialogTheme.shadowColor,
+              color:
+                  theme.dialogTheme.backgroundColor ??
+                  theme.colorScheme.surface,
+              borderRadius: BorderRadius.circular(AppConfig.borderRadius),
+              clipBehavior: Clip.hardEdge,
+              child: Padding(
+                padding: const EdgeInsets.all(20),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      title,
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 12),
+                    Text(message, textAlign: TextAlign.center),
+                    const SizedBox(height: 20),
+                    for (final action in actions)
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 2),
+                        child: SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: theme.colorScheme.surfaceBright,
+                              foregroundColor: action.destructive
+                                  ? theme.colorScheme.error
+                                  : theme.colorScheme.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(
+                                  AppConfig.borderRadius,
+                                ),
+                              ),
+                            ),
+                            onPressed: () =>
+                                Navigator.of(context).pop(action.value),
+                            child: Text(action.label),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    },
+  );
+}


### PR DESCRIPTION
Closes #7284

## Problem
Tapping the interior of an incoming chat/DM/course invite popup (the empty card areas, not a button) could close it. The popup was an `AlertDialog.adaptive`, whose Cupertino card is opaque to *paint* but not to *hit-testing*, so taps on its padding fell through to the dismiss barrier behind it.

## Fix
Move the three invite popups (chat/DM invite in `chat_list.dart`, the course-chat invite in `course_chats_page.dart`, and the space/course `RoomInviteDialog`) onto one shared `showInviteDialog` helper that renders the app's standard opaque dialog and wraps the card in a `GestureDetector(behavior: HitTestBehavior.opaque)` that swallows interior taps as a no-op. Tapping the dimmed surround outside still dismisses (returns null); the Accept / Decline / Block buttons work as before. This is the same absorber idiom that fixed the poll popup (#7261).

Per the chosen behavior: tapping inside the popup keeps it open, tapping outside closes it. Side effect: on macOS the popup now uses the app's standard rounded dialog (full-width stacked buttons) instead of the macOS-native Cupertino style, matching every other platform.

## Verification
Built locally and driven in-browser: all four interior-card spots (incl. the message-to-button gap that leaked before) stay open; outside-tap still closes; Accept/Decline/Block remain interactive. `flutter analyze` + `dart format` clean.

## TO TEST
- [ ] Receive a chat/DM invite, tap the row to open the popup.
- [ ] Click the empty card areas (padding, gaps between/around buttons) — the popup stays open.
- [ ] Click the dimmed area outside the popup — it closes.
- [ ] Accept / Decline / Block still work.
- [ ] Same for a course/space invite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a redesigned invite dialog for chats and rooms with clearer, full-width action buttons.
  * Invite prompts now show more relevant room names and context-aware messages.

* **Bug Fixes**
  * Improved tap handling so interactions inside the dialog are less likely to dismiss it accidentally.
  * Kept accept/decline flows working consistently after the dialog update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->