### PR TITLE
build: translations

### DIFF
--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ar",
-    "@@last_modified": "2026-06-18 09:35:31.891232",
+    "@@last_modified": "2026-06-26 10:50:47.740291",
     "about": "حول",
     "@about": {
         "type": "String",
@@ -10210,6 +10210,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "انضم إلى دورة تتضمن هذا النشاط للعبه.",
+    "resizeCoursePanel": "تغيير حجم لوحة الدورة",
+    "undo": "تراجع",
+    "unlock": "فتح",
+    "zoomIn": "تكبير",
+    "zoomOut": "تصغير",
+    "stars": "نجوم",
+    "addNewCourse": "إضافة دورة جديدة",
+    "world": "عالم",
+    "addCourseStartMyOwn": "بدء دورتي الخاصة",
+    "addCourseEnterCode": "أدخل الرمز للدورة الخاصة",
+    "addCourseBrowsePublic": "تصفح الدورات العامة",
+    "browsePublicCourses": "تصفح الدورات العامة",
+    "editProfile": "تعديل الملف الشخصي",
+    "numObjectives": "{count} أهداف",
+    "mapSearchHint": "ابحث عن الأنشطة",
+    "mapSearchNoResults": "لا توجد تطابقات في العرض",
+    "mapFilterAllLanguages": "جميع اللغات",
+    "mapFilterNotStarted": "لم يبدأ بعد",
+    "mapFilterInProgress": "قيد التقدم",
+    "mapFilterCompleted": "مكتمل",
+    "mapFilterReset": "إعادة تعيين",
+    "activityTypeConversation": "محادثة",
+    "lockedMissionRequirement": "أكمل المهمة السابقة لفتحها",
+    "playAgain": "العب مرة أخرى",
+    "reviewActivity": "مراجعة",
+    "mapEmptyInView": "لا شيء هنا بمستواك أو لغتك. قم بتوسيع الفلاتر أو قم بالتكبير للخارج.",
+    "welcomeToPangeaChat": "مرحبًا بك في دردشة بانجيا",
+    "claimTrial": "احصل على تجربتك",
+    "thanksForSigningUp": "شكرًا لتسجيلك! إليك",
+    "sevenDaysFree": "7 أيام مجانية",
+    "manageTrialInSettings": "إدارة تجربتك في أي وقت في\nإعدادات الاشتراك",
+    "noCreditCardRequired": "لا حاجة لبطاقة ائتمان.",
+    "proFeatures": "مميزات احترافية",
+    "widenSearch": "توسيع البحث",
+    "scrollToBottom": "التمرير إلى الأسفل",
+    "courseImage": "صورة الدورة",
+    "avatarPreview": "معاينة الصورة الرمزية",
+    "activityPhoto": "صورة النشاط",
+    "emotePreview": "معاينة الإيموجي: {name}",
+    "activityLabel": "النشاط: {title}",
+    "resetMapView": "إعادة تعيين عرض الخريطة",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_be.arb
+++ b/lib/l10n/intl_be.arb
@@ -3933,7 +3933,7 @@
     "playWithAI": "Пакуль гуляйце з ШІ",
     "courseStartDesc": "Pangea Bot гатовы да працы ў любы час!\n\n...але навучанне лепш з сябрамі!",
     "@@locale": "be",
-    "@@last_modified": "2026-06-18 09:35:24.976054",
+    "@@last_modified": "2026-06-26 10:49:16.098369",
     "@ignore": {
         "type": "String",
         "placeholders": {}
@@ -9884,6 +9884,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Далучайцеся да курса, які ўключае гэтую дзейнасць, каб яе прайграць.",
+    "resizeCoursePanel": "Змяніць памер панэлі курса",
+    "undo": "Скасаваць",
+    "unlock": "Разблакаваць",
+    "zoomIn": "Павялічыць",
+    "zoomOut": "Зменшыць",
+    "stars": "Зоркі",
+    "addNewCourse": "Дадаць новы курс",
+    "world": "Свет",
+    "addCourseStartMyOwn": "Пачаць свой уласны",
+    "addCourseEnterCode": "Увядзіце код для прыватнага курса",
+    "addCourseBrowsePublic": "Прагляд публічных курсаў",
+    "browsePublicCourses": "Прагляд публічных курсаў",
+    "editProfile": "Рэдагаваць профіль",
+    "numObjectives": "{count} мэтаў",
+    "mapSearchHint": "Шукаць актыўнасці",
+    "mapSearchNoResults": "Супадзенняў не знойдзена",
+    "mapFilterAllLanguages": "Усе мовы",
+    "mapFilterNotStarted": "Не пачата",
+    "mapFilterInProgress": "У працэсе",
+    "mapFilterCompleted": "Завершана",
+    "mapFilterReset": "Скінуць",
+    "activityTypeConversation": "Размова",
+    "lockedMissionRequirement": "Завяршыце папярэднюю місію, каб разблакаваць",
+    "playAgain": "Пагуляць яшчэ раз",
+    "reviewActivity": "Агляд",
+    "mapEmptyInView": "Тут нічога няма на вашым узроўні або мове. Распашыце фільтры або аддаляйцеся.",
+    "welcomeToPangeaChat": "Сардэчна запрашаем у Pangea Chat",
+    "claimTrial": "Атрымаць ваш бясплатны перыяд",
+    "thanksForSigningUp": "Дзякуй за рэгістрацыю! Вось",
+    "sevenDaysFree": "7 ДНЁЎ БЯСПЛАТНА",
+    "manageTrialInSettings": "Кіруйце сваім пробным перыядам у любы час у\nНаладах падпіскі",
+    "noCreditCardRequired": "Крэдытная карта не патрабуецца.",
+    "proFeatures": "ПРО",
+    "widenSearch": "Пашырыць пошук",
+    "scrollToBottom": "Пракруціць уніз",
+    "courseImage": "Выява курса",
+    "avatarPreview": "Папярэдні прагляд аватара",
+    "activityPhoto": "Фота актыўнасці",
+    "emotePreview": "Папярэдні прагляд эмоцыі: {name}",
+    "activityLabel": "Дзейнасць: {title}",
+    "resetMapView": "Скінуць выгляд карты",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_bn.arb
+++ b/lib/l10n/intl_bn.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:35:41.482770",
+    "@@last_modified": "2026-06-26 10:52:56.565990",
     "about": "সম্পর্কে",
     "@about": {
         "type": "String",
@@ -10585,6 +10585,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "এই কার্যকলাপটি খেলতে একটি কোর্সে যোগ দিন।",
+    "resizeCoursePanel": "কোর্স প্যানেল আকার পরিবর্তন করুন",
+    "undo": "পুনরুদ্ধার করুন",
+    "unlock": "মুক্ত করুন",
+    "zoomIn": "জুম ইন করুন",
+    "zoomOut": "জুম আউট করুন",
+    "stars": "তারা",
+    "addNewCourse": "নতুন কোর্স যোগ করুন",
+    "world": "বিশ্ব",
+    "addCourseStartMyOwn": "আমার নিজস্ব শুরু করুন",
+    "addCourseEnterCode": "গোপন কোর্সের জন্য কোড প্রবেশ করুন",
+    "addCourseBrowsePublic": "সার্বজনীন কোর্স ব্রাউজ করুন",
+    "browsePublicCourses": "সার্বজনীন কোর্স ব্রাউজ করুন",
+    "editProfile": "প্রোফাইল সম্পাদনা করুন",
+    "numObjectives": "{count} লক্ষ্য",
+    "mapSearchHint": "কার্যকলাপ অনুসন্ধান করুন",
+    "mapSearchNoResults": "দৃশ্যে কোন মিল নেই",
+    "mapFilterAllLanguages": "সমস্ত ভাষা",
+    "mapFilterNotStarted": "শুরু হয়নি",
+    "mapFilterInProgress": "চলমান",
+    "mapFilterCompleted": "সম্পন্ন",
+    "mapFilterReset": "রিসেট",
+    "activityTypeConversation": "আলাপ",
+    "lockedMissionRequirement": "মিশন আনলক করতে পূর্ববর্তী মিশন সম্পন্ন করুন",
+    "playAgain": "পুনরায় খেলুন",
+    "reviewActivity": "পর্যালোচনা",
+    "mapEmptyInView": "আপনার স্তর বা ভাষায় এখানে কিছুই নেই। আপনার ফিল্টারগুলি প্রসারিত করুন বা জুম আউট করুন।",
+    "welcomeToPangeaChat": "প্যাঙ্গিয়া চ্যাটে স্বাগতম",
+    "claimTrial": "আপনার ট্রায়াল দাবি করুন",
+    "thanksForSigningUp": "সাইন আপ করার জন্য ধন্যবাদ! এখানে",
+    "sevenDaysFree": "৭ দিন ফ্রি",
+    "manageTrialInSettings": "আপনার ট্রায়াল যেকোনো সময় পরিচালনা করুন\nসাবস্ক্রিপশন সেটিংসে",
+    "noCreditCardRequired": "কোন ক্রেডিট কার্ডের প্রয়োজন নেই।",
+    "proFeatures": "প্রো",
+    "widenSearch": "অনুসন্ধান সম্প্রসারিত করুন",
+    "scrollToBottom": "নিচে স্ক্রোল করুন",
+    "courseImage": "কোর্সের ছবি",
+    "avatarPreview": "অ্যাভাটার প্রিভিউ",
+    "activityPhoto": "অ্যাক্টিভিটি ফটো",
+    "emotePreview": "ইমোট প্রিভিউ: {name}",
+    "activityLabel": "কার্যকলাপ: {title}",
+    "resetMapView": "মানচিত্রের দৃশ্য পুনরায় সেট করুন",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_bo.arb
+++ b/lib/l10n/intl_bo.arb
@@ -3193,7 +3193,7 @@
     "loginToAccount": "ངའི་ཁུལ་གཅིག་ལ་སྤྱོད་ལམ་སྤྱོད་འབད།",
     "languages": "ཚོད་ལྟ",
     "@@locale": "bo",
-    "@@last_modified": "2026-06-18 09:35:39.019351",
+    "@@last_modified": "2026-06-26 10:52:31.395444",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -9542,6 +9542,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Join a course that includes this activity to play it.",
+    "resizeCoursePanel": "Resize course panel",
+    "undo": "Undo",
+    "unlock": "Unlock",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "stars": "Stars",
+    "addNewCourse": "Add new course",
+    "world": "World",
+    "addCourseStartMyOwn": "Start my own",
+    "addCourseEnterCode": "Shkruani kodin për kursin privat",
+    "addCourseBrowsePublic": "Shfletoni kurset publike",
+    "browsePublicCourses": "Shfletoni kurset publike",
+    "editProfile": "Redaktoni profilin",
+    "numObjectives": "{count} objektiva",
+    "mapSearchHint": "Kërkoni aktivitete",
+    "mapSearchNoResults": "Nuk ka përputhje në pamje",
+    "mapFilterAllLanguages": "Të gjitha gjuhët",
+    "mapFilterNotStarted": "Nuk ka filluar",
+    "mapFilterInProgress": "Në proces",
+    "mapFilterCompleted": "Komplet",
+    "mapFilterReset": "Reset",
+    "activityTypeConversation": "Konversasi",
+    "lockedMissionRequirement": "Selesaikan misi sebelumnya untuk membuka kunci",
+    "playAgain": "Main lagi",
+    "reviewActivity": "Tinjau",
+    "mapEmptyInView": "Tidak ada di sini pada level atau bahasa Anda. Perluas filter Anda atau perbesar.",
+    "welcomeToPangeaChat": "Selamat datang di Pangea Chat",
+    "claimTrial": "Klaim percobaan Anda",
+    "thanksForSigningUp": "Terima kasih telah mendaftar! Ini dia",
+    "sevenDaysFree": "7 DITË TË LIRA",
+    "manageTrialInSettings": "Menaxhoni provën tuaj në çdo kohë në\nCilësimet e Abonimit",
+    "noCreditCardRequired": "Nuk kërkohet kartë krediti.",
+    "proFeatures": "PRO",
+    "widenSearch": "Zgjatni kërkimin",
+    "scrollToBottom": "Rrokullisni poshtë",
+    "courseImage": "Imazhi i kursit",
+    "avatarPreview": "Paraprak i avatarit",
+    "activityPhoto": "Foto e aktivitetit",
+    "emotePreview": "Paraprak i emote: {name}",
+    "activityLabel": "Aktivitet: {title}",
+    "resetMapView": "Nulstil kortvisning",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ca.arb
+++ b/lib/l10n/intl_ca.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:35:25.710040",
+    "@@last_modified": "2026-06-26 10:49:25.003668",
     "about": "Quant a",
     "@about": {
         "type": "String",
@@ -10021,6 +10021,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Uneix-te a un curs que inclogui aquesta activitat per jugar-la.",
+    "resizeCoursePanel": "Redimensionar el panell del curs",
+    "undo": "Desfer",
+    "unlock": "Desbloquejar",
+    "zoomIn": "Augmentar",
+    "zoomOut": "Reduir",
+    "stars": "Estrelles",
+    "addNewCourse": "Afegir nou curs",
+    "world": "Món",
+    "addCourseStartMyOwn": "Començar el meu propi",
+    "addCourseEnterCode": "Introdueix el codi per al curs privat",
+    "addCourseBrowsePublic": "Explora cursos públics",
+    "browsePublicCourses": "Explora cursos públics",
+    "editProfile": "Edita el perfil",
+    "numObjectives": "{count} objectius",
+    "mapSearchHint": "Cerca activitats",
+    "mapSearchNoResults": "Sense coincidències a la vista",
+    "mapFilterAllLanguages": "Totes les llengües",
+    "mapFilterNotStarted": "No iniciat",
+    "mapFilterInProgress": "En curs",
+    "mapFilterCompleted": "Complet",
+    "mapFilterReset": "Restableix",
+    "activityTypeConversation": "Conversació",
+    "lockedMissionRequirement": "Acaba la missió anterior per desbloquejar",
+    "playAgain": "Juga de nou",
+    "reviewActivity": "Revisar",
+    "mapEmptyInView": "No hi ha res aquí al teu nivell o idioma. Ampliu els vostres filtres o allunyeu-vos.",
+    "welcomeToPangeaChat": "Benvingut a Pangea Chat",
+    "claimTrial": "Reclama la teva prova",
+    "thanksForSigningUp": "Gràcies per registrar-te! Aquí tens",
+    "sevenDaysFree": "7 DIES GRATUÏTS",
+    "manageTrialInSettings": "Gestiona la teva prova en qualsevol moment a\nConfiguració de subscripcions",
+    "noCreditCardRequired": "No es requereix targeta de crèdit.",
+    "proFeatures": "PRO",
+    "widenSearch": "Ampliar cerca",
+    "scrollToBottom": "Desplaçar-se fins a la part inferior",
+    "courseImage": "Imatge del curs",
+    "avatarPreview": "Previsualització de l'avatar",
+    "activityPhoto": "Foto de l'activitat",
+    "emotePreview": "Previsualització d'emocions: {name}",
+    "activityLabel": "Activitat: {title}",
+    "resetMapView": "Restableix la vista del mapa",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "cs",
-    "@@last_modified": "2026-06-18 09:34:30.516264",
+    "@@last_modified": "2026-06-26 10:48:52.475399",
     "about": "O aplikaci",
     "@about": {
         "type": "String",
@@ -10424,6 +10424,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Připojte se k kurzu, který zahrnuje tuto aktivitu, abyste ji mohli hrát.",
+    "resizeCoursePanel": "Změnit velikost panelu kurzu",
+    "undo": "Zpět",
+    "unlock": "Odemknout",
+    "zoomIn": "Přiblížit",
+    "zoomOut": "Oddálit",
+    "stars": "Hvězdy",
+    "addNewCourse": "Přidat nový kurz",
+    "world": "Svět",
+    "addCourseStartMyOwn": "Začít svůj vlastní",
+    "addCourseEnterCode": "Zadejte kód pro soukromý kurz",
+    "addCourseBrowsePublic": "Procházet veřejné kurzy",
+    "browsePublicCourses": "Procházet veřejné kurzy",
+    "editProfile": "Upravit profil",
+    "numObjectives": "{count} cíle",
+    "mapSearchHint": "Hledat aktivity",
+    "mapSearchNoResults": "Žádné shody v zobrazení",
+    "mapFilterAllLanguages": "Všechny jazyky",
+    "mapFilterNotStarted": "Nebylo zahájeno",
+    "mapFilterInProgress": "Probíhá",
+    "mapFilterCompleted": "Dokončeno",
+    "mapFilterReset": "Resetovat",
+    "activityTypeConversation": "Konverzace",
+    "lockedMissionRequirement": "Dokončete předchozí misi, abyste odemkli",
+    "playAgain": "Hrát znovu",
+    "reviewActivity": "Přehled",
+    "mapEmptyInView": "Na vaší úrovni nebo jazyce není nic. Rozšiřte své filtry nebo se přiblížte.",
+    "welcomeToPangeaChat": "Vítejte v Pangea Chatu",
+    "claimTrial": "Uplatněte svou zkušební verzi",
+    "thanksForSigningUp": "Děkujeme za registraci! Tady je",
+    "sevenDaysFree": "7 DNÍ ZDARMA",
+    "manageTrialInSettings": "Spravujte svou zkušební verzi kdykoli v\nNastavení předplatného",
+    "noCreditCardRequired": "Není vyžadována kreditní karta.",
+    "proFeatures": "PRO",
+    "widenSearch": "Rozšířit hledání",
+    "scrollToBottom": "Přejít na konec",
+    "courseImage": "Obrázek kurzu",
+    "avatarPreview": "Náhled avatara",
+    "activityPhoto": "Fotografie aktivity",
+    "emotePreview": "Náhled emoce: {name}",
+    "activityLabel": "Aktivita: {title}",
+    "resetMapView": "Obnovit zobrazení mapy",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_da.arb
+++ b/lib/l10n/intl_da.arb
@@ -1477,7 +1477,7 @@
     "playWithAI": "Leg med AI for nu",
     "courseStartDesc": "Pangea Bot er klar til at starte når som helst!\n\n...men læring er bedre med venner!",
     "@@locale": "da",
-    "@@last_modified": "2026-06-18 09:34:13.810527",
+    "@@last_modified": "2026-06-26 10:44:52.707365",
     "@aboutHomeserver": {
         "type": "String",
         "placeholders": {
@@ -10964,6 +10964,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Deltag i et kursus, der inkluderer denne aktivitet for at spille den.",
+    "resizeCoursePanel": "Ændr størrelse på kursuspanelet",
+    "undo": "Fortryd",
+    "unlock": "Lås op",
+    "zoomIn": "Zoom ind",
+    "zoomOut": "Zoom ud",
+    "stars": "Stjerner",
+    "addNewCourse": "Tilføj nyt kursus",
+    "world": "Verden",
+    "addCourseStartMyOwn": "Start mit eget",
+    "addCourseEnterCode": "Indtast kode for privat kursus",
+    "addCourseBrowsePublic": "Gennemse offentlige kurser",
+    "browsePublicCourses": "Gennemse offentlige kurser",
+    "editProfile": "Rediger profil",
+    "numObjectives": "{count} mål",
+    "mapSearchHint": "Søg aktiviteter",
+    "mapSearchNoResults": "Ingen matches i visningen",
+    "mapFilterAllLanguages": "Alle sprog",
+    "mapFilterNotStarted": "Ikke startet",
+    "mapFilterInProgress": "I gang",
+    "mapFilterCompleted": "Fuldført",
+    "mapFilterReset": "Nulstil",
+    "activityTypeConversation": "Samtale",
+    "lockedMissionRequirement": "Afslut den forrige mission for at låse op",
+    "playAgain": "Spil igen",
+    "reviewActivity": "Gennemgå",
+    "mapEmptyInView": "Der er intet her på dit niveau eller sprog. Udvid dine filtre eller zoom ud.",
+    "welcomeToPangeaChat": "Velkommen til Pangea Chat",
+    "claimTrial": "Gør krav på din prøve",
+    "thanksForSigningUp": "Tak for tilmeldingen! Her er",
+    "sevenDaysFree": "7 DAGE GRATIS",
+    "manageTrialInSettings": "Administrer din prøveperiode når som helst i\nAbonnementsindstillinger",
+    "noCreditCardRequired": "Ingen kreditkort kræves.",
+    "proFeatures": "PRO",
+    "widenSearch": "Udvid søgning",
+    "scrollToBottom": "Rul til bunden",
+    "courseImage": "Kursusbillede",
+    "avatarPreview": "Avatar forhåndsvisning",
+    "activityPhoto": "Aktivitetsbillede",
+    "emotePreview": "Emote forhåndsvisning: {name}",
+    "activityLabel": "Aktivitet: {title}",
+    "resetMapView": "Nulstil kortvisning",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "de",
-    "@@last_modified": "2026-06-18 09:34:26.216503",
+    "@@last_modified": "2026-06-26 10:47:42.580046",
     "alwaysUse24HourFormat": "true",
     "@alwaysUse24HourFormat": {
         "description": "Set to true to always display time of day in 24 hour format."
@@ -9849,6 +9849,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Tritt einem Kurs bei, der diese Aktivität enthält, um sie zu spielen.",
+    "resizeCoursePanel": "Kursfenstergröße ändern",
+    "undo": "Rückgängig machen",
+    "unlock": "Freischalten",
+    "zoomIn": "Hineinzoomen",
+    "zoomOut": "Herauszoomen",
+    "stars": "Sterne",
+    "addNewCourse": "Neuen Kurs hinzufügen",
+    "world": "Welt",
+    "addCourseStartMyOwn": "Eigenen Kurs starten",
+    "addCourseEnterCode": "Geben Sie den Code für den privaten Kurs ein",
+    "addCourseBrowsePublic": "Öffentliche Kurse durchsuchen",
+    "browsePublicCourses": "Öffentliche Kurse durchsuchen",
+    "editProfile": "Profil bearbeiten",
+    "numObjectives": "{count} Ziele",
+    "mapSearchHint": "Aktivitäten suchen",
+    "mapSearchNoResults": "Keine Übereinstimmungen in der Ansicht",
+    "mapFilterAllLanguages": "Alle Sprachen",
+    "mapFilterNotStarted": "Nicht gestartet",
+    "mapFilterInProgress": "In Bearbeitung",
+    "mapFilterCompleted": "Abgeschlossen",
+    "mapFilterReset": "Zurücksetzen",
+    "activityTypeConversation": "Gespräch",
+    "lockedMissionRequirement": "Beende die vorherige Mission, um freizuschalten",
+    "playAgain": "Nochmals spielen",
+    "reviewActivity": "Überprüfen",
+    "mapEmptyInView": "Nichts hier auf deinem Niveau oder in deiner Sprache. Erweitere deine Filter oder zoome heraus.",
+    "welcomeToPangeaChat": "Willkommen bei Pangea Chat",
+    "claimTrial": "Fordere deine Testversion an",
+    "thanksForSigningUp": "Danke für die Anmeldung! Hier ist",
+    "sevenDaysFree": "7 TAGE KOSTENLOS",
+    "manageTrialInSettings": "Verwalten Sie Ihre Testversion jederzeit in\nAbonnement-Einstellungen",
+    "noCreditCardRequired": "Keine Kreditkarte erforderlich.",
+    "proFeatures": "PRO",
+    "widenSearch": "Suche erweitern",
+    "scrollToBottom": "Zum Ende scrollen",
+    "courseImage": "Kursbild",
+    "avatarPreview": "Avatar-Vorschau",
+    "activityPhoto": "Aktivitätsfoto",
+    "emotePreview": "Emote-Vorschau: {name}",
+    "activityLabel": "Aktivität: {title}",
+    "resetMapView": "Kartenansicht zurücksetzen",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_el.arb
+++ b/lib/l10n/intl_el.arb
@@ -3771,7 +3771,7 @@
     "playWithAI": "Παίξτε με την Τεχνητή Νοημοσύνη προς το παρόν",
     "courseStartDesc": "Ο Pangea Bot είναι έτοιμος να ξεκινήσει οποιαδήποτε στιγμή!\n\n...αλλά η μάθηση είναι καλύτερη με φίλους!",
     "@@locale": "el",
-    "@@last_modified": "2026-06-18 09:35:49.167319",
+    "@@last_modified": "2026-06-26 10:53:45.106656",
     "@checkList": {
         "type": "String",
         "placeholders": {}
@@ -10919,6 +10919,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Εγγραφείτε σε ένα μάθημα που περιλαμβάνει αυτή τη δραστηριότητα για να το παίξετε.",
+    "resizeCoursePanel": "Αλλαγή μεγέθους πίνακα μαθήματος",
+    "undo": "Αναίρεση",
+    "unlock": "Ξεκλείδωμα",
+    "zoomIn": "Ζουμ εντός",
+    "zoomOut": "Ζουμ εκτός",
+    "stars": "Αστέρια",
+    "addNewCourse": "Προσθήκη νέου μαθήματος",
+    "world": "Κόσμος",
+    "addCourseStartMyOwn": "Ξεκινήστε το δικό μου",
+    "addCourseEnterCode": "Εισάγετε τον κωδικό για ιδιωτικό μάθημα",
+    "addCourseBrowsePublic": "Περιήγηση σε δημόσια μαθήματα",
+    "browsePublicCourses": "Περιήγηση σε δημόσια μαθήματα",
+    "editProfile": "Επεξεργασία προφίλ",
+    "numObjectives": "{count} στόχοι",
+    "mapSearchHint": "Αναζητήστε δραστηριότητες",
+    "mapSearchNoResults": "Δεν υπάρχουν αποτελέσματα στην προβολή",
+    "mapFilterAllLanguages": "Όλες οι γλώσσες",
+    "mapFilterNotStarted": "Δεν έχει ξεκινήσει",
+    "mapFilterInProgress": "Σε εξέλιξη",
+    "mapFilterCompleted": "Ολοκληρώθηκε",
+    "mapFilterReset": "Επαναφορά",
+    "activityTypeConversation": "Συζήτηση",
+    "lockedMissionRequirement": "Ολοκληρώστε την προηγούμενη αποστολή για να ξεκλειδώσετε",
+    "playAgain": "Παίξτε ξανά",
+    "reviewActivity": "Αξιολόγηση",
+    "mapEmptyInView": "Δεν υπάρχει τίποτα εδώ στο επίπεδό σας ή στη γλώσσα σας. Διευρύνετε τα φίλτρα σας ή απομακρυνθείτε.",
+    "welcomeToPangeaChat": "Καλώς ήρθατε στο Pangea Chat",
+    "claimTrial": "Διεκδικήστε τη δοκιμή σας",
+    "thanksForSigningUp": "Ευχαριστούμε που εγγραφήκατε! Να τι είναι",
+    "sevenDaysFree": "7 ΗΜΕΡΕΣ ΔΩΡΕΑΝ",
+    "manageTrialInSettings": "Διαχειριστείτε τη δοκιμή σας οποιαδήποτε στιγμή στις\nΡυθμίσεις Συνδρομής",
+    "noCreditCardRequired": "Δεν απαιτείται πιστωτική κάρτα.",
+    "proFeatures": "PRO",
+    "widenSearch": "Διεύρυνση αναζήτησης",
+    "scrollToBottom": "Κύλιση προς τα κάτω",
+    "courseImage": "Εικόνα μαθήματος",
+    "avatarPreview": "Προεπισκόπηση avatar",
+    "activityPhoto": "Φωτογραφία δραστηριότητας",
+    "emotePreview": "Προεπισκόπηση emote: {name}",
+    "activityLabel": "Δραστηριότητα: {title}",
+    "resetMapView": "Επαναφορά προβολής χάρτη",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_eo.arb
+++ b/lib/l10n/intl_eo.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:35:51.806388",
+    "@@last_modified": "2026-06-26 10:54:31.498946",
     "about": "Prio",
     "@about": {
         "type": "String",
@@ -10989,6 +10989,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Aliĝu al kurso, kiu inkluzivas ĉi tiun aktivon por ludi ĝin.",
+    "resizeCoursePanel": "Redimensioni kurspanelon",
+    "undo": "Malfari",
+    "unlock": "Malŝlosi",
+    "zoomIn": "Proksimigi",
+    "zoomOut": "Malproksimigi",
+    "stars": "Steloj",
+    "addNewCourse": "Aldoni novan kurson",
+    "world": "Mondo",
+    "addCourseStartMyOwn": "Komenci mian propran",
+    "addCourseEnterCode": "Enigu kodon por privata kurso",
+    "addCourseBrowsePublic": "Serĉu publikajn kursojn",
+    "browsePublicCourses": "Serĉu publikajn kursojn",
+    "editProfile": "Redaktu profilon",
+    "numObjectives": "{count} celoj",
+    "mapSearchHint": "Serĉu aktivecojn",
+    "mapSearchNoResults": "Neniuj kongruoj en vido",
+    "mapFilterAllLanguages": "Ĉiuj lingvoj",
+    "mapFilterNotStarted": "Ne komencita",
+    "mapFilterInProgress": "En progreso",
+    "mapFilterCompleted": "Finita",
+    "mapFilterReset": "Reagordi",
+    "activityTypeConversation": "Konversacio",
+    "lockedMissionRequirement": "Fini la antaŭan misio por malŝlosi",
+    "playAgain": "Ludi denove",
+    "reviewActivity": "Revizii",
+    "mapEmptyInView": "Nenio ĉi tie ĉe via nivelo aŭ lingvo. Larĝigu viajn filtrilojn aŭ malproksimiĝu.",
+    "welcomeToPangeaChat": "Bonvenon al Pangea Ĉat",
+    "claimTrial": "Postuli vian provon",
+    "thanksForSigningUp": "Dankon pro aliĝi! Jen",
+    "sevenDaysFree": "7 TAGOJ SENKOSTA",
+    "manageTrialInSettings": "Administru vian provon iam en\nAbonaj Agordoj",
+    "noCreditCardRequired": "Neniu kreditkarto necesa.",
+    "proFeatures": "PRO",
+    "widenSearch": "Larĝigu serĉon",
+    "scrollToBottom": "Rulumu al fundo",
+    "courseImage": "Kursa bildo",
+    "avatarPreview": "Antaŭprezento de avataro",
+    "activityPhoto": "Aktiveca foto",
+    "emotePreview": "Emota antaŭprezento: {name}",
+    "activityLabel": "Aktiveco: {title}",
+    "resetMapView": "Reagordi mapan vidon",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "es",
-    "@@last_modified": "2026-06-18 09:34:11.312335",
+    "@@last_modified": "2026-06-26 10:43:40.368410",
     "about": "Acerca de",
     "@about": {
         "type": "String",
@@ -7964,6 +7964,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Únete a un curso que incluya esta actividad para jugarla.",
+    "resizeCoursePanel": "Redimensionar panel del curso",
+    "undo": "Deshacer",
+    "unlock": "Desbloquear",
+    "zoomIn": "Acercar",
+    "zoomOut": "Alejar",
+    "stars": "Estrellas",
+    "addNewCourse": "Agregar nuevo curso",
+    "world": "Mundo",
+    "addCourseStartMyOwn": "Iniciar mi propio",
+    "addCourseEnterCode": "Ingrese el código para el curso privado",
+    "addCourseBrowsePublic": "Explorar cursos públicos",
+    "browsePublicCourses": "Explorar cursos públicos",
+    "editProfile": "Editar perfil",
+    "numObjectives": "{count} objetivos",
+    "mapSearchHint": "Buscar actividades",
+    "mapSearchNoResults": "No hay coincidencias en la vista",
+    "mapFilterAllLanguages": "Todos los idiomas",
+    "mapFilterNotStarted": "No iniciado",
+    "mapFilterInProgress": "En progreso",
+    "mapFilterCompleted": "Completado",
+    "mapFilterReset": "Restablecer",
+    "activityTypeConversation": "Conversación",
+    "lockedMissionRequirement": "Termina la misión anterior para desbloquear",
+    "playAgain": "Jugar de nuevo",
+    "reviewActivity": "Revisar",
+    "mapEmptyInView": "No hay nada aquí en tu nivel o idioma. Amplía tus filtros o aleja.",
+    "welcomeToPangeaChat": "Bienvenido a Pangea Chat",
+    "claimTrial": "Reclama tu prueba",
+    "thanksForSigningUp": "¡Gracias por registrarte! Aquí está",
+    "sevenDaysFree": "7 DÍAS GRATIS",
+    "manageTrialInSettings": "Gestiona tu prueba en cualquier momento en\nConfiguración de suscripción",
+    "noCreditCardRequired": "No se requiere tarjeta de crédito.",
+    "proFeatures": "PRO",
+    "widenSearch": "Ampliar búsqueda",
+    "scrollToBottom": "Desplazarse hasta el final",
+    "courseImage": "Imagen del curso",
+    "avatarPreview": "Vista previa del avatar",
+    "activityPhoto": "Foto de actividad",
+    "emotePreview": "Vista previa de emote: {name}",
+    "activityLabel": "Actividad: {title}",
+    "resetMapView": "Restablecer vista del mapa",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_et.arb
+++ b/lib/l10n/intl_et.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "et",
-    "@@last_modified": "2026-06-18 09:34:25.378080",
+    "@@last_modified": "2026-06-26 10:47:28.117472",
     "about": "Rakenduse teave",
     "@about": {
         "type": "String",
@@ -9867,6 +9867,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Liitu kursusega, mis sisaldab seda tegevust, et seda mängida.",
+    "resizeCoursePanel": "Kursuse paneeli suuruse muutmine",
+    "undo": "Tühista",
+    "unlock": "Avage",
+    "zoomIn": "Suurenda",
+    "zoomOut": "Vähenda",
+    "stars": "Tähte",
+    "addNewCourse": "Lisa uus kursus",
+    "world": "Maailm",
+    "addCourseStartMyOwn": "Alusta oma",
+    "addCourseEnterCode": "Sisestage privaatse kursuse kood",
+    "addCourseBrowsePublic": "Sirvi avalikke kursusi",
+    "browsePublicCourses": "Sirvi avalikke kursusi",
+    "editProfile": "Muuda profiili",
+    "numObjectives": "{count} eesmärki",
+    "mapSearchHint": "Otsi tegevusi",
+    "mapSearchNoResults": "Vaates ei ole vasteid",
+    "mapFilterAllLanguages": "Kõik keeled",
+    "mapFilterNotStarted": "Alustamata",
+    "mapFilterInProgress": "Käimas",
+    "mapFilterCompleted": "Lõpetatud",
+    "mapFilterReset": "Lähtesta",
+    "activityTypeConversation": "Vestlus",
+    "lockedMissionRequirement": "Eelmise missiooni lõpetamiseks, et avada",
+    "playAgain": "Mängi uuesti",
+    "reviewActivity": "Ülevaade",
+    "mapEmptyInView": "Sinu tasemel või keeles ei ole siin midagi. Laienda oma filtreid või suumi välja.",
+    "welcomeToPangeaChat": "Tere tulemast Pangea Chati",
+    "claimTrial": "Nõua oma prooviversioon",
+    "thanksForSigningUp": "Aitäh registreerumise eest! Siin on",
+    "sevenDaysFree": "7 PÄEVA TASUTA",
+    "manageTrialInSettings": "Halda oma prooviperioodi igal ajal\nTellimuse seadetes",
+    "noCreditCardRequired": "Krediitkaarti ei ole vaja.",
+    "proFeatures": "PRO",
+    "widenSearch": "Laienda otsingut",
+    "scrollToBottom": "Kerige alla",
+    "courseImage": "Kursuse pilt",
+    "avatarPreview": "Avatar eelvaade",
+    "activityPhoto": "Tegevuse foto",
+    "emotePreview": "Emote eelvaade: {name}",
+    "activityLabel": "Tegevus: {title}",
+    "resetMapView": "Lähtesta kaardi vaade",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_eu.arb
+++ b/lib/l10n/intl_eu.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "eu",
-    "@@last_modified": "2026-06-18 09:34:23.757627",
+    "@@last_modified": "2026-06-26 10:47:06.861952",
     "about": "Honi buruz",
     "@about": {
         "type": "String",
@@ -9870,6 +9870,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Jarduera hau jokatzeko ikastaro batera batu.",
+    "resizeCoursePanel": "Ikastaro panelaren tamaina aldatu",
+    "undo": "Ezeztatu",
+    "unlock": "Desblokeatu",
+    "zoomIn": "Hurbildu",
+    "zoomOut": "Urrundu",
+    "stars": "Izarrak",
+    "addNewCourse": "Gehitu ikastaro berri bat",
+    "world": "Mundua",
+    "addCourseStartMyOwn": "Nire propioa hasi",
+    "addCourseEnterCode": "Sartu pribatuko ikastaroaren kodea",
+    "addCourseBrowsePublic": "Arakatu publiko ikastaroak",
+    "browsePublicCourses": "Arakatu publiko ikastaroak",
+    "editProfile": "Editatu profila",
+    "numObjectives": "{count} helburu",
+    "mapSearchHint": "Bilatu jarduerak",
+    "mapSearchNoResults": "Ez dago bat etorritakoen ikuspegian",
+    "mapFilterAllLanguages": "Hizkuntza guztiak",
+    "mapFilterNotStarted": "Hasita ez",
+    "mapFilterInProgress": "Prozesuan",
+    "mapFilterCompleted": "Osatua",
+    "mapFilterReset": "Berrezarri",
+    "activityTypeConversation": "Elkarrizketa",
+    "lockedMissionRequirement": "Desblokeatzeko aurreko misioa amaitu",
+    "playAgain": "Jolastu berriro",
+    "reviewActivity": "Berrikusi",
+    "mapEmptyInView": "Ez dago ezer zure mailan edo hizkuntzan. Zabaldu zure iragazkiak edo hurbildu.",
+    "welcomeToPangeaChat": "Ongi etorri Pangea Chat-era",
+    "claimTrial": "Eska itzazu zure probak",
+    "thanksForSigningUp": "Eskerrik asko izena emateagatik! Hona hemen",
+    "sevenDaysFree": "7 EGUN DOHAIN",
+    "manageTrialInSettings": "Kudeatu zure probaldia edozein unetan\nHarpidetzaren Ezarpenetan",
+    "noCreditCardRequired": "Ez da kreditu txartelik behar.",
+    "proFeatures": "PRO",
+    "widenSearch": "Bilaketa zabaldu",
+    "scrollToBottom": "Behera irristatu",
+    "courseImage": "Ikastaroaren irudia",
+    "avatarPreview": "Avatar aurrebista",
+    "activityPhoto": "Jardueraren argazkia",
+    "emotePreview": "Emote aurrebista: {name}",
+    "activityLabel": "Jarduera: {title}",
+    "resetMapView": "Berrezarri mapa ikuskera",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fa.arb
+++ b/lib/l10n/intl_fa.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:35:42.589865",
+    "@@last_modified": "2026-06-26 10:53:08.843132",
     "repeatPassword": "تکرار گذرواژه",
     "@repeatPassword": {},
     "about": "درباره",
@@ -9982,6 +9982,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "به یک دوره بپیوندید که این فعالیت را شامل می‌شود تا بتوانید آن را بازی کنید.",
+    "resizeCoursePanel": "اندازه پنل دوره را تغییر دهید",
+    "undo": "بازگشت",
+    "unlock": "باز کردن",
+    "zoomIn": "زوم در",
+    "zoomOut": "زوم خارج",
+    "stars": "ستاره‌ها",
+    "addNewCourse": "دوره جدید اضافه کنید",
+    "world": "جهان",
+    "addCourseStartMyOwn": "دوره خودم را شروع کنم",
+    "addCourseEnterCode": "کد دوره خصوصی را وارد کنید",
+    "addCourseBrowsePublic": "دوره‌های عمومی را مرور کنید",
+    "browsePublicCourses": "دوره‌های عمومی را مرور کنید",
+    "editProfile": "ویرایش پروفایل",
+    "numObjectives": "{count} هدف",
+    "mapSearchHint": "جستجوی فعالیت‌ها",
+    "mapSearchNoResults": "هیچ تطابقی در نمای فعلی وجود ندارد",
+    "mapFilterAllLanguages": "تمام زبان‌ها",
+    "mapFilterNotStarted": "شروع نشده",
+    "mapFilterInProgress": "در حال پیشرفت",
+    "mapFilterCompleted": "تکمیل شده",
+    "mapFilterReset": "تنظیم مجدد",
+    "activityTypeConversation": "گفتگو",
+    "lockedMissionRequirement": "برای باز کردن، مأموریت قبلی را تمام کنید",
+    "playAgain": "دوباره بازی کنید",
+    "reviewActivity": "بررسی",
+    "mapEmptyInView": "هیچ چیزی در سطح یا زبان شما وجود ندارد. فیلترهای خود را گسترش دهید یا زوم کنید.",
+    "welcomeToPangeaChat": "به چت پانژیا خوش آمدید",
+    "claimTrial": "دریافت دوره آزمایشی خود",
+    "thanksForSigningUp": "از ثبت نام شما متشکریم! اینجا",
+    "sevenDaysFree": "۷ روز رایگان",
+    "manageTrialInSettings": "هر زمان که بخواهید می‌توانید دوره آزمایشی خود را در\nتنظیمات اشتراک مدیریت کنید",
+    "noCreditCardRequired": "نیازی به کارت اعتباری نیست.",
+    "proFeatures": "ویژگی‌های پرو",
+    "widenSearch": "جستجو را گسترش دهید",
+    "scrollToBottom": "به پایین صفحه بروید",
+    "courseImage": "تصویر دوره",
+    "avatarPreview": "پیش‌نمایش آواتار",
+    "activityPhoto": "عکس فعالیت",
+    "emotePreview": "پیش‌نمایش ایموجی: {name}",
+    "activityLabel": "فعالیت: {title}",
+    "resetMapView": "بازنشانی نمای نقشه",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fi.arb
+++ b/lib/l10n/intl_fi.arb
@@ -3913,7 +3913,7 @@
     "playWithAI": "Leiki tekoälyn kanssa nyt",
     "courseStartDesc": "Pangea Bot on valmis milloin tahansa!\n\n...mutta oppiminen on parempaa ystävien kanssa!",
     "@@locale": "fi",
-    "@@last_modified": "2026-06-18 09:34:12.919646",
+    "@@last_modified": "2026-06-26 10:44:40.248327",
     "@notificationRuleJitsi": {
         "type": "String",
         "placeholders": {}
@@ -9919,6 +9919,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Liity kurssille, joka sisältää tämän aktiviteetin pelataksesi sitä.",
+    "resizeCoursePanel": "Muuta kurssipaneelin kokoa",
+    "undo": "Kumoa",
+    "unlock": "Avaa lukitus",
+    "zoomIn": "Lähennä",
+    "zoomOut": "Loitonna",
+    "stars": "Tähdet",
+    "addNewCourse": "Lisää uusi kurssi",
+    "world": "Maailma",
+    "addCourseStartMyOwn": "Aloita oma",
+    "addCourseEnterCode": "Syötä koodi yksityiselle kurssille",
+    "addCourseBrowsePublic": "Selaa julkisia kursseja",
+    "browsePublicCourses": "Selaa julkisia kursseja",
+    "editProfile": "Muokkaa profiilia",
+    "numObjectives": "{count} tavoitetta",
+    "mapSearchHint": "Etsi aktiviteetteja",
+    "mapSearchNoResults": "Ei osumia näkymässä",
+    "mapFilterAllLanguages": "Kaikki kielet",
+    "mapFilterNotStarted": "Ei aloitettu",
+    "mapFilterInProgress": "Käynnissä",
+    "mapFilterCompleted": "Valmis",
+    "mapFilterReset": "Nollaa",
+    "activityTypeConversation": "Keskustelu",
+    "lockedMissionRequirement": "Suorita edellinen tehtävä avatakseksi",
+    "playAgain": "Pelaa uudelleen",
+    "reviewActivity": "Arvioi",
+    "mapEmptyInView": "Täällä ei ole mitään tasollasi tai kielelläsi. Laajenna suodattimiasi tai zoomaa ulos.",
+    "welcomeToPangeaChat": "Tervetuloa Pangea Chatiin",
+    "claimTrial": "Vaatia kokeilujakso",
+    "thanksForSigningUp": "Kiitos rekisteröitymisestä! Tässä on",
+    "sevenDaysFree": "7 PÄIVÄÄ ILMAISEKSI",
+    "manageTrialInSettings": "Hallitse kokeilujaksoasi milloin tahansa\nTilauksen asetuksissa",
+    "noCreditCardRequired": "Ei luottokorttia vaadita.",
+    "proFeatures": "PRO",
+    "widenSearch": "Laajenna hakua",
+    "scrollToBottom": "Vieritä alas",
+    "courseImage": "Kurssikuva",
+    "avatarPreview": "Avatarin esikatselu",
+    "activityPhoto": "Toimintakuva",
+    "emotePreview": "Emote-esikatselu: {name}",
+    "activityLabel": "Toiminta: {title}",
+    "resetMapView": "Nollaa karttanäkymä",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fil.arb
+++ b/lib/l10n/intl_fil.arb
@@ -2257,7 +2257,7 @@
     "selectAll": "Piliin lahat",
     "deselectAll": "Huwag piliin lahat",
     "@@locale": "fil",
-    "@@last_modified": "2026-06-18 09:35:30.346598",
+    "@@last_modified": "2026-06-26 10:50:26.093278",
     "@setCustomPermissionLevel": {
         "type": "String",
         "placeholders": {}
@@ -10889,6 +10889,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Sumali sa isang kurso na kasama ang aktibidad na ito upang maglaro.",
+    "resizeCoursePanel": "I-resize ang panel ng kurso",
+    "undo": "I-undo",
+    "unlock": "I-unlock",
+    "zoomIn": "Palakihin",
+    "zoomOut": "Paliitin",
+    "stars": "Mga Bituin",
+    "addNewCourse": "Magdagdag ng bagong kurso",
+    "world": "Mundo",
+    "addCourseStartMyOwn": "Simulan ang sarili kong kurso",
+    "addCourseEnterCode": "Ilagay ang code para sa pribadong kurso",
+    "addCourseBrowsePublic": "Mag-browse ng mga pampublikong kurso",
+    "browsePublicCourses": "Mag-browse ng mga pampublikong kurso",
+    "editProfile": "I-edit ang profile",
+    "numObjectives": "{count} mga layunin",
+    "mapSearchHint": "Maghanap ng mga aktibidad",
+    "mapSearchNoResults": "Walang tugma sa view",
+    "mapFilterAllLanguages": "Lahat ng wika",
+    "mapFilterNotStarted": "Hindi pa nagsimula",
+    "mapFilterInProgress": "Nasa proseso",
+    "mapFilterCompleted": "Natapos",
+    "mapFilterReset": "I-reset",
+    "activityTypeConversation": "Usapan",
+    "lockedMissionRequirement": "Kumpletuhin ang nakaraang misyon upang i-unlock",
+    "playAgain": "Maglaro muli",
+    "reviewActivity": "Suriin",
+    "mapEmptyInView": "Walang nandito sa iyong antas o wika. Palawakin ang iyong mga filter o mag-zoom out.",
+    "welcomeToPangeaChat": "Maligayang pagdating sa Pangea Chat",
+    "claimTrial": "Kunin ang iyong pagsubok",
+    "thanksForSigningUp": "Salamat sa pag-sign up! Narito ang",
+    "sevenDaysFree": "7 ARAW NA LIBRE",
+    "manageTrialInSettings": "Pamahalaan ang iyong pagsubok anumang oras sa\nMga Setting ng Subscription",
+    "noCreditCardRequired": "Walang kinakailangang credit card.",
+    "proFeatures": "PRO",
+    "widenSearch": "Palawakin ang paghahanap",
+    "scrollToBottom": "Mag-scroll sa ibaba",
+    "courseImage": "Larawan ng kurso",
+    "avatarPreview": "Preview ng avatar",
+    "activityPhoto": "Larawan ng aktibidad",
+    "emotePreview": "Preview ng emote: {name}",
+    "activityLabel": "Aktibidad: {title}",
+    "resetMapView": "I-reset ang view ng mapa",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "fr",
-    "@@last_modified": "2026-06-18 09:35:56.873556",
+    "@@last_modified": "2026-06-26 10:55:32.208815",
     "about": "À propos",
     "@about": {
         "type": "String",
@@ -10267,6 +10267,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Rejoignez un cours qui inclut cette activité pour y jouer.",
+    "resizeCoursePanel": "Redimensionner le panneau de cours",
+    "undo": "Annuler",
+    "unlock": "Déverrouiller",
+    "zoomIn": "Zoomer",
+    "zoomOut": "Dézoomer",
+    "stars": "Étoiles",
+    "addNewCourse": "Ajouter un nouveau cours",
+    "world": "Monde",
+    "addCourseStartMyOwn": "Commencer le mien",
+    "addCourseEnterCode": "Entrez le code pour le cours privé",
+    "addCourseBrowsePublic": "Parcourir les cours publics",
+    "browsePublicCourses": "Parcourir les cours publics",
+    "editProfile": "Modifier le profil",
+    "numObjectives": "{count} objectifs",
+    "mapSearchHint": "Rechercher des activités",
+    "mapSearchNoResults": "Aucun résultat dans la vue",
+    "mapFilterAllLanguages": "Toutes les langues",
+    "mapFilterNotStarted": "Pas commencé",
+    "mapFilterInProgress": "En cours",
+    "mapFilterCompleted": "Terminé",
+    "mapFilterReset": "Réinitialiser",
+    "activityTypeConversation": "Conversation",
+    "lockedMissionRequirement": "Terminez la mission précédente pour déverrouiller",
+    "playAgain": "Jouer à nouveau",
+    "reviewActivity": "Réviser",
+    "mapEmptyInView": "Rien ici à votre niveau ou langue. Élargissez vos filtres ou dézoomez.",
+    "welcomeToPangeaChat": "Bienvenue dans Pangea Chat",
+    "claimTrial": "Réclamez votre essai",
+    "thanksForSigningUp": "Merci de vous être inscrit ! Voici",
+    "sevenDaysFree": "7 JOURS GRATUITS",
+    "manageTrialInSettings": "Gérez votre essai à tout moment dans\nParamètres d'abonnement",
+    "noCreditCardRequired": "Aucune carte de crédit requise.",
+    "proFeatures": "PRO",
+    "widenSearch": "Élargir la recherche",
+    "scrollToBottom": "Faire défiler vers le bas",
+    "courseImage": "Image du cours",
+    "avatarPreview": "Aperçu de l'avatar",
+    "activityPhoto": "Photo d'activité",
+    "emotePreview": "Aperçu de l'émoticône : {name}",
+    "activityLabel": "Activité : {title}",
+    "resetMapView": "Réinitialiser la vue de la carte",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ga.arb
+++ b/lib/l10n/intl_ga.arb
@@ -3948,7 +3948,7 @@
     "playWithAI": "Imir le AI faoi láthair",
     "courseStartDesc": "Tá Bot Pangea réidh chun dul am ar bith!\n\n...ach is fearr foghlaim le cairde!",
     "@@locale": "ga",
-    "@@last_modified": "2026-06-18 09:35:56.036456",
+    "@@last_modified": "2026-06-26 10:55:22.486434",
     "@writeAMessageLangCodes": {
         "type": "String",
         "placeholders": {
@@ -9881,6 +9881,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Bí i gcúrsa a chuimsíonn an gníomhaíocht seo chun é a imirt.",
+    "resizeCoursePanel": "Athraigh méid painéil an chúrsa",
+    "undo": "Athraigh",
+    "unlock": "Díghlas",
+    "zoomIn": "Méadú gníomh",
+    "zoomOut": "Laghdú gníomh",
+    "stars": "Réaltaí",
+    "addNewCourse": "Cuir cúrsa nua leis",
+    "world": "Domhan",
+    "addCourseStartMyOwn": "Tosaigh mo chuid féin",
+    "addCourseEnterCode": "Cuir isteach cód don chúrsa príobháideach",
+    "addCourseBrowsePublic": "Brabhsáil cúrsaí poiblí",
+    "browsePublicCourses": "Brabhsáil cúrsaí poiblí",
+    "editProfile": "Cuir in eagar próifíl",
+    "numObjectives": "{count} cuspóirí",
+    "mapSearchHint": "Cuardaigh gníomhaíochtaí",
+    "mapSearchNoResults": "Níl aon comhoiriúnachtaí le feiceáil",
+    "mapFilterAllLanguages": "Gach teanga",
+    "mapFilterNotStarted": "Níl tosaithe",
+    "mapFilterInProgress": "I gcion",
+    "mapFilterCompleted": "Críochnaithe",
+    "mapFilterReset": "Athshocraigh",
+    "activityTypeConversation": "Comhrá",
+    "lockedMissionRequirement": "Críochnaigh an misean roimhe seo chun é a dhíghlasáil",
+    "playAgain": "Imir arís",
+    "reviewActivity": "Athbhreithniú",
+    "mapEmptyInView": "Níl aon rud anseo ag do leibhéal nó do theanga. Leathnaigh do scagairí nó déan an radharc níos mó.",
+    "welcomeToPangeaChat": "Fáilte go Pangea Chat",
+    "claimTrial": "Éiligh do thriail",
+    "thanksForSigningUp": "Go raibh maith agat as clárú! Seo",
+    "sevenDaysFree": "7 LAETHANTA SAOR IN AISCE",
+    "manageTrialInSettings": "Bainistigh do thrialach aon uair sa\nSocruithe Suibscríofa",
+    "noCreditCardRequired": "Níl cárta creidmheasa ag teastáil.",
+    "proFeatures": "PRO",
+    "widenSearch": "Leathnaigh cuardach",
+    "scrollToBottom": "Scrollaigh go bun",
+    "courseImage": "Íomhá cúrsa",
+    "avatarPreview": "Réamhamharc ar avatar",
+    "activityPhoto": "Grianghraf gníomhaíochta",
+    "emotePreview": "Réamhamharc ar emote: {name}",
+    "activityLabel": "Gníomhaíocht: {title}",
+    "resetMapView": "Athshocraigh an léarscáil",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_gl.arb
+++ b/lib/l10n/intl_gl.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "gl",
-    "@@last_modified": "2026-06-18 09:34:12.150605",
+    "@@last_modified": "2026-06-26 10:43:56.307820",
     "about": "Acerca de",
     "@about": {
         "type": "String",
@@ -9870,6 +9870,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Únete a un curso que inclúa esta actividade para xogar.",
+    "resizeCoursePanel": "Redimensionar paneis do curso",
+    "undo": "Desfacer",
+    "unlock": "Desbloquear",
+    "zoomIn": "Acercar",
+    "zoomOut": "Afastar",
+    "stars": "Estrelas",
+    "addNewCourse": "Engadir novo curso",
+    "world": "Mundo",
+    "addCourseStartMyOwn": "Comezar o meu propio",
+    "addCourseEnterCode": "Introduza o código para o curso privado",
+    "addCourseBrowsePublic": "Explorar cursos públicos",
+    "browsePublicCourses": "Explorar cursos públicos",
+    "editProfile": "Editar perfil",
+    "numObjectives": "{count} obxectivos",
+    "mapSearchHint": "Buscar actividades",
+    "mapSearchNoResults": "Sen coincidencias na vista",
+    "mapFilterAllLanguages": "Todas as linguas",
+    "mapFilterNotStarted": "Non comezado",
+    "mapFilterInProgress": "En progreso",
+    "mapFilterCompleted": "Completo",
+    "mapFilterReset": "Restablecer",
+    "activityTypeConversation": "Conversación",
+    "lockedMissionRequirement": "Termina a misión anterior para desbloquear",
+    "playAgain": "Xogar de novo",
+    "reviewActivity": "Revisión",
+    "mapEmptyInView": "Nada aquí no teu nivel ou idioma. Amplía os teus filtros ou afasta.",
+    "welcomeToPangeaChat": "Benvido a Pangea Chat",
+    "claimTrial": "Reclama a túa proba",
+    "thanksForSigningUp": "Grazas por inscribirte! Aquí está",
+    "sevenDaysFree": "7 DÍAS GRATIS",
+    "manageTrialInSettings": "Xestiona a túa proba en calquera momento en\nConfiguración de subscrición",
+    "noCreditCardRequired": "Non se require tarxeta de crédito.",
+    "proFeatures": "PRO",
+    "widenSearch": "Ampliar busca",
+    "scrollToBottom": "Desprázate ata o fondo",
+    "courseImage": "Imaxe do curso",
+    "avatarPreview": "Previsualización do avatar",
+    "activityPhoto": "Foto da actividade",
+    "emotePreview": "Previsualización do emote: {name}",
+    "activityLabel": "Actividade: {title}",
+    "resetMapView": "Restablecer vista do mapa",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_he.arb
+++ b/lib/l10n/intl_he.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:34:20.152416",
+    "@@last_modified": "2026-06-26 10:46:27.946162",
     "about": "אודות",
     "@about": {
         "type": "String",
@@ -10949,6 +10949,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "הצטרף לקורס שכולל את הפעילות הזו כדי לשחק בה.",
+    "resizeCoursePanel": "שנה גודל פאנל הקורס",
+    "undo": "בטל",
+    "unlock": "שחרר",
+    "zoomIn": "התקרב",
+    "zoomOut": "התרחק",
+    "stars": "כוכבים",
+    "addNewCourse": "הוסף קורס חדש",
+    "world": "עולם",
+    "addCourseStartMyOwn": "התחל את שלי",
+    "addCourseEnterCode": "הזן קוד לקורס פרטי",
+    "addCourseBrowsePublic": "עיין בקורסים ציבוריים",
+    "browsePublicCourses": "עיין בקורסים ציבוריים",
+    "editProfile": "ערוך פרופיל",
+    "numObjectives": "{count} מטרות",
+    "mapSearchHint": "חפש פעילויות",
+    "mapSearchNoResults": "אין תוצאות בתצוגה",
+    "mapFilterAllLanguages": "כל השפות",
+    "mapFilterNotStarted": "לא התחיל",
+    "mapFilterInProgress": "בתהליך",
+    "mapFilterCompleted": "הושלם",
+    "mapFilterReset": "אפס",
+    "activityTypeConversation": "שיחה",
+    "lockedMissionRequirement": "סיים את המשימה הקודמת כדי לפתוח",
+    "playAgain": "שחק שוב",
+    "reviewActivity": "סקירה",
+    "mapEmptyInView": "אין כאן כלום ברמתך או בשפתך. הרחב את המסננים שלך או התקרב.",
+    "welcomeToPangeaChat": "ברוך הבא לפנגיאה צ'אט",
+    "claimTrial": "דרוש את הניסיון שלך",
+    "thanksForSigningUp": "תודה על ההרשמה! הנה",
+    "sevenDaysFree": "7 ימים חינם",
+    "manageTrialInSettings": "נהל את הניסיון שלך בכל עת ב\nהגדרות המנוי",
+    "noCreditCardRequired": "אין צורך בכרטיס אשראי.",
+    "proFeatures": "פרו",
+    "widenSearch": "הרחב חיפוש",
+    "scrollToBottom": "גלול לתחתית",
+    "courseImage": "תמונת קורס",
+    "avatarPreview": "תצוגה מקדימה של אווטאר",
+    "activityPhoto": "תמונת פעילות",
+    "emotePreview": "תצוגה מקדימה של אמוט: {name}",
+    "activityLabel": "פעילות: {title}",
+    "resetMapView": "אפס את תצוגת המפה",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_hi.arb
+++ b/lib/l10n/intl_hi.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "अभी के लिए एआई के साथ खेलें",
     "courseStartDesc": "पैंजिया बॉट कभी भी जाने के लिए तैयार है!\n\n...लेकिन दोस्तों के साथ सीखना बेहतर है!",
     "@@locale": "hi",
-    "@@last_modified": "2026-06-18 09:35:50.962394",
+    "@@last_modified": "2026-06-26 10:54:17.170602",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10589,6 +10589,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "इस गतिविधि को खेलने के लिए एक पाठ्यक्रम में शामिल हों।",
+    "resizeCoursePanel": "पाठ्यक्रम पैनल का आकार बदलें",
+    "undo": "पूर्ववत करें",
+    "unlock": "अनलॉक करें",
+    "zoomIn": "ज़ूम इन करें",
+    "zoomOut": "ज़ूम आउट करें",
+    "stars": "तारे",
+    "addNewCourse": "नया पाठ्यक्रम जोड़ें",
+    "world": "दुनिया",
+    "addCourseStartMyOwn": "अपना खुद का शुरू करें",
+    "addCourseEnterCode": "निजी पाठ्यक्रम के लिए कोड दर्ज करें",
+    "addCourseBrowsePublic": "सार्वजनिक पाठ्यक्रम ब्राउज़ करें",
+    "browsePublicCourses": "सार्वजनिक पाठ्यक्रम ब्राउज़ करें",
+    "editProfile": "प्रोफ़ाइल संपादित करें",
+    "numObjectives": "{count} उद्देश्य",
+    "mapSearchHint": "गतिविधियों की खोज करें",
+    "mapSearchNoResults": "दृश्य में कोई मेल नहीं",
+    "mapFilterAllLanguages": "सभी भाषाएँ",
+    "mapFilterNotStarted": "शुरू नहीं हुआ",
+    "mapFilterInProgress": "प्रगति पर",
+    "mapFilterCompleted": "पूर्ण",
+    "mapFilterReset": "रीसेट",
+    "activityTypeConversation": "संवाद",
+    "lockedMissionRequirement": "अनलॉक करने के लिए पिछले मिशन को पूरा करें",
+    "playAgain": "फिर से खेलें",
+    "reviewActivity": "समीक्षा करें",
+    "mapEmptyInView": "आपके स्तर या भाषा में यहाँ कुछ नहीं है। अपने फ़िल्टर को चौड़ा करें या ज़ूम आउट करें।",
+    "welcomeToPangeaChat": "Pangea चैट में आपका स्वागत है",
+    "claimTrial": "अपना परीक्षण दावा करें",
+    "thanksForSigningUp": "साइन अप करने के लिए धन्यवाद! यहाँ है",
+    "sevenDaysFree": "7 दिन मुफ्त",
+    "manageTrialInSettings": "किसी भी समय अपने ट्रायल को प्रबंधित करें\nसदस्यता सेटिंग्स में",
+    "noCreditCardRequired": "कोई क्रेडिट कार्ड आवश्यक नहीं है।",
+    "proFeatures": "प्रो",
+    "widenSearch": "खोज को विस्तारित करें",
+    "scrollToBottom": "नीचे स्क्रॉल करें",
+    "courseImage": "कोर्स छवि",
+    "avatarPreview": "अवतार पूर्वावलोकन",
+    "activityPhoto": "गतिविधि फोटो",
+    "emotePreview": "इमोट पूर्वावलोकन: {name}",
+    "activityLabel": "गतिविधि: {title}",
+    "resetMapView": "मानचित्र दृश्य रीसेट करें",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_hr.arb
+++ b/lib/l10n/intl_hr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "hr",
-    "@@last_modified": "2026-06-18 09:34:19.355393",
+    "@@last_modified": "2026-06-26 10:46:15.659555",
     "about": "Informacije",
     "@about": {
         "type": "String",
@@ -10354,6 +10354,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Pridružite se tečaju koji uključuje ovu aktivnost da biste je igrali.",
+    "resizeCoursePanel": "Promijeni veličinu panela tečaja",
+    "undo": "Poništi",
+    "unlock": "Otključaj",
+    "zoomIn": "Povećaj",
+    "zoomOut": "Smanji",
+    "stars": "Zvijezde",
+    "addNewCourse": "Dodaj novi tečaj",
+    "world": "Svijet",
+    "addCourseStartMyOwn": "Započni svoj vlastiti",
+    "addCourseEnterCode": "Unesite kod za privatni tečaj",
+    "addCourseBrowsePublic": "Pretraži javne tečajeve",
+    "browsePublicCourses": "Pretraži javne tečajeve",
+    "editProfile": "Uredi profil",
+    "numObjectives": "{count} ciljeva",
+    "mapSearchHint": "Pretraži aktivnosti",
+    "mapSearchNoResults": "Nema podudaranja u prikazu",
+    "mapFilterAllLanguages": "Svi jezici",
+    "mapFilterNotStarted": "Nije započeto",
+    "mapFilterInProgress": "U tijeku",
+    "mapFilterCompleted": "Završeno",
+    "mapFilterReset": "Ponovno postavi",
+    "activityTypeConversation": "Razgovor",
+    "lockedMissionRequirement": "Završi prethodnu misiju da bi otključao",
+    "playAgain": "Igraj ponovo",
+    "reviewActivity": "Pregledaj",
+    "mapEmptyInView": "Nema ništa ovdje na tvojoj razini ili jeziku. Proširi svoje filtre ili odmakni se.",
+    "welcomeToPangeaChat": "Dobrodošao u Pangea Chat",
+    "claimTrial": "Zatraži svoj probni period",
+    "thanksForSigningUp": "Hvala na prijavi! Evo",
+    "sevenDaysFree": "7 DANA BESPLATNO",
+    "manageTrialInSettings": "Upravite svoju probu u bilo kojem trenutku u\nPostavkama pretplate",
+    "noCreditCardRequired": "Nema potrebe za kreditnom karticom.",
+    "proFeatures": "PRO",
+    "widenSearch": "Proširi pretraživanje",
+    "scrollToBottom": "Pomakni se do dna",
+    "courseImage": "Slika tečaja",
+    "avatarPreview": "Pregled avatara",
+    "activityPhoto": "Fotografija aktivnosti",
+    "emotePreview": "Pregled emota: {name}",
+    "activityLabel": "Aktivnost: {title}",
+    "resetMapView": "Poništi prikaz karte",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_hu.arb
+++ b/lib/l10n/intl_hu.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "hu",
-    "@@last_modified": "2026-06-18 09:34:14.728048",
+    "@@last_modified": "2026-06-26 10:45:12.990244",
     "about": "Névjegy",
     "@about": {
         "type": "String",
@@ -9997,6 +9997,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Csatlakozz egy olyan kurzushoz, amely tartalmazza ezt a tevékenységet, hogy játszhass vele.",
+    "resizeCoursePanel": "Kurzuspanel átméretezése",
+    "undo": "Visszavonás",
+    "unlock": "Feloldás",
+    "zoomIn": "Nagyítás",
+    "zoomOut": "Kicsinyítés",
+    "stars": "Csillagok",
+    "addNewCourse": "Új kurzus hozzáadása",
+    "world": "Világ",
+    "addCourseStartMyOwn": "Saját kurzus indítása",
+    "addCourseEnterCode": "Írja be a kódot a privát kurzushoz",
+    "addCourseBrowsePublic": "Böngésszen a nyilvános kurzusok között",
+    "browsePublicCourses": "Böngésszen a nyilvános kurzusok között",
+    "editProfile": "Profil szerkesztése",
+    "numObjectives": "{count} cél",
+    "mapSearchHint": "Tevékenységek keresése",
+    "mapSearchNoResults": "Nincsenek találatok a nézetben",
+    "mapFilterAllLanguages": "Minden nyelv",
+    "mapFilterNotStarted": "Nem indult el",
+    "mapFilterInProgress": "Folyamatban",
+    "mapFilterCompleted": "Befejezett",
+    "mapFilterReset": "Visszaállítás",
+    "activityTypeConversation": "Beszélgetés",
+    "lockedMissionRequirement": "Fejezd be az előző küldetést a feloldáshoz",
+    "playAgain": "Játssz újra",
+    "reviewActivity": "Áttekintés",
+    "mapEmptyInView": "Itt semmi sincs a szintedhez vagy nyelvedhez. Szélesítsd a szűrőidet vagy nagyíts ki.",
+    "welcomeToPangeaChat": "Üdvözlünk a Pangea Chatben",
+    "claimTrial": "Kérd az ingyenes próbát",
+    "thanksForSigningUp": "Köszönjük, hogy regisztráltál! Itt van",
+    "sevenDaysFree": "7 NAP INGYEN",
+    "manageTrialInSettings": "Kezeld a próbádat bármikor a\nElőfizetés beállításokban",
+    "noCreditCardRequired": "Nincs szükség hitelkártyára.",
+    "proFeatures": "PRO",
+    "widenSearch": "Keresés szélesítése",
+    "scrollToBottom": "Görgetés az aljára",
+    "courseImage": "Tanfolyam kép",
+    "avatarPreview": "Avatar előnézet",
+    "activityPhoto": "Tevékenység fénykép",
+    "emotePreview": "Emote előnézet: {name}",
+    "activityLabel": "Tevékenység: {title}",
+    "resetMapView": "Térkép nézet visszaállítása",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ia.arb
+++ b/lib/l10n/intl_ia.arb
@@ -1505,7 +1505,7 @@
     "playWithAI": "Joca con le IA pro ora",
     "courseStartDesc": "Pangea Bot es preste a comenzar a qualunque momento!\n\n...ma apprender es melior con amicos!",
     "@@locale": "ia",
-    "@@last_modified": "2026-06-18 09:34:20.913941",
+    "@@last_modified": "2026-06-26 10:46:40.851270",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10980,6 +10980,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Joi un cursu ke incluy esta actividad pa xugarlo.",
+    "resizeCoursePanel": "Redimensionar panel de cursu",
+    "undo": "Desfacer",
+    "unlock": "Desbloquear",
+    "zoomIn": "Ampliar",
+    "zoomOut": "Reducir",
+    "stars": "Estrellas",
+    "addNewCourse": "Añadir nuevu cursu",
+    "world": "Mundu",
+    "addCourseStartMyOwn": "Empezar el mio propiu",
+    "addCourseEnterCode": "Entro kodo por privata kurso",
+    "addCourseBrowsePublic": "Brosu publikajn kursojn",
+    "browsePublicCourses": "Brosu publikajn kursojn",
+    "editProfile": "Redaktu profilon",
+    "numObjectives": "{count} objektivoj",
+    "mapSearchHint": "Serĉu aktivecojn",
+    "mapSearchNoResults": "Neniuj kongruoj en vido",
+    "mapFilterAllLanguages": "Ĉiuj lingvoj",
+    "mapFilterNotStarted": "Ne komencita",
+    "mapFilterInProgress": "En progreso",
+    "mapFilterCompleted": "Completo",
+    "mapFilterReset": "Resetar",
+    "activityTypeConversation": "Conversa",
+    "lockedMissionRequirement": "Termine a missão anterior para desbloquear",
+    "playAgain": "Jogar novamente",
+    "reviewActivity": "Revisar",
+    "mapEmptyInView": "Nada aqui no seu nível ou idioma. Amplie seus filtros ou afaste-se.",
+    "welcomeToPangeaChat": "Bem-vindo ao Pangea Chat",
+    "claimTrial": "Reivindique seu teste",
+    "thanksForSigningUp": "Obrigado por se inscrever! Aqui está",
+    "sevenDaysFree": "7 DIAS LIBRES",
+    "manageTrialInSettings": "Gestiona tu prueba en cualquier momento en\nConfiguración de Suscripción",
+    "noCreditCardRequired": "No se requiere tarjeta de crédito.",
+    "proFeatures": "PRO",
+    "widenSearch": "Ampliar búsqueda",
+    "scrollToBottom": "Desplazarse hasta el final",
+    "courseImage": "Imagen del curso",
+    "avatarPreview": "Vista previa del avatar",
+    "activityPhoto": "Foto de actividad",
+    "emotePreview": "Vista previa de emote: {name}",
+    "activityLabel": "Aktiviteet: {title}",
+    "resetMapView": "Resetti kaardi vaade",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:34:15.472313",
+    "@@last_modified": "2026-06-26 10:45:24.455054",
     "setAsCanonicalAlias": "Atur sebagai alias utama",
     "@setAsCanonicalAlias": {
         "type": "String",
@@ -9967,6 +9967,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Bergabunglah dengan kursus yang mencakup aktivitas ini untuk memainkannya.",
+    "resizeCoursePanel": "Ubah ukuran panel kursus",
+    "undo": "Batalkan",
+    "unlock": "Buka kunci",
+    "zoomIn": "Perbesar",
+    "zoomOut": "Perkecil",
+    "stars": "Bintang",
+    "addNewCourse": "Tambahkan kursus baru",
+    "world": "Dunia",
+    "addCourseStartMyOwn": "Mulai kursus saya sendiri",
+    "addCourseEnterCode": "Masukkan kode untuk kursus pribadi",
+    "addCourseBrowsePublic": "Jelajahi kursus publik",
+    "browsePublicCourses": "Jelajahi kursus publik",
+    "editProfile": "Edit profil",
+    "numObjectives": "{count} tujuan",
+    "mapSearchHint": "Cari aktivitas",
+    "mapSearchNoResults": "Tidak ada kecocokan dalam tampilan",
+    "mapFilterAllLanguages": "Semua bahasa",
+    "mapFilterNotStarted": "Belum dimulai",
+    "mapFilterInProgress": "Sedang berlangsung",
+    "mapFilterCompleted": "Selesai",
+    "mapFilterReset": "Atur Ulang",
+    "activityTypeConversation": "Percakapan",
+    "lockedMissionRequirement": "Selesaikan misi sebelumnya untuk membuka kunci",
+    "playAgain": "Main lagi",
+    "reviewActivity": "Tinjau",
+    "mapEmptyInView": "Tidak ada di sini pada level atau bahasa Anda. Perluas filter Anda atau perbesar.",
+    "welcomeToPangeaChat": "Selamat datang di Pangea Chat",
+    "claimTrial": "Klaim percobaan Anda",
+    "thanksForSigningUp": "Terima kasih telah mendaftar! Ini dia",
+    "sevenDaysFree": "7 HARI GRATIS",
+    "manageTrialInSettings": "Kelola percobaan Anda kapan saja di\nPengaturan Langganan",
+    "noCreditCardRequired": "Tidak diperlukan kartu kredit.",
+    "proFeatures": "PRO",
+    "widenSearch": "Perluas pencarian",
+    "scrollToBottom": "Gulir ke bawah",
+    "courseImage": "Gambar kursus",
+    "avatarPreview": "Prabaca avatar",
+    "activityPhoto": "Foto aktivitas",
+    "emotePreview": "Prabaca emote: {name}",
+    "activityLabel": "Aktivitas: {title}",
+    "resetMapView": "Atur ulang tampilan peta",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ie.arb
+++ b/lib/l10n/intl_ie.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "Joca con AI pro ora",
     "courseStartDesc": "Pangea Bot es preste a partir a qualunque momento!\n\n...ma apprender es melior con amicos!",
     "@@locale": "ie",
-    "@@last_modified": "2026-06-18 09:34:18.121248",
+    "@@last_modified": "2026-06-26 10:45:58.469008",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10589,6 +10589,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Bain páirt i gcúrsa a chuimsíonn an gníomhaíocht seo chun é a imirt.",
+    "resizeCoursePanel": "Athraigh méid painéil an chúrsa",
+    "undo": "Athghairm",
+    "unlock": "Díghlas",
+    "zoomIn": "Méadú",
+    "zoomOut": "Laghdú",
+    "stars": "Réaltaí",
+    "addNewCourse": "Cuir cúrsa nua leis",
+    "world": "Domhan",
+    "addCourseStartMyOwn": "Tosaigh mo chuid féin",
+    "addCourseEnterCode": "Entrez le code pour le cours privé",
+    "addCourseBrowsePublic": "Parcourir les cours publics",
+    "browsePublicCourses": "Parcourir les cours publics",
+    "editProfile": "Modifier le profil",
+    "numObjectives": "{count} objectifs",
+    "mapSearchHint": "Rechercher des activités",
+    "mapSearchNoResults": "Aucun résultat dans la vue",
+    "mapFilterAllLanguages": "Toutes les langues",
+    "mapFilterNotStarted": "Pas commencé",
+    "mapFilterInProgress": "En cours",
+    "mapFilterCompleted": "Completado",
+    "mapFilterReset": "Reiniciar",
+    "activityTypeConversation": "Conversación",
+    "lockedMissionRequirement": "Termina la misión anterior para desbloquear",
+    "playAgain": "Jugar de nuevo",
+    "reviewActivity": "Revisar",
+    "mapEmptyInView": "Nada aquí en tu nivel o idioma. Amplía tus filtros o aleja.",
+    "welcomeToPangeaChat": "Bienvenido a Pangea Chat",
+    "claimTrial": "Reclama tu prueba",
+    "thanksForSigningUp": "¡Gracias por registrarte! Aquí está",
+    "sevenDaysFree": "7 DIAS GRÁTIS",
+    "manageTrialInSettings": "Gerencie seu teste a qualquer momento em\nConfigurações de Assinatura",
+    "noCreditCardRequired": "Nenhum cartão de crédito necessário.",
+    "proFeatures": "PRO",
+    "widenSearch": "Ampliar busca",
+    "scrollToBottom": "Role até o final",
+    "courseImage": "Imagem do curso",
+    "avatarPreview": "Pré-visualização do avatar",
+    "activityPhoto": "Foto da atividade",
+    "emotePreview": "Pré-visualização do emote: {name}",
+    "activityLabel": "Gníomhaíocht: {title}",
+    "resetMapView": "Athshocraigh an léarscáil",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:34:28.759613",
+    "@@last_modified": "2026-06-26 10:48:19.981294",
     "about": "Informazioni",
     "@about": {
         "type": "String",
@@ -9961,6 +9961,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Unisciti a un corso che include questa attività per giocarla.",
+    "resizeCoursePanel": "Ridimensiona il pannello del corso",
+    "undo": "Annulla",
+    "unlock": "Sblocca",
+    "zoomIn": "Ingrandisci",
+    "zoomOut": "Riduci",
+    "stars": "Stelle",
+    "addNewCourse": "Aggiungi nuovo corso",
+    "world": "Mondo",
+    "addCourseStartMyOwn": "Inizia il mio",
+    "addCourseEnterCode": "Inserisci il codice per il corso privato",
+    "addCourseBrowsePublic": "Sfoglia i corsi pubblici",
+    "browsePublicCourses": "Sfoglia i corsi pubblici",
+    "editProfile": "Modifica profilo",
+    "numObjectives": "{count} obiettivi",
+    "mapSearchHint": "Cerca attività",
+    "mapSearchNoResults": "Nessuna corrispondenza in vista",
+    "mapFilterAllLanguages": "Tutte le lingue",
+    "mapFilterNotStarted": "Non iniziato",
+    "mapFilterInProgress": "In corso",
+    "mapFilterCompleted": "Completato",
+    "mapFilterReset": "Ripristina",
+    "activityTypeConversation": "Conversazione",
+    "lockedMissionRequirement": "Completa la missione precedente per sbloccare",
+    "playAgain": "Gioca di nuovo",
+    "reviewActivity": "Recensione",
+    "mapEmptyInView": "Niente qui al tuo livello o lingua. Allarga i tuoi filtri o allontanati.",
+    "welcomeToPangeaChat": "Benvenuto in Pangea Chat",
+    "claimTrial": "Richiedi la tua prova",
+    "thanksForSigningUp": "Grazie per esserti registrato! Ecco",
+    "sevenDaysFree": "7 GIORNI GRATIS",
+    "manageTrialInSettings": "Gestisci la tua prova in qualsiasi momento in\nImpostazioni abbonamento",
+    "noCreditCardRequired": "Nessuna carta di credito richiesta.",
+    "proFeatures": "PRO",
+    "widenSearch": "Amplia la ricerca",
+    "scrollToBottom": "Scorri fino in fondo",
+    "courseImage": "Immagine del corso",
+    "avatarPreview": "Anteprima dell'avatar",
+    "activityPhoto": "Foto dell'attività",
+    "emotePreview": "Anteprima dell'emote: {name}",
+    "activityLabel": "Attività: {title}",
+    "resetMapView": "Ripristina la vista della mappa",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ja",
-    "@@last_modified": "2026-06-18 09:35:50.121318",
+    "@@last_modified": "2026-06-26 10:54:00.565831",
     "about": "このアプリについて",
     "@about": {
         "type": "String",
@@ -10738,6 +10738,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "このアクティビティをプレイするには、これを含むコースに参加してください。",
+    "resizeCoursePanel": "コースパネルのサイズを変更",
+    "undo": "元に戻す",
+    "unlock": "ロック解除",
+    "zoomIn": "ズームイン",
+    "zoomOut": "ズームアウト",
+    "stars": "星",
+    "addNewCourse": "新しいコースを追加",
+    "world": "世界",
+    "addCourseStartMyOwn": "自分のコースを始める",
+    "addCourseEnterCode": "プライベートコースのコードを入力してください",
+    "addCourseBrowsePublic": "公開コースをブラウズ",
+    "browsePublicCourses": "公開コースをブラウズ",
+    "editProfile": "プロフィールを編集",
+    "numObjectives": "{count} の目標",
+    "mapSearchHint": "アクティビティを検索",
+    "mapSearchNoResults": "表示中に一致するものはありません",
+    "mapFilterAllLanguages": "すべての言語",
+    "mapFilterNotStarted": "未開始",
+    "mapFilterInProgress": "進行中",
+    "mapFilterCompleted": "完了",
+    "mapFilterReset": "リセット",
+    "activityTypeConversation": "会話",
+    "lockedMissionRequirement": "前のミッションを完了してロックを解除してください",
+    "playAgain": "再度プレイ",
+    "reviewActivity": "レビュー",
+    "mapEmptyInView": "あなたのレベルまたは言語では何もありません。フィルターを広げるか、ズームアウトしてください。",
+    "welcomeToPangeaChat": "Pangea Chatへようこそ",
+    "claimTrial": "トライアルを請求する",
+    "thanksForSigningUp": "サインアップありがとうございます！こちらが",
+    "sevenDaysFree": "7日間無料",
+    "manageTrialInSettings": "サブスクリプション設定でいつでもトライアルを管理できます",
+    "noCreditCardRequired": "クレジットカードは不要です。",
+    "proFeatures": "プロ",
+    "widenSearch": "検索を広げる",
+    "scrollToBottom": "下にスクロール",
+    "courseImage": "コース画像",
+    "avatarPreview": "アバタープレビュー",
+    "activityPhoto": "アクティビティ写真",
+    "emotePreview": "エモートプレビュー: {name}",
+    "activityLabel": "アクティビティ: {title}",
+    "resetMapView": "マップビューをリセット",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ka.arb
+++ b/lib/l10n/intl_ka.arb
@@ -2098,7 +2098,7 @@
     "playWithAI": "ამ დროისთვის ითამაშეთ AI-თან",
     "courseStartDesc": "Pangea Bot მზადაა ნებისმიერ დროს გასასვლელად!\n\n...მაგრამ სწავლა უკეთესია მეგობრებთან ერთად!",
     "@@locale": "ka",
-    "@@last_modified": "2026-06-18 09:35:53.870844",
+    "@@last_modified": "2026-06-26 10:55:00.665826",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10938,6 +10938,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "შეერთდით კურსს, რომელიც მოიცავს ამ აქტივობას, რომ ითამაშოთ იგი.",
+    "resizeCoursePanel": "კურსის პანელის ზომის შეცვლა",
+    "undo": "გაუქმება",
+    "unlock": "გახსნა",
+    "zoomIn": "ზომის გაზრდა",
+    "zoomOut": "ზომის შემცირება",
+    "stars": "ვარსკვლავები",
+    "addNewCourse": "ახალი კურსის დამატება",
+    "world": "მსოფლიო",
+    "addCourseStartMyOwn": "ჩემი საკუთარი დაწყება",
+    "addCourseEnterCode": "შეიყვანეთ კოდი კერძო კურსისთვის",
+    "addCourseBrowsePublic": "გადახედეთ საჯარო კურსებს",
+    "browsePublicCourses": "გადახედეთ საჯარო კურსებს",
+    "editProfile": "რედაქტირება პროფილში",
+    "numObjectives": "{count} მიზანი",
+    "mapSearchHint": "ძებნა აქტივობებში",
+    "mapSearchNoResults": "არ არის შესაბამისი შედეგები",
+    "mapFilterAllLanguages": "ყველა ენა",
+    "mapFilterNotStarted": "არ დაწყებულა",
+    "mapFilterInProgress": "მიმდინარეა",
+    "mapFilterCompleted": "დასრულებულია",
+    "mapFilterReset": "გაასუფთავე",
+    "activityTypeConversation": "საუბარი",
+    "lockedMissionRequirement": "გთხოვთ, დაასრულოთ წინა მისია, რომ გაახსნათ",
+    "playAgain": "მორიგე თამაში",
+    "reviewActivity": "მიმოხილვა",
+    "mapEmptyInView": "აქ არაფერია თქვენს დონეზე ან ენაზე. გააფართოვეთ თქვენი ფილტრები ან დააკლებეთ ზუმი.",
+    "welcomeToPangeaChat": "კეთილი იყოს თქვენი მობრძანება Pangea Chat-ში",
+    "claimTrial": "მიითვისეთ თქვენი საცდელი ვადა",
+    "thanksForSigningUp": "გმადლობთ რეგისტრაციისთვის! აი",
+    "sevenDaysFree": "7 დღე უფასოდ",
+    "manageTrialInSettings": "მართეთ თქვენი საცდელი ვადა ნებისმიერ დროს\nწევრობის პარამეტრებში",
+    "noCreditCardRequired": "არ არის საჭირო საკრედიტო ბარათი.",
+    "proFeatures": "პროფესიონალური",
+    "widenSearch": "ძებნის გაფართოება",
+    "scrollToBottom": "ქვედა მხარეზე გადახვევა",
+    "courseImage": "კურსის სურათი",
+    "avatarPreview": "ავატარის წინასწარი ნახვა",
+    "activityPhoto": "აქტივობის ფოტო",
+    "emotePreview": "ემოჯის წინასწარი ნახვა: {name}",
+    "activityLabel": "აქტივობა: {title}",
+    "resetMapView": "მონიტორის ხედვის აღდგენა",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:34:09.795788",
+    "@@last_modified": "2026-06-26 10:43:27.209838",
     "about": "소개",
     "@about": {
         "type": "String",
@@ -10087,6 +10087,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "이 활동을 플레이하려면 이 활동이 포함된 코스를 가입하세요.",
+    "resizeCoursePanel": "코스 패널 크기 조정",
+    "undo": "실행 취소",
+    "unlock": "잠금 해제",
+    "zoomIn": "확대",
+    "zoomOut": "축소",
+    "stars": "별",
+    "addNewCourse": "새 코스 추가",
+    "world": "세계",
+    "addCourseStartMyOwn": "내 코스 시작",
+    "addCourseEnterCode": "비공식 과정 코드를 입력하세요",
+    "addCourseBrowsePublic": "공개 과정 탐색",
+    "browsePublicCourses": "공개 과정 탐색",
+    "editProfile": "프로필 수정",
+    "numObjectives": "{count} 개의 목표",
+    "mapSearchHint": "활동 검색",
+    "mapSearchNoResults": "일치하는 항목이 없습니다",
+    "mapFilterAllLanguages": "모든 언어",
+    "mapFilterNotStarted": "시작하지 않음",
+    "mapFilterInProgress": "진행 중",
+    "mapFilterCompleted": "완료됨",
+    "mapFilterReset": "재설정",
+    "activityTypeConversation": "대화",
+    "lockedMissionRequirement": "이전 미션을 완료하여 잠금을 해제하세요",
+    "playAgain": "다시 플레이",
+    "reviewActivity": "검토",
+    "mapEmptyInView": "귀하의 수준이나 언어에 해당하는 내용이 없습니다. 필터를 넓히거나 축소하세요.",
+    "welcomeToPangeaChat": "Pangea Chat에 오신 것을 환영합니다",
+    "claimTrial": "체험판을 신청하세요",
+    "thanksForSigningUp": "가입해 주셔서 감사합니다! 여기에",
+    "sevenDaysFree": "7일 무료",
+    "manageTrialInSettings": "구독 설정에서 언제든지 체험판을 관리하세요",
+    "noCreditCardRequired": "신용카드가 필요하지 않습니다.",
+    "proFeatures": "프로",
+    "widenSearch": "검색 범위 넓히기",
+    "scrollToBottom": "맨 아래로 스크롤",
+    "courseImage": "강의 이미지",
+    "avatarPreview": "아바타 미리보기",
+    "activityPhoto": "활동 사진",
+    "emotePreview": "이모티콘 미리보기: {name}",
+    "activityLabel": "활동: {title}",
+    "resetMapView": "지도 보기 초기화",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_lt.arb
+++ b/lib/l10n/intl_lt.arb
@@ -3245,7 +3245,7 @@
     "playWithAI": "Žaiskite su dirbtiniu intelektu dabar",
     "courseStartDesc": "Pangea botas pasiruošęs bet kada pradėti!\n\n...bet mokymasis yra geresnis su draugais!",
     "@@locale": "lt",
-    "@@last_modified": "2026-06-18 09:35:34.862247",
+    "@@last_modified": "2026-06-26 10:51:37.535298",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10756,6 +10756,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Prisijunkite prie kurso, kuris apima šią veiklą, kad galėtumėte ją žaisti.",
+    "resizeCoursePanel": "Pakeisti kurso skydelio dydį",
+    "undo": "Atšaukti",
+    "unlock": "Atrakinti",
+    "zoomIn": "Priartinti",
+    "zoomOut": "Nutolinti",
+    "stars": "Žvaigždės",
+    "addNewCourse": "Pridėti naują kursą",
+    "world": "Pasaulis",
+    "addCourseStartMyOwn": "Pradėti savo",
+    "addCourseEnterCode": "Įveskite privatų kurso kodą",
+    "addCourseBrowsePublic": "Naršyti viešus kursus",
+    "browsePublicCourses": "Naršyti viešus kursus",
+    "editProfile": "Redaguoti profilį",
+    "numObjectives": "{count} tikslai",
+    "mapSearchHint": "Ieškoti veiklų",
+    "mapSearchNoResults": "Nėra atitikmenų",
+    "mapFilterAllLanguages": "Visos kalbos",
+    "mapFilterNotStarted": "Nepradėta",
+    "mapFilterInProgress": "Vyksta",
+    "mapFilterCompleted": "Užbaigta",
+    "mapFilterReset": "Atstatyti",
+    "activityTypeConversation": "Pokalbis",
+    "lockedMissionRequirement": "Baigkite ankstesnę misiją, kad atrakintumėte",
+    "playAgain": "Žaisti vėl",
+    "reviewActivity": "Peržiūrėti",
+    "mapEmptyInView": "Čia nieko nėra jūsų lygyje ar kalba. Išplėskite filtrus arba priartinkite.",
+    "welcomeToPangeaChat": "Sveiki atvykę į Pangea Chat",
+    "claimTrial": "Prašome gauti savo bandomąją versiją",
+    "thanksForSigningUp": "Ačiū, kad užsiregistravote! Štai",
+    "sevenDaysFree": "7 DIENOS NEMOKAMAI",
+    "manageTrialInSettings": "Valdykite savo bandomąją versiją bet kada\nPrenumeratos nustatymuose",
+    "noCreditCardRequired": "Nereikia kredito kortelės.",
+    "proFeatures": "PRO",
+    "widenSearch": "Išplėsti paiešką",
+    "scrollToBottom": "Slinkti žemyn",
+    "courseImage": "Kurso nuotrauka",
+    "avatarPreview": "Avataro peržiūra",
+    "activityPhoto": "Veiklos nuotrauka",
+    "emotePreview": "Emocijos peržiūra: {name}",
+    "activityLabel": "Veikla: {title}",
+    "resetMapView": "Atstatyti žemėlapio vaizdą",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_lv.arb
+++ b/lib/l10n/intl_lv.arb
@@ -3919,7 +3919,7 @@
     "playWithAI": "Tagad spēlējiet ar AI",
     "courseStartDesc": "Pangea bots ir gatavs jebkurā laikā!\n\n...bet mācīties ir labāk ar draugiem!",
     "@@locale": "lv",
-    "@@last_modified": "2026-06-18 09:35:31.308871",
+    "@@last_modified": "2026-06-26 10:50:38.010880",
     "analyticsInactiveTitle": "Pieprasījumi neaktīviem lietotājiem nevar tikt nosūtīti",
     "analyticsInactiveDesc": "Neaktīvi lietotāji, kuri nav pieteikušies kopš šīs funkcijas ieviešanas, neredzēs jūsu pieprasījumu.\n\nPieprasījuma poga parādīsies, kad viņi atgriezīsies. Jūs varat atkārtoti nosūtīt pieprasījumu vēlāk, noklikšķinot uz pieprasījuma pogas viņu vārdā, kad tā būs pieejama.",
     "accessRequestedTitle": "Pieprasījums piekļūt analītikai",
@@ -9870,6 +9870,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Pievienojieties kursam, kas ietver šo aktivitāti, lai to spēlētu.",
+    "resizeCoursePanel": "Mainīt kursa paneļa izmēru",
+    "undo": "Atcelt",
+    "unlock": "Atbloķēt",
+    "zoomIn": "Tuvojiet",
+    "zoomOut": "Attālināt",
+    "stars": "Zvaigznes",
+    "addNewCourse": "Pievienot jaunu kursu",
+    "world": "Pasaule",
+    "addCourseStartMyOwn": "Sākt savu",
+    "addCourseEnterCode": "Ievadiet koda privātajam kursam",
+    "addCourseBrowsePublic": "Pārlūkot publiskos kursus",
+    "browsePublicCourses": "Pārlūkot publiskos kursus",
+    "editProfile": "Rediģēt profilu",
+    "numObjectives": "{count} mērķi",
+    "mapSearchHint": "Meklēt aktivitātes",
+    "mapSearchNoResults": "Nav atbilžu skatā",
+    "mapFilterAllLanguages": "Visas valodas",
+    "mapFilterNotStarted": "Nav uzsākts",
+    "mapFilterInProgress": "Norisinās",
+    "mapFilterCompleted": "Pabeigts",
+    "mapFilterReset": "Atjaunot",
+    "activityTypeConversation": "Saruna",
+    "lockedMissionRequirement": "Pabeidziet iepriekšējo misiju, lai atbloķētu",
+    "playAgain": "Spēlēt vēlreiz",
+    "reviewActivity": "Pārskatīt",
+    "mapEmptyInView": "Šeit nav nekas jūsu līmenī vai valodā. Paplašiniet savus filtrus vai tālummaiņu.",
+    "welcomeToPangeaChat": "Laipni lūdzam Pangea Čatā",
+    "claimTrial": "Pieteikties izmēģinājumam",
+    "thanksForSigningUp": "Paldies, ka reģistrējāties! Šeit ir",
+    "sevenDaysFree": "7 DIENAS BEZ MAKSAS",
+    "manageTrialInSettings": "Pārvaldiet savu izmēģinājumu jebkurā laikā\nAbonēšanas iestatījumos",
+    "noCreditCardRequired": "Nav nepieciešama kredītkarte.",
+    "proFeatures": "PRO",
+    "widenSearch": "Paplašināt meklēšanu",
+    "scrollToBottom": "Ritināt uz leju",
+    "courseImage": "Kursa attēls",
+    "avatarPreview": "Apskata attēls",
+    "activityPhoto": "Aktivitātes foto",
+    "emotePreview": "Emocijas priekšskatījums: {name}",
+    "activityLabel": "Aktivitāte: {title}",
+    "resetMapView": "Atjaunot kartes skatu",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_nb.arb
+++ b/lib/l10n/intl_nb.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:35:23.890472",
+    "@@last_modified": "2026-06-26 10:49:03.296123",
     "about": "Om",
     "@about": {
         "type": "String",
@@ -9930,6 +9930,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Bli med i et kurs som inkluderer denne aktiviteten for å spille den.",
+    "resizeCoursePanel": "Endre størrelse på kurspanel",
+    "undo": "Angre",
+    "unlock": "Lås opp",
+    "zoomIn": "Zoom inn",
+    "zoomOut": "Zoom ut",
+    "stars": "Stjerner",
+    "addNewCourse": "Legg til nytt kurs",
+    "world": "Verden",
+    "addCourseStartMyOwn": "Start mitt eget",
+    "addCourseEnterCode": "Skriv inn kode for privat kurs",
+    "addCourseBrowsePublic": "Bla gjennom offentlige kurs",
+    "browsePublicCourses": "Bla gjennom offentlige kurs",
+    "editProfile": "Rediger profil",
+    "numObjectives": "{count} mål",
+    "mapSearchHint": "Søk aktiviteter",
+    "mapSearchNoResults": "Ingen treff i visningen",
+    "mapFilterAllLanguages": "Alle språk",
+    "mapFilterNotStarted": "Ikke startet",
+    "mapFilterInProgress": "Pågår",
+    "mapFilterCompleted": "Fullført",
+    "mapFilterReset": "Tilbakestill",
+    "activityTypeConversation": "Samtale",
+    "lockedMissionRequirement": "Fullfør den forrige oppgaven for å låse opp",
+    "playAgain": "Spill igjen",
+    "reviewActivity": "Vurder",
+    "mapEmptyInView": "Ingenting her på ditt nivå eller språk. Utvid filtrene dine eller zoom ut.",
+    "welcomeToPangeaChat": "Velkommen til Pangea Chat",
+    "claimTrial": "Krev din prøveperiode",
+    "thanksForSigningUp": "Takk for at du registrerte deg! Her er",
+    "sevenDaysFree": "7 DAGER GRATIS",
+    "manageTrialInSettings": "Administrer prøveversjonen når som helst i\nAbonnementsinnstillinger",
+    "noCreditCardRequired": "Ingen kredittkort nødvendig.",
+    "proFeatures": "PRO",
+    "widenSearch": "Utvid søk",
+    "scrollToBottom": "Rull til bunnen",
+    "courseImage": "Kursbilde",
+    "avatarPreview": "Avatar forhåndsvisning",
+    "activityPhoto": "Aktivitetsbilde",
+    "emotePreview": "Emote forhåndsvisning: {name}",
+    "activityLabel": "Aktivitet: {title}",
+    "resetMapView": "Tilbakestill kartvisning",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:35:37.820513",
+    "@@last_modified": "2026-06-26 10:52:13.213148",
     "about": "Over ons",
     "@about": {
         "type": "String",
@@ -9870,6 +9870,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Sluit je aan bij een cursus die deze activiteit bevat om deze te spelen.",
+    "resizeCoursePanel": "Wijzig de grootte van het cursuspaneel",
+    "undo": "Ongedaan maken",
+    "unlock": "Ontgrendelen",
+    "zoomIn": "Inzoomen",
+    "zoomOut": "Uitzoomen",
+    "stars": "Sterren",
+    "addNewCourse": "Voeg nieuwe cursus toe",
+    "world": "Wereld",
+    "addCourseStartMyOwn": "Begin mijn eigen",
+    "addCourseEnterCode": "Voer code in voor privécursus",
+    "addCourseBrowsePublic": "Blader door openbare cursussen",
+    "browsePublicCourses": "Blader door openbare cursussen",
+    "editProfile": "Bewerk profiel",
+    "numObjectives": "{count} doelstellingen",
+    "mapSearchHint": "Zoek activiteiten",
+    "mapSearchNoResults": "Geen overeenkomsten in weergave",
+    "mapFilterAllLanguages": "Alle talen",
+    "mapFilterNotStarted": "Niet gestart",
+    "mapFilterInProgress": "Bezig",
+    "mapFilterCompleted": "Voltooid",
+    "mapFilterReset": "Resetten",
+    "activityTypeConversation": "Gesprek",
+    "lockedMissionRequirement": "Voltooi de vorige missie om te ontgrendelen",
+    "playAgain": "Speel opnieuw",
+    "reviewActivity": "Beoordelen",
+    "mapEmptyInView": "Niets hier op jouw niveau of taal. Verbreed je filters of zoom uit.",
+    "welcomeToPangeaChat": "Welkom bij Pangea Chat",
+    "claimTrial": "Claim je proefperiode",
+    "thanksForSigningUp": "Bedankt voor je aanmelding! Hier is",
+    "sevenDaysFree": "7 DAGEN GRATIS",
+    "manageTrialInSettings": "Beheer je proefperiode op elk moment in\nAbonnementsinstellingen",
+    "noCreditCardRequired": "Geen creditcard vereist.",
+    "proFeatures": "PRO",
+    "widenSearch": "Zoekopdracht verbreden",
+    "scrollToBottom": "Scroll naar beneden",
+    "courseImage": "Cursusafbeelding",
+    "avatarPreview": "Avatarvoorbeeld",
+    "activityPhoto": "Activiteitsfoto",
+    "emotePreview": "Emotevoorbeeld: {name}",
+    "activityLabel": "Activiteit: {title}",
+    "resetMapView": "Reset kaartweergave",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "pl",
-    "@@last_modified": "2026-06-18 09:35:43.631577",
+    "@@last_modified": "2026-06-26 10:53:19.015923",
     "about": "O aplikacji",
     "@about": {
         "type": "String",
@@ -9979,6 +9979,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Dołącz do kursu, który zawiera tę aktywność, aby w nią zagrać.",
+    "resizeCoursePanel": "Zmień rozmiar panelu kursu",
+    "undo": "Cofnij",
+    "unlock": "Odblokuj",
+    "zoomIn": "Powiększ",
+    "zoomOut": "Pomniejsz",
+    "stars": "Gwiazdy",
+    "addNewCourse": "Dodaj nowy kurs",
+    "world": "Świat",
+    "addCourseStartMyOwn": "Rozpocznij mój własny",
+    "addCourseEnterCode": "Wprowadź kod dla prywatnego kursu",
+    "addCourseBrowsePublic": "Przeglądaj publiczne kursy",
+    "browsePublicCourses": "Przeglądaj publiczne kursy",
+    "editProfile": "Edytuj profil",
+    "numObjectives": "{count} celów",
+    "mapSearchHint": "Szukaj aktywności",
+    "mapSearchNoResults": "Brak dopasowań w widoku",
+    "mapFilterAllLanguages": "Wszystkie języki",
+    "mapFilterNotStarted": "Nie rozpoczęto",
+    "mapFilterInProgress": "W trakcie",
+    "mapFilterCompleted": "Zakończone",
+    "mapFilterReset": "Resetuj",
+    "activityTypeConversation": "Rozmowa",
+    "lockedMissionRequirement": "Zakończ poprzednią misję, aby odblokować",
+    "playAgain": "Graj ponownie",
+    "reviewActivity": "Przegląd",
+    "mapEmptyInView": "Nic tutaj na twoim poziomie lub języku. Poszerz swoje filtry lub oddal widok.",
+    "welcomeToPangeaChat": "Witamy w Pangea Chat",
+    "claimTrial": "Zgłoś swoją wersję próbną",
+    "thanksForSigningUp": "Dziękujemy za rejestrację! Oto",
+    "sevenDaysFree": "7 DNI ZA DARMO",
+    "manageTrialInSettings": "Zarządzaj swoim okresem próbnym w każdej chwili w\nUstawieniach subskrypcji",
+    "noCreditCardRequired": "Nie jest wymagana karta kredytowa.",
+    "proFeatures": "PRO",
+    "widenSearch": "Poszerz wyszukiwanie",
+    "scrollToBottom": "Przewiń na dół",
+    "courseImage": "Obraz kursu",
+    "avatarPreview": "Podgląd awatara",
+    "activityPhoto": "Zdjęcie aktywności",
+    "emotePreview": "Podgląd emotki: {name}",
+    "activityLabel": "Aktywność: {title}",
+    "resetMapView": "Zresetuj widok mapy",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:34:24.479254",
+    "@@last_modified": "2026-06-26 10:47:17.883561",
     "copiedToClipboard": "Copiada para a área de transferência",
     "@copiedToClipboard": {
         "type": "String",
@@ -10988,6 +10988,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Junte-se a um curso que inclua esta atividade para jogá-la.",
+    "resizeCoursePanel": "Redimensionar painel do curso",
+    "undo": "Desfazer",
+    "unlock": "Desbloquear",
+    "zoomIn": "Aproximar",
+    "zoomOut": "Afastar",
+    "stars": "Estrelas",
+    "addNewCourse": "Adicionar novo curso",
+    "world": "Mundo",
+    "addCourseStartMyOwn": "Começar o meu próprio",
+    "addCourseEnterCode": "Insira o código para o curso privado",
+    "addCourseBrowsePublic": "Navegar por cursos públicos",
+    "browsePublicCourses": "Navegar por cursos públicos",
+    "editProfile": "Editar perfil",
+    "numObjectives": "{count} objetivos",
+    "mapSearchHint": "Pesquisar atividades",
+    "mapSearchNoResults": "Nenhuma correspondência na visualização",
+    "mapFilterAllLanguages": "Todos os idiomas",
+    "mapFilterNotStarted": "Não iniciado",
+    "mapFilterInProgress": "Em andamento",
+    "mapFilterCompleted": "Concluído",
+    "mapFilterReset": "Redefinir",
+    "activityTypeConversation": "Conversa",
+    "lockedMissionRequirement": "Termine a missão anterior para desbloquear",
+    "playAgain": "Jogar novamente",
+    "reviewActivity": "Revisar",
+    "mapEmptyInView": "Nada aqui no seu nível ou idioma. Amplie seus filtros ou afaste-se.",
+    "welcomeToPangeaChat": "Bem-vindo ao Pangea Chat",
+    "claimTrial": "Reivindique seu teste",
+    "thanksForSigningUp": "Obrigado por se inscrever! Aqui está",
+    "sevenDaysFree": "7 DIAS GRÁTIS",
+    "manageTrialInSettings": "Gerencie seu teste a qualquer momento em\nConfigurações de Assinatura",
+    "noCreditCardRequired": "Nenhum cartão de crédito necessário.",
+    "proFeatures": "PRO",
+    "widenSearch": "Ampliar busca",
+    "scrollToBottom": "Role para baixo",
+    "courseImage": "Imagem do curso",
+    "avatarPreview": "Pré-visualização do avatar",
+    "activityPhoto": "Foto da atividade",
+    "emotePreview": "Pré-visualização do emote: {name}",
+    "activityLabel": "Atividade: {title}",
+    "resetMapView": "Redefinir visualização do mapa",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pt_BR.arb
+++ b/lib/l10n/intl_pt_BR.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:34:21.811854",
+    "@@last_modified": "2026-06-26 10:46:52.919434",
     "about": "Sobre",
     "@about": {
         "type": "String",
@@ -9870,6 +9870,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Junte-se a um curso que inclua esta atividade para jogá-la.",
+    "resizeCoursePanel": "Redimensionar painel do curso",
+    "undo": "Desfazer",
+    "unlock": "Desbloquear",
+    "zoomIn": "Aproximar",
+    "zoomOut": "Afastar",
+    "stars": "Estrelas",
+    "addNewCourse": "Adicionar novo curso",
+    "world": "Mundo",
+    "addCourseStartMyOwn": "Começar meu próprio",
+    "addCourseEnterCode": "Digite o código do curso privado",
+    "addCourseBrowsePublic": "Navegar por cursos públicos",
+    "browsePublicCourses": "Navegar por cursos públicos",
+    "editProfile": "Editar perfil",
+    "numObjectives": "{count} objetivos",
+    "mapSearchHint": "Pesquisar atividades",
+    "mapSearchNoResults": "Nenhuma correspondência na visualização",
+    "mapFilterAllLanguages": "Todos os idiomas",
+    "mapFilterNotStarted": "Não iniciado",
+    "mapFilterInProgress": "Em andamento",
+    "mapFilterCompleted": "Concluído",
+    "mapFilterReset": "Redefinir",
+    "activityTypeConversation": "Conversa",
+    "lockedMissionRequirement": "Termine a missão anterior para desbloquear",
+    "playAgain": "Jogar novamente",
+    "reviewActivity": "Revisar",
+    "mapEmptyInView": "Nada aqui no seu nível ou idioma. Amplie seus filtros ou afaste-se.",
+    "welcomeToPangeaChat": "Bem-vindo ao Pangea Chat",
+    "claimTrial": "Reivindique seu teste",
+    "thanksForSigningUp": "Obrigado por se inscrever! Aqui está",
+    "sevenDaysFree": "7 DIAS GRÁTIS",
+    "manageTrialInSettings": "Gerencie seu teste a qualquer momento em\nConfigurações de Assinatura",
+    "noCreditCardRequired": "Nenhum cartão de crédito necessário.",
+    "proFeatures": "PRO",
+    "widenSearch": "Ampliar busca",
+    "scrollToBottom": "Role para baixo",
+    "courseImage": "Imagem do curso",
+    "avatarPreview": "Pré-visualização do avatar",
+    "activityPhoto": "Foto da atividade",
+    "emotePreview": "Pré-visualização do emote: {name}",
+    "activityLabel": "Atividade: {title}",
+    "resetMapView": "Redefinir visualização do mapa",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pt_PT.arb
+++ b/lib/l10n/intl_pt_PT.arb
@@ -2776,7 +2776,7 @@
     "selectAll": "Selecionar tudo",
     "deselectAll": "Desmarcar tudo",
     "@@locale": "pt_PT",
-    "@@last_modified": "2026-06-18 09:35:27.623475",
+    "@@last_modified": "2026-06-26 10:49:46.508383",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10946,6 +10946,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Junte-se a um curso que inclua esta atividade para jogá-la.",
+    "resizeCoursePanel": "Redimensionar painel do curso",
+    "undo": "Desfazer",
+    "unlock": "Desbloquear",
+    "zoomIn": "Aproximar",
+    "zoomOut": "Afastar",
+    "stars": "Estrelas",
+    "addNewCourse": "Adicionar novo curso",
+    "world": "Mundo",
+    "addCourseStartMyOwn": "Começar o meu próprio",
+    "addCourseEnterCode": "Insira o código do curso privado",
+    "addCourseBrowsePublic": "Navegar por cursos públicos",
+    "browsePublicCourses": "Navegar por cursos públicos",
+    "editProfile": "Editar perfil",
+    "numObjectives": "{count} objetivos",
+    "mapSearchHint": "Pesquisar atividades",
+    "mapSearchNoResults": "Nenhuma correspondência na visualização",
+    "mapFilterAllLanguages": "Todos os idiomas",
+    "mapFilterNotStarted": "Não iniciado",
+    "mapFilterInProgress": "Em andamento",
+    "mapFilterCompleted": "Concluído",
+    "mapFilterReset": "Redefinir",
+    "activityTypeConversation": "Conversa",
+    "lockedMissionRequirement": "Termine a missão anterior para desbloquear",
+    "playAgain": "Jogar novamente",
+    "reviewActivity": "Revisar",
+    "mapEmptyInView": "Nada aqui no seu nível ou idioma. Amplie seus filtros ou afaste-se.",
+    "welcomeToPangeaChat": "Bem-vindo ao Pangea Chat",
+    "claimTrial": "Reivindique seu teste",
+    "thanksForSigningUp": "Obrigado por se inscrever! Aqui está",
+    "sevenDaysFree": "7 DIAS GRÁTIS",
+    "manageTrialInSettings": "Gerencie seu teste a qualquer momento em\nConfigurações de Assinatura",
+    "noCreditCardRequired": "Nenhum cartão de crédito necessário.",
+    "proFeatures": "PRO",
+    "widenSearch": "Ampliar busca",
+    "scrollToBottom": "Role para baixo",
+    "courseImage": "Imagem do curso",
+    "avatarPreview": "Pré-visualização do avatar",
+    "activityPhoto": "Foto da atividade",
+    "emotePreview": "Pré-visualização do emote: {name}",
+    "activityLabel": "Atividade: {title}",
+    "resetMapView": "Redefinir visualização do mapa",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ro.arb
+++ b/lib/l10n/intl_ro.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:34:16.330789",
+    "@@last_modified": "2026-06-26 10:45:35.414261",
     "about": "Despre",
     "@about": {
         "type": "String",
@@ -10695,6 +10695,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Alătură-te unui curs care include această activitate pentru a o juca.",
+    "resizeCoursePanel": "Redimensionează panoul cursului",
+    "undo": "Anulează",
+    "unlock": "Dezactivează",
+    "zoomIn": "Mărește",
+    "zoomOut": "Micșorează",
+    "stars": "Stele",
+    "addNewCourse": "Adaugă curs nou",
+    "world": "Lume",
+    "addCourseStartMyOwn": "Începe propriul meu curs",
+    "addCourseEnterCode": "Introduceți codul pentru cursul privat",
+    "addCourseBrowsePublic": "Răsfoiți cursurile publice",
+    "browsePublicCourses": "Răsfoiți cursurile publice",
+    "editProfile": "Editează profilul",
+    "numObjectives": "{count} obiective",
+    "mapSearchHint": "Căutați activități",
+    "mapSearchNoResults": "Niciun rezultat în vizualizare",
+    "mapFilterAllLanguages": "Toate limbile",
+    "mapFilterNotStarted": "Nepornit",
+    "mapFilterInProgress": "În desfășurare",
+    "mapFilterCompleted": "Finalizat",
+    "mapFilterReset": "Resetare",
+    "activityTypeConversation": "Conversație",
+    "lockedMissionRequirement": "Finalizați misiunea anterioară pentru a debloca",
+    "playAgain": "Joacă din nou",
+    "reviewActivity": "Recenzie",
+    "mapEmptyInView": "Nimic aici la nivelul sau limba ta. Lărgiți filtrele sau faceți zoom out.",
+    "welcomeToPangeaChat": "Bine ai venit la Pangea Chat",
+    "claimTrial": "Solicită perioada de probă",
+    "thanksForSigningUp": "Mulțumim pentru înscriere! Iată",
+    "sevenDaysFree": "7 ZILE GRATUITE",
+    "manageTrialInSettings": "Gestionează-ți perioada de probă oricând în\nSetările Abonamentului",
+    "noCreditCardRequired": "Nu este necesară o carte de credit.",
+    "proFeatures": "PRO",
+    "widenSearch": "Lărgește căutarea",
+    "scrollToBottom": "Derulează la fund",
+    "courseImage": "Imagine curs",
+    "avatarPreview": "Previzualizare avatar",
+    "activityPhoto": "Fotografie activitate",
+    "emotePreview": "Previzualizare emote: {name}",
+    "activityLabel": "Activitate: {title}",
+    "resetMapView": "Resetează vederea hărții",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ru",
-    "@@last_modified": "2026-06-18 09:35:52.642076",
+    "@@last_modified": "2026-06-26 10:54:47.262513",
     "about": "О проекте",
     "@about": {
         "type": "String",
@@ -10884,6 +10884,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Присоединитесь к курсу, который включает в себя это занятие, чтобы сыграть в него.",
+    "resizeCoursePanel": "Изменить размер панели курса",
+    "undo": "Отменить",
+    "unlock": "Разблокировать",
+    "zoomIn": "Увеличить",
+    "zoomOut": "Уменьшить",
+    "stars": "Звезды",
+    "addNewCourse": "Добавить новый курс",
+    "world": "Мир",
+    "addCourseStartMyOwn": "Начать свой собственный",
+    "addCourseEnterCode": "Введите код для частного курса",
+    "addCourseBrowsePublic": "Просмотреть публичные курсы",
+    "browsePublicCourses": "Просмотреть публичные курсы",
+    "editProfile": "Редактировать профиль",
+    "numObjectives": "{count} целей",
+    "mapSearchHint": "Поиск мероприятий",
+    "mapSearchNoResults": "Нет совпадений в области видимости",
+    "mapFilterAllLanguages": "Все языки",
+    "mapFilterNotStarted": "Не начато",
+    "mapFilterInProgress": "В процессе",
+    "mapFilterCompleted": "Завершено",
+    "mapFilterReset": "Сбросить",
+    "activityTypeConversation": "Разговор",
+    "lockedMissionRequirement": "Завершите предыдущую миссию, чтобы разблокировать",
+    "playAgain": "Играть снова",
+    "reviewActivity": "Обзор",
+    "mapEmptyInView": "Здесь ничего нет на вашем уровне или языке. Расширьте свои фильтры или уменьшите масштаб.",
+    "welcomeToPangeaChat": "Добро пожаловать в Pangea Chat",
+    "claimTrial": "Получите свою пробную версию",
+    "thanksForSigningUp": "Спасибо за регистрацию! Вот",
+    "sevenDaysFree": "7 ДНЕЙ БЕСПЛАТНО",
+    "manageTrialInSettings": "Управляйте своей пробной версией в любое время в\nНастройках подписки",
+    "noCreditCardRequired": "Кредитная карта не требуется.",
+    "proFeatures": "ПРО",
+    "widenSearch": "Расширить поиск",
+    "scrollToBottom": "Прокрутить вниз",
+    "courseImage": "Изображение курса",
+    "avatarPreview": "Предварительный просмотр аватара",
+    "activityPhoto": "Фото активности",
+    "emotePreview": "Предварительный просмотр эмоции: {name}",
+    "activityLabel": "Активность: {title}",
+    "resetMapView": "Сбросить вид карты",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "sk",
-    "@@last_modified": "2026-06-18 09:34:17.410181",
+    "@@last_modified": "2026-06-26 10:45:47.706824",
     "about": "O aplikácii",
     "@about": {
         "type": "String",
@@ -10986,6 +10986,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Pridajte sa k kurzu, ktorý obsahuje túto aktivitu, aby ste ju mohli hrať.",
+    "resizeCoursePanel": "Zmeniť veľkosť panelu kurzu",
+    "undo": "Zrušiť",
+    "unlock": "Odomknúť",
+    "zoomIn": "Priblížiť",
+    "zoomOut": "Oddialiť",
+    "stars": "Hvězdy",
+    "addNewCourse": "Pridať nový kurz",
+    "world": "Svet",
+    "addCourseStartMyOwn": "Začať svoj vlastný",
+    "addCourseEnterCode": "Zadajte kód pre súkromný kurz",
+    "addCourseBrowsePublic": "Prehľadávať verejné kurzy",
+    "browsePublicCourses": "Prehľadávať verejné kurzy",
+    "editProfile": "Upraviť profil",
+    "numObjectives": "{count} ciele",
+    "mapSearchHint": "Hľadať aktivity",
+    "mapSearchNoResults": "Žiadne zhodné výsledky",
+    "mapFilterAllLanguages": "Všetky jazyky",
+    "mapFilterNotStarted": "Nebol začatý",
+    "mapFilterInProgress": "Prebieha",
+    "mapFilterCompleted": "Dokončené",
+    "mapFilterReset": "Obnoviť",
+    "activityTypeConversation": "Konverzácia",
+    "lockedMissionRequirement": "Dokončite predchádzajúcu misiu, aby ste odomkli",
+    "playAgain": "Hraj znova",
+    "reviewActivity": "Prehľad",
+    "mapEmptyInView": "Tu nie je nič na vašej úrovni alebo jazyku. Rozšírte svoje filtre alebo priblížte.",
+    "welcomeToPangeaChat": "Vitajte v Pangea Chate",
+    "claimTrial": "Uplatnite svoju skúšobnú verziu",
+    "thanksForSigningUp": "Ďakujeme za registráciu! Tu je",
+    "sevenDaysFree": "7 DNÍ ZADARMO",
+    "manageTrialInSettings": "Spravujte svoju skúšobnú verziu kedykoľvek v\nNastaveniach predplatného",
+    "noCreditCardRequired": "Nie je potrebná kreditná karta.",
+    "proFeatures": "PRO",
+    "widenSearch": "Rozšíriť vyhľadávanie",
+    "scrollToBottom": "Posuňte sa na dno",
+    "courseImage": "Obrázok kurzu",
+    "avatarPreview": "Náhľad avatara",
+    "activityPhoto": "Fotografia aktivity",
+    "emotePreview": "Náhľad emócie: {name}",
+    "activityLabel": "Aktivita: {title}",
+    "resetMapView": "Obnoviť zobrazenie mapy",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sl.arb
+++ b/lib/l10n/intl_sl.arb
@@ -1962,7 +1962,7 @@
     "playWithAI": "Za zdaj igrajte z AI-jem",
     "courseStartDesc": "Pangea Bot je pripravljen kadarkoli!\n\n...ampak je bolje učiti se s prijatelji!",
     "@@locale": "sl",
-    "@@last_modified": "2026-06-18 09:34:27.092267",
+    "@@last_modified": "2026-06-26 10:47:54.519621",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10986,6 +10986,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Pridružite se tečaju, ki vključuje to dejavnost, da jo igrate.",
+    "resizeCoursePanel": "Spremeni velikost panela tečaja",
+    "undo": "Razveljavi",
+    "unlock": "Odkleni",
+    "zoomIn": "Povečaj",
+    "zoomOut": "Pomanjšaj",
+    "stars": "Zvezde",
+    "addNewCourse": "Dodaj nov tečaj",
+    "world": "Svet",
+    "addCourseStartMyOwn": "Začni svojega",
+    "addCourseEnterCode": "Vnesite kodo za zasebni tečaj",
+    "addCourseBrowsePublic": "Brskajte po javnih tečajih",
+    "browsePublicCourses": "Brskajte po javnih tečajih",
+    "editProfile": "Uredi profil",
+    "numObjectives": "{count} ciljev",
+    "mapSearchHint": "Išči aktivnosti",
+    "mapSearchNoResults": "Brez ujemanj v pogledu",
+    "mapFilterAllLanguages": "Vsi jeziki",
+    "mapFilterNotStarted": "Ni začeto",
+    "mapFilterInProgress": "V teku",
+    "mapFilterCompleted": "Dokončano",
+    "mapFilterReset": "Ponastavi",
+    "activityTypeConversation": "Pogovor",
+    "lockedMissionRequirement": "Dokončajte prejšnjo nalogo, da jo odklenete",
+    "playAgain": "Igraj znova",
+    "reviewActivity": "Pregled",
+    "mapEmptyInView": "Tu ni ničesar na vaši ravni ali jeziku. Razširite svoje filtre ali poglejte od daleč.",
+    "welcomeToPangeaChat": "Dobrodošli v Pangea Chat",
+    "claimTrial": "Zahtevajte svojo preizkusno različico",
+    "thanksForSigningUp": "Hvala, da ste se prijavili! Tukaj je",
+    "sevenDaysFree": "7 DNI BREZPLAČNO",
+    "manageTrialInSettings": "Upravljajte svojo preizkušnjo kadarkoli v\nNastavitvah naročnine",
+    "noCreditCardRequired": "Brez potrebe po kreditni kartici.",
+    "proFeatures": "PRO",
+    "widenSearch": "Razširi iskanje",
+    "scrollToBottom": "Pomakni se na dno",
+    "courseImage": "Slika tečaja",
+    "avatarPreview": "Predogled avatarja",
+    "activityPhoto": "Fotografija aktivnosti",
+    "emotePreview": "Predogled emojija: {name}",
+    "activityLabel": "Dejavnost: {title}",
+    "resetMapView": "Ponastavi pogled na zemljevid",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sr.arb
+++ b/lib/l10n/intl_sr.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:35:54.891213",
+    "@@last_modified": "2026-06-26 10:55:12.660606",
     "about": "О програму",
     "@about": {
         "type": "String",
@@ -10993,6 +10993,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Pridružite se kursu koji uključuje ovu aktivnost da biste je igrali.",
+    "resizeCoursePanel": "Promenite veličinu panela kursa",
+    "undo": "Poništi",
+    "unlock": "Otključaj",
+    "zoomIn": "Uvećaj",
+    "zoomOut": "Smanji",
+    "stars": "Zvezde",
+    "addNewCourse": "Dodaj novi kurs",
+    "world": "Svet",
+    "addCourseStartMyOwn": "Započni svoj sopstveni",
+    "addCourseEnterCode": "Unesite kod za privatni kurs",
+    "addCourseBrowsePublic": "Pretraži javne kurseve",
+    "browsePublicCourses": "Pretraži javne kurseve",
+    "editProfile": "Izmeni profil",
+    "numObjectives": "{count} ciljeva",
+    "mapSearchHint": "Pretraži aktivnosti",
+    "mapSearchNoResults": "Nema podudaranja u pregledu",
+    "mapFilterAllLanguages": "Svi jezici",
+    "mapFilterNotStarted": "Nije započeto",
+    "mapFilterInProgress": "U toku",
+    "mapFilterCompleted": "Završeno",
+    "mapFilterReset": "Poništi",
+    "activityTypeConversation": "Razgovor",
+    "lockedMissionRequirement": "Završite prethodnu misiju da biste otključali",
+    "playAgain": "Igraj ponovo",
+    "reviewActivity": "Pregled",
+    "mapEmptyInView": "Nema ništa ovde na vašem nivou ili jeziku. Proširite svoje filtere ili zumirajte.",
+    "welcomeToPangeaChat": "Dobrodošli u Pangea Chat",
+    "claimTrial": "Zatražite svoj probni period",
+    "thanksForSigningUp": "Hvala što ste se prijavili! Evo",
+    "sevenDaysFree": "7 DANA BESPLATNO",
+    "manageTrialInSettings": "Upravljajte svojim probnim periodom u\nPodešavanjima pretplate",
+    "noCreditCardRequired": "Nema potrebe za kreditnom karticom.",
+    "proFeatures": "PRO",
+    "widenSearch": "Proširi pretragu",
+    "scrollToBottom": "Pomeri na dno",
+    "courseImage": "Slika kursa",
+    "avatarPreview": "Pregled avatara",
+    "activityPhoto": "Fotografija aktivnosti",
+    "emotePreview": "Pregled emota: {name}",
+    "activityLabel": "Aktivnost: {title}",
+    "resetMapView": "Resetuj prikaz mape",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sv.arb
+++ b/lib/l10n/intl_sv.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:35:44.610610",
+    "@@last_modified": "2026-06-26 10:53:30.016514",
     "about": "Om",
     "@about": {
         "type": "String",
@@ -10457,6 +10457,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Gå med i en kurs som inkluderar denna aktivitet för att spela den.",
+    "resizeCoursePanel": "Ändra storlek på kurspanelen",
+    "undo": "Ångra",
+    "unlock": "Lås upp",
+    "zoomIn": "Zooma in",
+    "zoomOut": "Zooma ut",
+    "stars": "Stjärnor",
+    "addNewCourse": "Lägg till ny kurs",
+    "world": "Värld",
+    "addCourseStartMyOwn": "Starta min egen",
+    "addCourseEnterCode": "Ange kod för privat kurs",
+    "addCourseBrowsePublic": "Bläddra bland offentliga kurser",
+    "browsePublicCourses": "Bläddra bland offentliga kurser",
+    "editProfile": "Redigera profil",
+    "numObjectives": "{count} mål",
+    "mapSearchHint": "Sök aktiviteter",
+    "mapSearchNoResults": "Inga träffar i vyn",
+    "mapFilterAllLanguages": "Alla språk",
+    "mapFilterNotStarted": "Ej påbörjad",
+    "mapFilterInProgress": "Pågår",
+    "mapFilterCompleted": "Avslutad",
+    "mapFilterReset": "Återställ",
+    "activityTypeConversation": "Konversation",
+    "lockedMissionRequirement": "Avsluta den föregående uppdraget för att låsa upp",
+    "playAgain": "Spela igen",
+    "reviewActivity": "Granska",
+    "mapEmptyInView": "Ingenting här på din nivå eller språk. Bredare dina filter eller zooma ut.",
+    "welcomeToPangeaChat": "Välkommen till Pangea Chat",
+    "claimTrial": "Kräv din provperiod",
+    "thanksForSigningUp": "Tack för att du registrerade dig! Här är",
+    "sevenDaysFree": "7 DAGAR GRATIS",
+    "manageTrialInSettings": "Hantera din provperiod när som helst i\nPrenumerationsinställningar",
+    "noCreditCardRequired": "Ingen kreditkort krävs.",
+    "proFeatures": "PRO",
+    "widenSearch": "Bredda sökningen",
+    "scrollToBottom": "Scrolla till botten",
+    "courseImage": "Kursbild",
+    "avatarPreview": "Avatarförhandsvisning",
+    "activityPhoto": "Aktivitetsfoto",
+    "emotePreview": "Emoteförhandsvisning: {name}",
+    "activityLabel": "Aktivitet: {title}",
+    "resetMapView": "Återställ kartvyn",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ta.arb
+++ b/lib/l10n/intl_ta.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:35:37.076778",
+    "@@last_modified": "2026-06-26 10:52:02.600230",
     "acceptedTheInvitation": "👍 {username} அழைப்பை ஏற்றுக்கொண்டது",
     "@acceptedTheInvitation": {
         "type": "String",
@@ -9986,6 +9986,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "இந்த செயல்பாட்டை விளையாட ஒரு பாடத்தை சேர்க்கவும்.",
+    "resizeCoursePanel": "பாடப் பானலின் அளவை மாற்றவும்",
+    "undo": "மீட்டெடுக்கவும்",
+    "unlock": "திறக்கவும்",
+    "zoomIn": "உள்ளே நுழையவும்",
+    "zoomOut": "வெளியே செல்லவும்",
+    "stars": "நட்சத்திரங்கள்",
+    "addNewCourse": "புதிய பாடத்தைச் சேர்க்கவும்",
+    "world": "உலகம்",
+    "addCourseStartMyOwn": "என் சொந்தத்தை தொடங்கவும்",
+    "addCourseEnterCode": "தனியார் பாடத்திற்கான குறியீட்டை உள்ளிடவும்",
+    "addCourseBrowsePublic": "பொது பாடங்களை உலாவவும்",
+    "browsePublicCourses": "பொது பாடங்களை உலாவவும்",
+    "editProfile": "சுயவிவரத்தை திருத்தவும்",
+    "numObjectives": "{count} குறிக்கோள்கள்",
+    "mapSearchHint": "செயல்பாடுகளை தேடவும்",
+    "mapSearchNoResults": "காண்பில் பொருத்தங்கள் இல்லை",
+    "mapFilterAllLanguages": "எல்லா மொழிகளும்",
+    "mapFilterNotStarted": "தொடங்கவில்லை",
+    "mapFilterInProgress": "நடந்து கொண்டிருக்கிறது",
+    "mapFilterCompleted": "முடிந்தது",
+    "mapFilterReset": "மீட்டமை",
+    "activityTypeConversation": "சரசரி",
+    "lockedMissionRequirement": "அன்லாக் செய்ய முந்தைய மிஷனை முடிக்கவும்",
+    "playAgain": "மீண்டும் விளையாடவும்",
+    "reviewActivity": "மதிப்பீடு",
+    "mapEmptyInView": "உங்கள் நிலை அல்லது மொழியில் இங்கு எதுவும் இல்லை. உங்கள் வடிகட்டிகளை விரிவாக்கவும் அல்லது வெளியே zoom செய்யவும்.",
+    "welcomeToPangeaChat": "பாஙேஆ சாட்டிற்கு வரவேற்கிறோம்",
+    "claimTrial": "உங்கள் சோதனையை கோருங்கள்",
+    "thanksForSigningUp": "பதிவு செய்ததற்கு நன்றி! இதோ",
+    "sevenDaysFree": "7 நாட்கள் இலவசம்",
+    "manageTrialInSettings": "உங்கள் சோதனைக்கு எப்போது வேண்டுமானாலும்\nசந்தா அமைப்புகளில் நிர்வகிக்கவும்",
+    "noCreditCardRequired": "கிரெடிட் கார்டு தேவையில்லை.",
+    "proFeatures": "PRO",
+    "widenSearch": "தேடலை விரிவாக்கவும்",
+    "scrollToBottom": "கீழே உருட்டவும்",
+    "courseImage": "பாடத்தின் படம்",
+    "avatarPreview": "அவதார் முன்னோட்டம்",
+    "activityPhoto": "செயல்பாட்டு படம்",
+    "emotePreview": "எமோட் முன்னோட்டம்: {name}",
+    "activityLabel": "செயல்: {title}",
+    "resetMapView": "மெப்பத்தை மீட்டமைக்கவும்",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_te.arb
+++ b/lib/l10n/intl_te.arb
@@ -1467,7 +1467,7 @@
     "playWithAI": "ఇప్పుడే AI తో ఆడండి",
     "courseStartDesc": "పాంజియా బాట్ ఎప్పుడైనా సిద్ధంగా ఉంటుంది!\n\n...కానీ స్నేహితులతో నేర్చుకోవడం మెరుగైనది!",
     "@@locale": "te",
-    "@@last_modified": "2026-06-18 09:35:34.098122",
+    "@@last_modified": "2026-06-26 10:51:24.198509",
     "@setCustomPermissionLevel": {
         "type": "String",
         "placeholders": {}
@@ -10994,6 +10994,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "ఈ కార్యకలాపాన్ని ఆడడానికి ఈ కోర్సులో చేరండి.",
+    "resizeCoursePanel": "కోర్సు ప్యానెల్‌ను పరిమాణం మార్చండి",
+    "undo": "తిరిగి చేయండి",
+    "unlock": "అన్లాక్ చేయండి",
+    "zoomIn": "జూమ్ ఇన్",
+    "zoomOut": "జూమ్ అవుట్",
+    "stars": "తారలు",
+    "addNewCourse": "కొత్త కోర్సు జోడించండి",
+    "world": "ప్రపంచం",
+    "addCourseStartMyOwn": "నా స్వంతాన్ని ప్రారంభించండి",
+    "addCourseEnterCode": "ప్రైవేట్ కోర్సు కోడ్ నమోదు చేయండి",
+    "addCourseBrowsePublic": "ప్రజా కోర్సులను బ్రౌజ్ చేయండి",
+    "browsePublicCourses": "ప్రజా కోర్సులను బ్రౌజ్ చేయండి",
+    "editProfile": "ప్రొఫైల్ సవరించండి",
+    "numObjectives": "{count} లక్ష్యాలు",
+    "mapSearchHint": "చర్యలను శోధించండి",
+    "mapSearchNoResults": "చూపులో సరిపోలడం లేదు",
+    "mapFilterAllLanguages": "అన్ని భాషలు",
+    "mapFilterNotStarted": "ప్రారంభించలేదు",
+    "mapFilterInProgress": "జరుగుతోంది",
+    "mapFilterCompleted": "పూర్తి",
+    "mapFilterReset": "మళ్లీ సెట్ చేయండి",
+    "activityTypeConversation": "సంభాషణ",
+    "lockedMissionRequirement": "అన్లాక్ చేయడానికి మునుపటి మిషన్‌ను పూర్తి చేయండి",
+    "playAgain": "మళ్లీ ఆడండి",
+    "reviewActivity": "సమీక్ష",
+    "mapEmptyInView": "మీ స్థాయిలో లేదా భాషలో ఇక్కడ ఏమి లేదు. మీ ఫిల్టర్లను విస్తరించండి లేదా జూమ్ అవుట్ చేయండి.",
+    "welcomeToPangeaChat": "పాంజియా చాట్‌కు స్వాగతం",
+    "claimTrial": "మీ ట్రయల్‌ను క్లెయిమ్ చేయండి",
+    "thanksForSigningUp": "సైన్ అప్ చేసినందుకు ధన్యవాదాలు! ఇది",
+    "sevenDaysFree": "7 రోజులు ఉచితం",
+    "manageTrialInSettings": "మీ ట్రయల్‌ను ఎప్పుడైనా నిర్వహించండి\nసబ్‌స్క్రిప్షన్ సెట్టింగ్స్‌లో",
+    "noCreditCardRequired": "క్రెడిట్ కార్డు అవసరం లేదు.",
+    "proFeatures": "ప్రో",
+    "widenSearch": "శోధనను విస్తరించండి",
+    "scrollToBottom": "కిందకు స్క్రోల్ చేయండి",
+    "courseImage": "కోర్సు చిత్రం",
+    "avatarPreview": "అవతార్ ప్రివ్యూ",
+    "activityPhoto": "చర్య ఫోటో",
+    "emotePreview": "ఎమోట్ ప్రివ్యూ: {name}",
+    "activityLabel": "చర్య: {title}",
+    "resetMapView": "నకశా దృశ్యాన్ని పునఃసెట్ చేయండి",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "เล่นกับ AI ชั่วคราว",
     "courseStartDesc": "Pangea Bot พร้อมที่จะเริ่มต้นได้ทุกเมื่อ!\n\n...แต่การเรียนรู้ดีกว่ากับเพื่อน!",
     "@@locale": "th",
-    "@@last_modified": "2026-06-18 09:35:26.726051",
+    "@@last_modified": "2026-06-26 10:49:36.372164",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10589,6 +10589,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "เข้าร่วมหลักสูตรที่รวมกิจกรรมนี้เพื่อเล่นมัน",
+    "resizeCoursePanel": "ปรับขนาดแผงหลักสูตร",
+    "undo": "ย้อนกลับ",
+    "unlock": "ปลดล็อก",
+    "zoomIn": "ขยาย",
+    "zoomOut": "ย่อ",
+    "stars": "ดาว",
+    "addNewCourse": "เพิ่มหลักสูตรใหม่",
+    "world": "โลก",
+    "addCourseStartMyOwn": "เริ่มหลักสูตรของฉันเอง",
+    "addCourseEnterCode": "กรอกรหัสสำหรับหลักสูตรส่วนตัว",
+    "addCourseBrowsePublic": "เรียกดูหลักสูตรสาธารณะ",
+    "browsePublicCourses": "เรียกดูหลักสูตรสาธารณะ",
+    "editProfile": "แก้ไขโปรไฟล์",
+    "numObjectives": "{count} เป้าหมาย",
+    "mapSearchHint": "ค้นหากิจกรรม",
+    "mapSearchNoResults": "ไม่มีผลลัพธ์ในมุมมอง",
+    "mapFilterAllLanguages": "ทุกภาษา",
+    "mapFilterNotStarted": "ยังไม่เริ่ม",
+    "mapFilterInProgress": "กำลังดำเนินการ",
+    "mapFilterCompleted": "เสร็จสิ้น",
+    "mapFilterReset": "รีเซ็ต",
+    "activityTypeConversation": "การสนทนา",
+    "lockedMissionRequirement": "ทำภารกิจที่แล้วให้เสร็จเพื่อปลดล็อก",
+    "playAgain": "เล่นอีกครั้ง",
+    "reviewActivity": "ตรวจสอบ",
+    "mapEmptyInView": "ไม่มีอะไรที่นี่ในระดับหรือภาษาของคุณ ขยายตัวกรองของคุณหรือซูมออก",
+    "welcomeToPangeaChat": "ยินดีต้อนรับสู่ Pangea Chat",
+    "claimTrial": "ขอรับการทดลองใช้งาน",
+    "thanksForSigningUp": "ขอบคุณที่ลงทะเบียน! นี่คือ",
+    "sevenDaysFree": "7 วันฟรี",
+    "manageTrialInSettings": "จัดการการทดลองของคุณได้ทุกเมื่อใน\nการตั้งค่าการสมัครสมาชิก",
+    "noCreditCardRequired": "ไม่ต้องใช้บัตรเครดิต.",
+    "proFeatures": "โปร",
+    "widenSearch": "ขยายการค้นหา",
+    "scrollToBottom": "เลื่อนลงไปที่ด้านล่าง",
+    "courseImage": "ภาพหลักสูตร",
+    "avatarPreview": "ตัวอย่างอวาตาร์",
+    "activityPhoto": "ภาพกิจกรรม",
+    "emotePreview": "ตัวอย่างอิโมจิ: {name}",
+    "activityLabel": "กิจกรรม: {title}",
+    "resetMapView": "รีเซ็ตมุมมองแผนที่",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "tr",
-    "@@last_modified": "2026-06-18 09:35:32.981317",
+    "@@last_modified": "2026-06-26 10:50:59.134058",
     "about": "Hakkında",
     "@about": {
         "type": "String",
@@ -10201,6 +10201,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Bu etkinliği oynamak için bu etkinliği içeren bir kursa katılın.",
+    "resizeCoursePanel": "Kurs panelini yeniden boyutlandır",
+    "undo": "Geri al",
+    "unlock": "Kilidi aç",
+    "zoomIn": "Yakınlaştır",
+    "zoomOut": "Uzaklaştır",
+    "stars": "Yıldızlar",
+    "addNewCourse": "Yeni kurs ekle",
+    "world": "Dünya",
+    "addCourseStartMyOwn": "Kendi kursumu başlat",
+    "addCourseEnterCode": "Özel kurs için kodu girin",
+    "addCourseBrowsePublic": "Açık kursları göz atın",
+    "browsePublicCourses": "Açık kursları göz atın",
+    "editProfile": "Profili düzenle",
+    "numObjectives": "{count} hedef",
+    "mapSearchHint": "Aktiviteleri ara",
+    "mapSearchNoResults": "Görüntüde eşleşme yok",
+    "mapFilterAllLanguages": "Tüm diller",
+    "mapFilterNotStarted": "Başlamadı",
+    "mapFilterInProgress": "Devam ediyor",
+    "mapFilterCompleted": "Tamamlandı",
+    "mapFilterReset": "Sıfırla",
+    "activityTypeConversation": "Konuşma",
+    "lockedMissionRequirement": "Kilidi açmak için önceki görevi tamamlayın",
+    "playAgain": "Tekrar oyna",
+    "reviewActivity": "Gözden geçir",
+    "mapEmptyInView": "Seviyenizde veya dilinizde burada hiçbir şey yok. Filtrelerinizi genişletin veya uzaklaştırın.",
+    "welcomeToPangeaChat": "Pangea Chat'e hoş geldiniz",
+    "claimTrial": "Denemenizi talep edin",
+    "thanksForSigningUp": "Kaydolduğunuz için teşekkürler! İşte",
+    "sevenDaysFree": "7 GÜN ÜCRETSİZ",
+    "manageTrialInSettings": "Denemenizi istediğiniz zaman\nAbonelik Ayarları'nda yönetin",
+    "noCreditCardRequired": "Kredi kartı gerekmez.",
+    "proFeatures": "PRO",
+    "widenSearch": "Aramayı genişlet",
+    "scrollToBottom": "Sona kaydır",
+    "courseImage": "Kurs resmi",
+    "avatarPreview": "Avatar önizlemesi",
+    "activityPhoto": "Etkinlik fotoğrafı",
+    "emotePreview": "Emote önizlemesi: {name}",
+    "activityLabel": "Etkinlik: {title}",
+    "resetMapView": "Harita görünümünü sıfırla",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "uk",
-    "@@last_modified": "2026-06-18 09:34:29.720478",
+    "@@last_modified": "2026-06-26 10:48:39.333903",
     "about": "Про застосунок",
     "@about": {
         "type": "String",
@@ -9870,6 +9870,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Приєднайтеся до курсу, який включає цю активність, щоб грати в неї.",
+    "resizeCoursePanel": "Змінити розмір панелі курсу",
+    "undo": "Скасувати",
+    "unlock": "Розблокувати",
+    "zoomIn": "Збільшити",
+    "zoomOut": "Зменшити",
+    "stars": "Зірки",
+    "addNewCourse": "Додати новий курс",
+    "world": "Світ",
+    "addCourseStartMyOwn": "Розпочати свій власний",
+    "addCourseEnterCode": "Введіть код для приватного курсу",
+    "addCourseBrowsePublic": "Переглянути публічні курси",
+    "browsePublicCourses": "Переглянути публічні курси",
+    "editProfile": "Редагувати профіль",
+    "numObjectives": "{count} цілей",
+    "mapSearchHint": "Шукати активності",
+    "mapSearchNoResults": "Немає збігів у виді",
+    "mapFilterAllLanguages": "Усі мови",
+    "mapFilterNotStarted": "Не розпочато",
+    "mapFilterInProgress": "В процесі",
+    "mapFilterCompleted": "Завершено",
+    "mapFilterReset": "Скинути",
+    "activityTypeConversation": "Розмова",
+    "lockedMissionRequirement": "Завершіть попередню місію, щоб розблокувати",
+    "playAgain": "Грати знову",
+    "reviewActivity": "Огляд",
+    "mapEmptyInView": "Тут нічого немає на вашому рівні або мові. Розширте свої фільтри або зменшіть масштаб.",
+    "welcomeToPangeaChat": "Ласкаво просимо до Pangea Chat",
+    "claimTrial": "Отримайте свій безкоштовний пробний період",
+    "thanksForSigningUp": "Дякуємо за реєстрацію! Ось",
+    "sevenDaysFree": "7 ДНІВ БЕЗКОШТОВНО",
+    "manageTrialInSettings": "Керуйте своїм безкоштовним періодом у будь-який час у\nНалаштуваннях підписки",
+    "noCreditCardRequired": "Кредитна картка не потрібна.",
+    "proFeatures": "ПРО",
+    "widenSearch": "Розширити пошук",
+    "scrollToBottom": "Прокрутити донизу",
+    "courseImage": "Зображення курсу",
+    "avatarPreview": "Попередній перегляд аватара",
+    "activityPhoto": "Фото активності",
+    "emotePreview": "Попередній перегляд емодзі: {name}",
+    "activityLabel": "Активність: {title}",
+    "resetMapView": "Скинути вигляд карти",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_uz.arb
+++ b/lib/l10n/intl_uz.arb
@@ -3194,7 +3194,7 @@
     "setupChatBackup": "Chat zaxirasini sozlash",
     "@setupChatBackup": {},
     "@@locale": "uz",
-    "@@last_modified": "2026-06-18 09:35:29.531145",
+    "@@last_modified": "2026-06-26 10:50:14.767864",
     "noMoreResultsFound": "Boshqa natijalar topilmadi",
     "chatSearchedUntil": "Chat {time} gacha qidirildi",
     "federationBaseUrl": "Federatsiya Asos URL",
@@ -9874,6 +9874,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Bu faoliyatni o'ynash uchun ushbu kursga qo'shiling.",
+    "resizeCoursePanel": "Kurs panelini o'lchamini o'zgartirish",
+    "undo": "Qaytarish",
+    "unlock": "Kilitni ochish",
+    "zoomIn": "Kirishni kattalashtirish",
+    "zoomOut": "Kirishni kichraytirish",
+    "stars": "Yulduzlar",
+    "addNewCourse": "Yangi kurs qo'shish",
+    "world": "Dunyo",
+    "addCourseStartMyOwn": "O'z kursimni boshlash",
+    "addCourseEnterCode": "Maxfiy kurs uchun kodni kiriting",
+    "addCourseBrowsePublic": "Ommaviy kurslarni ko'ring",
+    "browsePublicCourses": "Ommaviy kurslarni ko'ring",
+    "editProfile": "Profilni tahrirlash",
+    "numObjectives": "{count} maqsadlar",
+    "mapSearchHint": "Faoliyatlarni qidiring",
+    "mapSearchNoResults": "Ko'rinishda hech qanday moslik yo'q",
+    "mapFilterAllLanguages": "Barcha tillar",
+    "mapFilterNotStarted": "Boshlanmagan",
+    "mapFilterInProgress": "Jarayonda",
+    "mapFilterCompleted": "Tamamlandi",
+    "mapFilterReset": "Qayta tiklash",
+    "activityTypeConversation": "Muloqot",
+    "lockedMissionRequirement": "Ochiq qilish uchun oldingi missiyani tugatish",
+    "playAgain": "Yana o'ynang",
+    "reviewActivity": "Ko'rib chiqish",
+    "mapEmptyInView": "Sizning darajangizda yoki tilingizda hech narsa yo'q. Filtrlaringizni kengaytiring yoki zoom qiling.",
+    "welcomeToPangeaChat": "Pangea Chat'ga xush kelibsiz",
+    "claimTrial": "Sinovni talab qiling",
+    "thanksForSigningUp": "Ro'yxatdan o'tganingiz uchun rahmat! Bu yerda",
+    "sevenDaysFree": "7 KUN BEPUL",
+    "manageTrialInSettings": "Obuna sozlamalarida sinovni istalgan vaqtda boshqaring",
+    "noCreditCardRequired": "Kredit karta talab qilinmaydi.",
+    "proFeatures": "PRO",
+    "widenSearch": "Qidiruvni kengaytiring",
+    "scrollToBottom": "Pastga aylantiring",
+    "courseImage": "Kurs rasmi",
+    "avatarPreview": "Avatar oldindan ko‘rish",
+    "activityPhoto": "Faoliyat rasmi",
+    "emotePreview": "Emote oldindan ko‘rish: {name}",
+    "activityLabel": "Faoliyat: {title}",
+    "resetMapView": "Xarita ko'rinishini tiklash",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:35:35.945591",
+    "@@last_modified": "2026-06-26 10:51:49.983684",
     "about": "Giới thiệu",
     "@about": {
         "type": "String",
@@ -6953,6 +6953,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "Tham gia một khóa học bao gồm hoạt động này để chơi.",
+    "resizeCoursePanel": "Thay đổi kích thước bảng khóa học",
+    "undo": "Hoàn tác",
+    "unlock": "Mở khóa",
+    "zoomIn": "Phóng to",
+    "zoomOut": "Thu nhỏ",
+    "stars": "Sao",
+    "addNewCourse": "Thêm khóa học mới",
+    "world": "Thế giới",
+    "addCourseStartMyOwn": "Bắt đầu khóa học của riêng tôi",
+    "addCourseEnterCode": "Nhập mã cho khóa học riêng",
+    "addCourseBrowsePublic": "Duyệt các khóa học công khai",
+    "browsePublicCourses": "Duyệt các khóa học công khai",
+    "editProfile": "Chỉnh sửa hồ sơ",
+    "numObjectives": "{count} mục tiêu",
+    "mapSearchHint": "Tìm kiếm hoạt động",
+    "mapSearchNoResults": "Không có kết quả nào trong chế độ xem",
+    "mapFilterAllLanguages": "Tất cả các ngôn ngữ",
+    "mapFilterNotStarted": "Chưa bắt đầu",
+    "mapFilterInProgress": "Đang tiến hành",
+    "mapFilterCompleted": "Đã hoàn thành",
+    "mapFilterReset": "Đặt lại",
+    "activityTypeConversation": "Cuộc trò chuyện",
+    "lockedMissionRequirement": "Hoàn thành nhiệm vụ trước để mở khóa",
+    "playAgain": "Chơi lại",
+    "reviewActivity": "Xem lại",
+    "mapEmptyInView": "Không có gì ở cấp độ hoặc ngôn ngữ của bạn. Mở rộng bộ lọc của bạn hoặc thu nhỏ.",
+    "welcomeToPangeaChat": "Chào mừng đến với Pangea Chat",
+    "claimTrial": "Nhận thử nghiệm của bạn",
+    "thanksForSigningUp": "Cảm ơn bạn đã đăng ký! Đây là",
+    "sevenDaysFree": "7 NGÀY MIỄN PHÍ",
+    "manageTrialInSettings": "Quản lý thử nghiệm của bạn bất cứ lúc nào trong\nCài đặt Đăng ký",
+    "noCreditCardRequired": "Không cần thẻ tín dụng.",
+    "proFeatures": "CHUYÊN NGHIỆP",
+    "widenSearch": "Mở rộng tìm kiếm",
+    "scrollToBottom": "Cuộn xuống dưới cùng",
+    "courseImage": "Hình ảnh khóa học",
+    "avatarPreview": "Xem trước avatar",
+    "activityPhoto": "Ảnh hoạt động",
+    "emotePreview": "Xem trước biểu cảm: {name}",
+    "activityLabel": "Hoạt động: {title}",
+    "resetMapView": "Đặt lại chế độ xem bản đồ",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_yue.arb
+++ b/lib/l10n/intl_yue.arb
@@ -1406,7 +1406,7 @@
     "selectAll": "全選",
     "deselectAll": "取消全選",
     "@@locale": "yue",
-    "@@last_modified": "2026-06-18 09:34:28.035443",
+    "@@last_modified": "2026-06-26 10:48:06.043456",
     "@ignoreUser": {
         "type": "String",
         "placeholders": {}
@@ -11001,6 +11001,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "加入一個包含此活動的課程以進行遊玩。",
+    "resizeCoursePanel": "調整課程面板大小",
+    "undo": "撤銷",
+    "unlock": "解鎖",
+    "zoomIn": "放大",
+    "zoomOut": "縮小",
+    "stars": "星星",
+    "addNewCourse": "添加新課程",
+    "world": "世界",
+    "addCourseStartMyOwn": "開始我自己的課程",
+    "addCourseEnterCode": "輸入私人課程代碼",
+    "addCourseBrowsePublic": "瀏覽公共課程",
+    "browsePublicCourses": "瀏覽公共課程",
+    "editProfile": "編輯個人資料",
+    "numObjectives": "{count} 個目標",
+    "mapSearchHint": "搜索活動",
+    "mapSearchNoResults": "視圖中沒有匹配項",
+    "mapFilterAllLanguages": "所有語言",
+    "mapFilterNotStarted": "尚未開始",
+    "mapFilterInProgress": "進行中",
+    "mapFilterCompleted": "完成",
+    "mapFilterReset": "重置",
+    "activityTypeConversation": "對話",
+    "lockedMissionRequirement": "完成前一個任務以解鎖",
+    "playAgain": "再玩一次",
+    "reviewActivity": "檢視",
+    "mapEmptyInView": "在你的級別或語言中沒有任何東西。擴大你的篩選或縮小視圖。",
+    "welcomeToPangeaChat": "歡迎來到 Pangea Chat",
+    "claimTrial": "索取你的試用",
+    "thanksForSigningUp": "感謝你註冊！這裡是",
+    "sevenDaysFree": "7 天免費",
+    "manageTrialInSettings": "隨時在\n訂閱設置中管理你的試用",
+    "noCreditCardRequired": "無需信用卡。",
+    "proFeatures": "專業版",
+    "widenSearch": "擴大搜索",
+    "scrollToBottom": "滾動到底部",
+    "courseImage": "課程圖片",
+    "avatarPreview": "頭像預覽",
+    "activityPhoto": "活動照片",
+    "emotePreview": "表情預覽: {name}",
+    "activityLabel": "活動: {title}",
+    "resetMapView": "重置地圖視圖",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "zh",
-    "@@last_modified": "2026-06-18 09:35:39.900236",
+    "@@last_modified": "2026-06-26 10:52:42.545763",
     "about": "关于",
     "@about": {
         "type": "String",
@@ -9870,6 +9870,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "加入一个包含此活动的课程以进行游戏。",
+    "resizeCoursePanel": "调整课程面板大小",
+    "undo": "撤销",
+    "unlock": "解锁",
+    "zoomIn": "放大",
+    "zoomOut": "缩小",
+    "stars": "星星",
+    "addNewCourse": "添加新课程",
+    "world": "世界",
+    "addCourseStartMyOwn": "开始我自己的课程",
+    "addCourseEnterCode": "输入私有课程代码",
+    "addCourseBrowsePublic": "浏览公开课程",
+    "browsePublicCourses": "浏览公开课程",
+    "editProfile": "编辑个人资料",
+    "numObjectives": "{count} 个目标",
+    "mapSearchHint": "搜索活动",
+    "mapSearchNoResults": "视图中没有匹配项",
+    "mapFilterAllLanguages": "所有语言",
+    "mapFilterNotStarted": "未开始",
+    "mapFilterInProgress": "进行中",
+    "mapFilterCompleted": "完成",
+    "mapFilterReset": "重置",
+    "activityTypeConversation": "对话",
+    "lockedMissionRequirement": "完成前一个任务以解锁",
+    "playAgain": "再玩一次",
+    "reviewActivity": "回顾",
+    "mapEmptyInView": "在您的级别或语言中没有任何内容。扩大您的过滤器或缩小视图。",
+    "welcomeToPangeaChat": "欢迎来到 Pangea Chat",
+    "claimTrial": "领取您的试用",
+    "thanksForSigningUp": "感谢您的注册！这是",
+    "sevenDaysFree": "7天免费",
+    "manageTrialInSettings": "随时在\n订阅设置中管理您的试用",
+    "noCreditCardRequired": "无需信用卡。",
+    "proFeatures": "专业版",
+    "widenSearch": "扩大搜索",
+    "scrollToBottom": "滚动到底部",
+    "courseImage": "课程图片",
+    "avatarPreview": "头像预览",
+    "activityPhoto": "活动照片",
+    "emotePreview": "表情预览: {name}",
+    "activityLabel": "活动: {title}",
+    "resetMapView": "重置地图视图",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_zh_Hant.arb
+++ b/lib/l10n/intl_zh_Hant.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-18 09:35:28.477521",
+    "@@last_modified": "2026-06-26 10:49:59.616852",
     "about": "關於",
     "@about": {
         "type": "String",
@@ -10000,6 +10000,228 @@
         "placeholders": {}
     },
     "@viewCurrentOrFinished": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "joinTheCourseToPlay": "加入包含此活動的課程以進行遊玩。",
+    "resizeCoursePanel": "調整課程面板大小",
+    "undo": "撤銷",
+    "unlock": "解鎖",
+    "zoomIn": "放大",
+    "zoomOut": "縮小",
+    "stars": "星星",
+    "addNewCourse": "新增課程",
+    "world": "世界",
+    "addCourseStartMyOwn": "開始我自己的課程",
+    "addCourseEnterCode": "輸入私人課程代碼",
+    "addCourseBrowsePublic": "瀏覽公共課程",
+    "browsePublicCourses": "瀏覽公共課程",
+    "editProfile": "編輯個人資料",
+    "numObjectives": "{count} 個目標",
+    "mapSearchHint": "搜尋活動",
+    "mapSearchNoResults": "視圖中沒有匹配項",
+    "mapFilterAllLanguages": "所有語言",
+    "mapFilterNotStarted": "尚未開始",
+    "mapFilterInProgress": "進行中",
+    "mapFilterCompleted": "完成",
+    "mapFilterReset": "重置",
+    "activityTypeConversation": "對話",
+    "lockedMissionRequirement": "完成前一個任務以解鎖",
+    "playAgain": "再玩一次",
+    "reviewActivity": "檢視",
+    "mapEmptyInView": "在您的等級或語言中沒有任何內容。擴大您的篩選條件或縮小視圖。",
+    "welcomeToPangeaChat": "歡迎來到 Pangea Chat",
+    "claimTrial": "索取您的試用",
+    "thanksForSigningUp": "感謝您註冊！這裡是",
+    "sevenDaysFree": "7 天免費",
+    "manageTrialInSettings": "隨時在\n訂閱設定中管理您的試用",
+    "noCreditCardRequired": "無需信用卡。",
+    "proFeatures": "專業版",
+    "widenSearch": "擴大搜尋",
+    "scrollToBottom": "滾動到底部",
+    "courseImage": "課程圖片",
+    "avatarPreview": "頭像預覽",
+    "activityPhoto": "活動照片",
+    "emotePreview": "表情預覽: {name}",
+    "activityLabel": "活動: {title}",
+    "resetMapView": "重置地圖視圖",
+    "@joinTheCourseToPlay": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@resizeCoursePanel": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@undo": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unlock": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomIn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@zoomOut": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@stars": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addNewCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@world": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseStartMyOwn": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseEnterCode": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@addCourseBrowsePublic": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@browsePublicCourses": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@editProfile": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@numObjectives": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "int"
+            }
+        }
+    },
+    "@mapSearchHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapSearchNoResults": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterAllLanguages": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterNotStarted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterInProgress": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterCompleted": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapFilterReset": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityTypeConversation": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@lockedMissionRequirement": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@playAgain": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@reviewActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@mapEmptyInView": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@welcomeToPangeaChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@claimTrial": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@thanksForSigningUp": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@sevenDaysFree": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@manageTrialInSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@noCreditCardRequired": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@proFeatures": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@widenSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@scrollToBottom": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@courseImage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@avatarPreview": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@activityPhoto": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@emotePreview": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@activityLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@resetMapView": {
         "type": "String",
         "placeholders": {}
     }


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
