### PR TITLE
fix: resume joined activity session from map pin instead of fresh start (#7257)

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -9,6 +9,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
+import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/workspace_query.dart';
 import 'package:fluffychat/features/quests/lo_progression.dart';
@@ -853,9 +854,18 @@ class WorldMapController extends State<WorldMap>
       'm',
       'activity',
       'autoplay',
+      'roomid',
     });
 
     parts.add('activity=${card.activityId}');
+    // #7257: if the learner already holds a started/joined session for this
+    // activity, bind the overlay to that room (`roomid=`) so the start page
+    // resumes it (selectRole/confirmedRole) instead of offering a fresh
+    // instance. Pin entry stays unscoped — only the session room is added.
+    final myRoom = client?.myActivityInstance(card.activityId);
+    if (myRoom != null) {
+      parts.add('roomid=${shortRoomId(myRoom.id)}');
+    }
     context.go(WorkspaceQuery.location('/', parts));
     collapse();
   }

--- a/lib/routes/world/world_map_client_extension.dart
+++ b/lib/routes/world/world_map_client_extension.dart
@@ -8,6 +8,33 @@ import 'package:fluffychat/routes/world/world_map_search_overlay.dart';
 import 'package:fluffychat/routes/world/world_map_signals.dart';
 
 extension WorldMapClientExtension on Client {
+  /// The learner's OWN session room for [activityId] — a room they have *joined*
+  /// (membership join), whether or not they have confirmed a role. Prefers a
+  /// room where they hold a role, then the most recently active. This is the
+  /// inverse of [bestJoinableActivityInstance] (which finds a free seat in
+  /// *another* learner's open session): here we resolve "my started/joined
+  /// session" so a map-pin tap reopens it (binding the overlay via `roomid=`)
+  /// instead of spawning a fresh instance (#7257).
+  Room? myActivityInstance(String activityId) {
+    Room? best;
+    var bestHasRole = false;
+    for (final r in rooms) {
+      if (r.activityId != activityId) continue;
+      if (r.membership != Membership.join) continue;
+      final hasRole = r.ownRole != null;
+      final ms = r.lastEvent?.originServerTs.millisecondsSinceEpoch ?? 0;
+      final bestMs =
+          best?.lastEvent?.originServerTs.millisecondsSinceEpoch ?? 0;
+      if (best == null ||
+          (hasRole && !bestHasRole) ||
+          (hasRole == bestHasRole && ms > bestMs)) {
+        best = r;
+        bestHasRole = hasRole;
+      }
+    }
+    return best;
+  }
+
   Room? bestJoinableActivityInstance(String activityId) {
     Room? best;
     for (final r in rooms) {


### PR DESCRIPTION
Closes #7257.

## Problem

Tapping a green "own/joined" activity pin on the world map always opened a **fresh** instance ("start a new instance" page) even when the learner already had a started or joined session for that activity.

## Root cause

The large-card tap routes through `WorldMapController.openActivity`, which built an unscoped `?activity=<id>` overlay with **no `roomid=`**. The activity start page derives its state from `widget.roomId`: when it is null (and the user isn't actively launching), `_sessionState` returns `SessionState.notStarted` (`activity_session_start_page.dart:256-268`). So the overlay never resolved the learner's existing room.

`bestJoinableActivityInstance` only finds a *free seat in another* learner's open session (the user is not bound to it), so it could not answer "which session is mine?".

## Fix

- New `Client.myActivityInstance(activityId)` (the inverse of `bestJoinableActivityInstance`): the learner's own **joined** room for the activity (membership join), preferring one where they hold a role, then most-recently-active. Covers the issue's "joined but no role confirmed yet" case.
- `openActivity` now binds the overlay to that room via `roomid=<short>` when one exists. Pin entry stays unscoped (no `?m=course:`); only the session room is added, so the start page resumes the session (`selectRole` / `confirmedRole`) instead of offering a fresh instance. When the learner has no joined session, behavior is unchanged.

This builds directly on #7267's token-native `roomid=` plumbing (`activityFor` → `widget.roomId`).

## Changes to review
- `lib/routes/world/world_map_client_extension.dart` — `myActivityInstance` helper.
- `lib/routes/world/world_map.dart` — `openActivity` adds `roomid=` for an existing joined session; drops any stale `roomid` first; imports `room_id_url`.

## TO TEST
- [ ] Find a green "joined" activity on the map (start or join one, with or without confirming a role).
- [ ] Tap it: you land on that session (resume / role-confirm), not the "start a new instance" page.
- [ ] Tap a non-joined activity pin: still opens the fresh start page (unchanged).
