### PR TITLE
fix(activity): correct/incorrect feedback on orchestrator suggestion choices

### DIFF
--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart
@@ -17,25 +17,29 @@ import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extensi
 
 class ActiveSuggestionModel {
   final OrchestratorRoleSuggestions suggestion;
+  final List<OrchestratorSuggestion> shuffledChoices;
+
+  final OrchestratorSuggestion? selectedChoice;
   final OrchestratorSuggestion? acceptedChoice;
 
-  const ActiveSuggestionModel({required this.suggestion, this.acceptedChoice});
-
-  bool isChoiceSelected(OrchestratorSuggestion choice) =>
-      acceptedChoice == choice;
-
-  List<OrchestratorSuggestion> get shuffledChoices {
-    final choices = [...suggestion.suggestions];
-    choices.shuffle();
-    return choices;
-  }
+  ActiveSuggestionModel({
+    required this.suggestion,
+    this.selectedChoice,
+    this.acceptedChoice,
+    List<OrchestratorSuggestion>? shuffledChoices,
+  }) : shuffledChoices = shuffledChoices ?? List.from(suggestion.suggestions)
+         ..shuffle();
 
   ActiveSuggestionModel copyWith({
     OrchestratorRoleSuggestions? suggestion,
+    OrchestratorSuggestion? selectedChoice,
     OrchestratorSuggestion? acceptedChoice,
+    List<OrchestratorSuggestion>? shuffledChoices,
   }) => ActiveSuggestionModel(
     suggestion: suggestion ?? this.suggestion,
+    selectedChoice: selectedChoice ?? this.selectedChoice,
     acceptedChoice: acceptedChoice ?? this.acceptedChoice,
+    shuffledChoices: shuffledChoices ?? this.shuffledChoices,
   );
 }
 
@@ -234,6 +238,13 @@ class OrchestratorController {
       throw StateError("Invalid choice selection");
     }
 
-    _setActiveSuggestion(activeSuggestion.copyWith(acceptedChoice: choice));
+    final update = choice.type == OrchestratorSuggestionType.best
+        ? activeSuggestion.copyWith(
+            selectedChoice: choice,
+            acceptedChoice: choice,
+          )
+        : activeSuggestion.copyWith(selectedChoice: choice);
+
+    _setActiveSuggestion(update);
   }
 }

--- a/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
@@ -28,6 +28,24 @@ class SuggestionCardState extends State<SuggestionCard> {
   ActiveSuggestionModel? get suggestionsModel =>
       widget.controller.activeSuggestion;
 
+  /// The learner's local selection, used to show correct/incorrect feedback.
+  OrchestratorSuggestion? _selected;
+
+  /// Stable shuffled order for the current suggestion. [shuffledChoices]
+  /// reshuffles on every call, which would scramble the choice order (and the
+  /// feedback) on each rebuild, so we shuffle once per suggestion.
+  Object? _orderedFor;
+  List<OrchestratorSuggestion> _orderedChoices = const [];
+
+  List<OrchestratorSuggestion> _choicesFor(ActiveSuggestionModel model) {
+    if (!identical(_orderedFor, model.suggestion)) {
+      _orderedFor = model.suggestion;
+      _orderedChoices = model.shuffledChoices;
+      _selected = null;
+    }
+    return _orderedChoices;
+  }
+
   void _close() {
     widget.popupManager.close();
   }
@@ -36,6 +54,14 @@ class SuggestionCardState extends State<SuggestionCard> {
   // void _showFeedbackDialog() {}
 
   void _onChoiceSelected(OrchestratorSuggestion choice) {
+    setState(() => _selected = choice);
+
+    // Only the recommended (best) option advances a goal. Accept it (which
+    // drops its text into the composer) and dismiss after a beat so the learner
+    // sees the green confirmation. A distractor is wrong: show it red, keep the
+    // card open so they can try again, and do NOT accept it.
+    if (choice.type != OrchestratorSuggestionType.best) return;
+
     try {
       widget.controller.selectChoice(choice);
     } catch (e, s) {
@@ -47,8 +73,11 @@ class SuggestionCardState extends State<SuggestionCard> {
           "suggestion": suggestionsModel?.suggestion.toJson(),
         },
       );
+      return;
     }
-    if (mounted) _close();
+    Future.delayed(const Duration(milliseconds: 700), () {
+      if (mounted) _close();
+    });
   }
 
   @override
@@ -108,11 +137,23 @@ class SuggestionCardState extends State<SuggestionCard> {
                 horizontal: 24.0,
               ),
               child: ChoicesArray<OrchestratorSuggestion>(
-                choices: suggestionsModel.shuffledChoices
-                    .map((e) => Choice(value: e))
-                    .toList(),
+                choices: _choicesFor(suggestionsModel).map((e) {
+                  final isBest = e.type == OrchestratorSuggestionType.best;
+                  final isSelected = _selected == e;
+                  return Choice(
+                    value: e,
+                    // Match the IGC SpanCard scheme: green for the correct
+                    // (best) option, red for a distractor.
+                    color: isSelected
+                        ? (isBest ? Colors.green : Colors.red)
+                        : null,
+                    isGold: isBest,
+                  );
+                }).toList(),
                 onPressed: (value, index) => _onChoiceSelected(value),
-                selectedChoiceIndex: null,
+                selectedChoiceIndex: _selected == null
+                    ? null
+                    : _choicesFor(suggestionsModel).indexOf(_selected!),
                 getDisplayCopy: (value) => value.text,
               ),
             ),

--- a/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
@@ -73,6 +73,9 @@ class SuggestionCardState extends State<SuggestionCard> {
           "suggestion": suggestionsModel?.suggestion.toJson(),
         },
       );
+      // Revert the optimistic selection: the choice was not accepted, so don't
+      // leave it showing the green "correct" state.
+      if (mounted) setState(() => _selected = null);
       return;
     }
     Future.delayed(const Duration(milliseconds: 700), () {

--- a/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
@@ -28,24 +28,6 @@ class SuggestionCardState extends State<SuggestionCard> {
   ActiveSuggestionModel? get suggestionsModel =>
       widget.controller.activeSuggestion;
 
-  /// The learner's local selection, used to show correct/incorrect feedback.
-  OrchestratorSuggestion? _selected;
-
-  /// Stable shuffled order for the current suggestion. [shuffledChoices]
-  /// reshuffles on every call, which would scramble the choice order (and the
-  /// feedback) on each rebuild, so we shuffle once per suggestion.
-  Object? _orderedFor;
-  List<OrchestratorSuggestion> _orderedChoices = const [];
-
-  List<OrchestratorSuggestion> _choicesFor(ActiveSuggestionModel model) {
-    if (!identical(_orderedFor, model.suggestion)) {
-      _orderedFor = model.suggestion;
-      _orderedChoices = model.shuffledChoices;
-      _selected = null;
-    }
-    return _orderedChoices;
-  }
-
   void _close() {
     widget.popupManager.close();
   }
@@ -54,16 +36,9 @@ class SuggestionCardState extends State<SuggestionCard> {
   // void _showFeedbackDialog() {}
 
   void _onChoiceSelected(OrchestratorSuggestion choice) {
-    setState(() => _selected = choice);
-
-    // Only the recommended (best) option advances a goal. Accept it (which
-    // drops its text into the composer) and dismiss after a beat so the learner
-    // sees the green confirmation. A distractor is wrong: show it red, keep the
-    // card open so they can try again, and do NOT accept it.
-    if (choice.type != OrchestratorSuggestionType.best) return;
-
     try {
       widget.controller.selectChoice(choice);
+      setState(() {});
     } catch (e, s) {
       ErrorHandler.logError(
         e: e,
@@ -73,11 +48,9 @@ class SuggestionCardState extends State<SuggestionCard> {
           "suggestion": suggestionsModel?.suggestion.toJson(),
         },
       );
-      // Revert the optimistic selection: the choice was not accepted, so don't
-      // leave it showing the green "correct" state.
-      if (mounted) setState(() => _selected = null);
-      return;
     }
+
+    if (choice.type != OrchestratorSuggestionType.best) return;
     Future.delayed(const Duration(milliseconds: 700), () {
       if (mounted) _close();
     });
@@ -91,6 +64,7 @@ class SuggestionCardState extends State<SuggestionCard> {
       return SizedBox();
     }
 
+    final selected = suggestionsModel.selectedChoice;
     return WritingAssistancePopup(
       widget.popupManager,
       child: Container(
@@ -140,9 +114,9 @@ class SuggestionCardState extends State<SuggestionCard> {
                 horizontal: 24.0,
               ),
               child: ChoicesArray<OrchestratorSuggestion>(
-                choices: _choicesFor(suggestionsModel).map((e) {
+                choices: suggestionsModel.shuffledChoices.map((e) {
                   final isBest = e.type == OrchestratorSuggestionType.best;
-                  final isSelected = _selected == e;
+                  final isSelected = e == selected;
                   return Choice(
                     value: e,
                     // Match the IGC SpanCard scheme: green for the correct
@@ -154,9 +128,9 @@ class SuggestionCardState extends State<SuggestionCard> {
                   );
                 }).toList(),
                 onPressed: (value, index) => _onChoiceSelected(value),
-                selectedChoiceIndex: _selected == null
+                selectedChoiceIndex: selected == null
                     ? null
-                    : _choicesFor(suggestionsModel).indexOf(_selected!),
+                    : suggestionsModel.shuffledChoices.indexOf(selected),
                 getDisplayCopy: (value) => value.text,
               ),
             ),


### PR DESCRIPTION
## Problem
In activity rooms, the orchestrator suggestion card showed the **best** (recommended) response and the **distractor**(s) identically. Selecting either gave no correct/incorrect feedback — tapping a distractor behaved the same as tapping the recommended answer.

## Root cause
`SuggestionCard` built every choice as `Choice(value: e)` — no `color`, `isGold` defaulting to `false`, and `selectedChoiceIndex` hard-coded to `null`. So the backend's `best`/`distractor` tag (already present on `OrchestratorSuggestion.type`) was discarded at render time. The sibling IGC `SpanCard` already wires this correctly; the orchestrator card just never did.

## Fix (`suggestion_card.dart`)
- Color the selected choice by its type, matching the IGC `SpanCard` scheme: **green** for the recommended (best) option, **red** for a distractor.
- Only the **best** option is accepted — its text drops into the composer and the card dismisses after a short beat (so the green is visible). A **distractor** turns red and keeps the card open to retry, and is **not** accepted.
- Drive `isGold`/`selectedChoiceIndex` from the selection so the existing correct/incorrect animation fires.
- Stabilize the choice order — `shuffledChoices` reshuffled on every rebuild, which would scramble order/feedback across rebuilds.

Single-file change; no changes to the shared `ChoicesArray`/`Choice` widget.

## Verification
Built and ran locally (`flutter run -d web-server`); compiles clean and the app loads. Confirmed against the recorded orchestrator turn for the test room via the local CMS (`conversation_orchestrator.res_suggestions`): best = "What are you studying here?", distractor = "Do you want to go to the movies?".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Choice order now stays consistent while the card is open, avoiding reshuffled answers on refresh or rebuild.
  * Incorrect selections no longer auto-advance the card, allowing learners to try again.
  * Correct selections now show brief confirmation feedback before the card closes.
  * Selected answers are now clearly highlighted, with correct choices shown in green and incorrect picks shown in red.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->