### PR TITLE
refactor: split up world map into smaller function-specific files

### DIFF
--- a/lib/routes/world/map_context.dart
+++ b/lib/routes/world/map_context.dart
@@ -42,17 +42,3 @@ abstract class MapContextController {
     if (notifier.value != context) notifier.value = context;
   }
 }
-
-/// Whether a map-pin preview is open on a narrow screen — where the preview
-/// renders as a bottom sheet over the map rather than a glued-to-pin popup. The
-/// persistent map (which owns the pin selection) writes it; the shell reads it
-/// to hide the bottom nav while the sheet is up (a bottom sheet replaces the
-/// bottom nav). A simple bool: the map keeps the selected pin / its loading
-/// plan, this only signals "a pin sheet is showing." See `routing.instructions.md`.
-abstract class MapPinController {
-  static final ValueNotifier<bool> notifier = ValueNotifier<bool>(false);
-
-  static void set(bool open) {
-    if (notifier.value != open) notifier.value = open;
-  }
-}

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -334,7 +334,7 @@ class WorldMapController extends State<WorldMap>
     if (mounted) setState(() => _loadingPins = true);
 
     try {
-      _pinsManager.loadWorldScopedPins(
+      await _pinsManager.loadWorldScopedPins(
         bounds: bounds,
         l2: _filterState.filter.l2Only ? user.userL2Code : null,
         l1: user.userL1Code,

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -339,9 +339,7 @@ class WorldMapController extends State<WorldMap>
         l2: _filterState.filter.l2Only ? user.userL2Code : null,
         l1: user.userL1Code,
       );
-      if (!mounted) return;
-      setState(() => _loadingPins = false);
-    } catch (_) {
+    } finally {
       if (mounted) setState(() => _loadingPins = false);
     }
   }

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -8,6 +8,7 @@ import 'package:latlong2/latlong.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
+import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/workspace_query.dart';
@@ -103,7 +104,10 @@ class WorldMapController extends State<WorldMap>
   double _camTargetZoom = 0;
 
   Client? _client;
+
   StreamSubscription<dynamic>? _syncSub;
+  StreamSubscription? _languageSubscription;
+  StreamSubscription? _cefrLevelSubscription;
 
   final WorldMapFilterState _filterState = WorldMapFilterState();
   final WorldMapPinsManager _pinsManager = WorldMapPinsManager();
@@ -131,6 +135,24 @@ class WorldMapController extends State<WorldMap>
 
     // Rebuild when a featured large card's full plan hydrates (image + goals).
     ActivityPlanRepo.instance.addListener(_onPlanHydrate);
+
+    final user = MatrixState.pangeaController.userController;
+
+    _languageSubscription?.cancel();
+    _languageSubscription = user.languageStream.stream.listen((update) {
+      if (update.targetLang != _filterState.filter.l2) {
+        _setL2(update.targetLang);
+      }
+    });
+
+    _cefrLevelSubscription?.cancel();
+    _cefrLevelSubscription = user.settingsUpdateStream.stream.listen((update) {
+      if (!_filterState.filter.cefrFilter.contains(
+        update.userSettings.cefrLevel,
+      )) {
+        _setCefrLevel(update.userSettings.cefrLevel);
+      }
+    });
   }
 
   @override
@@ -164,8 +186,9 @@ class WorldMapController extends State<WorldMap>
     // Personalized default: my CEFR band (at/below my level). Applied once the
     // user controller is available.
     if (!_filterState.filter.filterDefaultsApplied) {
+      final l2 = MatrixState.pangeaController.userController.userL2;
       final cefr = MatrixState.pangeaController.userController.userCefrLevel;
-      _filterState.applyDefaults(cefrLevel: cefr);
+      _filterState.applyDefaults(l2: l2, cefrLevel: cefr);
     }
   }
 
@@ -189,6 +212,8 @@ class WorldMapController extends State<WorldMap>
   @override
   void dispose() {
     _syncSub?.cancel();
+    _languageSubscription?.cancel();
+    _cefrLevelSubscription?.cancel();
     _refetchDebounce?.cancel();
     _fitDebounce?.cancel();
     _cameraAnimation.dispose();
@@ -336,7 +361,9 @@ class WorldMapController extends State<WorldMap>
     try {
       await _pinsManager.loadWorldScopedPins(
         bounds: bounds,
-        l2: _filterState.filter.l2Only ? user.userL2Code : null,
+        l2: _filterState.filter.l2Only
+            ? _filterState.filter.l2?.langCode
+            : null,
         l1: user.userL1Code,
       );
     } finally {
@@ -345,6 +372,14 @@ class WorldMapController extends State<WorldMap>
   }
 
   void setQuery(String q) => setState(() => _filterState.setQuery(q));
+
+  void _setL2(LanguageModel? l2) {
+    setState(() => _filterState.setL2(l2));
+    loadWorldPins();
+  }
+
+  void _setCefrLevel(LanguageLevelTypeEnum? cefrLevel) =>
+      setState(() => _filterState.setCefrLevel(cefrLevel));
 
   void toggleL2() {
     setState(() => _filterState.toggleL2());

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -8,21 +8,17 @@ import 'package:latlong2/latlong.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
-import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
 import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/workspace_query.dart';
-import 'package:fluffychat/features/quests/lo_progression.dart';
 import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
 import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
-import 'package:fluffychat/features/quests/quests_client_extension.dart';
-import 'package:fluffychat/features/quests/repo/activity_map_repo.dart';
-import 'package:fluffychat/features/quests/repo/quest_repo.dart';
-import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
-import 'package:fluffychat/routes/world/joined_objective_cache.dart';
 import 'package:fluffychat/routes/world/map_context.dart';
 import 'package:fluffychat/routes/world/world_map_client_extension.dart';
+import 'package:fluffychat/routes/world/world_map_constants.dart';
+import 'package:fluffychat/routes/world/world_map_filter.dart';
+import 'package:fluffychat/routes/world/world_map_pins_manager.dart';
 import 'package:fluffychat/routes/world/world_map_ranking.dart';
 import 'package:fluffychat/routes/world/world_map_search_overlay.dart';
 import 'package:fluffychat/routes/world/world_map_view.dart';
@@ -92,150 +88,49 @@ class WorldMapController extends State<WorldMap>
     with SingleTickerProviderStateMixin {
   final MapController _ownController = MapController();
 
-  /// The camera zoom range — the single source for FlutterMap's MapOptions, the
-  /// +/- step clamp in [zoomBy], the World reset in [resetToWorld], and the
-  /// on-map control disabled states (#7171). minZoom 3 is the whole world.
-  static const double minZoom = 3.0;
-  static const double maxZoom = 18.0;
-
-  /// Whether a zoom-in / zoom-out step would still change the camera, i.e. the
-  /// on-map + / - button should be enabled. At a limit the matching button is
-  /// disabled so it can't no-op (#7171).
-  static bool canZoomIn(double zoom) => zoom < maxZoom;
-  static bool canZoomOut(double zoom) => zoom > minZoom;
-
-  /// The activity pins currently shown — the active context's set (the whole
-  /// world, or a selected quest's activities). Thin: id, title, point.
-  List<QuestActivityCard> _pins = [];
-
-  /// The activity a learner tapped to expand to its large card in place: a
-  /// small/mid pin promotes to the large tier on tap, and the large card then
-  /// taps through to the plan page. Null when nothing is promoted; tapping the
-  /// empty map clears it. Stays on the persistent map — no navigation, no second
-  /// map, no preview popup.
-  String? _promotedActivityId;
-
-  Client? _client;
-  StreamSubscription<dynamic>? _syncSub;
-
-  // Search + filter state (World context only). The personalized default is the
-  // initial state — my L2 + at/below my CEFR — and search/filters refine it.
-  String _query = '';
-  bool _l2Only = true;
-  Set<LanguageLevelTypeEnum> _cefrFilter = {};
-  Set<LanguageLevelTypeEnum> _defaultCefr = {};
-  final Set<MapCompletionFilter> _completionFilter = {};
-  bool _filterDefaultsApplied = false;
-
-  bool _loadingPins = false;
-  Timer? _refetchDebounce;
-
   /// Debounce for context-driven camera fits: when you click through courses,
   /// the camera waits until you've settled (~2s) before gliding, rather than
   /// snapping on every hop. Re-armed on each request; only the last fires.
   Timer? _fitDebounce;
-  static const Duration _fitSettleDelay = Duration(seconds: 2);
-
-  /// The zoom the camera glides to when an activity is focused (opened) — close
-  /// enough to read it as "this specific spot" (neighborhood/building level).
-  static const double _focusZoom = 16.0;
 
   /// Drives the smooth camera glide (center + zoom tween) instead of an instant
   /// `fitCamera` snap. Retargets cleanly if a new fit lands mid-flight.
-  AnimationController? _camAnim;
-  CurvedAnimation? _camCurve;
+  late final AnimationController _cameraAnimationController;
+  late final CurvedAnimation _cameraAnimation;
   LatLng? _camStart;
   LatLng? _camTarget;
   double _camStartZoom = 0;
   double _camTargetZoom = 0;
-  static const Duration _camGlideDuration = Duration(milliseconds: 600);
 
-  /// Cached per-activity live signals (state + fill + recency + pinged),
-  /// completion, and the learner's star total per activity, recomputed on room
-  /// sync (not per frame) so the O(rooms) scan doesn't run every build.
-  /// [_completion] backs the completion filter chip; [_userStars] feeds the
-  /// progression resolver's per-Mission star rollup ([_resolveProgression]).
-  Map<String, PinSignals> _signals = {};
-  Map<String, int> _userStars = {};
-  Map<String, MapCompletionFilter> _completion = {};
+  Client? _client;
+  StreamSubscription<dynamic>? _syncSub;
 
-  /// Learning-objective ids across the learner's joined courses, for relevance
-  /// banding. Rebuilt async on course join/leave (see [_maybeRebuildObjectiveCache]).
-  final JoinedObjectiveCache _objectiveCache = JoinedObjectiveCache();
+  final WorldMapFilterState _filterState = WorldMapFilterState();
+  final WorldMapPinsManager _pinsManager = WorldMapPinsManager();
 
-  /// The joined-course uuids [_objectiveCache] was last (re)built from. The
-  /// initial build happens on client-set, but the joined-course rooms (or their
-  /// outlines) may not be ready yet; tracking the set lets the sync listener
-  /// rebuild when it changes — or when a prior build resolved nothing — instead
-  /// of the banding + gate staying blank for the whole session.
-  Set<String> _objectiveCacheUuids = const {};
-
-  /// Guards against overlapping objective-cache rebuilds (and stops a
-  /// persistently-failing course from rebuilding on every single sync).
-  bool _objectiveCacheRebuilding = false;
-
-  /// Activity ids with a recently-pinged open session (best-effort, scanned from
-  /// joined course-space messages). Folded into [_signals].
-  Set<String> _pingedActivityIds = {};
-
-  /// The shared next-Mission resolution the relevance band ranks toward, resolved
-  /// from the objective cache's outlines + [_userStars]. Recomputed where its
-  /// inputs change — the objective cache rebuilds (course join/leave) and user
-  /// stars change on room sync — NOT per frame. See world-map.instructions.md.
-  ProgressionResolution _progression = ProgressionResolution.empty;
-
-  /// The viewed course's outline when the map is scoped to a course the learner
-  /// has NOT joined: a course-scoped map ranks toward that course's next Mission
-  /// even before joining (Will's decision). Null on the world view or when the
-  /// scoped course is already a joined course (its outline is in the cache).
-  CourseLoOutline? _scopedCourseOutline;
-
-  /// The course-plan id [_scopedCourseOutline] was resolved for, so a re-scope to
-  /// the same course doesn't re-fetch and a re-scope away clears it.
-  String? _scopedCourseOutlineId;
-
-  // ---- View-facing accessors (read by WorldMapView) -------------------------
-
-  /// The flutter_map controller (a caller-provided override, or our own). The
-  /// view passes it to [FlutterMap] and reads its camera; the controller
-  /// animates it.
-  MapController get mapController => widget.controller ?? _ownController;
-
-  bool get isWorld => MapContextController.notifier.value is! CourseMapContext;
-  String? get promotedActivityId => _promotedActivityId;
-  Client? get client => _client;
-  bool get loadingPins => _loadingPins;
-  Map<String, PinSignals> get signals => _signals;
-  Map<String, int> get userStars => _userStars;
-  Map<String, MapCompletionFilter> get completion => _completion;
-  JoinedObjectiveCache get objectiveCache => _objectiveCache;
-
-  /// The shared next-Mission resolution the relevance band ranks toward. Cached
-  /// (recomputed on its inputs changing, not per frame); the view reads it.
-  ProgressionResolution get progression => _progression;
-  String get query => _query;
-  bool get l2Only => _l2Only;
-  Set<LanguageLevelTypeEnum> get cefrFilter => _cefrFilter;
-  Set<MapCompletionFilter> get completionFilter => _completionFilter;
+  bool _loadingPins = false;
+  Timer? _refetchDebounce;
 
   @override
   void initState() {
     super.initState();
-    // Invariant: the shell owns a single persistent instance, so this runs
-    // once per app session — section navigation overlays the map, never
-    // remounts it.
-    _camAnim = AnimationController(vsync: this, duration: _camGlideDuration)
-      ..addListener(_onCamGlideTick);
-    _camCurve = CurvedAnimation(parent: _camAnim!, curve: Curves.easeInOut);
+    _cameraAnimationController = AnimationController(
+      vsync: this,
+      duration: WorldMapConstants.camGlideDuration,
+    )..addListener(_onCamGlideTick);
+
+    _cameraAnimation = CurvedAnimation(
+      parent: _cameraAnimationController,
+      curve: Curves.easeInOut,
+    );
+
     _loadForContext();
+
     MapContextController.notifier.addListener(_onContextChange);
-    MapPinController.notifier.addListener(_onPinControllerChange);
+    WorldMapPinsManager.notifier.addListener(_onPinControllerChange);
+
     // Rebuild when a featured large card's full plan hydrates (image + goals).
     ActivityPlanRepo.instance.addListener(_onPlanHydrate);
-  }
-
-  void _onPlanHydrate() {
-    if (mounted) setState(() {});
   }
 
   @override
@@ -265,154 +160,13 @@ class WorldMapController extends State<WorldMap>
             _maybeRebuildObjectiveCache(client);
           });
     }
+
     // Personalized default: my CEFR band (at/below my level). Applied once the
     // user controller is available.
-    if (!_filterDefaultsApplied) {
-      _filterDefaultsApplied = true;
-      _defaultCefr = LanguageLevelTypeEnum.bandAtOrBelow(
-        MatrixState.pangeaController.userController.userCefrLevel,
-      );
-      _cefrFilter = {..._defaultCefr};
+    if (!_filterState.filter.filterDefaultsApplied) {
+      final cefr = MatrixState.pangeaController.userController.userCefrLevel;
+      _filterState.applyDefaults(cefrLevel: cefr);
     }
-  }
-
-  void _recomputeProgress() {
-    final client = _client;
-    if (client == null) return;
-    final signals = client.deriveActivitySignals(
-      pingedActivityIds: _pingedActivityIds,
-    );
-    final userStars = client.userStarsByActivity;
-    final completion = client.activityCompletionStatuses;
-
-    if (!mounted) {
-      _signals = signals;
-      _userStars = userStars;
-      _completion = completion;
-      _resolveProgression();
-      return;
-    }
-
-    setState(() {
-      _signals = signals;
-      _userStars = userStars;
-      _completion = completion;
-      _resolveProgression();
-    });
-  }
-
-  /// Re-resolve the cached [_progression] from the objective cache's outlines (+
-  /// any course-scoped outline) and the learner's current per-activity stars.
-  /// Called where the inputs change — stars on room sync, the objective cache on
-  /// course join/leave, and a course re-scope — never per frame.
-  void _resolveProgression() {
-    _progression = _objectiveCache.resolution(
-      _userStars,
-      extraOutlines: _scopedCourseOutline == null
-          ? const []
-          : [_scopedCourseOutline!],
-    );
-  }
-
-  /// The learner's joined course spaces (a space they belong to that carries a
-  /// course plan) — the source set for the objective cache + relevance banding.
-  List<Room> _joinedCourseRooms(Client client) => client.rooms
-      .where(
-        (r) =>
-            r.isSpace &&
-            r.membership == Membership.join &&
-            r.coursePlan != null,
-      )
-      .toList();
-
-  /// Rebuild the joined-course outlines (a few quest reads), reading each
-  /// course's teacher override for the stars-to-unlock threshold, then re-rank.
-  /// Guarded so overlapping syncs don't stack rebuilds. A course whose outline
-  /// fails to resolve is logged (not silently dropped): an empty cache means no
-  /// relevance banding and a fail-open gate, which is otherwise invisible.
-  Future<void> _rebuildObjectiveCache(Client client) async {
-    if (_objectiveCacheRebuilding) return;
-    _objectiveCacheRebuilding = true;
-    try {
-      final courseRooms = _joinedCourseRooms(client);
-      final uuids = courseRooms.map((r) => r.coursePlan!.uuid).toList();
-      final thresholds = <String, int>{
-        for (final r in courseRooms)
-          r.coursePlan!.uuid:
-              r.teacherMode.starsToUnlockObjective ??
-              kDefaultStarsToUnlockObjective,
-      };
-      await _objectiveCache.rebuild(
-        uuids,
-        starsToUnlockOf: (uuid) =>
-            thresholds[uuid] ?? kDefaultStarsToUnlockObjective,
-        onError: (uuid, e, s) => ErrorHandler.logError(
-          e: e,
-          s: s,
-          m: 'JoinedObjectiveCache: course outline failed to resolve',
-          data: {'courseUuid': uuid},
-        ),
-      );
-      _objectiveCacheUuids = uuids.toSet();
-      _resolveProgression(); // re-resolve the band with the loaded outlines
-      if (mounted) setState(() {}); // re-rank
-    } finally {
-      _objectiveCacheRebuilding = false;
-    }
-  }
-
-  /// Rebuild the objective cache when the joined-course set has changed since the
-  /// last build, or when it resolved nothing while courses exist (the rooms or
-  /// their outlines weren't ready at the initial build, or a read transiently
-  /// failed). Idempotent for an unchanged, already-populated set, so it's safe on
-  /// every sync; the in-flight guard keeps a persistently-failing course from
-  /// rebuilding more than once at a time, and it self-heals once the data is fixed.
-  void _maybeRebuildObjectiveCache(Client client) {
-    if (_objectiveCacheRebuilding) return;
-    final uuids = _joinedCourseRooms(
-      client,
-    ).map((r) => r.coursePlan!.uuid).toSet();
-    final setChanged =
-        uuids.length != _objectiveCacheUuids.length ||
-        !uuids.containsAll(_objectiveCacheUuids);
-    final emptyButHasCourses = _objectiveCache.ids.isEmpty && uuids.isNotEmpty;
-    if (setChanged || emptyButHasCourses) _rebuildObjectiveCache(client);
-  }
-
-  /// Best-effort pinged detection: scan joined course spaces' recent messages
-  /// for the host's recruit ping (carries `pangea.activity.id`), within a day.
-  /// A ping leaves no persistent room state, so this proxy is intentionally
-  /// approximate — its efficacy is worth watching (world-map.instructions.md).
-  Future<void> _recomputePinged(Client client) async {
-    final pinged = <String>{};
-    final cutoff = DateTime.now().subtract(const Duration(hours: 24));
-    final spaces = client.rooms.where(
-      (r) =>
-          r.isSpace && r.membership == Membership.join && r.coursePlan != null,
-    );
-    for (final space in spaces) {
-      try {
-        final timeline = await space.getTimeline();
-        for (final e in timeline.events) {
-          if (!e.originServerTs.isAfter(cutoff)) continue;
-          final id = e.content['pangea.activity.id'];
-          if (id is String && id.isNotEmpty) pinged.add(id);
-        }
-        timeline.cancelSubscriptions();
-      } catch (_) {
-        // A space whose timeline won't load just contributes no pings.
-      }
-    }
-    if (!mounted ||
-        (pinged.length == _pingedActivityIds.length &&
-            pinged.containsAll(_pingedActivityIds))) {
-      return;
-    }
-    _pingedActivityIds = pinged;
-
-    setState(() {
-      _signals = client.deriveActivitySignals(pingedActivityIds: pinged);
-    });
   }
 
   @override
@@ -437,16 +191,70 @@ class WorldMapController extends State<WorldMap>
     _syncSub?.cancel();
     _refetchDebounce?.cancel();
     _fitDebounce?.cancel();
-    _camCurve?.dispose();
-    _camAnim?.dispose();
+    _cameraAnimation.dispose();
+    _cameraAnimationController.dispose();
     MapContextController.notifier.removeListener(_onContextChange);
-    MapPinController.notifier.removeListener(_onPinControllerChange);
+    WorldMapPinsManager.notifier.removeListener(_onPinControllerChange);
     ActivityPlanRepo.instance.removeListener(_onPlanHydrate);
     // Reset the process-global so a pin selected at teardown (e.g. logging out
     // with a pin sheet up) can't strand a stale `true` that would hide the bottom
     // nav at the bare map on the next mount. See `routing.instructions.md`.
-    MapPinController.set(false);
+    WorldMapPinsManager.set(false);
     super.dispose();
+  }
+
+  MapController get mapController => widget.controller ?? _ownController;
+
+  bool get isWorld => MapContextController.notifier.value is! CourseMapContext;
+  String? get promotedActivityId => _pinsManager.promotedActivityId;
+  Client? get client => _client;
+  bool get loadingPins => _loadingPins;
+
+  WorldMapFilter get filter => _filterState.filter;
+  Map<String, PinSignals> get signals => _pinsManager.signals;
+  ProgressionResolution get progression => _pinsManager.progression;
+
+  /// The pins actually shown: the loaded set narrowed by the active CEFR band,
+  /// completion filter, and free-text query. World only; a course shows its set.
+  List<QuestActivityCard> get visiblePins => _pinsManager.filteredPins((c) {
+    if (!isWorld) return true;
+
+    final status = _pinsManager.activityCompletionStatus(c.activityId);
+    return _filterState.include(c, status ?? MapCompletionFilter.notStarted);
+  });
+
+  int? activityStarsEarned(String activityId) =>
+      _pinsManager.activityStarsEarned(activityId);
+
+  void _onPlanHydrate() {
+    if (mounted) setState(() {});
+  }
+
+  void _recomputeProgress() {
+    final client = _client;
+    if (client == null) return;
+    _pinsManager.recomputeProgress(client);
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _rebuildObjectiveCache(Client client) async {
+    await _pinsManager.rebuildObjectiveCache(client);
+    if (mounted) setState(() {});
+  }
+
+  Future<void> _maybeRebuildObjectiveCache(Client client) async {
+    if (_pinsManager.shouldRebuildObjectiveCache(client)) {
+      return _rebuildObjectiveCache(client);
+    }
+  }
+
+  /// Best-effort pinged detection: scan joined course spaces' recent messages
+  /// for the host's recruit ping (carries `pangea.activity.id`), within a day.
+  /// A ping leaves no persistent room state, so this proxy is intentionally
+  /// approximate — its efficacy is worth watching (world-map.instructions.md).
+  Future<void> _recomputePinged(Client client) async {
+    await _pinsManager.recomputePinged(client);
+    if (mounted) setState(() {});
   }
 
   /// The shell sets [MapPinController] false when the map is covered by a
@@ -455,10 +263,8 @@ class WorldMapController extends State<WorldMap>
   /// that here — drop our own selection when the controller is cleared by anyone
   /// else. Guarded so our own clears (which also set it false) don't loop.
   void _onPinControllerChange() {
-    if (!MapPinController.notifier.value &&
-        _promotedActivityId != null &&
-        mounted) {
-      collapse();
+    if (!WorldMapPinsManager.notifier.value && mounted) {
+      demoteActivity();
     }
   }
 
@@ -468,8 +274,8 @@ class WorldMapController extends State<WorldMap>
     // so clicking through courses doesn't snap the camera on every hop — it
     // glides only after you've settled on one.
     if (mounted) {
-      setState(() => _promotedActivityId = null);
-      MapPinController.set(false);
+      demoteActivity();
+      WorldMapPinsManager.set(false);
     }
     _loadForContext(debounceFit: true);
   }
@@ -481,26 +287,25 @@ class WorldMapController extends State<WorldMap>
   /// and from onMapReady / onPositionChanged).
   Future<void> _loadForContext({bool debounceFit = false}) async {
     final mapContext = MapContextController.notifier.value;
-    if (mapContext is CourseMapContext) {
-      _ensureScopedCourseOutline(mapContext.coursePlanId);
-      try {
-        final pins = await QuestRepo.questPins(mapContext.coursePlanId);
-        if (!mounted) return;
-        setState(() => _pins = pins);
-        _fitToContext(debounce: debounceFit);
-      } catch (_) {
-        // Map stays usable without activity pins.
-      }
-      return;
+    switch (mapContext) {
+      case CourseMapContext():
+        _ensureScopedCourseOutline(mapContext.coursePlanId);
+        try {
+          await _pinsManager.loadCourseScopedPins(mapContext.coursePlanId);
+
+          if (!mounted) return;
+          setState(() {});
+
+          _fitToContext(debounce: debounceFit);
+        } catch (_) {
+          // Map stays usable without activity pins.
+        }
+        return;
+      case WorldMapContext():
+        _pinsManager.resetScopedCourseOutline();
+        loadWorldPins();
+        return;
     }
-    // World view: drop any course-scoped outline so the band ranks on the
-    // learner's joined quests only.
-    if (_scopedCourseOutline != null || _scopedCourseOutlineId != null) {
-      _scopedCourseOutline = null;
-      _scopedCourseOutlineId = null;
-      _resolveProgression();
-    }
-    loadWorldPins();
   }
 
   /// Resolve the viewed course's outline for a course-scoped map so the band
@@ -508,28 +313,8 @@ class WorldMapController extends State<WorldMap>
   /// (Will's decision). Skipped when the course is already a joined course (its
   /// outline is in the objective cache) or already resolved for this scope.
   Future<void> _ensureScopedCourseOutline(String coursePlanId) async {
-    if (_scopedCourseOutlineId == coursePlanId) return;
-    _scopedCourseOutlineId = coursePlanId;
-    _scopedCourseOutline = null;
-    if (_objectiveCacheUuids.contains(coursePlanId)) {
-      _resolveProgression(); // joined: the cache already carries it
-      return;
-    }
-    try {
-      final outline = (await QuestRepo.outline(
-        coursePlanId,
-      )).toCourseLoOutline();
-      // A re-scope may have raced ahead; only apply if still the active scope.
-      if (_scopedCourseOutlineId != coursePlanId) return;
-      _scopedCourseOutline = outline;
-    } catch (_) {
-      // Fail soft: the band falls back to the joined-quest resolution.
-    }
-    if (!mounted) {
-      _resolveProgression();
-      return;
-    }
-    setState(_resolveProgression);
+    await _pinsManager.ensureScopedCourseOutline(coursePlanId);
+    if (mounted) setState(() {});
   }
 
   /// World pins for the current viewport, personalized to the user's language
@@ -544,102 +329,61 @@ class WorldMapController extends State<WorldMap>
     } catch (_) {
       return; // camera not ready yet
     }
+
     final user = MatrixState.pangeaController.userController;
     if (mounted) setState(() => _loadingPins = true);
+
     try {
-      final pins = await ActivityMapRepo.bboxPins(
+      _pinsManager.loadWorldScopedPins(
         bounds: bounds,
-        l2: _l2Only ? user.userL2Code : null,
+        l2: _filterState.filter.l2Only ? user.userL2Code : null,
         l1: user.userL1Code,
       );
       if (!mounted) return;
-      setState(() {
-        _pins = pins;
-        _loadingPins = false;
-      });
+      setState(() => _loadingPins = false);
     } catch (_) {
       if (mounted) setState(() => _loadingPins = false);
     }
   }
 
-  /// Debounced viewport reload, called by the view as the camera pans/zooms.
-  /// Course pins are context-bound, so this is World-only.
-  void handleMapPositionChanged() {
-    if (!isWorld) return;
-    _refetchDebounce?.cancel();
-    _refetchDebounce = Timer(const Duration(milliseconds: 500), loadWorldPins);
-  }
-
-  // ---- filtering ------------------------------------------------------------
-
-  bool _cefrMatches(QuestActivityCard card) {
-    final cefr = card.cefr;
-    if (cefr == null || cefr.isEmpty) return true; // unknown level: keep
-    final norm = cefr.toUpperCase().replaceAll('_', '');
-    return _cefrFilter.any((l) => l.string == norm);
-  }
-
-  bool _completionMatches(QuestActivityCard card) {
-    if (_completionFilter.isEmpty) return true;
-    final status =
-        _completion[card.activityId] ?? MapCompletionFilter.notStarted;
-    return _completionFilter.contains(status);
-  }
-
-  /// The pins actually shown: the loaded set narrowed by the active CEFR band,
-  /// completion filter, and free-text query. World only; a course shows its set.
-  List<QuestActivityCard> get visiblePins {
-    if (!isWorld) return _pins;
-    return _pins
-        .where(
-          (c) =>
-              _cefrMatches(c) &&
-              _completionMatches(c) &&
-              c.matchesQuery(_query),
-        )
-        .toList();
-  }
-
-  bool get canReset =>
-      _query.isNotEmpty ||
-      !_l2Only ||
-      _completionFilter.isNotEmpty ||
-      _cefrFilter.length != _defaultCefr.length ||
-      !_cefrFilter.containsAll(_defaultCefr);
-
-  // ---- filter actions -------------------------------------------------------
-
-  void setQuery(String q) => setState(() => _query = q);
+  void setQuery(String q) => setState(() => _filterState.setQuery(q));
 
   void toggleL2() {
-    setState(() => _l2Only = !_l2Only);
+    setState(() => _filterState.toggleL2());
     loadWorldPins(); // L2 changes the working set → re-fetch
   }
 
-  void toggleCefr(LanguageLevelTypeEnum level) {
-    setState(() {
-      if (!_cefrFilter.remove(level)) _cefrFilter.add(level);
-    });
-  }
+  void toggleCefr(LanguageLevelTypeEnum level) =>
+      setState(() => _filterState.toggleCefr(level));
 
-  void toggleCompletion(MapCompletionFilter c) {
-    setState(() {
-      if (!_completionFilter.remove(c)) _completionFilter.add(c);
-    });
-  }
+  void toggleCompletion(MapCompletionFilter c) =>
+      setState(() => _filterState.toggleCompletion(c));
 
   void resetFilters({bool l2Only = true}) {
-    final toggleL2Only = _l2Only != l2Only;
+    final toggleL2Only = _filterState.filter.l2Only != l2Only;
     setState(() {
-      _query = '';
-      _completionFilter.clear();
-      _cefrFilter = {..._defaultCefr};
-      _l2Only = l2Only;
+      _filterState.resetFilters(l2Only: l2Only);
     });
 
     if (toggleL2Only) {
       loadWorldPins(); // L2 narrowed again → re-fetch
     }
+  }
+
+  /// As [promoteToLarge] but by id. The clustered small/mid markers route their
+  /// tap here via the cluster layer's `onMarkerTap`: the marker-cluster package
+  /// intercepts marker taps, so a marker's own `onTap` never fires for a pointer
+  /// (it only centered the camera, the #7072 symptom). The tapped marker carries
+  /// its activity id as its key, which is all promotion needs.
+  void promoteActivity(String activityId) {
+    final promoted = _pinsManager.promoteActivity(activityId);
+    if (promoted) setState(() {});
+    ActivityPlanRepo.instance.ensure(activityId);
+  }
+
+  void demoteActivity() {
+    final demoted = _pinsManager.demoteActivity();
+    if (demoted) setState(() {});
   }
 
   /// Fly to a search result and open its preview (the Maps-style result tap).
@@ -663,36 +407,15 @@ class WorldMapController extends State<WorldMap>
         );
       } catch (_) {}
     }
-    promoteToLarge(card);
-  }
-
-  /// Promote [card] to its large card in place: a small/mid pin expands to the
-  /// large tier on tap (the large card then taps through to the plan page). The
-  /// large marker hydrates the full plan itself (image + star total), so this
-  /// only flips the tier. No navigation, no preview popup.
-  void promoteToLarge(QuestActivityCard card) =>
-      promoteToLargeById(card.activityId);
-
-  /// As [promoteToLarge] but by id. The clustered small/mid markers route their
-  /// tap here via the cluster layer's `onMarkerTap`: the marker-cluster package
-  /// intercepts marker taps, so a marker's own `onTap` never fires for a pointer
-  /// (it only centered the camera, the #7072 symptom). The tapped marker carries
-  /// its activity id as its key, which is all promotion needs.
-  void promoteToLargeById(String activityId) {
-    setState(() => _promotedActivityId = activityId);
-    ActivityPlanRepo.instance.ensure(activityId);
-  }
-
-  void collapse() {
-    if (_promotedActivityId == null) return;
-    setState(() => _promotedActivityId = null);
+    promoteActivity(card.activityId);
   }
 
   /// Glide back to the whole-world view (the initial camera). Pins, clusters,
   /// and search only ever zoom the camera IN, so this is the one explicit
   /// "zoom out to everything" affordance (#7086). Camera-only: the course scope
   /// and open panels are untouched.
-  void resetToWorld() => _animateCameraTo(const LatLng(20, 0), minZoom);
+  void resetToWorld() =>
+      _animateCameraTo(const LatLng(20, 0), WorldMapConstants.minZoom);
 
   /// Step the zoom by [delta] levels around the current center, clamped to the
   /// map's range — backs the on-map +/- buttons, since a tap/search only ever
@@ -700,28 +423,16 @@ class WorldMapController extends State<WorldMap>
   /// mid-glide live zoom), so rapid clicks each advance a full level instead of
   /// under-shooting, and snaps to integer levels so the steps land crisply.
   void zoomBy(double delta) {
-    final base = (_camAnim?.isAnimating ?? false)
+    final base = _cameraAnimationController.isAnimating
         ? _camTargetZoom
         : mapController.camera.zoom;
+
     _animateCameraTo(
       mapController.camera.center,
-      (base + delta).clamp(minZoom, maxZoom).roundToDouble(),
+      (base + delta)
+          .clamp(WorldMapConstants.minZoom, WorldMapConstants.maxZoom)
+          .roundToDouble(),
     );
-  }
-
-  /// Resolve a [MapFocus] to a map coordinate, or null if not resolvable yet.
-  /// Exhaustive over the sealed [MapFocus]: adding a focus kind makes this a
-  /// compile error until its arm is added — that is the extension seam.
-  LatLng? _focusPoint(MapFocus? focus) {
-    switch (focus) {
-      case null:
-        return null;
-      case ActivityFocus(:final activityId):
-        for (final card in _pins) {
-          if (card.activityId == activityId) return card.point;
-        }
-        return null;
-    }
   }
 
   /// Centers the current selection within the *exposed* canvas — the map area
@@ -739,7 +450,7 @@ class WorldMapController extends State<WorldMap>
       _runFitToContext();
       return;
     }
-    _fitDebounce = Timer(_fitSettleDelay, _runFitToContext);
+    _fitDebounce = Timer(WorldMapConstants.fitSettleDelay, _runFitToContext);
   }
 
   void _runFitToContext() {
@@ -760,15 +471,15 @@ class WorldMapController extends State<WorldMap>
         // (neighborhood/building) zoom, never zooming out past where we already
         // are. Today that is an activity; new focus kinds resolve in
         // [_focusPoint].
-        final point = _focusPoint(widget.focus);
+        final point = _pinsManager.focusPoint(widget.focus);
         if (point != null) {
           _animateFit(
             CameraFit.coordinates(
               coordinates: [point],
               padding: padding,
-              maxZoom: mapController.camera.zoom > _focusZoom
+              maxZoom: mapController.camera.zoom > WorldMapConstants.focusZoom
                   ? mapController.camera.zoom
-                  : _focusZoom,
+                  : WorldMapConstants.focusZoom,
             ),
           );
           return;
@@ -776,7 +487,8 @@ class WorldMapController extends State<WorldMap>
 
         // Otherwise a course context fits all of its activities.
         if (MapContextController.notifier.value is! CourseMapContext) return;
-        final points = _pins.map((c) => c.point).whereType<LatLng>().toList();
+
+        final points = _pinsManager.focusPoints;
         if (points.isEmpty) return;
         _animateFit(
           CameraFit.bounds(
@@ -802,8 +514,8 @@ class WorldMapController extends State<WorldMap>
   /// Tween the camera center + zoom over [_camGlideDuration]. Re-targets cleanly
   /// if called mid-flight (the glide restarts from the current position).
   void _animateCameraTo(LatLng center, double zoom) {
-    final anim = _camAnim;
-    if (anim == null || !mounted) {
+    final anim = _cameraAnimationController;
+    if (!mounted) {
       try {
         mapController.move(center, zoom);
       } catch (_) {}
@@ -821,8 +533,9 @@ class WorldMapController extends State<WorldMap>
   void _onCamGlideTick() {
     final start = _camStart;
     final end = _camTarget;
-    final curve = _camCurve;
-    if (start == null || end == null || curve == null) return;
+    final curve = _cameraAnimation;
+    if (start == null || end == null) return;
+
     final t = curve.value;
     final lat = start.latitude + (end.latitude - start.latitude) * t;
     final lng = start.longitude + (end.longitude - start.longitude) * t;
@@ -832,6 +545,14 @@ class WorldMapController extends State<WorldMap>
     } catch (_) {
       // Camera not ready / disposed mid-tick.
     }
+  }
+
+  /// Debounced viewport reload, called by the view as the camera pans/zooms.
+  /// Course pins are context-bound, so this is World-only.
+  void onMapPositionChanged() {
+    if (!isWorld) return;
+    _refetchDebounce?.cancel();
+    _refetchDebounce = Timer(const Duration(milliseconds: 500), loadWorldPins);
   }
 
   /// Open the activity detail in-place, preserving the current route (course
@@ -867,7 +588,7 @@ class WorldMapController extends State<WorldMap>
       parts.add('roomid=${shortRoomId(myRoom.id)}');
     }
     context.go(WorkspaceQuery.location('/', parts));
-    collapse();
+    demoteActivity();
   }
 
   @override

--- a/lib/routes/world/world_map_client_extension.dart
+++ b/lib/routes/world/world_map_client_extension.dart
@@ -2,6 +2,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
 import 'package:fluffychat/routes/world/world_map_ranking.dart';
 import 'package:fluffychat/routes/world/world_map_search_overlay.dart';
@@ -47,6 +48,17 @@ extension WorldMapClientExtension on Client {
     }
     return best;
   }
+
+  /// The learner's joined course spaces (a space they belong to that carries a
+  /// course plan) — the source set for the objective cache + relevance banding.
+  List<Room> get joinedCourseRooms => rooms
+      .where(
+        (r) =>
+            r.isSpace &&
+            r.membership == Membership.join &&
+            r.coursePlan != null,
+      )
+      .toList();
 
   Map<String, MapCompletionFilter> get activityCompletionStatuses {
     final facts = <ActivityCompletionFacts>[];

--- a/lib/routes/world/world_map_constants.dart
+++ b/lib/routes/world/world_map_constants.dart
@@ -1,0 +1,20 @@
+class WorldMapConstants {
+  /// The camera zoom range — the single source for FlutterMap's MapOptions, the
+  /// +/- step clamp in [zoomBy], the World reset in [resetToWorld], and the
+  /// on-map control disabled states (#7171). minZoom 3 is the whole world.
+  static const double minZoom = 3.0;
+  static const double maxZoom = 18.0;
+
+  /// Whether a zoom-in / zoom-out step would still change the camera, i.e. the
+  /// on-map + / - button should be enabled. At a limit the matching button is
+  /// disabled so it can't no-op (#7171).
+  static bool canZoomIn(double zoom) => zoom < maxZoom;
+  static bool canZoomOut(double zoom) => zoom > minZoom;
+
+  /// The zoom the camera glides to when an activity is focused (opened) — close
+  /// enough to read it as "this specific spot" (neighborhood/building level).
+  static const double focusZoom = 16.0;
+
+  static const Duration fitSettleDelay = Duration(seconds: 2);
+  static const Duration camGlideDuration = Duration(milliseconds: 600);
+}

--- a/lib/routes/world/world_map_filter.dart
+++ b/lib/routes/world/world_map_filter.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
 import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
 import 'package:fluffychat/routes/world/world_map_search_overlay.dart';
@@ -5,6 +6,7 @@ import 'package:fluffychat/routes/world/world_map_search_overlay.dart';
 class WorldMapFilter {
   final String query;
   final bool l2Only;
+  final LanguageModel? l2;
   final Set<LanguageLevelTypeEnum> cefrFilter;
   final Set<LanguageLevelTypeEnum> defaultCefr;
   final Set<MapCompletionFilter> completionFilter;
@@ -13,6 +15,7 @@ class WorldMapFilter {
   const WorldMapFilter({
     this.query = '',
     this.l2Only = true,
+    this.l2,
     this.cefrFilter = const {},
     this.defaultCefr = const {},
     this.completionFilter = const {},
@@ -29,6 +32,7 @@ class WorldMapFilter {
   WorldMapFilter copyWith({
     String? query,
     bool? l2Only,
+    LanguageModel? l2,
     Set<LanguageLevelTypeEnum>? cefrFilter,
     Set<LanguageLevelTypeEnum>? defaultCefr,
     Set<MapCompletionFilter>? completionFilter,
@@ -36,6 +40,7 @@ class WorldMapFilter {
   }) => WorldMapFilter(
     query: query ?? this.query,
     l2Only: l2Only ?? this.l2Only,
+    l2: l2 ?? this.l2,
     cefrFilter: cefrFilter ?? this.cefrFilter,
     defaultCefr: defaultCefr ?? this.defaultCefr,
     completionFilter: completionFilter ?? this.completionFilter,
@@ -45,6 +50,7 @@ class WorldMapFilter {
   Map<String, dynamic> toJson() => {
     "query": query,
     "l2_only": l2Only,
+    "l2": l2?.toJson(),
     "cefr_filter": cefrFilter.toList(),
     "default_cefr": defaultCefr.toList(),
     "completion_filters": completionFilter.toList(),
@@ -58,9 +64,17 @@ class WorldMapFilterState {
   WorldMapFilter get filter => _filter;
 
   bool include(QuestActivityCard card, MapCompletionFilter status) {
-    return _cefrMatches(card) &&
+    return _langMatches(card) &&
+        _cefrMatches(card) &&
         _completionMatches(status) &&
         card.matchesQuery(_filter.query);
+  }
+
+  bool _langMatches(QuestActivityCard card) {
+    final filterL2 = _filter.l2;
+    if (!_filter.l2Only || filterL2 == null) return true;
+    final l2 = card.l2;
+    return filterL2.langCodeShort == l2.split('-').first;
   }
 
   bool _cefrMatches(QuestActivityCard card) {
@@ -75,8 +89,12 @@ class WorldMapFilterState {
         _filter.completionFilter.contains(status);
   }
 
-  bool applyDefaults({required LanguageLevelTypeEnum? cefrLevel}) {
+  bool applyDefaults({
+    required LanguageLevelTypeEnum? cefrLevel,
+    required LanguageModel? l2,
+  }) {
     if (_filter.filterDefaultsApplied) return false;
+
     final filterDefaultsApplied = true;
     final defaultCefr = LanguageLevelTypeEnum.bandAtOrBelow(cefrLevel);
     final cefrFilter = {...defaultCefr};
@@ -84,11 +102,23 @@ class WorldMapFilterState {
       filterDefaultsApplied: filterDefaultsApplied,
       defaultCefr: defaultCefr,
       cefrFilter: cefrFilter,
+      l2: l2,
     );
     return true;
   }
 
   void setQuery(String q) => _filter = _filter.copyWith(query: q);
+
+  void setL2(LanguageModel? l2) => _filter = _filter.copyWith(l2: l2);
+
+  void setCefrLevel(LanguageLevelTypeEnum? cefrLevel) {
+    final defaultCefr = LanguageLevelTypeEnum.bandAtOrBelow(cefrLevel);
+    final cefrFilter = {...defaultCefr};
+    _filter = _filter.copyWith(
+      defaultCefr: defaultCefr,
+      cefrFilter: cefrFilter,
+    );
+  }
 
   void toggleL2() => _filter = _filter.copyWith(l2Only: !_filter.l2Only);
 

--- a/lib/routes/world/world_map_filter.dart
+++ b/lib/routes/world/world_map_filter.dart
@@ -1,0 +1,103 @@
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+import 'package:fluffychat/routes/world/world_map_search_overlay.dart';
+
+class WorldMapFilter {
+  final String query;
+  final bool l2Only;
+  final Set<LanguageLevelTypeEnum> cefrFilter;
+  final Set<LanguageLevelTypeEnum> defaultCefr;
+  final Set<MapCompletionFilter> completionFilter;
+  final bool filterDefaultsApplied;
+
+  const WorldMapFilter({
+    this.query = '',
+    this.l2Only = false,
+    this.cefrFilter = const {},
+    this.defaultCefr = const {},
+    this.completionFilter = const {},
+    this.filterDefaultsApplied = false,
+  });
+
+  bool get canReset =>
+      query.isNotEmpty ||
+      !l2Only ||
+      completionFilter.isNotEmpty ||
+      cefrFilter.length != defaultCefr.length ||
+      !cefrFilter.containsAll(defaultCefr);
+
+  WorldMapFilter copyWith({
+    String? query,
+    bool? l2Only,
+    Set<LanguageLevelTypeEnum>? cefrFilter,
+    Set<LanguageLevelTypeEnum>? defaultCefr,
+    Set<MapCompletionFilter>? completionFilter,
+    bool? filterDefaultsApplied,
+  }) => WorldMapFilter(
+    query: query ?? this.query,
+    l2Only: l2Only ?? this.l2Only,
+    cefrFilter: cefrFilter ?? this.cefrFilter,
+    defaultCefr: defaultCefr ?? this.defaultCefr,
+    completionFilter: completionFilter ?? this.completionFilter,
+    filterDefaultsApplied: filterDefaultsApplied ?? this.filterDefaultsApplied,
+  );
+}
+
+class WorldMapFilterState {
+  WorldMapFilter _filter = WorldMapFilter();
+
+  WorldMapFilter get filter => _filter;
+
+  bool include(QuestActivityCard card, MapCompletionFilter status) {
+    return _cefrMatches(card) &&
+        _completionMatches(status) &&
+        card.matchesQuery(_filter.query);
+  }
+
+  bool _cefrMatches(QuestActivityCard card) {
+    final cefr = card.cefr;
+    if (cefr == null || cefr.isEmpty) return true; // unknown level: keep
+    final norm = cefr.toUpperCase().replaceAll('_', '');
+    return _filter.cefrFilter.any((l) => l.string == norm);
+  }
+
+  bool _completionMatches(MapCompletionFilter status) {
+    return _filter.completionFilter.contains(status);
+  }
+
+  void applyDefaults({required LanguageLevelTypeEnum? cefrLevel}) {
+    final filterDefaultsApplied = true;
+    final defaultCefr = LanguageLevelTypeEnum.bandAtOrBelow(cefrLevel);
+    final cefrFilter = {...defaultCefr};
+    _filter = _filter.copyWith(
+      filterDefaultsApplied: filterDefaultsApplied,
+      defaultCefr: defaultCefr,
+      cefrFilter: cefrFilter,
+    );
+  }
+
+  void setQuery(String q) => _filter = _filter.copyWith(query: q);
+
+  void toggleL2() => _filter = _filter.copyWith(l2Only: !_filter.l2Only);
+
+  void toggleCefr(LanguageLevelTypeEnum level) {
+    final updated = {..._filter.cefrFilter};
+    updated.contains(level) ? updated.remove(level) : updated.add(level);
+    _filter = _filter.copyWith(cefrFilter: updated);
+  }
+
+  void toggleCompletion(MapCompletionFilter c) {
+    final updated = {..._filter.completionFilter};
+    updated.contains(c) ? updated.remove(c) : updated.add(c);
+    _filter = _filter.copyWith(completionFilter: updated);
+  }
+
+  void resetFilters({bool l2Only = true}) {
+    _filter = _filter.copyWith(
+      query: '',
+      completionFilter: {},
+      cefrFilter: {..._filter.defaultCefr},
+      l2Only: l2Only,
+    );
+  }
+}

--- a/lib/routes/world/world_map_filter.dart
+++ b/lib/routes/world/world_map_filter.dart
@@ -12,7 +12,7 @@ class WorldMapFilter {
 
   const WorldMapFilter({
     this.query = '',
-    this.l2Only = false,
+    this.l2Only = true,
     this.cefrFilter = const {},
     this.defaultCefr = const {},
     this.completionFilter = const {},
@@ -41,6 +41,15 @@ class WorldMapFilter {
     completionFilter: completionFilter ?? this.completionFilter,
     filterDefaultsApplied: filterDefaultsApplied ?? this.filterDefaultsApplied,
   );
+
+  Map<String, dynamic> toJson() => {
+    "query": query,
+    "l2_only": l2Only,
+    "cefr_filter": cefrFilter.toList(),
+    "default_cefr": defaultCefr.toList(),
+    "completion_filters": completionFilter.toList(),
+    "filter_defaults_applied": filterDefaultsApplied,
+  };
 }
 
 class WorldMapFilterState {
@@ -62,10 +71,12 @@ class WorldMapFilterState {
   }
 
   bool _completionMatches(MapCompletionFilter status) {
-    return _filter.completionFilter.contains(status);
+    return _filter.completionFilter.isEmpty ||
+        _filter.completionFilter.contains(status);
   }
 
-  void applyDefaults({required LanguageLevelTypeEnum? cefrLevel}) {
+  bool applyDefaults({required LanguageLevelTypeEnum? cefrLevel}) {
+    if (_filter.filterDefaultsApplied) return false;
     final filterDefaultsApplied = true;
     final defaultCefr = LanguageLevelTypeEnum.bandAtOrBelow(cefrLevel);
     final cefrFilter = {...defaultCefr};
@@ -74,6 +85,7 @@ class WorldMapFilterState {
       defaultCefr: defaultCefr,
       cefrFilter: cefrFilter,
     );
+    return true;
   }
 
   void setQuery(String q) => _filter = _filter.copyWith(query: q);

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
+import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/features/quests/lo_progression.dart';
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
+import 'package:fluffychat/features/quests/quests_client_extension.dart';
+import 'package:fluffychat/features/quests/repo/activity_map_repo.dart';
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/routes/world/joined_objective_cache.dart';
+import 'package:fluffychat/routes/world/world_map_client_extension.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_search_overlay.dart';
+
+class WorldMapPinsManager {
+  static final ValueNotifier<bool> notifier = ValueNotifier<bool>(false);
+
+  static void set(bool open) {
+    if (notifier.value != open) notifier.value = open;
+  }
+
+  /// The activity pins currently shown — the active context's set (the whole
+  /// world, or a selected quest's activities). Thin: id, title, point.
+  List<QuestActivityCard> _pins = [];
+
+  Map<String, PinSignals> _signals = {};
+  Map<String, int> _userStars = {};
+  Map<String, MapCompletionFilter> _completion = {};
+
+  /// The shared next-Mission resolution the relevance band ranks toward, resolved
+  /// from the objective cache's outlines + [_userStars]. Recomputed where its
+  /// inputs change — the objective cache rebuilds (course join/leave) and user
+  /// stars change on room sync — NOT per frame. See world-map.instructions.md.
+  ProgressionResolution _progression = ProgressionResolution.empty;
+
+  /// Learning-objective ids across the learner's joined courses, for relevance
+  /// banding. Rebuilt async on course join/leave (see [_maybeRebuildObjectiveCache]).
+  final JoinedObjectiveCache _objectiveCache = JoinedObjectiveCache();
+
+  /// The joined-course uuids [_objectiveCache] was last (re)built from. The
+  /// initial build happens on client-set, but the joined-course rooms (or their
+  /// outlines) may not be ready yet; tracking the set lets the sync listener
+  /// rebuild when it changes — or when a prior build resolved nothing — instead
+  /// of the banding + gate staying blank for the whole session.
+  Set<String> _objectiveCacheUuids = const {};
+
+  /// Guards against overlapping objective-cache rebuilds (and stops a
+  /// persistently-failing course from rebuilding on every single sync).
+  bool _objectiveCacheRebuilding = false;
+
+  /// The course-plan id [_scopedCourseOutline] was resolved for, so a re-scope to
+  /// the same course doesn't re-fetch and a re-scope away clears it.
+  String? _scopedCourseOutlineId;
+
+  /// The viewed course's outline when the map is scoped to a course the learner
+  /// has NOT joined: a course-scoped map ranks toward that course's next Mission
+  /// even before joining (Will's decision). Null on the world view or when the
+  /// scoped course is already a joined course (its outline is in the cache).
+  CourseLoOutline? _scopedCourseOutline;
+
+  /// Activity ids with a recently-pinged open session (best-effort, scanned from
+  /// joined course-space messages). Folded into [_signals].
+  Set<String> _pingedActivityIds = {};
+
+  String? _promotedActivityId;
+
+  String? get promotedActivityId => _promotedActivityId;
+
+  Map<String, PinSignals> get signals => _signals;
+
+  ProgressionResolution get progression => _progression;
+
+  /// Resolve a [MapFocus] to a map coordinate, or null if not resolvable yet.
+  /// Exhaustive over the sealed [MapFocus]: adding a focus kind makes this a
+  /// compile error until its arm is added — that is the extension seam.
+  LatLng? focusPoint(MapFocus? focus) {
+    switch (focus) {
+      case null:
+        return null;
+      case ActivityFocus(:final activityId):
+        for (final card in _pins) {
+          if (card.activityId == activityId) return card.point;
+        }
+        return null;
+    }
+  }
+
+  List<LatLng> get focusPoints =>
+      _pins.map((c) => c.point).whereType<LatLng>().toList();
+
+  List<QuestActivityCard> filteredPins(
+    bool Function(QuestActivityCard) filter,
+  ) => _pins.where(filter).toList();
+
+  MapCompletionFilter? activityCompletionStatus(String activityId) =>
+      _completion[activityId];
+
+  int? activityStarsEarned(String activityId) => _userStars[activityId];
+
+  bool promoteActivity(String activityId) {
+    if (_promotedActivityId == activityId) return false;
+    _promotedActivityId = activityId;
+    return true;
+  }
+
+  bool demoteActivity() {
+    if (_promotedActivityId == null) return false;
+    _promotedActivityId = null;
+    return true;
+  }
+
+  void resetScopedCourseOutline() {
+    if (_scopedCourseOutline != null || _scopedCourseOutlineId != null) {
+      _scopedCourseOutline = null;
+      _scopedCourseOutlineId = null;
+      resolveProgression();
+    }
+  }
+
+  /// Best-effort pinged detection: scan joined course spaces' recent messages
+  /// for the host's recruit ping (carries `pangea.activity.id`), within a day.
+  /// A ping leaves no persistent room state, so this proxy is intentionally
+  /// approximate — its efficacy is worth watching (world-map.instructions.md).
+  Future<void> recomputePinged(Client client) async {
+    final pinged = <String>{};
+    final cutoff = DateTime.now().subtract(const Duration(hours: 24));
+    final spaces = client.rooms.where(
+      (r) =>
+          r.isSpace && r.membership == Membership.join && r.coursePlan != null,
+    );
+
+    for (final space in spaces) {
+      try {
+        final timeline = await space.getTimeline();
+        for (final e in timeline.events) {
+          if (!e.originServerTs.isAfter(cutoff)) continue;
+          final id = e.content['pangea.activity.id'];
+          if (id is String && id.isNotEmpty) pinged.add(id);
+        }
+        timeline.cancelSubscriptions();
+      } catch (_) {
+        // A space whose timeline won't load just contributes no pings.
+      }
+    }
+
+    if (pinged.length == _pingedActivityIds.length &&
+        pinged.containsAll(_pingedActivityIds)) {
+      return;
+    }
+    _pingedActivityIds = pinged;
+    _signals = client.deriveActivitySignals(pingedActivityIds: pinged);
+  }
+
+  void recomputeProgress(Client client) {
+    final signals = client.deriveActivitySignals(
+      pingedActivityIds: _pingedActivityIds,
+    );
+    final userStars = client.userStarsByActivity;
+    final completion = client.activityCompletionStatuses;
+
+    _signals = signals;
+    _userStars = userStars;
+    _completion = completion;
+    resolveProgression();
+  }
+
+  /// Re-resolve the cached [_progression] from the objective cache's outlines (+
+  /// any course-scoped outline) and the learner's current per-activity stars.
+  /// Called where the inputs change — stars on room sync, the objective cache on
+  /// course join/leave, and a course re-scope — never per frame.
+  void resolveProgression() {
+    _progression = _objectiveCache.resolution(
+      _userStars,
+      extraOutlines: _scopedCourseOutline == null
+          ? const []
+          : [_scopedCourseOutline!],
+    );
+  }
+
+  /// Rebuild the joined-course outlines (a few quest reads), reading each
+  /// course's teacher override for the stars-to-unlock threshold, then re-rank.
+  /// Guarded so overlapping syncs don't stack rebuilds. A course whose outline
+  /// fails to resolve is logged (not silently dropped): an empty cache means no
+  /// relevance banding and a fail-open gate, which is otherwise invisible.
+  Future<void> rebuildObjectiveCache(Client client) async {
+    if (_objectiveCacheRebuilding) return;
+    _objectiveCacheRebuilding = true;
+    try {
+      final courseRooms = client.joinedCourseRooms;
+      final uuids = courseRooms.map((r) => r.coursePlan!.uuid).toList();
+      final thresholds = <String, int>{
+        for (final r in courseRooms)
+          r.coursePlan!.uuid:
+              r.teacherMode.starsToUnlockObjective ??
+              kDefaultStarsToUnlockObjective,
+      };
+      await _objectiveCache.rebuild(
+        uuids,
+        starsToUnlockOf: (uuid) =>
+            thresholds[uuid] ?? kDefaultStarsToUnlockObjective,
+        onError: (uuid, e, s) => ErrorHandler.logError(
+          e: e,
+          s: s,
+          m: 'JoinedObjectiveCache: course outline failed to resolve',
+          data: {'courseUuid': uuid},
+        ),
+      );
+      _objectiveCacheUuids = uuids.toSet();
+      resolveProgression(); // re-resolve the band with the loaded outlines
+    } finally {
+      _objectiveCacheRebuilding = false;
+    }
+  }
+
+  /// Rebuild the objective cache when the joined-course set has changed since the
+  /// last build, or when it resolved nothing while courses exist (the rooms or
+  /// their outlines weren't ready at the initial build, or a read transiently
+  /// failed). Idempotent for an unchanged, already-populated set, so it's safe on
+  /// every sync; the in-flight guard keeps a persistently-failing course from
+  /// rebuilding more than once at a time, and it self-heals once the data is fixed.
+  bool shouldRebuildObjectiveCache(Client client) {
+    if (_objectiveCacheRebuilding) return false;
+    final uuids = client.joinedCourseRooms
+        .map((r) => r.coursePlan!.uuid)
+        .toSet();
+
+    final setChanged =
+        uuids.length != _objectiveCacheUuids.length ||
+        !uuids.containsAll(_objectiveCacheUuids);
+
+    final emptyButHasCourses = _objectiveCache.ids.isEmpty && uuids.isNotEmpty;
+    return setChanged || emptyButHasCourses;
+  }
+
+  /// Resolve the viewed course's outline for a course-scoped map so the band
+  /// ranks toward that course's next Mission even before the learner joins it
+  /// (Will's decision). Skipped when the course is already a joined course (its
+  /// outline is in the objective cache) or already resolved for this scope.
+  Future<void> ensureScopedCourseOutline(String coursePlanId) async {
+    if (_scopedCourseOutlineId == coursePlanId) return;
+    _scopedCourseOutlineId = coursePlanId;
+    _scopedCourseOutline = null;
+    if (_objectiveCacheUuids.contains(coursePlanId)) {
+      resolveProgression(); // joined: the cache already carries it
+      return;
+    }
+    try {
+      final outline = (await QuestRepo.outline(
+        coursePlanId,
+      )).toCourseLoOutline();
+      // A re-scope may have raced ahead; only apply if still the active scope.
+      if (_scopedCourseOutlineId != coursePlanId) return;
+      _scopedCourseOutline = outline;
+    } catch (_) {
+      // Fail soft: the band falls back to the joined-quest resolution.
+    }
+    resolveProgression();
+  }
+
+  Future<void> loadCourseScopedPins(String courseId) async {
+    _pins = await QuestRepo.questPins(courseId);
+  }
+
+  Future<void> loadWorldScopedPins({
+    required LatLngBounds bounds,
+    String? l2,
+    String? l1,
+  }) async {
+    _pins = await ActivityMapRepo.bboxPins(bounds: bounds, l2: l2, l1: l1);
+  }
+}

--- a/lib/routes/world/world_map_search_overlay.dart
+++ b/lib/routes/world/world_map_search_overlay.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+import 'package:fluffychat/routes/world/world_map_filter.dart';
 
 /// Per-activity completion, derived client-side from Matrix session state.
 /// Public so the map and this overlay share one vocabulary.
@@ -14,53 +15,33 @@ enum MapCompletionFilter { notStarted, inProgress, completed }
 /// callbacks. World-only (the shell hides it elsewhere). See
 /// world-map.instructions.md.
 class WorldMapSearchOverlay extends StatefulWidget {
-  final String query;
-  final ValueChanged<String> onQueryChanged;
+  final WorldMapFilter filter;
 
-  /// L2 chip: when true the map is scoped to the user's language ([l2Label]);
-  /// toggling off widens to all languages (re-fetch).
-  final bool l2Only;
-  final String? l2Label;
-  final VoidCallback onToggleL2;
+  final VoidCallback onReset;
   final VoidCallback onWidenSearch;
 
-  /// CEFR band: [selectedCefr] is the active level set (default = at/below the
-  /// user's level); toggling a chip adds/removes a level.
-  final Set<LanguageLevelTypeEnum> selectedCefr;
-  final ValueChanged<LanguageLevelTypeEnum> onToggleCefr;
+  final VoidCallback onToggleL2;
+  final Function(String) updateQuery;
+  final Function(LanguageLevelTypeEnum) toggleCefr;
+  final Function(MapCompletionFilter) toggleCompletion;
 
-  final Set<MapCompletionFilter> selectedCompletion;
-  final ValueChanged<MapCompletionFilter> onToggleCompletion;
-
-  /// Live results for the current query (already filtered by the map). Shown as
-  /// a dropdown only while the query is non-empty. Selecting flies to the pin.
   final List<QuestActivityCard> results;
-  final ValueChanged<QuestActivityCard> onResultTap;
+  final Function(QuestActivityCard) onResultTap;
 
-  /// True when any filter differs from the personalized default; drives the
-  /// one-tap reset affordance.
-  final bool canReset;
-  final VoidCallback onReset;
-
-  /// True when the current filters leave no pins in view; drives the inline
-  /// widen affordance so personalization never dead-ends.
+  final String? l2Label;
   final bool emptyInView;
 
   const WorldMapSearchOverlay({
     super.key,
-    required this.query,
-    required this.onQueryChanged,
-    required this.l2Only,
+    required this.filter,
+    required this.updateQuery,
     required this.l2Label,
     required this.onToggleL2,
     required this.onWidenSearch,
-    required this.selectedCefr,
-    required this.onToggleCefr,
-    required this.selectedCompletion,
-    required this.onToggleCompletion,
+    required this.toggleCefr,
+    required this.toggleCompletion,
     required this.results,
     required this.onResultTap,
-    required this.canReset,
     required this.onReset,
     required this.emptyInView,
   });
@@ -71,7 +52,7 @@ class WorldMapSearchOverlay extends StatefulWidget {
 
 class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
   late final TextEditingController _controller = TextEditingController(
-    text: widget.query,
+    text: widget.filter.query,
   );
 
   static const _maxResults = 20;
@@ -81,8 +62,8 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
     super.didUpdateWidget(oldWidget);
     // Sync only external query changes (reset / clear) into the field; normal
     // typing flows out through onQueryChanged and must not re-seat the cursor.
-    if (widget.query != _controller.text) {
-      _controller.text = widget.query;
+    if (widget.filter.query != _controller.text) {
+      _controller.text = widget.filter.query;
     }
   }
 
@@ -107,7 +88,7 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = L10n.of(context);
-    final searching = widget.query.trim().isNotEmpty;
+    final searching = widget.filter.query.trim().isNotEmpty;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -119,7 +100,7 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
           color: theme.colorScheme.surface,
           child: TextField(
             controller: _controller,
-            onChanged: widget.onQueryChanged,
+            onChanged: widget.updateQuery,
             decoration: InputDecoration(
               isDense: true,
               filled: true,
@@ -130,7 +111,7 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
                   ? IconButton(
                       icon: const Icon(Icons.close),
                       tooltip: l10n.close,
-                      onPressed: () => widget.onQueryChanged(''),
+                      onPressed: () => widget.updateQuery(''),
                     )
                   : null,
               border: OutlineInputBorder(
@@ -147,9 +128,9 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
             children: [
               if (widget.l2Label != null) ...[
                 FilterChip(
-                  selected: widget.l2Only,
+                  selected: widget.filter.l2Only,
                   label: Text(
-                    widget.l2Only
+                    widget.filter.l2Only
                         ? widget.l2Label!
                         : l10n.mapFilterAllLanguages,
                   ),
@@ -161,21 +142,21 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
               for (final level in LanguageLevelTypeEnum.values)
                 if (level != LanguageLevelTypeEnum.preA1) ...[
                   FilterChip(
-                    selected: widget.selectedCefr.contains(level),
+                    selected: widget.filter.cefrFilter.contains(level),
                     label: Text(level.string),
-                    onSelected: (_) => widget.onToggleCefr(level),
+                    onSelected: (_) => widget.toggleCefr(level),
                   ),
                   const SizedBox(width: 6),
                 ],
               for (final c in MapCompletionFilter.values) ...[
                 FilterChip(
-                  selected: widget.selectedCompletion.contains(c),
+                  selected: widget.filter.completionFilter.contains(c),
                   label: Text(_completionLabel(l10n, c)),
-                  onSelected: (_) => widget.onToggleCompletion(c),
+                  onSelected: (_) => widget.toggleCompletion(c),
                 ),
                 const SizedBox(width: 6),
               ],
-              if (widget.canReset)
+              if (widget.filter.canReset)
                 ActionChip(
                   avatar: const Icon(Icons.restart_alt, size: 16),
                   label: Text(l10n.mapFilterReset),
@@ -243,7 +224,7 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
                 children: [
                   Text(l10n.mapEmptyInView, style: theme.textTheme.bodyMedium),
                   const SizedBox(height: 8),
-                  if (widget.l2Only && widget.l2Label != null)
+                  if (widget.filter.l2Only && widget.l2Label != null)
                     FilledButton.tonalIcon(
                       icon: const Icon(Icons.translate, size: 16),
                       label: Text(l10n.widenSearch),

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -12,6 +12,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/world/world_map.dart';
 import 'package:fluffychat/routes/world/world_map_client_extension.dart';
 import 'package:fluffychat/routes/world/world_map_cluster_bubble.dart';
+import 'package:fluffychat/routes/world/world_map_constants.dart';
 import 'package:fluffychat/routes/world/world_map_large_card.dart';
 import 'package:fluffychat/routes/world/world_map_ranking.dart';
 import 'package:fluffychat/routes/world/world_map_room_extension.dart';
@@ -185,7 +186,7 @@ class WorldMapView extends StatelessWidget {
             card: card,
             state: state,
             tier: tier,
-            onTap: () => controller.promoteToLarge(card),
+            onTap: () => controller.promoteActivity(card.activityId),
             pinged: render.pingedOf(card.activityId),
             fill: render.fillOf(card.activityId),
           ),
@@ -225,7 +226,7 @@ class WorldMapView extends StatelessWidget {
           state: state,
           pinged: render.pingedOf(card.activityId),
           plan: plan,
-          starsEarned: controller.userStars[card.activityId] ?? 0,
+          starsEarned: controller.activityStarsEarned(card.activityId) ?? 0,
           participants: joinableActivity?.largeCardParticipants ?? [],
           openSlots: joinableActivity?.numRemainingRoles ?? 0,
           onTap: () => controller.openActivity(card),
@@ -258,8 +259,8 @@ class WorldMapView extends StatelessWidget {
         // ±90 band is only ~1024px tall at z2 — that would freeze *all*
         // panning on windows taller than ~1024px (common when maximized).
         // z3 gives a ~2048px band, clearing any realistic viewport.
-        minZoom: WorldMapController.minZoom,
-        maxZoom: WorldMapController.maxZoom,
+        minZoom: WorldMapConstants.minZoom,
+        maxZoom: WorldMapConstants.maxZoom,
         // Clamp latitude only — leaving longitude free so the user can pan
         // east-west and the world wraps seamlessly ("rotate the world
         // around"). Epsg3857 replicates longitude, so tiles and markers
@@ -271,16 +272,14 @@ class WorldMapView extends StatelessWidget {
           flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
         ),
         // Tap empty map → collapse a promoted large card back to its pin.
-        onTap: (_, _) {
-          if (controller.promotedActivityId != null) controller.collapse();
-        },
+        onTap: (_, _) => controller.demoteActivity(),
         // World pins are viewport-bounded: load once the camera is ready, then
         // re-load (debounced) as the user pans/zooms. Course pins are
         // context-bound and unaffected.
         onMapReady: () {
           if (controller.isWorld) controller.loadWorldPins();
         },
-        onPositionChanged: (_, _) => controller.handleMapPositionChanged(),
+        onPositionChanged: (_, _) => controller.onMapPositionChanged(),
       ),
       children: [
         // Base tiles, switched by app theme: OpenStreetMap (light) / CartoDB
@@ -319,7 +318,7 @@ class WorldMapView extends StatelessWidget {
             onMarkerTap: (marker) {
               final key = marker.key;
               if (key is ValueKey<String>) {
-                controller.promoteToLargeById(key.value);
+                controller.promoteActivity(key.value);
               }
             },
             markers: _clusterMarkers(render),
@@ -387,19 +386,15 @@ class WorldMapView extends StatelessWidget {
           left: controller.widget.leftOverlayWidth + 12,
           width: 360,
           child: WorldMapSearchOverlay(
-            query: controller.query,
-            onQueryChanged: controller.setQuery,
-            l2Only: controller.l2Only,
+            filter: controller.filter,
+            updateQuery: controller.setQuery,
             l2Label: l2?.toUpperCase(),
             onToggleL2: controller.toggleL2,
             onWidenSearch: () => controller.resetFilters(l2Only: false),
-            selectedCefr: controller.cefrFilter,
-            onToggleCefr: controller.toggleCefr,
-            selectedCompletion: controller.completionFilter,
-            onToggleCompletion: controller.toggleCompletion,
+            toggleCefr: controller.toggleCefr,
+            toggleCompletion: controller.toggleCompletion,
             results: render.visible,
             onResultTap: controller.flyTo,
-            canReset: controller.canReset,
             onReset: controller.resetFilters,
             emptyInView: !controller.loadingPins && render.visible.isEmpty,
           ),
@@ -445,9 +440,8 @@ class _MapZoomControls extends StatelessWidget {
         stream: controller.mapController.mapEventStream,
         builder: (context, _) {
           final zoom = _currentZoom();
-          final canZoomIn = zoom == null || WorldMapController.canZoomIn(zoom);
-          final canZoomOut =
-              zoom == null || WorldMapController.canZoomOut(zoom);
+          final canZoomIn = zoom == null || WorldMapConstants.canZoomIn(zoom);
+          final canZoomOut = zoom == null || WorldMapConstants.canZoomOut(zoom);
           return Column(
             mainAxisSize: MainAxisSize.min,
             children: [

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -276,9 +276,7 @@ class WorldMapView extends StatelessWidget {
         // World pins are viewport-bounded: load once the camera is ready, then
         // re-load (debounced) as the user pans/zooms. Course pins are
         // context-bound and unaffected.
-        onMapReady: () {
-          if (controller.isWorld) controller.loadWorldPins();
-        },
+        onMapReady: controller.loadWorldPins,
         onPositionChanged: (_, _) => controller.onMapPositionChanged(),
       ),
       children: [

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -16,6 +16,7 @@ import 'package:fluffychat/routes/world/map_context.dart';
 import 'package:fluffychat/routes/world/panel_card.dart';
 import 'package:fluffychat/routes/world/right_panel/workspace_right_panel.dart';
 import 'package:fluffychat/routes/world/world_map.dart';
+import 'package:fluffychat/routes/world/world_map_pins_manager.dart';
 import 'package:fluffychat/routes/world/world_user_cluster.dart';
 import 'package:fluffychat/widgets/layouts/left_panel_layer.dart';
 import 'package:fluffychat/widgets/layouts/mobile_course_sheet.dart';
@@ -197,7 +198,7 @@ class WorkspaceShell extends StatelessWidget {
         // `routing.instructions.md`.
         bottomNavigationBar: l.showBottomNav
             ? ValueListenableBuilder<bool>(
-                valueListenable: MapPinController.notifier,
+                valueListenable: WorldMapPinsManager.notifier,
                 builder: (context, pinSheetOpen, child) =>
                     pinSheetOpen ? const SizedBox.shrink() : child!,
                 child: MobileBottomNav(state: state),
@@ -686,7 +687,7 @@ class _ShellLayout {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       MapContextController.set(mapContext);
       PanelFocusController.instance.set(focusedLeftToken);
-      if (mapCoveredByPanel) MapPinController.set(false);
+      if (mapCoveredByPanel) WorldMapPinsManager.set(false);
     });
   }
 }

--- a/test/pangea/world_map_zoom_test.dart
+++ b/test/pangea/world_map_zoom_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:fluffychat/routes/world/world_map.dart';
+import 'package:fluffychat/routes/world/world_map_constants.dart';
 
 void main() {
   // The on-map +/- buttons must grey out at the camera's zoom limits so a tap
@@ -8,28 +8,25 @@ void main() {
   // FlutterMap's MapOptions, zoomBy's clamp, and the World reset.
   group('WorldMapController zoom limits (#7171)', () {
     test('zoom-in is enabled below max and disabled at max', () {
-      expect(WorldMapController.canZoomIn(WorldMapController.minZoom), isTrue);
+      expect(WorldMapConstants.canZoomIn(WorldMapConstants.minZoom), isTrue);
       expect(
-        WorldMapController.canZoomIn(WorldMapController.maxZoom - 0.5),
+        WorldMapConstants.canZoomIn(WorldMapConstants.maxZoom - 0.5),
         isTrue,
       );
-      expect(WorldMapController.canZoomIn(WorldMapController.maxZoom), isFalse);
+      expect(WorldMapConstants.canZoomIn(WorldMapConstants.maxZoom), isFalse);
     });
 
     test('zoom-out is enabled above min and disabled at min', () {
-      expect(WorldMapController.canZoomOut(WorldMapController.maxZoom), isTrue);
+      expect(WorldMapConstants.canZoomOut(WorldMapConstants.maxZoom), isTrue);
       expect(
-        WorldMapController.canZoomOut(WorldMapController.minZoom + 0.5),
+        WorldMapConstants.canZoomOut(WorldMapConstants.minZoom + 0.5),
         isTrue,
       );
-      expect(
-        WorldMapController.canZoomOut(WorldMapController.minZoom),
-        isFalse,
-      );
+      expect(WorldMapConstants.canZoomOut(WorldMapConstants.minZoom), isFalse);
     });
 
     test('the zoom range is non-empty (min below max)', () {
-      expect(WorldMapController.minZoom, lessThan(WorldMapController.maxZoom));
+      expect(WorldMapConstants.minZoom, lessThan(WorldMapConstants.maxZoom));
     });
   });
 }


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified world map search and filtering into a single, synchronized experience (query, L2, CEFR, and completion) with better reset handling.
  * Improved world map interactions with centralized map/camera configuration, and added joined-course room discovery.

* **Bug Fixes**
  * Refreshed map pin preview and activity focus behavior for more consistent interaction when switching panels or opening map content.
  * Improved world map loading, filtering reloads, and camera/zoom behavior to keep pins and navigation aligned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->