### PR TITLE
fix: session/room close reads the live URL so it preserves the current right column (#7268)

### DIFF
--- a/lib/routes/world/left_panel/left_panel_close_button.dart
+++ b/lib/routes/world/left_panel/left_panel_close_button.dart
@@ -54,22 +54,39 @@ class LeftPanelCloseButton extends StatelessWidget {
         foldedOver || (!isColumnMode && parentIsOpen(currentUri, token)),
   );
 
+  /// The LIVE workspace URL at click time. The left panel does NOT rebuild when
+  /// only the RIGHT column changes (so the live chat/timeline is not torn down),
+  /// so the [currentUri] captured at this panel's last build can be STALE for the
+  /// right column. A token mutation (close / pop) preserves the rest of the query
+  /// verbatim, so running it on the stale uri would "restore" the right tab the
+  /// panel opened with and discard whatever the user switched to since — e.g.
+  /// closing a session review snapped the right column from `analytics:grammar`
+  /// back to the open-time `analytics:sessions` (#7268). Read the current url
+  /// instead, so the close drops only this token and leaves the right column as
+  /// the user left it.
+  Uri _liveUri(BuildContext context) =>
+      GoRouter.of(context).routeInformationProvider.value.uri;
+
   // A `room`/`session` is a token-only panel, so dropping its token closes it.
   // A section panel (a course) is also addressable by its map filter, so
   // closing it returns to the world map. See WorkspaceNav.closeSection.
-  void _close(BuildContext context) => context.go(
-    token.type == 'room' || token.type == 'session'
-        ? WorkspaceNav.closeLeft(currentUri, token)
-        : WorkspaceNav.closeSection(currentUri, token),
-  );
+  void _close(BuildContext context) {
+    final uri = _liveUri(context);
+    context.go(
+      token.type == 'room' || token.type == 'session'
+          ? WorkspaceNav.closeLeft(uri, token)
+          : WorkspaceNav.closeSection(uri, token),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     final page = token.param;
     if (_isPushedSubPage && page != null) {
       return BackButton(
-        onPressed: () =>
-            context.go(WorkspaceNav.popPage(currentUri, token.type, page)),
+        onPressed: () => context.go(
+          WorkspaceNav.popPage(_liveUri(context), token.type, page),
+        ),
       );
     }
 

--- a/test/pangea/navigation/left_panel_close_button_test.dart
+++ b/test/pangea/navigation/left_panel_close_button_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/left_panel/left_panel_close_button.dart';
+
+void main() {
+  testWidgets(
+    'closing a session reads the LIVE url, not a stale currentUri prop (#7268)',
+    (tester) async {
+      // The left panel does NOT rebuild when only the RIGHT column changes (so
+      // the live chat is not torn down). So the close button can hold a
+      // currentUri captured when the session opened (right=analytics:sessions)
+      // while the live url has since moved to analytics:grammar. Closing must use
+      // the live url, or closeLeft "restores" the stale open-time right tab.
+      final staleUri = Uri.parse('/?left=session:!x&right=analytics:sessions');
+      const liveLocation = '/?left=session:!x&right=analytics:grammar';
+
+      final router = GoRouter(
+        initialLocation: liveLocation,
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: LeftPanelCloseButton(
+                token: const PanelToken('session', '!x'),
+                currentUri: staleUri, // STALE on purpose
+                foldedOver: false,
+                isColumnMode: true,
+              ),
+            ),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: L10n.localizationsDelegates,
+          supportedLocales: L10n.supportedLocales,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      final result = router.routerDelegate.currentConfiguration.uri;
+      final panels = parseOpenPanels(result);
+
+      // The session token is dropped...
+      expect(
+        panels.left.any((t) => t.type == 'session'),
+        isFalse,
+        reason: 'the session token should be dropped on close',
+      );
+      // ...and the right column stays on the LIVE tab (grammar), NOT reverting to
+      // the stale open-time tab (sessions). Pre-fix this was analytics:sessions.
+      expect(
+        panels.right.any((t) => t.type == 'analytics' && t.param == 'grammar'),
+        isTrue,
+        reason:
+            'close must preserve the live right column (analytics:grammar), not '
+            'restore the stale open-time tab (analytics:sessions): got $result',
+      );
+    },
+  );
+}


### PR DESCRIPTION
Closes #7268.

## Symptom

Closing a saved (completed) activity review could swap the right column to the Stars/Activities list. Repro: open Stars, open a saved activity, switch the right panel to Grammar (or Vocab/Settings), then close the saved activity. The right column jumps from `analytics:grammar` back to `analytics:sessions`.

## Root cause (a stale-snapshot bug)

The saved activity opens as a left `session` panel beside the right `analytics` panel. When the user then switches the right tab, the LEFT panel is deliberately NOT rebuilt (so the live chat/timeline is not torn down). `LeftPanelCloseButton` holds the `currentUri` it was given at that last build, which still has the open-time right column (`right=analytics:sessions`).

`WorkspaceNav.closeLeft` correctly drops only the left token and preserves the rest of the query verbatim, but it was being fed that STALE uri, so it "restored" the open-time `sessions` tab and discarded the `grammar` tab the user had switched to.

Confirmed by instrumenting the running build and reproducing live. The close handler logged:

`_close token=session:!NUl... from=/?left=session:!NUl...&right=analytics:sessions -> /?right=analytics:sessions`

The `from=` shows the close ran on `right=analytics:sessions` while the address bar was on `analytics:grammar`. This is why static analysis and a unit test could not find it: they assume `currentUri` is live. It is only observable at runtime.

## Fix

`LeftPanelCloseButton`'s click-time actions (the close, and the pushed-sub-page back) now read the LIVE url via `GoRouter.of(context).routeInformationProvider.value.uri` instead of the captured `currentUri` prop. So a close drops only its token and leaves the right column exactly as the user left it. No behavior changes when `currentUri` is already current.

## Test

`test/pangea/navigation/left_panel_close_button_test.dart`: renders the close button with a deliberately stale `currentUri` (`right=analytics:sessions`) over a router whose live location is `right=analytics:grammar`, taps close, and asserts the result keeps `analytics:grammar` and drops the session token. Pre-fix this produced `analytics:sessions` and fails.

## Changes to review
- `lib/routes/world/left_panel/left_panel_close_button.dart` - new `_liveUri(context)` helper; `_close` and the pushed-page back read the live url.
- `test/pangea/navigation/left_panel_close_button_test.dart` - regression test.

## TO TEST
- [ ] Open Stars, open a saved activity, switch the right panel to Grammar (and separately Vocab, Settings), then close the saved activity: the right panel stays where you left it instead of jumping to the Activities list.
- [ ] Close a saved activity with nothing else changed on the right: still returns to the Activities list it came from (unchanged).
- [ ] A normal chat/room close and a room sub-page back (members/search) still behave as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the left-panel close action to use the app’s current route state, preventing the right-side tab from reverting to an older selection when panels change without a full redraw.
  * Improved back/close behavior for nested pages so navigation now preserves the active right-column view more reliably.
* **Tests**
  * Added a widget test covering this navigation scenario to ensure the close button keeps the live route intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->