### PR TITLE
Remove duplicate room names from semantics

### DIFF
--- a/lib/routes/chat/chat_app_bar_title.dart
+++ b/lib/routes/chat/chat_app_bar_title.dart
@@ -51,15 +51,17 @@ class ChatAppBarTitle extends StatelessWidget {
         children: [
           Hero(
             tag: 'content_banner',
-            child: Avatar(
-              mxContent: room.avatar,
-              name: room.getLocalizedDisplayname(
-                MatrixLocals(L10n.of(context)),
+            child: ExcludeSemantics(
+              child: Avatar(
+                mxContent: room.avatar,
+                name: room.getLocalizedDisplayname(
+                  MatrixLocals(L10n.of(context)),
+                ),
+                // #Pangea
+                userId: room.directChatMatrixID,
+                // Pangea#
+                size: 32,
               ),
-              // #Pangea
-              userId: room.directChatMatrixID,
-              // Pangea#
-              size: 32,
             ),
           ),
           const SizedBox(width: 12),

--- a/lib/routes/chat/room_creation_state_event.dart
+++ b/lib/routes/chat/room_creation_state_event.dart
@@ -72,12 +72,14 @@ class RoomCreationStateEventState extends State<RoomCreationStateEvent> {
                 child: Column(
                   mainAxisSize: .min,
                   children: [
-                    Avatar(
-                      mxContent: event.room.avatar,
-                      name: roomName,
-                      size: Avatar.defaultSize * 2,
-                      userId: event.room.directChatMatrixID,
-                      useRive: true,
+                    ExcludeSemantics(
+                      child: Avatar(
+                        mxContent: event.room.avatar,
+                        name: roomName,
+                        size: Avatar.defaultSize * 2,
+                        userId: event.room.directChatMatrixID,
+                        useRive: true,
+                      ),
                     ),
                     Text(
                       roomName,


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility by hiding decorative avatar elements from screen readers in chat-related views.
  * No changes to layout, navigation, or tap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->