### PR TITLE
fix: collapse promoted map card on zoom-out + gentler combined pan/zoom glide (#7245, #7239)

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -115,6 +115,11 @@ class WorldMapController extends State<WorldMap>
   /// map, no preview popup.
   String? _promotedActivityId;
 
+  /// The highest camera zoom held since the current card was tap-promoted, so
+  /// zooming back out far enough collapses it to its dot (it stops covering
+  /// other pins when the view widens — #7245). Null when nothing is promoted.
+  double? _promotedPeakZoom;
+
   Client? _client;
   StreamSubscription<dynamic>? _syncSub;
 
@@ -143,12 +148,34 @@ class WorldMapController extends State<WorldMap>
   /// Drives the smooth camera glide (center + zoom tween) instead of an instant
   /// `fitCamera` snap. Retargets cleanly if a new fit lands mid-flight.
   AnimationController? _camAnim;
-  CurvedAnimation? _camCurve;
   LatLng? _camStart;
   LatLng? _camTarget;
   double _camStartZoom = 0;
   double _camTargetZoom = 0;
+
+  /// The glide's initial duration; [_animateCameraTo] overrides it per-move,
+  /// scaling by the zoom delta — gentle for a big focus move, snappy for a
+  /// single zoom step (#7239).
   static const Duration _camGlideDuration = Duration(milliseconds: 600);
+  static const double _camGlideMinMs = 500;
+  static const double _camGlideMaxMs = 1400;
+  static const double _camGlideMsPerZoom = 110;
+
+  /// A glide times its pan and zoom on two overlapping intervals so the PAN runs
+  /// at the LOWER zoom of the endpoints (the lead half) and the ZOOM at the other
+  /// (the trail half) — keeping the on-screen sweep small and tile loading low,
+  /// while the overlap reads as one continuous move rather than two phases
+  /// (#7239).
+  static const Curve _camLeadCurve = Interval(
+    0.0,
+    0.7,
+    curve: Curves.easeInOut,
+  );
+  static const Curve _camTrailCurve = Interval(
+    0.3,
+    1.0,
+    curve: Curves.easeInOut,
+  );
 
   /// Cached per-activity live signals (state + fill + recency + pinged),
   /// completion, and the learner's star total per activity, recomputed on room
@@ -226,7 +253,6 @@ class WorldMapController extends State<WorldMap>
     // remounts it.
     _camAnim = AnimationController(vsync: this, duration: _camGlideDuration)
       ..addListener(_onCamGlideTick);
-    _camCurve = CurvedAnimation(parent: _camAnim!, curve: Curves.easeInOut);
     _loadForContext();
     MapContextController.notifier.addListener(_onContextChange);
     MapPinController.notifier.addListener(_onPinControllerChange);
@@ -437,7 +463,6 @@ class WorldMapController extends State<WorldMap>
     _syncSub?.cancel();
     _refetchDebounce?.cancel();
     _fitDebounce?.cancel();
-    _camCurve?.dispose();
     _camAnim?.dispose();
     MapContextController.notifier.removeListener(_onContextChange);
     MapPinController.notifier.removeListener(_onPinControllerChange);
@@ -565,9 +590,43 @@ class WorldMapController extends State<WorldMap>
   /// Debounced viewport reload, called by the view as the camera pans/zooms.
   /// Course pins are context-bound, so this is World-only.
   void handleMapPositionChanged() {
+    _maybeCollapsePromotedOnZoomOut();
     if (!isWorld) return;
     _refetchDebounce?.cancel();
     _refetchDebounce = Timer(const Duration(milliseconds: 500), loadWorldPins);
+  }
+
+  /// How many zoom levels the learner must zoom out, below the highest zoom held
+  /// since promoting, before a tap-promoted card collapses (#7245). Loose enough
+  /// that pans and small adjustments keep it.
+  static const double _promotedCollapseMargin = 2.0;
+
+  /// #7245: a tap-promoted large card is an explicit zoom-in detail; once the
+  /// learner zooms back out [_promotedCollapseMargin] levels below the highest
+  /// zoom held since it was promoted, collapse it to its dot so an open box stops
+  /// covering the more compact pins (the tier "attention budget scales with
+  /// visible map size", world-map.instructions.md). Tracked against the peak
+  /// rather than the promote-time zoom, so a promotion that also glides the
+  /// camera in still collapses on the way back out. Pans never collapse it.
+  void _maybeCollapsePromotedOnZoomOut() {
+    if (_promotedActivityId == null) return;
+    final zoom = _safeZoom();
+    if (zoom == null) return;
+    final peak = _promotedPeakZoom ?? zoom;
+    if (zoom > peak) {
+      _promotedPeakZoom = zoom;
+      return;
+    }
+    if (zoom < peak - _promotedCollapseMargin) collapse();
+  }
+
+  /// The live camera zoom, or null before the map is laid out.
+  double? _safeZoom() {
+    try {
+      return mapController.camera.zoom;
+    } catch (_) {
+      return null;
+    }
   }
 
   // ---- filtering ------------------------------------------------------------
@@ -680,12 +739,14 @@ class WorldMapController extends State<WorldMap>
   /// its activity id as its key, which is all promotion needs.
   void promoteToLargeById(String activityId) {
     setState(() => _promotedActivityId = activityId);
+    _promotedPeakZoom = _safeZoom();
     ActivityPlanRepo.instance.ensure(activityId);
   }
 
   void collapse() {
     if (_promotedActivityId == null) return;
     setState(() => _promotedActivityId = null);
+    _promotedPeakZoom = null;
   }
 
   /// Glide back to the whole-world view (the initial camera). Pins, clusters,
@@ -813,6 +874,14 @@ class WorldMapController extends State<WorldMap>
     _camStartZoom = mapController.camera.zoom;
     _camTarget = center;
     _camTargetZoom = zoom;
+    // #7239: scale the glide length by the zoom delta — a deep focus zoom glides
+    // gently, a single zoom step stays quick — rather than a fixed 600ms.
+    final zoomDelta = (zoom - _camStartZoom).abs();
+    anim.duration = Duration(
+      milliseconds: (_camGlideMinMs + zoomDelta * _camGlideMsPerZoom)
+          .clamp(_camGlideMinMs, _camGlideMaxMs)
+          .round(),
+    );
     anim
       ..reset()
       ..forward();
@@ -821,12 +890,21 @@ class WorldMapController extends State<WorldMap>
   void _onCamGlideTick() {
     final start = _camStart;
     final end = _camTarget;
-    final curve = _camCurve;
-    if (start == null || end == null || curve == null) return;
-    final t = curve.value;
-    final lat = start.latitude + (end.latitude - start.latitude) * t;
-    final lng = start.longitude + (end.longitude - start.longitude) * t;
-    final zoom = _camStartZoom + (_camTargetZoom - _camStartZoom) * t;
+    final anim = _camAnim;
+    if (start == null || end == null || anim == null) return;
+    final t = anim.value;
+    // #7239: pan and zoom glide together as one gentle move, but the PAN is
+    // timed to the LOWER zoom of the two endpoints so the on-screen sweep is
+    // small and few tiles load — not the old linear tween that flung the map
+    // across at high zoom (the jarring "zoom in, then pan"). Zooming IN: pan
+    // leads, zoom trails; zooming OUT: zoom leads, pan trails. The overlapping
+    // intervals keep it continuous, not a hard two-phase snap.
+    final zoomingIn = _camTargetZoom >= _camStartZoom;
+    final tPan = (zoomingIn ? _camLeadCurve : _camTrailCurve).transform(t);
+    final tZoom = (zoomingIn ? _camTrailCurve : _camLeadCurve).transform(t);
+    final lat = start.latitude + (end.latitude - start.latitude) * tPan;
+    final lng = start.longitude + (end.longitude - start.longitude) * tPan;
+    final zoom = _camStartZoom + (_camTargetZoom - _camStartZoom) * tZoom;
     try {
       mapController.move(LatLng(lat, lng), zoom);
     } catch (_) {


### PR DESCRIPTION
Closes #7245. Closes #7239.

Two map-camera/zoom fixes in `world_map.dart`, both aligned with the pin-tier design (`world-map.instructions.md`: tiers are an attention budget that scales with the visible map size; promotion is emergent from zoom).

## #7245 - collapse a tap-promoted card on zoom-out

A tap-promoted large card stayed large at any zoom, so once you zoomed back out it covered the more compact pins. Now the controller tracks the highest zoom held since the card was promoted (`_promotedPeakZoom`), and `handleMapPositionChanged` collapses it to its dot once you zoom `_promotedCollapseMargin` (2 levels) below that peak. Tracked against the peak (not the promote-time zoom) so a promotion that also glides the camera in still collapses on the way back out; pans and small adjustments keep it. Runs in both World and course contexts.

## #7239 - gentler, combined pan + zoom glide

The focus glide tweened center and zoom linearly, so the on-screen sweep accelerated hard as zoom climbed - reading as "zoom in, then fling across" and loading a lot of tiles. Now the glide times its pan and zoom on two overlapping intervals so the pan runs at the LOWER zoom of the two endpoints (zoom-in: pan leads, zoom trails; zoom-out: zoom leads, pan trails). The on-screen sweep stays small and few tiles load, while the overlap keeps it one continuous move rather than two phases. The glide duration also scales with the zoom delta (gentle for a deep focus move, snappy for a single zoom step) instead of a fixed 600ms.

## Changes to review
- `world_map.dart` - `_promotedPeakZoom` + `_maybeCollapsePromotedOnZoomOut` (wired into `handleMapPositionChanged`); `promoteToLargeById`/`collapse` track/clear the peak.
- `world_map.dart` - `_onCamGlideTick` uses directional lead/trail `Interval` curves off the raw animation value (drops the single `easeInOut` `_camCurve`); `_animateCameraTo` scales the duration by the zoom delta.

## TO TEST
#7245:
- [ ] Zoom in, tap an activity to promote it to its large card, then zoom out ~2+ levels: the card collapses back to its dot.
- [ ] Promote a card and pan / make small zoom adjustments: it stays promoted.
#7239:
- [ ] Open (focus) an activity from a wider view: the camera pans toward it while still zoomed out, then zooms in - one gentle continuous move, not a zoom-then-fling, and noticeably fewer tiles flashing in.
- [ ] World reset (zoom-out) glides smoothly; a single +/- zoom step still feels quick.
- [ ] Tune note: collapse margin (2.0) and glide timing (`_camGlideMinMs`/`Max`/`PerZoom`, the 0.7/0.3 interval overlap) are the knobs if the feel needs adjusting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved map camera movement for smoother zooming and panning.
  * Promoted large cards now collapse more reliably when you zoom back out after zooming in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->