### PR TITLE
fix: practice Done returns to the analytics tab via token, not a dead legacy route (#7227)

### DIFF
--- a/lib/routes/analytics/construct_analytics/practice/completed_analytics_practice_exercises_view.dart
+++ b/lib/routes/analytics/construct_analytics/practice/completed_analytics_practice_exercises_view.dart
@@ -3,6 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/analytics/construct_type_enum.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/practice/analytics_practice_constants.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/practice/analytics_practice_session_model.dart';
@@ -141,7 +144,19 @@ class CompletedAnalyticsPracticeExercisesView extends StatelessWidget {
                     ),
                   ),
                   onPressed: () {
-                    context.go('/rooms/analytics/vocab');
+                    // #7227: return to the analytics page the practice was
+                    // launched from (vocab or grammar) via the world_v2 token,
+                    // not the dead legacy `/rooms/analytics/...` path. Practice
+                    // is a right-column takeover, so swap it back for the
+                    // matching analytics summary tab.
+                    final tab = session.type == ConstructTypeEnum.morph
+                        ? 'grammar'
+                        : 'vocab';
+                    context.go(
+                      WorkspaceNav.setRight(GoRouterState.of(context).uri, [
+                        PanelToken('analytics', tab),
+                      ]),
+                    );
                   },
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
Closes #7227.

## Bug
Clicking **Done** on the practice-complete screen navigated to `context.go('/rooms/analytics/vocab')` — a legacy path that no longer exists in world_v2 (everything is a token over `/`), so it dead-ended on a missing route. It also always went to *vocab*, even after grammar practice.

## Fix
The Done button now returns to the analytics page the practice was launched from, token-natively. Practice is a right-column takeover (`right=practice:<type>`), so `WorkspaceNav.setRight` swaps it back for the matching analytics summary tab — `grammar` after morph practice, `vocab` after vocab practice (from `session.type`).

## Changes to review
- `completed_analytics_practice_exercises_view.dart` — Done `onPressed` builds `setRight(uri, [analytics:<vocab|grammar>])` instead of the legacy path; adds the `WorkspaceNav` / `PanelToken` / `ConstructTypeEnum` imports.

## TO TEST
- [ ] Finish a **vocab** practice session, click Done: lands on the vocab analytics page (not a blank/missing route).
- [ ] Finish a **grammar** practice session, click Done: lands on the grammar analytics page.
