### PR TITLE
fix: don't show 'course needs a plan' message to users with no courses (#7172)

### DIFF
--- a/lib/routes/world/left_panel/left_panel_courses_list_view.dart
+++ b/lib/routes/world/left_panel/left_panel_courses_list_view.dart
@@ -55,17 +55,10 @@ class LeftPanelCoursesListView extends StatelessWidget {
           padding: const EdgeInsets.fromLTRB(12.0, 4.0, 12.0, 16.0),
           children: [
             for (final space in courses) CourseListTile(space),
-            if (courses.isEmpty)
-              Padding(
-                padding: const EdgeInsets.symmetric(vertical: 16.0),
-                child: Text(
-                  l10n.noCourseFound,
-                  textAlign: TextAlign.center,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-              ),
+            // #7172: a user in no courses isn't a course-without-a-plan, so don't
+            // show the "this course needs a plan" message here — the "Add new
+            // course" section below is the empty state and invites them to join
+            // or create one.
             const SizedBox(height: 4.0),
             // "Add new course" section divider + the add options.
             Row(


### PR DESCRIPTION
Closes #7172.

## Bug
The Courses panel's empty state (user is in no courses) rendered `l10n.noCourseFound`, whose text is "Oh, this course needs a plan!" — a planless-course message that is confusing for someone who has no courses at all.

## Fix
Drop that message from the empty state. The "Add new course" divider + add-course options (start my own / enter a code / browse public) already render right below as the empty state and invite the user to join or create a course, which is what the issue asks for ("encourage them to add a course or not show"). The `noCourseFound` string was used only here.

## Changes to review
- `left_panel_courses_list_view.dart` — remove the `courses.isEmpty` planless-course text; the add-course section is the empty state.

## TO TEST
- [ ] On an account in no courses, open the Courses panel: no "this course needs a plan" message; the "Add new course" options are shown.
- [ ] On an account in one or more courses: the course tiles still list normally, with the add-course section below.
