### PR TITLE
fix: show the default color theme as selected when there's no system swatch (#7176)

### DIFF
--- a/lib/routes/settings/settings_style/settings_style_view.dart
+++ b/lib/routes/settings/settings_style/settings_style_view.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 
 import 'package:dynamic_color/dynamic_color.dart';
 
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
@@ -122,7 +123,17 @@ class SettingsStyleView extends StatelessWidget {
                             child: SizedBox(
                               width: colorPickerSize,
                               height: colorPickerSize,
-                              child: controller.currentColor == color
+                              child:
+                                  (controller.currentColor == color ||
+                                      // #7176: on the default (null) colour the
+                                      // system swatch carries the selection, but
+                                      // where there is no system colour (web) that
+                                      // swatch is removed and the app falls back to
+                                      // its default colour — mark that swatch
+                                      // selected so a theme always reads as chosen.
+                                      (controller.currentColor == null &&
+                                          systemColor == null &&
+                                          color == AppConfig.chatColor))
                                   ? Center(
                                       child: Icon(
                                         Icons.check,


### PR DESCRIPTION
Closes #7176.

## Bug
On the Change-your-style screen no color swatch showed as selected, even though a theme is always active. Verified in-browser (before: no checkmark on any swatch; after: the default swatch is checked).

## Cause
The color swatches include a `null` "system" entry, shown selected when `currentColor == null` (the default). But `DynamicColorBuilder` yields no system color on web, so that `null` swatch is removed (`settings_style_view.dart`'s `colors.remove(null)`). A default-theme user has `currentColor == null`, which then matches no remaining swatch — so nothing reads as selected, while the app is silently using its default color (`AppConfig.chatColor`).

## Fix
When `currentColor` is null and there's no system color (so the `null` swatch is gone), mark the `AppConfig.chatColor` swatch — the color the app actually falls back to — as selected. Set custom colors still match by value as before; the system swatch still carries the selection on platforms that have a system color.

## Changes to review
- `settings_style_view.dart` — selection check also matches the default `AppConfig.chatColor` swatch when `currentColor == null && systemColor == null`; adds the `app_config` import.

## TO TEST
- [ ] On web, default theme: the first (default) color swatch shows a checkmark.
- [ ] Pick another color: that swatch shows the checkmark; after a reload it's still selected.
