### PR TITLE
fix: move map attributions to the bottom-left, clear of the on-map controls (#7218)

### DIFF
--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -347,6 +347,10 @@ class WorldMapView extends StatelessWidget {
         // on desktop plus any pin promoted by a tap.
         MarkerLayer(markers: _largeMarkers(render)),
         RichAttributionWidget(
+          // #7218: bottom-LEFT so the attribution and its expand popup don't sit
+          // under the bottom-right zoom/World controls (where it was covered and
+          // hard to read, especially in dark mode).
+          alignment: AttributionAlignment.bottomLeft,
           attributions: [
             TextSourceAttribution('OpenStreetMap contributors', onTap: () {}),
             if (dark) TextSourceAttribution('CARTO', onTap: () {}),


### PR DESCRIPTION
Closes #7218.

The OpenStreetMap/CARTO attribution (and its expand popup) sat at the map's bottom-right, overlapping the on-map zoom/World controls pill — covered and hard to read, especially in dark mode (reproduced in-browser). Moving the `RichAttributionWidget` to the bottom-left (`AttributionAlignment.bottomLeft`) clears the right-edge controls; the conventional attribution corner.

## Changes to review
- `world_map_view.dart` — `RichAttributionWidget(alignment: AttributionAlignment.bottomLeft)`.

## TO TEST
- [ ] World/course map: the attribution "i" + logo sit at the bottom-left, not under the bottom-right zoom/World controls; still visible in dark mode.

Note: bug reproduced + fix is analyze-clean; the live re-verify was blocked by a degraded local dev boot after repeated restarts.
