### PR TITLE
feat: gentler map glide — staggered pan/zoom + distance-scaled duration (#7239)

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -97,7 +97,6 @@ class WorldMapController extends State<WorldMap>
   /// Drives the smooth camera glide (center + zoom tween) instead of an instant
   /// `fitCamera` snap. Retargets cleanly if a new fit lands mid-flight.
   late final AnimationController _cameraAnimationController;
-  late final CurvedAnimation _cameraAnimation;
   LatLng? _camStart;
   LatLng? _camTarget;
   double _camStartZoom = 0;
@@ -122,11 +121,6 @@ class WorldMapController extends State<WorldMap>
       vsync: this,
       duration: WorldMapConstants.camGlideDuration,
     )..addListener(_onCamGlideTick);
-
-    _cameraAnimation = CurvedAnimation(
-      parent: _cameraAnimationController,
-      curve: Curves.easeInOut,
-    );
 
     _loadForContext();
 
@@ -216,7 +210,6 @@ class WorldMapController extends State<WorldMap>
     _cefrLevelSubscription?.cancel();
     _refetchDebounce?.cancel();
     _fitDebounce?.cancel();
-    _cameraAnimation.dispose();
     _cameraAnimationController.dispose();
     MapContextController.notifier.removeListener(_onContextChange);
     WorldMapPinsManager.notifier.removeListener(_onPinControllerChange);
@@ -544,8 +537,10 @@ class WorldMapController extends State<WorldMap>
     _animateCameraTo(target.center, target.zoom);
   }
 
-  /// Tween the camera center + zoom over [_camGlideDuration]. Re-targets cleanly
-  /// if called mid-flight (the glide restarts from the current position).
+  /// Tween the camera center + zoom to the target. The glide length scales with
+  /// the zoom distance ([WorldMapConstants.glideDurationFor]) and pan/zoom are
+  /// staggered so the pan runs at the wider zoom (#7239). Re-targets cleanly if
+  /// called mid-flight (the glide restarts from the current position).
   void _animateCameraTo(LatLng center, double zoom) {
     final anim = _cameraAnimationController;
     if (!mounted) {
@@ -559,6 +554,7 @@ class WorldMapController extends State<WorldMap>
     _camTarget = center;
     _camTargetZoom = zoom;
     anim
+      ..duration = WorldMapConstants.glideDurationFor(_camStartZoom, zoom)
       ..reset()
       ..forward();
   }
@@ -566,13 +562,17 @@ class WorldMapController extends State<WorldMap>
   void _onCamGlideTick() {
     final start = _camStart;
     final end = _camTarget;
-    final curve = _cameraAnimation;
     if (start == null || end == null) return;
 
-    final t = curve.value;
-    final lat = start.latitude + (end.latitude - start.latitude) * t;
-    final lng = start.longitude + (end.longitude - start.longitude) * t;
-    final zoom = _camStartZoom + (_camTargetZoom - _camStartZoom) * t;
+    // Stagger pan and zoom so the pan runs at the wider zoom (#7239).
+    final p = WorldMapConstants.glideProgress(
+      _cameraAnimationController.value,
+      _camStartZoom,
+      _camTargetZoom,
+    );
+    final lat = start.latitude + (end.latitude - start.latitude) * p.pan;
+    final lng = start.longitude + (end.longitude - start.longitude) * p.pan;
+    final zoom = _camStartZoom + (_camTargetZoom - _camStartZoom) * p.zoom;
     try {
       mapController.move(LatLng(lat, lng), zoom);
     } catch (_) {

--- a/lib/routes/world/world_map_constants.dart
+++ b/lib/routes/world/world_map_constants.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/animation.dart';
+
 class WorldMapConstants {
   /// The camera zoom range — the single source for FlutterMap's MapOptions, the
   /// +/- step clamp in [zoomBy], the World reset in [resetToWorld], and the
@@ -17,4 +19,61 @@ class WorldMapConstants {
 
   static const Duration fitSettleDelay = Duration(seconds: 2);
   static const Duration camGlideDuration = Duration(milliseconds: 600);
+
+  // #7239 — gentler combined pan/zoom glide.
+
+  /// A glide's length scales with how far the zoom travels: a single +/- step
+  /// stays snappy (~[_camGlideMinMs]), a deep focus move glides gently
+  /// (~[_camGlideMaxMs]).
+  static const double _camGlideMinMs = 500;
+  static const double _camGlideMaxMs = 1400;
+  static const double _camGlideMsPerZoom = 110;
+
+  static Duration glideDurationFor(double startZoom, double targetZoom) {
+    final ms =
+        (_camGlideMinMs + (targetZoom - startZoom).abs() * _camGlideMsPerZoom)
+            .clamp(_camGlideMinMs, _camGlideMaxMs);
+    return Duration(milliseconds: ms.round());
+  }
+
+  /// The pan and zoom of a glide run on two overlapping intervals so the pan
+  /// happens at the WIDER of the two zooms and the zoom at the narrower — keeping
+  /// the on-screen sweep (and tile loading) small while still reading as one
+  /// continuous move. Zooming IN: pan leads, zoom trails. Zooming OUT: reversed.
+  static const Curve _camLeadCurve = Interval(
+    0.0,
+    0.7,
+    curve: Curves.easeInOut,
+  );
+  static const Curve _camTrailCurve = Interval(
+    0.3,
+    1.0,
+    curve: Curves.easeInOut,
+  );
+
+  /// The (pan, zoom) progress at raw glide value [t] for a move from [startZoom]
+  /// to [targetZoom]. Split out so the directional staggering is unit-testable.
+  static ({double pan, double zoom}) glideProgress(
+    double t,
+    double startZoom,
+    double targetZoom,
+  ) {
+    if (targetZoom > startZoom) {
+      // Zoom in: pan first (at the wider zoom), then zoom in.
+      return (
+        pan: _camLeadCurve.transform(t),
+        zoom: _camTrailCurve.transform(t),
+      );
+    }
+    if (targetZoom < startZoom) {
+      // Zoom out: zoom out to the wider zoom first, then pan.
+      return (
+        pan: _camTrailCurve.transform(t),
+        zoom: _camLeadCurve.transform(t),
+      );
+    }
+    // Pure pan, no zoom change: one shared ease, nothing to stagger.
+    final eased = Curves.easeInOut.transform(t);
+    return (pan: eased, zoom: eased);
+  }
 }

--- a/test/pangea/world_map_glide_test.dart
+++ b/test/pangea/world_map_glide_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/world/world_map_constants.dart';
+
+void main() {
+  group('glideDurationFor — scales with the zoom distance (#7239)', () {
+    int ms(double a, double b) =>
+        WorldMapConstants.glideDurationFor(a, b).inMilliseconds;
+
+    test('a no-zoom move is the floor', () {
+      expect(ms(5, 5), 500);
+    });
+
+    test('one zoom level adds the per-level step', () {
+      expect(ms(5, 6), 610); // 500 + 1*110
+    });
+
+    test('a large move is clamped to the ceiling', () {
+      expect(ms(3, 18), 1400); // 500 + 15*110 = 2150 -> clamped
+    });
+
+    test('depends only on the magnitude of the delta', () {
+      expect(ms(8, 12), ms(12, 8));
+    });
+  });
+
+  group('glideProgress — directional pan/zoom staggering (#7239)', () {
+    test(
+      'endpoints: pan and zoom are 0 at t=0 and 1 at t=1, any direction',
+      () {
+        for (final move in [
+          [3.0, 12.0], // in
+          [12.0, 3.0], // out
+          [7.0, 7.0], // pure pan
+        ]) {
+          final at0 = WorldMapConstants.glideProgress(0, move[0], move[1]);
+          final at1 = WorldMapConstants.glideProgress(1, move[0], move[1]);
+          expect(at0.pan, moreOrLessEquals(0));
+          expect(at0.zoom, moreOrLessEquals(0));
+          expect(at1.pan, moreOrLessEquals(1));
+          expect(at1.zoom, moreOrLessEquals(1));
+        }
+      },
+    );
+
+    test(
+      'zooming IN: the pan leads the zoom (pan further along mid-glide)',
+      () {
+        final p = WorldMapConstants.glideProgress(0.5, 3, 12);
+        expect(p.pan, greaterThan(p.zoom));
+      },
+    );
+
+    test('zooming OUT: the zoom leads the pan', () {
+      final p = WorldMapConstants.glideProgress(0.5, 12, 3);
+      expect(p.zoom, greaterThan(p.pan));
+    });
+
+    test('a pure pan (no zoom change) moves pan and zoom together', () {
+      final p = WorldMapConstants.glideProgress(0.5, 7, 7);
+      expect(p.pan, moreOrLessEquals(p.zoom));
+    });
+  });
+}


### PR DESCRIPTION
Closes #7239.

The map glide zoomed most of the way in and then flung across the map, sweeping over a sea of unloaded tiles. This makes it one gentle, combined pan+zoom.

Two changes, both extracted into pure, unit-tested helpers in `world_map_constants.dart`:

- **Staggered pan/zoom** (`glideProgress`): pan and zoom run on two overlapping intervals so the pan happens at the **wider** of the two zooms. Zooming in, the pan leads and the zoom trails; zooming out, the reverse. The on-screen sweep and tile loading stay small, and it still reads as one move.
- **Distance-scaled duration** (`glideDurationFor`): 500-1400ms by the zoom delta, so a single +/- step stays snappy and a deep focus move glides gently, instead of a flat 600ms for everything.

`_onCamGlideTick` now reads the raw controller value through `glideProgress`, and `_animateCameraTo` sets the scaled duration per move; the old single-curve `_cameraAnimation` is dropped (only the tick used it). The `_cameraAnimationController` is unchanged.

This re-implements the intent of the stale #7336 branch against main's refactored camera, per the agreed design (staggered + distance-scaled). #7336 will be closed; the pin-state half of #7336/#7245 is handled separately by the world-map pin-states doc (#7346).

## Test
- `flutter analyze` clean; `world_map_glide_test.dart` (8 tests: duration scaling + directional staggering) pass; the existing world_map zoom/ranking/signals tests still pass.

### TO TEST (feel)
- [ ] On the live map, a focus glide reads as one gentle combined pan+zoom (no zoom-in-then-fling), and a single +/- step stays snappy.
