### PR TITLE
feat(hooks): register branch-guard and flutter-skill PreToolUse hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,10 @@
           {
             "type": "command",
             "command": "python3 \"$HOME/PangeaChat/.github/scripts/intent-gate.py\""
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/PangeaChat/.github/scripts/branch-guard.py\""
           }
         ]
       },
@@ -26,6 +30,10 @@
           {
             "type": "command",
             "command": "bash \"$HOME/PangeaChat/.github/scripts/pretooluse-reminders.sh\""
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/.github/scripts/pretooluse-flutter-skill.sh\""
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,54 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/PangeaChat/.github/scripts/sync-copilot-to-claude.py\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/PangeaChat/.github/scripts/intent-gate.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/PangeaChat/.github/scripts/pretooluse-reminders.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/PangeaChat/.github/scripts/sync-copilot-on-edit.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if jq -r '.tool_input.command // empty' 2>/dev/null | grep -qE '\\bgh pr merge\\b'; then \"$HOME/PangeaChat/.github/scripts/sweep-worktrees.sh\" --emit-claude; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/scripts/pretooluse-flutter-skill.sh
+++ b/.github/scripts/pretooluse-flutter-skill.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# PreToolUse(Bash) nudge — client only. When the agent is about to spin up the Flutter web
+# client (`flutter run`), point to the run-flutter-web-local skill if it likely isn't already
+# in context. The skill is the clean-restart procedure that avoids the recurring local hang;
+# this only points to it (the procedure lives in the skill, not here). Fires once per session.
+# Advisory only; never blocks (always exit 0).
+payload=$(cat)
+cmd=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null)
+printf '%s' "$cmd" | grep -qE '\bflutter run\b' || exit 0
+
+session=$(printf '%s' "$payload" | jq -r '.session_id // "nosess"' 2>/dev/null)
+flag="${TMPDIR:-/tmp}/flutter-skill-${session}.flag"
+[ -f "$flag" ] && exit 0   # already pointed this session — assume it's in context now
+: > "$flag"
+
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","additionalContext":"%s"}}' \
+  "Before spinning up the Flutter client: if the run-flutter-web-local skill isn't already in context, read .github/skills/run-flutter-web-local/SKILL.md first. It is the clean-restart procedure that avoids the recurring local hang — stale-DWDS r/R timeouts that kill port 8090, and orphaned compilers from kill -9. Use it for the start AND every restart."
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,8 @@ CLAUDE.md
 .mcp.json.generated_by_sync
 # E2E test artifacts
 test-results/
+
+# Claude Code team config (per-repo) — track the team hooks, ignore the rest of .claude/ and the generated org-guide copy
+.claude/*
+!.claude/settings.json
+.github/_org-copilot-instructions.md


### PR DESCRIPTION
## Why

Wires up two repo-specific hooks for the client that ship via the per-repo harness pattern documented in harness-sync.instructions.md.

## What changed

**`.github/scripts/pretooluse-flutter-skill.sh`** (new) — fires once per session when an agent is about to run `flutter run`. If the run-flutter-web-local skill is not already in context, surfaces a pointer to `.github/skills/run-flutter-web-local/SKILL.md` (the clean-restart procedure) before the command runs.

**`.claude/settings.json`** (updated) — registers both hooks under PreToolUse: branch-guard (Edit|Write) pointing to the shared `$HOME/PangeaChat/.github/scripts/branch-guard.py`, and flutter-skill (Bash) pointing to `${CLAUDE_PROJECT_DIR}/.github/scripts/pretooluse-flutter-skill.sh`.

## TO TEST

- Open a client session and run `flutter run` without having read the run-flutter-web-local skill first; should see a one-time pointer to the skill.
- Run `flutter run` again in the same session; should fire no second nudge.
- Edit a client file on a clean main branch; should see branch-guard nudge to branch off main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session and tool-use guidance for the coding assistant to streamline workflows and reduce setup issues.
  * Added a one-time reminder when running Flutter locally to help avoid repeated hangs and restart problems.

* **Bug Fixes**
  * Improved handling around editing and command actions to better guide safe, consistent usage.

* **Chores**
  * Updated ignore rules for repository-specific configuration and generated guidance files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->