### PR TITLE
fix(a11y): fix hover highlight and tab order on course tiles

### DIFF
--- a/lib/routes/courses/course_list_tile.dart
+++ b/lib/routes/courses/course_list_tile.dart
@@ -57,65 +57,65 @@ class CourseListTile extends StatelessWidget {
                 borderRadius: BorderRadius.circular(12.0),
                 border: Border.all(color: theme.colorScheme.outlineVariant),
               ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                ExcludeSemantics(
-                  child: Avatar(
-                    mxContent: space.avatar,
-                    name: displayname,
-                    size: 44.0,
-                    borderRadius: BorderRadius.circular(10.0),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ExcludeSemantics(
+                    child: Avatar(
+                      mxContent: space.avatar,
+                      name: displayname,
+                      size: 44.0,
+                      borderRadius: BorderRadius.circular(10.0),
+                    ),
                   ),
-                ),
-                const SizedBox(width: 10.0),
-                Expanded(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      ExcludeSemantics(
-                        child: Text(
-                          displayname,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.titleSmall?.copyWith(
-                            fontWeight: FontWeight.bold,
+                  const SizedBox(width: 10.0),
+                  Expanded(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        ExcludeSemantics(
+                          child: Text(
+                            displayname,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.titleSmall?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
                         ),
-                      ),
-                      const SizedBox(height: 8.0),
-                      Wrap(
-                        spacing: 12.0,
-                        runSpacing: 6.0,
-                        crossAxisAlignment: WrapCrossAlignment.center,
-                        children: [
-                          CourseInfoChip(
-                            icon: Icons.group,
-                            text: '$members',
-                            fontSize: 12.0,
-                            iconSize: 14.0,
-                          ),
-                          // Language / level / modules hydrate once the course
-                          // plan loads (CourseInfoChips shows nothing until
-                          // ready).
-                          if (courseId != null)
-                            CourseInfoChips(
-                              courseId,
+                        const SizedBox(height: 8.0),
+                        Wrap(
+                          spacing: 12.0,
+                          runSpacing: 6.0,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: [
+                            CourseInfoChip(
+                              icon: Icons.group,
+                              text: '$members',
                               fontSize: 12.0,
                               iconSize: 14.0,
                             ),
-                        ],
-                      ),
-                    ],
+                            // Language / level / modules hydrate once the course
+                            // plan loads (CourseInfoChips shows nothing until
+                            // ready).
+                            if (courseId != null)
+                              CourseInfoChips(
+                                courseId,
+                                fontSize: 12.0,
+                                iconSize: 14.0,
+                              ),
+                          ],
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),
       ),
-    ),
     );
   }
 }

--- a/lib/routes/courses/course_list_tile.dart
+++ b/lib/routes/courses/course_list_tile.dart
@@ -45,16 +45,18 @@ class CourseListTile extends StatelessWidget {
       child: Semantics(
         button: true,
         label: '$displayname, $members ${l10n.participants}',
-        child: InkWell(
-          onTap: () => _open(context),
+        child: Material(
+          color: theme.colorScheme.surfaceContainerLow,
           borderRadius: BorderRadius.circular(12.0),
-          child: Container(
-            padding: const EdgeInsets.all(10.0),
-            decoration: BoxDecoration(
-              color: theme.colorScheme.surfaceContainerLow,
-              borderRadius: BorderRadius.circular(12.0),
-              border: Border.all(color: theme.colorScheme.outlineVariant),
-            ),
+          child: InkWell(
+            onTap: () => _open(context),
+            borderRadius: BorderRadius.circular(12.0),
+            child: Container(
+              padding: const EdgeInsets.all(10.0),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12.0),
+                border: Border.all(color: theme.colorScheme.outlineVariant),
+              ),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
@@ -113,6 +115,7 @@ class CourseListTile extends StatelessWidget {
           ),
         ),
       ),
+    ),
     );
   }
 }

--- a/lib/routes/courses/find_course_page.dart
+++ b/lib/routes/courses/find_course_page.dart
@@ -451,124 +451,124 @@ class _PublicCourseTile extends StatelessWidget {
 
     return FocusTraversalGroup(
       child: Padding(
-      padding: const EdgeInsets.only(bottom: 10.0),
-      child: Material(
-        color: theme.colorScheme.surfaceContainerLow,
-        borderRadius: BorderRadius.circular(12.0),
-        child: InkWell(
-          // Tapping the card scopes the map to this course's activities
-          // (world_v2); the Knock/Join pill opens the join flow.
-          onTap: () => MapContextController.set(CourseMapContext(courseId)),
+        padding: const EdgeInsets.only(bottom: 10.0),
+        child: Material(
+          color: theme.colorScheme.surfaceContainerLow,
           borderRadius: BorderRadius.circular(12.0),
-          child: Container(
-            padding: const EdgeInsets.all(10.0),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12.0),
-              border: Border.all(color: theme.colorScheme.outlineVariant),
-            ),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                ImageByUrl(
-                  imageUrl: space.avatarUrl,
-                  width: 44.0,
-                  borderRadius: BorderRadius.circular(10.0),
-                  replacement: Avatar(
-                    name: displayname,
+          child: InkWell(
+            // Tapping the card scopes the map to this course's activities
+            // (world_v2); the Knock/Join pill opens the join flow.
+            onTap: () => MapContextController.set(CourseMapContext(courseId)),
+            borderRadius: BorderRadius.circular(12.0),
+            child: Container(
+              padding: const EdgeInsets.all(10.0),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12.0),
+                border: Border.all(color: theme.colorScheme.outlineVariant),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ImageByUrl(
+                    imageUrl: space.avatarUrl,
+                    width: 44.0,
                     borderRadius: BorderRadius.circular(10.0),
-                    size: 44.0,
+                    replacement: Avatar(
+                      name: displayname,
+                      borderRadius: BorderRadius.circular(10.0),
+                      size: 44.0,
+                    ),
                   ),
-                ),
-                const SizedBox(width: 10.0),
-                Expanded(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Expanded(
-                            child: Padding(
-                              padding: const EdgeInsets.only(top: 2.0),
-                              child: Text(
-                                displayname,
-                                style: theme.textTheme.titleSmall?.copyWith(
-                                  fontWeight: FontWeight.bold,
-                                ),
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 8.0),
-                          FilledButton.tonal(
-                            onPressed: () => _navigateToCoursePage(context),
-                            style: FilledButton.styleFrom(
-                              backgroundColor:
-                                  theme.colorScheme.primaryContainer,
-                              foregroundColor:
-                                  theme.colorScheme.onPrimaryContainer,
-                              visualDensity: VisualDensity.compact,
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 16.0,
-                              ),
-                              minimumSize: const Size(0, 32),
-                              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(20.0),
-                              ),
-                            ),
-                            child: Text(
-                              isKnock
-                                  ? L10n.of(context).knock
-                                  : L10n.of(context).join,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: 8.0),
-                      if (course != null)
-                        Wrap(
-                          spacing: 6.0,
-                          runSpacing: 6.0,
+                  const SizedBox(width: 10.0),
+                  Expanded(
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            _chip(
-                              context,
-                              Icons.language,
-                              course.targetLanguage
-                                  .split('-')
-                                  .first
-                                  .toUpperCase(),
+                            Expanded(
+                              child: Padding(
+                                padding: const EdgeInsets.only(top: 2.0),
+                                child: Text(
+                                  displayname,
+                                  style: theme.textTheme.titleSmall?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
                             ),
-                            _chip(
-                              context,
-                              Icons.group,
-                              '${space.numJoinedMembers}',
-                            ),
-                            _chip(
-                              context,
-                              Icons.location_on,
-                              '${course.topicIds.length}',
-                            ),
-                            _chip(
-                              context,
-                              Icons.school,
-                              course.cefrLevel.string.replaceFirst(
-                                'PREA1',
-                                'PRE-A1',
+                            const SizedBox(width: 8.0),
+                            FilledButton.tonal(
+                              onPressed: () => _navigateToCoursePage(context),
+                              style: FilledButton.styleFrom(
+                                backgroundColor:
+                                    theme.colorScheme.primaryContainer,
+                                foregroundColor:
+                                    theme.colorScheme.onPrimaryContainer,
+                                visualDensity: VisualDensity.compact,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 16.0,
+                                ),
+                                minimumSize: const Size(0, 32),
+                                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(20.0),
+                                ),
+                              ),
+                              child: Text(
+                                isKnock
+                                    ? L10n.of(context).knock
+                                    : L10n.of(context).join,
                               ),
                             ),
                           ],
                         ),
-                    ],
+                        const SizedBox(height: 8.0),
+                        if (course != null)
+                          Wrap(
+                            spacing: 6.0,
+                            runSpacing: 6.0,
+                            children: [
+                              _chip(
+                                context,
+                                Icons.language,
+                                course.targetLanguage
+                                    .split('-')
+                                    .first
+                                    .toUpperCase(),
+                              ),
+                              _chip(
+                                context,
+                                Icons.group,
+                                '${space.numJoinedMembers}',
+                              ),
+                              _chip(
+                                context,
+                                Icons.location_on,
+                                '${course.topicIds.length}',
+                              ),
+                              _chip(
+                                context,
+                                Icons.school,
+                                course.cefrLevel.string.replaceFirst(
+                                  'PREA1',
+                                  'PRE-A1',
+                                ),
+                              ),
+                            ],
+                          ),
+                      ],
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),
-      ),
       ),
     );
   }

--- a/lib/routes/courses/find_course_page.dart
+++ b/lib/routes/courses/find_course_page.dart
@@ -449,10 +449,12 @@ class _PublicCourseTile extends StatelessWidget {
         space.name ?? space.canonicalAlias ?? L10n.of(context).emptyChat;
     final isKnock = space.joinRule == JoinRules.knock.name;
 
-    return Padding(
+    return FocusTraversalGroup(
+      child: Padding(
       padding: const EdgeInsets.only(bottom: 10.0),
       child: Material(
-        type: MaterialType.transparency,
+        color: theme.colorScheme.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(12.0),
         child: InkWell(
           // Tapping the card scopes the map to this course's activities
           // (world_v2); the Knock/Join pill opens the join flow.
@@ -461,7 +463,6 @@ class _PublicCourseTile extends StatelessWidget {
           child: Container(
             padding: const EdgeInsets.all(10.0),
             decoration: BoxDecoration(
-              color: theme.colorScheme.surfaceContainerLow,
               borderRadius: BorderRadius.circular(12.0),
               border: Border.all(color: theme.colorScheme.outlineVariant),
             ),
@@ -567,6 +568,7 @@ class _PublicCourseTile extends StatelessWidget {
             ),
           ),
         ),
+      ),
       ),
     );
   }


### PR DESCRIPTION
## What

- Move tile background color from `Container` to `Material` so `InkWell` ripple/hover overlays are no longer painted over in `CourseListTile` and `_PublicCourseTile`
- Wrap each `_PublicCourseTile` in `FocusTraversalGroup` so keyboard Tab order follows course→knock→course2→knock2→...→Load More instead of all courses then all knock buttons

## Why

Closes #7222

## Testing

- `flutter analyze` on both changed files: no issues
- `flutter test test/pangea/courses/ test/pangea/navigation/mobile_course_sheet_test.dart`: 6/6 pass
- Visual keyboard/hover verification requires manual web testing (no headless path for ink overlays or focus traversal order)

## Deploy Notes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the visual styling of course tiles for a more consistent background, spacing, and rounded-corner appearance.
  - Updated course search results to better support keyboard navigation and focus behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->