### PR TITLE
fix: closing a course card keeps its open management page (#7317)

### DIFF
--- a/lib/features/navigation/route_facts.dart
+++ b/lib/features/navigation/route_facts.dart
@@ -350,8 +350,10 @@ List<PanelToken> _parsePanelList(Uri uri, String key) {
   // the `?m=course:<id>` map filter, not the token, so without that filter they
   // have nothing to render — a blank, close-less card a hand-edited or stale URL
   // could strand the user on (especially on a narrow single pane). Drop them when
-  // no course is scoped, mirroring closeSection / openCourseFilter, which already
-  // shed a dependent coursepage. See `routing.instructions.md`.
+  // no course is scoped. This is the only place a coursepage is shed for lost
+  // scope: closeSection keeps it (the filter survives a card close), and
+  // openCourseFilter sheds the previous course's page only because it re-targets
+  // the scope to a different course. See `routing.instructions.md`.
   if (column == PanelColumn.left && activeSpaceIdFor(uri) == null) {
     tokens.removeWhere((t) => t.type == 'course' || t.type == 'coursepage');
   }

--- a/lib/features/navigation/workspace_nav.dart
+++ b/lib/features/navigation/workspace_nav.dart
@@ -379,17 +379,13 @@ abstract class WorkspaceNav {
   /// ever a token, so it just drops its own token via [closeLeft].
   static String closeSection(Uri current, PanelToken token) {
     final lists = parseOpenPanels(current);
-    // A course's management page (`coursepage`) is the card's detail, so closing
-    // the card drops it too (it has no master to return to) — mirrors
-    // closeSettings dropping settingspage. See routing.instructions.md.
-    final dropDependentCoursePage = token.type == 'course';
-    final left = lists.left
-        .where(
-          (t) =>
-              t != token &&
-              !(dropDependentCoursePage && t.type == 'coursepage'),
-        )
-        .toList();
+    // Drop only this token, nothing else — "closing a panel drops its token and
+    // nothing else" (routing.instructions.md). A course card's management page
+    // (`coursepage`) therefore stays open when the card closes, exactly as the
+    // chat list's `room` child stays when the list closes; both read on from the
+    // surviving `?m=course:` filter / their own id. (A coursepage left with no
+    // course scoped at all is shed by route_facts, not here.)
+    final left = lists.left.where((t) => t != token).toList();
     // Preserve unrelated one-shot query the way closeLeft/_mutate already do —
     // recompute only m/left/right and carry the rest forward. Critically this
     // keeps `?activity=`/`?launch=`/`?roomid=` (a launching or running activity

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -369,6 +369,26 @@ void main() {
     );
 
     test(
+      'closing a course card keeps an open coursepage management page (#7317)',
+      () {
+        // Closing the master drops only its own token (like the chat list
+        // keeping its room); the coursepage child reads on from the surviving
+        // ?m= filter, so the edit page must NOT close with the card.
+        final loc = WorkspaceNav.closeSection(
+          u('/?m=course:!s&left=course,coursepage:edit'),
+          const PanelToken('course'),
+        );
+        expect(loc.contains('m=course'), isTrue); // scope survives
+        final lists = parseOpenPanels(u(loc));
+        expect(lists.left.any((t) => t.type == 'course'), isFalse); // card gone
+        expect(
+          lists.left.where((t) => t.type == 'coursepage').single,
+          const PanelToken('coursepage', 'edit'),
+        ); // edit page kept
+      },
+    );
+
+    test(
       'closing the course card alone keeps the scoped map, not bare world',
       () {
         final loc = WorkspaceNav.closeSection(


### PR DESCRIPTION
Closes #7317

## Problem

Closing a course **card** while its **edit course** page was open closed the edit page too — inconsistent with the other master/detail flows, where closing the master leaves the child open (close the chat list → the chat stays; close the analytics summary → the construct detail stays).

## Root cause

Not a legacy-routing issue — edit course is already a standard `coursepage:edit` token panel (opened via `WorkspaceNav.openCoursePage`, closed via `closeLeft` on the token). The divergence was a deliberate special-case in `WorkspaceNav.closeSection`: `dropDependentCoursePage` force-dropped any `coursepage` whenever a `course` token closed. That same helper is shared with the chat list, where no such drop happens — so the two master closes behaved differently.

It also contradicted the documented rule in routing.instructions.md: *"Closing a panel drops its token and nothing else, because the token is the only place it lives."*

## Change

- `closeSection` now drops only the token it's given, nothing else — so closing a course card keeps an open `coursepage` exactly as closing the chat list keeps its `room` child. The page reads its space id from the surviving `?m=course:<id>` filter, so it renders fine with the card gone.
- A genuinely stranded `coursepage` (no course scoped at all — a hand-edited or stale URL) is still shed by `route_facts` (unchanged guard). Switching to a different course still drops the previous course's page via `openCourseFilter` (unchanged).
- Updated the stale in-code comments in `closeSection` and `route_facts` to match.

No design doc change needed: this aligns the code with the existing routing.instructions.md rule.

## Testing

- `flutter test test/pangea/navigation/` — **178 pass**, including a new regression test: *"closing a course card keeps an open coursepage management page (#7317)"*.
- Verified the render path statically: `workspace_left_panel.dart` builds a `coursepage` from `activeSpaceIdFor(uri)` (the `?m=` filter), not from a sibling `course` token, so it renders with the card closed.
- `flutter analyze` clean on the changed files.

Not exercised in-browser (the edit-course entry requires an instructor-owned course) — see TO TEST.

## TO TEST
- [ ] Open a course you own → open its **Edit course** page (course card More menu) → close the **course card**. Expect: the edit page **stays open** over the course-scoped map; closing it then reveals the map.
- [ ] Regression — closing the **edit course page** itself (its own X/back) still reveals the course card behind it.
- [ ] Regression — the other two flows are unchanged: close chat list → chat stays; open analytics → open a lemma detail → close analytics → lemma stays.
- [ ] Switching to a *different* course while a management page is open still drops the previous course's page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Closing a course panel now leaves related course page panels open instead of removing them too.
  * Preserves the current course map scope when navigating away from the course card.
* **Tests**
  * Added coverage for course management navigation to confirm the updated panel-closing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->