### PR TITLE
Add title to email signup page

### DIFF
--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ar",
-    "@@last_modified": "2026-06-26 10:50:47.740291",
+    "@@last_modified": "2026-06-29 10:33:52.751401",
     "about": "حول",
     "@about": {
         "type": "String",
@@ -10434,5 +10434,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "سجل باستخدام البريد الإلكتروني",
+    "unreadLabel": "غير مقروء: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_be.arb
+++ b/lib/l10n/intl_be.arb
@@ -3933,7 +3933,7 @@
     "playWithAI": "Пакуль гуляйце з ШІ",
     "courseStartDesc": "Pangea Bot гатовы да працы ў любы час!\n\n...але навучанне лепш з сябрамі!",
     "@@locale": "be",
-    "@@last_modified": "2026-06-26 10:49:16.098369",
+    "@@last_modified": "2026-06-29 10:33:45.119194",
     "@ignore": {
         "type": "String",
         "placeholders": {}
@@ -10108,5 +10108,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Зарэгістравацца з дапамогай электроннай пошты",
+    "unreadLabel": "Непрачытана: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_bn.arb
+++ b/lib/l10n/intl_bn.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:52:56.565990",
+    "@@last_modified": "2026-06-29 10:34:02.148033",
     "about": "সম্পর্কে",
     "@about": {
         "type": "String",
@@ -10809,5 +10809,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "ইমেইল দিয়ে সাইন আপ করুন",
+    "unreadLabel": "অপঠিত: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_bo.arb
+++ b/lib/l10n/intl_bo.arb
@@ -3193,7 +3193,7 @@
     "loginToAccount": "ངའི་ཁུལ་གཅིག་ལ་སྤྱོད་ལམ་སྤྱོད་འབད།",
     "languages": "ཚོད་ལྟ",
     "@@locale": "bo",
-    "@@last_modified": "2026-06-26 10:52:31.395444",
+    "@@last_modified": "2026-06-29 10:33:59.702585",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -9766,5 +9766,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Signe upp med e-post",
+    "unreadLabel": "Oläst: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_ca.arb
+++ b/lib/l10n/intl_ca.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:49:25.003668",
+    "@@last_modified": "2026-06-29 10:33:45.990789",
     "about": "Quant a",
     "@about": {
         "type": "String",
@@ -10245,5 +10245,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Registra't amb correu electrònic",
+    "unreadLabel": "No llegit: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "cs",
-    "@@last_modified": "2026-06-26 10:48:52.475399",
+    "@@last_modified": "2026-06-29 10:33:43.321546",
     "about": "O aplikaci",
     "@about": {
         "type": "String",
@@ -10648,5 +10648,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Zaregistrujte se pomocí e-mailu",
+    "unreadLabel": "Nepřečteno: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_da.arb
+++ b/lib/l10n/intl_da.arb
@@ -1477,7 +1477,7 @@
     "playWithAI": "Leg med AI for nu",
     "courseStartDesc": "Pangea Bot er klar til at starte når som helst!\n\n...men læring er bedre med venner!",
     "@@locale": "da",
-    "@@last_modified": "2026-06-26 10:44:52.707365",
+    "@@last_modified": "2026-06-29 10:33:26.110019",
     "@aboutHomeserver": {
         "type": "String",
         "placeholders": {
@@ -11188,5 +11188,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Tilmeld dig med e-mail",
+    "unreadLabel": "Ulæst: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "de",
-    "@@last_modified": "2026-06-26 10:47:42.580046",
+    "@@last_modified": "2026-06-29 10:33:38.811463",
     "alwaysUse24HourFormat": "true",
     "@alwaysUse24HourFormat": {
         "description": "Set to true to always display time of day in 24 hour format."
@@ -10073,5 +10073,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Mit E-Mail anmelden",
+    "unreadLabel": "Ungelesen: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_el.arb
+++ b/lib/l10n/intl_el.arb
@@ -3771,7 +3771,7 @@
     "playWithAI": "Παίξτε με την Τεχνητή Νοημοσύνη προς το παρόν",
     "courseStartDesc": "Ο Pangea Bot είναι έτοιμος να ξεκινήσει οποιαδήποτε στιγμή!\n\n...αλλά η μάθηση είναι καλύτερη με φίλους!",
     "@@locale": "el",
-    "@@last_modified": "2026-06-26 10:53:45.106656",
+    "@@last_modified": "2026-06-29 10:34:06.468472",
     "@checkList": {
         "type": "String",
         "placeholders": {}
@@ -11143,5 +11143,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Εγγραφή με email",
+    "unreadLabel": "Αδιάβαστο: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -4942,6 +4942,7 @@
         }
     },
     "resetMapView": "Reset map view",
+    "signUpWithEmail": "Sign up with email",
     "unreadLabel": "Unread: {count}",
     "@unreadLabel": {
         "placeholders": {

--- a/lib/l10n/intl_eo.arb
+++ b/lib/l10n/intl_eo.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:54:31.498946",
+    "@@last_modified": "2026-06-29 10:34:09.328914",
     "about": "Prio",
     "@about": {
         "type": "String",
@@ -11213,5 +11213,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Registriĝi per retpoŝto",
+    "unreadLabel": "Legitaj: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "es",
-    "@@last_modified": "2026-06-26 10:43:40.368410",
+    "@@last_modified": "2026-06-29 10:33:23.443752",
     "about": "Acerca de",
     "@about": {
         "type": "String",
@@ -8188,5 +8188,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Regístrate con correo electrónico",
+    "unreadLabel": "No leído: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_et.arb
+++ b/lib/l10n/intl_et.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "et",
-    "@@last_modified": "2026-06-26 10:47:28.117472",
+    "@@last_modified": "2026-06-29 10:33:38.062200",
     "about": "Rakenduse teave",
     "@about": {
         "type": "String",
@@ -10091,5 +10091,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Registreeru e-posti teel",
+    "unreadLabel": "Lugemata: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_eu.arb
+++ b/lib/l10n/intl_eu.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "eu",
-    "@@last_modified": "2026-06-26 10:47:06.861952",
+    "@@last_modified": "2026-06-29 10:33:36.314356",
     "about": "Honi buruz",
     "@about": {
         "type": "String",
@@ -10094,5 +10094,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Izena eman emailarekin",
+    "unreadLabel": "Irakurri gabe: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_fa.arb
+++ b/lib/l10n/intl_fa.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:53:08.843132",
+    "@@last_modified": "2026-06-29 10:34:02.917506",
     "repeatPassword": "تکرار گذرواژه",
     "@repeatPassword": {},
     "about": "درباره",
@@ -10206,5 +10206,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "با ایمیل ثبت نام کنید",
+    "unreadLabel": "خوانده نشده: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_fi.arb
+++ b/lib/l10n/intl_fi.arb
@@ -3913,7 +3913,7 @@
     "playWithAI": "Leiki tekoälyn kanssa nyt",
     "courseStartDesc": "Pangea Bot on valmis milloin tahansa!\n\n...mutta oppiminen on parempaa ystävien kanssa!",
     "@@locale": "fi",
-    "@@last_modified": "2026-06-26 10:44:40.248327",
+    "@@last_modified": "2026-06-29 10:33:25.323384",
     "@notificationRuleJitsi": {
         "type": "String",
         "placeholders": {}
@@ -10143,5 +10143,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Rekisteröidy sähköpostilla",
+    "unreadLabel": "Lukemattomat: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_fil.arb
+++ b/lib/l10n/intl_fil.arb
@@ -2257,7 +2257,7 @@
     "selectAll": "Piliin lahat",
     "deselectAll": "Huwag piliin lahat",
     "@@locale": "fil",
-    "@@last_modified": "2026-06-26 10:50:26.093278",
+    "@@last_modified": "2026-06-29 10:33:51.042007",
     "@setCustomPermissionLevel": {
         "type": "String",
         "placeholders": {}
@@ -11113,5 +11113,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Mag-sign up gamit ang email",
+    "unreadLabel": "Hindi nabasa: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "fr",
-    "@@last_modified": "2026-06-26 10:55:32.208815",
+    "@@last_modified": "2026-06-29 10:34:13.936566",
     "about": "À propos",
     "@about": {
         "type": "String",
@@ -10491,5 +10491,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Inscrivez-vous avec un e-mail",
+    "unreadLabel": "Non lu : {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_ga.arb
+++ b/lib/l10n/intl_ga.arb
@@ -3948,7 +3948,7 @@
     "playWithAI": "Imir le AI faoi láthair",
     "courseStartDesc": "Tá Bot Pangea réidh chun dul am ar bith!\n\n...ach is fearr foghlaim le cairde!",
     "@@locale": "ga",
-    "@@last_modified": "2026-06-26 10:55:22.486434",
+    "@@last_modified": "2026-06-29 10:34:13.019001",
     "@writeAMessageLangCodes": {
         "type": "String",
         "placeholders": {
@@ -10105,5 +10105,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Cláraigh le ríomhphost",
+    "unreadLabel": "Neamhléite: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_gl.arb
+++ b/lib/l10n/intl_gl.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "gl",
-    "@@last_modified": "2026-06-26 10:43:56.307820",
+    "@@last_modified": "2026-06-29 10:33:24.317981",
     "about": "Acerca de",
     "@about": {
         "type": "String",
@@ -10094,5 +10094,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Inscríbete con correo electrónico",
+    "unreadLabel": "Non lido: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_he.arb
+++ b/lib/l10n/intl_he.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:46:27.946162",
+    "@@last_modified": "2026-06-29 10:33:31.944470",
     "about": "אודות",
     "@about": {
         "type": "String",
@@ -11173,5 +11173,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "הירשם עם דוא\"ל",
+    "unreadLabel": "לא נקרא: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_hi.arb
+++ b/lib/l10n/intl_hi.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "अभी के लिए एआई के साथ खेलें",
     "courseStartDesc": "पैंजिया बॉट कभी भी जाने के लिए तैयार है!\n\n...लेकिन दोस्तों के साथ सीखना बेहतर है!",
     "@@locale": "hi",
-    "@@last_modified": "2026-06-26 10:54:17.170602",
+    "@@last_modified": "2026-06-29 10:34:08.535533",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10813,5 +10813,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "ईमेल के साथ साइन अप करें",
+    "unreadLabel": "अविकृत: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_hr.arb
+++ b/lib/l10n/intl_hr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "hr",
-    "@@last_modified": "2026-06-26 10:46:15.659555",
+    "@@last_modified": "2026-06-29 10:33:31.060781",
     "about": "Informacije",
     "@about": {
         "type": "String",
@@ -10578,5 +10578,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Prijavite se s emailom",
+    "unreadLabel": "Nepročitano: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_hu.arb
+++ b/lib/l10n/intl_hu.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "hu",
-    "@@last_modified": "2026-06-26 10:45:12.990244",
+    "@@last_modified": "2026-06-29 10:33:26.921214",
     "about": "Névjegy",
     "@about": {
         "type": "String",
@@ -10221,5 +10221,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Regisztrálj e-maillel",
+    "unreadLabel": "Olvasatlan: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_ia.arb
+++ b/lib/l10n/intl_ia.arb
@@ -1505,7 +1505,7 @@
     "playWithAI": "Joca con le IA pro ora",
     "courseStartDesc": "Pangea Bot es preste a comenzar a qualunque momento!\n\n...ma apprender es melior con amicos!",
     "@@locale": "ia",
-    "@@last_modified": "2026-06-26 10:46:40.851270",
+    "@@last_modified": "2026-06-29 10:33:34.369343",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -11204,5 +11204,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "S'inscrire avec un e-mail",
+    "unreadLabel": "Non lu : {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:45:24.455054",
+    "@@last_modified": "2026-06-29 10:33:27.819761",
     "setAsCanonicalAlias": "Atur sebagai alias utama",
     "@setAsCanonicalAlias": {
         "type": "String",
@@ -10191,5 +10191,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Daftar dengan email",
+    "unreadLabel": "Belum dibaca: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_ie.arb
+++ b/lib/l10n/intl_ie.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "Joca con AI pro ora",
     "courseStartDesc": "Pangea Bot es preste a partir a qualunque momento!\n\n...ma apprender es melior con amicos!",
     "@@locale": "ie",
-    "@@last_modified": "2026-06-26 10:45:58.469008",
+    "@@last_modified": "2026-06-29 10:33:30.392861",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10813,5 +10813,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "S'inscrire avec un e-mail",
+    "unreadLabel": "Non lu : {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:48:19.981294",
+    "@@last_modified": "2026-06-29 10:33:41.496121",
     "about": "Informazioni",
     "@about": {
         "type": "String",
@@ -10185,5 +10185,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Registrati con email",
+    "unreadLabel": "Non letti: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ja",
-    "@@last_modified": "2026-06-26 10:54:00.565831",
+    "@@last_modified": "2026-06-29 10:34:07.804266",
     "about": "このアプリについて",
     "@about": {
         "type": "String",
@@ -10962,5 +10962,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "メールでサインアップ",
+    "unreadLabel": "未読: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_ka.arb
+++ b/lib/l10n/intl_ka.arb
@@ -2098,7 +2098,7 @@
     "playWithAI": "ამ დროისთვის ითამაშეთ AI-თან",
     "courseStartDesc": "Pangea Bot მზადაა ნებისმიერ დროს გასასვლელად!\n\n...მაგრამ სწავლა უკეთესია მეგობრებთან ერთად!",
     "@@locale": "ka",
-    "@@last_modified": "2026-06-26 10:55:00.665826",
+    "@@last_modified": "2026-06-29 10:34:11.293097",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -11162,5 +11162,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "რეგისტრაცია ელფოსტით",
+    "unreadLabel": "არ წაკითხული: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:43:27.209838",
+    "@@last_modified": "2026-06-29 10:33:22.686499",
     "about": "소개",
     "@about": {
         "type": "String",
@@ -10311,5 +10311,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "이메일로 가입하기",
+    "unreadLabel": "읽지 않음: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_lt.arb
+++ b/lib/l10n/intl_lt.arb
@@ -3245,7 +3245,7 @@
     "playWithAI": "Žaiskite su dirbtiniu intelektu dabar",
     "courseStartDesc": "Pangea botas pasiruošęs bet kada pradėti!\n\n...bet mokymasis yra geresnis su draugais!",
     "@@locale": "lt",
-    "@@last_modified": "2026-06-26 10:51:37.535298",
+    "@@last_modified": "2026-06-29 10:33:55.931918",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10980,5 +10980,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Užsiregistruokite su el. paštu",
+    "unreadLabel": "Neskaitoma: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_lv.arb
+++ b/lib/l10n/intl_lv.arb
@@ -3919,7 +3919,7 @@
     "playWithAI": "Tagad spēlējiet ar AI",
     "courseStartDesc": "Pangea bots ir gatavs jebkurā laikā!\n\n...bet mācīties ir labāk ar draugiem!",
     "@@locale": "lv",
-    "@@last_modified": "2026-06-26 10:50:38.010880",
+    "@@last_modified": "2026-06-29 10:33:51.735693",
     "analyticsInactiveTitle": "Pieprasījumi neaktīviem lietotājiem nevar tikt nosūtīti",
     "analyticsInactiveDesc": "Neaktīvi lietotāji, kuri nav pieteikušies kopš šīs funkcijas ieviešanas, neredzēs jūsu pieprasījumu.\n\nPieprasījuma poga parādīsies, kad viņi atgriezīsies. Jūs varat atkārtoti nosūtīt pieprasījumu vēlāk, noklikšķinot uz pieprasījuma pogas viņu vārdā, kad tā būs pieejama.",
     "accessRequestedTitle": "Pieprasījums piekļūt analītikai",
@@ -10094,5 +10094,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Reģistrēties ar e-pastu",
+    "unreadLabel": "Nelasīts: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_nb.arb
+++ b/lib/l10n/intl_nb.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:49:03.296123",
+    "@@last_modified": "2026-06-29 10:33:44.103081",
     "about": "Om",
     "@about": {
         "type": "String",
@@ -10154,5 +10154,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Registrer deg med e-post",
+    "unreadLabel": "Ulest: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:52:13.213148",
+    "@@last_modified": "2026-06-29 10:33:58.913419",
     "about": "Over ons",
     "@about": {
         "type": "String",
@@ -10094,5 +10094,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Aanmelden met e-mail",
+    "unreadLabel": "Ongelezen: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "pl",
-    "@@last_modified": "2026-06-26 10:53:19.015923",
+    "@@last_modified": "2026-06-29 10:34:03.904079",
     "about": "O aplikacji",
     "@about": {
         "type": "String",
@@ -10203,5 +10203,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Zarejestruj się za pomocą e-maila",
+    "unreadLabel": "Nieprzeczytane: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:47:17.883561",
+    "@@last_modified": "2026-06-29 10:33:37.104092",
     "copiedToClipboard": "Copiada para a área de transferência",
     "@copiedToClipboard": {
         "type": "String",
@@ -11212,5 +11212,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Inscreva-se com e-mail",
+    "unreadLabel": "Não lido: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_pt_BR.arb
+++ b/lib/l10n/intl_pt_BR.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:46:52.919434",
+    "@@last_modified": "2026-06-29 10:33:35.317791",
     "about": "Sobre",
     "@about": {
         "type": "String",
@@ -10094,5 +10094,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Inscreva-se com e-mail",
+    "unreadLabel": "Não lido: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_pt_PT.arb
+++ b/lib/l10n/intl_pt_PT.arb
@@ -2776,7 +2776,7 @@
     "selectAll": "Selecionar tudo",
     "deselectAll": "Desmarcar tudo",
     "@@locale": "pt_PT",
-    "@@last_modified": "2026-06-26 10:49:46.508383",
+    "@@last_modified": "2026-06-29 10:33:48.199353",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -11170,5 +11170,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Inscreva-se com e-mail",
+    "unreadLabel": "Não lido: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_ro.arb
+++ b/lib/l10n/intl_ro.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:45:35.414261",
+    "@@last_modified": "2026-06-29 10:33:28.536216",
     "about": "Despre",
     "@about": {
         "type": "String",
@@ -10919,5 +10919,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Înscrie-te cu email",
+    "unreadLabel": "Nepreluat: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ru",
-    "@@last_modified": "2026-06-26 10:54:47.262513",
+    "@@last_modified": "2026-06-29 10:34:10.374418",
     "about": "О проекте",
     "@about": {
         "type": "String",
@@ -11108,5 +11108,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Зарегистрироваться с электронной почтой",
+    "unreadLabel": "Непрочитанные: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "sk",
-    "@@last_modified": "2026-06-26 10:45:47.706824",
+    "@@last_modified": "2026-06-29 10:33:29.539282",
     "about": "O aplikácii",
     "@about": {
         "type": "String",
@@ -11210,5 +11210,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Zaregistrujte sa pomocou e-mailu",
+    "unreadLabel": "Nečítané: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_sl.arb
+++ b/lib/l10n/intl_sl.arb
@@ -1962,7 +1962,7 @@
     "playWithAI": "Za zdaj igrajte z AI-jem",
     "courseStartDesc": "Pangea Bot je pripravljen kadarkoli!\n\n...ampak je bolje učiti se s prijatelji!",
     "@@locale": "sl",
-    "@@last_modified": "2026-06-26 10:47:54.519621",
+    "@@last_modified": "2026-06-29 10:33:39.816356",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -11210,5 +11210,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Prijavite se z e-pošto",
+    "unreadLabel": "Neodgovorjeno: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_sr.arb
+++ b/lib/l10n/intl_sr.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:55:12.660606",
+    "@@last_modified": "2026-06-29 10:34:12.177711",
     "about": "О програму",
     "@about": {
         "type": "String",
@@ -11217,5 +11217,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Prijavite se putem email-a",
+    "unreadLabel": "Nepročitano: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_sv.arb
+++ b/lib/l10n/intl_sv.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:53:30.016514",
+    "@@last_modified": "2026-06-29 10:34:05.581501",
     "about": "Om",
     "@about": {
         "type": "String",
@@ -10681,5 +10681,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Registrera dig med e-post",
+    "unreadLabel": "Oläst: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_ta.arb
+++ b/lib/l10n/intl_ta.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:52:02.600230",
+    "@@last_modified": "2026-06-29 10:33:57.900850",
     "acceptedTheInvitation": "👍 {username} அழைப்பை ஏற்றுக்கொண்டது",
     "@acceptedTheInvitation": {
         "type": "String",
@@ -10210,5 +10210,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "மின்னஞ்சலுடன் பதிவு செய்யவும்",
+    "unreadLabel": "படிக்கப்படாதது: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_te.arb
+++ b/lib/l10n/intl_te.arb
@@ -1467,7 +1467,7 @@
     "playWithAI": "ఇప్పుడే AI తో ఆడండి",
     "courseStartDesc": "పాంజియా బాట్ ఎప్పుడైనా సిద్ధంగా ఉంటుంది!\n\n...కానీ స్నేహితులతో నేర్చుకోవడం మెరుగైనది!",
     "@@locale": "te",
-    "@@last_modified": "2026-06-26 10:51:24.198509",
+    "@@last_modified": "2026-06-29 10:33:54.446506",
     "@setCustomPermissionLevel": {
         "type": "String",
         "placeholders": {}
@@ -11218,5 +11218,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "ఇమెయిల్‌తో నమోదు చేసుకోండి",
+    "unreadLabel": "చదవని: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "เล่นกับ AI ชั่วคราว",
     "courseStartDesc": "Pangea Bot พร้อมที่จะเริ่มต้นได้ทุกเมื่อ!\n\n...แต่การเรียนรู้ดีกว่ากับเพื่อน!",
     "@@locale": "th",
-    "@@last_modified": "2026-06-26 10:49:36.372164",
+    "@@last_modified": "2026-06-29 10:33:47.393744",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10813,5 +10813,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "ลงทะเบียนด้วยอีเมล",
+    "unreadLabel": "ยังไม่ได้อ่าน: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "tr",
-    "@@last_modified": "2026-06-26 10:50:59.134058",
+    "@@last_modified": "2026-06-29 10:33:53.593701",
     "about": "Hakkında",
     "@about": {
         "type": "String",
@@ -10425,5 +10425,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "E-posta ile kaydol",
+    "unreadLabel": "Okunmamış: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "uk",
-    "@@last_modified": "2026-06-26 10:48:39.333903",
+    "@@last_modified": "2026-06-29 10:33:42.434681",
     "about": "Про застосунок",
     "@about": {
         "type": "String",
@@ -10094,5 +10094,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Зареєструватися за електронною поштою",
+    "unreadLabel": "Непрочитано: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_uz.arb
+++ b/lib/l10n/intl_uz.arb
@@ -3194,7 +3194,7 @@
     "setupChatBackup": "Chat zaxirasini sozlash",
     "@setupChatBackup": {},
     "@@locale": "uz",
-    "@@last_modified": "2026-06-26 10:50:14.767864",
+    "@@last_modified": "2026-06-29 10:33:50.190783",
     "noMoreResultsFound": "Boshqa natijalar topilmadi",
     "chatSearchedUntil": "Chat {time} gacha qidirildi",
     "federationBaseUrl": "Federatsiya Asos URL",
@@ -10098,5 +10098,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Email orqali ro'yxatdan o'tish",
+    "unreadLabel": "O'qilmagan: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:51:49.983684",
+    "@@last_modified": "2026-06-29 10:33:56.976115",
     "about": "Giới thiệu",
     "@about": {
         "type": "String",
@@ -7177,5 +7177,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "Đăng ký bằng email",
+    "unreadLabel": "Chưa đọc: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_yue.arb
+++ b/lib/l10n/intl_yue.arb
@@ -1406,7 +1406,7 @@
     "selectAll": "全選",
     "deselectAll": "取消全選",
     "@@locale": "yue",
-    "@@last_modified": "2026-06-26 10:48:06.043456",
+    "@@last_modified": "2026-06-29 10:33:40.569586",
     "@ignoreUser": {
         "type": "String",
         "placeholders": {}
@@ -11225,5 +11225,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "用電郵註冊",
+    "unreadLabel": "未讀: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "zh",
-    "@@last_modified": "2026-06-26 10:52:42.545763",
+    "@@last_modified": "2026-06-29 10:34:00.589332",
     "about": "关于",
     "@about": {
         "type": "String",
@@ -10094,5 +10094,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "使用电子邮件注册",
+    "unreadLabel": "未读: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/l10n/intl_zh_Hant.arb
+++ b/lib/l10n/intl_zh_Hant.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-26 10:49:59.616852",
+    "@@last_modified": "2026-06-29 10:33:49.356871",
     "about": "關於",
     "@about": {
         "type": "String",
@@ -10224,5 +10224,19 @@
     "@resetMapView": {
         "type": "String",
         "placeholders": {}
+    },
+    "signUpWithEmail": "使用電子郵件註冊",
+    "unreadLabel": "未讀: {count}",
+    "@signUpWithEmail": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@unreadLabel": {
+        "type": "String",
+        "placeholders": {
+            "count": {
+                "type": "String"
+            }
+        }
     }
 }

--- a/lib/routes/home/signup/signup_with_email_view.dart
+++ b/lib/routes/home/signup/signup_with_email_view.dart
@@ -23,6 +23,7 @@ class SignupWithEmailView extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 BackButton(onPressed: Navigator.of(context).pop),
+                Text(L10n.of(context).signUpWithEmail),
                 const SizedBox(width: 40.0),
               ],
             ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized “Sign up with email” label across the app.
  * Added a new localized unread-count label with a dynamic number placeholder.
* **Bug Fixes**
  * Updated the sign-up screen header to display the localized title correctly.
* **Chores**
  * Refreshed localization metadata and translation entries for multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->