### PR TITLE
Increase carousel autoplay interval

### DIFF
--- a/lib/routes/home/login_or_signup_view.dart
+++ b/lib/routes/home/login_or_signup_view.dart
@@ -266,6 +266,7 @@ class _LoginCarousel extends StatelessWidget {
             height: double.infinity,
             viewportFraction: 1.0,
             autoPlay: true,
+            autoPlayInterval: const Duration(seconds: 8),
             onPageChanged: (index, _) => onPageChange(index),
           ),
         ),
@@ -311,6 +312,7 @@ class _LoginCarousel extends StatelessWidget {
         options: CarouselOptions(
           viewportFraction: 1.0,
           autoPlay: true,
+          autoPlayInterval: const Duration(seconds: 8),
           onPageChanged: (index, _) {
             onPageChange(index);
           },


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the login/sign-up carousel to advance on a consistent 8-second interval on both mobile and desktop.
  - Improved the timing of automatic slide changes for a smoother, more predictable experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->