### PR TITLE
fix: undo reversion of design changes in activity session start page

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_session_bottom_content.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_bottom_content.dart
@@ -9,12 +9,9 @@ import 'package:fluffychat/features/analytics/construct_type_enum.dart';
 import 'package:fluffychat/features/room_summaries/activity_summary_status_enum.dart';
 import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/not_started_session_controller.dart';
-import 'package:fluffychat/routes/chat_list/open_roles_indicator.dart';
 import 'package:fluffychat/widgets/avatar.dart';
-import 'package:fluffychat/widgets/users/member_actions_popup_menu_button.dart';
 
 class ActivitySessionBottomContent extends StatelessWidget {
   final ActivitySessionStateController controller;
@@ -38,33 +35,29 @@ class _NotStartedSessionBottomContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Existing sessions to join only live inside a course; a standalone
-    // activity has none to list.
-    final course = controller.course;
-    if (course == null) return const SizedBox.shrink();
+    if (controller.subPage.visibleStatuses.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
     return ConstrainedBox(
       constraints: const BoxConstraints(
         maxWidth: FluffyThemes.columnWidth * 1.5,
       ),
       child: Column(
         children: [
-          ...ActivitySummaryStatus.values
-              .where((s) => s.canView(course.isRoomAdmin))
-              .map((status) {
-                final roomSummaries = controller.activityStatuses
-                    .getSessionsByStatus(status);
+          ...controller.subPage.visibleStatuses.map((status) {
+            final roomSummaries = controller.activityStatuses
+                .getSessionsByStatus(status);
 
-                if (roomSummaries.isEmpty) {
-                  return const SizedBox.shrink();
-                }
+            if (roomSummaries.isEmpty) return const SizedBox.shrink();
 
-                return _ActivitySummaryStatusSection(
-                  status: status,
-                  roomSummaries: roomSummaries,
-                  course: course,
-                  onTap: controller.joinActivityByRoomId,
-                );
-              }),
+            return _ActivitySummaryStatusSection(
+              status: status,
+              roomSummaries: roomSummaries,
+              course: controller.course,
+              onTap: controller.joinActivityByRoomId,
+            );
+          }),
         ],
       ),
     );
@@ -75,7 +68,7 @@ class _ActivitySummaryStatusSection extends StatelessWidget {
   final ActivitySummaryStatus status;
   final Map<String, RoomSummaryResponse> roomSummaries;
 
-  final Room course;
+  final Room? course;
   final Function(String) onTap;
 
   const _ActivitySummaryStatusSection({
@@ -94,7 +87,7 @@ class _ActivitySummaryStatusSection extends StatelessWidget {
         vertical: 16.0,
       ),
       child: Column(
-        spacing: status == ActivitySummaryStatus.completed ? 12.0 : 0,
+        spacing: 12.0,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Padding(
@@ -106,23 +99,13 @@ class _ActivitySummaryStatusSection extends StatelessWidget {
               ),
             ),
           ),
-          if (status == ActivitySummaryStatus.completed)
-            ...roomSummaries.entries.map((e) {
-              return _ActivitySessionDetailsTile(
-                roomSummary: e.value,
-                course: course,
-                onTap: () => onTap(e.key),
-              );
-            })
-          else
-            ...roomSummaries.entries.map((e) {
-              return _ActivitySessionListTile(
-                roomSummary: e.value,
-                status: status,
-                course: course,
-                onTap: () => onTap(e.key),
-              );
-            }),
+          ...roomSummaries.entries.map((e) {
+            return _ActivitySessionDetailsTile(
+              roomSummary: e.value,
+              course: course,
+              onTap: () => onTap(e.key),
+            );
+          }),
         ],
       ),
     );
@@ -131,7 +114,7 @@ class _ActivitySummaryStatusSection extends StatelessWidget {
 
 class _ActivitySessionDetailsTile extends StatelessWidget {
   final RoomSummaryResponse roomSummary;
-  final Room course;
+  final Room? course;
   final VoidCallback onTap;
 
   const _ActivitySessionDetailsTile({
@@ -147,7 +130,7 @@ class _ActivitySessionDetailsTile extends StatelessWidget {
     final textSummary = activitySummary?.summary?.summary;
     final analytics = activitySummary?.analytics;
     final participants = roomSummary.membershipSummary.keys;
-    final users = course.getParticipants();
+    final users = course?.getParticipants();
     final theme = Theme.of(context);
 
     return Padding(
@@ -263,7 +246,6 @@ class _ActivitySessionDetailsTile extends StatelessWidget {
                       ),
                     ),
                     IconButton(
-                      tooltip: L10n.of(context).next,
                       icon: Icon(Icons.arrow_forward),
                       onPressed: onTap,
                     ),
@@ -277,7 +259,7 @@ class _ActivitySessionDetailsTile extends StatelessWidget {
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         ...participants.map((userId) {
-                          final user = users.firstWhereOrNull(
+                          final user = users?.firstWhereOrNull(
                             (u) => u.id == userId,
                           );
 
@@ -295,7 +277,7 @@ class _ActivitySessionDetailsTile extends StatelessWidget {
                               userSummary?.superlatives.firstOrNull;
 
                           return ConstrainedBox(
-                            constraints: const BoxConstraints(maxWidth: 90.0),
+                            constraints: BoxConstraints(maxWidth: 90.0),
                             child: Opacity(
                               opacity: role == null ? 0.5 : 1,
                               child: Column(
@@ -343,49 +325,6 @@ class _ActivitySessionDetailsTile extends StatelessWidget {
           ),
         ),
       ),
-    );
-  }
-}
-
-class _ActivitySessionListTile extends StatelessWidget {
-  final RoomSummaryResponse roomSummary;
-  final ActivitySummaryStatus status;
-
-  final Room course;
-  final VoidCallback onTap;
-
-  const _ActivitySessionListTile({
-    required this.roomSummary,
-    required this.status,
-    required this.course,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final activityPlan = roomSummary.activityPlan;
-
-    // If activity is completed, show all roles, even for users who have left the
-    // room (like the bot). Otherwise, show only joined users with roles
-    final activityRoles = status == ActivitySummaryStatus.completed
-        ? (roomSummary.activityRoles?.roles ?? {})
-        : roomSummary.joinedUsersWithRoles;
-
-    return ListTile(
-      title: OpenRolesIndicator(
-        roles: (activityPlan?.roles.values ?? [])
-            .sorted((a, b) => a.id.compareTo(b.id))
-            .toList(),
-        assignedRoles: activityRoles.values.toList(),
-        size: 40.0,
-        spacing: 8.0,
-        space: course,
-        onUserTap: (user, context) {
-          showMemberActionsPopupMenu(context: context, user: user);
-        },
-      ),
-      trailing: course.isRoomAdmin ? const Icon(Icons.arrow_forward) : null,
-      onTap: onTap,
     );
   }
 }

--- a/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/confirmed_role_session_controller.dart';
@@ -23,6 +24,7 @@ class ActivitySessionButtons extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final description = sessionController.descriptionText;
+
     return AnimatedSize(
       alignment: Alignment.bottomCenter,
       duration: FluffyThemes.animationDuration,
@@ -158,10 +160,11 @@ class _NotStartedSessionCTAButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final hasActiveSession = controller.canJoinExistingSession;
+    // Sub-pages show a single Back button.
+    if (controller.subPage != NotStartedSubPage.main) {
+      return _CTAButton(L10n.of(context).back, controller.goToMainPage);
+    }
 
-    // Nothing is gated: every activity is always playable (#7186). Progression
-    // only ranks content on the world map, it never blocks Start here.
     return FutureBuilder(
       future: controller.neededCourseParticipants,
       builder: (context, snapshot) {
@@ -195,16 +198,17 @@ class _NotStartedSessionCTAButtons extends StatelessWidget {
                 controller.goToJoinedActivity,
               ),
             ] else ...[
-              _CTAButton(
-                hasActiveSession
-                    ? L10n.of(context).startNewSession
-                    : L10n.of(context).start,
-                controller.startNewActivity,
-              ),
-              if (hasActiveSession)
+              _CTAButton(L10n.of(context).start, controller.startNewActivity),
+              if (controller.openSessionCount > 0)
                 _CTAButton(
-                  L10n.of(context).joinOpenSession,
-                  controller.joinExistingSession,
+                  '${L10n.of(context).joinOpenSession} (${controller.openSessionCount})',
+                  controller.goToJoinPage,
+                ),
+              if (controller.course?.isRoomAdmin == true &&
+                  controller.hasCurrentOrFinishedSessions)
+                _CTAButton(
+                  '${L10n.of(context).viewCurrentOrFinished} (${controller.currentOrFinishedSessionCount})',
+                  controller.goToViewPage,
                 ),
             ],
           ],
@@ -233,11 +237,6 @@ class _ConfirmedRoleSessionCTAButtons extends StatelessWidget {
           ),
           SizedBox(height: 16.0),
         ],
-        // The bot is now auto-invited and present from creation, so gating this
-        // on "bot not in room" would always hide it. This CTA block only renders
-        // on the start page (while !isActivityStarted, where the bot holds no
-        // role), so always offer the choice: "play with bot" writes the
-        // bot_participant marker and the bot claims the open role (#7027).
         if (controller.showInviteOptions)
           Padding(
             padding: EdgeInsetsGeometry.only(bottom: 16.0),

--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
@@ -11,13 +12,16 @@ import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/navigation/workspace_query.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/widgets/error_indicator.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_participant_list.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_bottom_content.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_button_widget.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_controller.dart';
-import 'package:fluffychat/routes/chat/activity_sessions/activity_summary_widget.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_vocab_widget.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/goal_status_widget.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
+import 'package:fluffychat/widgets/url_image_widget.dart';
 
 /// The location that closes a non-embedded activity plan opened as a room/
 /// session token (the chat list / a left panel): it drops ONLY that token, so
@@ -54,13 +58,14 @@ class ActivitySessionStartView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return StreamBuilder(
       stream: Matrix.of(context).client.onRoomState.stream
           .where((update) => update.roomId == controller.widget.roomId)
           .rateLimit(const Duration(seconds: 1)),
       builder: (context, snapshot) {
         final activity = controller.activity;
-        // #Pangea
+
         // The activity plan's close depends on whether a course is still scoped
         // (`?m=course:`) — the plan's contextual parent. Opened from the course
         // card's activity list, the scope survives (the card dropped its own
@@ -98,7 +103,6 @@ class ActivitySessionStartView extends StatelessWidget {
           return WorkspaceQuery.location('/', parts);
         }
 
-        // Pangea#
         return Scaffold(
           appBar: AppBar(
             leadingWidth: 52.0,
@@ -118,7 +122,6 @@ class ActivitySessionStartView extends StatelessWidget {
             leading: Padding(
               padding: const EdgeInsets.only(left: 12.0),
               child: Center(
-                // #Pangea
                 child: (embedded && courseScoped)
                     // Course still scoped → back-arrow reopens the course card.
                     ? IconButton(
@@ -161,7 +164,6 @@ class ActivitySessionStartView extends StatelessWidget {
                           }
                         },
                       ),
-                // Pangea#
               ),
             ),
             actions: [
@@ -170,12 +172,6 @@ class ActivitySessionStartView extends StatelessWidget {
                 icon: const Icon(Icons.flag_outlined),
                 onPressed: controller.submitActivityFeedback,
               ),
-              // #Pangea
-              // When embedded over a course (?activity=), the leading
-              // back-arrow already closes the session toward the course — a
-              // trailing X would be a redundant second control for the same
-              // gesture (one close control per panel; see routing.instructions.md).
-              // Pangea#
             ],
           ),
           body: SafeArea(
@@ -192,46 +188,157 @@ class ActivitySessionStartView extends StatelessWidget {
                       Expanded(
                         child: SingleChildScrollView(
                           controller: controller.scrollController,
-                          child: Container(
-                            constraints: const BoxConstraints(maxWidth: 600.0),
-                            padding: const EdgeInsets.all(12.0),
-                            child: Column(
-                              children: [
-                                ActivitySummary(
-                                  activity: activity,
-                                  room: controller.activityRoom,
-                                  course: controller.courseParent,
-                                  showInstructions: controller.showInstructions,
-                                  toggleInstructions:
-                                      controller.toggleInstructions,
-                                  onTapParticipant:
-                                      sessionController.selectRole,
-                                  isParticipantSelected:
-                                      sessionController.isRoleSelected,
-                                  isParticipantShimmering:
-                                      sessionController.isRoleShimmering,
-                                  canSelectParticipant:
-                                      sessionController.canSelectRole,
-                                  assignedRoles: controller.assignedRoles,
-                                  showStarsCard:
-                                      sessionController.showStarsCard,
-                                  completedGoalsForRole:
-                                      sessionController.completedGoalIdsForRole,
-                                  roleCardOpacity:
-                                      sessionController.roleCardOpacity,
-                                  showRoleCards:
-                                      sessionController.showRoleCards,
-                                  showDescriptionSection:
-                                      sessionController.showDescriptionSection,
-                                  goals: sessionController.selectedRoleGoals,
-                                  completedGoalIds: sessionController
-                                      .selectedRoleCompletedGoalIds,
-                                  goalsStartCollapsed:
-                                      sessionController.goalsStartCollapsed,
+                          child: Column(
+                            children: [
+                              Stack(
+                                children: [
+                                  SizedBox(
+                                    height: 350.0,
+                                    child: LayoutBuilder(
+                                      builder: (context, constraints) =>
+                                          ImageByUrl(
+                                            imageUrl: activity.imageURL,
+                                            borderRadius: BorderRadius.zero,
+                                            width: constraints.maxWidth,
+                                            replacement: Container(
+                                              width: constraints.maxWidth,
+                                              height: 350.0,
+                                              decoration: BoxDecoration(
+                                                gradient: LinearGradient(
+                                                  begin: Alignment.topCenter,
+                                                  end: Alignment.bottomCenter,
+                                                  colors: [
+                                                    theme
+                                                        .colorScheme
+                                                        .primaryContainer,
+                                                    theme.colorScheme.surface,
+                                                  ],
+                                                ),
+                                              ),
+                                            ),
+                                          ),
+                                    ),
+                                  ),
+                                  Positioned.fill(
+                                    top: 275.0,
+                                    child: Container(
+                                      decoration: BoxDecoration(
+                                        gradient: LinearGradient(
+                                          begin: Alignment.topCenter,
+                                          end: Alignment.center,
+                                          colors: [
+                                            theme.colorScheme.surface.withAlpha(
+                                              0,
+                                            ),
+                                            theme.colorScheme.surface,
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                  if (sessionController.showRoleCards)
+                                    Positioned(
+                                      bottom: 0,
+                                      left: 0,
+                                      right: 0,
+                                      child: Center(
+                                        child: Container(
+                                          padding: EdgeInsets.symmetric(
+                                            horizontal: 16.0,
+                                          ),
+                                          constraints: const BoxConstraints(
+                                            maxWidth: 600.0,
+                                          ),
+                                          child: Opacity(
+                                            opacity: sessionController
+                                                .roleCardOpacity,
+                                            child: ActivityParticipantList(
+                                              activity: activity,
+                                              room: controller.activityRoom,
+                                              assignedRoles:
+                                                  controller.assignedRoles,
+                                              course: controller.courseParent,
+                                              onTap:
+                                                  sessionController.selectRole,
+                                              canSelect: sessionController
+                                                  .canSelectRole,
+                                              isSelected: sessionController
+                                                  .isRoleSelected,
+                                              isShimmering: sessionController
+                                                  .isRoleShimmering,
+                                              showStarsCard: sessionController
+                                                  .showStarsCard,
+                                              completedGoalsForRole:
+                                                  sessionController
+                                                      .completedGoalIdsForRole,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  Positioned(
+                                    top: 0,
+                                    left: 0,
+                                    right: 0,
+                                    child: _ActivityGoalsDropdown(
+                                      goals:
+                                          sessionController.selectedRoleGoals,
+                                      completedGoalIds: sessionController
+                                          .selectedRoleCompletedGoalIds,
+                                      startCollapsed:
+                                          sessionController.goalsStartCollapsed,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              if (sessionController.showDescriptionSection)
+                                Center(
+                                  child: Container(
+                                    constraints: const BoxConstraints(
+                                      maxWidth: 600.0,
+                                    ),
+                                    padding: const EdgeInsets.fromLTRB(
+                                      16.0,
+                                      50.0,
+                                      16.0,
+                                      0.0,
+                                    ),
+                                    child: Column(
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      spacing: 12.0,
+                                      children: [
+                                        Text(
+                                          activity.description,
+                                          style: theme.textTheme.bodyLarge,
+                                        ),
+                                        if (activity.vocab.isNotEmpty)
+                                          ActivityVocabWidget(
+                                            key: ValueKey(
+                                              'activity-start-vocab-${activity.activityId}',
+                                            ),
+                                            vocab: activity.vocab,
+                                            langCode:
+                                                activity.req.targetLanguage,
+                                            targetId: 'activity-start-vocab',
+                                            usedVocab: null,
+                                            activityLangCode:
+                                                activity.req.targetLanguage,
+                                          ),
+                                      ],
+                                    ),
+                                  ),
                                 ),
-                                ActivitySessionBottomContent(sessionController),
-                              ],
-                            ),
+                              Container(
+                                constraints: const BoxConstraints(
+                                  maxWidth: 600.0,
+                                ),
+                                padding: const EdgeInsets.all(12.0),
+                                child: ActivitySessionBottomContent(
+                                  sessionController,
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ),
@@ -244,6 +351,161 @@ class ActivitySessionStartView extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+class _ActivityGoalsDropdown extends StatefulWidget {
+  final List<ActivityRoleGoal>? goals;
+  final Set<String> completedGoalIds;
+  final bool startCollapsed;
+
+  const _ActivityGoalsDropdown({
+    required this.goals,
+    required this.completedGoalIds,
+    this.startCollapsed = false,
+  });
+
+  @override
+  State<_ActivityGoalsDropdown> createState() => _ActivityGoalsDropdownState();
+}
+
+class _ActivityGoalsDropdownState extends State<_ActivityGoalsDropdown> {
+  bool _visible = false;
+  bool _innerExpanded = true;
+  List<ActivityRoleGoal>? _displayGoals;
+
+  @override
+  void initState() {
+    super.initState();
+    _displayGoals = widget.goals;
+    _visible = widget.goals != null && widget.goals!.isNotEmpty;
+    _innerExpanded = !widget.startCollapsed;
+  }
+
+  @override
+  void didUpdateWidget(covariant _ActivityGoalsDropdown old) {
+    super.didUpdateWidget(old);
+    if (old.goals != widget.goals) {
+      final hasGoals = widget.goals != null && widget.goals!.isNotEmpty;
+      if (hasGoals) {
+        setState(() {
+          _displayGoals = widget.goals;
+          _visible = true;
+          _innerExpanded = true;
+        });
+      } else {
+        setState(() => _visible = false);
+        Future.delayed(FluffyThemes.animationDuration, () {
+          if (mounted) setState(() => _displayGoals = null);
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final goals = _displayGoals ?? [];
+    final theme = Theme.of(context);
+    final firstGoal = goals.isNotEmpty ? goals.first : null;
+    final remainingGoals = goals.length > 1
+        ? goals.skip(1).toList()
+        : <ActivityRoleGoal>[];
+
+    return ClipRect(
+      child: AnimatedAlign(
+        duration: FluffyThemes.animationDuration,
+        curve: Curves.easeInOut,
+        heightFactor: _visible ? 1.0 : 0.0,
+        alignment: Alignment.topCenter,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (firstGoal != null)
+              InkWell(
+                onTap: remainingGoals.isNotEmpty
+                    ? () => setState(() => _innerExpanded = !_innerExpanded)
+                    : null,
+                child: Container(
+                  height: 55.0,
+                  padding: const EdgeInsets.symmetric(horizontal: 12.0),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.surface,
+                    border: Border(top: BorderSide(color: theme.dividerColor)),
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: GoalStatusWidget(
+                          goal: firstGoal,
+                          complete: widget.completedGoalIds.contains(
+                            firstGoal.id,
+                          ),
+                        ),
+                      ),
+                      if (remainingGoals.isNotEmpty)
+                        Icon(
+                          _innerExpanded
+                              ? Icons.expand_less
+                              : Icons.expand_more,
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            if (remainingGoals.isNotEmpty)
+              ClipRect(
+                child: AnimatedAlign(
+                  duration: FluffyThemes.animationDuration,
+                  curve: Curves.easeInOut,
+                  heightFactor: _innerExpanded ? 1.0 : 0.0,
+                  alignment: Alignment.topCenter,
+                  child: GestureDetector(
+                    onPanUpdate: (d) {
+                      if (d.delta.dy < -2) {
+                        setState(() => _innerExpanded = false);
+                      }
+                    },
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        final maxHeight =
+                            MediaQuery.of(context).size.height * 0.7;
+                        return ConstrainedBox(
+                          constraints: BoxConstraints(maxHeight: maxHeight),
+                          child: SingleChildScrollView(
+                            child: Container(
+                              width: double.infinity,
+                              color: theme.colorScheme.surface,
+                              padding: const EdgeInsets.fromLTRB(
+                                12.0,
+                                12.0,
+                                12.0,
+                                24.0,
+                              ),
+                              child: Column(
+                                spacing: 16.0,
+                                mainAxisSize: MainAxisSize.min,
+                                children: remainingGoals
+                                    .map(
+                                      (g) => GoalStatusWidget(
+                                        goal: g,
+                                        complete: widget.completedGoalIds
+                                            .contains(g.id),
+                                      ),
+                                    )
+                                    .toList(),
+                              ),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
@@ -16,7 +16,6 @@ import 'package:fluffychat/routes/chat/activity_sessions/activity_sessions_start
 import 'package:fluffychat/routes/chat/activity_sessions/bot_join_error_dialog.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
-import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -43,8 +42,6 @@ class ConfirmedRoleSession extends StatefulWidget {
 
 class ConfirmedRoleSessionController extends State<ConfirmedRoleSession>
     implements ActivitySessionStateController {
-  ConfirmedRoleSessionController();
-
   Timer? _pingCooldown;
   final _goalsHandler = GoalsSubscriptionHandler();
 
@@ -145,9 +142,6 @@ class ConfirmedRoleSessionController extends State<ConfirmedRoleSession>
   }
 
   void inviteFriends() {
-    // No marker is written here: the bot is auto-invited and stays idle, leaving
-    // the open seat for the friend. When they join (2 humans) the bot is a silent
-    // moderator. Only "play with bot" marks the bot as a participant (#7027).
     NavigationUtil.goToSpaceRoute(widget.room.id, ['invite'], context);
   }
 
@@ -181,7 +175,7 @@ class ConfirmedRoleSessionController extends State<ConfirmedRoleSession>
 
     if (mounted) {
       setState(() {});
-      ScaffoldMessenger.of(context).showSnackBarAnnounced(
+      ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(L10n.of(context).pingSent, textAlign: TextAlign.center),
           duration: const Duration(milliseconds: 2000),

--- a/lib/routes/chat/activity_sessions/not_started_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/not_started_session_controller.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
 import 'package:collection/collection.dart';
@@ -13,6 +11,7 @@ import 'package:fluffychat/features/course_plans/courses/course_plan_room_extens
 import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/room_summaries/activity_sessions_status_model.dart';
+import 'package:fluffychat/features/room_summaries/activity_summary_status_enum.dart';
 import 'package:fluffychat/features/room_summaries/room_summaries_model.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
@@ -21,6 +20,26 @@ import 'package:fluffychat/routes/chat/activity_sessions/activity_sessions_start
 import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
+
+enum NotStartedSubPage {
+  main,
+  join,
+  view;
+
+  List<ActivitySummaryStatus> get visibleStatuses {
+    switch (this) {
+      case NotStartedSubPage.join:
+        return [ActivitySummaryStatus.notStarted];
+      case NotStartedSubPage.view:
+        return [
+          ActivitySummaryStatus.inProgress,
+          ActivitySummaryStatus.completed,
+        ];
+      case NotStartedSubPage.main:
+        return [];
+    }
+  }
+}
 
 class NotStartedSession extends StatefulWidget {
   /// The course the activity is launched from, when there is one. Null for a
@@ -48,6 +67,7 @@ class NotStartedSession extends StatefulWidget {
 
 class NotStartedSessionController extends State<NotStartedSession>
     implements ActivitySessionStateController {
+  NotStartedSubPage _subPage = NotStartedSubPage.main;
   final _goalsHandler = GoalsSubscriptionHandler();
 
   @override
@@ -61,6 +81,12 @@ class NotStartedSessionController extends State<NotStartedSession>
     _goalsHandler.cancel();
     super.dispose();
   }
+
+  NotStartedSubPage get subPage => _subPage;
+
+  void goToJoinPage() => setState(() => _subPage = NotStartedSubPage.join);
+  void goToViewPage() => setState(() => _subPage = NotStartedSubPage.view);
+  void goToMainPage() => setState(() => _subPage = NotStartedSubPage.main);
 
   String? get joinedActivityRoomId =>
       widget.course?.activeActivityRoomId(widget.activityId);
@@ -100,15 +126,11 @@ class NotStartedSessionController extends State<NotStartedSession>
     activity: widget.activity,
   );
 
-  // world_v2: the join/view subpage navigation (NotStartedSubPage) was dropped
-  // in favor of inline join/list controls (joinExistingSession /
-  // joinActivityByRoomId + ActivitySessionBottomContent). Role cards and the
-  // description are always shown on the single page.
   @override
-  bool get showRoleCards => true;
+  bool get showRoleCards => _subPage == NotStartedSubPage.main;
 
   @override
-  bool get showDescriptionSection => true;
+  bool get showDescriptionSection => _subPage == NotStartedSubPage.main;
 
   @override
   List<ActivityRoleGoal>? get selectedRoleGoals => null;
@@ -116,10 +138,26 @@ class NotStartedSessionController extends State<NotStartedSession>
   @override
   Set<String> get selectedRoleCompletedGoalIds => {};
 
-  bool get canJoinExistingSession => widget.summaries.openSessions.isNotEmpty;
+  int get openSessionCount => widget.summaries.openSessions.length;
 
   ActivitySessionsStatusModel get activityStatuses =>
       widget.summaries.activitySessionStatuses;
+
+  bool get hasCurrentOrFinishedSessions =>
+      activityStatuses
+          .getSessionsByStatus(ActivitySummaryStatus.inProgress)
+          .isNotEmpty ||
+      activityStatuses
+          .getSessionsByStatus(ActivitySummaryStatus.completed)
+          .isNotEmpty;
+
+  int get currentOrFinishedSessionCount =>
+      activityStatuses
+          .getSessionsByStatus(ActivitySummaryStatus.inProgress)
+          .length +
+      activityStatuses
+          .getSessionsByStatus(ActivitySummaryStatus.completed)
+          .length;
 
   Future<int> get neededCourseParticipants async {
     // No course: the session launches standalone (the bot fills in), so no
@@ -191,54 +229,6 @@ class NotStartedSessionController extends State<NotStartedSession>
         'invite',
       ),
     );
-  }
-
-  Future<void> joinExistingSession() async {
-    final resp = await showFutureLoadingDialog(
-      context: context,
-      future: _joinExistingSession,
-    );
-
-    if (!resp.isError) {
-      NavigationUtil.goToSpaceRoute(resp.result, [], context);
-    }
-  }
-
-  Future<String> _joinExistingSession() async {
-    if (!canJoinExistingSession) {
-      throw Exception("No existing session to join");
-    }
-
-    final sessionIds = widget.summaries.openSessions;
-    String? joinedSessionId;
-    for (final sessionId in sessionIds) {
-      try {
-        await Matrix.of(context).client.joinRoom(
-          sessionId,
-          via: widget.course?.spaceChildren
-              .firstWhereOrNull((child) => child.roomId == sessionId)
-              ?.via,
-        );
-        joinedSessionId = sessionId;
-        break;
-      } catch (_) {
-        // try next session
-        continue;
-      }
-    }
-
-    if (joinedSessionId == null) {
-      throw Exception("Failed to join any existing session");
-    }
-
-    final room = Matrix.of(context).client.getRoomById(joinedSessionId);
-    if (room == null || room.membership != Membership.join) {
-      await Matrix.of(
-        context,
-      ).client.waitForRoomInSync(joinedSessionId, join: true);
-    }
-
-    return joinedSessionId;
   }
 
   Future<void> joinActivityByRoomId(String roomId) async {

--- a/lib/routes/chat/activity_sessions/select_role_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/select_role_session_controller.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
 import 'package:collection/collection.dart';
@@ -85,9 +83,6 @@ class SelectRoleSessionController extends State<SelectRoleSession>
           ? L10n.of(context).chooseRole
           : L10n.of(context).chooseRoleToParticipate;
     }
-
-    // A role is selected: its goals render in the goals dropdown, so the
-    // description area is hidden to avoid duplicating the goal text.
     return null;
   }
 
@@ -143,20 +138,8 @@ class SelectRoleSessionController extends State<SelectRoleSession>
 
   @override
   bool canSelectRole(String id) {
-    final activity = widget.activity;
-    if (activity == null) return false;
-
-    final availableRoles = activity.roles;
-    final assignedRoles =
-        activityRoom?.assignedRoles ??
-        widget.summary?.joinedUsersWithRoles ??
-        {};
-
-    final unassignedIds = availableRoles.keys
-        .where((id) => !assignedRoles.containsKey(id))
-        .toList();
-
-    return unassignedIds.contains(id);
+    if (widget.activity == null) return false;
+    return !widget.controller.assignedRoles.containsKey(id);
   }
 
   @override


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-page navigation for not-started sessions, letting users switch between main, join, and view states.
  * Expanded the activity start screen with a richer header, goal display, and role/participant sections.

* **Bug Fixes**
  * Updated session details to better handle missing course or participant data.
  * Improved role selection availability so already-assigned roles can’t be selected.
  * Simplified session action buttons to better reflect open, current, and finished sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->