### PR TITLE
Remove extra padding from grammar analytics

### DIFF
--- a/lib/routes/analytics/construct_analytics/morph_analytics_list_view.dart
+++ b/lib/routes/analytics/construct_analytics/morph_analytics_list_view.dart
@@ -26,19 +26,15 @@ class MorphAnalyticsListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const padding = EdgeInsets.symmetric(vertical: 10.0);
     final l2 =
         MatrixState.pangeaController.userController.userL2?.langCodeShort;
 
     return Column(
       children: [
         if (kIsWeb)
-          const Padding(
-            padding: padding,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [DownloadAnalyticsButton()],
-            ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [DownloadAnalyticsButton()],
           ),
         Expanded(
           child: CustomScrollView(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
