### PR TITLE
fix: add background to text in free trail onboarding page

### DIFF
--- a/lib/routes/onboarding/onboarding_step_views/free_trial_step_view.dart
+++ b/lib/routes/onboarding/onboarding_step_views/free_trial_step_view.dart
@@ -55,22 +55,32 @@ class FreeTrialStepView extends StatelessWidget {
                               Column(
                                 spacing: 16.0,
                                 children: [
-                                  Column(
-                                    spacing: 8.0,
-                                    children: [
-                                      Text(
-                                        L10n.of(context).thanksForSigningUp,
-                                        style: theme.textTheme.bodyLarge,
+                                  Container(
+                                    padding: EdgeInsets.all(2.0),
+                                    decoration: BoxDecoration(
+                                      color: theme.colorScheme.surface,
+                                      borderRadius: BorderRadius.circular(
+                                        AppConfig.borderRadius,
                                       ),
-                                      Text(
-                                        L10n.of(context).sevenDaysFree,
-                                        style: theme.textTheme.displayMedium
-                                            ?.copyWith(
-                                              color: gold,
-                                              fontWeight: FontWeight.w900,
-                                            ),
-                                      ),
-                                    ],
+                                    ),
+                                    child: Column(
+                                      spacing: 8.0,
+                                      children: [
+                                        Text(
+                                          L10n.of(context).thanksForSigningUp,
+                                          style: theme.textTheme.bodyLarge,
+                                        ),
+
+                                        Text(
+                                          L10n.of(context).sevenDaysFree,
+                                          style: theme.textTheme.displayMedium
+                                              ?.copyWith(
+                                                color: gold,
+                                                fontWeight: FontWeight.w900,
+                                              ),
+                                        ),
+                                      ],
+                                    ),
                                   ),
                                   ProFeaturesCard(
                                     padding: const EdgeInsets.all(12.0),
@@ -79,10 +89,19 @@ class FreeTrialStepView extends StatelessWidget {
                                     frameColor: gold,
                                     borderWidth: 2,
                                   ),
-                                  Text(
-                                    L10n.of(context).manageTrialInSettings,
-                                    textAlign: TextAlign.center,
-                                    style: theme.textTheme.bodyLarge,
+                                  Container(
+                                    padding: EdgeInsets.all(2.0),
+                                    decoration: BoxDecoration(
+                                      color: theme.colorScheme.surface,
+                                      borderRadius: BorderRadius.circular(
+                                        AppConfig.borderRadius,
+                                      ),
+                                    ),
+                                    child: Text(
+                                      L10n.of(context).manageTrialInSettings,
+                                      textAlign: TextAlign.center,
+                                      style: theme.textTheme.bodyLarge,
+                                    ),
                                   ),
                                 ],
                               ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
