### PR TITLE
Move analytics download button to app bar header

### DIFF
--- a/lib/routes/analytics/construct_analytics/morph_analytics_list_view.dart
+++ b/lib/routes/analytics/construct_analytics/morph_analytics_list_view.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/config/app_config.dart';
@@ -15,7 +14,6 @@ import 'package:fluffychat/pangea/morphs/morph_features_enum.dart';
 import 'package:fluffychat/pangea/morphs/morph_icon.dart';
 import 'package:fluffychat/routes/analytics/analytics_navigation_util.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/analytics_details_popup.dart';
-import 'package:fluffychat/routes/analytics/construct_analytics/analytics_download_button.dart';
 import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 

--- a/lib/routes/analytics/construct_analytics/morph_analytics_list_view.dart
+++ b/lib/routes/analytics/construct_analytics/morph_analytics_list_view.dart
@@ -31,11 +31,6 @@ class MorphAnalyticsListView extends StatelessWidget {
 
     return Column(
       children: [
-        if (kIsWeb)
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [DownloadAnalyticsButton()],
-          ),
         Expanded(
           child: CustomScrollView(
             key: const PageStorageKey<String>('morph-analytics'),

--- a/lib/routes/analytics/construct_analytics/vocab_analytics_list_view.dart
+++ b/lib/routes/analytics/construct_analytics/vocab_analytics_list_view.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:diacritic/diacritic.dart';
@@ -15,7 +14,6 @@ import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dar
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/analytics_navigation_util.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/analytics_details_popup.dart';
-import 'package:fluffychat/routes/analytics/construct_analytics/analytics_download_button.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/vocab_analytics_list_tile.dart';
 import 'package:fluffychat/routes/chat/events/text_to_speech/tts_controller.dart';
 import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';

--- a/lib/routes/analytics/construct_analytics/vocab_analytics_list_view.dart
+++ b/lib/routes/analytics/construct_analytics/vocab_analytics_list_view.dart
@@ -179,10 +179,6 @@ class VocabAnalyticsListView extends StatelessWidget {
       ),
     );
 
-    if (kIsWeb) {
-      filters.add(const DownloadAnalyticsButton());
-    }
-
     return Column(
       children: [
         AnimatedContainer(

--- a/lib/routes/world/right_panel/panel_card_with_header.dart
+++ b/lib/routes/world/right_panel/panel_card_with_header.dart
@@ -9,12 +9,14 @@ class PanelCardWithHeader extends StatelessWidget {
   final VoidCallback onLeading;
   final Widget child;
   final String tooltip;
+  final Widget? trailing;
 
   const PanelCardWithHeader({
     super.key,
     required this.icon,
     required this.title,
     required this.onLeading,
+    this.trailing,
     required this.child,
     required this.tooltip,
   });
@@ -31,6 +33,7 @@ class PanelCardWithHeader extends StatelessWidget {
               onPressed: onLeading,
             ),
             title: title,
+            trailing: trailing,
           ),
           Expanded(child: child),
         ],

--- a/lib/routes/world/right_panel/right_panel_analytics_subpage.dart
+++ b/lib/routes/world/right_panel/right_panel_analytics_subpage.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/features/analytics/construct_type_enum.dart';
@@ -5,6 +6,7 @@ import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/activities/activity_archive.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/analytics_details_popup.dart';
+import 'package:fluffychat/routes/analytics/construct_analytics/analytics_download_button.dart';
 import 'package:fluffychat/routes/analytics/level/level_analytics_details_content.dart';
 import 'package:fluffychat/routes/world/right_panel/panel_card_with_header.dart';
 
@@ -50,10 +52,13 @@ class RightPanelAnalyticsSubpage extends StatelessWidget {
       ),
     };
 
+    final showDownload = kIsWeb && (tab == 'grammar' || tab == 'vocab');
+
     return PanelCardWithHeader(
       title: title,
       icon: icon,
       onLeading: onLeading,
+      trailing: showDownload ? DownloadAnalyticsButton() : null,
       tooltip: tooltip,
       child: child,
     );

--- a/lib/routes/world/right_panel/workspace_right_panel.dart
+++ b/lib/routes/world/right_panel/workspace_right_panel.dart
@@ -130,7 +130,9 @@ class WorkspaceRightPanel extends StatelessWidget {
         icon: leadingIcon,
         onLeading: onLeading,
         tooltip: leadingTooltip,
-        trailing: kIsWeb ? DownloadAnalyticsButton() : null,
+        trailing: kIsWeb && _construct == null
+            ? DownloadAnalyticsButton()
+            : null,
         child: ConstructAnalyticsView(
           view: token.type == 'vocab'
               ? ConstructTypeEnum.vocab

--- a/lib/routes/world/right_panel/workspace_right_panel.dart
+++ b/lib/routes/world/right_panel/workspace_right_panel.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
@@ -14,6 +15,7 @@ import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/analytics_details_popup.dart';
+import 'package:fluffychat/routes/analytics/construct_analytics/analytics_download_button.dart';
 import 'package:fluffychat/routes/world/panel_card.dart';
 import 'package:fluffychat/routes/world/right_panel/panel_card_with_header.dart';
 import 'package:fluffychat/routes/world/right_panel/right_panel_analytics_practice_subpage.dart';
@@ -128,6 +130,7 @@ class WorkspaceRightPanel extends StatelessWidget {
         icon: leadingIcon,
         onLeading: onLeading,
         tooltip: leadingTooltip,
+        trailing: kIsWeb ? DownloadAnalyticsButton() : null,
         child: ConstructAnalyticsView(
           view: token.type == 'vocab'
               ? ConstructTypeEnum.vocab


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the analytics UI so the download option now appears in the right-panel header on web for supported analytics sections.

* **Bug Fixes**
  * Removed duplicate or misplaced download controls from analytics list views, resulting in a cleaner layout.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->