### PR TITLE
fix: don't re-shuffle choices in acive suggestion

### DIFF
--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart
@@ -27,19 +27,17 @@ class ActiveSuggestionModel {
     this.selectedChoice,
     this.acceptedChoice,
     List<OrchestratorSuggestion>? shuffledChoices,
-  }) : shuffledChoices = shuffledChoices ?? List.from(suggestion.suggestions)
-         ..shuffle();
+  }) : shuffledChoices =
+           shuffledChoices ?? (List.from(suggestion.suggestions)..shuffle());
 
   ActiveSuggestionModel copyWith({
-    OrchestratorRoleSuggestions? suggestion,
     OrchestratorSuggestion? selectedChoice,
     OrchestratorSuggestion? acceptedChoice,
-    List<OrchestratorSuggestion>? shuffledChoices,
   }) => ActiveSuggestionModel(
-    suggestion: suggestion ?? this.suggestion,
+    suggestion: suggestion,
     selectedChoice: selectedChoice ?? this.selectedChoice,
     acceptedChoice: acceptedChoice ?? this.acceptedChoice,
-    shuffledChoices: shuffledChoices ?? this.shuffledChoices,
+    shuffledChoices: shuffledChoices,
   );
 }
 


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
