### PR TITLE
Make cluster button labels and opened page titles consistent

### DIFF
--- a/lib/routes/world/right_panel/right_panel_analytics_subpage.dart
+++ b/lib/routes/world/right_panel/right_panel_analytics_subpage.dart
@@ -29,7 +29,7 @@ class RightPanelAnalyticsSubpage extends StatelessWidget {
     final tab = token.param;
     final title = switch (tab) {
       'grammar' => l10n.grammar,
-      'sessions' => l10n.activities,
+      'sessions' => l10n.stars,
       'level' => l10n.level,
       _ => l10n.vocab,
     };

--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -183,7 +183,7 @@ class _Avatar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final label = L10n.of(context).account;
+    final label = L10n.of(context).settings;
     return MouseRegion(
       cursor: SystemMouseCursors.click,
       child: Tooltip(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
