### PR TITLE
7324 w practice vocab confetti stops showing after 1 2 times

### DIFF
--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_page.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_page.dart
@@ -195,6 +195,7 @@ class AnalyticsPracticeState extends State<AnalyticsPractice>
       exercise is! VocabAudioPracticeExerciseModel;
 
   void _clearState() {
+    MatrixState.pAnyState.closeOverlay(StarRainWidget.practiceCompleteKey);
     _dataService.clear();
     _sessionController.clear();
     AnalyticsPractice.bypassExitConfirmation = true;
@@ -284,7 +285,7 @@ class AnalyticsPracticeState extends State<AnalyticsPractice>
     await _analyticsController.addSessionAnalytics(bonus, _l2!.langCodeShort);
 
     AnalyticsPractice.bypassExitConfirmation = true;
-    StarRainWidget.show(context, "completed-activity-star-rain");
+    StarRainWidget.show(context, StarRainWidget.practiceCompleteKey);
   }
 
   Future<void> _continueSession() async {

--- a/lib/widgets/star_rain_widget.dart
+++ b/lib/widgets/star_rain_widget.dart
@@ -12,6 +12,8 @@ import 'package:fluffychat/widgets/matrix.dart';
 class StarRainWidget extends StatefulWidget {
   final String overlayKey;
 
+  static const String practiceCompleteKey = "completed-activity-star-rain";
+
   const StarRainWidget({super.key, required this.overlayKey});
 
   static void show(BuildContext context, String overlayKey) {
@@ -20,7 +22,7 @@ class StarRainWidget extends StatefulWidget {
       child: StarRainWidget(overlayKey: overlayKey),
       displayDetails: CenteredOverlayDisplayDetails(
         closePrevOverlay: false,
-        canPop: false,
+        canPop: true,
         overlayKey: overlayKey,
         ignorePointer: true,
       ),
@@ -62,12 +64,11 @@ class _StarRainWidgetState extends State<StarRainWidget> {
 
     _fadeOpacity = 1.0;
     Future.delayed(rainDuration, () async {
-      if (!mounted) return;
-
-      setState(() => _fadeOpacity = 0.0);
-      await Future.delayed(opacityDuration);
+      if (mounted) {
+        setState(() => _fadeOpacity = 0.0);
+        await Future.delayed(opacityDuration);
+      }
       MatrixState.pAnyState.closeOverlay(widget.overlayKey);
-
       if (mounted) {
         _blastController.stop();
         _rainController.stop();


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the completion animation so it now closes correctly when resetting or finishing a practice session.
  * Made the celebration overlay dismissable and more reliable during fade-out, reducing the chance of it getting stuck on screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->