### PR TITLE
fix(a11y): contextual close-button labels for coexisting world panels

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -502,6 +502,40 @@
         "type": "String",
         "placeholders": {}
     },
+    "closeChats": "Close chat list",
+    "@closeChats": {},
+    "closeChat": "Close chat",
+    "@closeChat": {},
+    "closeSession": "Close activity review",
+    "@closeSession": {},
+    "closeCourse": "Close course",
+    "@closeCourse": {},
+    "closeCoursePage": "Close course page",
+    "@closeCoursePage": {},
+    "closeAddCourse": "Close add course",
+    "@closeAddCourse": {},
+    "closeAnalytics": "Close analytics",
+    "@closeAnalytics": {},
+    "closeVocabulary": "Close vocabulary",
+    "@closeVocabulary": {},
+    "closeGrammar": "Close grammar",
+    "@closeGrammar": {},
+    "closePractice": "Close practice",
+    "@closePractice": {},
+    "closeSettings": "Close settings",
+    "@closeSettings": {},
+    "closeActivity": "Close activity",
+    "@closeActivity": {},
+    "closeNamed": "Close {name}",
+    "@closeNamed": {
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "clearSearch": "Clear search",
+    "@clearSearch": {},
     "commandHint_markasdm": "Mark as direct message room for the giving Matrix ID",
     "@commandHint_markasdm": {},
     "commandHint_markasgroup": "Mark as group",

--- a/lib/routes/world/activity_detail_panel.dart
+++ b/lib/routes/world/activity_detail_panel.dart
@@ -213,7 +213,7 @@ class ActivityLoadingHeader extends StatelessWidget {
               onPressed: onBack,
             )
           : IconButton(
-              tooltip: L10n.of(context).close,
+              tooltip: L10n.of(context).closeActivity,
               icon: const Icon(Icons.close),
               onPressed: onClose,
             ),

--- a/lib/routes/world/close_button_labels.dart
+++ b/lib/routes/world/close_button_labels.dart
@@ -1,0 +1,38 @@
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+
+/// The accessible name (screen-reader label + tooltip) for a panel's close (X)
+/// control. Several panels can be open at once, each with its own X; a bare
+/// "Close" is indistinguishable to assistive tech, so the label names the panel
+/// it dismisses — derived from [PanelToken.type], the same identity the URL
+/// carries (#7274). [named] supplies a dynamic title (e.g. a settings page name)
+/// where one token type fronts many surfaces.
+String closeButtonLabel(L10n l10n, PanelToken token, {String? named}) {
+  if (named != null && named.isNotEmpty) return l10n.closeNamed(named);
+  switch (token.type) {
+    case 'chats':
+      return l10n.closeChats;
+    case 'room':
+      return l10n.closeChat;
+    case 'session':
+      return l10n.closeSession;
+    case 'course':
+      return l10n.closeCourse;
+    case 'coursepage':
+      return l10n.closeCoursePage;
+    case 'addcourse':
+      return l10n.closeAddCourse;
+    case 'analytics':
+      return l10n.closeAnalytics;
+    case 'vocab':
+      return l10n.closeVocabulary;
+    case 'grammar':
+      return l10n.closeGrammar;
+    case 'practice':
+      return l10n.closePractice;
+    case 'settings':
+      return l10n.closeSettings;
+    default:
+      return l10n.close;
+  }
+}

--- a/lib/routes/world/left_panel/left_panel_close_button.dart
+++ b/lib/routes/world/left_panel/left_panel_close_button.dart
@@ -7,6 +7,7 @@ import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/close_button_labels.dart';
 
 /// The panel's close control. A pushed sub-page ([_isPushedSubPage]) backs out
 /// ONE level via popPage (a course management page → the card; a room sub-page
@@ -94,7 +95,7 @@ class LeftPanelCloseButton extends StatelessWidget {
         ? BackButton(onPressed: () => _close(context))
         : IconButton(
             icon: const Icon(Icons.close),
-            tooltip: L10n.of(context).close,
+            tooltip: closeButtonLabel(L10n.of(context), token),
             onPressed: () => _close(context),
           );
   }

--- a/lib/routes/world/right_panel/workspace_right_panel.dart
+++ b/lib/routes/world/right_panel/workspace_right_panel.dart
@@ -14,6 +14,7 @@ import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/analytics_details_popup.dart';
+import 'package:fluffychat/routes/world/close_button_labels.dart';
 import 'package:fluffychat/routes/world/panel_card.dart';
 import 'package:fluffychat/routes/world/right_panel/panel_card_with_header.dart';
 import 'package:fluffychat/routes/world/right_panel/right_panel_analytics_practice_subpage.dart';
@@ -82,7 +83,13 @@ class WorkspaceRightPanel extends StatelessWidget {
 
     final leadingTooltip = aff.showBack
         ? MaterialLocalizations.of(context).backButtonTooltip
-        : l10n.close;
+        : closeButtonLabel(
+            l10n,
+            token,
+            named: token.type == 'settingspage'
+                ? SettingsPageEnum.fromString(page).title(l10n)
+                : null,
+          );
 
     final onLeading = aff.showBack && isPushed
         ? () => context.go(WorkspaceNav.popPage(currentUri, token.type, page))

--- a/lib/routes/world/world_map_search_overlay.dart
+++ b/lib/routes/world/world_map_search_overlay.dart
@@ -110,7 +110,7 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
               suffixIcon: searching
                   ? IconButton(
                       icon: const Icon(Icons.close),
-                      tooltip: l10n.close,
+                      tooltip: l10n.clearSearch,
                       onPressed: () => widget.updateQuery(''),
                     )
                   : null,

--- a/test/pangea/navigation/close_button_labels_test.dart
+++ b/test/pangea/navigation/close_button_labels_test.dart
@@ -59,7 +59,8 @@ void main() {
       expect(
         entry.value,
         isNot(l10n.close),
-        reason: '${entry.key} should carry a contextual close label, not "Close"',
+        reason:
+            '${entry.key} should carry a contextual close label, not "Close"',
       );
     }
 
@@ -76,7 +77,11 @@ void main() {
   ) async {
     await captureL10n(tester);
     expect(
-      closeButtonLabel(l10n, const PanelToken('settingspage'), named: 'Learning'),
+      closeButtonLabel(
+        l10n,
+        const PanelToken('settingspage'),
+        named: 'Learning',
+      ),
       l10n.closeNamed('Learning'),
     );
   });

--- a/test/pangea/navigation/close_button_labels_test.dart
+++ b/test/pangea/navigation/close_button_labels_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/close_button_labels.dart';
+
+/// Regression coverage for #7274 ("[SR] duplicate close button confusion"):
+/// several panels can be open at once, each with its own close (X). A bare
+/// "Close" is indistinguishable to a screen reader, so every panel type must
+/// yield its own contextual close label.
+void main() {
+  late L10n l10n;
+
+  Future<void> captureL10n(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            l10n = L10n.of(context);
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  // Every panel type whose close control routes through [closeButtonLabel].
+  const closeableTypes = [
+    'chats',
+    'room',
+    'session',
+    'course',
+    'coursepage',
+    'addcourse',
+    'analytics',
+    'vocab',
+    'grammar',
+    'practice',
+    'settings',
+  ];
+
+  testWidgets('every panel type gets a distinct, contextual close label', (
+    tester,
+  ) async {
+    await captureL10n(tester);
+
+    final labels = {
+      for (final type in closeableTypes)
+        type: closeButtonLabel(l10n, PanelToken(type)),
+    };
+
+    // None degrades to the bare "Close" the issue is about.
+    for (final entry in labels.entries) {
+      expect(
+        entry.value,
+        isNot(l10n.close),
+        reason: '${entry.key} should carry a contextual close label, not "Close"',
+      );
+    }
+
+    // All distinct — so coexisting close buttons are distinguishable by name.
+    expect(
+      labels.values.toSet().length,
+      labels.length,
+      reason: 'close labels must be unique per panel type: $labels',
+    );
+  });
+
+  testWidgets('a dynamic title (named) overrides the per-type label', (
+    tester,
+  ) async {
+    await captureL10n(tester);
+    expect(
+      closeButtonLabel(l10n, const PanelToken('settingspage'), named: 'Learning'),
+      l10n.closeNamed('Learning'),
+    );
+  });
+
+  testWidgets('an unknown panel type falls back to the generic close', (
+    tester,
+  ) async {
+    await captureL10n(tester);
+    expect(closeButtonLabel(l10n, const PanelToken('mysterymeat')), l10n.close);
+  });
+}


### PR DESCRIPTION
## What

Close buttons across the world_v2 panels now carry a **panel-specific** accessible name (tooltip + screen-reader label) — "Close analytics", "Close vocabulary", "Close course", "Clear search", etc. — instead of a generic "Close". Multiple panels can be open at once, each with its own X; a bare "Close" was indistinguishable to assistive tech. The label is derived from the panel's `token.type` (the same identity the URL carries), via a small `closeButtonLabel()` helper.

Sites updated: left-panel close, right-panel close (incl. the settings-page title via `named:`), the map search-overlay clear button, and the activity loading-header close.

## Why

Closes #7274

Aligns with `accessibility.instructions.md` (§ naming contracts: every control says *what it does*) and `routing.instructions.md` (close label flows from the URL token type).

## Testing

- `flutter analyze` on all touched files — **clean** ("No issues found").
- `flutter test test/pangea/navigation/` — **green**, including new `close_button_labels_test.dart` (asserts every panel type gets a unique, non-generic close label; `named` override; unknown-type → generic fallback). The two pre-existing close-button widget tests still pass.
- String/label-only change — no logic or widget-structure change. Final screen-reader verification is the manual TO TEST on #7274 (distinct labels announced for coexisting close buttons).

## Deploy Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved close-button labels so they reflect the current panel or item, including named titles when available.
  * Centralized panel-specific close/tooltip text generation for better accessibility.
  * Updated clear search icon to use “clear search” wording.
* **Bug Fixes**
  * Activity-session close tooltips now use the correct, context-aware “close activity” label.
* **Tests**
  * Added regression tests to ensure panel-specific close labels are unique, correct for named titles, and fall back to the generic label when unknown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->