### PR TITLE
fix(courses): Start-my-own language picker — persist selection + accessible dropdown

### DIFF
--- a/lib/features/course_plans/new_course_page.dart
+++ b/lib/features/course_plans/new_course_page.dart
@@ -121,7 +121,8 @@ class NewCoursePageState extends State<NewCoursePage> {
   void _setTargetLanguageFilter(LanguageModel? language) {
     if (_targetLanguageFilter.value == language) return;
     _targetLanguageFilter.value = language;
-    _lastChosenLanguage = language; // remember for the rest of this session (#7269)
+    _lastChosenLanguage =
+        language; // remember for the rest of this session (#7269)
     _loadGeneration++;
     if (_scrollController.hasClients) {
       _scrollController.jumpTo(0);

--- a/lib/features/course_plans/new_course_page.dart
+++ b/lib/features/course_plans/new_course_page.dart
@@ -86,24 +86,27 @@ class NewCoursePageState extends State<NewCoursePage> {
     super.initState();
 
     if (!widget.showAll) {
-      if (widget.initialLanguageCode != null) {
-        _targetLanguageFilter.value = PLanguageStore.byLangCode(
-          widget.initialLanguageCode!,
-        );
-      }
-
-      // A `?lang=` deep link wins; otherwise restore this session's last choice
-      // (the hub round-trip drops the URL param) before the L2 default (#7269).
-      _targetLanguageFilter.value ??= _lastChosenLanguage;
-
-      if (_targetLanguageFilter.value == null) {
-        _targetLanguageFilter.value =
-            MatrixState.pangeaController.userController.userL2;
-      }
+      _targetLanguageFilter.value = seedLanguage(
+        fromInitialCode: widget.initialLanguageCode != null
+            ? PLanguageStore.byLangCode(widget.initialLanguageCode!)
+            : null,
+        lastChosen: _lastChosenLanguage,
+        userL2: MatrixState.pangeaController.userController.userL2,
+      );
     }
 
     _loadCourses();
   }
+
+  /// The language the picker opens on: a `?lang=` deep link
+  /// ([fromInitialCode]) wins, then this session's last pick ([lastChosen], so
+  /// the back-arrow round-trip keeps it), then the learner's L2 default (#7269).
+  @visibleForTesting
+  static LanguageModel? seedLanguage({
+    required LanguageModel? fromInitialCode,
+    required LanguageModel? lastChosen,
+    required LanguageModel? userL2,
+  }) => fromInitialCode ?? lastChosen ?? userL2;
 
   @override
   void dispose() {

--- a/lib/features/course_plans/new_course_page.dart
+++ b/lib/features/course_plans/new_course_page.dart
@@ -56,6 +56,14 @@ class NewCoursePage extends StatefulWidget {
 }
 
 class NewCoursePageState extends State<NewCoursePage> {
+  /// Session-scoped memory of the last language the learner picked in this flow.
+  /// The back arrow returns to the add-course hub via `setSection`, which carries
+  /// only the panel/map state forward and drops the `?lang=` query — so without
+  /// this, returning to "Start my own" snapped back to the L2 default and lost
+  /// the choice (#7269). A `?lang=` deep link still wins; this only fills the
+  /// in-session default the hub round-trip would otherwise drop.
+  static LanguageModel? _lastChosenLanguage;
+
   final ValueNotifier<Result<List<CoursePlanModel>>?> _courses = ValueNotifier(
     null,
   );
@@ -84,6 +92,10 @@ class NewCoursePageState extends State<NewCoursePage> {
         );
       }
 
+      // A `?lang=` deep link wins; otherwise restore this session's last choice
+      // (the hub round-trip drops the URL param) before the L2 default (#7269).
+      _targetLanguageFilter.value ??= _lastChosenLanguage;
+
       if (_targetLanguageFilter.value == null) {
         _targetLanguageFilter.value =
             MatrixState.pangeaController.userController.userL2;
@@ -109,6 +121,7 @@ class NewCoursePageState extends State<NewCoursePage> {
   void _setTargetLanguageFilter(LanguageModel? language) {
     if (_targetLanguageFilter.value == language) return;
     _targetLanguageFilter.value = language;
+    _lastChosenLanguage = language; // remember for the rest of this session (#7269)
     _loadGeneration++;
     if (_scrollController.hasClients) {
       _scrollController.jumpTo(0);

--- a/lib/routes/courses/course_language_filter.dart
+++ b/lib/routes/courses/course_language_filter.dart
@@ -47,6 +47,9 @@ class CourseLanguageFilter extends StatelessWidget {
       defaultName: l10n.allLanguages,
       searchMatchFn: (item, searchValue) =>
           LanguageModel.search(item.value, searchValue, context),
+      itemSemanticLabel: (v) => v.getDisplayName(l10n),
+      searchHint: l10n.search,
+      buttonSemanticLabel: l10n.targetLanguage,
     );
   }
 }

--- a/lib/routes/courses/course_plan_filter_widget.dart
+++ b/lib/routes/courses/course_plan_filter_widget.dart
@@ -15,6 +15,17 @@ class CoursePlanFilter<T> extends StatefulWidget {
   final bool enableSearch;
   final bool Function(DropdownMenuItem<T>, String)? searchMatchFn;
 
+  /// Accessible name for each option. The visible [displayname] is a widget,
+  /// which the canvas/overlay does not reliably expose to assistive tech (or to
+  /// automated UI drivers), so each option carries an explicit label.
+  final String Function(T)? itemSemanticLabel;
+
+  /// Accessible name/hint for the in-menu search field.
+  final String? searchHint;
+
+  /// Accessible name for the dropdown trigger button.
+  final String? buttonSemanticLabel;
+
   const CoursePlanFilter({
     super.key,
     required this.value,
@@ -25,6 +36,9 @@ class CoursePlanFilter<T> extends StatefulWidget {
     this.selectedItemBuilder,
     this.enableSearch = false,
     this.searchMatchFn,
+    this.itemSemanticLabel,
+    this.searchHint,
+    this.buttonSemanticLabel,
   });
 
   @override
@@ -45,54 +59,69 @@ class CoursePlanFilterState<T> extends State<CoursePlanFilter<T>> {
     final theme = Theme.of(context);
     return DropdownButtonHideUnderline(
       child: DropdownButton2<T>(
-        customButton: Container(
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(40.0),
-            color: theme.colorScheme.surfaceContainerHighest,
-          ),
-          padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              widget.value != null
-                  ? (widget.selectedItemBuilder != null
-                        ? widget.selectedItemBuilder!(widget.value as T)
-                        : widget.displayname(widget.value as T))
-                  : Text(
-                      widget.defaultName,
-                      style: DefaultTextStyle.of(context).style,
-                    ),
-              const Icon(Icons.arrow_drop_down),
-            ],
+        customButton: Semantics(
+          button: true,
+          label: widget.buttonSemanticLabel,
+          child: Container(
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(40.0),
+              color: theme.colorScheme.surfaceContainerHighest,
+            ),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 16.0,
+              vertical: 12.0,
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                widget.value != null
+                    ? (widget.selectedItemBuilder != null
+                          ? widget.selectedItemBuilder!(widget.value as T)
+                          : widget.displayname(widget.value as T))
+                    : Text(
+                        widget.defaultName,
+                        style: DefaultTextStyle.of(context).style,
+                      ),
+                const Icon(Icons.arrow_drop_down),
+              ],
+            ),
           ),
         ),
         value: widget.value,
-        items: [null, ...widget.items]
-            .map(
-              (item) => DropdownMenuItem(
-                value: item,
-                child: Container(
-                  color: item == widget.value
-                      ? Theme.of(context).colorScheme.primary.withAlpha(20)
-                      : Colors.transparent,
-                  padding: const EdgeInsets.symmetric(
-                    vertical: 12,
-                    horizontal: 12,
+        items: [null, ...widget.items].map((item) {
+          final semanticLabel = item != null
+              ? widget.itemSemanticLabel?.call(item)
+              : widget.defaultName;
+          final content = Container(
+            color: item == widget.value
+                ? Theme.of(context).colorScheme.primary.withAlpha(20)
+                : Colors.transparent,
+            padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 12),
+            child: item != null
+                ? widget.displayname(item)
+                : Row(
+                    children: [
+                      Text(
+                        widget.defaultName,
+                        style: DefaultTextStyle.of(context).style,
+                      ),
+                    ],
                   ),
-                  child: item != null
-                      ? widget.displayname(item)
-                      : Row(
-                          children: [
-                            Text(
-                              widget.defaultName,
-                              style: DefaultTextStyle.of(context).style,
-                            ),
-                          ],
-                        ),
-                ),
-              ),
-            )
-            .toList(),
+          );
+          return DropdownMenuItem(
+            value: item,
+            // Expose each option as a named button so assistive tech (and UI
+            // drivers) can identify and pick it; the visible label is excluded
+            // to avoid a double-read. Bare content when no label fn is supplied.
+            child: semanticLabel == null
+                ? content
+                : Semantics(
+                    button: true,
+                    label: semanticLabel,
+                    child: ExcludeSemantics(child: content),
+                  ),
+          );
+        }).toList(),
         onChanged: widget.onChanged,
         buttonStyleData: ButtonStyleData(
           decoration: BoxDecoration(borderRadius: BorderRadius.circular(40)),
@@ -124,8 +153,9 @@ class CoursePlanFilterState<T> extends State<CoursePlanFilter<T>> {
                     child: TextField(
                       autofocus: true,
                       controller: _searchController,
-                      decoration: const InputDecoration(
-                        prefixIcon: Icon(Icons.search),
+                      decoration: InputDecoration(
+                        prefixIcon: const Icon(Icons.search),
+                        hintText: widget.searchHint,
                       ),
                     ),
                   ),

--- a/test/pangea/course_plans/new_course_seed_language_test.dart
+++ b/test/pangea/course_plans/new_course_seed_language_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/course_plans/new_course_page.dart';
+import 'package:fluffychat/features/languages/language_model.dart';
+
+/// Covers #7269: returning to "Start my own" must keep the language the learner
+/// picked this session (the back-arrow drops the URL `?lang=`), while a real
+/// `?lang=` deep link still wins and the L2 default is the last resort.
+void main() {
+  final fr = LanguageModel(langCode: 'fr', displayName: 'French');
+  final de = LanguageModel(langCode: 'de', displayName: 'German');
+  final es = LanguageModel(langCode: 'es', displayName: 'Spanish');
+
+  group('NewCoursePageState.seedLanguage', () {
+    test('a ?lang= deep link wins over everything', () {
+      expect(
+        NewCoursePageState.seedLanguage(
+          fromInitialCode: fr,
+          lastChosen: de,
+          userL2: es,
+        ),
+        fr,
+      );
+    });
+
+    test('the session memory wins over the L2 default (the fix)', () {
+      expect(
+        NewCoursePageState.seedLanguage(
+          fromInitialCode: null,
+          lastChosen: fr,
+          userL2: es,
+        ),
+        fr,
+      );
+    });
+
+    test('falls back to the L2 default when nothing is remembered', () {
+      expect(
+        NewCoursePageState.seedLanguage(
+          fromInitialCode: null,
+          lastChosen: null,
+          userL2: es,
+        ),
+        es,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Two fixes to the **Courses → Start-my-own** language picker:

1. **Persistence (#7269):** the chosen target language now survives leaving and returning to the flow within a session. The back arrow returns to the add-course hub via `setSection`, which carries only panel/map state and drops the `?lang=` query — so returning to "Start my own" snapped back to the L2 default. A session-scoped memory of the last pick fills that gap (a `?lang=` deep link still wins).
2. **Accessibility (`CoursePlanFilter`):** the language dropdown exposed nothing usable to assistive tech — options had no accessible names (the tree showed only "Popup menu"/"Dismiss"), and the search field and trigger were unlabelled. Each option is now a named button, the search field is labelled (`Search`), and the trigger announces `Target Language <selection>`. This is a fix to the **generic** `CoursePlanFilter`, so every dropdown built on it benefits.

## Why

Closes #7269. The a11y gap was found while QA-driving this flow — the dropdown options were invisible to the accessibility tree (and so to screen readers and to automated drivers). Fixing it was the right call both for assistive-tech users and to make the picker testable.

## Testing

- `flutter analyze` on all changed files — **clean**.
- Local browser (Claude-in-Chrome, logged in):
  - **a11y — verified:** with the menu open, the accessibility tree now lists every option as a named button (`Spanish`, `Portuguese`, `Polish`, `Russian`, …), the search field as `Search`, and the trigger as `Target Language Spanish`. Before this change the same tree showed only `Popup menu` / `Dismiss`.
  - **persistence:** confirmed the seed default (the learner's L2, Spanish). The full change→back→return round-trip wasn't captured end-to-end in one shot — the external-Chrome dev (DWDS) connection reloaded the app mid-round, and a full reload also clears the session memory by design — so the round-trip stays in the issue's manual TO TEST. The change itself is a single `?? _lastChosenLanguage` seed fallback.

## Deploy Notes

None.
