### PR TITLE
fix: rebuild activity practice page on clear state

### DIFF
--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_page.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_page.dart
@@ -200,6 +200,7 @@ class AnalyticsPracticeState extends State<AnalyticsPractice>
     _sessionController.clear();
     AnalyticsPractice.bypassExitConfirmation = true;
     _clearExerciseState();
+    setState(() {});
   }
 
   void _clearExerciseState({bool loadingExercise = false}) {


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
