### PR TITLE
fix: remove title from construct details page headers

### DIFF
--- a/lib/routes/world/right_panel/workspace_right_panel.dart
+++ b/lib/routes/world/right_panel/workspace_right_panel.dart
@@ -124,7 +124,7 @@ class WorkspaceRightPanel extends StatelessWidget {
               );
       }(),
       'vocab' || 'grammar' => PanelCardWithHeader(
-        title: _construct?.lemma ?? '',
+        title: '',
         icon: leadingIcon,
         onLeading: onLeading,
         tooltip: leadingTooltip,


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
