### PR TITLE
Show stars in saved activity list

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -4950,5 +4950,24 @@
         }
     },
     "writeAndSpeakWorryFree": "Write and speak worry-free with Pangea Bot anytime, anywhere!",
+    "starRowLabel": "{filled} out of {total} stars have been completed",
+    "@starRowLabel": {
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "difficultyLabel": "Difficulty: {cefr}",
+    "@difficultyLabel": {
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
     "joinLearningCommunities": "Join international learning communities, or start your own!"
 }

--- a/lib/routes/analytics/activities/activity_archive.dart
+++ b/lib/routes/analytics/activities/activity_archive.dart
@@ -13,6 +13,7 @@ import 'package:fluffychat/features/analytics/saved_analytics_extension.dart';
 import 'package:fluffychat/features/analytics_data/analytics_init_error_indicator.dart';
 import 'package:fluffychat/features/instructions/instructions_enum.dart';
 import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dart';
+import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/analytics_navigation_util.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
 import 'package:fluffychat/widgets/activity_star_row.dart';
@@ -134,10 +135,12 @@ class AnalyticsActivityItem extends StatelessWidget {
               duration: FluffyThemes.animationDuration,
               curve: FluffyThemes.animationCurve,
               scale: hovered ? 1.1 : 1.0,
-              child: Avatar(
-                borderRadius: BorderRadius.circular(4.0),
-                mxContent: room.avatar,
-                name: room.getLocalizedDisplayname(),
+              child: ExcludeSemantics(
+                child: Avatar(
+                  borderRadius: BorderRadius.circular(4.0),
+                  mxContent: room.avatar,
+                  name: room.getLocalizedDisplayname(),
+                ),
               ),
             ),
           ),
@@ -153,14 +156,19 @@ class AnalyticsActivityItem extends StatelessWidget {
             iconSize: 22.0,
           ),
           trailing: cefrLevel != null
-              ? Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8,
-                    vertical: 4,
-                  ),
-                  child: Text(
-                    cefrLevel.toUpperCase(),
-                    style: const TextStyle(fontSize: 14.0),
+              ? Semantics(
+                  label: L10n.of(context).difficultyLabel(cefrLevel),
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
+                    child: ExcludeSemantics(
+                      child: Text(
+                        cefrLevel.toUpperCase(),
+                        style: const TextStyle(fontSize: 14.0),
+                      ),
+                    ),
                   ),
                 )
               : null,

--- a/lib/routes/analytics/activities/activity_archive.dart
+++ b/lib/routes/analytics/activities/activity_archive.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_summary_room_extension.dart';
 import 'package:fluffychat/features/analytics/client_analytics_extension.dart';
@@ -13,6 +14,8 @@ import 'package:fluffychat/features/analytics_data/analytics_init_error_indicato
 import 'package:fluffychat/features/instructions/instructions_enum.dart';
 import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dart';
 import 'package:fluffychat/routes/analytics/analytics_navigation_util.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
+import 'package:fluffychat/widgets/activity_star_row.dart';
 import 'package:fluffychat/widgets/analytics_summary/learning_progress_indicators.dart';
 import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
 import 'package:fluffychat/widgets/hover_builder.dart';
@@ -110,7 +113,7 @@ class AnalyticsActivityItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final activity = room.activityPlan;
     final title = activity?.title ?? '';
-    final objective = activity?.learningObjective ?? '';
+    final goals = room.ownRole?.allGoals;
 
     final cefrLevel = room.activitySummaryByL1?.summary?.participants
         .firstWhereOrNull((p) => p.participantId == room.client.userID)
@@ -139,19 +142,15 @@ class AnalyticsActivityItem extends StatelessWidget {
             ),
           ),
           title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
-          subtitle: Row(
-            crossAxisAlignment: .start,
-            mainAxisAlignment: .center,
-            children: [
-              Expanded(
-                child: Text(
-                  objective,
-                  style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-            ],
+          subtitle: ActivityStarRow(
+            total: goals!.length,
+            earned:
+                room
+                    .orchestratorAwardedGoals
+                    .awards[room.ownRoleState?.id]
+                    ?.length ??
+                0,
+            iconSize: 22.0,
           ),
           trailing: cefrLevel != null
               ? Padding(

--- a/lib/routes/analytics/activities/activity_archive.dart
+++ b/lib/routes/analytics/activities/activity_archive.dart
@@ -145,16 +145,18 @@ class AnalyticsActivityItem extends StatelessWidget {
             ),
           ),
           title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
-          subtitle: ActivityStarRow(
-            total: goals!.length,
-            earned:
-                room
-                    .orchestratorAwardedGoals
-                    .awards[room.ownRoleState?.id]
-                    ?.length ??
-                0,
-            iconSize: 22.0,
-          ),
+          subtitle: goals != null
+              ? ActivityStarRow(
+                  total: goals.length,
+                  earned:
+                      room
+                          .orchestratorAwardedGoals
+                          .awards[room.ownRoleState?.id]
+                          ?.length ??
+                      0,
+                  iconSize: 22.0,
+                )
+              : null,
           trailing: cefrLevel != null
               ? Semantics(
                   label: L10n.of(context).difficultyLabel(cefrLevel),

--- a/lib/widgets/activity_star_row.dart
+++ b/lib/widgets/activity_star_row.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/l10n/l10n.dart';
 
 class ActivityStarRow extends StatelessWidget {
   final int total;
@@ -30,15 +31,18 @@ class ActivityStarRow extends StatelessWidget {
         ],
       );
     }
-    return Wrap(
-      spacing: 2.0,
-      runSpacing: 2.0,
-      children: List.generate(
-        total,
-        (i) => Icon(
-          i < filled ? Icons.star : Icons.star_border,
-          size: iconSize,
-          color: i < filled ? AppConfig.gold : AppConfig.grayText,
+    return Semantics(
+      label: L10n.of(context).starRowLabel(filled, total),
+      child: Wrap(
+        spacing: 2.0,
+        runSpacing: 2.0,
+        children: List.generate(
+          total,
+          (i) => Icon(
+            i < filled ? Icons.star : Icons.star_border,
+            size: iconSize,
+            color: i < filled ? AppConfig.gold : AppConfig.grayText,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [x] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity lists now show a star-based progress/goal indicator instead of the previous text-only summary.
  * Added localized labels for star counts and difficulty levels to support more languages.
* **Accessibility**
  * Improved screen reader support for activity star ratings and difficulty text.
  * Some decorative elements are now hidden from assistive technologies for clearer announcements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->