### PR TITLE
fix: when activity dropdown is expanded, don't restrict number of lin…

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_goals_dropdown.dart
+++ b/lib/routes/chat/activity_sessions/activity_goals_dropdown.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/goal_status_widget.dart';
+
+class ActivityGoalsDropdown extends StatefulWidget {
+  final List<ActivityRoleGoal>? goals;
+  final Set<String> completedGoalIds;
+  final bool startCollapsed;
+
+  const ActivityGoalsDropdown({
+    super.key,
+    required this.goals,
+    required this.completedGoalIds,
+    this.startCollapsed = false,
+  });
+
+  @override
+  State<ActivityGoalsDropdown> createState() => _ActivityGoalsDropdownState();
+}
+
+class _ActivityGoalsDropdownState extends State<ActivityGoalsDropdown> {
+  bool _visible = false;
+  bool _innerExpanded = true;
+  List<ActivityRoleGoal>? _displayGoals;
+
+  @override
+  void initState() {
+    super.initState();
+    _displayGoals = widget.goals;
+    _visible = widget.goals != null && widget.goals!.isNotEmpty;
+    _innerExpanded = !widget.startCollapsed;
+  }
+
+  @override
+  void didUpdateWidget(covariant ActivityGoalsDropdown old) {
+    super.didUpdateWidget(old);
+    if (old.goals != widget.goals) {
+      final hasGoals = widget.goals != null && widget.goals!.isNotEmpty;
+      if (hasGoals) {
+        setState(() {
+          _displayGoals = widget.goals;
+          _visible = true;
+          _innerExpanded = true;
+        });
+      } else {
+        setState(() => _visible = false);
+        Future.delayed(FluffyThemes.animationDuration, () {
+          if (mounted) setState(() => _displayGoals = null);
+        });
+      }
+    }
+  }
+
+  void _toggleVisiblity() => setState(() => _innerExpanded = !_innerExpanded);
+
+  @override
+  Widget build(BuildContext context) {
+    final goals = _displayGoals ?? [];
+    final theme = Theme.of(context);
+    final visible = goals.isNotEmpty ? goals.first : null;
+    final remainingGoals = goals.length > 1
+        ? goals.skip(1).toList()
+        : <ActivityRoleGoal>[];
+
+    return ClipRect(
+      child: AnimatedAlign(
+        duration: FluffyThemes.animationDuration,
+        curve: Curves.easeInOut,
+        heightFactor: _visible ? 1.0 : 0.0,
+        alignment: Alignment.topCenter,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (visible != null)
+              InkWell(
+                onTap: _toggleVisiblity,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 12.0),
+                  height: 55.0,
+                  decoration: BoxDecoration(
+                    border: Border(top: BorderSide(color: theme.dividerColor)),
+                    color: theme.colorScheme.surface,
+                  ),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: GoalStatusWidget(
+                          goal: visible,
+                          complete: widget.completedGoalIds.contains(
+                            visible.id,
+                          ),
+                          maxLines: _innerExpanded ? null : 2,
+                        ),
+                      ),
+                      if (remainingGoals.isNotEmpty)
+                        Icon(
+                          _innerExpanded
+                              ? Icons.expand_less
+                              : Icons.expand_more,
+                        ),
+                    ],
+                  ),
+                ),
+              ),
+            if (remainingGoals.isNotEmpty)
+              ClipRect(
+                child: AnimatedAlign(
+                  duration: FluffyThemes.animationDuration,
+                  curve: Curves.easeInOut,
+                  heightFactor: _innerExpanded ? 1.0 : 0.0,
+                  alignment: Alignment.topCenter,
+                  child: GestureDetector(
+                    onPanUpdate: (d) {
+                      if (d.delta.dy < -2) {
+                        setState(() => _innerExpanded = false);
+                      }
+                    },
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        final maxHeight =
+                            MediaQuery.of(context).size.height * 0.7;
+                        return ConstrainedBox(
+                          constraints: BoxConstraints(maxHeight: maxHeight),
+                          child: SingleChildScrollView(
+                            child: Container(
+                              width: double.infinity,
+                              color: theme.colorScheme.surface,
+                              padding: const EdgeInsets.fromLTRB(
+                                12.0,
+                                12.0,
+                                12.0,
+                                24.0,
+                              ),
+                              child: Column(
+                                spacing: 16.0,
+                                mainAxisSize: MainAxisSize.min,
+                                children: remainingGoals
+                                    .map(
+                                      (g) => GoalStatusWidget(
+                                        goal: g,
+                                        complete: widget.completedGoalIds
+                                            .contains(g.id),
+                                      ),
+                                    )
+                                    .toList(),
+                              ),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:fluffychat/config/themes.dart';
-import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
@@ -12,13 +11,13 @@ import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/navigation/workspace_query.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/widgets/error_indicator.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_goals_dropdown.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_participant_list.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_bottom_content.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_button_widget.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_vocab_widget.dart';
-import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/goal_status_widget.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/url_image_widget.dart';
@@ -280,7 +279,7 @@ class ActivitySessionStartView extends StatelessWidget {
                                     top: 0,
                                     left: 0,
                                     right: 0,
-                                    child: _ActivityGoalsDropdown(
+                                    child: ActivityGoalsDropdown(
                                       goals:
                                           sessionController.selectedRoleGoals,
                                       completedGoalIds: sessionController
@@ -351,161 +350,6 @@ class ActivitySessionStartView extends StatelessWidget {
           ),
         );
       },
-    );
-  }
-}
-
-class _ActivityGoalsDropdown extends StatefulWidget {
-  final List<ActivityRoleGoal>? goals;
-  final Set<String> completedGoalIds;
-  final bool startCollapsed;
-
-  const _ActivityGoalsDropdown({
-    required this.goals,
-    required this.completedGoalIds,
-    this.startCollapsed = false,
-  });
-
-  @override
-  State<_ActivityGoalsDropdown> createState() => _ActivityGoalsDropdownState();
-}
-
-class _ActivityGoalsDropdownState extends State<_ActivityGoalsDropdown> {
-  bool _visible = false;
-  bool _innerExpanded = true;
-  List<ActivityRoleGoal>? _displayGoals;
-
-  @override
-  void initState() {
-    super.initState();
-    _displayGoals = widget.goals;
-    _visible = widget.goals != null && widget.goals!.isNotEmpty;
-    _innerExpanded = !widget.startCollapsed;
-  }
-
-  @override
-  void didUpdateWidget(covariant _ActivityGoalsDropdown old) {
-    super.didUpdateWidget(old);
-    if (old.goals != widget.goals) {
-      final hasGoals = widget.goals != null && widget.goals!.isNotEmpty;
-      if (hasGoals) {
-        setState(() {
-          _displayGoals = widget.goals;
-          _visible = true;
-          _innerExpanded = true;
-        });
-      } else {
-        setState(() => _visible = false);
-        Future.delayed(FluffyThemes.animationDuration, () {
-          if (mounted) setState(() => _displayGoals = null);
-        });
-      }
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final goals = _displayGoals ?? [];
-    final theme = Theme.of(context);
-    final firstGoal = goals.isNotEmpty ? goals.first : null;
-    final remainingGoals = goals.length > 1
-        ? goals.skip(1).toList()
-        : <ActivityRoleGoal>[];
-
-    return ClipRect(
-      child: AnimatedAlign(
-        duration: FluffyThemes.animationDuration,
-        curve: Curves.easeInOut,
-        heightFactor: _visible ? 1.0 : 0.0,
-        alignment: Alignment.topCenter,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (firstGoal != null)
-              InkWell(
-                onTap: remainingGoals.isNotEmpty
-                    ? () => setState(() => _innerExpanded = !_innerExpanded)
-                    : null,
-                child: Container(
-                  height: 55.0,
-                  padding: const EdgeInsets.symmetric(horizontal: 12.0),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.surface,
-                    border: Border(top: BorderSide(color: theme.dividerColor)),
-                  ),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: GoalStatusWidget(
-                          goal: firstGoal,
-                          complete: widget.completedGoalIds.contains(
-                            firstGoal.id,
-                          ),
-                        ),
-                      ),
-                      if (remainingGoals.isNotEmpty)
-                        Icon(
-                          _innerExpanded
-                              ? Icons.expand_less
-                              : Icons.expand_more,
-                        ),
-                    ],
-                  ),
-                ),
-              ),
-            if (remainingGoals.isNotEmpty)
-              ClipRect(
-                child: AnimatedAlign(
-                  duration: FluffyThemes.animationDuration,
-                  curve: Curves.easeInOut,
-                  heightFactor: _innerExpanded ? 1.0 : 0.0,
-                  alignment: Alignment.topCenter,
-                  child: GestureDetector(
-                    onPanUpdate: (d) {
-                      if (d.delta.dy < -2) {
-                        setState(() => _innerExpanded = false);
-                      }
-                    },
-                    child: LayoutBuilder(
-                      builder: (context, constraints) {
-                        final maxHeight =
-                            MediaQuery.of(context).size.height * 0.7;
-                        return ConstrainedBox(
-                          constraints: BoxConstraints(maxHeight: maxHeight),
-                          child: SingleChildScrollView(
-                            child: Container(
-                              width: double.infinity,
-                              color: theme.colorScheme.surface,
-                              padding: const EdgeInsets.fromLTRB(
-                                12.0,
-                                12.0,
-                                12.0,
-                                24.0,
-                              ),
-                              child: Column(
-                                spacing: 16.0,
-                                mainAxisSize: MainAxisSize.min,
-                                children: remainingGoals
-                                    .map(
-                                      (g) => GoalStatusWidget(
-                                        goal: g,
-                                        complete: widget.completedGoalIds
-                                            .contains(g.id),
-                                      ),
-                                    )
-                                    .toList(),
-                              ),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-                ),
-              ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/lib/routes/chat/activity_sessions/activity_stats_menu.dart
+++ b/lib/routes/chat/activity_sessions/activity_stats_menu.dart
@@ -183,6 +183,7 @@ class ActivityStatsMenu extends StatelessWidget {
                                           ActivitySessionConstants.goalMenuStarTargetId(
                                             visibleGoal.id,
                                           ),
+                                      maxLines: showDropdown ? null : 2,
                                     ),
                                   ),
                                   if (_showDoneButtonHint && !showDropdown)

--- a/lib/routes/chat/activity_sessions/activity_summary_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_summary_widget.dart
@@ -9,10 +9,10 @@ import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_role_model.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_goals_dropdown.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_media_carousel.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_participant_list.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_vocab_widget.dart';
-import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/goal_status_widget.dart';
 
 class ActivitySummary extends StatelessWidget {
   final ActivityPlanModel activity;
@@ -153,165 +153,6 @@ class ActivitySummary extends StatelessWidget {
                       usedVocab: usedVocab,
                     ),
                   ],
-                ),
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class ActivityGoalsDropdown extends StatefulWidget {
-  final List<ActivityRoleGoal>? goals;
-  final Set<String> completedGoalIds;
-  final bool startCollapsed;
-
-  const ActivityGoalsDropdown({
-    super.key,
-    required this.goals,
-    required this.completedGoalIds,
-    this.startCollapsed = false,
-  });
-
-  @override
-  State<ActivityGoalsDropdown> createState() => _ActivityGoalsDropdownState();
-}
-
-class _ActivityGoalsDropdownState extends State<ActivityGoalsDropdown> {
-  bool _visible = false;
-  bool _innerExpanded = true;
-  List<ActivityRoleGoal>? _displayGoals;
-
-  @override
-  void initState() {
-    super.initState();
-    _displayGoals = widget.goals;
-    _visible = widget.goals != null && widget.goals!.isNotEmpty;
-    _innerExpanded = !widget.startCollapsed;
-  }
-
-  @override
-  void didUpdateWidget(covariant ActivityGoalsDropdown old) {
-    super.didUpdateWidget(old);
-    if (old.goals != widget.goals) {
-      final hasGoals = widget.goals != null && widget.goals!.isNotEmpty;
-      if (hasGoals) {
-        setState(() {
-          _displayGoals = widget.goals;
-          _visible = true;
-          _innerExpanded = true;
-        });
-      } else {
-        setState(() => _visible = false);
-        Future.delayed(FluffyThemes.animationDuration, () {
-          if (mounted) setState(() => _displayGoals = null);
-        });
-      }
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final goals = _displayGoals ?? [];
-    final theme = Theme.of(context);
-    final firstGoal = goals.isNotEmpty ? goals.first : null;
-    final remainingGoals = goals.length > 1
-        ? goals.skip(1).toList()
-        : <ActivityRoleGoal>[];
-
-    return ClipRect(
-      child: AnimatedAlign(
-        duration: FluffyThemes.animationDuration,
-        curve: Curves.easeInOut,
-        heightFactor: _visible ? 1.0 : 0.0,
-        alignment: Alignment.topCenter,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (firstGoal != null)
-              InkWell(
-                onTap: remainingGoals.isNotEmpty
-                    ? () => setState(() => _innerExpanded = !_innerExpanded)
-                    : null,
-                child: Container(
-                  height: 55.0,
-                  padding: const EdgeInsets.symmetric(horizontal: 12.0),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.surface,
-                    border: Border(top: BorderSide(color: theme.dividerColor)),
-                  ),
-                  child: Row(
-                    children: [
-                      Expanded(
-                        child: GoalStatusWidget(
-                          goal: firstGoal,
-                          complete: widget.completedGoalIds.contains(
-                            firstGoal.id,
-                          ),
-                        ),
-                      ),
-                      if (remainingGoals.isNotEmpty)
-                        Icon(
-                          _innerExpanded
-                              ? Icons.expand_less
-                              : Icons.expand_more,
-                        ),
-                    ],
-                  ),
-                ),
-              ),
-            if (remainingGoals.isNotEmpty)
-              ClipRect(
-                child: AnimatedAlign(
-                  duration: FluffyThemes.animationDuration,
-                  curve: Curves.easeInOut,
-                  heightFactor: _innerExpanded ? 1.0 : 0.0,
-                  alignment: Alignment.topCenter,
-                  child: GestureDetector(
-                    onPanUpdate: (d) {
-                      if (d.delta.dy < -2) {
-                        setState(() => _innerExpanded = false);
-                      }
-                    },
-                    child: LayoutBuilder(
-                      builder: (context, constraints) {
-                        final maxHeight =
-                            MediaQuery.of(context).size.height * 0.7;
-                        return ConstrainedBox(
-                          constraints: BoxConstraints(maxHeight: maxHeight),
-                          child: SingleChildScrollView(
-                            child: Container(
-                              width: double.infinity,
-                              color: theme.colorScheme.surface,
-                              padding: const EdgeInsets.fromLTRB(
-                                12.0,
-                                12.0,
-                                12.0,
-                                24.0,
-                              ),
-                              child: Column(
-                                spacing: 16.0,
-                                mainAxisSize: MainAxisSize.min,
-                                children: remainingGoals
-                                    .map(
-                                      (g) => SizedBox(
-                                        height: 55.0,
-                                        child: GoalStatusWidget(
-                                          goal: g,
-                                          complete: widget.completedGoalIds
-                                              .contains(g.id),
-                                        ),
-                                      ),
-                                    )
-                                    .toList(),
-                              ),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-                  ),
                 ),
               ),
           ],

--- a/lib/routes/chat/choreographer/activity_orchestrator/goal_status_widget.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/goal_status_widget.dart
@@ -8,11 +8,13 @@ class GoalStatusWidget extends StatelessWidget {
   final ActivityRoleGoal goal;
   final bool complete;
   final String? starTarget;
+  final int? maxLines;
 
   const GoalStatusWidget({
     required this.goal,
     required this.complete,
     this.starTarget,
+    this.maxLines,
     super.key,
   });
 
@@ -48,8 +50,8 @@ class GoalStatusWidget extends StatelessWidget {
         Flexible(
           child: Text(
             goal.description,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
+            maxLines: maxLines,
+            overflow: maxLines != null ? TextOverflow.ellipsis : null,
             style: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
           ),
         ),


### PR DESCRIPTION
…es for goal indicators

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible activity goals list in chat and activity session views, with smoother expand/collapse behavior and swipe-to-collapse support.
  * Goals now display more naturally in compact and expanded states, including better handling of longer text.

* **Bug Fixes**
  * Improved goal visibility updates when the available goals list changes.
  * Empty goal sections now hide immediately for a cleaner experience.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->