### PR TITLE
fix(world-map): activity-card affordances — dismiss X + pin tail

### DIFF
--- a/lib/routes/world/world_map_large_card.dart
+++ b/lib/routes/world/world_map_large_card.dart
@@ -211,7 +211,11 @@ class WorldMapLargeCard extends StatelessWidget {
       clipBehavior: Clip.none,
       children: [
         cardWithTail,
-        Positioned(top: 2, right: 2, child: _DismissButton(onPressed: onClose!)),
+        Positioned(
+          top: 2,
+          right: 2,
+          child: _DismissButton(onPressed: onClose!),
+        ),
       ],
     );
   }

--- a/lib/routes/world/world_map_large_card.dart
+++ b/lib/routes/world/world_map_large_card.dart
@@ -23,6 +23,11 @@ typedef LargeCardParticipant = ({Uri? avatar, String name});
 /// The full [plan] carries the image and goal total - null while it hydrates
 /// Tapping the card opens the activity's plan page.
 class WorldMapLargeCard extends StatelessWidget {
+  /// Height of the downward caret that tethers the card to its pin. The marker
+  /// reserves this beneath the card so the tail isn't clipped (#7153).
+  static const double tailHeight = 11.0;
+  static const double _tailWidth = 22.0;
+
   final QuestActivityCard card;
   final ActivityPinState state;
   final bool pinged;
@@ -175,7 +180,29 @@ class WorldMapLargeCard extends StatelessWidget {
       ),
     );
 
-    if (onClose == null) return cardButton;
+    // A downward caret tethers the card to its pin: the card floats just above
+    // the dot and the tail points back to it. Same surface fill as the card,
+    // with the accent border continued down its two edges and overlapping the
+    // card's bottom border so the two read as one speech-bubble shape (#7153,
+    // world-map Figma).
+    final cardWithTail = Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        cardButton,
+        Transform.translate(
+          offset: const Offset(0, -1.5),
+          child: CustomPaint(
+            size: const Size(_tailWidth, tailHeight),
+            painter: _CaretPainter(
+              fill: Theme.of(context).colorScheme.surface,
+              edge: state.accent,
+            ),
+          ),
+        ),
+      ],
+    );
+
+    if (onClose == null) return cardWithTail;
 
     // The dismiss sits at the card's top-right corner. The Stack keeps it out of
     // the card's own tap target so tapping the X clears the peek (onClose) rather
@@ -183,7 +210,7 @@ class WorldMapLargeCard extends StatelessWidget {
     return Stack(
       clipBehavior: Clip.none,
       children: [
-        cardButton,
+        cardWithTail,
         Positioned(top: 2, right: 2, child: _DismissButton(onPressed: onClose!)),
       ],
     );
@@ -216,6 +243,45 @@ class _DismissButton extends StatelessWidget {
       ),
     );
   }
+}
+
+/// A downward speech-bubble tail: a [fill]-filled triangle whose two upper edges
+/// are stroked in [edge] (the card's accent border), with the top (base) left
+/// open so it merges into the card's bottom border above it.
+class _CaretPainter extends CustomPainter {
+  final Color fill;
+  final Color edge;
+
+  const _CaretPainter({required this.fill, required this.edge});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final w = size.width;
+    final h = size.height;
+    final triangle = Path()
+      ..moveTo(0, 0)
+      ..lineTo(w, 0)
+      ..lineTo(w / 2, h)
+      ..close();
+    canvas.drawPath(triangle, Paint()..color = fill);
+
+    // Stroke only the two diagonals; the base connects to the card border above.
+    canvas.drawPath(
+      Path()
+        ..moveTo(0, 0)
+        ..lineTo(w / 2, h)
+        ..moveTo(w, 0)
+        ..lineTo(w / 2, h),
+      Paint()
+        ..color = edge
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2
+        ..strokeJoin = StrokeJoin.round,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_CaretPainter old) => old.fill != fill || old.edge != edge;
 }
 
 class _Header extends StatelessWidget {

--- a/lib/routes/world/world_map_large_card.dart
+++ b/lib/routes/world/world_map_large_card.dart
@@ -32,6 +32,13 @@ class WorldMapLargeCard extends StatelessWidget {
   final int openSlots;
   final VoidCallback onTap;
 
+  /// When non-null, the card shows an explicit dismiss (X) that returns it to a
+  /// pin without opening it. Set only on the **selected** (tap-peek) card — a
+  /// card stacked over another can otherwise only be cleared by tapping empty
+  /// map, which isn't discoverable (#7207). Auto-featured cards leave it null
+  /// (they re-rank and clear on pan/zoom).
+  final VoidCallback? onClose;
+
   const WorldMapLargeCard({
     super.key,
     required this.card,
@@ -40,6 +47,7 @@ class WorldMapLargeCard extends StatelessWidget {
     required this.plan,
     required this.starsEarned,
     required this.onTap,
+    this.onClose,
     this.participants = const [],
     this.openSlots = 0,
   });
@@ -74,7 +82,7 @@ class WorldMapLargeCard extends StatelessWidget {
 
     final earned = starsEarned.clamp(0, total);
 
-    return GestureDetector(
+    final cardButton = GestureDetector(
       onTap: onTap,
       // #Pangea: announce the card as a single "Activity: <title>" button so the
       // screen reader gets context and the title is not double-read (#7185).
@@ -162,6 +170,47 @@ class WorldMapLargeCard extends StatelessWidget {
                   ),
               ],
             ),
+          ),
+        ),
+      ),
+    );
+
+    if (onClose == null) return cardButton;
+
+    // The dismiss sits at the card's top-right corner. The Stack keeps it out of
+    // the card's own tap target so tapping the X clears the peek (onClose) rather
+    // than opening the activity (onTap).
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        cardButton,
+        Positioned(top: 2, right: 2, child: _DismissButton(onPressed: onClose!)),
+      ],
+    );
+  }
+}
+
+class _DismissButton extends StatelessWidget {
+  final VoidCallback onPressed;
+
+  const _DismissButton({required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      button: true,
+      label: L10n.of(context).close,
+      child: Material(
+        color: theme.colorScheme.surface,
+        shape: const CircleBorder(),
+        elevation: 2,
+        child: InkWell(
+          customBorder: const CircleBorder(),
+          onTap: onPressed,
+          child: const Padding(
+            padding: EdgeInsets.all(2.0),
+            child: Icon(Icons.close, size: 16),
           ),
         ),
       ),

--- a/lib/routes/world/world_map_large_card.dart
+++ b/lib/routes/world/world_map_large_card.dart
@@ -420,12 +420,17 @@ class _TypeChip extends StatelessWidget {
         children: [
           Icon(icon, size: 12, color: fg),
           const SizedBox(width: 4),
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 11,
-              color: fg,
-              fontWeight: FontWeight.w600,
+          // Ellipsize rather than overflow when the type label is wider than the
+          // card's chip slot (long-translation locales; #7153/#7207 card work).
+          Flexible(
+            child: Text(
+              label,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                fontSize: 11,
+                color: fg,
+                fontWeight: FontWeight.w600,
+              ),
             ),
           ),
         ],

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -428,10 +428,13 @@ class _WorldMapViewState extends State<WorldMapView> {
       // different height: locked has no star row, completed adds an action row,
       // joinable adds the avatar row). Height here is only a ceiling so the
       // tallest variant isn't clipped; shorter cards don't stretch to fill it.
-      height: tier.dotHeight(state),
+      // The extra tailHeight reserves room beneath the card for the pin tail.
+      height: tier.dotHeight(state) + WorldMapLargeCard.tailHeight,
       alignment: Alignment.topCenter,
       child: Align(
-        alignment: Alignment.topCenter,
+        // Bottom-align so the card+tail hugs its pin (the tail tip lands on the
+        // dot) instead of floating with a gap above it (#7153).
+        alignment: Alignment.bottomCenter,
         child: WorldMapLargeCard(
           card: card,
           state: state,

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -442,6 +442,11 @@ class _WorldMapViewState extends State<WorldMapView> {
           participants: joinableActivity?.largeCardParticipants ?? [],
           openSlots: joinableActivity?.numRemainingRoles ?? 0,
           onTap: () => widget.controller.openActivity(card),
+          // Only the tap-selected card gets the explicit dismiss; auto-featured
+          // cards re-rank and clear on pan/zoom (#7207).
+          onClose: card.activityId == widget.controller.selectedActivityId
+              ? () => widget.controller.deselectActivity()
+              : null,
         ),
       ),
     );

--- a/test/pangea/world/world_map_large_card_test.dart
+++ b/test/pangea/world/world_map_large_card_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/world_map_large_card.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+
+/// Covers #7207: the tap-selected card gets a dismiss X that returns it to a
+/// pin **without** opening the activity; auto-featured cards get none.
+void main() {
+  const card = QuestActivityCard(
+    activityId: 'a1',
+    title: 'Test Activity',
+    l2: 'es',
+    coordinates: [0, 0],
+    learningObjectiveRefs: [],
+  );
+
+  Future<void> pumpCard(
+    WidgetTester tester, {
+    VoidCallback? onClose,
+    VoidCallback? onTap,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: Center(
+            child: WorldMapLargeCard(
+              card: card,
+              state: ActivityPinState.unlocked,
+              pinged: false,
+              plan: null,
+              starsEarned: 0,
+              onTap: onTap ?? () {},
+              onClose: onClose,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets(
+    'a selected card shows a dismiss X that fires onClose, not onTap',
+    (tester) async {
+      var closed = false;
+      var opened = false;
+      await pumpCard(
+        tester,
+        onClose: () => closed = true,
+        onTap: () => opened = true,
+      );
+
+      final x = find.byIcon(Icons.close);
+      expect(x, findsOneWidget);
+
+      await tester.tap(x);
+      await tester.pumpAndSettle();
+      expect(closed, isTrue, reason: 'the X dismisses the card (onClose)');
+      expect(
+        opened,
+        isFalse,
+        reason: 'the X must not open the activity (onTap stays unfired)',
+      );
+    },
+  );
+
+  testWidgets('an auto-featured card (no onClose) shows no dismiss X', (
+    tester,
+  ) async {
+    await pumpCard(tester, onClose: null);
+    expect(find.byIcon(Icons.close), findsNothing);
+  });
+}


### PR DESCRIPTION
## What

Two affordances for the world-map activity card (`WorldMapLargeCard`):

1. **Dismiss X (#7207):** the tap-**selected** card gets an explicit X (top-right) that returns it to a pin without opening the activity. Only the selected (tap-peek) card shows it — auto-featured cards re-rank and clear on pan/zoom on their own.
2. **Pin tail (#7153):** every large card now grows a downward speech-bubble **tail** from its bottom-center that points back to its pin, and the card is bottom-anchored so the tail tip lands on the dot (previously the card floated with a gap above it, feeling disconnected). The tail is the card's surface fill with the accent border continued down its two edges, matching the [world-map Figma](https://www.figma.com/design/n2qX4WsnVhYqT2KV6pMVbl/Everything-outside-of-Chat?node-id=12912-348899).

## Why

Closes #7207. Closes #7153.

## Testing

- `flutter analyze` on the changed files — **clean**.
- Local browser (Claude-in-Chrome, logged in), verified visually:
  - **#7207:** tapped a dot → it promoted to a selected card with the X; featured cards showed none; clicking the X collapsed the card back to its dot and **did not** open the activity.
  - **#7153:** featured *and* selected cards render the tail (surface fill, accent edges) pointing down to the pin; the tail tip lands on the clicked dot (gap closed); the X and tail coexist on a selected card.

## Deploy Notes

None.
