### PR TITLE
feat: add onboarding steps

### DIFF
--- a/lib/features/tutorials/tutorial_overlay_controller.dart
+++ b/lib/features/tutorials/tutorial_overlay_controller.dart
@@ -348,7 +348,7 @@ class TutorialOverlayController {
     final previousStepIndex = _state.model.stepIndex;
 
     previousType?.saveProgress(previousStepIndex + 1);
-    GoogleAnalytics.completeTutorialStep(previousType!, previousStepIndex);
+    GoogleAnalytics.completeTutorialStep(previousType!.name, previousStepIndex);
 
     _state.dispatch(ForwardTutorialEvent());
     final updatedType = _state.tutorialType;

--- a/lib/pangea/common/utils/firebase_analytics.dart
+++ b/lib/pangea/common/utils/firebase_analytics.dart
@@ -7,7 +7,6 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 import 'package:fluffychat/features/bot/bot_target_event_name_enum.dart';
 import 'package:fluffychat/features/subscription/models/subscription_details.dart';
-import 'package:fluffychat/features/tutorials/tutorial_enum.dart';
 import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/constants/model_keys.dart';
 import 'package:fluffychat/routes/chat/toolbar/reading_assistance/select_mode_buttons.dart';
@@ -280,10 +279,10 @@ class GoogleAnalytics {
     );
   }
 
-  static void completeTutorialStep(TutorialEnum type, int step) {
+  static void completeTutorialStep(String tutorialName, int step) {
     logEvent(
       'tutorial_progress',
-      parameters: {'tutorial_name': type.name, 'tutorial_step': step},
+      parameters: {'tutorial_name': tutorialName, 'tutorial_step': step},
     );
   }
 

--- a/lib/routes/onboarding/onboarding_navigation_controller.dart
+++ b/lib/routes/onboarding/onboarding_navigation_controller.dart
@@ -14,6 +14,8 @@ class OnboardingNavigationController {
 
   int _currentStepIndex = 1;
 
+  int get currentStepIndex => _currentStepIndex;
+
   final Queue<OnboardingStep> _prevSteps = Queue();
 
   OnboardingStep get step => _currentStep;

--- a/lib/routes/onboarding/onboarding_page.dart
+++ b/lib/routes/onboarding/onboarding_page.dart
@@ -12,6 +12,7 @@ import 'package:fluffychat/routes/onboarding/onboarding_state_controller.dart';
 import 'package:fluffychat/routes/onboarding/onboarding_step_views/onboarding_step_view.dart';
 import 'package:fluffychat/routes/onboarding/onboarding_steps/onboarding_step.dart';
 import 'package:fluffychat/routes/onboarding/onboarding_steps/profile_setup_onboarding_step.dart';
+import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
 import 'package:fluffychat/routes/onboarding/trial_info_provider.dart';
 import 'package:fluffychat/widgets/animated_progress_bar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -78,6 +79,7 @@ class OnboardingController extends State<Onboarding> {
       );
 
   Future<void> _forward() async {
+    GoogleAnalytics.completeTutorialStep('onboarding', _navigation.currentStepIndex);
     _loading.value = true;
     _dispatchNavigationResult(await _navigation.forward());
   }

--- a/lib/routes/onboarding/onboarding_page.dart
+++ b/lib/routes/onboarding/onboarding_page.dart
@@ -79,7 +79,10 @@ class OnboardingController extends State<Onboarding> {
       );
 
   Future<void> _forward() async {
-    GoogleAnalytics.completeTutorialStep('onboarding', _navigation.currentStepIndex);
+    GoogleAnalytics.completeTutorialStep(
+      'onboarding',
+      _navigation.currentStepIndex,
+    );
     _loading.value = true;
     _dispatchNavigationResult(await _navigation.forward());
   }


### PR DESCRIPTION
Adds steps for the onboarding flow.
This changes the GA call from enum to string for the tutorial name.

Partially addresses https://github.com/pangeachat/business/issues/80

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved onboarding and tutorial progress tracking so completed steps are recorded more consistently.

* **Bug Fixes**
  * Fixed step completion reporting to use the correct tutorial name, helping analytics and progress events stay accurate.
  * Added support for reading the current onboarding step, enabling smoother navigation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->