### PR TITLE
Publish self-destroying service worker to evict stale clients

### DIFF
--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -55,6 +55,12 @@ jobs:
           VERSION=${GITHUB_SHA::8}
           sed -i "s|__BUILD_VERSION__|$VERSION|g" build/web/index.html
         
+      - name: Publish self-unregistering service worker
+        # Overwrites Flutter's empty (--pwa-strategy=none) flutter_service_worker.js
+        # so browsers still holding the old offline-first worker evict it. Inert for
+        # fresh visitors, who never register a service worker. See the script header.
+        run: cp scripts/self_destroying_service_worker.js build/web/flutter_service_worker.js
+
       - name: Upload files
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,11 @@ jobs:
       # bundled asset, so the build output needs an explicit copy.
       - name: Add env to web root
         run: cp .env build/web/.env
+      - name: Publish self-unregistering service worker
+        # Overwrites Flutter's empty (--pwa-strategy=none) flutter_service_worker.js
+        # so browsers still holding the old offline-first worker evict it. Inert for
+        # fresh visitors, who never register a service worker. See the script header.
+        run: cp scripts/self_destroying_service_worker.js build/web/flutter_service_worker.js
       - name: Create archive
         run: tar -czf pangeachat-web.tar.gz build/web/
       - name: Upload Web Build

--- a/scripts/self_destroying_service_worker.js
+++ b/scripts/self_destroying_service_worker.js
@@ -1,0 +1,32 @@
+// Self-destroying service worker.
+//
+// Older web builds shipped Flutter's offline-first service worker, which
+// precached the app shell and kept serving it across reloads. Current builds use
+// --pwa-strategy=none and register no service worker, but browsers that
+// registered the old one stay pinned to a stale build: the empty worker the
+// build now emits only takes over once every tab of the origin closes, so a
+// plain reload never evicts the old one.
+//
+// This script is published at /flutter_service_worker.js. Fresh visitors never
+// fetch it (nothing registers a service worker). A browser that still holds an
+// old registration fetches it on its next update check, installs it, and because
+// it calls skipWaiting() it activates immediately, clears the stale caches,
+// unregisters itself, and reloads open tabs onto the current build. Keep it
+// published long term so infrequent returning users are still caught.
+
+self.addEventListener('install', () => self.skipWaiting());
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cacheKeys = await caches.keys();
+      await Promise.all(cacheKeys.map((key) => caches.delete(key)));
+      await self.clients.claim();
+      const windowClients = await self.clients.matchAll({ type: 'window' });
+      for (const client of windowClients) {
+        client.navigate(client.url);
+      }
+      await self.registration.unregister();
+    })(),
+  );
+});


### PR DESCRIPTION
## Problem

Returning web users can be pinned to a stale build. Older web builds shipped Flutter's default offline-first service worker, which precached the app shell and serves it from Cache Storage across reloads, bypassing our `no-cache` headers on `main.dart.js`. We now build with `--pwa-strategy=none`, which emits an empty `flutter_service_worker.js` and registers nothing, but a browser that already registered the old worker only swaps to the empty one once every tab of the origin closes. A plain reload never evicts it, so those users keep running old code (observed as a stuck splash plus a flood of 404s for deprecated `course-plan-*` media that current code no longer requests).

## Fix

Publish a small self-destroying script at `/flutter_service_worker.js` instead of the empty file. It calls `skipWaiting()` so it activates immediately, then clears caches, unregisters itself, and reloads open tabs onto the current build. Both the staging (`main_deploy.yaml`) and production (`release.yaml`) web builds now copy the stub over Flutter's empty worker before upload; it is served `no-cache` by the existing runtime-files logic.

## Blast radius

Surgical. Fresh visitors never fetch `flutter_service_worker.js` because nothing registers a service worker, so they are unaffected. Only browsers that still hold an old registration fetch it on their next update check and self-heal. The stub should stay published long term so infrequent returning users are still caught.

## Test plan

- Merge to `main` deploys staging; confirm `https://app.staging.pangea.chat/flutter_service_worker.js` serves the stub with `Cache-Control: no-cache`.
- A browser currently stuck on the old staging build recovers to the current build after one reload, with no manual cache clear.
- A fresh incognito load of staging still works and registers no service worker.
- Production inherits the change on the next release cut.