### PR TITLE
fix(world-map): keep a tap-selected card on-screen by nudging the camera

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -405,8 +405,70 @@ class WorldMapController extends State<WorldMap>
   /// [onMapPositionChanged]). See world-map.instructions.md.
   void selectActivity(String activityId) {
     final changed = _pinsManager.selectActivity(activityId);
-    if (changed) setState(() {});
+    if (changed) {
+      setState(() {});
+      _nudgeSelectionOnScreen(activityId);
+    }
     ActivityPlanRepo.instance.ensure(activityId);
+  }
+
+  /// A tap-selected pin promotes to a large card that floats up from it. If that
+  /// card would clip a viewport edge or sit under a side panel, glide the camera
+  /// the minimum needed to bring it into the uncovered canvas — keeping the zoom,
+  /// and not moving at all when it already fits (#7155; world-map.instructions.md
+  /// step 4 — selected cards never shrink, and a deliberate tap glides at once).
+  void _nudgeSelectionOnScreen(String activityId) {
+    final point = _pinsManager.pointForActivity(activityId);
+    if (point == null) return;
+    try {
+      final camera = mapController.camera;
+      final size = camera.size;
+      final pin = camera.latLngToScreenOffset(point);
+
+      // The card spans up from its pin (the pin is the card's bottom-centre).
+      // Use the tallest card height (+ tail) so a shorter card is never clipped.
+      const cardWidth = 260.0; // PinTier.large.dotWidth
+      final cardHeight =
+          PinTier.large.dotHeight(ActivityPinState.joinable) + 12.0;
+      final card = Rect.fromLTWH(
+        pin.dx - cardWidth / 2,
+        pin.dy - cardHeight,
+        cardWidth,
+        cardHeight,
+      );
+
+      // The uncovered canvas: the viewport minus the side panels, with a margin.
+      const margin = 12.0;
+      final safe = Rect.fromLTRB(
+        widget.leftOverlayWidth + margin,
+        margin,
+        size.width - widget.rightOverlayWidth - margin,
+        size.height - margin,
+      );
+
+      // Minimal screen shift to bring the card inside the safe area; if the card
+      // is larger than the safe area, align its top/left so the header stays
+      // visible rather than zooming out (cards never shrink).
+      double shift(double lo, double hi, double safeLo, double safeHi) {
+        if (lo < safeLo) return safeLo - lo;
+        if (hi > safeHi) return safeHi - hi;
+        return 0;
+      }
+
+      final dx = shift(card.left, card.right, safe.left, safe.right);
+      final dy = shift(card.top, card.bottom, safe.top, safe.bottom);
+      if (dx == 0 && dy == 0) return; // already fully visible — don't move
+
+      // Pan so the content shifts by (dx, dy): the camera centre moves to the
+      // LatLng currently shown at (screen-centre − shift). Zoom is unchanged.
+      final screenCenter = Offset(size.width / 2, size.height / 2);
+      final newCenter = camera.screenOffsetToLatLng(
+        screenCenter - Offset(dx, dy),
+      );
+      _animateCameraTo(newCenter, camera.zoom);
+    } catch (_) {
+      // Camera not ready yet; a later interaction will reframe.
+    }
   }
 
   void deselectActivity() {

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -446,29 +446,36 @@ class WorldMapController extends State<WorldMap>
         size.height - margin,
       );
 
-      // Minimal screen shift to bring the card inside the safe area; if the card
-      // is larger than the safe area, align its top/left so the header stays
-      // visible rather than zooming out (cards never shrink).
-      double shift(double lo, double hi, double safeLo, double safeHi) {
-        if (lo < safeLo) return safeLo - lo;
-        if (hi > safeHi) return safeHi - hi;
-        return 0;
-      }
+      // Minimal screen shift to bring the card inside the safe area.
+      final shift = minimalShiftToFit(card, safe);
+      if (shift == Offset.zero) return; // already fully visible — don't move
 
-      final dx = shift(card.left, card.right, safe.left, safe.right);
-      final dy = shift(card.top, card.bottom, safe.top, safe.bottom);
-      if (dx == 0 && dy == 0) return; // already fully visible — don't move
-
-      // Pan so the content shifts by (dx, dy): the camera centre moves to the
+      // Pan so the content shifts by [shift]: the camera centre moves to the
       // LatLng currently shown at (screen-centre − shift). Zoom is unchanged.
       final screenCenter = Offset(size.width / 2, size.height / 2);
-      final newCenter = camera.screenOffsetToLatLng(
-        screenCenter - Offset(dx, dy),
-      );
+      final newCenter = camera.screenOffsetToLatLng(screenCenter - shift);
       _animateCameraTo(newCenter, camera.zoom);
     } catch (_) {
       // Camera not ready yet; a later interaction will reframe.
     }
+  }
+
+  /// The minimal screen translation that brings [card] fully inside [safe]: zero
+  /// on an axis where it already fits, otherwise just enough to clear the
+  /// overflowing edge. If [card] is larger than [safe] on an axis, aligns its low
+  /// edge (top/left) so the header stays visible rather than zooming (#7155).
+  @visibleForTesting
+  static Offset minimalShiftToFit(Rect card, Rect safe) {
+    double axis(double lo, double hi, double safeLo, double safeHi) {
+      if (lo < safeLo) return safeLo - lo;
+      if (hi > safeHi) return safeHi - hi;
+      return 0;
+    }
+
+    return Offset(
+      axis(card.left, card.right, safe.left, safe.right),
+      axis(card.top, card.bottom, safe.top, safe.bottom),
+    );
   }
 
   void deselectActivity() {

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -94,6 +94,15 @@ class WorldMapPinsManager {
   List<LatLng> get focusPoints =>
       _pins.map((c) => c.point).whereType<LatLng>().toList();
 
+  /// The map coordinate of a specific activity pin, or null if it isn't in the
+  /// current set — used to reframe a tap-selected card on-screen (#7155).
+  LatLng? pointForActivity(String activityId) {
+    for (final card in _pins) {
+      if (card.activityId == activityId) return card.point;
+    }
+    return null;
+  }
+
   List<QuestActivityCard> filteredPins(
     bool Function(QuestActivityCard) filter,
   ) => _pins.where(filter).toList();

--- a/test/pangea/world/world_map_shift_test.dart
+++ b/test/pangea/world/world_map_shift_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/world/world_map.dart';
+
+/// Covers the geometry behind #7155 — the minimal camera nudge that keeps a
+/// tap-selected card on-screen. The card's footprint sits above its pin; this
+/// computes the least screen translation that brings it into the uncovered area.
+void main() {
+  group('WorldMapController.minimalShiftToFit (#7155)', () {
+    const safe = Rect.fromLTRB(0, 0, 1000, 800);
+
+    test('no shift when the card already fits', () {
+      expect(
+        WorldMapController.minimalShiftToFit(
+          const Rect.fromLTWH(300, 300, 260, 184),
+          safe,
+        ),
+        Offset.zero,
+      );
+    });
+
+    test('shifts left when the card overflows the right edge', () {
+      // right = 760 + 260 = 1020, i.e. 20px past safe.right (1000).
+      expect(
+        WorldMapController.minimalShiftToFit(
+          const Rect.fromLTWH(760, 300, 260, 184),
+          safe,
+        ),
+        const Offset(-20, 0),
+      );
+    });
+
+    test('shifts right when the card overflows the left edge', () {
+      // left = -30, i.e. 30px short of safe.left (0).
+      expect(
+        WorldMapController.minimalShiftToFit(
+          const Rect.fromLTWH(-30, 300, 260, 184),
+          safe,
+        ),
+        const Offset(30, 0),
+      );
+    });
+
+    test('shifts down when the card overflows the top edge', () {
+      // top = -40, i.e. 40px above safe.top (0); the card sits above its pin.
+      expect(
+        WorldMapController.minimalShiftToFit(
+          const Rect.fromLTWH(300, -40, 260, 184),
+          safe,
+        ),
+        const Offset(0, 40),
+      );
+    });
+
+    test('aligns top-left when the card is larger than the safe area', () {
+      // A narrow uncovered area (panels open): the card can't fully fit, so it
+      // aligns its top/left rather than zooming out — the header stays visible.
+      expect(
+        WorldMapController.minimalShiftToFit(
+          const Rect.fromLTWH(50, 50, 260, 184),
+          const Rect.fromLTRB(100, 100, 200, 200),
+        ),
+        const Offset(50, 50),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Tapping a pin promotes it to a large card that floats up from the dot. If that card would clip a viewport edge (or sit under a side panel), the camera now glides the **minimum** needed to bring the card fully into the uncovered canvas — keeping the current zoom, and **not moving at all** when the card already fits. This is the unimplemented half of world-map.instructions.md step 4 ("Selected and Focused never shrink: when their card would fall off an edge, the camera nudges to bring it fully on-screen") and routing's "a deliberate tap glides immediately".

`selectActivity` now calls `_nudgeSelectionOnScreen`, which projects the pin to screen, builds the card's footprint (tallest card height, so a shorter one is never clipped), compares it to the safe area (viewport minus `leftOverlayWidth`/`rightOverlayWidth`, 12px margin), and — only if it clips — pans via `screenOffsetToLatLng` (zoom unchanged).

## Why

Closes #7155.

## Testing

- `flutter analyze` on the changed files — **clean**.
- Local browser (Claude-in-Chrome, logged in): verified the **no-move** case — tapping a pin whose card already fits does **not** move the camera (no spurious glide); this exercises the projection, footprint, and the `dx==dy==0` guard. The minimal-pan direction is correct by construction (content shifts toward the clipped edge; the camera centre moves to the opposite LatLng).
- The edge-clip nudge itself couldn't be staged reliably through the agent-driven canvas (its zoom/cluster gestures are non-deterministic), so the "card near an edge nudges fully into view" case is the issue's **manual TO TEST** ("zoom in to a screen with multiple chat dots, click between them, ensure they shift to keep the popup in view").

## Deploy Notes

None.
