### PR TITLE
fix(a11y): label the activity-session details arrow

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_session_bottom_content.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_bottom_content.dart
@@ -247,6 +247,7 @@ class _ActivitySessionDetailsTile extends StatelessWidget {
                     ),
                     IconButton(
                       icon: Icon(Icons.arrow_forward),
+                      tooltip: L10n.of(context).details,
                       onPressed: onTap,
                     ),
                   ],


### PR DESCRIPTION
## What
The `arrow_forward` `IconButton` in `_ActivitySessionDetailsTile` had no accessible name, so `accessibility_floor_check` (the source-level a11y gate in `integrate.yaml`) was **failing on `main`** — and therefore red on every open PR. Added `tooltip: L10n.of(context).details`.

## Why
Unblocks the a11y gate for `main` and all in-flight PRs. (Found while triaging CI on the world-map cluster PRs.)

## Testing
- `python3 scripts/a11y_floor_check.py` → **OK** (was failing on this control).
- `flutter analyze` clean; `dart format … --set-exit-if-changed` clean.

## Deploy Notes
None.