### PR TITLE
Harden SW kill-switch + page-side legacy service worker eviction

### DIFF
--- a/scripts/self_destroying_service_worker.js
+++ b/scripts/self_destroying_service_worker.js
@@ -1,32 +1,38 @@
-// Self-destroying service worker.
+// flutter_service_worker.js — self-destroying kill-switch.
 //
 // Older web builds shipped Flutter's offline-first service worker, which
-// precached the app shell and kept serving it across reloads. Current builds use
-// --pwa-strategy=none and register no service worker, but browsers that
-// registered the old one stay pinned to a stale build: the empty worker the
-// build now emits only takes over once every tab of the origin closes, so a
-// plain reload never evicts the old one.
+// precached the app shell and served it across reloads. Current builds use
+// --pwa-strategy=none and register no service worker, so fresh visitors never
+// fetch this file. A browser that still holds an old registration fetches it on
+// its next update check: it clears the stale caches, unregisters itself, and
+// asks open pages to reload onto the current build. Keep it published long term
+// so infrequent returning users are still caught.
 //
-// This script is published at /flutter_service_worker.js. Fresh visitors never
-// fetch it (nothing registers a service worker). A browser that still holds an
-// old registration fetches it on its next update check, installs it, and because
-// it calls skipWaiting() it activates immediately, clears the stale caches,
-// unregisters itself, and reloads open tabs onto the current build. Keep it
-// published long term so infrequent returning users are still caught.
+// Do NOT call clients.navigate() from inside activate: reloading the controlling
+// document mid-activation aborts the activation and wedges the worker in
+// "installing" (the bug the first version of this file hit). Reloads are
+// page-driven instead — via the postMessage below and the eviction script in
+// index.html.
 
-self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
+});
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     (async () => {
       const cacheKeys = await caches.keys();
       await Promise.all(cacheKeys.map((key) => caches.delete(key)));
+      try {
+        await self.registration.unregister();
+      } catch (e) {
+        /* best effort */
+      }
       await self.clients.claim();
       const windowClients = await self.clients.matchAll({ type: 'window' });
       for (const client of windowClients) {
-        client.navigate(client.url);
+        client.postMessage({ type: 'SW_SELF_DESTRUCT_RELOAD' });
       }
-      await self.registration.unregister();
     })(),
   );
 });

--- a/web/index.html
+++ b/web/index.html
@@ -19,6 +19,43 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+
+  <!-- #Pangea: one-time eviction of any legacy service worker.
+       Current builds use --pwa-strategy=none and register no service worker.
+       Returning users from older offline-first builds still have one registered
+       that serves a stale app shell from Cache Storage. The old worker serves
+       index.html online-first, so this runs on their next load, before the
+       Flutter bootstrap: it unregisters all workers, clears all caches, and
+       reloads once. Inert for fresh users (no registration -> no-op). -->
+  <script>
+    (function () {
+      if (!('serviceWorker' in navigator)) return;
+      var KEY = 'pangea-sw-killswitch';
+      var reloadOnce = function () {
+        try {
+          if (sessionStorage.getItem(KEY)) return;
+          sessionStorage.setItem(KEY, '1');
+        } catch (e) {
+          return; // can't guard against a reload loop -> leave it to a manual reload
+        }
+        location.reload();
+      };
+      navigator.serviceWorker.getRegistrations().then(function (regs) {
+        if (!regs.length) return;
+        Promise.all(regs.map(function (r) { return r.unregister().catch(function () {}); }))
+          .then(function () { return window.caches ? caches.keys() : []; })
+          .then(function (keys) {
+            return Promise.all(keys.map(function (k) { return caches.delete(k); }));
+          })
+          .then(reloadOnce);
+      }).catch(function () {});
+      navigator.serviceWorker.addEventListener('message', function (e) {
+        if (e.data && e.data.type === 'SW_SELF_DESTRUCT_RELOAD') reloadOnce();
+      });
+    })();
+  </script>
+  <!-- Pangea# -->
+
   <!-- #Pangea -->
   <!-- <meta name="description" content="The cutest messenger in the Matrix network."> -->
   <meta name="description" content="Learn a language while texting your friends.">


### PR DESCRIPTION
Follow-up to #7392, which shipped a self-destroying `flutter_service_worker.js` that did not actually evict the legacy worker.

## Root cause (confirmed by multi-agent investigation + live repro)

The stub called `clients.navigate()` inside its `activate` handler. Reloading the controlling document mid-activation aborts the activation, so the new worker stays wedged in `installing` forever and the old offline-first worker keeps serving the stale app shell from Cache Storage, bypassing our `no-cache` headers. A live stuck browser showed exactly this: old worker `active`, a worker perpetually `installing`, and three reloads did not recover.

## Fix (two parts; the second is the reliable one)

1. **Harden the worker** (`scripts/self_destroying_service_worker.js`): `await skipWaiting()` in install; in activate, clear caches, then `unregister()`, then `clients.claim()`, then `postMessage` the page to reload. No `navigate()` from inside activate.
2. **Page-side eviction in `web/index.html`** (above the Flutter bootstrap): the legacy Flutter worker serves `index.html` online-first, so a fresh `index.html` reaches a stuck tab on its next reload and runs before `main.dart.js` boots. It unregisters all workers, clears all caches, and reloads once (sessionStorage-guarded against loops). This is the primary recovery path; the worker is the backup.

## Blast radius

Inert for anyone not already stuck. The page script early-returns when there is no registration, and current builds register no worker, so fresh and incognito visitors are a no-op. Only browsers holding a legacy registration unregister and reload once.

## Test plan

- Staging deploys on merge. Confirm `index.html` serves the inline script (`no-cache`) and the stub serves the new bytes for both `/flutter_service_worker.js` and the `?v=` variant.
- On a browser still stuck on the old build, a single normal reload auto-recovers: caches cleared, registration emptied, app loads past the splash, no service worker, Sentry 429 loop stops.
- Fresh incognito still loads normally and registers no worker.
- Production inherits the change on the next release cut. The `index.html` script and the worker stub ship together in this PR.