### PR TITLE
Trigger legacy SW eviction on controller (race-proof)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -24,12 +24,19 @@
        Current builds use --pwa-strategy=none and register no service worker.
        Returning users from older offline-first builds still have one registered
        that serves a stale app shell from Cache Storage. The old worker serves
-       index.html online-first, so this runs on their next load, before the
-       Flutter bootstrap: it unregisters all workers, clears all caches, and
-       reloads once. Inert for fresh users (no registration -> no-op). -->
+       index.html online-first, so this fresh copy reaches them on their next
+       load, before the Flutter bootstrap, and unregisters the worker, clears all
+       caches, and reloads once onto the current build.
+
+       Trigger on navigator.serviceWorker.controller (set synchronously for a
+       controlled document) rather than getRegistrations(), which can resolve
+       empty during early head-parse and silently no-op. Unregister via
+       serviceWorker.ready (reliably resolves with the active registration).
+       Inert for fresh users: no controller -> immediate return. -->
   <script>
     (function () {
-      if (!('serviceWorker' in navigator)) return;
+      var sw = navigator.serviceWorker;
+      if (!sw || !sw.controller) return;
       var KEY = 'pangea-sw-killswitch';
       var reloadOnce = function () {
         try {
@@ -40,16 +47,19 @@
         }
         location.reload();
       };
-      navigator.serviceWorker.getRegistrations().then(function (regs) {
-        if (!regs.length) return;
-        Promise.all(regs.map(function (r) { return r.unregister().catch(function () {}); }))
-          .then(function () { return window.caches ? caches.keys() : []; })
-          .then(function (keys) {
-            return Promise.all(keys.map(function (k) { return caches.delete(k); }));
-          })
-          .then(reloadOnce);
-      }).catch(function () {});
-      navigator.serviceWorker.addEventListener('message', function (e) {
+      Promise.all([
+        sw.ready.then(function (reg) { return reg.unregister(); }).catch(function () {}),
+        sw.getRegistrations().then(function (regs) {
+          return Promise.all(regs.map(function (r) { return r.unregister().catch(function () {}); }));
+        }).catch(function () {}),
+      ])
+        .then(function () { return window.caches ? caches.keys() : []; })
+        .then(function (keys) {
+          return Promise.all(keys.map(function (k) { return caches.delete(k); }));
+        })
+        .then(reloadOnce)
+        .catch(function () {});
+      sw.addEventListener('message', function (e) {
         if (e.data && e.data.type === 'SW_SELF_DESTRUCT_RELOAD') reloadOnce();
       });
     })();


### PR DESCRIPTION
Follow-up to #7395. The page-side eviction script shipped there did not fire: on a live stuck browser it loaded the fresh `index.html` (eviction script present) but never unregistered anything.

## Root cause

The script gated on `navigator.serviceWorker.getRegistrations()`, which can resolve with an **empty array** during early `<head>` parse even when the page is controlled by a worker. It hit `if (!regs.length) return` and bailed. Confirmed on a stuck browser: the loaded document contained the eviction script, the sessionStorage guard was never set, yet a registration was still present.

## Fix

- Gate on `navigator.serviceWorker.controller`, which is set **synchronously** for a controlled document and cannot race. Still inert for fresh users (no controller).
- Unregister via `navigator.serviceWorker.ready` (reliably resolves with the active registration), plus `getRegistrations()` as a belt, then clear all caches and reload once.

No change to the worker stub (already hardened in #7395) or to deploy config.

## Test

Validated on a real stuck staging browser: a single normal reload should now unregister the legacy worker, clear `flutter-app-*` caches, and reload onto the current build. Inert for fresh/incognito users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app recovery when service worker updates or cleanup are needed.
  * Fresh visits now skip unnecessary cleanup steps, reducing the chance of reload issues.
  * Stale service worker registrations and cached data are more reliably cleared before reloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->