### PR TITLE
refactor(world): activity plan is a first-class left panel (#7385)

### DIFF
--- a/.github/instructions/routing.instructions.md
+++ b/.github/instructions/routing.instructions.md
@@ -70,7 +70,9 @@ deliberately-upstream `/rooms/:roomid` room shape (kept verbatim for push /
 `matrix.to`); the pre-login + utility routes (`/home`, `/onboarding`,
 `/registration`, `/logs`, `/configs`); the route-driven Completer flows that can't
 ride a token URL (`/courses/own/:courseid[/invite]`, `/courses/:spaceid/addcourse/:courseId`);
-the public-course preview; and the first-class `/:activityId`. Everything else is a
+and the public-course preview. The standalone activity link `/<uuid>` is **not** a
+render route — like `/rooms/:roomid` it is an inbound shim `LegacyRedirects` rewrites
+to its `left=activity:<id>` token before anything renders. Everything else is a
 token. `PRoutes`'s `chats`/`analytics`/`settings`/`profile`/`rooms` constants are
 **legacy section paths** — redirect sources and `sectionFor` identities, never
 navigation targets.
@@ -313,7 +315,7 @@ the (scoped) map rather than a full-screen page — the Google-Maps "map + sheet
 pattern — so the map (a course's activity pins, or the activity's own pin) stays
 visible above it, with the cluster floating top-right. Dragging the sheet up
 reveals the full content. On a wide screen the same content is a bounded panel
-beside the map (a course as a left panel; an activity plan as a center detail, the
+beside the map (both a course and an activity plan as left-column panels, the
 map peeking). Starting an activity from its plan launches the session, which then
 runs as an ordinary chat room — a live left-column chat, not map content.
 
@@ -355,7 +357,7 @@ behaves the same on mobile and desktop.
 | Learning settings (shortcut) | the cluster's **language flag** | right | opens the learning-settings page directly — the flag doubles as a shortcut to it |
 | A settings leaf (password, blocked users, emotes, …) | within its settings page | the settings panel | push |
 | Courses (your courses + add a course) | the **Courses** rail icon | left | open panel (master) — a flat list of joined-course tiles (image, name, participants, level, modules), with the add-course options (start-my-own / browse / enter-code) below |
-| Activity plan | a course's activity list, a large pin card (tap) | map content | over the map (a left-column detail; a bottom sheet on mobile), camera on the activity's pin — like a course. Its close follows the **course scope** (`?m=course:`), its contextual parent: opened from the course's activity list the scope survives (the card dropped `left=course` but kept the filter), so the plan is the card's **child** and closes with a back-arrow that reopens the card; opened from a map pin the pin handler drops the scope, so the plan is parentless and closes with an **X** to the map. No entry flag is needed: surviving scope is the discriminator. **Start** launches the session, which runs as a chat room (one live view) |
+| Activity plan | a course's activity list, a large pin card (tap) | map content | a first-class **left-column panel** (`left=activity:<id>`) over the map (a bottom sheet on mobile), camera on the activity's pin — like a course, but it claims the single **live view**: a `liveView` sibling of `room`/`session`, so opening an activity drops any open chat and starting the session (a `room` token) drops the activity. It sizes by the registry like a `room` (min 360 / ideal 720), never the old floorless canvas-detail (#7385). Its close follows the **course scope** (`?m=course:`), its contextual parent: opened from the course's activity list the scope survives (the card dropped `left=course` but kept the filter), so the plan closes with a back-arrow that reopens the card; opened from a map pin the scope is absent, so it closes with an **X** to the map. Surviving scope is the discriminator. **Start** launches the session, which runs as a chat room (one live view) |
 
 ### One live session at a time
 

--- a/lib/config/routes.dart
+++ b/lib/config/routes.dart
@@ -20,7 +20,6 @@ import 'package:fluffychat/routes/join_with_link/join_with_link_page.dart';
 import 'package:fluffychat/routes/new_private_chat/new_private_chat.dart';
 import 'package:fluffychat/routes/onboarding/onboarding_page.dart';
 import 'package:fluffychat/routes/registration/create_pangea_account_page.dart';
-import 'package:fluffychat/routes/world/activity_detail_panel.dart';
 import 'package:fluffychat/widgets/config_viewer.dart';
 import 'package:fluffychat/widgets/layouts/empty_page.dart';
 import 'package:fluffychat/widgets/layouts/workspace_shell.dart';
@@ -316,23 +315,11 @@ abstract class AppRoutes {
         // tokens (legacy_redirects).
         // Pangea#
         // #Pangea
-        // First-class activity URLs: /<activityId> (UUID). Declared after
-        // /rooms so literal routes always win; the inline regex prevents
-        // single-segment paths like /home from matching.
-        GoRoute(
-          path:
-              '/:activityId([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})',
-          redirect: loggedOutRedirect,
-          pageBuilder: (context, state) => defaultPageBuilder(
-            context,
-            state,
-            ActivityDetailPanel(
-              activityId: state.pathParameters['activityId']!,
-              roomId: state.uri.queryParameters['roomid'],
-              launch: state.uri.queryParameters['launch'] == 'true',
-            ),
-          ),
-        ),
+        // world_v2: the standalone activity link `/<uuid>` is NOT a render route.
+        // Like `/rooms/:roomid` it is an inbound shim `LegacyRedirects` rewrites to
+        // its `left=activity:<id>` token before anything renders (#7385), so the
+        // shell hosts the activity as a first-class left panel, not a canvas
+        // detail. See `routing.instructions.md`.
         // Pangea#
       ],
     ),

--- a/lib/features/navigation/legacy_redirects.dart
+++ b/lib/features/navigation/legacy_redirects.dart
@@ -124,16 +124,34 @@ abstract class LegacyRedirects {
           : '/?right=${PanelToken('analytics', tab).encode()}';
     }
 
+    // world_v2: a standalone activity deep link `/<uuid>` (old map-pin bookmarks /
+    // push, and the in-app `PRoutes.activityStandalone`) opens the immersive
+    // activity panel as a `left=activity:<id>` token over the world map — mirroring
+    // how `/rooms/:roomid` → a `room` token. roomid/launch ride alongside as
+    // one-shot params the panel reads; any prior `left=`/`m=` is dropped (this IS
+    // the activity). Idempotent: the result has no UUID path segment, so it never
+    // re-fires. See `routing.instructions.md`.
+    if (segments.length == 1 && PRoutes.isWorldObjectId(segments.first)) {
+      final kept = WorkspaceQuery.parts(uri.query);
+      WorkspaceQuery.removeKeys(kept, {'left', 'm'});
+      final parts = [
+        'left=${PanelToken('activity', segments.first).encode()}',
+        ...kept,
+      ];
+      return '${PRoutes.world}?${parts.join('&')}';
+    }
+
     if (segments.isEmpty || segments.first != 'rooms') return null;
 
     final rest = segments.sublist(1);
 
     // The retired nested activity route `/rooms/spaces/:spaceid/activity/:id`
-    // (old push notifications, bookmarks) → the canonical in-course overlay
-    // `/courses/:spaceid?activity=:id`, preserving roomid/launch/tab. The space
-    // id is kept so the activity opens in its course even for a user who has
-    // not yet joined it. Must precede the generic `spaces` arm below, which
-    // would otherwise rebuild the deleted nested path.
+    // (old push notifications, bookmarks) → `/courses/:spaceid?activity=:id`,
+    // preserving roomid/launch/tab; that re-resolves through `_toCourseWorkspace`
+    // to the canonical `left=activity:<id>` token. The space id is kept so the
+    // activity opens in its course even for a user who has not yet joined it. Must
+    // precede the generic `spaces` arm below, which would otherwise rebuild the
+    // deleted nested path.
     if (rest.length >= 4 && rest[0] == 'spaces' && rest[2] == 'activity') {
       final query = <String, String>{
         'activity': rest[3],
@@ -225,6 +243,22 @@ abstract class LegacyRedirects {
   /// has no `courses` path segment, so the course arms never re-fire.
   static String _toCourseWorkspace(Uri uri, String space, String? room) {
     final parts = WorkspaceQuery.parts(uri.query);
+
+    // An inbound activity overlay (`?activity=` — legacy external links and the
+    // retired nested route) is the immersive activity panel: seat it as the sole
+    // live-view left token (`left=activity:<id>`) over the course scope, NOT beside
+    // a course card. roomid/launch/autoplay ride alongside as one-shot params the
+    // panel reads. Mirrors `WorkspaceNav.openCourseActivity`.
+    final activityId = WorkspaceQuery.valueOf(uri.query, 'activity');
+    if (activityId != null && activityId.isNotEmpty) {
+      WorkspaceQuery.removeKeys(parts, {'left', 'm', 'activity'});
+      final query = <String>[
+        'm=${PanelToken('course', space).encode()}',
+        'left=${PanelToken('activity', activityId).encode()}',
+        ...parts,
+      ];
+      return '/?${query.join('&')}';
+    }
 
     // Lift out any existing left list (keep tokens already there) and drop the
     // prior `left=`/`m=` so the course filter + left can be rebuilt cleanly.

--- a/lib/features/navigation/panel_registry.dart
+++ b/lib/features/navigation/panel_registry.dart
@@ -88,11 +88,12 @@ class PanelDef {
   final bool pushable;
 
   /// Whether this panel is **map content** — a selection on the world map (a
-  /// course, the add-course flow). On a narrow screen map content is meant to
-  /// render as a Google-Maps bottom sheet over the (scoped) map rather than a
-  /// full-screen panel; today the shell wires the **course** to that sheet
-  /// (`MobileCourseSheet`), and the add-course flow still renders as a normal
-  /// panel (same pattern to follow). See `routing.instructions.md`.
+  /// course, an activity plan, the add-course flow). On a narrow screen map
+  /// content renders as a Google-Maps bottom sheet over the (scoped) map rather
+  /// than a full-screen panel; the shell wires the **course** and the **activity**
+  /// to that sheet (`MobileCourseSheet`, via `mobileSheetIndex`), and the
+  /// add-course flow still renders as a normal panel (same pattern to follow). See
+  /// `routing.instructions.md`.
   final bool mapContent;
 
   /// When this panel opens as a DETAIL, its same-column master always folds
@@ -176,6 +177,27 @@ abstract class PanelRegistry {
       // A session is BOTH a live timeline (one at a time with `room`) AND a
       // "zoom" detail (one at a time with vocab/grammar, across columns).
       siblingGroups: {'liveView', 'detail'},
+    ),
+    // An activity plan/preview — a root master opened from a map pin or a
+    // course's activity list (`?m=course:<id>` scopes the map; the plan rides
+    // over it). It is **map content** like a `course` (narrow → bottom sheet),
+    // but unlike a course it claims the single live view: it is a `liveView`
+    // sibling of `room`/`session`, so opening an activity drops any open chat and
+    // starting the session (which opens a `room` token) drops the activity. Same
+    // widths/priority as `room` — it IS the live work surface before the chat
+    // exists — so it never shrinks past the chat's floor (the bug #7385 fixed by
+    // pulling it out of the canvas-detail exception into the allocator budget). No
+    // sub-pages in its param (the plan never drills in; starting opens a room), so
+    // not pushable. See `routing.instructions.md`.
+    'activity': PanelDef(
+      type: 'activity',
+      column: PanelColumn.left,
+      minWidth: 360,
+      reasonableMinWidth: 480,
+      idealWidth: 720,
+      priority: 80,
+      siblingGroups: {'liveView'},
+      mapContent: true,
     ),
     // A course card — a root master (opened from a map pin / the Courses
     // launcher). Its detail is a `coursepage` management page.

--- a/lib/features/navigation/route_facts.dart
+++ b/lib/features/navigation/route_facts.dart
@@ -64,19 +64,14 @@ enum AnalyticsPanelTab { sessions, grammar, vocab }
 /// matching anyway). The shell reads this via [canvasFor].
 bool isMapHole(String? fullPath) => fullPath == PRoutes.world;
 
-/// The effective canvas for the current route's sideView. An open activity
-/// (`?activity=` over the map, or the `/<uuid>` route) is the **plan/preview**
-/// page — **map content**, like a course: a bounded `detail` with the map peeking
-/// beside it (desktop) / a bottom sheet (narrow, handled by the shell), camera
-/// focused on the activity's pin. (Starting it launches the session, which runs
-/// as an ordinary chat room — there is no separate full-bleed activity surface.)
-/// The world root `/` is a map hole (sideView offstage, full map shows); the
-/// activity check comes first so an activity over the world map is still a detail,
-/// not a hole. Everything else reached by a real route — a course-wizard step, a
-/// public-course preview, a chat archive — is also a bounded `detail`. See
-/// `routing.instructions.md`.
+/// The effective canvas for the current route's sideView. The world root `/` is a
+/// map hole (sideView offstage, full map shows); everything reached by a real
+/// route — a course-wizard step, a public-course preview, a chat archive — is a
+/// bounded `detail` with the map peeking beside it. An open activity is **not** a
+/// canvas exception anymore (#7385): it rides as a first-class `left=activity:`
+/// panel over the map hole (sized by the allocator like a `room`, a bottom sheet
+/// on narrow), not a floorless center detail. See `routing.instructions.md`.
 CanvasMode canvasFor(GoRouterState state, bool isColumnMode) {
-  if (activityFor(state) != null) return CanvasMode.detail;
   if (isMapHole(state.fullPath)) return CanvasMode.mapHole;
   return CanvasMode.detail;
 }
@@ -218,19 +213,29 @@ String? activeRoomIdFor(GoRouterState state) {
   return activeRoomIdFromPanels(state.uri);
 }
 
-/// The activity an open route addresses: the in-course overlay (`?activity=`)
-/// or the standalone uuid route (`/:activityId`). Carries the optional session
-/// `roomid` and `launch` flag that the canonical open uses.
+/// The activity an open route addresses. world_v2 canonical: a `left=activity:`
+/// panel token whose param is the activity id. Legacy inbound forms — the
+/// in-course `?activity=` overlay and the standalone `/:activityId` path — are
+/// read as a fallback so an un-rewritten deep link still resolves until
+/// `LegacyRedirects` rewrites it to the token. Carries the optional session
+/// `roomid` and `launch` flag (one-shot query params the open carries) for
+/// re-entering a session.
 ({String id, String? roomId, bool launch})? activityFor(GoRouterState state) {
-  final id =
-      state.uri.queryParameters['activity'] ??
-      state.pathParameters['activityId'];
+  final uri = state.uri;
+  String? id;
+  for (final token in parseOpenPanels(uri).left) {
+    if (token.type == 'activity' && (token.param?.isNotEmpty ?? false)) {
+      id = token.param;
+      break;
+    }
+  }
+  id ??= uri.queryParameters['activity'] ?? state.pathParameters['activityId'];
   if (id == null || id.isEmpty) return null;
-  final roomId = state.uri.queryParameters['roomid'];
+  final roomId = uri.queryParameters['roomid'];
   return (
     id: id,
     roomId: roomId == null ? null : fullRoomId(roomId),
-    launch: state.uri.queryParameters['launch'] == 'true',
+    launch: uri.queryParameters['launch'] == 'true',
   );
 }
 

--- a/lib/features/navigation/workspace_nav.dart
+++ b/lib/features/navigation/workspace_nav.dart
@@ -213,15 +213,18 @@ abstract class WorkspaceNav {
     final lists = parseOpenPanels(current);
     final left = <PanelToken>[
       PanelToken('course', tab),
-      // Drop any prior course token, the Courses launcher (`addcourse`), and a
-      // stale management page (`coursepage`) — picking a specific course replaces
-      // the launcher rather than stacking beside it, and a coursepage left from
-      // the previous course would silently re-target the new one.
+      // Drop any prior course token, the Courses launcher (`addcourse`), a stale
+      // management page (`coursepage`), and an open immersive `activity` —
+      // picking/re-showing a course card is an exit FROM the activity (the
+      // in-course "Pick different activity" / "Return to course" buttons route
+      // here), so the live-view activity must not co-render beside the card
+      // (#7385). A live `room` is kept (a course can scope a chat).
       ...lists.left.where(
         (t) =>
             t.type != 'course' &&
             t.type != 'addcourse' &&
-            t.type != 'coursepage',
+            t.type != 'coursepage' &&
+            t.type != 'activity',
       ),
     ];
     final parts = WorkspaceQuery.parts(current.query);
@@ -240,12 +243,20 @@ abstract class WorkspaceNav {
   /// active tab, so switching tabs is opening the course token with a new tab
   /// (the `m` filter is preserved by `_mutate`). A live room and the chat list
   /// are kept (a course can scope a room). See `routing.instructions.md`.
-  static String openCourse(Uri current, PanelToken token) =>
-      _mutate(current, 'left', (tokens) {
-        final next = tokens.where((t) => t.type != 'course').toList();
-        next.insert(0, token);
-        return next;
-      });
+  static String openCourse(Uri current, PanelToken token) => _mutate(
+    current,
+    'left',
+    (tokens) {
+      // Drop any prior course token AND an open immersive `activity` — showing
+      // the course card is an exit from the activity, so the live-view activity
+      // must not co-render beside it (#7385). A live `room` is kept.
+      final next = tokens
+          .where((t) => t.type != 'course' && t.type != 'activity')
+          .toList();
+      next.insert(0, token);
+      return next;
+    },
+  );
 
   /// Open a course-management page (invite / edit / access / permissions /
   /// emotes / change-course) as the course card's DETAIL — a `coursepage` panel
@@ -267,21 +278,23 @@ abstract class WorkspaceNav {
   static String openCoursePageFor(Uri current, String spaceId, String page) =>
       openCoursePage(Uri.parse(openCourseFilter(current, spaceId)), page);
 
-  /// Open an in-course activity as the immersive `?activity=` overlay over the
-  /// course-scoped map — the token-native producer for "open this activity in
-  /// its course". Sets the `?m=course:<spaceId>` scope and the `activity=<id>`
-  /// overlay on a CLEAN workspace (no `left`/`right` tokens): an activity is an
-  /// immersive task that REPLACES the open panels rather than stacking beside
-  /// them, and the surviving `?m=course:` scope makes the plan the card's child
-  /// (its close is a back-arrow that reopens the card). [launch] skips the lobby
-  /// straight to role selection; [roomId] reopens/rejoins a specific session
-  /// room; [autoplay] autostarts the plan's hero media (muted, block 0).
+  /// Open an in-course activity as the immersive `left=activity:<id>` panel over
+  /// the course-scoped map — the token-native producer for "open this activity in
+  /// its course". Sets the `?m=course:<spaceId>` scope and seats the activity as
+  /// the SOLE left token (no chat list / room / course card beside it): an
+  /// activity is an immersive task that claims the single live view — its registry
+  /// `liveView` sibling group drops any open `room`/`session`, and starting the
+  /// session (which opens a `room` token) drops the activity in turn. The
+  /// surviving `?m=course:` scope keeps the plan's close a back-arrow that reopens
+  /// the card. [launch] skips the lobby straight to role selection; [roomId]
+  /// reopens/rejoins a specific session room; [autoplay] autostarts the plan's
+  /// hero media (muted, block 0) — all three ride as one-shot query params the
+  /// panel reads.
   ///
-  /// Replaces the legacy `/courses/:id?activity=` path producer: `context.go`-ing
-  /// that path made `LegacyRedirects` rewrite it back to tokens INCLUDING
-  /// `left=course`, re-opening the course card beside the activity (#7267).
-  /// Inbound `/courses/:id?activity=` external links still map through
-  /// `legacy_redirects` unchanged. See `routing.instructions.md`.
+  /// Inbound `/courses/:id?activity=` external links and the standalone `/<uuid>`
+  /// link map to this same token form through `legacy_redirects`. The clean-left
+  /// seating also fixes #7267 (the legacy path producer re-opened `left=course`
+  /// beside the activity). See `routing.instructions.md`.
   static String openCourseActivity(
     String spaceId,
     String activityId, {
@@ -291,7 +304,7 @@ abstract class WorkspaceNav {
   }) {
     final parts = <String>[
       'm=${PanelToken('course', shortRoomId(spaceId)).encode()}',
-      'activity=$activityId',
+      'left=${PanelToken('activity', activityId).encode()}',
       if (roomId != null) 'roomid=${shortRoomId(roomId)}',
       if (launch) 'launch=true',
       if (autoplay) 'autoplay=0',

--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -76,29 +76,37 @@ class ActivitySessionStartView extends StatelessWidget {
         // is needed: surviving scope IS the discriminator. See
         // `routing.instructions.md`.
         final uri = GoRouter.of(context).routeInformationProvider.value.uri;
-        final embedded = uri.queryParameters['activity'] != null;
+        final embedded = parseOpenPanels(
+          uri,
+        ).left.any((t) => t.type == 'activity');
         final courseScoped =
             uri.queryParameters['m']?.startsWith('course:') ?? false;
 
-        // Drop the activity overlay, keeping `?m=` and the rest of the query
-        // verbatim — rebuilt from the RAW query so the `?m=course:` filter isn't
-        // re-encoded (`uri.replace(queryParameters:)` turns `:`→`%3A`, which the
-        // raw-query parser can't read, de-scoping the map and orphan-dropping any
-        // reopened card). [reopenCard] additionally restores `left=course` over the
-        // surviving scope (the parent card, reconstructed from the scope).
+        // Drop the `left=activity:` token + its one-shot session params, keeping
+        // `?m=` and the rest of the query verbatim — rebuilt from the RAW query so
+        // the `?m=course:` filter isn't re-encoded (`uri.replace(queryParameters:)`
+        // turns `:`→`%3A`, which the raw-query parser can't read, de-scoping the
+        // map and orphan-dropping any reopened card). [reopenCard] additionally
+        // restores `left=course` over the surviving scope (the parent card,
+        // reconstructed from the scope).
         String overlayDropped({required bool reopenCard}) {
           final parts = WorkspaceQuery.parts(uri.query);
           WorkspaceQuery.removeKeys(parts, {
-            'activity',
             'roomid',
             'launch',
             'autoplay',
+            'left',
           });
           final scoped = parts.any((p) => p.startsWith('m=course:'));
-          final hasLeft = parts.any(
-            (p) => p == 'left' || p.startsWith('left='),
-          );
-          if (reopenCard && scoped && !hasLeft) parts.add('left=course');
+          final left = parseOpenPanels(
+            uri,
+          ).left.where((t) => t.type != 'activity').toList();
+          if (reopenCard && scoped && left.every((t) => t.type != 'course')) {
+            left.insert(0, const PanelToken('course'));
+          }
+          if (left.isNotEmpty) {
+            parts.add('left=${left.map((t) => t.encode()).join(',')}');
+          }
           return WorkspaceQuery.location('/', parts);
         }
 

--- a/lib/routes/onboarding/onboarding_page.dart
+++ b/lib/routes/onboarding/onboarding_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
 
+import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
 import 'package:fluffychat/routes/onboarding/account_updater.dart';
 import 'package:fluffychat/routes/onboarding/avatar_provider.dart';
 import 'package:fluffychat/routes/onboarding/course_provider.dart';
@@ -12,7 +13,6 @@ import 'package:fluffychat/routes/onboarding/onboarding_state_controller.dart';
 import 'package:fluffychat/routes/onboarding/onboarding_step_views/onboarding_step_view.dart';
 import 'package:fluffychat/routes/onboarding/onboarding_steps/onboarding_step.dart';
 import 'package:fluffychat/routes/onboarding/onboarding_steps/profile_setup_onboarding_step.dart';
-import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
 import 'package:fluffychat/routes/onboarding/trial_info_provider.dart';
 import 'package:fluffychat/widgets/animated_progress_bar.dart';
 import 'package:fluffychat/widgets/matrix.dart';

--- a/lib/routes/world/activity_detail_panel.dart
+++ b/lib/routes/world/activity_detail_panel.dart
@@ -3,19 +3,22 @@ import 'package:flutter/material.dart';
 import 'package:collection/collection.dart';
 import 'package:go_router/go_router.dart';
 
+import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/features/navigation/workspace_query.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
 import 'package:fluffychat/routes/world/activity_course_resolver.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
-/// Activity detail, rendered as a capped detail panel over the persistent map
-/// (world_v2). Two entry points share it: in-place via the `?activity=<id>`
-/// query param over another route (e.g. a course), and the first-class
-/// `/<activityId>` route. Either way it renders the activity session start
-/// flow — it never remounts a second map. Closing drops the `?activity` param
-/// (returning to the underlying route) or, on the standalone route, returns to
-/// the world map.
+/// Activity detail, rendered as a first-class `left=activity:<id>` panel over the
+/// persistent map (world_v2) — hosted by `WorkspaceLeftPanel` like any other left
+/// panel, sized by the allocator (#7385), a bottom sheet on narrow. The token
+/// param is the activity id; the in-course/standalone/legacy entry points all
+/// resolve to that token (see `WorkspaceNav.openCourseActivity` /
+/// `LegacyRedirects`). It renders the activity session start flow — it never
+/// remounts a second map. Closing drops the activity token, returning to the
+/// course-scoped map (or the bare map).
 ///
 /// The parent course is the active course space when one is selected;
 /// otherwise the first joined course whose plan includes the activity (or none
@@ -109,27 +112,28 @@ class _ActivityDetailPanelState extends State<ActivityDetailPanel> {
 
   void _close() {
     final uri = GoRouter.of(context).routeInformationProvider.value.uri;
-    // In-place (`?activity=`): drop the overlay params (activity/roomid/launch)
-    // to return to the underlying route, preserving everything else (e.g.
-    // `tab`). Standalone (`/<activityId>`): no overlay param, so go to World.
-    if (!uri.queryParameters.containsKey('activity')) {
+    final left = parseOpenPanels(uri).left;
+    // Drop the `left=activity:` token (and its one-shot session params) to return
+    // to the underlying workspace — the course-scoped map (`?m=course:` kept) or
+    // the bare map. Rebuilt from the RAW query so the PanelToken-encoded `m=`
+    // filter isn't re-encoded (`uri.replace(queryParameters:)` turns `:`→`%3A`,
+    // de-scoping the map). No activity token (an un-rewritten legacy URL) → World.
+    if (!left.any((t) => t.type == 'activity')) {
       context.go('/');
       return;
     }
-    final params = Map<String, String>.from(uri.queryParameters)
-      ..remove('activity')
-      ..remove('roomid')
-      ..remove('launch');
-    context.go(
-      params.isEmpty
-          ? uri.path
-          : uri.replace(queryParameters: params).toString(),
-    );
+    final parts = WorkspaceQuery.parts(uri.query);
+    WorkspaceQuery.removeKeys(parts, {'left', 'roomid', 'launch', 'autoplay'});
+    final kept = left.where((t) => t.type != 'activity').toList();
+    if (kept.isNotEmpty) {
+      parts.add('left=${kept.map((t) => t.encode()).join(',')}');
+    }
+    context.go(WorkspaceQuery.location('/', parts));
   }
 
   /// Back returns toward the course: pop history if there's something to pop,
-  /// otherwise just drop the `?activity` param. Either way the course context
-  /// stays — this never leaves for the standalone activity page.
+  /// otherwise just drop the activity token. Either way the course context stays
+  /// (the `?m=course:` scope survives) — this never leaves for a standalone open.
   void _back() {
     if (context.canPop()) {
       context.pop();
@@ -160,7 +164,7 @@ class _ActivityDetailPanelState extends State<ActivityDetailPanel> {
     // standalone), so it dismisses to the map. Rendering both ← and X here was a
     // redundant pair that did the same thing in the pin case (#7115).
     final uri = GoRouter.of(context).routeInformationProvider.value.uri;
-    final embedded = uri.queryParameters['activity'] != null;
+    final embedded = parseOpenPanels(uri).left.any((t) => t.type == 'activity');
     final courseScoped =
         uri.queryParameters['m']?.startsWith('course:') ?? false;
     final showBack = embedded && courseScoped;

--- a/lib/routes/world/left_panel/workspace_left_panel.dart
+++ b/lib/routes/world/left_panel/workspace_left_panel.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/routes/world/activity_detail_panel.dart';
 import 'package:fluffychat/routes/world/left_panel/left_panel_add_course_subpage.dart';
 import 'package:fluffychat/routes/world/left_panel/left_panel_chat_list_subpage.dart';
 import 'package:fluffychat/routes/world/left_panel/left_panel_course_details_subpage.dart';
@@ -83,6 +85,26 @@ class WorkspaceLeftPanel extends StatelessWidget {
         foldedOver: foldedOver,
         isColumnMode: isColumnMode,
       ),
+      // An activity plan/preview — the immersive live-view surface before the
+      // session room exists (#7385). Its identity is the token param (the activity
+      // id); the parent course rides the `?m=course:` scope, and the one-shot
+      // `?roomid=`/`?launch=` session params let it re-enter / auto-launch a
+      // session. It brings its own Scaffold + close affordance (a back-arrow toward
+      // the course, or an X to the map — see `activity_sessions_start_view.dart`),
+      // so PanelCard just supplies the floating chrome like every other panel.
+      'activity' => () {
+        final activityId = token.param;
+        if (activityId == null || activityId.isEmpty) {
+          return const SizedBox.shrink();
+        }
+        final roomId = currentUri.queryParameters['roomid'];
+        return ActivityDetailPanel(
+          activityId: activityId,
+          parentSpaceId: activeSpaceIdFor(currentUri),
+          roomId: roomId == null ? null : fullRoomId(roomId),
+          launch: currentUri.queryParameters['launch'] == 'true',
+        );
+      }(),
       'coursepage' => () {
         final courseSpaceId = activeSpaceIdFor(currentUri);
         final page = token.param;

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -9,6 +9,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
 import 'package:fluffychat/features/languages/language_model.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/workspace_query.dart';
@@ -667,19 +668,19 @@ class WorldMapController extends State<WorldMap>
     _refetchDebounce = Timer(const Duration(milliseconds: 500), loadWorldPins);
   }
 
-  /// Open the activity detail in-place, preserving the current route (course
-  /// stays selected, map stays put) via the `?activity=<id>` param. The detail
-  /// panel fetches the full plan on open. Reached from the preview's "Details".
+  /// Open the activity detail in-place, preserving the current route (map stays
+  /// put) as a `left=activity:<id>` panel token. The panel fetches the full plan
+  /// on open. Reached from the preview's "Details".
   void openActivity(QuestActivityCard card) {
     final uri = GoRouter.of(context).routeInformationProvider.value.uri;
     // Open the activity plan as map content. Pin entry is UNSCOPED: drop the
-    // `?m=course:` filter along with the left/right panels (the plan replaces the
-    // left-primary surface) and add `activity=`. The absence of course scope is
-    // what makes this a parentless overlay — its close is an X to the map, not a
-    // back-arrow to a course card (a course-list tap keeps the scope and so gets
-    // the back-arrow). The map still focuses the activity's pin via the
-    // `activity=` param (`mapFocusFor` → `ActivityFocus`), independent of scope.
-    // See `routing.instructions.md`.
+    // `?m=course:` filter along with the other panels and seat the activity as the
+    // sole `left=activity:<id>` token (its `liveView` sibling group drops any open
+    // chat). The absence of course scope is what makes this a parentless overlay —
+    // its close is an X to the map, not a back-arrow to a course card (a
+    // course-list tap keeps the scope and so gets the back-arrow). The map still
+    // focuses the activity's pin via the token (`mapFocusFor` → `ActivityFocus`),
+    // independent of scope. See `routing.instructions.md`.
     final parts = WorkspaceQuery.parts(uri.query);
     WorkspaceQuery.removeKeys(parts, {
       'left',
@@ -690,7 +691,7 @@ class WorldMapController extends State<WorldMap>
       'roomid',
     });
 
-    parts.add('activity=${card.activityId}');
+    parts.add('left=${PanelToken('activity', card.activityId).encode()}');
     // #7257: if the learner already holds a started/joined session for this
     // activity, bind the overlay to that room (`roomid=`) so the start page
     // resumes it (selectRole/confirmedRole) instead of offering a fresh

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -10,7 +10,6 @@ import 'package:fluffychat/features/navigation/panel_focus.dart';
 import 'package:fluffychat/features/navigation/panel_registry.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
-import 'package:fluffychat/routes/world/activity_detail_panel.dart';
 import 'package:fluffychat/routes/world/left_panel/workspace_left_panel.dart';
 import 'package:fluffychat/routes/world/map_context.dart';
 import 'package:fluffychat/routes/world/panel_card.dart';
@@ -220,8 +219,9 @@ class WorkspaceShell extends StatelessWidget {
             /// The route canvas, as one stable child so the sideView Navigator never
             /// remounts when the canvas mode changes:
             ///  • mapHole → Offstage so pan/zoom/tap reach the map below.
-            ///  • detail → capped, bounded by the right panel zone; map peeks (an activity
-            ///    plan on a wide screen; a course-wizard step).
+            ///  • detail → capped, bounded by the right panel zone; map peeks (a
+            ///    route-driven page — a course-wizard step, a public-course preview, a
+            ///    chat archive; the activity plan is a left panel now, not here).
             Positioned(
               left: l.leftInset,
               top: 0,
@@ -229,38 +229,34 @@ class WorkspaceShell extends StatelessWidget {
               right: l.canvas == CanvasMode.detail ? null : 0,
               width: l.canvas == CanvasMode.detail ? l.detailWidth : null,
               child: Offstage(
-                // A map hole shows the full map through; a narrow activity plan is
-                // offstaged here too because its content rides in the bottom sheet below.
-                // Otherwise the center detail (an activity plan on a wide screen, a
-                // course-wizard step, a public-course preview) gets the same floating-card
+                // A map hole shows the full map through (the world root, or an
+                // activity / room / course riding over it as a left panel).
+                // Otherwise the center detail (a course-wizard step, a
+                // public-course preview, a chat archive) gets the same floating-card
                 // chrome as the column panels via [PanelCard].
-                offstage: l.canvas == CanvasMode.mapHole || l.isMobileActivity,
+                offstage: l.canvas == CanvasMode.mapHole,
                 child: l.canvas == CanvasMode.detail
                     ? PanelCard(child: l.canvasChild)
                     : l.canvasChild,
               ),
             ),
 
-            /// A narrow course rides in a draggable bottom sheet over the course-scoped
-            /// map (Google-Maps "map + sheet"). The course content is the same
-            /// WorkspaceLeftPanel surface, hosted [bare] (the sheet is the card). The
-            /// left-panel loop skips this index so it is not also drawn full-screen. See
-            /// `routing.instructions.md`.
-            if (l.mobileCourseIndex != null)
+            /// Narrow **map content** (a course card or an activity plan) rides in a
+            /// draggable bottom sheet over the (scoped) map (Google-Maps "map + sheet")
+            /// instead of a full-screen panel — both are `mapContent` panels. The content
+            /// is the same WorkspaceLeftPanel surface, hosted [bare] (the sheet is the
+            /// card). The left-panel loop skips this index so it is not also drawn
+            /// full-screen. See `routing.instructions.md`.
+            if (l.mobileSheetIndex != null)
               Positioned.fill(
                 child: MobileCourseSheet(
                   child: WorkspaceLeftPanel(
-                    token: l.leftTokens[l.mobileCourseIndex!],
+                    token: l.leftTokens[l.mobileSheetIndex!],
                     currentUri: state.uri,
                     bare: true,
                   ),
                 ),
               ),
-
-            /// A narrow activity plan rides in the same bottom sheet over the map (camera
-            /// on its pin); the center canvas is offstaged for it in [_canvasLayer].
-            if (l.isMobileActivity)
-              Positioned.fill(child: MobileCourseSheet(child: l.canvasChild)),
 
             /// The nav rail must size to its content, NOT fill the Stack: this Stack is
             /// StackFit.expand, which forces non-positioned children to full size — and the
@@ -290,9 +286,10 @@ class WorkspaceShell extends StatelessWidget {
             /// its ChatController repositions rather than remounts when the slot moves.
             ...[
               for (var i = 0; i < l.leftTokens.length; i++)
-                // Skip a narrow course card — it renders in the bottom sheet above, not as
-                // a full-screen left panel (no double-render).
-                if (i != l.mobileCourseIndex &&
+                // Skip narrow map content (a course card or activity plan) — it renders
+                // in the bottom sheet above, not as a full-screen left panel (no
+                // double-render).
+                if (i != l.mobileSheetIndex &&
                     l.allocation.left[i].vis != PanelVis.hidden)
                   Positioned(
                     key: ValueKey(l.leftTokens[i].encode()),
@@ -344,13 +341,12 @@ class WorkspaceShell extends StatelessWidget {
 
             /// The persistent top-right user cluster — the right column's entry point. It
             /// sits in the gutter the allocator reserves beside the panels; hidden behind a
-            /// narrow full-screen panel. Shown over a narrow course or activity sheet too
-            /// (the map is visible above the sheet, so the floating cluster reads as
-            /// Maps-style chrome and keeps analytics reachable). The caller gates
-            /// visibility; this only places it.
+            /// narrow full-screen panel. Shown over a narrow map-content sheet too (a
+            /// course or an activity — the map is visible above the sheet, so the floating
+            /// cluster reads as Maps-style chrome and keeps analytics reachable). The
+            /// caller gates visibility; this only places it.
             if ((l.mapVisible && l.allocation.clusterVisible) ||
-                l.isMobileCourse ||
-                l.isMobileActivity)
+                l.isMobileSheet)
               Positioned(
                 top: _ShellLayout.chromeMargin + screenPadding.top,
                 right: _ShellLayout.chromeMargin + screenPadding.right,
@@ -390,21 +386,22 @@ class _ShellLayout {
   /// padding) from [PanelAllocator].
   final WorkspaceLayout allocation;
 
-  /// The effective center canvas (an open activity overlay already resolved to a
-  /// detail panel inside [canvasFor]).
+  /// The effective center canvas. An open activity is NOT a canvas mode anymore
+  /// (#7385) — it rides as a left panel; this is `detail` only for route-driven
+  /// pages (a course-wizard step, a public-course preview, a chat archive), else
+  /// `mapHole`.
   final CanvasMode canvas;
 
-  /// `?activity=<id>` opens the activity detail in-place over the map; this is
-  /// the resolved canvas child (the activity panel, else the route [sideView]).
+  /// The route-driven center detail child (a course-wizard step, a public-course
+  /// preview, a chat archive), else the route [sideView]. The activity plan is no
+  /// longer rendered here — it is a left panel hosted by [WorkspaceLeftPanel].
   final Widget canvasChild;
 
-  /// Index into [leftTokens] of a narrow joined-course card that rides in the
-  /// bottom sheet (null otherwise); [isMobileCourse] is its presence.
-  final int? mobileCourseIndex;
-  final bool isMobileCourse;
-
-  /// A narrow activity plan rides in the bottom sheet over the map.
-  final bool isMobileActivity;
+  /// Index into [leftTokens] of narrow **map content** (a joined-course card or an
+  /// activity plan) that rides in the bottom sheet (null otherwise);
+  /// [isMobileSheet] is its presence.
+  final int? mobileSheetIndex;
+  final bool isMobileSheet;
 
   /// The narrow bottom nav (section switcher) shows only at a section-root level.
   final bool showBottomNav;
@@ -436,9 +433,8 @@ class _ShellLayout {
     required this.allocation,
     required this.canvas,
     required this.canvasChild,
-    required this.mobileCourseIndex,
-    required this.isMobileCourse,
-    required this.isMobileActivity,
+    required this.mobileSheetIndex,
+    required this.isMobileSheet,
     required this.showBottomNav,
     required this.mapVisible,
     required this.leftInset,
@@ -493,10 +489,10 @@ class _ShellLayout {
     // it.
     final columnWidth = railWidth == 0 ? 0.0 : railWidth + chromeMargin * 2;
 
-    // The effective canvas (an open activity overlay already resolves to a
-    // detail panel inside [canvasFor]).
+    // The effective canvas: `detail` only for route-driven pages (a course-wizard
+    // step, a public-course preview, a chat archive); `mapHole` otherwise. An open
+    // activity rides as a left panel, not a canvas (#7385).
     final canvas = canvasFor(state, isColumnMode);
-    final activity = activityFor(state);
     final activeSpaceId = activeSpaceIdFor(state.uri);
 
     final viewport = MediaQuery.sizeOf(context).width;
@@ -538,33 +534,25 @@ class _ShellLayout {
       focusHint: focusHint,
     );
 
-    // world_v2 mobile: a joined COURSE on a narrow screen rides in a draggable
-    // bottom sheet over the (course-scoped) map — the Google-Maps "map + sheet"
-    // pattern — instead of a full-screen panel. Active when the focused narrow
-    // panel is the `course` card (an in-course `room` or an activity shows itself
-    // instead; switching course tabs still focuses the card). The course content
-    // is hosted bare in the sheet, and the normal left-panel loop skips this index
-    // so the course is not also drawn full-screen behind the sheet — the
-    // double-render the old `canvas == detail` predicate (always false for a
-    // course on `/`) never guarded. See `routing.instructions.md`.
-    int? mobileCourseIndex;
-    if (!isColumnMode && activity == null && activeSpaceId != null) {
+    // world_v2 mobile: **map content** on a narrow screen — a joined COURSE card or
+    // an ACTIVITY plan — rides in a draggable bottom sheet over the (scoped) map
+    // (the Google-Maps "map + sheet" pattern) instead of a full-screen panel. Both
+    // are `mapContent` panels; the focused full-vis one rides the sheet (an
+    // in-course `room` shows itself instead). The content is hosted bare in the
+    // sheet, and the normal left-panel loop skips this index so it is not also drawn
+    // full-screen behind it. See `routing.instructions.md`.
+    int? mobileSheetIndex;
+    if (!isColumnMode) {
       for (var i = 0; i < leftTokens.length; i++) {
-        if (leftTokens[i].type == 'course' &&
+        final type = leftTokens[i].type;
+        if ((type == 'course' || type == 'activity') &&
             layout.left[i].vis == PanelVis.full) {
-          mobileCourseIndex = i;
+          mobileSheetIndex = i;
           break;
         }
       }
     }
-    final isMobileCourse = mobileCourseIndex != null;
-
-    // An activity's plan/preview is map content too: on a narrow screen it rides
-    // in the same bottom sheet over the map (camera on the activity's pin), not a
-    // full-screen page — the `?activity=` center canvas is offstaged and the sheet
-    // hosts it. On a wide screen it stays a bounded center detail with the map
-    // peeking beside it. See `routing.instructions.md`.
-    final isMobileActivity = !isColumnMode && activity != null;
+    final isMobileSheet = mobileSheetIndex != null;
 
     // The narrow bottom nav is only the section switcher (World / Chats /
     // Courses), so it shows only at a "section-root" level: the bare map (no
@@ -611,21 +599,20 @@ class _ShellLayout {
     // bottom sheet over the FULL map, not a left panel, so the camera uses the
     // whole width (the sheet covers the bottom, which the left/right overlays
     // don't model). See `routing.instructions.md`.
-    final leftInset = (isMobileCourse || isMobileActivity)
+    final leftInset = isMobileSheet
         ? 0.0
         : (hasLeftTokens ? layout.mapLeftOverlay : columnWidth);
 
-    // Bound the route-driven center detail by the left inset and the right-
-    // covered width so it can never slide under a panel (the non-overlap
-    // guarantee). A narrow activity plan is a bottom sheet, not a center detail,
-    // so it claims no center width here (the sheet hosts it below).
-    final detailWidth = canvas == CanvasMode.detail && !isMobileActivity
+    // Bound the route-driven center detail by the left inset and the right-covered
+    // width so it can never slide under a panel (the non-overlap guarantee). Only
+    // route-driven pages use the center detail now — the activity is a left panel.
+    final detailWidth = canvas == CanvasMode.detail
         ? math.min(
             PanelAllocator.detailMax,
             math.max(0.0, viewport - leftInset - layout.mapRightOverlay),
           )
         : null;
-    final mapLeftOverlay = (isMobileCourse || isMobileActivity)
+    final mapLeftOverlay = isMobileSheet
         ? 0.0
         : leftInset +
               (canvas == CanvasMode.detail ? (detailWidth ?? 0.0) : 0.0);
@@ -646,17 +633,12 @@ class _ShellLayout {
     // SHEET leaves the map visible above it, so it does not clear the pin. The
     // map clears its own selection in response. See `routing.instructions.md`.
     final mapCoveredByPanel =
-        !isColumnMode && focusedNarrowType != null && !isMobileCourse;
+        !isColumnMode && focusedNarrowType != null && !isMobileSheet;
 
-    // `?activity=<id>` opens the activity detail in-place over the map.
-    final canvasChild = activity != null
-        ? ActivityDetailPanel(
-            activityId: activity.id,
-            parentSpaceId: activeSpaceId,
-            roomId: activity.roomId,
-            launch: activity.launch,
-          )
-        : sideView;
+    // Route-driven center detail only (a course-wizard step, a public-course
+    // preview, a chat archive). The activity plan is a left panel now, not a canvas
+    // child (#7385).
+    final canvasChild = sideView;
 
     return _ShellLayout(
       navRail: navRail,
@@ -665,9 +647,8 @@ class _ShellLayout {
       allocation: layout,
       canvas: canvas,
       canvasChild: canvasChild,
-      mobileCourseIndex: mobileCourseIndex,
-      isMobileCourse: isMobileCourse,
-      isMobileActivity: isMobileActivity,
+      mobileSheetIndex: mobileSheetIndex,
+      isMobileSheet: isMobileSheet,
       showBottomNav: showBottomNav,
       mapVisible: mapVisible,
       leftInset: leftInset,

--- a/test/pangea/navigation/legacy_redirects_test.dart
+++ b/test/pangea/navigation/legacy_redirects_test.dart
@@ -81,6 +81,20 @@ void main() {
       );
     });
 
+    test('standalone activity link `/<uuid>` becomes a left=activity token '
+        '(#7385)', () {
+      // Like `/rooms/:roomid` → a room token, the parentless activity deep link
+      // (old map-pin bookmarks / push) opens the immersive activity panel as the
+      // sole left token over the world map.
+      const id = '32ad3c08-e501-41c5-b544-0875026090ed';
+      expect(resolve('/$id'), '/?left=activity:$id');
+      // One-shot session params (launch / an existing session room) ride along.
+      expect(resolve('/$id?launch=true'), '/?left=activity:$id&launch=true');
+      // Any prior left list / map filter is dropped — this navigation IS the
+      // activity (it claims the single live view).
+      expect(resolve('/$id?m=course:!s&left=chats'), '/?left=activity:$id');
+    });
+
     test('encoded segments survive the rewrite', () {
       // e.g. analytics constructs with encoded slashes.
       expect(
@@ -142,11 +156,13 @@ void main() {
         resolve('/courses/!s/!room'),
         '/?m=course:!s&left=course,room:!room',
       );
-      // The in-course activity overlay: the path collapses to the filter, the
-      // ?activity= (and any other) query is preserved.
+      // The in-course activity: the path collapses to the course filter and the
+      // inbound `?activity=` overlay becomes a first-class `left=activity:` panel
+      // token (the sole left token — it claims the live view, no course card
+      // beside it). #7385.
       expect(
         resolve('/courses/!s?activity=a'),
-        '/?m=course:!s&left=course&activity=a',
+        '/?m=course:!s&left=activity:a',
       );
       // An open right column carries through the rewrite untouched.
       expect(

--- a/test/pangea/navigation/panel_allocator_test.dart
+++ b/test/pangea/navigation/panel_allocator_test.dart
@@ -412,6 +412,25 @@ void main() {
         }
       }
     });
+
+    test('the activity panel is a left-column liveView map-content root (#7385)', () {
+      final activity = PanelRegistry.defs['activity']!;
+      // A root master like `course` (opens from the map/course, no parent) — so it
+      // never folds behind anything and is the narrow-focus leaf when open.
+      expect(activity.column, PanelColumn.left);
+      expect(activity.parent, isNull);
+      // Claims the single live view: a `liveView` sibling of room/session, so
+      // opening an activity drops any open chat and vice versa.
+      expect(activity.siblingGroups, contains('liveView'));
+      // Map content → a bottom sheet on a narrow screen, like a course.
+      expect(activity.mapContent, isTrue);
+      // Sized like a `room` (the live work surface) so it never shrinks past the
+      // chat's floor — the bug #7385 fixed by pulling it into the allocator budget.
+      final room = PanelRegistry.defs['room']!;
+      expect(activity.minWidth, room.minWidth);
+      expect(activity.reasonableMin, room.reasonableMin);
+      expect(activity.idealWidth, room.idealWidth);
+    });
   });
 
   group('exclusive panel holds the screen', () {

--- a/test/pangea/navigation/route_facts_test.dart
+++ b/test/pangea/navigation/route_facts_test.dart
@@ -166,4 +166,34 @@ void main() {
       expect(active('/?left=chats,room:!abc:matrix.org'), '!abc:matrix.org');
     });
   });
+
+  // #7385: the activity plan is a first-class `left=activity:` panel token (no
+  // longer the `?activity=` canvas overlay). It is a left-column `liveView`
+  // sibling of `room`/`session`, so the parser keeps it like any registered panel
+  // and enforces one-live-view exclusivity. `activityFor` reads this same token.
+  group('activity left token (#7385)', () {
+    List<String> leftTypes(String location) => [
+      for (final t in parseOpenPanels(Uri.parse(location)).left) t.type,
+    ];
+    String? activityParam(String location) => parseOpenPanels(
+      Uri.parse(location),
+    ).left.firstWhere((t) => t.type == 'activity').param;
+
+    test('an `activity` left token parses with its id as the param', () {
+      expect(leftTypes('/?left=activity:abc'), ['activity']);
+      expect(activityParam('/?left=activity:abc'), 'abc');
+      expect(
+        activityParam(
+          '/?m=course:!s&left=activity:32ad3c08-e501-41c5-b544-0875026090ed',
+        ),
+        '32ad3c08-e501-41c5-b544-0875026090ed',
+      );
+    });
+
+    test('activity and room are liveView siblings — only the first survives', () {
+      // Opening an activity claims the single live view (a chat can\'t coexist).
+      expect(leftTypes('/?left=activity:a,room:!r'), ['activity']);
+      expect(leftTypes('/?left=room:!r,activity:a'), ['room']);
+    });
+  });
 }

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -189,6 +189,25 @@ void main() {
       expect(left.any((t) => t.type == 'room'), isTrue);
       expect(left.any((t) => t.type == 'course'), isTrue);
     });
+
+    test('reopening the course card sheds an open immersive activity (#7385)', () {
+      // The in-course "Pick different activity" / "Return to course" exits route
+      // through openCourse/openCourseFilter: showing the card is leaving the
+      // activity, so the live-view activity token must NOT co-render beside it
+      // (it is not a sibling of `course`, so only an explicit drop clears it).
+      final fromActivity = u('/?m=course:!s&left=activity:abc');
+      final viaOpenCourse = parseOpenPanels(
+        u(WorkspaceNav.openCourse(fromActivity, const PanelToken('course'))),
+      ).left;
+      expect(viaOpenCourse.any((t) => t.type == 'activity'), isFalse);
+      expect(viaOpenCourse.any((t) => t.type == 'course'), isTrue);
+
+      final viaFilter = parseOpenPanels(
+        u(WorkspaceNav.openCourseFilter(fromActivity, '!s', tab: 'course')),
+      ).left;
+      expect(viaFilter.any((t) => t.type == 'activity'), isFalse);
+      expect(viaFilter.any((t) => t.type == 'course'), isTrue);
+    });
   });
 
   group('openConstructDetail (one detail at a time, across columns)', () {
@@ -831,13 +850,13 @@ void main() {
     );
   });
 
-  group('openCourseActivity (token-native in-course overlay, #7267)', () {
+  group('openCourseActivity (token-native activity panel, #7385/#7267)', () {
     // Bare localpart ids (no `:domain`): shortRoomId only strips the home
     // server_name, which is unavailable in a unit test (no MatrixState), so a
     // `!x:server.com` would ride the URL whole. The existing course helpers test
     // the same way — the id format is orthogonal to what this producer asserts.
-    test('sets the course scope + activity overlay on a clean workspace — no '
-        'left/right panels (the #7267 split)', () {
+    test('sets the course scope + a sole `left=activity:` token — no other '
+        'left/right panels (#7385 first-class panel, #7267 split)', () {
       final loc = WorkspaceNav.openCourseActivity('!space', 'act-123');
       final uri = u(loc);
       expect(uri.path, '/'); // over the persistent world map
@@ -846,10 +865,15 @@ void main() {
         WorkspaceQuery.valueOf(uri.query, 'm'),
         const PanelToken('course', '!space').encode(),
       );
-      expect(uri.queryParameters['activity'], 'act-123');
-      // The whole point of the fix: an activity REPLACES the panels, so no
-      // `left=course` card (or any right panel) re-opens beside it.
-      expect(WorkspaceQuery.valueOf(uri.query, 'left'), isNull);
+      // #7385: the activity is a first-class left panel token (claims the single
+      // live view), not the old `?activity=` canvas overlay.
+      expect(
+        WorkspaceQuery.valueOf(uri.query, 'left'),
+        const PanelToken('activity', 'act-123').encode(),
+      );
+      expect(uri.queryParameters['activity'], isNull);
+      // #7267: the activity REPLACES the panels, so no `left=course` card rides
+      // beside it and no right panel survives.
       expect(WorkspaceQuery.valueOf(uri.query, 'right'), isNull);
     });
 


### PR DESCRIPTION
Closes #7385.

## What

The activity start page was the only exception in the world_v2 layout. It rendered as a center "canvas detail" keyed on `?activity=`, with a width that capped at detailMax but had no minimum floor and was not in the PanelAllocator budget, so it shrank past the chat's min and slid under panels.

This makes the activity a first-class left-column panel, so there are zero layout exceptions:

- New `activity` PanelDef (left column, root, `liveView` sibling of room/session, `mapContent`, widths 360/480/720 like a room). It is now in the allocator budget with a real min floor, so it can never shrink past the chat's min or slide under a panel (the bug being fixed).
- The `?activity=<id>` overlay becomes a `left=activity:<id>` panel token. `activityFor()` reads the token first, with the legacy query/path kept as a fallback.
- Openers emit the token (`openCourseActivity`, `world_map.openActivity`); inbound legacy deep links (`/<uuid>`, `/courses/:id?activity=`, `/rooms/spaces/:s/activity/:id`) all resolve to the token; the `/:activityId` render route is replaced by an inbound redirect (mirroring `/rooms/:roomid`).
- The shell drops the activity canvas-detail path entirely; `mobileCourseIndex` generalizes to `mobileSheetIndex`, so a narrow course or activity rides the same bottom sheet, and the activity renders through `WorkspaceLeftPanel` like every other panel.
- Opening an activity claims the single live view (drops an open chat); starting the session replaces the activity with the room token. The in-course "Pick different activity" / "Return to course" exits now shed the activity token too.

Design intent is captured in `routing.instructions.md`, updated in this PR.

## Testing

- `flutter test test/pangea/navigation/` (186) and the world-map suite (65) pass; full `flutter analyze` is clean; the `dart format` gate is green.
- New unit coverage: the activity token parse + liveView exclusivity, the registry shape, the `/<uuid>` and `?activity=` redirects, the token-emitting opener, and the course-card exits shedding the activity (a state leak a 10-agent adversarial review caught, fixed here with a regression test).
- Local browser preview could not run: the dev server's hot restart fails on a Flutter framework `hitTestTransform` mismatch (a toolchain issue unrelated to this change). Since this is a visible layout change, I will smoke the render on staging once the deploy lands (activity opens as a left panel that holds the chat's min width; start, close, and the back/X affordances behave).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity links now open as a left-side panel over the map, including on mobile as a bottom sheet.
  * Course-linked activity views now use the same panel-based navigation, with clearer behavior when opening or closing related content.

* **Bug Fixes**
  * Improved deep-link handling for standalone activity URLs.
  * Fixed navigation so opening a course or activity no longer leaves conflicting panels or stale filters behind.
  * Closing an activity view now returns users to the correct underlying screen more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->