### PR TITLE
Isolate self-destruct worker activate steps so activation never rejects

### DIFF
--- a/scripts/self_destroying_service_worker.js
+++ b/scripts/self_destroying_service_worker.js
@@ -9,12 +9,16 @@
 // so infrequent returning users are still caught.
 //
 // Do NOT call clients.navigate() from inside activate: reloading the controlling
-// document mid-activation aborts the activation and wedges the worker in
+// document mid-activation rejects activation and wedges the worker in
 // "installing" (the bug the first version of this file hit). Reloads are
 // page-driven instead — via controllerchange and the postMessage below, handled
 // by the eviction script in index.html. The page triggers this worker's install
 // by calling registration.update() (the only lever that works in WebKit/Safari,
 // where a page cannot unregister its own controller).
+//
+// Every activate step is individually guarded so a single rejection can never
+// fail activation. A failed activate discards the worker and re-strands the user
+// on the old controller — the exact failure mode we are evicting.
 
 self.addEventListener('install', (event) => {
   event.waitUntil(self.skipWaiting());
@@ -23,19 +27,31 @@ self.addEventListener('install', (event) => {
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     (async () => {
-      // Claim first so the controllerchange the page waits on fires even if
-      // unregister() throws on a wedged registration.
-      await self.clients.claim();
-      const cacheKeys = await caches.keys();
-      await Promise.all(cacheKeys.map((key) => caches.delete(key)));
       try {
-        await self.registration.unregister();
+        // Claim first so the controllerchange the page waits on fires even if a
+        // later step throws.
+        await self.clients.claim();
+        try {
+          const cacheKeys = await caches.keys();
+          await Promise.all(cacheKeys.map((key) => caches.delete(key)));
+        } catch (e) {
+          /* best effort */
+        }
+        try {
+          await self.registration.unregister();
+        } catch (e) {
+          /* best effort */
+        }
+        try {
+          const windowClients = await self.clients.matchAll({ type: 'window' });
+          for (const client of windowClients) {
+            client.postMessage({ type: 'SW_SELF_DESTRUCT_RELOAD' });
+          }
+        } catch (e) {
+          /* best effort */
+        }
       } catch (e) {
-        /* best effort */
-      }
-      const windowClients = await self.clients.matchAll({ type: 'window' });
-      for (const client of windowClients) {
-        client.postMessage({ type: 'SW_SELF_DESTRUCT_RELOAD' });
+        /* never let activate reject */
       }
     })(),
   );


### PR DESCRIPTION
Follow-up hardening to #7397, from a verification pass on the Safari eviction.

The self-destruct worker is functionally correct, but its `activate` runs `clients.claim()`, `caches.delete()`, and `postMessage` under one `waitUntil`. If any single step rejects, the whole activation rejects, which discards the worker and re-strands the user on the old controller. That is the same failure class that the v1 `clients.navigate()` bug triggered.

This wraps each step in its own try/catch and the whole body in an outer guard so `activate` can never reject. No behavior change on the success path. Still no `clients.navigate()` (reloads stay page-driven via `controllerchange` + the postMessage).

Verified by research: `event.waitUntil(self.skipWaiting())` resolves immediately and cannot strand a worker in `installing`; the observed stuck-installing state on one tester's browser is the v1 `navigate()` poison (registration-local), not a general WebKit failure of this pattern.