### PR TITLE
build: translations

### DIFF
--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ar",
-    "@@last_modified": "2026-06-29 12:25:09.327088",
+    "@@last_modified": "2026-06-30 09:35:35.763799",
     "about": "حول",
     "@about": {
         "type": "String",
@@ -9817,16 +9817,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "انقر على فقاعة الرسالة لتحديدها",
-    "writingAssistanceTutorialInputBar": "يمكنك الكتابة بأي لغة. لا تقلق بشأن الأخطاء! سنساعدك في تصحيحها.",
     "writingAssistanceTutorialIGCButton": "بعد كتابة رسالتك، انقر على هذا الزر لبدء المساعدة في الكتابة",
     "selectModeTutorialTranslate": "انقر هنا لترجمة الرسالة",
     "selectModeTutorialAudio": "انقر هنا للاستماع إلى الرسالة",
     "selectModeTutorialExit": "انقر على الخلفية للعودة إلى الدردشة",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10446,6 +10441,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "إغلاق قائمة الدردشات",
+    "closeChat": "إغلاق الدردشة",
+    "closeSession": "إغلاق مراجعة النشاط",
+    "closeCourse": "إغلاق الدورة",
+    "closeCoursePage": "إغلاق صفحة الدورة",
+    "closeAddCourse": "إغلاق إضافة دورة",
+    "closeAnalytics": "إغلاق التحليلات",
+    "closeVocabulary": "إغلاق المفردات",
+    "closeGrammar": "إغلاق القواعد",
+    "closePractice": "إغلاق الممارسة",
+    "closeSettings": "إغلاق الإعدادات",
+    "closeActivity": "إغلاق النشاط",
+    "closeNamed": "إغلاق {name}",
+    "clearSearch": "مسح البحث",
+    "starRowLabel": "تم إكمال {filled} من أصل {total} نجوم",
+    "difficultyLabel": "الصعوبة: {cefr}",
+    "writingAssistanceTutorialInputBar": "يمكنك الكتابة بأي لغة! سنساعدك في تصحيح الأخطاء.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_be.arb
+++ b/lib/l10n/intl_be.arb
@@ -3933,7 +3933,7 @@
     "playWithAI": "Пакуль гуляйце з ШІ",
     "courseStartDesc": "Pangea Bot гатовы да працы ў любы час!\n\n...але навучанне лепш з сябрамі!",
     "@@locale": "be",
-    "@@last_modified": "2026-06-29 12:24:57.933766",
+    "@@last_modified": "2026-06-30 09:34:59.500393",
     "@ignore": {
         "type": "String",
         "placeholders": {}
@@ -9491,16 +9491,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Націсніце на паветранае паведамленне, каб выбраць яго",
-    "writingAssistanceTutorialInputBar": "Вы можаце пісаць на любой мове. Не хвалюйцеся пра памылкі! Мы дапаможам вам іх выправіць.",
     "writingAssistanceTutorialIGCButton": "Пасля таго, як вы напішаце сваё паведамленне, націсніце гэтую кнопку, каб пачаць дапамогу ў пісьме",
     "selectModeTutorialTranslate": "Націсніце тут, каб перакласці паведамленне",
     "selectModeTutorialAudio": "Націсніце тут, каб паслухаць паведамленне",
     "selectModeTutorialExit": "Націсніце на фон, каб вярнуцца да размовы",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10120,6 +10115,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Зачыніць спіс чатаў",
+    "closeChat": "Зачыніць чат",
+    "closeSession": "Зачыніць агляд дзейнасці",
+    "closeCourse": "Зачыніць курс",
+    "closeCoursePage": "Зачыніць старонку курса",
+    "closeAddCourse": "Зачыніць дадаць курс",
+    "closeAnalytics": "Зачыніць аналітыку",
+    "closeVocabulary": "Зачыніць слоўнік",
+    "closeGrammar": "Зачыніць граматыку",
+    "closePractice": "Зачыніць практыку",
+    "closeSettings": "Закрыць налады",
+    "closeActivity": "Закрыць актыўнасць",
+    "closeNamed": "Закрыць {name}",
+    "clearSearch": "Ачысціць пошук",
+    "starRowLabel": "{filled} з {total} зорак былі завершаны",
+    "difficultyLabel": "Складанасць: {cefr}",
+    "writingAssistanceTutorialInputBar": "Вы можаце пісаць на любой мове! Мы дапаможам вам выправіць памылкі.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_bn.arb
+++ b/lib/l10n/intl_bn.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:25:21.512557",
+    "@@last_modified": "2026-06-30 09:36:19.055994",
     "about": "সম্পর্কে",
     "@about": {
         "type": "String",
@@ -10192,16 +10192,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "বার্তাটি নির্বাচন করতে বার্তা বুদবুদে ক্লিক করুন",
-    "writingAssistanceTutorialInputBar": "আপনি যেকোনো ভাষায় লিখতে পারেন। ভুল নিয়ে চিন্তা করবেন না! আমরা আপনাকে সেগুলি সংশোধন করতে সাহায্য করব।",
     "writingAssistanceTutorialIGCButton": "আপনার বার্তা লেখার পর, লেখার সহায়তা শুরু করতে এই বোতামে ক্লিক করুন",
     "selectModeTutorialTranslate": "বার্তাটি অনুবাদ করতে এখানে ক্লিক করুন",
     "selectModeTutorialAudio": "বার্তাটি শোনার জন্য এখানে ক্লিক করুন",
     "selectModeTutorialExit": "চ্যাটিংয়ে ফিরে যেতে পটভূমিতে ক্লিক করুন",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10821,6 +10816,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "চ্যাট তালিকা বন্ধ করুন",
+    "closeChat": "চ্যাট বন্ধ করুন",
+    "closeSession": "কার্যকলাপ পর্যালোচনা বন্ধ করুন",
+    "closeCourse": "কোর্স বন্ধ করুন",
+    "closeCoursePage": "কোর্স পৃষ্ঠা বন্ধ করুন",
+    "closeAddCourse": "কোর্স যোগ করা বন্ধ করুন",
+    "closeAnalytics": "বিশ্লেষণ বন্ধ করুন",
+    "closeVocabulary": "শব্দভাণ্ডার বন্ধ করুন",
+    "closeGrammar": "ব্যাকরণ বন্ধ করুন",
+    "closePractice": "অভ্যাস বন্ধ করুন",
+    "closeSettings": "সেটিংস বন্ধ করুন",
+    "closeActivity": "কার্যকলাপ বন্ধ করুন",
+    "closeNamed": "বন্ধ করুন {name}",
+    "clearSearch": "অনুসন্ধান পরিষ্কার করুন",
+    "starRowLabel": "{filled} এর মধ্যে {total} টি তারকা সম্পন্ন হয়েছে",
+    "difficultyLabel": "কঠিনতা: {cefr}",
+    "writingAssistanceTutorialInputBar": "আপনি যেকোনো ভাষায় লিখতে পারেন! আমরা আপনাকে ভুলগুলি সংশোধন করতে সাহায্য করব।",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_bo.arb
+++ b/lib/l10n/intl_bo.arb
@@ -3193,7 +3193,7 @@
     "loginToAccount": "ངའི་ཁུལ་གཅིག་ལ་སྤྱོད་ལམ་སྤྱོད་འབད།",
     "languages": "ཚོད་ལྟ",
     "@@locale": "bo",
-    "@@last_modified": "2026-06-29 12:25:18.557461",
+    "@@last_modified": "2026-06-30 09:36:10.750767",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -9149,16 +9149,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Klik di gelembung pesan untuk memilihnya",
-    "writingAssistanceTutorialInputBar": "Anda dapat menulis dalam bahasa apa pun. Jangan khawatir tentang kesalahan! Kami akan membantu Anda memperbaikinya.",
     "writingAssistanceTutorialIGCButton": "Setelah menulis pesan Anda, klik tombol ini untuk memulai bantuan penulisan",
     "selectModeTutorialTranslate": "Klik di sini untuk menerjemahkan pesan",
     "selectModeTutorialAudio": "Klik di sini untuk mendengarkan pesan",
     "selectModeTutorialExit": "Klik latar belakang untuk kembali ke obrolan",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -9778,6 +9773,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Bok chat list",
+    "closeChat": "Bok chat",
+    "closeSession": "Bok activity review",
+    "closeCourse": "Bok course",
+    "closeCoursePage": "Bok course page",
+    "closeAddCourse": "Bok add course",
+    "closeAnalytics": "Bok analytics",
+    "closeVocabulary": "Bok vocabulary",
+    "closeGrammar": "Bok grammar",
+    "closePractice": "Bok practice",
+    "closeSettings": "Tutup pengaturan",
+    "closeActivity": "Tutup aktivitas",
+    "closeNamed": "Tutup {name}",
+    "clearSearch": "Bersihkan pencarian",
+    "starRowLabel": "{filled} dari {total} bintang telah diselesaikan",
+    "difficultyLabel": "Kesulitan: {cefr}",
+    "writingAssistanceTutorialInputBar": "Anda dapat menulis dalam bahasa apa pun! Kami akan membantu Anda memperbaiki kesalahan.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ca.arb
+++ b/lib/l10n/intl_ca.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:24:59.505117",
+    "@@last_modified": "2026-06-30 09:35:03.468240",
     "about": "Quant a",
     "@about": {
         "type": "String",
@@ -9628,16 +9628,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Feu clic a la bombolla de missatge per seleccionar-la",
-    "writingAssistanceTutorialInputBar": "Podeu escriure en qualsevol idioma. No us preocupeu pels errors! Us ajudarem a corregir-los.",
     "writingAssistanceTutorialIGCButton": "Després d'escriure el vostre missatge, feu clic a aquest botó per començar l'assistència d'escriptura",
     "selectModeTutorialTranslate": "Feu clic aquí per traduir el missatge",
     "selectModeTutorialAudio": "Feu clic aquí per escoltar el missatge",
     "selectModeTutorialExit": "Feu clic al fons per tornar a xatejar",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10257,6 +10252,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Tancar la llista de xats",
+    "closeChat": "Tancar xat",
+    "closeSession": "Tancar la revisió d'activitat",
+    "closeCourse": "Tancar curs",
+    "closeCoursePage": "Tancar la pàgina del curs",
+    "closeAddCourse": "Tancar afegir curs",
+    "closeAnalytics": "Tancar analítiques",
+    "closeVocabulary": "Tancar vocabulari",
+    "closeGrammar": "Tancar gramàtica",
+    "closePractice": "Tancar pràctica",
+    "closeSettings": "Tanca la configuració",
+    "closeActivity": "Tanca l'activitat",
+    "closeNamed": "Tanca {name}",
+    "clearSearch": "Neteja la cerca",
+    "starRowLabel": "{filled} de {total} estrelles s'han completat",
+    "difficultyLabel": "Dificultat: {cefr}",
+    "writingAssistanceTutorialInputBar": "Pots escriure en qualsevol idioma! T'ajudarem a corregir errors.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "cs",
-    "@@last_modified": "2026-06-29 12:24:55.006635",
+    "@@last_modified": "2026-06-30 09:34:51.691542",
     "about": "O aplikaci",
     "@about": {
         "type": "String",
@@ -10031,16 +10031,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Klikněte na bublinu zprávy, abyste ji vybrali",
-    "writingAssistanceTutorialInputBar": "Můžete psát v jakémkoli jazyce. Nebojte se chyb! Pomůžeme vám je opravit.",
     "writingAssistanceTutorialIGCButton": "Po napsání zprávy klikněte na toto tlačítko pro zahájení asistence při psaní",
     "selectModeTutorialTranslate": "Klikněte sem pro překlad zprávy",
     "selectModeTutorialAudio": "Klikněte sem pro poslech zprávy",
     "selectModeTutorialExit": "Klikněte na pozadí, abyste se vrátili k chatování",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10660,6 +10655,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Zavřít seznam chatů",
+    "closeChat": "Zavřít chat",
+    "closeSession": "Zavřít přehled aktivity",
+    "closeCourse": "Zavřít kurz",
+    "closeCoursePage": "Zavřít stránku kurzu",
+    "closeAddCourse": "Zavřít přidání kurzu",
+    "closeAnalytics": "Zavřít analytiku",
+    "closeVocabulary": "Zavřít slovní zásobu",
+    "closeGrammar": "Zavřít gramatiku",
+    "closePractice": "Zavřít cvičení",
+    "closeSettings": "Zavřít nastavení",
+    "closeActivity": "Zavřít aktivitu",
+    "closeNamed": "Zavřít {name}",
+    "clearSearch": "Vymazat hledání",
+    "starRowLabel": "{filled} z {total} hvězd bylo dokončeno",
+    "difficultyLabel": "Obtížnost: {cefr}",
+    "writingAssistanceTutorialInputBar": "Můžete psát v jakémkoli jazyce! Pomůžeme vám opravit chyby.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_da.arb
+++ b/lib/l10n/intl_da.arb
@@ -1477,7 +1477,7 @@
     "playWithAI": "Leg med AI for nu",
     "courseStartDesc": "Pangea Bot er klar til at starte når som helst!\n\n...men læring er bedre med venner!",
     "@@locale": "da",
-    "@@last_modified": "2026-06-29 12:24:27.501428",
+    "@@last_modified": "2026-06-30 09:33:37.144253",
     "@aboutHomeserver": {
         "type": "String",
         "placeholders": {
@@ -10571,16 +10571,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Klik på beskedboblen for at vælge den",
-    "writingAssistanceTutorialInputBar": "Du kan skrive på ethvert sprog. Bekymr dig ikke om fejl! Vi hjælper dig med at rette dem.",
     "writingAssistanceTutorialIGCButton": "Efter at have skrevet din besked, klik på denne knap for at starte skriveassistance",
     "selectModeTutorialTranslate": "Klik her for at oversætte beskeden",
     "selectModeTutorialAudio": "Klik her for at lytte til beskeden",
     "selectModeTutorialExit": "Klik på baggrunden for at gå tilbage til chatten",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11200,6 +11195,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Luk chatliste",
+    "closeChat": "Luk chat",
+    "closeSession": "Luk aktivitetsgennemgang",
+    "closeCourse": "Luk kursus",
+    "closeCoursePage": "Luk kursusside",
+    "closeAddCourse": "Luk tilføj kursus",
+    "closeAnalytics": "Luk analyser",
+    "closeVocabulary": "Luk ordforråd",
+    "closeGrammar": "Luk grammatik",
+    "closePractice": "Luk øvelse",
+    "closeSettings": "Luk indstillinger",
+    "closeActivity": "Luk aktivitet",
+    "closeNamed": "Luk {name}",
+    "clearSearch": "Ryd søgning",
+    "starRowLabel": "{filled} ud af {total} stjerner er blevet fuldført",
+    "difficultyLabel": "Sværhedsgrad: {cefr}",
+    "writingAssistanceTutorialInputBar": "Du kan skrive på ethvert sprog! Vi hjælper dig med at rette fejl.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "de",
-    "@@last_modified": "2026-06-29 12:24:47.838494",
+    "@@last_modified": "2026-06-30 09:34:30.799561",
     "alwaysUse24HourFormat": "true",
     "@alwaysUse24HourFormat": {
         "description": "Set to true to always display time of day in 24 hour format."
@@ -9456,16 +9456,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Klicken Sie auf die Nachrichtenblase, um sie auszuwählen",
-    "writingAssistanceTutorialInputBar": "Sie können in jeder Sprache schreiben. Machen Sie sich keine Sorgen über Fehler! Wir helfen Ihnen, sie zu korrigieren.",
     "writingAssistanceTutorialIGCButton": "Nachdem Sie Ihre Nachricht geschrieben haben, klicken Sie auf diese Schaltfläche, um die Schreibassistenz zu starten",
     "selectModeTutorialTranslate": "Klicken Sie hier, um die Nachricht zu übersetzen",
     "selectModeTutorialAudio": "Klicken Sie hier, um die Nachricht anzuhören",
     "selectModeTutorialExit": "Klicken Sie auf den Hintergrund, um zum Chat zurückzukehren",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10085,6 +10080,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Chatliste schließen",
+    "closeChat": "Chat schließen",
+    "closeSession": "Aktivitätsüberprüfung schließen",
+    "closeCourse": "Kurs schließen",
+    "closeCoursePage": "Kursseite schließen",
+    "closeAddCourse": "Kurs hinzufügen schließen",
+    "closeAnalytics": "Analytik schließen",
+    "closeVocabulary": "Wortschatz schließen",
+    "closeGrammar": "Grammatik schließen",
+    "closePractice": "Übung schließen",
+    "closeSettings": "Einstellungen schließen",
+    "closeActivity": "Aktivität schließen",
+    "closeNamed": "{name} schließen",
+    "clearSearch": "Suche löschen",
+    "starRowLabel": "{filled} von {total} Sternen wurden abgeschlossen",
+    "difficultyLabel": "Schwierigkeit: {cefr}",
+    "writingAssistanceTutorialInputBar": "Sie können in jeder Sprache schreiben! Wir helfen Ihnen, Fehler zu korrigieren.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_el.arb
+++ b/lib/l10n/intl_el.arb
@@ -3771,7 +3771,7 @@
     "playWithAI": "Παίξτε με την Τεχνητή Νοημοσύνη προς το παρόν",
     "courseStartDesc": "Ο Pangea Bot είναι έτοιμος να ξεκινήσει οποιαδήποτε στιγμή!\n\n...αλλά η μάθηση είναι καλύτερη με φίλους!",
     "@@locale": "el",
-    "@@last_modified": "2026-06-29 12:25:32.289202",
+    "@@last_modified": "2026-06-30 09:36:34.944245",
     "@checkList": {
         "type": "String",
         "placeholders": {}
@@ -10526,16 +10526,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Κάντε κλικ στη φούσκα μηνύματος για να την επιλέξετε",
-    "writingAssistanceTutorialInputBar": "Μπορείτε να γράψετε σε οποιαδήποτε γλώσσα. Μην ανησυχείτε για τα λάθη! Θα σας βοηθήσουμε να τα διορθώσετε.",
     "writingAssistanceTutorialIGCButton": "Αφού γράψετε το μήνυμά σας, κάντε κλικ σε αυτό το κουμπί για να ξεκινήσετε τη βοήθεια γραφής",
     "selectModeTutorialTranslate": "Κάντε κλικ εδώ για να μεταφράσετε το μήνυμα",
     "selectModeTutorialAudio": "Κάντε κλικ εδώ για να ακούσετε το μήνυμα",
     "selectModeTutorialExit": "Κάντε κλικ στο φόντο για να επιστρέψετε στη συνομιλία",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11155,6 +11150,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Κλείσιμο λίστας συνομιλιών",
+    "closeChat": "Κλείσιμο συνομιλίας",
+    "closeSession": "Κλείσιμο ανασκόπησης δραστηριότητας",
+    "closeCourse": "Κλείσιμο μαθήματος",
+    "closeCoursePage": "Κλείσιμο σελίδας μαθήματος",
+    "closeAddCourse": "Κλείσιμο προσθήκης μαθήματος",
+    "closeAnalytics": "Κλείσιμο αναλύσεων",
+    "closeVocabulary": "Κλείσιμο λεξιλογίου",
+    "closeGrammar": "Κλείσιμο γραμματικής",
+    "closePractice": "Κλείσιμο πρακτικής",
+    "closeSettings": "Κλείσιμο ρυθμίσεων",
+    "closeActivity": "Κλείσιμο δραστηριότητας",
+    "closeNamed": "Κλείσιμο {name}",
+    "clearSearch": "Καθαρισμός αναζήτησης",
+    "starRowLabel": "{filled} από {total} αστέρια έχουν ολοκληρωθεί",
+    "difficultyLabel": "Δυσκολία: {cefr}",
+    "writingAssistanceTutorialInputBar": "Μπορείτε να γράψετε σε οποιαδήποτε γλώσσα! Θα σας βοηθήσουμε να διορθώσετε τα λάθη.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -4841,7 +4841,6 @@
     "blockUsernameHint": "Block username",
     "errorTryAgainSoon": "Writing assistance is taking a bit longer than expected. Try again in a second!",
     "readingAssistanceTutorialClickMessage": "Click on the message bubble to select it",
-    "writingAssistanceTutorialInputBar": "You can write in any language. Don't worry about mistakes! We'll help you correct them.",
     "writingAssistanceTutorialIGCButton": "After writing your message, click this button to start writing assistance",
     "selectModeTutorialTranslate": "Click here to translate the message",
     "selectModeTutorialAudio": "Click here to listen to the message",
@@ -5003,5 +5002,6 @@
             }
         }
     },
-    "joinLearningCommunities": "Join international learning communities, or start your own!"
+    "joinLearningCommunities": "Join international learning communities, or start your own!",
+    "writingAssistanceTutorialInputBar": "You can write in any language! We'll help you correct mistakes."
 }

--- a/lib/l10n/intl_eo.arb
+++ b/lib/l10n/intl_eo.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:25:36.475781",
+    "@@last_modified": "2026-06-30 09:36:47.721639",
     "about": "Prio",
     "@about": {
         "type": "String",
@@ -10596,16 +10596,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Klaku sur la mesaĝbublo por elekti ĝin",
-    "writingAssistanceTutorialInputBar": "Vi povas skribi en ajna lingvo. Ne zorgu pri eraroj! Ni helpos vin korekti ilin.",
     "writingAssistanceTutorialIGCButton": "Post skribado de via mesaĝo, klaku ĉi tiun butonon por komenci skriban asistadon",
     "selectModeTutorialTranslate": "Klaku ĉi tie por traduki la mesaĝon",
     "selectModeTutorialAudio": "Klaku ĉi tie por aŭdi la mesaĝon",
     "selectModeTutorialExit": "Klaku la fonon por reveni al babado",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11225,6 +11220,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Fermi ĉatliston",
+    "closeChat": "Fermi ĉaton",
+    "closeSession": "Fermi aktivan revizion",
+    "closeCourse": "Fermi kurson",
+    "closeCoursePage": "Fermi kurspagon",
+    "closeAddCourse": "Fermi aldoni kurson",
+    "closeAnalytics": "Fermi analitiko",
+    "closeVocabulary": "Fermi vortaron",
+    "closeGrammar": "Fermi gramatikon",
+    "closePractice": "Fermi praktikon",
+    "closeSettings": "Fermi agordojn",
+    "closeActivity": "Fermi aktivecon",
+    "closeNamed": "Fermi {name}",
+    "clearSearch": "Malplenigi serĉon",
+    "starRowLabel": "{filled} el {total} steloj estas kompletigitaj",
+    "difficultyLabel": "Malfacileco: {cefr}",
+    "writingAssistanceTutorialInputBar": "Vi povas skribi en ajna lingvo! Ni helpos vin korekti erarojn.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "es",
-    "@@last_modified": "2026-06-29 12:24:23.564627",
+    "@@last_modified": "2026-06-30 09:33:20.956127",
     "about": "Acerca de",
     "@about": {
         "type": "String",
@@ -7571,16 +7571,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Haz clic en la burbuja de mensaje para seleccionarla",
-    "writingAssistanceTutorialInputBar": "Puedes escribir en cualquier idioma. ¡No te preocupes por los errores! Te ayudaremos a corregirlos.",
     "writingAssistanceTutorialIGCButton": "Después de escribir tu mensaje, haz clic en este botón para comenzar la asistencia de escritura",
     "selectModeTutorialTranslate": "Haz clic aquí para traducir el mensaje",
     "selectModeTutorialAudio": "Haz clic aquí para escuchar el mensaje",
     "selectModeTutorialExit": "Haz clic en el fondo para volver a chatear",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -8200,6 +8195,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Cerrar lista de chats",
+    "closeChat": "Cerrar chat",
+    "closeSession": "Cerrar revisión de actividad",
+    "closeCourse": "Cerrar curso",
+    "closeCoursePage": "Cerrar página del curso",
+    "closeAddCourse": "Cerrar agregar curso",
+    "closeAnalytics": "Cerrar análisis",
+    "closeVocabulary": "Cerrar vocabulario",
+    "closeGrammar": "Cerrar gramática",
+    "closePractice": "Cerrar práctica",
+    "closeSettings": "Cerrar configuraciones",
+    "closeActivity": "Cerrar actividad",
+    "closeNamed": "Cerrar {name}",
+    "clearSearch": "Borrar búsqueda",
+    "starRowLabel": "{filled} de {total} estrellas han sido completadas",
+    "difficultyLabel": "Dificultad: {cefr}",
+    "writingAssistanceTutorialInputBar": "¡Puedes escribir en cualquier idioma! Te ayudaremos a corregir errores.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_et.arb
+++ b/lib/l10n/intl_et.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "et",
-    "@@last_modified": "2026-06-29 12:24:46.709321",
+    "@@last_modified": "2026-06-30 09:34:26.914132",
     "about": "Rakenduse teave",
     "@about": {
         "type": "String",
@@ -9474,16 +9474,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Klõpsake sõnumi mullile, et see valida",
-    "writingAssistanceTutorialInputBar": "Saate kirjutada igas keeles. Ärge muretsege vigade pärast! Me aitame teil neid parandada.",
     "writingAssistanceTutorialIGCButton": "Pärast sõnumi kirjutamist klõpsake seda nuppu, et alustada kirjutamisabi",
     "selectModeTutorialTranslate": "Klõpsake siin, et sõnumit tõlkida",
     "selectModeTutorialAudio": "Klõpsake siin, et sõnumit kuulata",
     "selectModeTutorialExit": "Klõpsake taustal, et naasta vestlusse",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10103,6 +10098,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Sulge vestlusloend",
+    "closeChat": "Sulge vestlus",
+    "closeSession": "Sulge tegevuse ülevaade",
+    "closeCourse": "Sulge kursus",
+    "closeCoursePage": "Sulge kursuse leht",
+    "closeAddCourse": "Sulge kursuse lisamine",
+    "closeAnalytics": "Sulge analüütika",
+    "closeVocabulary": "Sulge sõnavara",
+    "closeGrammar": "Sulge grammatika",
+    "closePractice": "Sulge harjutus",
+    "closeSettings": "Sulge seaded",
+    "closeActivity": "Sulge tegevus",
+    "closeNamed": "Sulge {name}",
+    "clearSearch": "Kustuta otsing",
+    "starRowLabel": "{filled} {total} tähest on täidetud",
+    "difficultyLabel": "Raskusaste: {cefr}",
+    "writingAssistanceTutorialInputBar": "Sa saad kirjutada igas keeles! Me aitame sul vigu parandada.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_eu.arb
+++ b/lib/l10n/intl_eu.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "eu",
-    "@@last_modified": "2026-06-29 12:24:44.251229",
+    "@@last_modified": "2026-06-30 09:34:19.850202",
     "about": "Honi buruz",
     "@about": {
         "type": "String",
@@ -9477,16 +9477,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Egin klik mezulari burbuila hautatzeko",
-    "writingAssistanceTutorialInputBar": "Egin dezakezu edozein hizkuntzatan idazteko. Ez kezkatu akatsetaz! Lagunduko dizugu zuzentzen.",
     "writingAssistanceTutorialIGCButton": "Zure mezua idatzi ondoren, egin klik botoi honetan idazteko laguntza hasteko",
     "selectModeTutorialTranslate": "Egin klik hemen mezua itzultzeko",
     "selectModeTutorialAudio": "Egin klik hemen mezua entzuteko",
     "selectModeTutorialExit": "Egin klik atzeko planoan txatera itzultzeko",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10106,6 +10101,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Itxi txat zerrenda",
+    "closeChat": "Itxi txata",
+    "closeSession": "Itxi jarduera irizpena",
+    "closeCourse": "Itxi ikastaroa",
+    "closeCoursePage": "Itxi ikastaro orria",
+    "closeAddCourse": "Itxi ikastaro gehitu",
+    "closeAnalytics": "Itxi analitika",
+    "closeVocabulary": "Itxi hiztegia",
+    "closeGrammar": "Itxi gramatika",
+    "closePractice": "Itxi praktika",
+    "closeSettings": "Itxi ezarpenak",
+    "closeActivity": "Itxi jarduera",
+    "closeNamed": "Itxi {name}",
+    "clearSearch": "Garbitu bilaketa",
+    "starRowLabel": "{filled} {total} izarretatik bete dira",
+    "difficultyLabel": "Zailtasuna: {cefr}",
+    "writingAssistanceTutorialInputBar": "Edozein hizkuntzatan idatzi dezakezu! Akatsak zuzentzen lagunduko dizugu.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fa.arb
+++ b/lib/l10n/intl_fa.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:25:27.890147",
+    "@@last_modified": "2026-06-30 09:36:22.729933",
     "repeatPassword": "تکرار گذرواژه",
     "@repeatPassword": {},
     "about": "درباره",
@@ -9589,16 +9589,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "روی حباب پیام کلیک کنید تا آن را انتخاب کنید",
-    "writingAssistanceTutorialInputBar": "شما می‌توانید به هر زبانی بنویسید. نگران اشتباهات نباشید! ما به شما در اصلاح آن‌ها کمک خواهیم کرد.",
     "writingAssistanceTutorialIGCButton": "پس از نوشتن پیام خود، روی این دکمه کلیک کنید تا کمک نوشتن شروع شود",
     "selectModeTutorialTranslate": "اینجا کلیک کنید تا پیام را ترجمه کنید",
     "selectModeTutorialAudio": "اینجا کلیک کنید تا پیام را بشنوید",
     "selectModeTutorialExit": "روی پس‌زمینه کلیک کنید تا به چت برگردید",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10218,6 +10213,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "بستن لیست چت",
+    "closeChat": "بستن چت",
+    "closeSession": "بستن بررسی فعالیت",
+    "closeCourse": "بستن دوره",
+    "closeCoursePage": "بستن صفحه دوره",
+    "closeAddCourse": "بستن افزودن دوره",
+    "closeAnalytics": "بستن تجزیه و تحلیل",
+    "closeVocabulary": "بستن واژگان",
+    "closeGrammar": "بستن گرامر",
+    "closePractice": "بستن تمرین",
+    "closeSettings": "بستن تنظیمات",
+    "closeActivity": "بستن فعالیت",
+    "closeNamed": "بستن {name}",
+    "clearSearch": "پاک کردن جستجو",
+    "starRowLabel": "{filled} از {total} ستاره تکمیل شده است",
+    "difficultyLabel": "سختی: {cefr}",
+    "writingAssistanceTutorialInputBar": "شما می‌توانید به هر زبانی بنویسید! ما به شما در اصلاح اشتباهات کمک خواهیم کرد.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fi.arb
+++ b/lib/l10n/intl_fi.arb
@@ -3913,7 +3913,7 @@
     "playWithAI": "Leiki tekoälyn kanssa nyt",
     "courseStartDesc": "Pangea Bot on valmis milloin tahansa!\n\n...mutta oppiminen on parempaa ystävien kanssa!",
     "@@locale": "fi",
-    "@@last_modified": "2026-06-29 12:24:26.245302",
+    "@@last_modified": "2026-06-30 09:33:33.750891",
     "@notificationRuleJitsi": {
         "type": "String",
         "placeholders": {}
@@ -9526,16 +9526,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Napsauta viestikuplaa valitaksesi sen",
-    "writingAssistanceTutorialInputBar": "Voit kirjoittaa millä tahansa kielellä. Älä huoli virheistä! Autamme sinua korjaamaan ne.",
     "writingAssistanceTutorialIGCButton": "Kirjoitettuasi viestisi, napsauta tätä painiketta aloittaaksesi kirjoitusavun",
     "selectModeTutorialTranslate": "Napsauta täällä kääntääksesi viestin",
     "selectModeTutorialAudio": "Napsauta täällä kuunnellaksesi viestiä",
     "selectModeTutorialExit": "Napsauta taustaa palataksesi keskusteluun",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10155,6 +10150,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Sulje keskustelulista",
+    "closeChat": "Sulje keskustelu",
+    "closeSession": "Sulje aktiviteettikatsaus",
+    "closeCourse": "Sulje kurssi",
+    "closeCoursePage": "Sulje kurssisivu",
+    "closeAddCourse": "Sulje lisää kurssi",
+    "closeAnalytics": "Sulje analytiikka",
+    "closeVocabulary": "Sulje sanasto",
+    "closeGrammar": "Sulje kielioppi",
+    "closePractice": "Sulje harjoittelu",
+    "closeSettings": "Sulje asetukset",
+    "closeActivity": "Sulje toiminta",
+    "closeNamed": "Sulje {name}",
+    "clearSearch": "Tyhjennä haku",
+    "starRowLabel": "{filled} {total} tähdestä on suoritettu",
+    "difficultyLabel": "Vaikeusaste: {cefr}",
+    "writingAssistanceTutorialInputBar": "Voit kirjoittaa millä kielellä tahansa! Autamme sinua korjaamaan virheitä.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fil.arb
+++ b/lib/l10n/intl_fil.arb
@@ -2257,7 +2257,7 @@
     "selectAll": "Piliin lahat",
     "deselectAll": "Huwag piliin lahat",
     "@@locale": "fil",
-    "@@last_modified": "2026-06-29 12:25:06.885203",
+    "@@last_modified": "2026-06-30 09:35:25.776368",
     "@setCustomPermissionLevel": {
         "type": "String",
         "placeholders": {}
@@ -10496,16 +10496,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "I-click ang mensahe na bula upang piliin ito",
-    "writingAssistanceTutorialInputBar": "Maaari kang sumulat sa anumang wika. Huwag mag-alala tungkol sa mga pagkakamali! Tutulungan ka naming ituwid ang mga ito.",
     "writingAssistanceTutorialIGCButton": "Matapos isulat ang iyong mensahe, i-click ang button na ito upang simulan ang tulong sa pagsusulat",
     "selectModeTutorialTranslate": "I-click dito upang isalin ang mensahe",
     "selectModeTutorialAudio": "I-click dito upang pakinggan ang mensahe",
     "selectModeTutorialExit": "I-click ang background upang bumalik sa pakikipag-chat",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11125,6 +11120,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Isara ang listahan ng chat",
+    "closeChat": "Isara ang chat",
+    "closeSession": "Isara ang pagsusuri ng aktibidad",
+    "closeCourse": "Isara ang kurso",
+    "closeCoursePage": "Isara ang pahina ng kurso",
+    "closeAddCourse": "Isara ang magdagdag ng kurso",
+    "closeAnalytics": "Isara ang analytics",
+    "closeVocabulary": "Isara ang bokabularyo",
+    "closeGrammar": "Isara ang gramatika",
+    "closePractice": "Isara ang pagsasanay",
+    "closeSettings": "Isara ang mga setting",
+    "closeActivity": "Isara ang aktibidad",
+    "closeNamed": "Isara ang {name}",
+    "clearSearch": "I-clear ang paghahanap",
+    "starRowLabel": "{filled} sa {total} na bituin ang natapos",
+    "difficultyLabel": "Kahirapan: {cefr}",
+    "writingAssistanceTutorialInputBar": "Maaari kang sumulat sa anumang wika! Tutulungan ka naming ituwid ang mga pagkakamali.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "fr",
-    "@@last_modified": "2026-06-29 12:25:43.046793",
+    "@@last_modified": "2026-06-30 09:37:11.762721",
     "about": "À propos",
     "@about": {
         "type": "String",
@@ -9874,16 +9874,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Cliquez sur la bulle de message pour la sélectionner",
-    "writingAssistanceTutorialInputBar": "Vous pouvez écrire dans n'importe quelle langue. Ne vous inquiétez pas pour les erreurs ! Nous vous aiderons à les corriger.",
     "writingAssistanceTutorialIGCButton": "Après avoir écrit votre message, cliquez sur ce bouton pour commencer l'assistance à l'écriture",
     "selectModeTutorialTranslate": "Cliquez ici pour traduire le message",
     "selectModeTutorialAudio": "Cliquez ici pour écouter le message",
     "selectModeTutorialExit": "Cliquez sur l'arrière-plan pour revenir à la discussion",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10503,6 +10498,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Fermer la liste des discussions",
+    "closeChat": "Fermer la discussion",
+    "closeSession": "Fermer l'examen d'activité",
+    "closeCourse": "Fermer le cours",
+    "closeCoursePage": "Fermer la page du cours",
+    "closeAddCourse": "Fermer l'ajout de cours",
+    "closeAnalytics": "Fermer les analyses",
+    "closeVocabulary": "Fermer le vocabulaire",
+    "closeGrammar": "Fermer la grammaire",
+    "closePractice": "Fermer la pratique",
+    "closeSettings": "Fermer les paramètres",
+    "closeActivity": "Fermer l'activité",
+    "closeNamed": "Fermer {name}",
+    "clearSearch": "Effacer la recherche",
+    "starRowLabel": "{filled} sur {total} étoiles ont été complétées",
+    "difficultyLabel": "Difficulté : {cefr}",
+    "writingAssistanceTutorialInputBar": "Vous pouvez écrire dans n'importe quelle langue ! Nous vous aiderons à corriger les erreurs.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ga.arb
+++ b/lib/l10n/intl_ga.arb
@@ -3948,7 +3948,7 @@
     "playWithAI": "Imir le AI faoi láthair",
     "courseStartDesc": "Tá Bot Pangea réidh chun dul am ar bith!\n\n...ach is fearr foghlaim le cairde!",
     "@@locale": "ga",
-    "@@last_modified": "2026-06-29 12:25:41.798959",
+    "@@last_modified": "2026-06-30 09:37:06.706851",
     "@writeAMessageLangCodes": {
         "type": "String",
         "placeholders": {
@@ -9488,16 +9488,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Cliceáil ar an mbabhta teachtaireachta chun é a roghnú",
-    "writingAssistanceTutorialInputBar": "Is féidir leat scríobh i dteanga ar bith. Ná bíodh imní ort faoi earráidí! Cuirfimid cabhair ort chun iad a cheartú.",
     "writingAssistanceTutorialIGCButton": "Tar éis duit do theachtaireacht a scríobh, cliceáil ar an gcnaipe seo chun tús a chur le cabhair scríbhneoireachta",
     "selectModeTutorialTranslate": "Cliceáil anseo chun an teachtaireacht a aistriú",
     "selectModeTutorialAudio": "Cliceáil anseo chun an teachtaireacht a éisteacht",
     "selectModeTutorialExit": "Cliceáil ar an gcúlra chun dul ar ais chuig an gcomhrá",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10117,6 +10112,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Dún liosta comhoibrithe",
+    "closeChat": "Dún comhoibriú",
+    "closeSession": "Dún athbhreithniú gníomhaíochta",
+    "closeCourse": "Dún cúrsa",
+    "closeCoursePage": "Dún leathanach cúrsa",
+    "closeAddCourse": "Dún cuir cúrsa leis",
+    "closeAnalytics": "Dún anailís",
+    "closeVocabulary": "Dún foclóir",
+    "closeGrammar": "Dún gramadach",
+    "closePractice": "Dún cleachtadh",
+    "closeSettings": "Dún socruithe",
+    "closeActivity": "Dún gníomhaíocht",
+    "closeNamed": "Dún {name}",
+    "clearSearch": "Glan cuardach",
+    "starRowLabel": "{filled} as {total} réaltaí atá críochnaithe",
+    "difficultyLabel": "Deacracht: {cefr}",
+    "writingAssistanceTutorialInputBar": "Is féidir leat scríobh i dteanga ar bith! Cuirfimid cabhair ar fáil duit chun botúin a cheartú.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_gl.arb
+++ b/lib/l10n/intl_gl.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "gl",
-    "@@last_modified": "2026-06-29 12:24:24.900721",
+    "@@last_modified": "2026-06-30 09:33:24.656243",
     "about": "Acerca de",
     "@about": {
         "type": "String",
@@ -9477,16 +9477,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Fai clic na burbulla de mensaxe para seleccionala",
-    "writingAssistanceTutorialInputBar": "Podes escribir en calquera idioma. Non te preocupes polas faltas! Axudarémosche a corrixilas.",
     "writingAssistanceTutorialIGCButton": "Despois de escribir a túa mensaxe, fai clic neste botón para comezar a asistencia de escritura",
     "selectModeTutorialTranslate": "Fai clic aquí para traducir a mensaxe",
     "selectModeTutorialAudio": "Fai clic aquí para escoitar a mensaxe",
     "selectModeTutorialExit": "Fai clic no fondo para volver a chatear",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10106,6 +10101,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Pechar lista de chats",
+    "closeChat": "Pechar chat",
+    "closeSession": "Pechar revisión de actividades",
+    "closeCourse": "Pechar curso",
+    "closeCoursePage": "Pechar páxina do curso",
+    "closeAddCourse": "Pechar engadir curso",
+    "closeAnalytics": "Pechar analíticas",
+    "closeVocabulary": "Pechar vocabulario",
+    "closeGrammar": "Pechar gramática",
+    "closePractice": "Pechar práctica",
+    "closeSettings": "Pechar configuracións",
+    "closeActivity": "Pechar actividade",
+    "closeNamed": "Pechar {name}",
+    "clearSearch": "Limpar busca",
+    "starRowLabel": "{filled} de {total} estrelas foron completadas",
+    "difficultyLabel": "Dificultade: {cefr}",
+    "writingAssistanceTutorialInputBar": "Podes escribir en calquera idioma! Axudarémosche a corrixir erros.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_he.arb
+++ b/lib/l10n/intl_he.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:24:40.448308",
+    "@@last_modified": "2026-06-30 09:34:09.052899",
     "about": "אודות",
     "@about": {
         "type": "String",
@@ -10556,16 +10556,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "לחץ על בועת ההודעה כדי לבחור אותה",
-    "writingAssistanceTutorialInputBar": "אתה יכול לכתוב בכל שפה. אל תדאג לגבי טעויות! אנחנו נעזור לך לתקן אותן.",
     "writingAssistanceTutorialIGCButton": "לאחר שכתבת את ההודעה שלך, לחץ על כפתור זה כדי להתחיל בעזרה בכתיבה",
     "selectModeTutorialTranslate": "לחץ כאן כדי לתרגם את ההודעה",
     "selectModeTutorialAudio": "לחץ כאן כדי להקשיב להודעה",
     "selectModeTutorialExit": "לחץ על הרקע כדי לחזור לשיחה",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11185,6 +11180,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "סגור רשימת צ'אטים",
+    "closeChat": "סגור צ'אט",
+    "closeSession": "סגור סקירת פעילות",
+    "closeCourse": "סגור קורס",
+    "closeCoursePage": "סגור דף קורס",
+    "closeAddCourse": "סגור הוספת קורס",
+    "closeAnalytics": "סגור אנליטיקה",
+    "closeVocabulary": "סגור אוצר מילים",
+    "closeGrammar": "סגור דקדוק",
+    "closePractice": "סגור תרגול",
+    "closeSettings": "סגור הגדרות",
+    "closeActivity": "סגור פעילות",
+    "closeNamed": "סגור {name}",
+    "clearSearch": "נקה חיפוש",
+    "starRowLabel": "{filled} מתוך {total} כוכבים הושלמו",
+    "difficultyLabel": "קושי: {cefr}",
+    "writingAssistanceTutorialInputBar": "אתה יכול לכתוב בכל שפה! אנחנו נעזור לך לתקן טעויות.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_hi.arb
+++ b/lib/l10n/intl_hi.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "अभी के लिए एआई के साथ खेलें",
     "courseStartDesc": "पैंजिया बॉट कभी भी जाने के लिए तैयार है!\n\n...लेकिन दोस्तों के साथ सीखना बेहतर है!",
     "@@locale": "hi",
-    "@@last_modified": "2026-06-29 12:25:35.142796",
+    "@@last_modified": "2026-06-30 09:36:43.764370",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10196,16 +10196,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "संदेश बबल पर क्लिक करें ताकि आप इसे चुन सकें",
-    "writingAssistanceTutorialInputBar": "आप किसी भी भाषा में लिख सकते हैं। गलतियों की चिंता न करें! हम आपकी मदद करेंगे उन्हें सुधारने में।",
     "writingAssistanceTutorialIGCButton": "अपने संदेश को लिखने के बाद, लेखन सहायता शुरू करने के लिए इस बटन पर क्लिक करें",
     "selectModeTutorialTranslate": "संदेश का अनुवाद करने के लिए यहां क्लिक करें",
     "selectModeTutorialAudio": "संदेश सुनने के लिए यहां क्लिक करें",
     "selectModeTutorialExit": "चैटिंग पर वापस जाने के लिए पृष्ठभूमि पर क्लिक करें",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10825,6 +10820,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "चैट सूची बंद करें",
+    "closeChat": "चैट बंद करें",
+    "closeSession": "गतिविधि समीक्षा बंद करें",
+    "closeCourse": "कोर्स बंद करें",
+    "closeCoursePage": "कोर्स पृष्ठ बंद करें",
+    "closeAddCourse": "कोर्स जोड़ें बंद करें",
+    "closeAnalytics": "विश्लेषण बंद करें",
+    "closeVocabulary": "शब्दावली बंद करें",
+    "closeGrammar": "व्याकरण बंद करें",
+    "closePractice": "अभ्यास बंद करें",
+    "closeSettings": "सेटिंग्स बंद करें",
+    "closeActivity": "गतिविधि बंद करें",
+    "closeNamed": "{name} बंद करें",
+    "clearSearch": "खोज साफ करें",
+    "starRowLabel": "{filled} में से {total} सितारे पूरे हो चुके हैं",
+    "difficultyLabel": "कठिनाई: {cefr}",
+    "writingAssistanceTutorialInputBar": "आप किसी भी भाषा में लिख सकते हैं! हम आपकी गलतियों को सुधारने में मदद करेंगे।",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_hr.arb
+++ b/lib/l10n/intl_hr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "hr",
-    "@@last_modified": "2026-06-29 12:24:36.954454",
+    "@@last_modified": "2026-06-30 09:34:04.896532",
     "about": "Informacije",
     "@about": {
         "type": "String",
@@ -9961,16 +9961,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Kliknite na balon s porukom da biste ga odabrali",
-    "writingAssistanceTutorialInputBar": "Možete pisati na bilo kojem jeziku. Ne brinite o greškama! Pomoći ćemo vam da ih ispravite.",
     "writingAssistanceTutorialIGCButton": "Nakon što napišete svoju poruku, kliknite na ovu tipku za početak pomoći pri pisanju",
     "selectModeTutorialTranslate": "Kliknite ovdje za prevođenje poruke",
     "selectModeTutorialAudio": "Kliknite ovdje da biste poslušali poruku",
     "selectModeTutorialExit": "Kliknite na pozadinu da se vratite razgovoru",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10590,6 +10585,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Zatvori popis razgovora",
+    "closeChat": "Zatvori razgovor",
+    "closeSession": "Zatvori pregled aktivnosti",
+    "closeCourse": "Zatvori tečaj",
+    "closeCoursePage": "Zatvori stranicu tečaja",
+    "closeAddCourse": "Zatvori dodavanje tečaja",
+    "closeAnalytics": "Zatvori analitiku",
+    "closeVocabulary": "Zatvori rječnik",
+    "closeGrammar": "Zatvori gramatiku",
+    "closePractice": "Zatvori vježbu",
+    "closeSettings": "Zatvori postavke",
+    "closeActivity": "Zatvori aktivnost",
+    "closeNamed": "Zatvori {name}",
+    "clearSearch": "Očisti pretraživanje",
+    "starRowLabel": "{filled} od {total} zvjezdica je dovršeno",
+    "difficultyLabel": "Težina: {cefr}",
+    "writingAssistanceTutorialInputBar": "Možete pisati na bilo kojem jeziku! Pomoći ćemo vam ispraviti greške.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_hu.arb
+++ b/lib/l10n/intl_hu.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "hu",
-    "@@last_modified": "2026-06-29 12:24:29.128377",
+    "@@last_modified": "2026-06-30 09:33:41.863573",
     "about": "Névjegy",
     "@about": {
         "type": "String",
@@ -9604,16 +9604,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Kattints az üzenetbuborékra a kiválasztáshoz",
-    "writingAssistanceTutorialInputBar": "Bármilyen nyelven írhat. Ne aggódjon a hibák miatt! Segítünk kijavítani őket.",
     "writingAssistanceTutorialIGCButton": "Üzenete megírása után kattintson erre a gombra az írási asszisztens elindításához",
     "selectModeTutorialTranslate": "Kattintson ide az üzenet lefordításához",
     "selectModeTutorialAudio": "Kattintson ide az üzenet meghallgatásához",
     "selectModeTutorialExit": "Kattintson a háttérre a csevegéshez való visszatéréshez",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10233,6 +10228,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Csevegőlista bezárása",
+    "closeChat": "Csevegés bezárása",
+    "closeSession": "Tevékenység-áttekintés bezárása",
+    "closeCourse": "Tanfolyam bezárása",
+    "closeCoursePage": "Tanfolyam oldal bezárása",
+    "closeAddCourse": "Tanfolyam hozzáadása bezárása",
+    "closeAnalytics": "Elemzés bezárása",
+    "closeVocabulary": "Szókincs bezárása",
+    "closeGrammar": "Nyelvtan bezárása",
+    "closePractice": "Gyakorlás bezárása",
+    "closeSettings": "Beállítások bezárása",
+    "closeActivity": "Tevékenység bezárása",
+    "closeNamed": "Bezárás: {name}",
+    "clearSearch": "Keresés törlése",
+    "starRowLabel": "{filled} a {total} csillagból teljesítve",
+    "difficultyLabel": "Nehézség: {cefr}",
+    "writingAssistanceTutorialInputBar": "Bármilyen nyelven írhat! Segítünk a hibák javításában.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ia.arb
+++ b/lib/l10n/intl_ia.arb
@@ -1505,7 +1505,7 @@
     "playWithAI": "Joca con le IA pro ora",
     "courseStartDesc": "Pangea Bot es preste a comenzar a qualunque momento!\n\n...ma apprender es melior con amicos!",
     "@@locale": "ia",
-    "@@last_modified": "2026-06-29 12:24:41.808226",
+    "@@last_modified": "2026-06-30 09:34:12.383020",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10587,16 +10587,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Clicca sulla bolla del messaggio per selezionarlo",
-    "writingAssistanceTutorialInputBar": "Puoi scrivere in qualsiasi lingua. Non preoccuparti degli errori! Ti aiuteremo a correggerli.",
     "writingAssistanceTutorialIGCButton": "Dopo aver scritto il tuo messaggio, clicca questo pulsante per iniziare l'assistenza alla scrittura",
     "selectModeTutorialTranslate": "Clicca qui per tradurre il messaggio",
     "selectModeTutorialAudio": "Clicca qui per ascoltare il messaggio",
     "selectModeTutorialExit": "Clicca sullo sfondo per tornare a chattare",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11216,6 +11211,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Fermar lista de chats",
+    "closeChat": "Fermar chat",
+    "closeSession": "Fermar revisión de actividad",
+    "closeCourse": "Fermar curso",
+    "closeCoursePage": "Fermar página de curso",
+    "closeAddCourse": "Fermar añadir curso",
+    "closeAnalytics": "Fermar analíticas",
+    "closeVocabulary": "Fermar vocabulario",
+    "closeGrammar": "Fermar gramática",
+    "closePractice": "Fermar práctica",
+    "closeSettings": "Chèchè réglages",
+    "closeActivity": "Chèchè activité",
+    "closeNamed": "Chèchè {name}",
+    "clearSearch": "Vider recherche",
+    "starRowLabel": "{filled} sur {total} étoiles ont été complétées",
+    "difficultyLabel": "Difficulté : {cefr}",
+    "writingAssistanceTutorialInputBar": "Vous pouvez écrire dans n'importe quelle langue ! Nous vous aiderons à corriger les erreurs.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:24:31.164020",
+    "@@last_modified": "2026-06-30 09:33:46.036856",
     "setAsCanonicalAlias": "Atur sebagai alias utama",
     "@setAsCanonicalAlias": {
         "type": "String",
@@ -9574,16 +9574,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Klik pada gelembung pesan untuk memilihnya",
-    "writingAssistanceTutorialInputBar": "Anda dapat menulis dalam bahasa apa pun. Jangan khawatir tentang kesalahan! Kami akan membantu Anda memperbaikinya.",
     "writingAssistanceTutorialIGCButton": "Setelah menulis pesan Anda, klik tombol ini untuk memulai bantuan penulisan",
     "selectModeTutorialTranslate": "Klik di sini untuk menerjemahkan pesan",
     "selectModeTutorialAudio": "Klik di sini untuk mendengarkan pesan",
     "selectModeTutorialExit": "Klik latar belakang untuk kembali ke obrolan",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10203,6 +10198,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Tutup daftar obrolan",
+    "closeChat": "Tutup obrolan",
+    "closeSession": "Tutup tinjauan aktivitas",
+    "closeCourse": "Tutup kursus",
+    "closeCoursePage": "Tutup halaman kursus",
+    "closeAddCourse": "Tutup tambah kursus",
+    "closeAnalytics": "Tutup analitik",
+    "closeVocabulary": "Tutup kosakata",
+    "closeGrammar": "Tutup tata bahasa",
+    "closePractice": "Tutup latihan",
+    "closeSettings": "Tutup pengaturan",
+    "closeActivity": "Tutup aktivitas",
+    "closeNamed": "Tutup {name}",
+    "clearSearch": "Bersihkan pencarian",
+    "starRowLabel": "{filled} dari {total} bintang telah diselesaikan",
+    "difficultyLabel": "Kesulitan: {cefr}",
+    "writingAssistanceTutorialInputBar": "Anda dapat menulis dalam bahasa apa pun! Kami akan membantu Anda memperbaiki kesalahan.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ie.arb
+++ b/lib/l10n/intl_ie.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "Joca con AI pro ora",
     "courseStartDesc": "Pangea Bot es preste a partir a qualunque momento!\n\n...ma apprender es melior con amicos!",
     "@@locale": "ie",
-    "@@last_modified": "2026-06-29 12:24:34.942439",
+    "@@last_modified": "2026-06-30 09:33:59.675955",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10196,16 +10196,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Clicca sulla bolla del messaggio per selezionarla",
-    "writingAssistanceTutorialInputBar": "Puoi scrivere in qualsiasi lingua. Non preoccuparti degli errori! Ti aiuteremo a correggerli.",
     "writingAssistanceTutorialIGCButton": "Dopo aver scritto il tuo messaggio, clicca questo pulsante per iniziare l'assistenza alla scrittura",
     "selectModeTutorialTranslate": "Clicca qui per tradurre il messaggio",
     "selectModeTutorialAudio": "Clicca qui per ascoltare il messaggio",
     "selectModeTutorialExit": "Clicca sullo sfondo per tornare a chattare",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10825,6 +10820,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Dún liosta comhoibrithe",
+    "closeChat": "Dún comhoibriú",
+    "closeSession": "Dún athbhreithniú gníomhaíochta",
+    "closeCourse": "Dún cúrsa",
+    "closeCoursePage": "Dún leathanach cúrsa",
+    "closeAddCourse": "Dún cur cúrsa leis",
+    "closeAnalytics": "Dún anailís",
+    "closeVocabulary": "Dún foclóir",
+    "closeGrammar": "Dún gramadach",
+    "closePractice": "Dún cleachtadh",
+    "closeSettings": "Dún socruithe",
+    "closeActivity": "Dún gníomhaíocht",
+    "closeNamed": "Dún {name}",
+    "clearSearch": "Glan cuardach",
+    "starRowLabel": "{filled} as {total} réaltaí atá críochnaithe",
+    "difficultyLabel": "Deacracht: {cefr}",
+    "writingAssistanceTutorialInputBar": "Is féidir leat scríobh i dteanga ar bith! Cuirfimid cabhair ar fáil chun botúin a cheartú.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:24:52.045946",
+    "@@last_modified": "2026-06-30 09:34:44.198374",
     "about": "Informazioni",
     "@about": {
         "type": "String",
@@ -9568,16 +9568,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Clicca sulla bolla del messaggio per selezionarla",
-    "writingAssistanceTutorialInputBar": "Puoi scrivere in qualsiasi lingua. Non preoccuparti degli errori! Ti aiuteremo a correggerli.",
     "writingAssistanceTutorialIGCButton": "Dopo aver scritto il tuo messaggio, clicca su questo pulsante per iniziare l'assistenza alla scrittura",
     "selectModeTutorialTranslate": "Clicca qui per tradurre il messaggio",
     "selectModeTutorialAudio": "Clicca qui per ascoltare il messaggio",
     "selectModeTutorialExit": "Clicca sullo sfondo per tornare a chattare",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10197,6 +10192,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Chiudi l'elenco chat",
+    "closeChat": "Chiudi chat",
+    "closeSession": "Chiudi revisione attività",
+    "closeCourse": "Chiudi corso",
+    "closeCoursePage": "Chiudi pagina corso",
+    "closeAddCourse": "Chiudi aggiungi corso",
+    "closeAnalytics": "Chiudi analisi",
+    "closeVocabulary": "Chiudi vocabolario",
+    "closeGrammar": "Chiudi grammatica",
+    "closePractice": "Chiudi pratica",
+    "closeSettings": "Chiudi impostazioni",
+    "closeActivity": "Chiudi attività",
+    "closeNamed": "Chiudi {name}",
+    "clearSearch": "Cancella ricerca",
+    "starRowLabel": "{filled} su {total} stelle sono state completate",
+    "difficultyLabel": "Difficoltà: {cefr}",
+    "writingAssistanceTutorialInputBar": "Puoi scrivere in qualsiasi lingua! Ti aiuteremo a correggere gli errori.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ja",
-    "@@last_modified": "2026-06-29 12:25:33.528601",
+    "@@last_modified": "2026-06-30 09:36:40.342115",
     "about": "このアプリについて",
     "@about": {
         "type": "String",
@@ -10345,16 +10345,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "メッセージバブルをクリックして選択します",
-    "writingAssistanceTutorialInputBar": "どの言語でも書くことができます。間違いを心配しないでください！私たちが修正を手伝います。",
     "writingAssistanceTutorialIGCButton": "メッセージを書いた後、このボタンをクリックしてライティングアシスタンスを開始します",
     "selectModeTutorialTranslate": "ここをクリックしてメッセージを翻訳します",
     "selectModeTutorialAudio": "ここをクリックしてメッセージを聞きます",
     "selectModeTutorialExit": "背景をクリックしてチャットに戻ります",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10974,6 +10969,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "チャットリストを閉じる",
+    "closeChat": "チャットを閉じる",
+    "closeSession": "アクティビティレビューを閉じる",
+    "closeCourse": "コースを閉じる",
+    "closeCoursePage": "コースページを閉じる",
+    "closeAddCourse": "コース追加を閉じる",
+    "closeAnalytics": "分析を閉じる",
+    "closeVocabulary": "語彙を閉じる",
+    "closeGrammar": "文法を閉じる",
+    "closePractice": "練習を閉じる",
+    "closeSettings": "設定を閉じる",
+    "closeActivity": "アクティビティを閉じる",
+    "closeNamed": "{name}を閉じる",
+    "clearSearch": "検索をクリア",
+    "starRowLabel": "{filled} / {total} の星が完了しました",
+    "difficultyLabel": "難易度: {cefr}",
+    "writingAssistanceTutorialInputBar": "どの言語でも書けます！私たちが間違いを修正するのを手伝います。",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ka.arb
+++ b/lib/l10n/intl_ka.arb
@@ -2098,7 +2098,7 @@
     "playWithAI": "ამ დროისთვის ითამაშეთ AI-თან",
     "courseStartDesc": "Pangea Bot მზადაა ნებისმიერ დროს გასასვლელად!\n\n...მაგრამ სწავლა უკეთესია მეგობრებთან ერთად!",
     "@@locale": "ka",
-    "@@last_modified": "2026-06-29 12:25:39.126363",
+    "@@last_modified": "2026-06-30 09:36:57.140034",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10545,16 +10545,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "დააჭირეთ შეტყობინების ბუშტს, რომ აირჩიოთ იგი",
-    "writingAssistanceTutorialInputBar": "თქვენ შეგიძლიათ დაწეროთ ნებისმიერ ენაზე. ნუ ინერვიულებთ შეცდომებზე! ჩვენ დაგეხმარებით მათი გამოსწორებაში.",
     "writingAssistanceTutorialIGCButton": "შეტყობინების დაწერის შემდეგ, დააჭირეთ ამ ღილაკს, რომ დაიწყოთ წერის დახმარება",
     "selectModeTutorialTranslate": "დააჭირეთ აქ, რომ თარგმნოთ შეტყობინება",
     "selectModeTutorialAudio": "დააჭირეთ აქ, რომ მოისმინოთ შეტყობინება",
     "selectModeTutorialExit": "დააჭირეთ ფონზე, რომ დაბრუნდეთ ჩატში",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11174,6 +11169,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "დახურეთ ჩეთის სია",
+    "closeChat": "დახურეთ ჩეთი",
+    "closeSession": "დახურეთ აქტივობის მიმოხილვა",
+    "closeCourse": "დახურეთ კურსი",
+    "closeCoursePage": "დახურეთ კურსის გვერდი",
+    "closeAddCourse": "დახურეთ კურსის დამატება",
+    "closeAnalytics": "დახურეთ ანალიტიკა",
+    "closeVocabulary": "დახურეთ ლექსიკა",
+    "closeGrammar": "დახურეთ გრამატიკა",
+    "closePractice": "დახურეთ პრაქტიკა",
+    "closeSettings": "დახურეთ პარამეტრები",
+    "closeActivity": "დახურეთ აქტივობა",
+    "closeNamed": "დახურეთ {name}",
+    "clearSearch": "წაშალეთ ძიება",
+    "starRowLabel": "{filled} מתוך {total} ვარსკვლავი დასრულებულია",
+    "difficultyLabel": "სირთულე: {cefr}",
+    "writingAssistanceTutorialInputBar": "თქვენ შეგიძლიათ დაწეროთ ნებისმიერ ენაზე! ჩვენ დაგეხმარებით შეცდომების გამოსწორებაში.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:24:22.483523",
+    "@@last_modified": "2026-06-30 09:33:16.875242",
     "about": "소개",
     "@about": {
         "type": "String",
@@ -9694,16 +9694,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "메시지 풍선을 클릭하여 선택하세요",
-    "writingAssistanceTutorialInputBar": "어떤 언어로든 작성할 수 있습니다. 실수에 대해 걱정하지 마세요! 우리가 수정하는 데 도와드릴 것입니다.",
     "writingAssistanceTutorialIGCButton": "메시지를 작성한 후, 이 버튼을 클릭하여 작문 지원을 시작하세요",
     "selectModeTutorialTranslate": "여기를 클릭하여 메시지를 번역하세요",
     "selectModeTutorialAudio": "여기를 클릭하여 메시지를 들어보세요",
     "selectModeTutorialExit": "배경을 클릭하여 채팅으로 돌아가세요",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10323,6 +10318,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "채팅 목록 닫기",
+    "closeChat": "채팅 닫기",
+    "closeSession": "활동 검토 닫기",
+    "closeCourse": "강좌 닫기",
+    "closeCoursePage": "강좌 페이지 닫기",
+    "closeAddCourse": "강좌 추가 닫기",
+    "closeAnalytics": "분석 닫기",
+    "closeVocabulary": "어휘 닫기",
+    "closeGrammar": "문법 닫기",
+    "closePractice": "연습 닫기",
+    "closeSettings": "설정 닫기",
+    "closeActivity": "활동 닫기",
+    "closeNamed": "{name} 닫기",
+    "clearSearch": "검색 지우기",
+    "starRowLabel": "{filled} 개 중 {total} 개의 별이 완료되었습니다",
+    "difficultyLabel": "난이도: {cefr}",
+    "writingAssistanceTutorialInputBar": "어떤 언어로든 작성할 수 있습니다! 우리는 당신의 실수를 수정하는 데 도움을 줄 것입니다.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_lt.arb
+++ b/lib/l10n/intl_lt.arb
@@ -3245,7 +3245,7 @@
     "playWithAI": "Žaiskite su dirbtiniu intelektu dabar",
     "courseStartDesc": "Pangea botas pasiruošęs bet kada pradėti!\n\n...bet mokymasis yra geresnis su draugais!",
     "@@locale": "lt",
-    "@@last_modified": "2026-06-29 12:25:13.836979",
+    "@@last_modified": "2026-06-30 09:35:51.299779",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10363,16 +10363,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Paspauskite ant pranešimo burbulo, kad jį pasirinktumėte",
-    "writingAssistanceTutorialInputBar": "Galite rašyti bet kuria kalba. Nesijaudinkite dėl klaidų! Mes jums padėsime jas ištaisyti.",
     "writingAssistanceTutorialIGCButton": "Parašę savo pranešimą, paspauskite šį mygtuką, kad pradėtumėte rašymo pagalbą",
     "selectModeTutorialTranslate": "Paspauskite čia, kad išverstumėte pranešimą",
     "selectModeTutorialAudio": "Paspauskite čia, kad išgirstumėte pranešimą",
     "selectModeTutorialExit": "Paspauskite fono sritį, kad grįžtumėte prie pokalbio",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10992,6 +10987,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Uždaryti pokalbių sąrašą",
+    "closeChat": "Uždaryti pokalbį",
+    "closeSession": "Uždaryti veiklos apžvalgą",
+    "closeCourse": "Uždaryti kursą",
+    "closeCoursePage": "Uždaryti kurso puslapį",
+    "closeAddCourse": "Uždaryti pridėti kursą",
+    "closeAnalytics": "Uždaryti analitiką",
+    "closeVocabulary": "Uždaryti žodyną",
+    "closeGrammar": "Uždaryti gramatiką",
+    "closePractice": "Uždaryti praktiką",
+    "closeSettings": "Uždaryti nustatymus",
+    "closeActivity": "Uždaryti veiklą",
+    "closeNamed": "Uždaryti {name}",
+    "clearSearch": "Išvalyti paiešką",
+    "starRowLabel": "{filled} iš {total} žvaigždžių buvo užpildytos",
+    "difficultyLabel": "Sunkumas: {cefr}",
+    "writingAssistanceTutorialInputBar": "Galite rašyti bet kuria kalba! Mes padėsime jums ištaisyti klaidas.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_lv.arb
+++ b/lib/l10n/intl_lv.arb
@@ -3919,7 +3919,7 @@
     "playWithAI": "Tagad spēlējiet ar AI",
     "courseStartDesc": "Pangea bots ir gatavs jebkurā laikā!\n\n...bet mācīties ir labāk ar draugiem!",
     "@@locale": "lv",
-    "@@last_modified": "2026-06-29 12:25:07.984629",
+    "@@last_modified": "2026-06-30 09:35:30.810304",
     "analyticsInactiveTitle": "Pieprasījumi neaktīviem lietotājiem nevar tikt nosūtīti",
     "analyticsInactiveDesc": "Neaktīvi lietotāji, kuri nav pieteikušies kopš šīs funkcijas ieviešanas, neredzēs jūsu pieprasījumu.\n\nPieprasījuma poga parādīsies, kad viņi atgriezīsies. Jūs varat atkārtoti nosūtīt pieprasījumu vēlāk, noklikšķinot uz pieprasījuma pogas viņu vārdā, kad tā būs pieejama.",
     "accessRequestedTitle": "Pieprasījums piekļūt analītikai",
@@ -9477,16 +9477,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Noklikšķiniet uz ziņojuma burbuļa, lai to izvēlētos",
-    "writingAssistanceTutorialInputBar": "Jūs varat rakstīt jebkurā valodā. Neuztraucieties par kļūdām! Mēs jums palīdzēsim tās labot.",
     "writingAssistanceTutorialIGCButton": "Pēc ziņojuma uzrakstīšanas noklikšķiniet uz šīs pogas, lai sāktu rakstīšanas palīdzību",
     "selectModeTutorialTranslate": "Noklikšķiniet šeit, lai tulkotu ziņojumu",
     "selectModeTutorialAudio": "Noklikšķiniet šeit, lai klausītos ziņojumu",
     "selectModeTutorialExit": "Noklikšķiniet uz fona, lai atgrieztos sarunā",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10106,6 +10101,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Aizvērt čatu sarakstu",
+    "closeChat": "Aizvērt čatu",
+    "closeSession": "Aizvērt aktivitātes pārskatu",
+    "closeCourse": "Aizvērt kursu",
+    "closeCoursePage": "Aizvērt kursa lapu",
+    "closeAddCourse": "Aizvērt pievienot kursu",
+    "closeAnalytics": "Aizvērt analītiku",
+    "closeVocabulary": "Aizvērt vārdu krājumu",
+    "closeGrammar": "Aizvērt gramatiku",
+    "closePractice": "Aizvērt praksi",
+    "closeSettings": "Aizvērt iestatījumus",
+    "closeActivity": "Aizvērt aktivitāti",
+    "closeNamed": "Aizvērt {name}",
+    "clearSearch": "Notīrīt meklēšanu",
+    "starRowLabel": "{filled} no {total} zvaigznēm ir pabeigtas",
+    "difficultyLabel": "Grūtības pakāpe: {cefr}",
+    "writingAssistanceTutorialInputBar": "Jūs varat rakstīt jebkurā valodā! Mēs palīdzēsim jums labot kļūdas.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_nb.arb
+++ b/lib/l10n/intl_nb.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:24:56.339198",
+    "@@last_modified": "2026-06-30 09:34:55.990915",
     "about": "Om",
     "@about": {
         "type": "String",
@@ -9537,16 +9537,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Klikk på meldingsboblen for å velge den",
-    "writingAssistanceTutorialInputBar": "Du kan skrive på hvilket som helst språk. Ikke bekymre deg for feil! Vi hjelper deg med å rette dem.",
     "writingAssistanceTutorialIGCButton": "Etter å ha skrevet meldingen din, klikk på denne knappen for å starte skriveassistanse",
     "selectModeTutorialTranslate": "Klikk her for å oversette meldingen",
     "selectModeTutorialAudio": "Klikk her for å lytte til meldingen",
     "selectModeTutorialExit": "Klikk på bakgrunnen for å gå tilbake til chatting",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10166,6 +10161,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Lukk chatliste",
+    "closeChat": "Lukk chat",
+    "closeSession": "Lukk aktivitetsgjennomgang",
+    "closeCourse": "Lukk kurs",
+    "closeCoursePage": "Lukk kursside",
+    "closeAddCourse": "Lukk legg til kurs",
+    "closeAnalytics": "Lukk analyser",
+    "closeVocabulary": "Lukk ordforråd",
+    "closeGrammar": "Lukk grammatikk",
+    "closePractice": "Lukk øvelse",
+    "closeSettings": "Lukk innstillinger",
+    "closeActivity": "Lukk aktivitet",
+    "closeNamed": "Lukk {name}",
+    "clearSearch": "Fjern søk",
+    "starRowLabel": "{filled} av {total} stjerner er fullført",
+    "difficultyLabel": "Vanskelighetsgrad: {cefr}",
+    "writingAssistanceTutorialInputBar": "Du kan skrive på hvilket som helst språk! Vi hjelper deg med å rette feil.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:25:17.417604",
+    "@@last_modified": "2026-06-30 09:36:04.578478",
     "about": "Over ons",
     "@about": {
         "type": "String",
@@ -9477,16 +9477,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Klik op de berichtbubble om deze te selecteren",
-    "writingAssistanceTutorialInputBar": "Je kunt in elke taal schrijven. Maak je geen zorgen over fouten! We helpen je ze te corrigeren.",
     "writingAssistanceTutorialIGCButton": "Klik op deze knop om na het schrijven van je bericht met de schrijfassistentie te beginnen",
     "selectModeTutorialTranslate": "Klik hier om het bericht te vertalen",
     "selectModeTutorialAudio": "Klik hier om naar het bericht te luisteren",
     "selectModeTutorialExit": "Klik op de achtergrond om terug te gaan naar het chatten",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10106,6 +10101,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Sluit chatlijst",
+    "closeChat": "Sluit chat",
+    "closeSession": "Sluit activiteitsoverzicht",
+    "closeCourse": "Sluit cursus",
+    "closeCoursePage": "Sluit cursuspagina",
+    "closeAddCourse": "Sluit cursus toevoegen",
+    "closeAnalytics": "Sluit analytics",
+    "closeVocabulary": "Sluit vocabulaire",
+    "closeGrammar": "Sluit grammatica",
+    "closePractice": "Sluit oefening",
+    "closeSettings": "Sluit instellingen",
+    "closeActivity": "Sluit activiteit",
+    "closeNamed": "Sluit {name}",
+    "clearSearch": "Wis zoekopdracht",
+    "starRowLabel": "{filled} van de {total} sterren zijn voltooid",
+    "difficultyLabel": "Moeilijkheidsgraad: {cefr}",
+    "writingAssistanceTutorialInputBar": "Je kunt in elke taal schrijven! We helpen je om fouten te corrigeren.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "pl",
-    "@@last_modified": "2026-06-29 12:25:29.308885",
+    "@@last_modified": "2026-06-30 09:36:27.446177",
     "about": "O aplikacji",
     "@about": {
         "type": "String",
@@ -9586,16 +9586,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Kliknij na dymek wiadomości, aby go wybrać",
-    "writingAssistanceTutorialInputBar": "Możesz pisać w dowolnym języku. Nie martw się o błędy! Pomożemy Ci je poprawić.",
     "writingAssistanceTutorialIGCButton": "Po napisaniu wiadomości kliknij ten przycisk, aby rozpocząć pomoc w pisaniu",
     "selectModeTutorialTranslate": "Kliknij tutaj, aby przetłumaczyć wiadomość",
     "selectModeTutorialAudio": "Kliknij tutaj, aby posłuchać wiadomości",
     "selectModeTutorialExit": "Kliknij w tle, aby wrócić do czatu",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10215,6 +10210,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Zamknij listę czatów",
+    "closeChat": "Zamknij czat",
+    "closeSession": "Zamknij przegląd aktywności",
+    "closeCourse": "Zamknij kurs",
+    "closeCoursePage": "Zamknij stronę kursu",
+    "closeAddCourse": "Zamknij dodawanie kursu",
+    "closeAnalytics": "Zamknij analitykę",
+    "closeVocabulary": "Zamknij słownictwo",
+    "closeGrammar": "Zamknij gramatykę",
+    "closePractice": "Zamknij ćwiczenia",
+    "closeSettings": "Zamknij ustawienia",
+    "closeActivity": "Zamknij aktywność",
+    "closeNamed": "Zamknij {name}",
+    "clearSearch": "Wyczyść wyszukiwanie",
+    "starRowLabel": "{filled} z {total} gwiazdek zostało ukończonych",
+    "difficultyLabel": "Trudność: {cefr}",
+    "writingAssistanceTutorialInputBar": "Możesz pisać w dowolnym języku! Pomożemy Ci poprawić błędy.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:24:45.181466",
+    "@@last_modified": "2026-06-30 09:34:23.399324",
     "copiedToClipboard": "Copiada para a área de transferência",
     "@copiedToClipboard": {
         "type": "String",
@@ -10595,16 +10595,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Clique na bolha de mensagem para selecioná-la",
-    "writingAssistanceTutorialInputBar": "Você pode escrever em qualquer idioma. Não se preocupe com erros! Nós o ajudaremos a corrigi-los.",
     "writingAssistanceTutorialIGCButton": "Após escrever sua mensagem, clique neste botão para iniciar a assistência de escrita",
     "selectModeTutorialTranslate": "Clique aqui para traduzir a mensagem",
     "selectModeTutorialAudio": "Clique aqui para ouvir a mensagem",
     "selectModeTutorialExit": "Clique no fundo para voltar a conversar",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11224,6 +11219,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Fechar lista de chats",
+    "closeChat": "Fechar chat",
+    "closeSession": "Fechar revisão de atividade",
+    "closeCourse": "Fechar curso",
+    "closeCoursePage": "Fechar página do curso",
+    "closeAddCourse": "Fechar adicionar curso",
+    "closeAnalytics": "Fechar análises",
+    "closeVocabulary": "Fechar vocabulário",
+    "closeGrammar": "Fechar gramática",
+    "closePractice": "Fechar prática",
+    "closeSettings": "Fechar configurações",
+    "closeActivity": "Fechar atividade",
+    "closeNamed": "Fechar {name}",
+    "clearSearch": "Limpar pesquisa",
+    "starRowLabel": "{filled} de {total} estrelas foram completadas",
+    "difficultyLabel": "Dificuldade: {cefr}",
+    "writingAssistanceTutorialInputBar": "Você pode escrever em qualquer idioma! Nós ajudaremos você a corrigir erros.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pt_BR.arb
+++ b/lib/l10n/intl_pt_BR.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:24:43.024542",
+    "@@last_modified": "2026-06-30 09:34:16.046841",
     "about": "Sobre",
     "@about": {
         "type": "String",
@@ -9477,16 +9477,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Clique na bolha de mensagem para selecioná-la",
-    "writingAssistanceTutorialInputBar": "Você pode escrever em qualquer idioma. Não se preocupe com erros! Nós vamos ajudá-lo a corrigi-los.",
     "writingAssistanceTutorialIGCButton": "Depois de escrever sua mensagem, clique neste botão para iniciar a assistência de escrita",
     "selectModeTutorialTranslate": "Clique aqui para traduzir a mensagem",
     "selectModeTutorialAudio": "Clique aqui para ouvir a mensagem",
     "selectModeTutorialExit": "Clique no fundo para voltar a conversar",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10106,6 +10101,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Fechar lista de chats",
+    "closeChat": "Fechar chat",
+    "closeSession": "Fechar revisão de atividade",
+    "closeCourse": "Fechar curso",
+    "closeCoursePage": "Fechar página do curso",
+    "closeAddCourse": "Fechar adicionar curso",
+    "closeAnalytics": "Fechar análises",
+    "closeVocabulary": "Fechar vocabulário",
+    "closeGrammar": "Fechar gramática",
+    "closePractice": "Fechar prática",
+    "closeSettings": "Fechar configurações",
+    "closeActivity": "Fechar atividade",
+    "closeNamed": "Fechar {name}",
+    "clearSearch": "Limpar pesquisa",
+    "starRowLabel": "{filled} de {total} estrelas foram completadas",
+    "difficultyLabel": "Dificuldade: {cefr}",
+    "writingAssistanceTutorialInputBar": "Você pode escrever em qualquer idioma! Nós ajudaremos você a corrigir erros.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pt_PT.arb
+++ b/lib/l10n/intl_pt_PT.arb
@@ -2776,7 +2776,7 @@
     "selectAll": "Selecionar tudo",
     "deselectAll": "Desmarcar tudo",
     "@@locale": "pt_PT",
-    "@@last_modified": "2026-06-29 12:25:01.867893",
+    "@@last_modified": "2026-06-30 09:35:11.966357",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10553,16 +10553,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Clique na bolha de mensagem para selecioná-la",
-    "writingAssistanceTutorialInputBar": "Você pode escrever em qualquer idioma. Não se preocupe com erros! Nós o ajudaremos a corrigi-los.",
     "writingAssistanceTutorialIGCButton": "Após escrever sua mensagem, clique neste botão para iniciar a assistência de escrita",
     "selectModeTutorialTranslate": "Clique aqui para traduzir a mensagem",
     "selectModeTutorialAudio": "Clique aqui para ouvir a mensagem",
     "selectModeTutorialExit": "Clique no fundo para voltar a conversar",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11182,6 +11177,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Fechar lista de chats",
+    "closeChat": "Fechar chat",
+    "closeSession": "Fechar revisão de atividade",
+    "closeCourse": "Fechar curso",
+    "closeCoursePage": "Fechar página do curso",
+    "closeAddCourse": "Fechar adicionar curso",
+    "closeAnalytics": "Fechar análises",
+    "closeVocabulary": "Fechar vocabulário",
+    "closeGrammar": "Fechar gramática",
+    "closePractice": "Fechar prática",
+    "closeSettings": "Fechar configurações",
+    "closeActivity": "Fechar atividade",
+    "closeNamed": "Fechar {name}",
+    "clearSearch": "Limpar pesquisa",
+    "starRowLabel": "{filled} de {total} estrelas foram completadas",
+    "difficultyLabel": "Dificuldade: {cefr}",
+    "writingAssistanceTutorialInputBar": "Você pode escrever em qualquer idioma! Nós ajudaremos você a corrigir erros.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ro.arb
+++ b/lib/l10n/intl_ro.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:24:32.381329",
+    "@@last_modified": "2026-06-30 09:33:51.995992",
     "about": "Despre",
     "@about": {
         "type": "String",
@@ -10302,16 +10302,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Faceți clic pe bula de mesaj pentru a o selecta",
-    "writingAssistanceTutorialInputBar": "Puteți scrie în orice limbă. Nu vă faceți griji cu privire la greșeli! Vă vom ajuta să le corectați.",
     "writingAssistanceTutorialIGCButton": "După ce ați scris mesajul, faceți clic pe acest buton pentru a începe asistența la scriere",
     "selectModeTutorialTranslate": "Faceți clic aici pentru a traduce mesajul",
     "selectModeTutorialAudio": "Faceți clic aici pentru a asculta mesajul",
     "selectModeTutorialExit": "Faceți clic pe fundal pentru a reveni la chat",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10931,6 +10926,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Închide lista de chat-uri",
+    "closeChat": "Închide chat-ul",
+    "closeSession": "Închide revizuirea activității",
+    "closeCourse": "Închide cursul",
+    "closeCoursePage": "Închide pagina cursului",
+    "closeAddCourse": "Închide adăugarea cursului",
+    "closeAnalytics": "Închide analitica",
+    "closeVocabulary": "Închide vocabularul",
+    "closeGrammar": "Închide gramatica",
+    "closePractice": "Închide practica",
+    "closeSettings": "Închide setările",
+    "closeActivity": "Închide activitatea",
+    "closeNamed": "Închide {name}",
+    "clearSearch": "Șterge căutarea",
+    "starRowLabel": "{filled} din {total} stele au fost completate",
+    "difficultyLabel": "Dificultate: {cefr}",
+    "writingAssistanceTutorialInputBar": "Poți scrie în orice limbă! Te vom ajuta să corectezi greșelile.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ru",
-    "@@last_modified": "2026-06-29 12:25:37.912093",
+    "@@last_modified": "2026-06-30 09:36:52.110383",
     "about": "О проекте",
     "@about": {
         "type": "String",
@@ -10491,16 +10491,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Нажмите на пузырь сообщения, чтобы выбрать его",
-    "writingAssistanceTutorialInputBar": "Вы можете писать на любом языке. Не беспокойтесь о ошибках! Мы поможем вам их исправить.",
     "writingAssistanceTutorialIGCButton": "После написания вашего сообщения нажмите эту кнопку, чтобы начать помощь в написании",
     "selectModeTutorialTranslate": "Нажмите здесь, чтобы перевести сообщение",
     "selectModeTutorialAudio": "Нажмите здесь, чтобы прослушать сообщение",
     "selectModeTutorialExit": "Нажмите на фон, чтобы вернуться к чату",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11120,6 +11115,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Закрыть список чатов",
+    "closeChat": "Закрыть чат",
+    "closeSession": "Закрыть обзор активности",
+    "closeCourse": "Закрыть курс",
+    "closeCoursePage": "Закрыть страницу курса",
+    "closeAddCourse": "Закрыть добавление курса",
+    "closeAnalytics": "Закрыть аналитику",
+    "closeVocabulary": "Закрыть словарь",
+    "closeGrammar": "Закрыть грамматику",
+    "closePractice": "Закрыть практику",
+    "closeSettings": "Закрыть настройки",
+    "closeActivity": "Закрыть активность",
+    "closeNamed": "Закрыть {name}",
+    "clearSearch": "Очистить поиск",
+    "starRowLabel": "{filled} из {total} звезд завершены",
+    "difficultyLabel": "Сложность: {cefr}",
+    "writingAssistanceTutorialInputBar": "Вы можете писать на любом языке! Мы поможем вам исправить ошибки.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "sk",
-    "@@last_modified": "2026-06-29 12:24:33.792738",
+    "@@last_modified": "2026-06-30 09:33:55.832351",
     "about": "O aplikácii",
     "@about": {
         "type": "String",
@@ -10593,16 +10593,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Kliknite na bublinu správy, aby ste ju vybrali",
-    "writingAssistanceTutorialInputBar": "Môžete písať v akomkoľvek jazyku. Nebojte sa chýb! Pomôžeme vám ich opraviť.",
     "writingAssistanceTutorialIGCButton": "Po napísaní správy kliknite na toto tlačidlo, aby ste spustili pomoc pri písaní",
     "selectModeTutorialTranslate": "Kliknite sem na preloženie správy",
     "selectModeTutorialAudio": "Kliknite sem na vypočutie správy",
     "selectModeTutorialExit": "Kliknite na pozadie, aby ste sa vrátili k chatovaniu",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11222,6 +11217,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Zavrieť zoznam chatov",
+    "closeChat": "Zavrieť chat",
+    "closeSession": "Zavrieť prehľad aktivity",
+    "closeCourse": "Zavrieť kurz",
+    "closeCoursePage": "Zavrieť stránku kurzu",
+    "closeAddCourse": "Zavrieť pridanie kurzu",
+    "closeAnalytics": "Zavrieť analytiku",
+    "closeVocabulary": "Zavrieť slovnú zásobu",
+    "closeGrammar": "Zavrieť gramatiku",
+    "closePractice": "Zavrieť cvičenie",
+    "closeSettings": "Zavrieť nastavenia",
+    "closeActivity": "Zavrieť aktivitu",
+    "closeNamed": "Zavrieť {name}",
+    "clearSearch": "Vymazať vyhľadávanie",
+    "starRowLabel": "{filled} z {total} hviezd bolo dokončených",
+    "difficultyLabel": "Obtiažnosť: {cefr}",
+    "writingAssistanceTutorialInputBar": "Môžete písať v akomkoľvek jazyku! Pomôžeme vám opraviť chyby.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sl.arb
+++ b/lib/l10n/intl_sl.arb
@@ -1962,7 +1962,7 @@
     "playWithAI": "Za zdaj igrajte z AI-jem",
     "courseStartDesc": "Pangea Bot je pripravljen kadarkoli!\n\n...ampak je bolje učiti se s prijatelji!",
     "@@locale": "sl",
-    "@@last_modified": "2026-06-29 12:24:49.687324",
+    "@@last_modified": "2026-06-30 09:34:34.695218",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10593,16 +10593,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Kliknite na mehurček sporočila, da ga izberete",
-    "writingAssistanceTutorialInputBar": "Lahko pišete v katerem koli jeziku. Ne skrbite zaradi napak! Pomagali vam bomo, da jih popravite.",
     "writingAssistanceTutorialIGCButton": "Po tem, ko napišete svoje sporočilo, kliknite to gumb, da začnete pomoč pri pisanju",
     "selectModeTutorialTranslate": "Kliknite tukaj, da prevedete sporočilo",
     "selectModeTutorialAudio": "Kliknite tukaj, da poslušate sporočilo",
     "selectModeTutorialExit": "Kliknite na ozadje, da se vrnete k klepetu",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11222,6 +11217,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Zapri seznam klepetov",
+    "closeChat": "Zapri klepet",
+    "closeSession": "Zapri pregled aktivnosti",
+    "closeCourse": "Zapri tečaj",
+    "closeCoursePage": "Zapri stran tečaja",
+    "closeAddCourse": "Zapri dodaj tečaj",
+    "closeAnalytics": "Zapri analitiko",
+    "closeVocabulary": "Zapri besedišče",
+    "closeGrammar": "Zapri slovnico",
+    "closePractice": "Zapri prakso",
+    "closeSettings": "Zapri nastavitve",
+    "closeActivity": "Zapri dejavnost",
+    "closeNamed": "Zapri {name}",
+    "clearSearch": "Počisti iskanje",
+    "starRowLabel": "{filled} od {total} zvezdic je bilo dokončanih",
+    "difficultyLabel": "Težavnost: {cefr}",
+    "writingAssistanceTutorialInputBar": "Lahko pišete v katerem koli jeziku! Pomagali vam bomo popraviti napake.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sr.arb
+++ b/lib/l10n/intl_sr.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:25:40.466198",
+    "@@last_modified": "2026-06-30 09:37:02.357546",
     "about": "О програму",
     "@about": {
         "type": "String",
@@ -10600,16 +10600,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Kliknite na balon poruke da biste ga odabrali",
-    "writingAssistanceTutorialInputBar": "Možete pisati na bilo kojem jeziku. Ne brinite o greškama! Pomoći ćemo vam da ih ispravite.",
     "writingAssistanceTutorialIGCButton": "Nakon što napišete svoju poruku, kliknite na ovaj dugme da započnete pomoć pri pisanju",
     "selectModeTutorialTranslate": "Kliknite ovde da prevedete poruku",
     "selectModeTutorialAudio": "Kliknite ovde da slušate poruku",
     "selectModeTutorialExit": "Kliknite na pozadinu da se vratite na čat",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11229,6 +11224,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Zatvori listu četa",
+    "closeChat": "Zatvori čat",
+    "closeSession": "Zatvori pregled aktivnosti",
+    "closeCourse": "Zatvori kurs",
+    "closeCoursePage": "Zatvori stranicu kursa",
+    "closeAddCourse": "Zatvori dodavanje kursa",
+    "closeAnalytics": "Zatvori analitiku",
+    "closeVocabulary": "Zatvori rečnik",
+    "closeGrammar": "Zatvori gramatiku",
+    "closePractice": "Zatvori vežbu",
+    "closeSettings": "Zatvori podešavanja",
+    "closeActivity": "Zatvori aktivnost",
+    "closeNamed": "Zatvori {name}",
+    "clearSearch": "Obriši pretragu",
+    "starRowLabel": "{filled} od {total} zvezdica je završeno",
+    "difficultyLabel": "Težina: {cefr}",
+    "writingAssistanceTutorialInputBar": "Možete pisati na bilo kom jeziku! Pomoći ćemo vam da ispravite greške.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sv.arb
+++ b/lib/l10n/intl_sv.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:25:30.910355",
+    "@@last_modified": "2026-06-30 09:36:30.741780",
     "about": "Om",
     "@about": {
         "type": "String",
@@ -10064,16 +10064,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Klicka på meddelandebubblan för att välja den",
-    "writingAssistanceTutorialInputBar": "Du kan skriva på vilket språk som helst. Oroa dig inte för misstag! Vi hjälper dig att rätta dem.",
     "writingAssistanceTutorialIGCButton": "Efter att du har skrivit ditt meddelande, klicka på den här knappen för att börja skrivhjälpen",
     "selectModeTutorialTranslate": "Klicka här för att översätta meddelandet",
     "selectModeTutorialAudio": "Klicka här för att lyssna på meddelandet",
     "selectModeTutorialExit": "Klicka på bakgrunden för att gå tillbaka till chattandet",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10693,6 +10688,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Stäng chattlista",
+    "closeChat": "Stäng chatt",
+    "closeSession": "Stäng aktivitetsgranskning",
+    "closeCourse": "Stäng kurs",
+    "closeCoursePage": "Stäng kursida",
+    "closeAddCourse": "Stäng lägg till kurs",
+    "closeAnalytics": "Stäng analys",
+    "closeVocabulary": "Stäng ordförråd",
+    "closeGrammar": "Stäng grammatik",
+    "closePractice": "Stäng övning",
+    "closeSettings": "Stäng inställningar",
+    "closeActivity": "Stäng aktivitet",
+    "closeNamed": "Stäng {name}",
+    "clearSearch": "Rensa sökning",
+    "starRowLabel": "{filled} av {total} stjärnor har slutförts",
+    "difficultyLabel": "Svårighetsgrad: {cefr}",
+    "writingAssistanceTutorialInputBar": "Du kan skriva på vilket språk som helst! Vi hjälper dig att rätta till misstag.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ta.arb
+++ b/lib/l10n/intl_ta.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:25:16.416437",
+    "@@last_modified": "2026-06-30 09:36:00.213407",
     "acceptedTheInvitation": "👍 {username} அழைப்பை ஏற்றுக்கொண்டது",
     "@acceptedTheInvitation": {
         "type": "String",
@@ -9593,16 +9593,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "செய்தி புளூபிள் மீது கிளிக் செய்து அதை தேர்ந்தெடுக்கவும்",
-    "writingAssistanceTutorialInputBar": "நீங்கள் எந்த மொழியிலும் எழுதலாம். தவறுகள் குறித்து கவலைப்பட வேண்டாம்! அவற்றை சரிசெய்ய நாங்கள் உங்களுக்கு உதவுவோம்.",
     "writingAssistanceTutorialIGCButton": "உங்கள் செய்தியை எழுதிய பிறகு, எழுதும் உதவியை தொடங்க இந்த பொத்தானை கிளிக் செய்யவும்",
     "selectModeTutorialTranslate": "செய்தியை மொழிபெயர்க்க இங்கே கிளிக் செய்யவும்",
     "selectModeTutorialAudio": "செய்தியை கேட்க இங்கே கிளிக் செய்யவும்",
     "selectModeTutorialExit": "மீண்டும் உரையாடலுக்கு செல்ல பின்னணி மீது கிளிக் செய்யவும்",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10222,6 +10217,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "சாட் பட்டியலை மூடு",
+    "closeChat": "சாட் மூடு",
+    "closeSession": "செயல்பாடு மதிப்பீட்டை மூடு",
+    "closeCourse": "பாடத்தை மூடு",
+    "closeCoursePage": "பாடப் பக்கம் மூடு",
+    "closeAddCourse": "பாடத்தைச் சேர்க்க மூடு",
+    "closeAnalytics": "அணுகுமுறை மூடு",
+    "closeVocabulary": "வார்த்தைபடத்தை மூடு",
+    "closeGrammar": "இயல்பியல் மூடு",
+    "closePractice": "பயிற்சியை மூடு",
+    "closeSettings": "அமைப்புகளை மூடு",
+    "closeActivity": "செயல்பாட்டை மூடு",
+    "closeNamed": "{name} ஐ மூடு",
+    "clearSearch": "தேடலை அழி",
+    "starRowLabel": "{filled} {total} நட்சத்திரங்களில் நிறைவேற்றப்பட்டுள்ளது",
+    "difficultyLabel": "கஷ்டம்: {cefr}",
+    "writingAssistanceTutorialInputBar": "நீங்கள் எந்த மொழியிலும் எழுதலாம்! தவறுகளை சரிசெய்ய நாங்கள் உங்களுக்கு உதவுவோம்.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_te.arb
+++ b/lib/l10n/intl_te.arb
@@ -1467,7 +1467,7 @@
     "playWithAI": "ఇప్పుడే AI తో ఆడండి",
     "courseStartDesc": "పాంజియా బాట్ ఎప్పుడైనా సిద్ధంగా ఉంటుంది!\n\n...కానీ స్నేహితులతో నేర్చుకోవడం మెరుగైనది!",
     "@@locale": "te",
-    "@@last_modified": "2026-06-29 12:25:12.313681",
+    "@@last_modified": "2026-06-30 09:35:45.435753",
     "@setCustomPermissionLevel": {
         "type": "String",
         "placeholders": {}
@@ -10601,16 +10601,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "సందేశ బబుల్‌ను ఎంచుకోవడానికి క్లిక్ చేయండి",
-    "writingAssistanceTutorialInputBar": "మీరు ఏ భాషలోనైనా రాయవచ్చు. తప్పుల గురించి ఆందోళన చెందవద్దు! మేము వాటిని సరిదిద్దడంలో మీకు సహాయపడుతాము.",
     "writingAssistanceTutorialIGCButton": "మీ సందేశాన్ని రాసిన తర్వాత, రాయడం సహాయాన్ని ప్రారంభించడానికి ఈ బటన్‌పై క్లిక్ చేయండి",
     "selectModeTutorialTranslate": "సందేశాన్ని అనువదించడానికి ఇక్కడ క్లిక్ చేయండి",
     "selectModeTutorialAudio": "సందేశాన్ని వినడానికి ఇక్కడ క్లిక్ చేయండి",
     "selectModeTutorialExit": "చాటింగ్‌కు తిరిగి వెళ్లడానికి నేపథ్యంపై క్లిక్ చేయండి",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11230,6 +11225,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "చాట్ జాబితాను మూసివేయండి",
+    "closeChat": "చాట్‌ను మూసివేయండి",
+    "closeSession": "చర్య సమీక్షను మూసివేయండి",
+    "closeCourse": "కోర్సును మూసివేయండి",
+    "closeCoursePage": "కోర్సు పేజీని మూసివేయండి",
+    "closeAddCourse": "కోర్సు జోడించడాన్ని మూసివేయండి",
+    "closeAnalytics": "విశ్లేషణను మూసివేయండి",
+    "closeVocabulary": "పదకోశాన్ని మూసివేయండి",
+    "closeGrammar": "వ్యాకరణాన్ని మూసివేయండి",
+    "closePractice": "అభ్యాసాన్ని మూసివేయండి",
+    "closeSettings": "సెట్టింగ్స్‌ను మూసివేయండి",
+    "closeActivity": "చర్యను మూసివేయండి",
+    "closeNamed": "{name}ను మూసివేయండి",
+    "clearSearch": "శోధనను క్లియర్ చేయండి",
+    "starRowLabel": "{filled} లో {total} నక్షత్రాలు పూర్తయ్యాయి",
+    "difficultyLabel": "కష్టత: {cefr}",
+    "writingAssistanceTutorialInputBar": "మీరు ఏ భాషలోనైనా రాయవచ్చు! మేము మీ తప్పులను సరిదిద్దడంలో మీకు సహాయపడతాము.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "เล่นกับ AI ชั่วคราว",
     "courseStartDesc": "Pangea Bot พร้อมที่จะเริ่มต้นได้ทุกเมื่อ!\n\n...แต่การเรียนรู้ดีกว่ากับเพื่อน!",
     "@@locale": "th",
-    "@@last_modified": "2026-06-29 12:25:00.934106",
+    "@@last_modified": "2026-06-30 09:35:07.570686",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10196,16 +10196,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "คลิกที่ฟองข้อความเพื่อเลือกมัน",
-    "writingAssistanceTutorialInputBar": "คุณสามารถเขียนได้ในทุกภาษา ไม่ต้องกังวลเกี่ยวกับข้อผิดพลาด! เราจะช่วยคุณแก้ไขมัน",
     "writingAssistanceTutorialIGCButton": "หลังจากเขียนข้อความของคุณแล้ว คลิกปุ่มนี้เพื่อเริ่มการช่วยเขียน",
     "selectModeTutorialTranslate": "คลิกที่นี่เพื่อแปลข้อความ",
     "selectModeTutorialAudio": "คลิกที่นี่เพื่อฟังข้อความ",
     "selectModeTutorialExit": "คลิกที่พื้นหลังเพื่อกลับไปที่การสนทนา",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10825,6 +10820,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "ปิดรายการแชท",
+    "closeChat": "ปิดแชท",
+    "closeSession": "ปิดการตรวจสอบกิจกรรม",
+    "closeCourse": "ปิดหลักสูตร",
+    "closeCoursePage": "ปิดหน้าหลักสูตร",
+    "closeAddCourse": "ปิดการเพิ่มหลักสูตร",
+    "closeAnalytics": "ปิดการวิเคราะห์",
+    "closeVocabulary": "ปิดคำศัพท์",
+    "closeGrammar": "ปิดไวยากรณ์",
+    "closePractice": "ปิดการฝึกฝน",
+    "closeSettings": "ปิดการตั้งค่า",
+    "closeActivity": "ปิดกิจกรรม",
+    "closeNamed": "ปิด {name}",
+    "clearSearch": "ล้างการค้นหา",
+    "starRowLabel": "ทำเสร็จแล้ว {filled} จาก {total} ดาว",
+    "difficultyLabel": "ความยาก: {cefr}",
+    "writingAssistanceTutorialInputBar": "คุณสามารถเขียนได้ในทุกภาษา! เราจะช่วยคุณแก้ไขข้อผิดพลาด.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "tr",
-    "@@last_modified": "2026-06-29 12:25:10.690680",
+    "@@last_modified": "2026-06-30 09:35:39.623753",
     "about": "Hakkında",
     "@about": {
         "type": "String",
@@ -9808,16 +9808,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Mesaj balonuna tıklayarak onu seçin",
-    "writingAssistanceTutorialInputBar": "Herhangi bir dilde yazabilirsiniz. Hatalar hakkında endişelenmeyin! Onları düzeltmenize yardımcı olacağız.",
     "writingAssistanceTutorialIGCButton": "Mesajınızı yazdıktan sonra, yazma yardımını başlatmak için bu düğmeye tıklayın",
     "selectModeTutorialTranslate": "Mesajı çevirmek için buraya tıklayın",
     "selectModeTutorialAudio": "Mesajı dinlemek için buraya tıklayın",
     "selectModeTutorialExit": "Sohbete geri dönmek için arka plana tıklayın",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10437,6 +10432,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Sohbet listesini kapat",
+    "closeChat": "Sohbeti kapat",
+    "closeSession": "Etkinlik incelemesini kapat",
+    "closeCourse": "Dersi kapat",
+    "closeCoursePage": "Ders sayfasını kapat",
+    "closeAddCourse": "Ders eklemeyi kapat",
+    "closeAnalytics": "Analitiği kapat",
+    "closeVocabulary": "Kelimeleri kapat",
+    "closeGrammar": "Grameri kapat",
+    "closePractice": "Pratiği kapat",
+    "closeSettings": "Ayarları kapat",
+    "closeActivity": "Etkinliği kapat",
+    "closeNamed": "{name} kapat",
+    "clearSearch": "Aramayı temizle",
+    "starRowLabel": "{filled} üzerinden {total} yıldız tamamlandı",
+    "difficultyLabel": "Zorluk: {cefr}",
+    "writingAssistanceTutorialInputBar": "Herhangi bir dilde yazabilirsiniz! Hatalarınızı düzeltmenize yardımcı olacağız.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "uk",
-    "@@last_modified": "2026-06-29 12:24:53.372568",
+    "@@last_modified": "2026-06-30 09:34:47.333865",
     "about": "Про застосунок",
     "@about": {
         "type": "String",
@@ -9477,16 +9477,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Натисніть на повідомлення, щоб вибрати його",
-    "writingAssistanceTutorialInputBar": "Ви можете писати будь-якою мовою. Не хвилюйтеся про помилки! Ми допоможемо вам їх виправити.",
     "writingAssistanceTutorialIGCButton": "Після написання вашого повідомлення натисніть цю кнопку, щоб почати допомогу в написанні",
     "selectModeTutorialTranslate": "Натисніть тут, щоб перекласти повідомлення",
     "selectModeTutorialAudio": "Натисніть тут, щоб прослухати повідомлення",
     "selectModeTutorialExit": "Натисніть на фон, щоб повернутися до чату",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10106,6 +10101,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Закрити список чатів",
+    "closeChat": "Закрити чат",
+    "closeSession": "Закрити огляд активності",
+    "closeCourse": "Закрити курс",
+    "closeCoursePage": "Закрити сторінку курсу",
+    "closeAddCourse": "Закрити додавання курсу",
+    "closeAnalytics": "Закрити аналітику",
+    "closeVocabulary": "Закрити словник",
+    "closeGrammar": "Закрити граматику",
+    "closePractice": "Закрити практику",
+    "closeSettings": "Закрити налаштування",
+    "closeActivity": "Закрити активність",
+    "closeNamed": "Закрити {name}",
+    "clearSearch": "Очистити пошук",
+    "starRowLabel": "{filled} з {total} зірок було завершено",
+    "difficultyLabel": "Складність: {cefr}",
+    "writingAssistanceTutorialInputBar": "Ви можете писати будь-якою мовою! Ми допоможемо вам виправити помилки.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_uz.arb
+++ b/lib/l10n/intl_uz.arb
@@ -3194,7 +3194,7 @@
     "setupChatBackup": "Chat zaxirasini sozlash",
     "@setupChatBackup": {},
     "@@locale": "uz",
-    "@@last_modified": "2026-06-29 12:25:05.377418",
+    "@@last_modified": "2026-06-30 09:35:21.396168",
     "noMoreResultsFound": "Boshqa natijalar topilmadi",
     "chatSearchedUntil": "Chat {time} gacha qidirildi",
     "federationBaseUrl": "Federatsiya Asos URL",
@@ -9481,16 +9481,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Xabar pufakchasini tanlash uchun bosing",
-    "writingAssistanceTutorialInputBar": "Siz har qanday tilni yozishingiz mumkin. Xatolar haqida xavotir olmang! Biz sizga ularni to'g'rilashda yordam beramiz.",
     "writingAssistanceTutorialIGCButton": "Xabaringizni yozgandan so'ng, yozish yordamiga kirish uchun ushbu tugmani bosing",
     "selectModeTutorialTranslate": "Xabarni tarjima qilish uchun bu yerga bosing",
     "selectModeTutorialAudio": "Xabarni tinglash uchun bu yerga bosing",
     "selectModeTutorialExit": "Suhbatga qaytish uchun fonni bosing",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10110,6 +10105,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Suhbatlar ro'yxatini yopish",
+    "closeChat": "Suhbatni yopish",
+    "closeSession": "Faoliyatni ko'rishni yopish",
+    "closeCourse": "Kursni yopish",
+    "closeCoursePage": "Kurs sahifasini yopish",
+    "closeAddCourse": "Kurs qo'shishni yopish",
+    "closeAnalytics": "Tahlilni yopish",
+    "closeVocabulary": "Lug'atni yopish",
+    "closeGrammar": "Grammatika ni yopish",
+    "closePractice": "Amaliyotni yopish",
+    "closeSettings": "Sozlamalarni yopish",
+    "closeActivity": "Faoliyatni yopish",
+    "closeNamed": "{name} ni yopish",
+    "clearSearch": "Qidiruvni tozalash",
+    "starRowLabel": "{filled} ta {total} yulduzdan bajarildi",
+    "difficultyLabel": "Qiyinchilik: {cefr}",
+    "writingAssistanceTutorialInputBar": "Siz har qanday tilni yozishingiz mumkin! Biz sizga xatolarni tuzatishda yordam beramiz.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:25:14.871346",
+    "@@last_modified": "2026-06-30 09:35:55.800318",
     "about": "Giới thiệu",
     "@about": {
         "type": "String",
@@ -6560,16 +6560,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "Nhấp vào bong bóng tin nhắn để chọn nó",
-    "writingAssistanceTutorialInputBar": "Bạn có thể viết bằng bất kỳ ngôn ngữ nào. Đừng lo lắng về lỗi! Chúng tôi sẽ giúp bạn sửa chúng.",
     "writingAssistanceTutorialIGCButton": "Sau khi viết tin nhắn của bạn, nhấp vào nút này để bắt đầu hỗ trợ viết",
     "selectModeTutorialTranslate": "Nhấp vào đây để dịch tin nhắn",
     "selectModeTutorialAudio": "Nhấp vào đây để nghe tin nhắn",
     "selectModeTutorialExit": "Nhấp vào nền để quay lại trò chuyện",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -7189,6 +7184,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "Đóng danh sách trò chuyện",
+    "closeChat": "Đóng trò chuyện",
+    "closeSession": "Đóng đánh giá hoạt động",
+    "closeCourse": "Đóng khóa học",
+    "closeCoursePage": "Đóng trang khóa học",
+    "closeAddCourse": "Đóng thêm khóa học",
+    "closeAnalytics": "Đóng phân tích",
+    "closeVocabulary": "Đóng từ vựng",
+    "closeGrammar": "Đóng ngữ pháp",
+    "closePractice": "Đóng thực hành",
+    "closeSettings": "Đóng cài đặt",
+    "closeActivity": "Đóng hoạt động",
+    "closeNamed": "Đóng {name}",
+    "clearSearch": "Xóa tìm kiếm",
+    "starRowLabel": "{filled} trong số {total} sao đã được hoàn thành",
+    "difficultyLabel": "Độ khó: {cefr}",
+    "writingAssistanceTutorialInputBar": "Bạn có thể viết bằng bất kỳ ngôn ngữ nào! Chúng tôi sẽ giúp bạn sửa lỗi.",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_yue.arb
+++ b/lib/l10n/intl_yue.arb
@@ -1406,7 +1406,7 @@
     "selectAll": "全選",
     "deselectAll": "取消全選",
     "@@locale": "yue",
-    "@@last_modified": "2026-06-29 12:24:50.929418",
+    "@@last_modified": "2026-06-30 09:34:40.434154",
     "@ignoreUser": {
         "type": "String",
         "placeholders": {}
@@ -10608,16 +10608,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "點擊消息氣泡以選擇它",
-    "writingAssistanceTutorialInputBar": "你可以用任何語言寫作。不要擔心錯誤！我們會幫你糾正它們。",
     "writingAssistanceTutorialIGCButton": "寫完你的消息後，點擊這個按鈕開始寫作輔助",
     "selectModeTutorialTranslate": "點擊這裡翻譯消息",
     "selectModeTutorialAudio": "點擊這裡收聽消息",
     "selectModeTutorialExit": "點擊背景以返回聊天",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -11237,6 +11232,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "關閉聊天列表",
+    "closeChat": "關閉聊天",
+    "closeSession": "關閉活動回顧",
+    "closeCourse": "關閉課程",
+    "closeCoursePage": "關閉課程頁面",
+    "closeAddCourse": "關閉添加課程",
+    "closeAnalytics": "關閉分析",
+    "closeVocabulary": "關閉詞彙",
+    "closeGrammar": "關閉語法",
+    "closePractice": "關閉練習",
+    "closeSettings": "關閉設置",
+    "closeActivity": "關閉活動",
+    "closeNamed": "關閉 {name}",
+    "clearSearch": "清除搜索",
+    "starRowLabel": "已完成 {filled} 顆星中的 {total} 顆星",
+    "difficultyLabel": "難度: {cefr}",
+    "writingAssistanceTutorialInputBar": "你可以用任何語言寫作！我們會幫你糾正錯誤。",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "zh",
-    "@@last_modified": "2026-06-29 12:25:20.110438",
+    "@@last_modified": "2026-06-30 09:36:14.104667",
     "about": "关于",
     "@about": {
         "type": "String",
@@ -9477,16 +9477,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "点击消息气泡以选择它",
-    "writingAssistanceTutorialInputBar": "您可以使用任何语言进行书写。不要担心错误！我们会帮助您纠正它们。",
     "writingAssistanceTutorialIGCButton": "写完您的消息后，点击此按钮以开始写作辅助",
     "selectModeTutorialTranslate": "点击这里翻译消息",
     "selectModeTutorialAudio": "点击这里收听消息",
     "selectModeTutorialExit": "点击背景以返回聊天",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10106,6 +10101,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "关闭聊天列表",
+    "closeChat": "关闭聊天",
+    "closeSession": "关闭活动回顾",
+    "closeCourse": "关闭课程",
+    "closeCoursePage": "关闭课程页面",
+    "closeAddCourse": "关闭添加课程",
+    "closeAnalytics": "关闭分析",
+    "closeVocabulary": "关闭词汇",
+    "closeGrammar": "关闭语法",
+    "closePractice": "关闭练习",
+    "closeSettings": "关闭设置",
+    "closeActivity": "关闭活动",
+    "closeNamed": "关闭 {name}",
+    "clearSearch": "清除搜索",
+    "starRowLabel": "已完成 {filled} 个，共 {total} 个星星",
+    "difficultyLabel": "难度: {cefr}",
+    "writingAssistanceTutorialInputBar": "您可以使用任何语言写作！我们将帮助您纠正错误。",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_zh_Hant.arb
+++ b/lib/l10n/intl_zh_Hant.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-29 12:25:04.019623",
+    "@@last_modified": "2026-06-30 09:35:16.047341",
     "about": "關於",
     "@about": {
         "type": "String",
@@ -9607,16 +9607,11 @@
         "placeholders": {}
     },
     "readingAssistanceTutorialClickMessage": "點擊消息氣泡以選擇它",
-    "writingAssistanceTutorialInputBar": "您可以使用任何語言書寫。不要擔心錯誤！我們會幫助您更正它們。",
     "writingAssistanceTutorialIGCButton": "在撰寫消息後，點擊此按鈕以開始寫作輔助",
     "selectModeTutorialTranslate": "點擊這裡以翻譯消息",
     "selectModeTutorialAudio": "點擊這裡以聆聽消息",
     "selectModeTutorialExit": "點擊背景以返回聊天",
     "@readingAssistanceTutorialClickMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     },
@@ -10236,6 +10231,106 @@
         "placeholders": {}
     },
     "@joinLearningCommunities": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "closeChats": "關閉聊天列表",
+    "closeChat": "關閉聊天",
+    "closeSession": "關閉活動回顧",
+    "closeCourse": "關閉課程",
+    "closeCoursePage": "關閉課程頁面",
+    "closeAddCourse": "關閉新增課程",
+    "closeAnalytics": "關閉分析",
+    "closeVocabulary": "關閉詞彙",
+    "closeGrammar": "關閉文法",
+    "closePractice": "關閉練習",
+    "closeSettings": "關閉設定",
+    "closeActivity": "關閉活動",
+    "closeNamed": "關閉 {name}",
+    "clearSearch": "清除搜尋",
+    "starRowLabel": "已完成 {filled} 顆星中的 {total} 顆星",
+    "difficultyLabel": "難度: {cefr}",
+    "writingAssistanceTutorialInputBar": "您可以使用任何語言寫作！我們將幫助您糾正錯誤。",
+    "@closeChats": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeChat": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSession": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeCoursePage": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAddCourse": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeAnalytics": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeVocabulary": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeGrammar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closePractice": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeSettings": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeActivity": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@closeNamed": {
+        "type": "String",
+        "placeholders": {
+            "name": {
+                "type": "String"
+            }
+        }
+    },
+    "@clearSearch": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starRowLabel": {
+        "type": "String",
+        "placeholders": {
+            "filled": {
+                "type": "int"
+            },
+            "total": {
+                "type": "int"
+            }
+        }
+    },
+    "@difficultyLabel": {
+        "type": "String",
+        "placeholders": {
+            "cefr": {
+                "type": "String"
+            }
+        }
+    },
+    "@writingAssistanceTutorialInputBar": {
         "type": "String",
         "placeholders": {}
     }


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new localized labels for closing chats, sessions, courses, settings, and other panels.
  * Added/updated labels for clearing search and showing star/difficulty information.

* **Bug Fixes**
  * Refined the “writing assistance” tutorial prompt across many languages for clearer wording and consistency.
  * Updated locale metadata to keep translations current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->