### PR TITLE
fix: only add gap to top of chat when activity dropdown menu is visible

### DIFF
--- a/lib/routes/chat/chat_event_list.dart
+++ b/lib/routes/chat/chat_event_list.dart
@@ -5,6 +5,7 @@ import 'package:collection/collection.dart';
 import 'package:scroll_to_index/scroll_to_index.dart';
 
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_user_summaries_widget.dart';
@@ -116,7 +117,9 @@ class ChatEventList extends StatelessWidget {
               // Request history button or progress indicator:
               // #Pangea
               if (i == events.length + 3) {
-                return SizedBox(height: 50);
+                return controller.room.ownRole?.allGoals.isNotEmpty == true
+                    ? SizedBox(height: 50)
+                    : SizedBox.shrink();
               }
 
               // if (i == events.length + 1) {


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the chat message list footer so extra spacing appears only when needed.
  * Reduced unnecessary blank space at the bottom of conversations for rooms without relevant goals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->