### PR TITLE
fix: on mobile, show banner overlays within chat view

### DIFF
--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -612,7 +612,7 @@ class ChatController extends State<ChatPageWithRoom>
           backDropToDismiss: false,
           closePrevOverlay: false,
           canPop: false,
-          rootOverlay: true,
+          rootOverlay: kIsWeb,
         ),
       );
 
@@ -644,7 +644,7 @@ class ChatController extends State<ChatPageWithRoom>
             backDropToDismiss: false,
             closePrevOverlay: false,
             canPop: false,
-            rootOverlay: true,
+            rootOverlay: kIsWeb,
           ),
         );
 


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
