### PR TITLE
fix: make TOS agreement text one semantic element

### DIFF
--- a/lib/routes/home/login/login_options_view.dart
+++ b/lib/routes/home/login/login_options_view.dart
@@ -1,12 +1,10 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
-import 'package:url_launcher/url_launcher_string.dart';
 
-import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/home/login/login.dart';
+import 'package:fluffychat/routes/home/login/tos_indicator.dart';
 import 'package:fluffychat/routes/home/p_sso_button.dart';
 import 'package:fluffychat/routes/home/pangea_logo_svg.dart';
 import 'package:fluffychat/routes/home/sso_provider_enum.dart';
@@ -124,34 +122,7 @@ class LoginOptionsViewState extends State<LoginOptionsView> {
                 ),
                 Padding(
                   padding: const EdgeInsets.all(12.0),
-                  child: RichText(
-                    textAlign: TextAlign.justify,
-                    text: TextSpan(
-                      text: L10n.of(context).byUsingPangeaChat,
-                      children: [
-                        TextSpan(
-                          text: L10n.of(context).termsAndConditions,
-                          style: TextStyle(
-                            decoration: TextDecoration.underline,
-                            color: theme.colorScheme.primary,
-                          ),
-                          recognizer: TapGestureRecognizer()
-                            ..onTap = () {
-                              launchUrlString(AppConfig.termsOfServiceUrl);
-                            },
-                        ),
-                        TextSpan(
-                          text: L10n.of(
-                            context,
-                          ).andCertifyIAmAtLeast13YearsOfAge,
-                        ),
-                      ],
-                      style: TextStyle(
-                        fontSize: 12,
-                        color: Theme.of(context).colorScheme.onSurface,
-                      ),
-                    ),
-                  ),
+                  child: TOSIndicator(),
                 ),
               ],
             ),

--- a/lib/routes/home/login/tos_indicator.dart
+++ b/lib/routes/home/login/tos_indicator.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import 'package:url_launcher/url_launcher_string.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+
+class TOSIndicator extends StatelessWidget {
+  const TOSIndicator({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return MergeSemantics(
+      child: RichText(
+        textAlign: TextAlign.justify,
+        text: TextSpan(
+          children: [
+            TextSpan(text: L10n.of(context).byUsingPangeaChat),
+            TextSpan(
+              text: L10n.of(context).termsAndConditions,
+              style: TextStyle(
+                decoration: TextDecoration.underline,
+                color: theme.colorScheme.primary,
+              ),
+              recognizer: TapGestureRecognizer()
+                ..onTap = () {
+                  launchUrlString(AppConfig.termsOfServiceUrl);
+                },
+            ),
+            TextSpan(text: L10n.of(context).andCertifyIAmAtLeast13YearsOfAge),
+          ],
+          style: TextStyle(
+            fontSize: 12,
+            color: Theme.of(context).colorScheme.onSurface,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/home/signup/signup_view.dart
+++ b/lib/routes/home/signup/signup_view.dart
@@ -4,10 +4,9 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
-import 'package:url_launcher/url_launcher_string.dart';
 
-import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/home/login/tos_indicator.dart';
 import 'package:fluffychat/routes/home/p_sso_button.dart';
 import 'package:fluffychat/routes/home/pangea_logo_svg.dart';
 import 'package:fluffychat/routes/home/sso_provider_enum.dart';
@@ -110,34 +109,7 @@ class SignupPageView extends StatelessWidget {
 
                   Padding(
                     padding: const EdgeInsets.all(12.0),
-                    child: RichText(
-                      textAlign: TextAlign.justify,
-                      text: TextSpan(
-                        text: L10n.of(context).byUsingPangeaChat,
-                        children: [
-                          TextSpan(
-                            text: L10n.of(context).termsAndConditions,
-                            style: TextStyle(
-                              decoration: TextDecoration.underline,
-                              color: theme.colorScheme.primary,
-                            ),
-                            recognizer: TapGestureRecognizer()
-                              ..onTap = () {
-                                launchUrlString(AppConfig.termsOfServiceUrl);
-                              },
-                          ),
-                          TextSpan(
-                            text: L10n.of(
-                              context,
-                            ).andCertifyIAmAtLeast13YearsOfAge,
-                          ),
-                        ],
-                        style: TextStyle(
-                          fontSize: 12,
-                          color: Theme.of(context).colorScheme.onSurface,
-                        ),
-                      ),
-                    ),
+                    child: TOSIndicator(),
                   ),
                 ],
               ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
