### PR TITLE
feat(world-map): distinct focus ring on the focused activity pin (#7349)

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -226,6 +226,27 @@ class WorldMapController extends State<WorldMap>
 
   bool get isWorld => MapContextController.notifier.value is! CourseMapContext;
   String? get selectedActivityId => _pinsManager.selectedActivityId;
+
+  /// The id of the activity the detail panel is focused on, or null. Focus is
+  /// the persistent "I'm working with this one" state (its panel is open and the
+  /// camera settled on it); it drives a distinct focus marker on the pin at
+  /// whatever tier it sits, and survives zoom/pan, clearing only when the panel
+  /// closes or another activity is focused. Derived purely from [widget.focus]
+  /// (the `?activity=` token via `mapFocusFor`), so no extra state is needed and
+  /// it auto-clears when the focus signal changes. See world-map.instructions.md
+  /// ("Featured, selected, and focused").
+  String? get focusedActivityId => focusedActivityIdOf(widget.focus);
+
+  /// The activity id a [MapFocus] focuses, or null for a non-activity / absent
+  /// focus. Pure so the focus-marker resolution is unit-testable without pumping
+  /// the map (#7349). Exhaustive over the sealed [MapFocus]: a new focus kind
+  /// that isn't an activity simply yields null here.
+  @visibleForTesting
+  static String? focusedActivityIdOf(MapFocus? focus) => switch (focus) {
+    ActivityFocus(:final activityId) => activityId,
+    _ => null,
+  };
+
   Client? get client => _client;
   bool get loadingPins => _loadingPins;
 

--- a/lib/routes/world/world_map_large_card.dart
+++ b/lib/routes/world/world_map_large_card.dart
@@ -37,6 +37,13 @@ class WorldMapLargeCard extends StatelessWidget {
   final int openSlots;
   final VoidCallback onTap;
 
+  /// When true, the activity is focused (its detail panel is open): the card
+  /// draws a distinct primary-coloured focus ring around its state-accent
+  /// border, persistent through zoom/pan and cleared when the panel closes or
+  /// another activity is focused (#7349). Decoupled from selection and
+  /// featuring. See world-map.instructions.md.
+  final bool isFocused;
+
   /// When non-null, the card shows an explicit dismiss (X) that returns it to a
   /// pin without opening it. Set only on the **selected** (tap-peek) card — a
   /// card stacked over another can otherwise only be cleared by tapping empty
@@ -52,6 +59,7 @@ class WorldMapLargeCard extends StatelessWidget {
     required this.plan,
     required this.starsEarned,
     required this.onTap,
+    this.isFocused = false,
     this.onClose,
     this.participants = const [],
     this.openSlots = 0,
@@ -87,6 +95,25 @@ class WorldMapLargeCard extends StatelessWidget {
 
     final earned = starsEarned.clamp(0, total);
 
+    // When focused, a primary-coloured ring (a soft outer glow + a primary
+    // border outside the state-accent border) wraps the card so it reads as the
+    // deliberately worked-with one, distinct from the colour-state accent
+    // (#7349). Null when not focused — the card draws its plain accent border.
+    final primary = Theme.of(context).colorScheme.primary;
+    final focusDecoration = isFocused
+        ? BoxDecoration(
+            borderRadius: BorderRadius.circular(15),
+            border: Border.all(color: primary, width: 2.5),
+            boxShadow: [
+              BoxShadow(
+                color: primary.withValues(alpha: 0.45),
+                blurRadius: 7,
+                spreadRadius: 0.5,
+              ),
+            ],
+          )
+        : null;
+
     final cardButton = GestureDetector(
       onTap: onTap,
       // #Pangea: announce the card as a single "Activity: <title>" button so the
@@ -94,86 +121,94 @@ class WorldMapLargeCard extends StatelessWidget {
       child: Semantics(
         label: L10n.of(context).activityLabel(card.title),
         button: true,
-        child: Material(
-          elevation: 6,
-          borderRadius: BorderRadius.circular(12),
-          color: Theme.of(context).colorScheme.surface,
-          child: Container(
-            width: 260,
-            padding: const EdgeInsets.all(10),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(12),
-              border: Border.all(color: state.accent, width: 2),
-            ),
-            child: Column(
-              spacing: 8.0,
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _Header(
-                  card: card,
-                  plan: plan,
-                  completed: completed,
-                  pinged: pinged,
-                  foregroundColor: state.accent,
-                ),
-                // Fixed height prevents the card from jumping when `plan`
-                // hydrates and total goes from 0 → actual goal count.
-                SizedBox(
-                  height: 16,
-                  child: ActivityStarRow(
-                    total: total,
-                    earned: earned,
-                    condensed: total > 12,
+        // The focus ring sits OUTSIDE the card with a small gap (the padding)
+        // so the primary halo and the state-accent border never blend (#7349).
+        child: Container(
+          padding: focusDecoration == null
+              ? EdgeInsets.zero
+              : const EdgeInsets.all(2.5),
+          decoration: focusDecoration,
+          child: Material(
+            elevation: 6,
+            borderRadius: BorderRadius.circular(12),
+            color: Theme.of(context).colorScheme.surface,
+            child: Container(
+              width: 260,
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: state.accent, width: 2),
+              ),
+              child: Column(
+                spacing: 8.0,
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _Header(
+                    card: card,
+                    plan: plan,
+                    completed: completed,
+                    pinged: pinged,
+                    foregroundColor: state.accent,
                   ),
-                ),
-                if (completed)
-                  Row(
-                    children: [
-                      _ActionPill(
-                        icon: Icons.refresh,
-                        label: L10n.of(context).playAgain,
-                        foregroundColor: AppConfig.purple,
-                        borderColor: const Color(0xFFCECBF6),
-                      ),
-                      const SizedBox(width: 6),
-                      _ActionPill(
-                        icon: Icons.visibility_outlined,
-                        label: L10n.of(context).reviewActivity,
-                        foregroundColor: AppConfig.grayText,
-                        borderColor: const Color(0xFFD3D1C7),
-                      ),
-                    ],
+                  // Fixed height prevents the card from jumping when `plan`
+                  // hydrates and total goes from 0 → actual goal count.
+                  SizedBox(
+                    height: 16,
+                    child: ActivityStarRow(
+                      total: total,
+                      earned: earned,
+                      condensed: total > 12,
+                    ),
                   ),
-                if (_showParticipants)
-                  Row(
-                    children: [
-                      for (final p in participants.take(4)) ...[
-                        Avatar(mxContent: p.avatar, name: p.name, size: 28),
-                        const SizedBox(width: 4),
+                  if (completed)
+                    Row(
+                      children: [
+                        _ActionPill(
+                          icon: Icons.refresh,
+                          label: L10n.of(context).playAgain,
+                          foregroundColor: AppConfig.purple,
+                          borderColor: const Color(0xFFCECBF6),
+                        ),
+                        const SizedBox(width: 6),
+                        _ActionPill(
+                          icon: Icons.visibility_outlined,
+                          label: L10n.of(context).reviewActivity,
+                          foregroundColor: AppConfig.grayText,
+                          borderColor: const Color(0xFFD3D1C7),
+                        ),
                       ],
-                      for (int i = 0; i < openSlots.clamp(0, 4); i++) ...[
-                        Container(
-                          width: 28,
-                          height: 28,
-                          decoration: const BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: Colors.black12,
-                          ),
-                          alignment: Alignment.center,
-                          child: const Text(
-                            '?',
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: Colors.black45,
+                    ),
+                  if (_showParticipants)
+                    Row(
+                      children: [
+                        for (final p in participants.take(4)) ...[
+                          Avatar(mxContent: p.avatar, name: p.name, size: 28),
+                          const SizedBox(width: 4),
+                        ],
+                        for (int i = 0; i < openSlots.clamp(0, 4); i++) ...[
+                          Container(
+                            width: 28,
+                            height: 28,
+                            decoration: const BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Colors.black12,
+                            ),
+                            alignment: Alignment.center,
+                            child: const Text(
+                              '?',
+                              style: TextStyle(
+                                fontWeight: FontWeight.bold,
+                                color: Colors.black45,
+                              ),
                             ),
                           ),
-                        ),
-                        const SizedBox(width: 4),
+                          const SizedBox(width: 4),
+                        ],
                       ],
-                    ],
-                  ),
-              ],
+                    ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/routes/world/world_map_state_dot.dart
+++ b/lib/routes/world/world_map_state_dot.dart
@@ -13,6 +13,13 @@ class WorldMapDot extends StatefulWidget {
   final bool pinged;
   final double fill;
 
+  /// When true, the activity is focused (its detail panel is open): the dot
+  /// draws a distinct focus ring (primary-coloured halo with a gap) around its
+  /// state-coloured body, persistent through zoom/pan and cleared when the
+  /// panel closes or another activity is focused (#7349). Decoupled from the
+  /// colour state and progress fill. See world-map.instructions.md.
+  final bool isFocused;
+
   /// When true, the pin plays its exit animation (scale → 0) then calls
   /// [onExited]. The parent keeps the widget in the tree until [onExited] fires.
   final bool dying;
@@ -26,6 +33,7 @@ class WorldMapDot extends StatefulWidget {
     required this.onTap,
     required this.pinged,
     this.fill = 0,
+    this.isFocused = false,
     this.dying = false,
     this.onExited,
   });
@@ -88,8 +96,13 @@ class _WorldMapDotState extends State<WorldMapDot>
                     state: widget.state,
                     pinged: widget.pinged,
                     fill: widget.fill,
+                    isFocused: widget.isFocused,
                   )
-                : _SmallDotContent(state: widget.state, fill: widget.fill),
+                : _SmallDotContent(
+                    state: widget.state,
+                    fill: widget.fill,
+                    isFocused: widget.isFocused,
+                  ),
           ),
         ),
       ),
@@ -100,8 +113,13 @@ class _WorldMapDotState extends State<WorldMapDot>
 class _SmallDotContent extends StatelessWidget {
   final ActivityPinState state;
   final double fill;
+  final bool isFocused;
 
-  const _SmallDotContent({required this.state, this.fill = 0});
+  const _SmallDotContent({
+    required this.state,
+    this.fill = 0,
+    this.isFocused = false,
+  });
 
   @override
   Widget build(BuildContext context) => _WorldMapStateDot(
@@ -109,6 +127,7 @@ class _SmallDotContent extends StatelessWidget {
     diameter: 18,
     borderWidth: 1.5,
     fill: fill,
+    isFocused: isFocused,
   );
 }
 
@@ -116,11 +135,13 @@ class _MediumDotContent extends StatelessWidget {
   final ActivityPinState state;
   final bool pinged;
   final double fill;
+  final bool isFocused;
 
   const _MediumDotContent({
     required this.state,
     required this.pinged,
     this.fill = 0,
+    this.isFocused = false,
   });
 
   @override
@@ -133,6 +154,7 @@ class _MediumDotContent extends StatelessWidget {
         diameter: 36,
         borderWidth: 2,
         fill: fill,
+        isFocused: isFocused,
         glyph: const Icon(
           Icons.chat_bubble_outline,
           size: 18,
@@ -164,12 +186,15 @@ class _MediumDotContent extends StatelessWidget {
 /// disc, an inner gold disc whose radius scales with [fill] (0..1 — stars earned
 /// toward the activity's total), and an optional [glyph] on top. The fill is
 /// linear in radius (`r = innerRadius·fill`), so a full activity reads as a solid
-/// gold centre while a fresh one shows none. Design: world-map.instructions.md.
+/// gold centre while a fresh one shows none. When [isFocused], a primary-coloured
+/// focus ring (a halo with a gap) wraps the disc, distinct from the white
+/// state-border (#7349). Design: world-map.instructions.md.
 class _WorldMapStateDot extends StatelessWidget {
   final ActivityPinState state;
   final double diameter;
   final double borderWidth;
   final double fill;
+  final bool isFocused;
   final Widget? glyph;
 
   const _WorldMapStateDot({
@@ -177,13 +202,14 @@ class _WorldMapStateDot extends StatelessWidget {
     required this.diameter,
     required this.borderWidth,
     this.fill = 0,
+    this.isFocused = false,
     this.glyph,
   });
 
   @override
   Widget build(BuildContext context) {
     final inner = (diameter - 2 * borderWidth) * fill.clamp(0.0, 1.0);
-    return Container(
+    final dot = Container(
       width: diameter,
       height: diameter,
       decoration: BoxDecoration(
@@ -207,6 +233,41 @@ class _WorldMapStateDot extends StatelessWidget {
           ?glyph,
         ],
       ),
+    );
+
+    if (!isFocused) return dot;
+
+    // The focus ring: a primary-coloured halo concentric with the disc, sitting
+    // OUTSIDE the white state-border with a small transparent gap so the two
+    // never blend — clearly the "I'm working with this one" marker, distinct
+    // from the colour-state border at every tier. Drawn with a Stack +
+    // Clip.none so it can overflow the fixed marker bounds without being
+    // clipped, and a soft outer glow so it reads at the small-dot size (#7349).
+    final primary = Theme.of(context).colorScheme.primary;
+    const ringWidth = 2.5;
+    const gap = 2.0;
+    final ringDiameter = diameter + 2 * (gap + ringWidth);
+    return Stack(
+      clipBehavior: Clip.none,
+      alignment: Alignment.center,
+      children: [
+        Container(
+          width: ringDiameter,
+          height: ringDiameter,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(color: primary, width: ringWidth),
+            boxShadow: [
+              BoxShadow(
+                color: primary.withValues(alpha: 0.45),
+                blurRadius: 5,
+                spreadRadius: 0.5,
+              ),
+            ],
+          ),
+        ),
+        dot,
+      ],
     );
   }
 }

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -35,6 +35,12 @@ class _PinRenderer {
   /// placed large card, so no count bubble ever forms beneath a card.
   final Set<String> suppressedIds;
 
+  /// The id of the focused activity (its detail panel is open), or null. The
+  /// pin/card carrying this id draws a distinct focus ring at whatever tier it
+  /// sits — persistent through zoom/pan, cleared when the panel closes or
+  /// another activity is focused (#7349). See world-map.instructions.md.
+  final String? focusedId;
+
   const _PinRenderer({
     required this.visible,
     required this.activityIdToFill,
@@ -42,6 +48,7 @@ class _PinRenderer {
     required this.activityIdToPingStatus,
     required this.activityIdToTier,
     required this.suppressedIds,
+    required this.focusedId,
   });
 
   List<QuestActivityCard> get largeCards => visible
@@ -190,6 +197,7 @@ class _WorldMapViewState extends State<WorldMapView> {
       largeIds: largeIds,
       mediumIds: mediumIds,
       suppressedIds: placement.suppressedIds,
+      focusedId: widget.controller.focusedActivityId,
     );
   }
 
@@ -276,6 +284,7 @@ class _WorldMapViewState extends State<WorldMapView> {
     required Set<String> largeIds,
     required Set<String> mediumIds,
     required Set<String> suppressedIds,
+    required String? focusedId,
   }) {
     final activityIds = visible.map((c) => c.activityId).toSet();
 
@@ -309,6 +318,7 @@ class _WorldMapViewState extends State<WorldMapView> {
       activityIdToState: states,
       activityIdToTier: tiers,
       suppressedIds: suppressedIds,
+      focusedId: focusedId,
     );
   }
 
@@ -346,6 +356,11 @@ class _WorldMapViewState extends State<WorldMapView> {
         ..write(render.pingedOf(card.activityId) ? 1 : 0)
         ..write('|')
         ..write(render.fillOf(card.activityId))
+        ..write('|')
+        // Focus is part of the marker's appearance, so a focus change must bust
+        // the cached marker list (it's a reference-identity check) — otherwise
+        // the focus ring wouldn't appear/clear on a small/mid pin (#7349).
+        ..write(card.activityId == render.focusedId ? 1 : 0)
         ..write(';');
     }
     final signature = sig.toString();
@@ -369,6 +384,7 @@ class _WorldMapViewState extends State<WorldMapView> {
           onTap: () => widget.controller.selectActivity(card.activityId),
           pinged: render.pingedOf(card.activityId),
           fill: render.fillOf(card.activityId),
+          isFocused: card.activityId == render.focusedId,
         ),
       );
     }).toList();
@@ -444,6 +460,7 @@ class _WorldMapViewState extends State<WorldMapView> {
               widget.controller.activityStarsEarned(card.activityId) ?? 0,
           participants: joinableActivity?.largeCardParticipants ?? [],
           openSlots: joinableActivity?.numRemainingRoles ?? 0,
+          isFocused: card.activityId == render.focusedId,
           onTap: () => widget.controller.openActivity(card),
           // Only the tap-selected card gets the explicit dismiss; auto-featured
           // cards re-rank and clear on pan/zoom (#7207).

--- a/test/pangea/world/world_map_focus_test.dart
+++ b/test/pangea/world/world_map_focus_test.dart
@@ -1,0 +1,138 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/world_map.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_state_dot.dart';
+
+/// #7349 — a focused activity drives a distinct focus marker on its pin. The
+/// marker is resolved purely from the inbound [MapFocus] (the `?activity=`
+/// token), so it survives zoom/pan and auto-clears when the focus changes with
+/// no extra state. This covers the resolution the render path threads through to
+/// every tier (small dot / mid pin / large card).
+void main() {
+  const card = QuestActivityCard(
+    activityId: 'a1',
+    title: 'Test Activity',
+    l2: 'es',
+    coordinates: [0, 0],
+    learningObjectiveRefs: [],
+  );
+
+  Future<void> pumpDot(
+    WidgetTester tester, {
+    required PinTier tier,
+    required bool isFocused,
+    required Color primary,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: primary,
+          ).copyWith(primary: primary),
+        ),
+        home: Scaffold(
+          body: Center(
+            child: WorldMapDot(
+              card: card,
+              state: ActivityPinState.unlocked,
+              tier: tier,
+              onTap: () {},
+              pinged: false,
+              isFocused: isFocused,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  bool hasBorderColored(WidgetTester tester, Color color) =>
+      tester.widgetList<Container>(find.byType(Container)).any((c) {
+        final d = c.decoration;
+        return d is BoxDecoration &&
+            d.border is Border &&
+            (d.border as Border).top.color == color;
+      });
+
+  group('WorldMapController.focusedActivityIdOf (#7349)', () {
+    test('an ActivityFocus resolves to its activity id', () {
+      expect(
+        WorldMapController.focusedActivityIdOf(const ActivityFocus('act-123')),
+        'act-123',
+      );
+    });
+
+    test('no focus resolves to null (the marker clears)', () {
+      expect(WorldMapController.focusedActivityIdOf(null), isNull);
+    });
+
+    test('the resolved id is exactly the focused activity, not another', () {
+      // The render path compares each pin id against this, so it must be the
+      // focused id verbatim — a stray transform would ring the wrong pin.
+      const focus = ActivityFocus('only-this-one');
+      final id = WorldMapController.focusedActivityIdOf(focus);
+      expect(id, 'only-this-one');
+      expect(id == 'another', isFalse);
+    });
+
+    test('switching focus moves the marker to the new activity', () {
+      // Focus is persistent but single: focusing a second activity clears the
+      // first (the id the render path rings changes wholesale).
+      expect(
+        WorldMapController.focusedActivityIdOf(const ActivityFocus('a')),
+        'a',
+      );
+      expect(
+        WorldMapController.focusedActivityIdOf(const ActivityFocus('b')),
+        'b',
+      );
+    });
+  });
+
+  group('WorldMapDot focus ring (#7349)', () {
+    const primary = Color(0xFF112233);
+
+    testWidgets('a focused small dot draws the primary focus ring', (
+      tester,
+    ) async {
+      await pumpDot(
+        tester,
+        tier: PinTier.small,
+        isFocused: true,
+        primary: primary,
+      );
+      expect(hasBorderColored(tester, primary), isTrue);
+    });
+
+    testWidgets('a focused mid pin draws the primary focus ring', (
+      tester,
+    ) async {
+      await pumpDot(
+        tester,
+        tier: PinTier.mid,
+        isFocused: true,
+        primary: primary,
+      );
+      expect(hasBorderColored(tester, primary), isTrue);
+    });
+
+    testWidgets('an unfocused dot has no primary focus ring', (tester) async {
+      await pumpDot(
+        tester,
+        tier: PinTier.small,
+        isFocused: false,
+        primary: primary,
+      );
+      expect(hasBorderColored(tester, primary), isFalse);
+    });
+  });
+}

--- a/test/pangea/world/world_map_large_card_test.dart
+++ b/test/pangea/world/world_map_large_card_test.dart
@@ -22,11 +22,18 @@ void main() {
     WidgetTester tester, {
     VoidCallback? onClose,
     VoidCallback? onTap,
+    bool isFocused = false,
+    Color primary = const Color(0xFF112233),
   }) async {
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates: L10n.localizationsDelegates,
         supportedLocales: L10n.supportedLocales,
+        theme: ThemeData(
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: primary,
+          ).copyWith(primary: primary),
+        ),
         home: Scaffold(
           body: Center(
             child: WorldMapLargeCard(
@@ -37,6 +44,7 @@ void main() {
               starsEarned: 0,
               onTap: onTap ?? () {},
               onClose: onClose,
+              isFocused: isFocused,
             ),
           ),
         ),
@@ -44,6 +52,16 @@ void main() {
     );
     await tester.pumpAndSettle();
   }
+
+  /// Whether any Container draws a border in [color] (the focus ring's primary
+  /// border) — the distinct focused marker (#7349).
+  bool hasBorderColored(WidgetTester tester, Color color) =>
+      tester.widgetList<Container>(find.byType(Container)).any((c) {
+        final d = c.decoration;
+        return d is BoxDecoration &&
+            d.border is Border &&
+            (d.border as Border).top.color == color;
+      });
 
   testWidgets(
     'a selected card shows a dismiss X that fires onClose, not onTap',
@@ -75,5 +93,29 @@ void main() {
   ) async {
     await pumpCard(tester, onClose: null);
     expect(find.byIcon(Icons.close), findsNothing);
+  });
+
+  group('focus ring (#7349)', () {
+    const primary = Color(0xFF112233);
+
+    testWidgets('a focused card draws a primary-coloured focus ring', (
+      tester,
+    ) async {
+      await pumpCard(tester, isFocused: true, primary: primary);
+      expect(
+        hasBorderColored(tester, primary),
+        isTrue,
+        reason: 'the focused card wraps in a primary-coloured ring',
+      );
+    });
+
+    testWidgets('an unfocused card has no primary focus ring', (tester) async {
+      await pumpCard(tester, isFocused: false, primary: primary);
+      expect(
+        hasBorderColored(tester, primary),
+        isFalse,
+        reason: 'only the focused state adds the primary ring',
+      );
+    });
   });
 }


### PR DESCRIPTION
Closes #7349.

## What

Per `world-map.instructions.md` ("Featured, selected, and focused"), the focused pin should carry a distinct marker. Today focus drives the camera and the detail panel, but the pin itself gets no treatment.

This adds a distinct focus ring to the focused activity's pin at every tier (small dot, mid, large card): a primary-coloured halo with a small gap outside the state-colour border, plus a soft glow so it reads at the 18px small-dot size. The focused id flows from the existing `ActivityFocus` signal (`widget.focus`, set when a `left=activity:` panel is open), threaded through the pin render path (`_PinRenderer.focusedId`); it persists through zoom and pan and clears when the panel closes or another activity is focused.

## Also in this cluster (#7348 follow-ups)

- **#7350** (selected card near edge nudges the camera): verified already satisfied by `_nudgeSelectionOnScreen` / `minimalShiftToFit` (covers all four edges plus the L/R overlay insets), and focused entry centres the pin via `CameraFit` so a tall card does not clip. Closing #7350 separately.
- **#7245** (return activities to dots on zoom-out): investigated. The selection-clear path is sound (a tap-selected card does clear on any real user zoom). What persists is a *featured* large card re-featuring at the new zoom, and there is no zoom-threshold rule that collapses featured large cards back to dots. That is a design decision (what zoom or density rule drops the large-card budget), so I left it for a design call rather than guess. Kept open.

## Testing

- New `test/pangea/world/world_map_focus_test.dart` (pure `focusedActivityIdOf` resolution + small/mid dot focus-ring widget tests) plus an extended large-card focus test. `flutter test test/pangea/world/` and the world-map suites pass; full `flutter analyze` clean; format + import-sorter gates green.
- The ring's appear/clear-on-focus-change relies on the cluster-marker cache signature including each pin's focus state, so the marker list rebuilds when focus moves; verified in code. I will confirm the live render on staging after the deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added focus-state support in the world map so the selected activity is highlighted.
  * Cards and map dots now show a primary-colored focus ring when active.

* **Bug Fixes**
  * Improved focus handling so map markers and large cards update correctly when selection changes.
  * Ensured cached map markers refresh when the focused activity changes.

* **Tests**
  * Added coverage for focus resolution and focus-ring rendering on map dots and large cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->