### PR TITLE
fix: in activty start page position roles list against the top of the…

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -200,7 +200,12 @@ class ActivitySessionStartView extends StatelessWidget {
                             children: [
                               Stack(
                                 children: [
-                                  SizedBox(
+                                  // Background image — now Positioned with explicit height instead of
+                                  // living inside a height-constrained Container
+                                  Positioned(
+                                    top: 0,
+                                    left: 0,
+                                    right: 0,
                                     height: 350.0,
                                     child: LayoutBuilder(
                                       builder: (context, constraints) =>
@@ -228,7 +233,7 @@ class ActivitySessionStartView extends StatelessWidget {
                                     ),
                                   ),
                                   Positioned.fill(
-                                    top: 275.0,
+                                    top: 225.0,
                                     child: Container(
                                       decoration: BoxDecoration(
                                         gradient: LinearGradient(
@@ -245,13 +250,13 @@ class ActivitySessionStartView extends StatelessWidget {
                                     ),
                                   ),
                                   if (sessionController.showRoleCards)
-                                    Positioned(
-                                      bottom: 0,
-                                      left: 0,
-                                      right: 0,
+                                    Padding(
+                                      padding: const EdgeInsets.only(
+                                        top: 200.0,
+                                      ),
                                       child: Center(
                                         child: Container(
-                                          padding: EdgeInsets.symmetric(
+                                          padding: const EdgeInsets.symmetric(
                                             horizontal: 16.0,
                                           ),
                                           constraints: const BoxConstraints(


### PR DESCRIPTION
… screen

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
