### PR TITLE
fix(courses): back from a course preview keeps the browse list + its language filter (#7400, #7230)

### DIFF
--- a/lib/routes/courses/find_course_page.dart
+++ b/lib/routes/courses/find_course_page.dart
@@ -32,6 +32,23 @@ class FindCoursePage extends StatefulWidget {
 }
 
 class FindCoursePageState extends State<FindCoursePage> {
+  /// Session-scoped memory of the last language filter the learner picked while
+  /// browsing public courses. Tapping a course opens the route-driven preview
+  /// (`/courses/preview/:courseroomid`); backing out of it **remounts** this
+  /// page, so without this the filter reset to the L2 default and lost the
+  /// choice (#7230). Mirrors `NewCoursePageState._lastChosenLanguage` (#7269) —
+  /// it survives the remount with no URL churn.
+  static LanguageModel? _lastChosenLanguage;
+
+  /// The language filter the browse list opens on: this session's last pick
+  /// ([lastChosen], so the preview round-trip keeps it), else the learner's L2
+  /// default (#7230).
+  @visibleForTesting
+  static LanguageModel? seedLanguage({
+    required LanguageModel? lastChosen,
+    required LanguageModel? l2Default,
+  }) => lastChosen ?? l2Default;
+
   final TextEditingController searchController = TextEditingController();
   final ScrollController scrollController = ScrollController();
   Timer? _coolDown;
@@ -54,14 +71,19 @@ class FindCoursePageState extends State<FindCoursePage> {
   @override
   void initState() {
     super.initState();
+    LanguageModel? l2Default;
     final l2 = MatrixState.pangeaController.userController.userL2;
     if (l2 != null) {
       final availableLanguages =
           MatrixState.pangeaController.pLanguageStore.unlocalizedTargetOptions;
-      targetLanguageFilter.value = availableLanguages.contains(l2)
-          ? l2
-          : l2.unlocalized;
+      l2Default = availableLanguages.contains(l2) ? l2 : l2.unlocalized;
     }
+    // Keep the language picked this session across the preview round-trip
+    // (#7230); fall back to the learner's L2 default.
+    targetLanguageFilter.value = seedLanguage(
+      lastChosen: _lastChosenLanguage,
+      l2Default: l2Default,
+    );
     loadMore();
   }
 
@@ -79,6 +101,8 @@ class FindCoursePageState extends State<FindCoursePage> {
   void setTargetLanguageFilter(LanguageModel? language) {
     if (targetLanguageFilter.value == language) return;
     targetLanguageFilter.value = language;
+    _lastChosenLanguage =
+        language; // remember for the rest of this session (#7230)
     visibleCourses.value = [];
     loading.value = false;
     _loadGeneration++;

--- a/lib/routes/courses/preview/public_course_preview.dart
+++ b/lib/routes/courses/preview/public_course_preview.dart
@@ -10,6 +10,8 @@ import 'package:fluffychat/features/analytics_access/join_room_analytics_consent
 import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
 import 'package:fluffychat/features/join_codes/knocked_rooms_extension.dart';
 import 'package:fluffychat/features/join_codes/space_code_controller.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
@@ -48,6 +50,23 @@ class PublicCoursePreviewController extends State<PublicCoursePreview>
     if (widget.roomID != oldWidget.roomID) {
       _loadSummary();
     }
+  }
+
+  /// world_v2: the public course preview is route-driven
+  /// (`/courses/preview/:courseroomid`) because its parent `/courses…` segments
+  /// render a blank `EmptyPage`. A plain auto-pop back surfaces that blank page
+  /// (#7400). The preview has a single entry mode — the browse-public list — so
+  /// back returns to that list (`addcourse:browse`) over the world map, mirroring
+  /// the route-driven course-detail fix (#7092).
+  void back() {
+    context.go(
+      WorkspaceNav.setSection(
+        GoRouterState.of(context).uri,
+        PRoutes.world,
+        const PanelToken('addcourse', 'browse'),
+        keepRoom: false,
+      ),
+    );
   }
 
   bool get loading => loadingCourse || loadingRoomSummary;

--- a/lib/routes/courses/preview/public_course_preview_view.dart
+++ b/lib/routes/courses/preview/public_course_preview_view.dart
@@ -35,6 +35,14 @@ class PublicCoursePreviewView extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
+        // world_v2: explicit token-based back. The auto-implied back would pop
+        // to the route-driven parent's blank EmptyPage (#7400); controller.back
+        // returns to the browse-public list instead.
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+          onPressed: controller.back,
+        ),
         title: Text(
           L10n.of(context).joinWithClassCode,
           style: FluffyThemes.isColumnMode(context)

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -667,6 +667,26 @@ void main() {
       ]);
       expect(parseOpenPanels(u(planList)).right, isEmpty);
     });
+
+    test('back from the route-driven public course preview lands on the '
+        'browse-public list (#7400)', () {
+      // The public course preview is route-driven
+      // (`/courses/preview/:courseroomid`), so its parent segments render a
+      // blank EmptyPage. `PublicCoursePreviewController.back` navigates to the
+      // browse-public list token over the world map rather than popping to that
+      // blank parent — even though the current URL is the legacy preview path.
+      final browseList = WorkspaceNav.setSection(
+        u('/courses/preview/!abc:server'),
+        '/',
+        const PanelToken('addcourse', 'browse'),
+        keepRoom: false,
+      );
+      expect(u(browseList).path, '/');
+      expect(parseOpenPanels(u(browseList)).left, [
+        const PanelToken('addcourse', 'browse'),
+      ]);
+      expect(parseOpenPanels(u(browseList)).right, isEmpty);
+    });
   });
 
   group('openDetail (generic, registry-driven exclusive groups)', () {

--- a/test/routes/courses/find_course_seed_language_test.dart
+++ b/test/routes/courses/find_course_seed_language_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/languages/language_model.dart';
+import 'package:fluffychat/routes/courses/find_course_page.dart';
+
+/// Covers #7230: the browse-public language filter must keep the language the
+/// learner picked this session. Tapping a course opens the route-driven preview
+/// (`/courses/preview/:courseroomid`); backing out remounts FindCoursePage, and
+/// without the session memory `initState` reset the filter to the L2 default.
+void main() {
+  final fr = LanguageModel(langCode: 'fr', displayName: 'French');
+  final es = LanguageModel(langCode: 'es', displayName: 'Spanish');
+
+  group('FindCoursePageState.seedLanguage', () {
+    test('the session memory wins over the L2 default (the fix)', () {
+      expect(
+        FindCoursePageState.seedLanguage(lastChosen: fr, l2Default: es),
+        fr,
+      );
+    });
+
+    test('falls back to the L2 default when nothing is remembered', () {
+      expect(
+        FindCoursePageState.seedLanguage(lastChosen: null, l2Default: es),
+        es,
+      );
+    });
+
+    test('a null L2 default with no memory yields null (no crash)', () {
+      expect(
+        FindCoursePageState.seedLanguage(lastChosen: null, l2Default: null),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Closes #7400. Closes #7230.

## What

Both are "back from a course preview loses state" bugs with a shared root cause: the public course preview is a route-driven page (a GoRoute) sitting over the token-driven panel workspace, so backing out of it broke two ways.

- **#7400** (empty page): the auto-implied back popped to the route's blank parent (the `/courses` segment renders an `EmptyPage`). Fixed by mirroring #7092: an explicit `back()` on the preview controller navigates to the browse-public list token (`setSection` → `addcourse:browse`), and the AppBar carries an explicit back button that calls it.
- **#7230** (language filter reset): the browse list (`FindCoursePage`) holds its language filter in widget state, which is remounted when the route-driven preview takes over and back returns, resetting the filter to the learner's L2. Fixed with the same session-static-memory pattern the sibling start-my-own step uses (#7269): a `_lastChosenLanguage` static seeded on init, so the filter survives the remount. (The URL approach would need a `?lang=` replace-write on every filter change, and `context.replace` is used nowhere in this codebase, so the static pattern is the consistent, churn-free choice.)

## Testing

- #7400: a pure nav test that the back location builds `/?left=addcourse:browse` (mirrors the #7090 test).
- #7230: a `seedLanguage` test (last pick wins over L2, L2 fallback, null-safe), mirroring #7269.
- `flutter test` (59) passes; full `flutter analyze` clean; format + import-sorter gates green.
- I will confirm both flows on staging after the deploy lands: back from the public preview returns to the browse list, and the language filter persists across the round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The course finder now remembers your last selected language during the current session, so returning to the page keeps your filter in place.
  * Public course previews now include a clear back button that returns you to the course browsing view.

* **Bug Fixes**
  * Improved navigation so backing out of a public course preview restores the expected browse section and view state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->