### PR TITLE
fix: explicitly set flags for enabling emoji selection and reactions …

### DIFF
--- a/lib/features/user/user_controller.dart
+++ b/lib/features/user/user_controller.dart
@@ -498,6 +498,4 @@ class UserController {
       userL2Code!.isNotEmpty &&
       userL1Code != LanguageKeys.unknownLanguage &&
       userL2Code != LanguageKeys.unknownLanguage;
-
-  bool get showTranscription => true;
 }

--- a/lib/routes/analytics/construct_analytics/construct_analytics_details/vocab_analytics_details_view.dart
+++ b/lib/routes/analytics/construct_analytics/construct_analytics_details/vocab_analytics_details_view.dart
@@ -106,6 +106,8 @@ class VocabDetailsView extends StatelessWidget {
                       ),
                   reloadNotifier: controller.reloadNotifier,
                   maxWidth: double.infinity,
+                  enableEmojiSelection: true,
+                  enableEmojiReactions: false,
                 ),
               ),
               if (construct != null)

--- a/lib/routes/chat/activity_sessions/activity_vocab_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_vocab_widget.dart
@@ -320,6 +320,8 @@ class _WordCardWrapperState extends State<_WordCardWrapper> {
         widget.onClose();
       },
       enableAnalyticsNavigation: true,
+      enableEmojiSelection: true,
+      enableEmojiReactions: false,
     );
   }
 }

--- a/lib/routes/chat/events/token_info_feedback/token_info_feedback_dialog.dart
+++ b/lib/routes/chat/events/token_info_feedback/token_info_feedback_dialog.dart
@@ -144,6 +144,7 @@ class TokenInfoFeedbackDialog extends StatelessWidget {
         morph: selectedToken.morph.map((k, v) => MapEntry(k.name, v)),
         langCode: langCode,
         enableEmojiSelection: false,
+        enableEmojiReactions: false,
       ),
     );
   }

--- a/lib/routes/chat/style_example_message.dart
+++ b/lib/routes/chat/style_example_message.dart
@@ -47,6 +47,8 @@ class _StyleExampleWordCard extends StatelessWidget {
         type: ConstructTypeEnum.vocab,
       ),
       pos: 'INTJ',
+      enableEmojiReactions: false,
+      enableEmojiSelection: false,
     );
   }
 }

--- a/lib/routes/chat/toolbar/word_card/lemma_reaction_picker.dart
+++ b/lib/routes/chat/toolbar/word_card/lemma_reaction_picker.dart
@@ -31,9 +31,9 @@ class LemmaReactionPicker extends StatefulWidget {
     super.key,
     required this.constructId,
     required this.langCode,
+    required this.enableSelection,
+    required this.enableReactions,
     this.event,
-    this.enableSelection = true,
-    this.enableReactions = true,
     this.form,
   });
 
@@ -188,6 +188,10 @@ class LemmaReactionPickerState extends State<LemmaReactionPicker>
     final globallyEnable = _matchesL2;
     final globallyEnableSelection = globallyEnable && widget.enableSelection;
     final globallyEnableReactions = globallyEnable && widget.enableReactions;
+
+    Logs().w(
+      "ENABLE REACTIONS: ${widget.enableReactions}. ENABLE SELECTION: ${widget.enableSelection}",
+    );
 
     final bool hasSentSelectedEmojiReaction =
         _selectedEmoji != null &&

--- a/lib/routes/chat/toolbar/word_card/reading_assistance_content.dart
+++ b/lib/routes/chat/toolbar/word_card/reading_assistance_content.dart
@@ -56,6 +56,7 @@ class ReadingAssistanceContent extends StatelessWidget {
         event: overlayController.event,
         onClose: () => overlayController.updateSelectedSpan(null),
         langCode: overlayController.pangeaMessageEvent.messageDisplayLangCode,
+        enableEmojiSelection: true,
         enableEmojiReactions:
             !overlayController.pangeaMessageEvent.room.isActivityFinished,
         enableAnalyticsNavigation: true,

--- a/lib/routes/chat/toolbar/word_card/word_zoom_widget.dart
+++ b/lib/routes/chat/toolbar/word_card/word_zoom_widget.dart
@@ -7,7 +7,6 @@ import 'package:fluffychat/features/analytics/construct_identifier.dart';
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/languages/p_language_store.dart';
 import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/pangea/common/widgets/word_audio_button.dart';
 import 'package:fluffychat/pangea/lemmas/lemma_info_response.dart';
 import 'package:fluffychat/routes/analytics/analytics_navigation_util.dart';
 import 'package:fluffychat/routes/chat/events/models/pangea_token_text_model.dart';
@@ -25,10 +24,9 @@ import 'package:fluffychat/widgets/matrix.dart';
 class WordZoomWidget extends StatelessWidget {
   final PangeaTokenText token;
   final ConstructIdentifier construct;
-
   final String langCode;
-  final VoidCallback? onClose;
 
+  final VoidCallback? onClose;
   final Event? event;
 
   /// POS tag for PT v2 disambiguation (e.g. "VERB").
@@ -51,11 +49,11 @@ class WordZoomWidget extends StatelessWidget {
     required this.construct,
     required this.langCode,
     required this.pos,
+    required this.enableEmojiSelection,
+    required this.enableEmojiReactions,
     this.onClose,
     this.event,
     this.morph,
-    this.enableEmojiSelection = true,
-    this.enableEmojiReactions = true,
     this.enableAnalyticsNavigation = false,
     this.onFlagTokenInfo,
     this.reloadNotifier,
@@ -79,135 +77,117 @@ class WordZoomWidget extends StatelessWidget {
       _showNewWordOverlay(context);
     });
 
-    final showTranscript =
-        MatrixState.pangeaController.userController.showTranscription;
-
     final Widget content =
         !MatrixState
             .pangeaController
             .subscriptionController
             .showSubscriptionGatedContent
         ? MessageUnsubscribedCard(token: token, onClose: onClose)
-        : Stack(
-            children: [
-              Container(
-                height: AppConfig.toolbarMaxHeight - 8,
-                padding: const EdgeInsets.all(12.0),
-                constraints: BoxConstraints(
-                  maxWidth: maxWidth ?? AppConfig.toolbarMinWidth,
-                ),
-                child: Column(
-                  spacing: 12.0,
-                  children: [
-                    SizedBox(
-                      height: 40.0,
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          onClose != null
-                              ? IconButton(
-                                  tooltip: L10n.of(context).close,
-                                  color: Theme.of(context).iconTheme.color,
-                                  icon: const Icon(Icons.close),
-                                  onPressed: onClose,
-                                )
-                              : const SizedBox(width: 40.0, height: 40.0),
-                          Flexible(
-                            child: InkWell(
-                              onTap: enableAnalyticsNavigation
-                                  ? () =>
-                                        AnalyticsNavigationUtil.navigateToAnalytics(
-                                          context: context,
-                                          view: ProgressIndicatorEnum.wordsUsed,
-                                          construct: construct,
-                                        )
-                                  : null,
-                              borderRadius: BorderRadius.circular(8.0),
-                              child: Container(
-                                constraints: const BoxConstraints(
-                                  minHeight: 40.0,
-                                ),
-                                alignment: Alignment.center,
-                                child: Text(
-                                  token.content,
-                                  textAlign: TextAlign.center,
-                                  style: TextStyle(
-                                    fontSize: 28.0,
-                                    fontWeight: FontWeight.w600,
-                                    height: 1.2,
-                                    color:
-                                        Theme.of(context).brightness ==
-                                            Brightness.light
-                                        ? AppConfig.yellowDark
-                                        : AppConfig.yellowLight,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                ),
+        : Container(
+            height: AppConfig.toolbarMaxHeight - 8,
+            padding: const EdgeInsets.all(12.0),
+            constraints: BoxConstraints(
+              maxWidth: maxWidth ?? AppConfig.toolbarMinWidth,
+            ),
+            child: Column(
+              spacing: 12.0,
+              children: [
+                SizedBox(
+                  height: 40.0,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      onClose != null
+                          ? IconButton(
+                              tooltip: L10n.of(context).close,
+                              color: Theme.of(context).iconTheme.color,
+                              icon: const Icon(Icons.close),
+                              onPressed: onClose,
+                            )
+                          : const SizedBox(width: 40.0, height: 40.0),
+                      Flexible(
+                        child: InkWell(
+                          onTap: enableAnalyticsNavigation
+                              ? () =>
+                                    AnalyticsNavigationUtil.navigateToAnalytics(
+                                      context: context,
+                                      view: ProgressIndicatorEnum.wordsUsed,
+                                      construct: construct,
+                                    )
+                              : null,
+                          borderRadius: BorderRadius.circular(8.0),
+                          child: Container(
+                            constraints: const BoxConstraints(minHeight: 40.0),
+                            alignment: Alignment.center,
+                            child: Text(
+                              token.content,
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                fontSize: 28.0,
+                                fontWeight: FontWeight.w600,
+                                height: 1.2,
+                                color:
+                                    Theme.of(context).brightness ==
+                                        Brightness.light
+                                    ? AppConfig.yellowDark
+                                    : AppConfig.yellowLight,
+                                overflow: TextOverflow.ellipsis,
                               ),
                             ),
                           ),
-                          onFlagTokenInfo != null
-                              ? TokenFeedbackButton(
-                                  textLanguage:
-                                      PLanguageStore.byLangCode(langCode) ??
-                                      LanguageModel.unknown,
-                                  constructId: construct,
-                                  text: token.content,
-                                  onFlagTokenInfo: onFlagTokenInfo!,
-                                  messageInfo: event?.content ?? {},
-                                )
-                              : const SizedBox(width: 40.0, height: 40.0),
-                        ],
+                        ),
                       ),
-                    ),
-                    Expanded(
-                      child: Column(
-                        spacing: 4.0,
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          showTranscript
-                              ? PhoneticTranscriptionWidget(
-                                  text: token.content,
-                                  textLanguage:
-                                      PLanguageStore.byLangCode(langCode) ??
-                                      LanguageModel.unknown,
-                                  pos: pos,
-                                  morph: morph,
-                                  style: const TextStyle(fontSize: 14.0),
-                                  iconSize: 24.0,
-                                  maxLines: 2,
-                                  reloadNotifier: reloadNotifier,
-                                )
-                              : WordAudioButton(
-                                  text: token.content,
-                                  pos: pos,
-                                  morph: morph,
-                                  uniqueID: "lemma-content-${token.content}",
-                                  langCode: langCode,
-                                  iconSize: 24.0,
-                                ),
-                          LemmaReactionPicker(
-                            constructId: construct,
-                            langCode: langCode,
-                            event: event,
-                            enableSelection: enableEmojiSelection,
-                            enableReactions: enableEmojiReactions,
-                            form: token.content,
-                          ),
-                          LemmaMeaningDisplay(
-                            langCode: langCode,
-                            constructId: construct,
-                            text: token.content,
-                            messageInfo: event?.content ?? {},
-                            reloadNotifier: reloadNotifier,
-                          ),
-                        ],
-                      ),
-                    ),
-                  ],
+                      onFlagTokenInfo != null
+                          ? TokenFeedbackButton(
+                              textLanguage:
+                                  PLanguageStore.byLangCode(langCode) ??
+                                  LanguageModel.unknown,
+                              constructId: construct,
+                              text: token.content,
+                              onFlagTokenInfo: onFlagTokenInfo!,
+                              messageInfo: event?.content ?? {},
+                            )
+                          : const SizedBox(width: 40.0, height: 40.0),
+                    ],
+                  ),
                 ),
-              ),
-            ],
+                Expanded(
+                  child: Column(
+                    spacing: 4.0,
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      PhoneticTranscriptionWidget(
+                        text: token.content,
+                        textLanguage:
+                            PLanguageStore.byLangCode(langCode) ??
+                            LanguageModel.unknown,
+                        pos: pos,
+                        morph: morph,
+                        style: const TextStyle(fontSize: 14.0),
+                        iconSize: 24.0,
+                        maxLines: 2,
+                        reloadNotifier: reloadNotifier,
+                      ),
+                      LemmaReactionPicker(
+                        constructId: construct,
+                        langCode: langCode,
+                        event: event,
+                        enableSelection: enableEmojiSelection,
+                        enableReactions: enableEmojiReactions,
+                        form: token.content,
+                      ),
+                      LemmaMeaningDisplay(
+                        langCode: langCode,
+                        constructId: construct,
+                        text: token.content,
+                        messageInfo: event?.content ?? {},
+                        reloadNotifier: reloadNotifier,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
           );
 
     return GestureDetector(


### PR DESCRIPTION
…for all word cards

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Emoji selection is now available in more word-card and analytics views.
  * Word-card zoom controls now require explicit emoji settings, making behavior more consistent across screens.

* **Bug Fixes**
  * Transcription is now always shown in word zoom views instead of being inconsistently hidden.
  * Emoji reactions are disabled in places where they should not appear, reducing unwanted interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->