### PR TITLE
fix: prevent goals dropdown from covering up role cards

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -206,7 +206,7 @@ class ActivitySessionStartView extends StatelessWidget {
                                     top: 0,
                                     left: 0,
                                     right: 0,
-                                    height: 350.0,
+                                    height: 375.0,
                                     child: LayoutBuilder(
                                       builder: (context, constraints) =>
                                           ImageByUrl(
@@ -233,7 +233,7 @@ class ActivitySessionStartView extends StatelessWidget {
                                     ),
                                   ),
                                   Positioned.fill(
-                                    top: 225.0,
+                                    top: 250.0,
                                     child: Container(
                                       decoration: BoxDecoration(
                                         gradient: LinearGradient(
@@ -252,7 +252,7 @@ class ActivitySessionStartView extends StatelessWidget {
                                   if (sessionController.showRoleCards)
                                     Padding(
                                       padding: const EdgeInsets.only(
-                                        top: 200.0,
+                                        top: 250.0,
                                       ),
                                       child: Center(
                                         child: Container(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
