### PR TITLE
fix: always show input bar popups above the input bar

### DIFF
--- a/lib/features/overlay/overlay.dart
+++ b/lib/features/overlay/overlay.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:fluffychat/features/overlay/centered_overlay_widget.dart';
 import 'package:fluffychat/features/overlay/overlay_container.dart';
 import 'package:fluffychat/features/overlay/overlay_display_details.dart';
+import 'package:fluffychat/features/overlay/overlay_position.dart';
 import 'package:fluffychat/features/overlay/top_overlay_widget.dart';
 import 'package:fluffychat/features/overlay/transparent_backdrop.dart';
 import '../../pangea/common/utils/error_handler.dart';
@@ -77,36 +78,43 @@ class OverlayUtil {
     required BuildContext context,
     required Widget cardToShow,
     required PositionedOverlayDisplayDetails displayDetails,
+    OverlayPosition? overlayPosition,
   }) {
     try {
       final targetRenderBox = MatrixState.pAnyState.getRenderBox(
         displayDetails.transformTargetId,
       );
 
-      final parentRenderBox =
-          Overlay.of(context).context.findRenderObject() as RenderBox?;
-      if (parentRenderBox == null || !parentRenderBox.hasSize) {
-        debugPrint("Cannot get renderbox for parent overlay");
+      final parentRenderBox = overlayRenderBox(context);
+
+      if (parentRenderBox == null || targetRenderBox == null) {
+        debugPrint("Cannot get renderbox for parent overlay or target");
         return;
       }
 
-      if (targetRenderBox == null) {
-        debugPrint("layerLinkAndKey.key.currentContext is null");
-        return;
+      const horizontalPadding = 10.0;
+
+      final targetSize = targetRenderBox.size;
+      final targetOffset = parentRenderBox.globalToLocal(
+        targetRenderBox.localToGlobal(Offset.zero),
+      );
+
+      final midpoint = targetOffset.dx + (targetSize.width / 2);
+      final leftEdge = midpoint - (displayDetails.maxWidth / 2);
+      final rightEdge = midpoint + (displayDetails.maxWidth / 2);
+
+      final minLeft = horizontalPadding;
+      final maxRight = parentRenderBox.size.width - horizontalPadding;
+
+      double dx = 0;
+
+      if (leftEdge < minLeft) {
+        dx = minLeft - leftEdge;
+      } else if (rightEdge > maxRight) {
+        dx = maxRight - rightEdge;
       }
 
-      final offset = _getPositionedOffset(
-        context,
-        targetRenderBox,
-        parentRenderBox,
-        displayDetails.maxWidth,
-      );
-
-      final hasTopOverflow = _hasTopOverflow(
-        targetRenderBox,
-        displayDetails.maxHeight,
-      );
-
+      final offset = Offset(dx, 0);
       final Widget child = displayDetails.addBorder
           ? Material(
               borderOnForeground: false,
@@ -121,17 +129,24 @@ class OverlayUtil {
             )
           : cardToShow;
 
+      final hasTopOverflow =
+          (displayDetails.maxHeight + kToolbarHeight) > targetOffset.dy;
+
+      final targetAnchor =
+          overlayPosition?.targetAnchor ??
+          (hasTopOverflow ? Alignment.bottomCenter : Alignment.topCenter);
+
+      final followerAnchor =
+          overlayPosition?.followerAnchor ??
+          (hasTopOverflow ? Alignment.topCenter : Alignment.bottomCenter);
+
       showOverlay(
         context: context,
         child: child,
         displayDetails: displayDetails.copyWith(
           offset: offset,
-          targetAnchor: hasTopOverflow
-              ? Alignment.bottomCenter
-              : Alignment.topCenter,
-          followerAnchor: hasTopOverflow
-              ? Alignment.topCenter
-              : Alignment.bottomCenter,
+          targetAnchor: targetAnchor,
+          followerAnchor: followerAnchor,
         ),
       );
     } catch (err, stack) {
@@ -140,39 +155,11 @@ class OverlayUtil {
     }
   }
 
-  static Offset _getPositionedOffset(
-    BuildContext context,
-    RenderBox targetRenderBox,
-    RenderBox parentRenderBox,
-    double maxWidth,
-  ) {
-    const horizontalPadding = 10.0;
+  static RenderBox? overlayRenderBox(BuildContext context) {
+    final renderBox =
+        Overlay.of(context).context.findRenderObject() as RenderBox?;
 
-    final targetSize = targetRenderBox.size;
-    final targetOffset = parentRenderBox.globalToLocal(
-      targetRenderBox.localToGlobal(Offset.zero),
-    );
-
-    final midpoint = targetOffset.dx + (targetSize.width / 2);
-    final leftEdge = midpoint - (maxWidth / 2);
-    final rightEdge = midpoint + (maxWidth / 2);
-
-    final minLeft = horizontalPadding;
-    final maxRight = parentRenderBox.size.width - horizontalPadding;
-
-    double dx = 0;
-
-    if (leftEdge < minLeft) {
-      dx = minLeft - leftEdge;
-    } else if (rightEdge > maxRight) {
-      dx = maxRight - rightEdge;
-    }
-
-    return Offset(dx, 0);
-  }
-
-  static bool _hasTopOverflow(RenderBox renderBox, double maxHeight) {
-    final targetOffset = (renderBox).localToGlobal(Offset.zero);
-    return maxHeight + kToolbarHeight > targetOffset.dy;
+    if (renderBox == null || !renderBox.hasSize) return null;
+    return renderBox;
   }
 }

--- a/lib/features/overlay/overlay_position.dart
+++ b/lib/features/overlay/overlay_position.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+enum OverlayPosition {
+  above,
+  below;
+
+  Alignment get targetAnchor => switch (this) {
+    OverlayPosition.above => Alignment.topCenter,
+    OverlayPosition.below => Alignment.bottomCenter,
+  };
+
+  Alignment get followerAnchor => switch (this) {
+    OverlayPosition.above => Alignment.bottomCenter,
+    OverlayPosition.below => Alignment.topCenter,
+  };
+}

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -44,6 +44,7 @@ import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/overlay/layer_link_and_key.dart';
 import 'package:fluffychat/features/overlay/overlay.dart';
 import 'package:fluffychat/features/overlay/overlay_display_details.dart';
+import 'package:fluffychat/features/overlay/overlay_position.dart';
 import 'package:fluffychat/features/overlay/transparent_backdrop.dart';
 import 'package:fluffychat/features/subscription/widgets/paywall_card.dart';
 import 'package:fluffychat/features/tutorials/tutorial_enum.dart';
@@ -2837,9 +2838,8 @@ class ChatController extends State<ChatPageWithRoom>
             transformTargetId: ChoreoConstants.inputTransformTargetKey,
             ignorePointer: true,
             isScrollable: false,
-            targetAnchor: Alignment.topCenter,
-            followerAnchor: Alignment.bottomCenter,
           ),
+          overlayPosition: OverlayPosition.above,
         ),
       );
     }
@@ -3058,6 +3058,7 @@ class ChatController extends State<ChatPageWithRoom>
         transformTargetId: ChoreoConstants.inputTransformTargetKey,
         overlayKey: 'disable_language_tools_popup',
       ),
+      overlayPosition: OverlayPosition.above,
     );
   }
 

--- a/lib/routes/chat/toolbar/layout/message_selection_positioner.dart
+++ b/lib/routes/chat/toolbar/layout/message_selection_positioner.dart
@@ -8,6 +8,7 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dart';
+import 'package:fluffychat/features/overlay/overlay.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/chat/chat.dart';
 import 'package:fluffychat/routes/chat/events/event_wrappers/pangea_message_event.dart';
@@ -176,16 +177,7 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
     null,
   );
 
-  RenderBox? get _parentRenderBox => _runWithLogging<RenderBox?>(
-    () {
-      final overlay = Overlay.of(context);
-      final renderBox = overlay.context.findRenderObject() as RenderBox?;
-      if (renderBox == null || !renderBox.hasSize) return null;
-      return renderBox;
-    },
-    "Error getting message render box",
-    null,
-  );
+  RenderBox? get _parentRenderBox => OverlayUtil.overlayRenderBox(context);
 
   double? get parentWidth => _parentRenderBox?.size.width;
 

--- a/lib/routes/settings/settings_learning/language_mismatch_popup.dart
+++ b/lib/routes/settings/settings_learning/language_mismatch_popup.dart
@@ -4,6 +4,7 @@ import 'package:fluffychat/features/bot/utils/bot_style.dart';
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/overlay/overlay.dart';
 import 'package:fluffychat/features/overlay/overlay_display_details.dart';
+import 'package:fluffychat/features/overlay/overlay_position.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/widgets/card_header.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
@@ -48,6 +49,7 @@ class LanguageMismatchPopup extends StatelessWidget {
         transformTargetId: targetId,
         overlayKey: 'language_mismatch_popup',
       ),
+      overlayPosition: OverlayPosition.above,
     );
   }
 


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
