### PR TITLE
Organize and label groups on stars analytics page

### DIFF
--- a/lib/features/analytics_data/analytics_init_error_indicator.dart
+++ b/lib/features/analytics_data/analytics_init_error_indicator.dart
@@ -13,7 +13,12 @@ class AnalyticsInitErrorIndicator extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          ErrorIndicator(message: L10n.of(context).oopsSomethingWentWrong),
+          Semantics(
+            container: true,
+            child: ErrorIndicator(
+              message: L10n.of(context).oopsSomethingWentWrong,
+            ),
+          ),
           SizedBox(height: 8.0),
           TextButton(
             onPressed: reinitialize,

--- a/lib/features/instructions/instructions_inline_tooltip.dart
+++ b/lib/features/instructions/instructions_inline_tooltip.dart
@@ -158,10 +158,26 @@ class InlineTooltipState extends State<InlineTooltip>
                   ),
                   Flexible(
                     child: Center(
-                      child: widget.richText != null
-                          ? RichText(
-                              text: TextSpan(
-                                children: widget.richText,
+                      child: Semantics(
+                        container: true,
+                        child: widget.richText != null
+                            ? RichText(
+                                text: TextSpan(
+                                  children: widget.richText,
+                                  style:
+                                      widget.textStyle ??
+                                      (FluffyThemes.isColumnMode(context)
+                                          ? Theme.of(
+                                              context,
+                                            ).textTheme.titleSmall
+                                          : Theme.of(
+                                              context,
+                                            ).textTheme.bodyMedium),
+                                ),
+                                textAlign: TextAlign.center,
+                              )
+                            : Text(
+                                widget.message,
                                 style:
                                     widget.textStyle ??
                                     (FluffyThemes.isColumnMode(context)
@@ -169,22 +185,13 @@ class InlineTooltipState extends State<InlineTooltip>
                                         : Theme.of(
                                             context,
                                           ).textTheme.bodyMedium),
+                                textAlign: TextAlign.center,
                               ),
-                              textAlign: TextAlign.center,
-                            )
-                          : Text(
-                              widget.message,
-                              style:
-                                  widget.textStyle ??
-                                  (FluffyThemes.isColumnMode(context)
-                                      ? Theme.of(context).textTheme.titleSmall
-                                      : Theme.of(context).textTheme.bodyMedium),
-                              textAlign: TextAlign.center,
-                            ),
+                      ),
                     ),
                   ),
                   IconButton(
-                    tooltip: L10n.of(context).close,
+                    tooltip: L10n.of(context).closeHint,
                     padding: const EdgeInsets.only(left: 6.0),
                     constraints: const BoxConstraints(),
                     icon: Icon(

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ar",
-    "@@last_modified": "2026-06-30 09:35:35.763799",
+    "@@last_modified": "2026-07-02 09:46:55.555748",
     "about": "حول",
     "@about": {
         "type": "String",
@@ -10541,6 +10541,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "صفحة {title}",
+    "closeHint": "إغلاق التلميح",
+    "starListLabel": "الأنشطة المحفوظة والنجوم",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_be.arb
+++ b/lib/l10n/intl_be.arb
@@ -3933,7 +3933,7 @@
     "playWithAI": "Пакуль гуляйце з ШІ",
     "courseStartDesc": "Pangea Bot гатовы да працы ў любы час!\n\n...але навучанне лепш з сябрамі!",
     "@@locale": "be",
-    "@@last_modified": "2026-06-30 09:34:59.500393",
+    "@@last_modified": "2026-07-02 09:46:36.818591",
     "@ignore": {
         "type": "String",
         "placeholders": {}
@@ -10215,6 +10215,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} старонка",
+    "closeHint": "Зачыніць падказку",
+    "starListLabel": "Захаваныя дзейнасці і зоркі",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_bn.arb
+++ b/lib/l10n/intl_bn.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:36:19.055994",
+    "@@last_modified": "2026-07-02 09:47:07.570290",
     "about": "সম্পর্কে",
     "@about": {
         "type": "String",
@@ -10916,6 +10916,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} পৃষ্ঠা",
+    "closeHint": "বন্ধ করার ইঙ্গিত",
+    "starListLabel": "সংরক্ষিত কার্যক্রম এবং তারা",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_bo.arb
+++ b/lib/l10n/intl_bo.arb
@@ -3193,7 +3193,7 @@
     "loginToAccount": "ངའི་ཁུལ་གཅིག་ལ་སྤྱོད་ལམ་སྤྱོད་འབད།",
     "languages": "ཚོད་ལྟ",
     "@@locale": "bo",
-    "@@last_modified": "2026-06-30 09:36:10.750767",
+    "@@last_modified": "2026-07-02 09:47:04.989704",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -9873,6 +9873,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} peji",
+    "closeHint": "Zavri namig",
+    "starListLabel": "Shranjene dejavnosti in zvezde",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ca.arb
+++ b/lib/l10n/intl_ca.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:35:03.468240",
+    "@@last_modified": "2026-07-02 09:46:44.803553",
     "about": "Quant a",
     "@about": {
         "type": "String",
@@ -10352,6 +10352,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} pàgina",
+    "closeHint": "Tanca la pista",
+    "starListLabel": "Activitats i estrelles desades",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "cs",
-    "@@last_modified": "2026-06-30 09:34:51.691542",
+    "@@last_modified": "2026-07-02 09:46:34.419613",
     "about": "O aplikaci",
     "@about": {
         "type": "String",
@@ -10755,6 +10755,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} stránka",
+    "closeHint": "Zavřít nápovědu",
+    "starListLabel": "Uložené aktivity a hvězdy",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_da.arb
+++ b/lib/l10n/intl_da.arb
@@ -1477,7 +1477,7 @@
     "playWithAI": "Leg med AI for nu",
     "courseStartDesc": "Pangea Bot er klar til at starte når som helst!\n\n...men læring er bedre med venner!",
     "@@locale": "da",
-    "@@last_modified": "2026-06-30 09:33:37.144253",
+    "@@last_modified": "2026-07-02 09:46:04.705265",
     "@aboutHomeserver": {
         "type": "String",
         "placeholders": {
@@ -11295,6 +11295,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} side",
+    "closeHint": "Luk hint",
+    "starListLabel": "Gemte aktiviteter og stjerner",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "de",
-    "@@last_modified": "2026-06-30 09:34:30.799561",
+    "@@last_modified": "2026-07-02 09:46:26.356427",
     "alwaysUse24HourFormat": "true",
     "@alwaysUse24HourFormat": {
         "description": "Set to true to always display time of day in 24 hour format."
@@ -10180,6 +10180,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} Seite",
+    "closeHint": "Hinweis schließen",
+    "starListLabel": "Gespeicherte Aktivitäten und Sterne",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_el.arb
+++ b/lib/l10n/intl_el.arb
@@ -3771,7 +3771,7 @@
     "playWithAI": "Παίξτε με την Τεχνητή Νοημοσύνη προς το παρόν",
     "courseStartDesc": "Ο Pangea Bot είναι έτοιμος να ξεκινήσει οποιαδήποτε στιγμή!\n\n...αλλά η μάθηση είναι καλύτερη με φίλους!",
     "@@locale": "el",
-    "@@last_modified": "2026-06-30 09:36:34.944245",
+    "@@last_modified": "2026-07-02 09:47:17.685760",
     "@checkList": {
         "type": "String",
         "placeholders": {}
@@ -11250,6 +11250,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} σελίδα",
+    "closeHint": "Κλείσιμο υποδείξεως",
+    "starListLabel": "Αποθηκευμένες δραστηριότητες και αστέρια",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -5003,5 +5003,15 @@
         }
     },
     "joinLearningCommunities": "Join international learning communities, or start your own!",
+    "pageLabel": "{title} page",
+    "@pageLabel": {
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "closeHint": "Close hint",
+    "starListLabel": "Saved activities and stars", 
     "writingAssistanceTutorialInputBar": "You can write in any language! We'll help you correct mistakes."
 }

--- a/lib/l10n/intl_eo.arb
+++ b/lib/l10n/intl_eo.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:36:47.721639",
+    "@@last_modified": "2026-07-02 09:47:21.685399",
     "about": "Prio",
     "@about": {
         "type": "String",
@@ -11320,6 +11320,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} paĝo",
+    "closeHint": "Fermi konsilon",
+    "starListLabel": "Konservitaj aktivecoj kaj steloj",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "es",
-    "@@last_modified": "2026-06-30 09:33:20.956127",
+    "@@last_modified": "2026-07-02 09:46:01.387772",
     "about": "Acerca de",
     "@about": {
         "type": "String",
@@ -8295,6 +8295,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} página",
+    "closeHint": "Cerrar pista",
+    "starListLabel": "Actividades guardadas y estrellas",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_et.arb
+++ b/lib/l10n/intl_et.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "et",
-    "@@last_modified": "2026-06-30 09:34:26.914132",
+    "@@last_modified": "2026-07-02 09:46:24.929865",
     "about": "Rakenduse teave",
     "@about": {
         "type": "String",
@@ -10198,6 +10198,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} leht",
+    "closeHint": "Sulge vihje",
+    "starListLabel": "Salvestatud tegevused ja tähed",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_eu.arb
+++ b/lib/l10n/intl_eu.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "eu",
-    "@@last_modified": "2026-06-30 09:34:19.850202",
+    "@@last_modified": "2026-07-02 09:46:21.665970",
     "about": "Honi buruz",
     "@about": {
         "type": "String",
@@ -10201,6 +10201,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} orria",
+    "closeHint": "Itxi iradokizuna",
+    "starListLabel": "Gordetako jarduerak eta izarrak",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fa.arb
+++ b/lib/l10n/intl_fa.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:36:22.729933",
+    "@@last_modified": "2026-07-02 09:47:08.800389",
     "repeatPassword": "تکرار گذرواژه",
     "@repeatPassword": {},
     "about": "درباره",
@@ -10313,6 +10313,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} صفحه",
+    "closeHint": "نکته را ببندید",
+    "starListLabel": "فعالیت‌ها و ستاره‌های ذخیره شده",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fi.arb
+++ b/lib/l10n/intl_fi.arb
@@ -3913,7 +3913,7 @@
     "playWithAI": "Leiki tekoälyn kanssa nyt",
     "courseStartDesc": "Pangea Bot on valmis milloin tahansa!\n\n...mutta oppiminen on parempaa ystävien kanssa!",
     "@@locale": "fi",
-    "@@last_modified": "2026-06-30 09:33:33.750891",
+    "@@last_modified": "2026-07-02 09:46:03.843564",
     "@notificationRuleJitsi": {
         "type": "String",
         "placeholders": {}
@@ -10250,6 +10250,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} sivu",
+    "closeHint": "Sulje vihje",
+    "starListLabel": "Tallennetut aktiviteetit ja tähdet",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fil.arb
+++ b/lib/l10n/intl_fil.arb
@@ -2257,7 +2257,7 @@
     "selectAll": "Piliin lahat",
     "deselectAll": "Huwag piliin lahat",
     "@@locale": "fil",
-    "@@last_modified": "2026-06-30 09:35:25.776368",
+    "@@last_modified": "2026-07-02 09:46:52.789242",
     "@setCustomPermissionLevel": {
         "type": "String",
         "placeholders": {}
@@ -11220,6 +11220,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} pahina",
+    "closeHint": "Isara ang pahiwatig",
+    "starListLabel": "Naka-save na mga aktibidad at bituin",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "fr",
-    "@@last_modified": "2026-06-30 09:37:11.762721",
+    "@@last_modified": "2026-07-02 09:47:29.028988",
     "about": "À propos",
     "@about": {
         "type": "String",
@@ -10598,6 +10598,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "page {title}",
+    "closeHint": "Fermer l'indice",
+    "starListLabel": "Activités enregistrées et étoiles",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ga.arb
+++ b/lib/l10n/intl_ga.arb
@@ -3948,7 +3948,7 @@
     "playWithAI": "Imir le AI faoi láthair",
     "courseStartDesc": "Tá Bot Pangea réidh chun dul am ar bith!\n\n...ach is fearr foghlaim le cairde!",
     "@@locale": "ga",
-    "@@last_modified": "2026-06-30 09:37:06.706851",
+    "@@last_modified": "2026-07-02 09:47:27.484486",
     "@writeAMessageLangCodes": {
         "type": "String",
         "placeholders": {
@@ -10212,6 +10212,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} leathanach",
+    "closeHint": "Dún an leideanna",
+    "starListLabel": "Gníomhaíochtaí agus réaltaí a shábháil",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_gl.arb
+++ b/lib/l10n/intl_gl.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "gl",
-    "@@last_modified": "2026-06-30 09:33:24.656243",
+    "@@last_modified": "2026-07-02 09:46:02.840804",
     "about": "Acerca de",
     "@about": {
         "type": "String",
@@ -10201,6 +10201,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} páxina",
+    "closeHint": "Pechar suxestión",
+    "starListLabel": "Actividades gardadas e estrelas",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_he.arb
+++ b/lib/l10n/intl_he.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:34:09.052899",
+    "@@last_modified": "2026-07-02 09:46:18.389382",
     "about": "אודות",
     "@about": {
         "type": "String",
@@ -11280,6 +11280,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} עמוד",
+    "closeHint": "סגור רמז",
+    "starListLabel": "פעילויות ושמות כוכבים שנשמרו",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_hi.arb
+++ b/lib/l10n/intl_hi.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "अभी के लिए एआई के साथ खेलें",
     "courseStartDesc": "पैंजिया बॉट कभी भी जाने के लिए तैयार है!\n\n...लेकिन दोस्तों के साथ सीखना बेहतर है!",
     "@@locale": "hi",
-    "@@last_modified": "2026-06-30 09:36:43.764370",
+    "@@last_modified": "2026-07-02 09:47:20.232446",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10920,6 +10920,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} पृष्ठ",
+    "closeHint": "संकेत बंद करें",
+    "starListLabel": "सहेजे गए गतिविधियाँ और सितारे",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_hr.arb
+++ b/lib/l10n/intl_hr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "hr",
-    "@@last_modified": "2026-06-30 09:34:04.896532",
+    "@@last_modified": "2026-07-02 09:46:16.834621",
     "about": "Informacije",
     "@about": {
         "type": "String",
@@ -10685,6 +10685,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} stranica",
+    "closeHint": "Zatvori savjet",
+    "starListLabel": "Spremne aktivnosti i zvjezdice",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_hu.arb
+++ b/lib/l10n/intl_hu.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "hu",
-    "@@last_modified": "2026-06-30 09:33:41.863573",
+    "@@last_modified": "2026-07-02 09:46:05.835868",
     "about": "Névjegy",
     "@about": {
         "type": "String",
@@ -10328,6 +10328,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} oldal",
+    "closeHint": "Bezárás",
+    "starListLabel": "Mentett tevékenységek és csillagok",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ia.arb
+++ b/lib/l10n/intl_ia.arb
@@ -1505,7 +1505,7 @@
     "playWithAI": "Joca con le IA pro ora",
     "courseStartDesc": "Pangea Bot es preste a comenzar a qualunque momento!\n\n...ma apprender es melior con amicos!",
     "@@locale": "ia",
-    "@@last_modified": "2026-06-30 09:34:12.383020",
+    "@@last_modified": "2026-07-02 09:46:19.358939",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -11311,6 +11311,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} paĝo",
+    "closeHint": "Fermi indikon",
+    "starListLabel": "Konservitaj agadoj kaj steloj",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:33:46.036856",
+    "@@last_modified": "2026-07-02 09:46:07.336727",
     "setAsCanonicalAlias": "Atur sebagai alias utama",
     "@setAsCanonicalAlias": {
         "type": "String",
@@ -10298,6 +10298,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "halaman {title}",
+    "closeHint": "Tutup petunjuk",
+    "starListLabel": "Aktivitas dan bintang yang disimpan",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ie.arb
+++ b/lib/l10n/intl_ie.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "Joca con AI pro ora",
     "courseStartDesc": "Pangea Bot es preste a partir a qualunque momento!\n\n...ma apprender es melior con amicos!",
     "@@locale": "ie",
-    "@@last_modified": "2026-06-30 09:33:59.675955",
+    "@@last_modified": "2026-07-02 09:46:13.036387",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10920,6 +10920,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} leathanach",
+    "closeHint": "Dún comhoibriú",
+    "starListLabel": "Gníomhaíochtaí agus réaltaí a shábháil",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:34:44.198374",
+    "@@last_modified": "2026-07-02 09:46:30.447570",
     "about": "Informazioni",
     "@about": {
         "type": "String",
@@ -10292,6 +10292,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "pagina {title}",
+    "closeHint": "Suggerimento di chiusura",
+    "starListLabel": "Attività salvate e stelle",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ja",
-    "@@last_modified": "2026-06-30 09:36:40.342115",
+    "@@last_modified": "2026-07-02 09:47:18.837894",
     "about": "このアプリについて",
     "@about": {
         "type": "String",
@@ -11069,6 +11069,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} ページ",
+    "closeHint": "ヒントを閉じる",
+    "starListLabel": "保存されたアクティビティとスター",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ka.arb
+++ b/lib/l10n/intl_ka.arb
@@ -2098,7 +2098,7 @@
     "playWithAI": "ამ დროისთვის ითამაშეთ AI-თან",
     "courseStartDesc": "Pangea Bot მზადაა ნებისმიერ დროს გასასვლელად!\n\n...მაგრამ სწავლა უკეთესია მეგობრებთან ერთად!",
     "@@locale": "ka",
-    "@@last_modified": "2026-06-30 09:36:57.140034",
+    "@@last_modified": "2026-07-02 09:47:23.967632",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -11269,6 +11269,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} გვერდი",
+    "closeHint": "დახურვის რჩევა",
+    "starListLabel": "შენახული აქტივობები და ვარსკვლავები",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:33:16.875242",
+    "@@last_modified": "2026-07-02 09:45:59.798063",
     "about": "소개",
     "@about": {
         "type": "String",
@@ -10418,6 +10418,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} 페이지",
+    "closeHint": "힌트 닫기",
+    "starListLabel": "저장된 활동 및 별",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_lt.arb
+++ b/lib/l10n/intl_lt.arb
@@ -3245,7 +3245,7 @@
     "playWithAI": "Žaiskite su dirbtiniu intelektu dabar",
     "courseStartDesc": "Pangea botas pasiruošęs bet kada pradėti!\n\n...bet mokymasis yra geresnis su draugais!",
     "@@locale": "lt",
-    "@@last_modified": "2026-06-30 09:35:51.299779",
+    "@@last_modified": "2026-07-02 09:46:59.570766",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -11087,6 +11087,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} puslapis",
+    "closeHint": "Uždaryti užuominą",
+    "starListLabel": "Išsaugotos veiklos ir žvaigždės",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_lv.arb
+++ b/lib/l10n/intl_lv.arb
@@ -3919,7 +3919,7 @@
     "playWithAI": "Tagad spēlējiet ar AI",
     "courseStartDesc": "Pangea bots ir gatavs jebkurā laikā!\n\n...bet mācīties ir labāk ar draugiem!",
     "@@locale": "lv",
-    "@@last_modified": "2026-06-30 09:35:30.810304",
+    "@@last_modified": "2026-07-02 09:46:54.122556",
     "analyticsInactiveTitle": "Pieprasījumi neaktīviem lietotājiem nevar tikt nosūtīti",
     "analyticsInactiveDesc": "Neaktīvi lietotāji, kuri nav pieteikušies kopš šīs funkcijas ieviešanas, neredzēs jūsu pieprasījumu.\n\nPieprasījuma poga parādīsies, kad viņi atgriezīsies. Jūs varat atkārtoti nosūtīt pieprasījumu vēlāk, noklikšķinot uz pieprasījuma pogas viņu vārdā, kad tā būs pieejama.",
     "accessRequestedTitle": "Pieprasījums piekļūt analītikai",
@@ -10201,6 +10201,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} lapa",
+    "closeHint": "Aizvērt norādi",
+    "starListLabel": "Saglabātās aktivitātes un zvaigznes",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_nb.arb
+++ b/lib/l10n/intl_nb.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:34:55.990915",
+    "@@last_modified": "2026-07-02 09:46:35.691377",
     "about": "Om",
     "@about": {
         "type": "String",
@@ -10261,6 +10261,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} side",
+    "closeHint": "Lukk hint",
+    "starListLabel": "Lagrede aktiviteter og stjerner",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:36:04.578478",
+    "@@last_modified": "2026-07-02 09:47:03.820791",
     "about": "Over ons",
     "@about": {
         "type": "String",
@@ -10201,6 +10201,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} pagina",
+    "closeHint": "Sluit hint",
+    "starListLabel": "Opgeslagen activiteiten en sterren",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "pl",
-    "@@last_modified": "2026-06-30 09:36:27.446177",
+    "@@last_modified": "2026-07-02 09:47:15.364169",
     "about": "O aplikacji",
     "@about": {
         "type": "String",
@@ -10310,6 +10310,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "Strona {title}",
+    "closeHint": "Zamknij podpowiedź",
+    "starListLabel": "Zapisane aktywności i gwiazdki",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:34:23.399324",
+    "@@last_modified": "2026-07-02 09:46:23.098419",
     "copiedToClipboard": "Copiada para a área de transferência",
     "@copiedToClipboard": {
         "type": "String",
@@ -11319,6 +11319,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "página {title}",
+    "closeHint": "Dica de fechamento",
+    "starListLabel": "Atividades salvas e estrelas",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pt_BR.arb
+++ b/lib/l10n/intl_pt_BR.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:34:16.046841",
+    "@@last_modified": "2026-07-02 09:46:20.562104",
     "about": "Sobre",
     "@about": {
         "type": "String",
@@ -10201,6 +10201,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "Página {title}",
+    "closeHint": "Fechar dica",
+    "starListLabel": "Atividades salvas e estrelas",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_pt_PT.arb
+++ b/lib/l10n/intl_pt_PT.arb
@@ -2776,7 +2776,7 @@
     "selectAll": "Selecionar tudo",
     "deselectAll": "Desmarcar tudo",
     "@@locale": "pt_PT",
-    "@@last_modified": "2026-06-30 09:35:11.966357",
+    "@@last_modified": "2026-07-02 09:46:47.470628",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -11277,6 +11277,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "página {title}",
+    "closeHint": "Dica de fechamento",
+    "starListLabel": "Atividades salvas e estrelas",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ro.arb
+++ b/lib/l10n/intl_ro.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:33:51.995992",
+    "@@last_modified": "2026-07-02 09:46:09.170131",
     "about": "Despre",
     "@about": {
         "type": "String",
@@ -11026,6 +11026,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} pagină",
+    "closeHint": "Închideți sugestia",
+    "starListLabel": "Activități salvate și stele",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "ru",
-    "@@last_modified": "2026-06-30 09:36:52.110383",
+    "@@last_modified": "2026-07-02 09:47:22.806073",
     "about": "О проекте",
     "@about": {
         "type": "String",
@@ -11215,6 +11215,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} страница",
+    "closeHint": "Закрыть подсказку",
+    "starListLabel": "Сохраненные активности и звезды",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "sk",
-    "@@last_modified": "2026-06-30 09:33:55.832351",
+    "@@last_modified": "2026-07-02 09:46:10.356871",
     "about": "O aplikácii",
     "@about": {
         "type": "String",
@@ -11317,6 +11317,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} stránka",
+    "closeHint": "Zavrieť nápovedu",
+    "starListLabel": "Uložené aktivity a hviezdy",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sl.arb
+++ b/lib/l10n/intl_sl.arb
@@ -1962,7 +1962,7 @@
     "playWithAI": "Za zdaj igrajte z AI-jem",
     "courseStartDesc": "Pangea Bot je pripravljen kadarkoli!\n\n...ampak je bolje učiti se s prijatelji!",
     "@@locale": "sl",
-    "@@last_modified": "2026-06-30 09:34:34.695218",
+    "@@last_modified": "2026-07-02 09:46:28.012318",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -11317,6 +11317,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} stran",
+    "closeHint": "Zapri namig",
+    "starListLabel": "Shranjene dejavnosti in zvezde",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sr.arb
+++ b/lib/l10n/intl_sr.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:37:02.357546",
+    "@@last_modified": "2026-07-02 09:47:25.495784",
     "about": "О програму",
     "@about": {
         "type": "String",
@@ -11324,6 +11324,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} страница",
+    "closeHint": "Затвори савет",
+    "starListLabel": "Сачуване активности и звезде",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_sv.arb
+++ b/lib/l10n/intl_sv.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:36:30.741780",
+    "@@last_modified": "2026-07-02 09:47:16.461118",
     "about": "Om",
     "@about": {
         "type": "String",
@@ -10788,6 +10788,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} sida",
+    "closeHint": "Stäng tips",
+    "starListLabel": "Sparade aktiviteter och stjärnor",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_ta.arb
+++ b/lib/l10n/intl_ta.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:36:00.213407",
+    "@@last_modified": "2026-07-02 09:47:02.587194",
     "acceptedTheInvitation": "👍 {username} அழைப்பை ஏற்றுக்கொண்டது",
     "@acceptedTheInvitation": {
         "type": "String",
@@ -10317,6 +10317,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} பக்கம்",
+    "closeHint": "மூடு குறிப்பு",
+    "starListLabel": "சேமிக்கப்பட்ட செயல்கள் மற்றும் நட்சத்திரங்கள்",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_te.arb
+++ b/lib/l10n/intl_te.arb
@@ -1467,7 +1467,7 @@
     "playWithAI": "ఇప్పుడే AI తో ఆడండి",
     "courseStartDesc": "పాంజియా బాట్ ఎప్పుడైనా సిద్ధంగా ఉంటుంది!\n\n...కానీ స్నేహితులతో నేర్చుకోవడం మెరుగైనది!",
     "@@locale": "te",
-    "@@last_modified": "2026-06-30 09:35:45.435753",
+    "@@last_modified": "2026-07-02 09:46:58.428755",
     "@setCustomPermissionLevel": {
         "type": "String",
         "placeholders": {}
@@ -11325,6 +11325,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} పేజీ",
+    "closeHint": "మూసివేయు సూచన",
+    "starListLabel": "సేవ్ చేసిన కార్యకలాపాలు మరియు నక్షత్రాలు",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -3377,7 +3377,7 @@
     "playWithAI": "เล่นกับ AI ชั่วคราว",
     "courseStartDesc": "Pangea Bot พร้อมที่จะเริ่มต้นได้ทุกเมื่อ!\n\n...แต่การเรียนรู้ดีกว่ากับเพื่อน!",
     "@@locale": "th",
-    "@@last_modified": "2026-06-30 09:35:07.570686",
+    "@@last_modified": "2026-07-02 09:46:46.307325",
     "@alwaysUse24HourFormat": {
         "type": "String",
         "placeholders": {}
@@ -10920,6 +10920,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} หน้า",
+    "closeHint": "ปิดคำแนะนำ",
+    "starListLabel": "กิจกรรมที่บันทึกและดาว",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "tr",
-    "@@last_modified": "2026-06-30 09:35:39.623753",
+    "@@last_modified": "2026-07-02 09:46:56.747154",
     "about": "Hakkında",
     "@about": {
         "type": "String",
@@ -10532,6 +10532,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} sayfası",
+    "closeHint": "Kapatma ipucu",
+    "starListLabel": "Kaydedilen etkinlikler ve yıldızlar",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "uk",
-    "@@last_modified": "2026-06-30 09:34:47.333865",
+    "@@last_modified": "2026-07-02 09:46:31.886126",
     "about": "Про застосунок",
     "@about": {
         "type": "String",
@@ -10201,6 +10201,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} сторінка",
+    "closeHint": "Закрити підказку",
+    "starListLabel": "Збережені активності та зірки",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_uz.arb
+++ b/lib/l10n/intl_uz.arb
@@ -3194,7 +3194,7 @@
     "setupChatBackup": "Chat zaxirasini sozlash",
     "@setupChatBackup": {},
     "@@locale": "uz",
-    "@@last_modified": "2026-06-30 09:35:21.396168",
+    "@@last_modified": "2026-07-02 09:46:50.979461",
     "noMoreResultsFound": "Boshqa natijalar topilmadi",
     "chatSearchedUntil": "Chat {time} gacha qidirildi",
     "federationBaseUrl": "Federatsiya Asos URL",
@@ -10205,6 +10205,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} sahifasi",
+    "closeHint": "Yopish maslahat",
+    "starListLabel": "Saqlangan faoliyatlar va yulduzlar",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:35:55.800318",
+    "@@last_modified": "2026-07-02 09:47:00.985483",
     "about": "Giới thiệu",
     "@about": {
         "type": "String",
@@ -7284,6 +7284,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "Trang {title}",
+    "closeHint": "Đóng gợi ý",
+    "starListLabel": "Các hoạt động và sao đã lưu",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_yue.arb
+++ b/lib/l10n/intl_yue.arb
@@ -1406,7 +1406,7 @@
     "selectAll": "全選",
     "deselectAll": "取消全選",
     "@@locale": "yue",
-    "@@last_modified": "2026-06-30 09:34:40.434154",
+    "@@last_modified": "2026-07-02 09:46:29.217674",
     "@ignoreUser": {
         "type": "String",
         "placeholders": {}
@@ -11332,6 +11332,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} 頁面",
+    "closeHint": "關閉提示",
+    "starListLabel": "已保存的活動和星星",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1,6 +1,6 @@
 {
     "@@locale": "zh",
-    "@@last_modified": "2026-06-30 09:36:14.104667",
+    "@@last_modified": "2026-07-02 09:47:06.203562",
     "about": "关于",
     "@about": {
         "type": "String",
@@ -10201,6 +10201,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} 页面",
+    "closeHint": "关闭提示",
+    "starListLabel": "保存的活动和星标",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/l10n/intl_zh_Hant.arb
+++ b/lib/l10n/intl_zh_Hant.arb
@@ -1,5 +1,5 @@
 {
-    "@@last_modified": "2026-06-30 09:35:16.047341",
+    "@@last_modified": "2026-07-02 09:46:48.286249",
     "about": "關於",
     "@about": {
         "type": "String",
@@ -10331,6 +10331,25 @@
         }
     },
     "@writingAssistanceTutorialInputBar": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "pageLabel": "{title} 頁面",
+    "closeHint": "關閉提示",
+    "starListLabel": "已儲存的活動和星星",
+    "@pageLabel": {
+        "type": "String",
+        "placeholders": {
+            "title": {
+                "type": "String"
+            }
+        }
+    },
+    "@closeHint": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "@starListLabel": {
         "type": "String",
         "placeholders": {}
     }

--- a/lib/routes/analytics/activities/activity_archive.dart
+++ b/lib/routes/analytics/activities/activity_archive.dart
@@ -58,6 +58,19 @@ class ActivityArchive extends StatelessWidget {
                     const LearningProgressIndicators(
                       selected: ProgressIndicatorEnum.activities,
                     ),
+                  if (!analyticsService.hasInitError)
+                    MaxWidthBody(
+                      showBorder: false,
+                      withScrolling: false,
+                      padding: .only(top: 48),
+                      addVerticalPadding: false,
+                      child: InstructionsInlineTooltip(
+                        instructionsEnum: archive.isEmpty
+                            ? InstructionsEnum.noSavedActivitiesYet
+                            : InstructionsEnum.activityAnalyticsList,
+                        padding: const EdgeInsets.all(8.0),
+                      ),
+                    ),
                   Expanded(
                     child: analyticsService.hasInitError
                         ? AnalyticsInitErrorIndicator(
@@ -66,28 +79,24 @@ class ActivityArchive extends StatelessWidget {
                         : MaxWidthBody(
                             showBorder: false,
                             withScrolling: false,
-                            child: ListView.builder(
-                              key: const PageStorageKey<String>(
-                                'activity-archive',
-                              ),
-                              physics: const ClampingScrollPhysics(),
-                              itemCount: archive.length + 1,
-                              itemBuilder: (BuildContext context, int i) {
-                                if (i == 0) {
-                                  return InstructionsInlineTooltip(
-                                    instructionsEnum: archive.isEmpty
-                                        ? InstructionsEnum.noSavedActivitiesYet
-                                        : InstructionsEnum
-                                              .activityAnalyticsList,
-                                    padding: const EdgeInsets.all(8.0),
+                            padding: .fromLTRB(32, 0, 32, 48),
+                            addVerticalPadding: false,
+                            child: Semantics(
+                              label: L10n.of(context).starListLabel,
+                              container: true,
+                              child: ListView.builder(
+                                key: const PageStorageKey<String>(
+                                  'activity-archive',
+                                ),
+                                physics: const ClampingScrollPhysics(),
+                                itemCount: archive.length,
+                                itemBuilder: (BuildContext context, int i) {
+                                  return AnalyticsActivityItem(
+                                    room: archive[i],
+                                    selected: archive[i].id == selectedRoomId,
                                   );
-                                }
-                                i--;
-                                return AnalyticsActivityItem(
-                                  room: archive[i],
-                                  selected: archive[i].id == selectedRoomId,
-                                );
-                              },
+                                },
+                              ),
                             ),
                           ),
                   ),
@@ -121,66 +130,69 @@ class AnalyticsActivityItem extends StatelessWidget {
         ?.cefrLevel;
 
     final theme = Theme.of(context);
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 1),
-      child: Material(
-        color: selected ? theme.colorScheme.secondaryContainer : null,
-        borderRadius: BorderRadius.circular(AppConfig.borderRadius),
-        clipBehavior: Clip.hardEdge,
-        child: ListTile(
-          visualDensity: const VisualDensity(vertical: -0.5),
-          contentPadding: const EdgeInsets.symmetric(horizontal: 8),
-          leading: HoverBuilder(
-            builder: (context, hovered) => AnimatedScale(
-              duration: FluffyThemes.animationDuration,
-              curve: FluffyThemes.animationCurve,
-              scale: hovered ? 1.1 : 1.0,
-              child: ExcludeSemantics(
-                child: Avatar(
-                  borderRadius: BorderRadius.circular(4.0),
-                  mxContent: room.avatar,
-                  name: room.getLocalizedDisplayname(),
+    return Semantics(
+      container: true,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 1),
+        child: Material(
+          color: selected ? theme.colorScheme.secondaryContainer : null,
+          borderRadius: BorderRadius.circular(AppConfig.borderRadius),
+          clipBehavior: Clip.hardEdge,
+          child: ListTile(
+            visualDensity: const VisualDensity(vertical: -0.5),
+            contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+            leading: HoverBuilder(
+              builder: (context, hovered) => AnimatedScale(
+                duration: FluffyThemes.animationDuration,
+                curve: FluffyThemes.animationCurve,
+                scale: hovered ? 1.1 : 1.0,
+                child: ExcludeSemantics(
+                  child: Avatar(
+                    borderRadius: BorderRadius.circular(4.0),
+                    mxContent: room.avatar,
+                    name: room.getLocalizedDisplayname(),
+                  ),
                 ),
               ),
             ),
-          ),
-          title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
-          subtitle: goals != null
-              ? ActivityStarRow(
-                  total: goals.length,
-                  earned:
-                      room
-                          .orchestratorAwardedGoals
-                          .awards[room.ownRoleState?.id]
-                          ?.length ??
-                      0,
-                  iconSize: 22.0,
-                )
-              : null,
-          trailing: cefrLevel != null
-              ? Semantics(
-                  label: L10n.of(context).difficultyLabel(cefrLevel),
-                  child: Padding(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 8,
-                      vertical: 4,
-                    ),
-                    child: ExcludeSemantics(
-                      child: Text(
-                        cefrLevel.toUpperCase(),
-                        style: const TextStyle(fontSize: 14.0),
+            title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
+            subtitle: goals != null
+                ? ActivityStarRow(
+                    total: goals.length,
+                    earned:
+                        room
+                            .orchestratorAwardedGoals
+                            .awards[room.ownRoleState?.id]
+                            ?.length ??
+                        0,
+                    iconSize: 22.0,
+                  )
+                : null,
+            trailing: cefrLevel != null
+                ? Semantics(
+                    label: L10n.of(context).difficultyLabel(cefrLevel),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 8,
+                        vertical: 4,
+                      ),
+                      child: ExcludeSemantics(
+                        child: Text(
+                          cefrLevel.toUpperCase(),
+                          style: const TextStyle(fontSize: 14.0),
+                        ),
                       ),
                     ),
-                  ),
-                )
-              : null,
-          onTap: () {
-            AnalyticsNavigationUtil.navigateToAnalytics(
-              context: context,
-              view: ProgressIndicatorEnum.activities,
-              activityRoomId: room.id,
-            );
-          },
+                  )
+                : null,
+            onTap: () {
+              AnalyticsNavigationUtil.navigateToAnalytics(
+                context: context,
+                view: ProgressIndicatorEnum.activities,
+                activityRoomId: room.id,
+              );
+            },
+          ),
         ),
       ),
     );

--- a/lib/routes/world/panel_header.dart
+++ b/lib/routes/world/panel_header.dart
@@ -41,15 +41,17 @@ class PanelHeader extends StatelessWidget {
           leading,
           const SizedBox(width: 8),
           Expanded(
-            child: Text(
-              title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: FluffyThemes.isColumnMode(context)
-                  ? Theme.of(context).textTheme.titleLarge
-                  : Theme.of(context).textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
+            child: ExcludeSemantics(
+              child: Text(
+                title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: FluffyThemes.isColumnMode(context)
+                    ? Theme.of(context).textTheme.titleLarge
+                    : Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+              ),
             ),
           ),
           ?trailing,

--- a/lib/routes/world/right_panel/panel_card_with_header.dart
+++ b/lib/routes/world/right_panel/panel_card_with_header.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/world/panel_card.dart';
 import 'package:fluffychat/routes/world/panel_header.dart';
 
@@ -23,20 +24,24 @@ class PanelCardWithHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PanelCard(
-      child: Column(
-        children: [
-          PanelHeader(
-            leading: IconButton(
-              tooltip: tooltip,
-              icon: Icon(icon),
-              onPressed: onLeading,
+    return Semantics(
+      label: L10n.of(context).pageLabel(title),
+      container: true,
+      child: PanelCard(
+        child: Column(
+          children: [
+            PanelHeader(
+              leading: IconButton(
+                tooltip: tooltip,
+                icon: Icon(icon),
+                onPressed: onLeading,
+              ),
+              title: title,
+              trailing: trailing,
             ),
-            title: title,
-            trailing: trailing,
-          ),
-          Expanded(child: child),
-        ],
+            Expanded(child: child),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
intl keys pageLabel, closeHint, and starListLabel need translation

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [x] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new localized text for page labels, close hints, and starred list labels across many languages.

* **Bug Fixes**
  * Improved accessibility labeling on analytics, tooltips, and panel content for screen readers.
  * Moved the instructions tooltip above the activity list and kept the archive list count accurate.
  * Updated the close button hint text for clearer behavior.

* **Style**
  * Minor layout and text-semantic adjustments to preserve a cleaner reading order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->