### PR TITLE
Use cleaner method for flag label outline

### DIFF
--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -458,36 +458,23 @@ class _LanguageFlag extends StatelessWidget {
     final l10n = L10n.of(context);
     final theme = Theme.of(context);
 
-    final outlinedText = Text(
-      language.langCodeShort.toUpperCase(),
-      style: TextStyle(
-        color: Colors.black,
-        fontSize: 18,
-        fontWeight: FontWeight.w700,
-        height: 1.0,
-        shadows: [
-          Shadow(
-            // bottomLeft
-            offset: Offset(-1.5, -1.5),
-            color: Colors.white,
+    final outlinedText = Stack(
+      children: <Widget>[
+        Text(
+          language.langCodeShort.toUpperCase(),
+          style: TextStyle(
+            fontSize: 18,
+            foreground: Paint()
+              ..style = PaintingStyle.stroke
+              ..strokeWidth = 4
+              ..color = Colors.white,
           ),
-          Shadow(
-            // bottomRight
-            offset: Offset(1.5, -1.5),
-            color: Colors.white,
-          ),
-          Shadow(
-            // topRight
-            offset: Offset(1.5, 1.5),
-            color: Colors.white,
-          ),
-          Shadow(
-            // topLeft
-            offset: Offset(-1.5, 1.5),
-            color: Colors.white,
-          ),
-        ],
-      ),
+        ),
+        Text(
+          language.langCodeShort.toUpperCase(),
+          style: TextStyle(fontSize: 18, color: Colors.black),
+        ),
+      ],
     );
 
     return MouseRegion(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
