### PR TITLE
Report legacy service worker degraded state to Sentry

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -41,6 +41,40 @@
     (function () {
       var sw = navigator.serviceWorker;
       if (!sw || !sw.controller) return; // fresh users: nothing to evict
+
+      // Report the degraded state to Sentry directly: the Flutter app and its
+      // Sentry SDK have not loaded yet, and we usually reload before they would.
+      // keepalive lets the POST outlive the eviction reload. The DSN mirrors the
+      // committed default in lib/pangea/common/config/environment.dart; the
+      // release token is injected by the deploy's __BUILD_VERSION__ sed.
+      var report = function (state, level) {
+        try {
+          var rk = 'pangea-sw-report-' + state;
+          try { if (sessionStorage.getItem(rk)) return; sessionStorage.setItem(rk, '1'); } catch (e) {}
+          var id = '';
+          try { if (self.crypto && crypto.randomUUID) id = crypto.randomUUID().replace(/-/g, ''); } catch (e) {}
+          while (id.length < 32) id += Math.floor(Math.random() * 16).toString(16);
+          var host = location.hostname;
+          var env = host.indexOf('staging') !== -1 ? 'staging'
+            : (host === 'app.pangea.chat' ? 'production' : 'development');
+          var ev = {
+            event_id: id, timestamp: Date.now() / 1000, platform: 'javascript',
+            logger: 'sw-killswitch', level: level, environment: env,
+            release: '__BUILD_VERSION__',
+            message: 'Legacy service worker degraded state (' + state + ')',
+            tags: { sw_state: state, sw_controller: (sw.controller && sw.controller.scriptURL) || 'unknown' },
+            request: { url: location.href, headers: { 'User-Agent': navigator.userAgent } }
+          };
+          var body = JSON.stringify({ event_id: id, sent_at: new Date().toISOString() })
+            + '\n{"type":"event"}\n' + JSON.stringify(ev);
+          fetch('https://o225078.ingest.sentry.io/api/1376295/envelope/'
+            + '?sentry_key=c2fd19ab2cdc4ebb939a32d01c0e9fa1&sentry_version=7',
+            { method: 'POST', body: body, keepalive: true,
+              headers: { 'Content-Type': 'application/x-sentry-envelope' } }).catch(function () {});
+        } catch (e) { /* never let reporting break eviction */ }
+      };
+      report('detected', 'warning');
+
       var KEY = 'pangea-sw-killswitch';
       var reloaded = false;
       var reloadOnce = function () {
@@ -72,6 +106,7 @@
       setTimeout(function () {
         if (reloaded || !navigator.serviceWorker.controller) return;
         try { if (sessionStorage.getItem(KEY)) return; } catch (e) {}
+        report('wedged', 'error'); // eviction failed; this is the stuck tail
         var bar = document.createElement('div');
         bar.setAttribute('role', 'alert');
         bar.style.cssText =


### PR DESCRIPTION
Adds observability to the legacy service worker eviction (see #7397). The eviction script in `index.html` now reports the degraded state to Sentry directly over HTTP, because it runs before the Flutter app (and its Sentry SDK) loads and usually reloads before they would. `keepalive` lets the POST outlive the eviction reload.

Two events, throttled once per session, tagged with the controller scriptURL, build hash (release), and environment (derived from hostname):

- `detected` (level `warning`) when a controlled/stale load is seen. This measures the size of the legacy-SW population and confirms the fix is reaching it.
- `wedged` (level `error`) when the fallback banner fires, i.e. auto-eviction could not promote a new worker. This is the genuinely-stuck tail worth alerting on. A healthy fix shows `detected` events with near-zero `wedged`.

Implementation notes:
- DSN mirrors the committed default in `lib/pangea/common/config/environment.dart` (project 1376295, shared by staging and prod, segmented by the `environment` tag). It is a public ingestion key, already shipped in the client bundle.
- `release` is injected by the existing `__BUILD_VERSION__` deploy sed, kept inside a string literal so it is safe for digit-leading shas.
- Envelope format verified accepted by Sentry ingest (HTTP 200) before merge.

No change to eviction behavior; reporting is wrapped so it can never throw into the eviction path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stalled or degraded update states in the web app.
  * When an update gets stuck, the app now more reliably records the issue and shows the “finish updating” message sooner.
  * Added better diagnostics for update-related failures to help surface problems more quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->