### PR TITLE
fix(activity): invite the bot atomically at room creation

### DIFF
--- a/lib/routes/chat/activity_sessions/bot_join_error_dialog.dart
+++ b/lib/routes/chat/activity_sessions/bot_join_error_dialog.dart
@@ -51,10 +51,25 @@ class PlayWithBotLoadingDialogState extends State<PlayWithBotLoadingDialog> {
         "",
         {},
       );
-      try {
-        await widget.room.invite(BotName.byEnvironment);
-      } catch (_) {
-        // Bot already in the room (the expected case); nothing to do.
+      // The bot is invited at room creation, so it is normally already present
+      // here. Only re-invite if it is genuinely absent (it left, or the
+      // create-time invite failed). A failed re-invite is logged rather than
+      // silently swallowed; the 5s timeout below still surfaces a stuck bot.
+      final botMembership = widget.room
+          .unsafeGetUserFromMemoryOrFallback(BotName.byEnvironment)
+          .membership;
+      if (botMembership != Membership.join &&
+          botMembership != Membership.invite) {
+        try {
+          await widget.room.invite(BotName.byEnvironment);
+        } catch (e, s) {
+          ErrorHandler.logError(
+            e: e,
+            s: s,
+            data: {'roomId': widget.room.id},
+            level: SentryLevel.warning,
+          );
+        }
       }
       await future.timeout(const Duration(seconds: 5));
       Navigator.of(context).pop();

--- a/lib/routes/chat/activity_sessions/bot_join_error_dialog.dart
+++ b/lib/routes/chat/activity_sessions/bot_join_error_dialog.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import 'package:collection/collection.dart';
 import 'package:matrix/matrix.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -53,11 +54,14 @@ class PlayWithBotLoadingDialogState extends State<PlayWithBotLoadingDialog> {
       );
       // The bot is invited at room creation, so it is normally already present
       // here. Only re-invite if it is genuinely absent (it left, or the
-      // create-time invite failed). A failed re-invite is logged rather than
-      // silently swallowed; the 5s timeout below still surfaces a stuck bot.
-      final botMembership = widget.room
-          .unsafeGetUserFromMemoryOrFallback(BotName.byEnvironment)
-          .membership;
+      // create-time invite failed). Look up membership from the authoritative
+      // participant list rather than possibly-stale in-memory state. A failed
+      // re-invite is logged rather than silently swallowed; the 5s timeout below
+      // still surfaces a stuck bot.
+      final participants = await widget.room.requestParticipants();
+      final botMembership = participants
+          .firstWhereOrNull((u) => u.id == BotName.byEnvironment)
+          ?.membership;
       if (botMembership != Membership.join &&
           botMembership != Membership.invite) {
         try {

--- a/lib/routes/chat/activity_sessions/launch_activity_session.dart
+++ b/lib/routes/chat/activity_sessions/launch_activity_session.dart
@@ -60,6 +60,15 @@ extension LaunchActivitySession on Client {
           'type': "${PangeaRoomTypes.activitySession}:${activity.activityId}",
         },
         visibility: sdk.Visibility.private,
+        // Invite the bot atomically at creation so it is present in every session
+        // from the start. It stays idle (no role, no messages) until the room
+        // admin chooses "play with bot", which writes pangea.bot_participant —
+        // the bot's gate to claim a role. On the "invite a friend" path no marker
+        // is written, so the seat stays open for the friend and the bot moderates
+        // silently once they join (#2595, #7027). Inviting here rather than in a
+        // post-create call avoids a sync race where the fresh room is not yet in
+        // the local store and the invite is silently skipped.
+        invite: [BotName.byEnvironment],
         name: activity.title,
         topic: activity.description,
         initialState: [
@@ -117,44 +126,9 @@ extension LaunchActivitySession on Client {
       }
     }
 
-    try {
-      await waitForRoomInSync(roomID).timeout(const Duration(seconds: 10));
-    } catch (e, s) {
-      ErrorHandler.logError(
-        e: e,
-        s: s,
-        data: {'roomId': roomID},
-        level: e is TimeoutException ? SentryLevel.warning : SentryLevel.error,
-      );
-      if (e is! TimeoutException) rethrow;
-    }
-
-    // Auto-invite the bot so it is present in every session from the start, but
-    // it stays idle (no role, no messages) until the room admin chooses "play
-    // with bot", which writes pangea.bot_participant. That marker is the bot's
-    // gate to claim a role. On the "invite a friend" path no marker is written,
-    // so the seat stays open for the friend and the bot is a silent moderator
-    // once they join (#2595, #7027). Best-effort: must not fail session creation.
-    try {
-      final botRoom = getRoomById(roomID);
-      if (botRoom == null) {
-        ErrorHandler.logError(
-          m: 'Auto-invite skipped: activity room not found after sync',
-          data: {'roomId': roomID},
-          level: SentryLevel.warning,
-        );
-      } else {
-        await botRoom.invite(BotName.byEnvironment);
-      }
-    } catch (e, s) {
-      ErrorHandler.logError(
-        e: e,
-        s: s,
-        data: {'roomId': roomID},
-        level: SentryLevel.warning,
-      );
-    }
-
+    // The bot was invited as part of createRoom above (atomic), so there is no
+    // post-create invite step to race against room sync. createPangeaRoom already
+    // waited for the creator to be joined before returning.
     return roomID;
   }
 }

--- a/lib/routes/chat/activity_sessions/launch_activity_session.dart
+++ b/lib/routes/chat/activity_sessions/launch_activity_session.dart
@@ -60,15 +60,6 @@ extension LaunchActivitySession on Client {
           'type': "${PangeaRoomTypes.activitySession}:${activity.activityId}",
         },
         visibility: sdk.Visibility.private,
-        // Invite the bot atomically at creation so it is present in every session
-        // from the start. It stays idle (no role, no messages) until the room
-        // admin chooses "play with bot", which writes pangea.bot_participant —
-        // the bot's gate to claim a role. On the "invite a friend" path no marker
-        // is written, so the seat stays open for the friend and the bot moderates
-        // silently once they join (#2595, #7027). Inviting here rather than in a
-        // post-create call avoids a sync race where the fresh room is not yet in
-        // the local store and the invite is silently skipped.
-        invite: [BotName.byEnvironment],
         name: activity.title,
         topic: activity.description,
         initialState: [
@@ -126,9 +117,28 @@ extension LaunchActivitySession on Client {
       }
     }
 
-    // The bot was invited as part of createRoom above (atomic), so there is no
-    // post-create invite step to race against room sync. createPangeaRoom already
-    // waited for the creator to be joined before returning.
+    // Invite the bot so it is present in every session from the start — idle (no
+    // role, no messages) until the room admin chooses "play with bot", which
+    // writes pangea.bot_participant (the bot's gate to claim a role). On the
+    // "invite a friend" path no marker is written, so the seat stays open and the
+    // bot moderates silently once the friend joins (#2595, #7027).
+    //
+    // Best-effort AND by room id (not the local Room object): inviteUser targets
+    // the homeserver directly, so it neither fails session creation on a transient
+    // invite error nor races the fresh room syncing into the local store — the old
+    // getRoomById(roomID) == null path silently skipped the invite, leaving the
+    // marker written but no bot in the room.
+    try {
+      await inviteUser(roomID, BotName.byEnvironment);
+    } catch (e, s) {
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {'roomId': roomID},
+        level: SentryLevel.warning,
+      );
+    }
+
     return roomID;
   }
 }


### PR DESCRIPTION
## What

Fixes an activity session that can get **permanently stuck after "play with bot"** — `pangea.bot_participant` gets written but the bot is never actually invited, so it never joins, never claims a role, and the UI hangs (*"waiting for 0 roles to fill"*).

## Root cause
The bot invite was a **best-effort, post-create** step that failed silently two ways:
1. **launch_activity_session** — after `waitForRoomInSync(10s)`, `getRoomById(roomID)` could be `null` (fresh room not yet in the local store) → *"Auto-invite skipped,"* no invite.
2. **bot_join_error_dialog** — the play-with-bot re-invite was wrapped in `catch (_) { /* already in room */ }`, swallowing a genuine failure.

Either path leaves the marker written but no bot member → stuck room. Confirmed by diagnosis: sending the missing invite by hand made the bot immediately join → claim its role → open.

## Fix
- **`launch_activity_session`** — invite the bot post-create via `client.inviteUser(roomID, …)` (targets the homeserver **by room id**, so it doesn't depend on the fresh room being in the local store — that was the race), and keep it **best-effort/non-fatal** (a transient invite failure is logged, not fatal to session creation). *(First revision bundled the invite into `createRoom`; reverted per review since a rejected invite would fail the whole launch.)*
- **`bot_join_error_dialog`** — re-invite **only when the bot is genuinely absent** (membership ≠ join/invite), and **log** a real re-invite failure instead of silently assuming "already in room."

---

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md).

### Pull Request has been tested on:

_Backend invite-logic change (no UI). Verified with `dart analyze` (no issues) and by live diagnosis against a stuck room (manual invite → bot joined/claimed/opened). No platform-specific UI behavior changed; full on-device runs deferred to the reviewer._

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based) — via local Flutter web stack
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [x] New or changed controls have an accessible name … — **N/A: no controls or images changed** (backend invite logic only).
<!-- Pangea# -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bot session setup by streamlining bot invitations immediately after room creation.
  * Reduced unnecessary bot re-invites by checking the bot’s current room membership before inviting.
  * Bot invitation failures are now captured and logged with warning details to prevent silent errors and aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->