### PR TITLE
refactor: save learning settings changes immeadiatley to replace butt…

### DIFF
--- a/lib/routes/chat_list/chat_list_item.dart
+++ b/lib/routes/chat_list/chat_list_item.dart
@@ -79,28 +79,6 @@ class ChatListItem extends StatelessWidget {
     final space = this.space;
 
     // #Pangea
-    final String messagePreview =
-        room.isSpace && room.membership == Membership.join
-        ? L10n.of(context).countChats(room.spaceChildCount)
-        : room.membership == Membership.invite
-        ? (room
-                  .getState(EventTypes.RoomMember, room.client.userID!)
-                  ?.content
-                  .tryGet<String>('reason') ??
-              (isDirectChat
-                  ? L10n.of(context).newChatRequest
-                  : L10n.of(context).inviteChat))
-        : lastEvent?.calcLocalizedBodyFallback(
-                MatrixLocals(L10n.of(context)),
-                hideReply: true,
-                hideEdit: true,
-                plaintextBody: true,
-                removeMarkdown: true,
-                withSenderNamePrefix:
-                    (!isDirectChat ||
-                    directChatMatrixId != room.lastEvent?.senderId),
-              ) ??
-              L10n.of(context).noMessagesYet;
     final String chatSemanticsLabel = unread
         ? '$displayname, ${L10n.of(context).unread}, '
         : '$displayname, ';

--- a/lib/routes/profile/user_home_page.dart
+++ b/lib/routes/profile/user_home_page.dart
@@ -34,7 +34,6 @@ class UserHomePage extends StatefulWidget {
 
 class _UserHomePageState extends State<UserHomePage> {
   final TextEditingController _aboutTextController = TextEditingController();
-  final ValueNotifier<String?> _languageMatchError = ValueNotifier(null);
   late final LearningSettingsViewModel _viewModel;
 
   Future<Profile>? _profileFuture;
@@ -57,7 +56,6 @@ class _UserHomePageState extends State<UserHomePage> {
   @override
   void dispose() {
     _aboutTextController.dispose();
-    _languageMatchError.dispose();
     _viewModel.dispose();
     super.dispose();
   }
@@ -177,13 +175,6 @@ class _UserHomePageState extends State<UserHomePage> {
   }
 
   Future<void> _updateProfile() async {
-    if (_viewModel.hasIdenticalLanguages) {
-      _languageMatchError.value = L10n.of(context).noIdenticalLanguages;
-      return;
-    }
-
-    _languageMatchError.value = null;
-
     try {
       await MatrixState.pangeaController.userController
           .updateProfile(

--- a/lib/routes/settings/settings_learning/learning_settings_tiles.dart
+++ b/lib/routes/settings/settings_learning/learning_settings_tiles.dart
@@ -15,15 +15,11 @@ import 'package:fluffychat/widgets/matrix.dart';
 class LearningSettingsTiles extends StatelessWidget {
   final LearningSettingsViewModel viewModel;
   final ValueNotifier<String?> languageErrorNotifier;
-  final TextEditingController aboutTextController;
-  final ExpansibleController? languageTileController;
 
   const LearningSettingsTiles({
     super.key,
     required this.viewModel,
     required this.languageErrorNotifier,
-    required this.aboutTextController,
-    this.languageTileController,
   });
 
   Future<bool> onEnableAutocorrect(BuildContext context) async {
@@ -158,10 +154,7 @@ class LearningSettingsTiles extends StatelessWidget {
                   leading: const Icon(Icons.lightbulb),
                   title: Text(L10n.of(context).resetInstructionTooltipsTitle),
                   subtitle: Text(L10n.of(context).resetInstructionTooltipsDesc),
-                  onTap: viewModel.resetInstructions
-                      ? null
-                      : viewModel.resetInstructionTooltips,
-                  selected: viewModel.resetInstructions,
+                  onTap: viewModel.resetInstructionTooltips,
                 ),
               ],
             ),

--- a/lib/routes/settings/settings_learning/learning_settings_view_model.dart
+++ b/lib/routes/settings/settings_learning/learning_settings_view_model.dart
@@ -22,7 +22,6 @@ class LearningSettingsViewModel extends ChangeNotifier {
     _updatedProfile = profile;
   }
 
-  bool _resetInstructions = false;
   Timer? _textDebounce;
 
   @override
@@ -40,7 +39,16 @@ class LearningSettingsViewModel extends ChangeNotifier {
       selectedSourceLanguage?.langCodeShort ==
       selectedTargetLanguage?.langCodeShort;
 
-  bool get resetInstructions => _resetInstructions;
+  Profile get _validProfile {
+    if (!hasIdenticalLanguages) return _updatedProfile;
+    final originalProfile = MatrixState.pangeaController.userController.profile;
+    return _updatedProfile.copyWith(
+      userSettings: _updatedProfile.userSettings.copyWith(
+        targetLanguage: originalProfile.userSettings.targetLanguage,
+        sourceLanguage: originalProfile.userSettings.sourceLanguage,
+      ),
+    );
+  }
 
   LanguageModel? get selectedSourceLanguage {
     return _selectedBaseLanguage ?? LanguageService.systemLanguage;
@@ -72,7 +80,7 @@ class LearningSettingsViewModel extends ChangeNotifier {
 
   String? get about => _updatedProfile.userSettings.about;
 
-  Profile get updatedProfile => _updatedProfile;
+  Profile get updatedProfile => _validProfile;
 
   GenderEnum get gender => _updatedProfile.userSettings.gender;
 
@@ -149,7 +157,6 @@ class LearningSettingsViewModel extends ChangeNotifier {
     final updated = _updatedProfile.copyWith(
       instructionSettings: InstructionSettings(),
     );
-    _resetInstructions = true;
     _updateProfile(updated);
   }
 

--- a/lib/routes/settings/settings_learning/settings_learning.dart
+++ b/lib/routes/settings/settings_learning/settings_learning.dart
@@ -2,21 +2,15 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
-import 'package:go_router/go_router.dart';
-
-import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/settings/settings_learning/learning_settings_view_model.dart';
 import 'package:fluffychat/routes/settings/settings_learning/settings_learning_view.dart';
-import 'package:fluffychat/utils/navigation_util.dart';
-import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
-import 'package:fluffychat/widgets/future_loading_dialog.dart';
+import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 class SettingsLearning extends StatefulWidget {
-  final bool isDialog;
-
-  const SettingsLearning({this.isDialog = true, super.key});
+  const SettingsLearning({super.key});
 
   @override
   SettingsLearningController createState() => SettingsLearningController();
@@ -27,45 +21,16 @@ class SettingsLearningController extends State<SettingsLearning> {
 
   final ValueNotifier<String?> languageMatchError = ValueNotifier(null);
   final ScrollController scrollController = ScrollController();
-  final TextEditingController aboutTextController = TextEditingController();
-  final ExpansibleController languageTileController = ExpansibleController();
-
-  // Used by the GoRoute's onExit to check unsaved changes and optionally save.
-  static SettingsLearningController? _activeInstance;
-
-  static Future<bool> handleExit(BuildContext context) async {
-    final instance = _activeInstance;
-    if (instance == null || !instance.viewModel.haveSettingsChanged) {
-      return true;
-    }
-
-    final resp = await showOkCancelAlertDialog(
-      title: L10n.of(context).exitWithoutSaving,
-      okLabel: L10n.of(context).submit,
-      cancelLabel: L10n.of(context).leave,
-      context: context,
-    );
-
-    if (resp == OkCancelResult.ok) {
-      return instance._saveChanges(context);
-    }
-    return true; // leave without saving
-  }
 
   @override
   void initState() {
     super.initState();
-    SettingsLearningController._activeInstance = this;
+
     viewModel = LearningSettingsViewModel(
       MatrixState.pangeaController.userController.profile,
-      onUpdateProfile: () {
-        if (languageMatchError.value != null &&
-            !viewModel.hasIdenticalLanguages) {
-          languageMatchError.value = null;
-        }
-      },
+      onUpdateProfile: _updateProfile,
     );
-    aboutTextController.text = viewModel.about ?? '';
+
     if (viewModel.hasIdenticalLanguages) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
@@ -77,73 +42,48 @@ class SettingsLearningController extends State<SettingsLearning> {
 
   @override
   void dispose() {
-    if (SettingsLearningController._activeInstance == this) {
-      SettingsLearningController._activeInstance = null;
-    }
     scrollController.dispose();
-    aboutTextController.dispose();
     viewModel.dispose();
     languageMatchError.dispose();
-    languageTileController.dispose();
     super.dispose();
   }
 
-  /// Close the learning-settings surface. As a dialog it pops; as the world_v2
-  /// settings panel there is nothing on the stack to pop to, so it navigates back
-  /// to the settings menu via its token instead of dead-ending on the loading
-  /// page (#7076).
-  void _closeSettings() => NavigationUtil.popOrGo(
-    context,
-    WorkspaceNav.settingsBack(GoRouterState.of(context).uri, 'learning'),
-  );
-
-  // if the settings have been changed, show a dialog the user wants to exit without saving
-  // if the settings have not been changed, just close the settings page
-  Future<void> onSettingsClose() async {
-    if (!viewModel.haveSettingsChanged) {
-      _closeSettings();
-      return;
-    }
-
-    final resp = await showOkCancelAlertDialog(
-      title: L10n.of(context).exitWithoutSaving,
-      okLabel: L10n.of(context).submit,
-      cancelLabel: L10n.of(context).leave,
-      context: context,
-    );
-
-    resp == OkCancelResult.ok ? await submit() : _closeSettings();
-  }
-
-  // Saves settings without navigating. Returns true if save succeeded.
-  Future<bool> _saveChanges(BuildContext context) async {
+  Future<void> _updateProfile() async {
     if (viewModel.hasIdenticalLanguages) {
       languageMatchError.value = L10n.of(context).noIdenticalLanguages;
-      languageTileController.expand();
       scrollController.animateTo(
         0,
         duration: const Duration(milliseconds: 300),
         curve: Curves.easeInOut,
       );
-      return false;
+    } else {
+      languageMatchError.value = null;
     }
 
-    languageMatchError.value = null;
-    await showFutureLoadingDialog(
-      context: context,
-      future: () async => MatrixState.pangeaController.userController
+    try {
+      await MatrixState.pangeaController.userController
           .updateProfile(
             (_) => viewModel.updatedProfile,
             waitForDataInSync: true,
           )
-          .timeout(const Duration(seconds: 15)),
-    );
-    return true;
-  }
+          .timeout(const Duration(seconds: 15));
+    } catch (e, s) {
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"updatedProfile": viewModel.updatedProfile.toJson()},
+      );
 
-  Future<void> submit() async {
-    if (await _saveChanges(context)) {
-      _closeSettings();
+      if (mounted) {
+        ScaffoldMessenger.of(context).hideCurrentSnackBar();
+        ScaffoldMessenger.of(context).showSnackBarAnnounced(
+          SnackBar(
+            content: Text(L10n.of(context).oopsSomethingWentWrong),
+            showCloseIcon: true,
+          ),
+          assertive: true,
+        );
+      }
     }
   }
 

--- a/lib/routes/settings/settings_learning/settings_learning_view.dart
+++ b/lib/routes/settings/settings_learning/settings_learning_view.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/features/user/user_constants.dart';
-import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/pangea/common/widgets/full_width_dialog.dart';
 import 'package:fluffychat/routes/settings/settings_learning/learning_settings_tiles.dart';
 import 'package:fluffychat/routes/settings/settings_learning/settings_learning.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
@@ -22,48 +20,16 @@ class SettingsLearningView extends StatelessWidget {
             );
       }),
       builder: (context, _) {
-        final dialogContent = SafeArea(
+        return SafeArea(
           child: Scaffold(
-            body: Column(
-              children: [
-                Expanded(
-                  child: MaxWidthBody(
-                    scrollController: controller.scrollController,
-                    showBorder: !controller.widget.isDialog,
-                    child: LearningSettingsTiles(
-                      viewModel: controller.viewModel,
-                      languageErrorNotifier: controller.languageMatchError,
-                      aboutTextController: controller.aboutTextController,
-                      languageTileController: controller.languageTileController,
-                    ),
-                  ),
-                ),
-                ListenableBuilder(
-                  listenable: controller.viewModel,
-                  builder: (context, _) => Container(
-                    padding: const EdgeInsets.all(16.0),
-                    constraints: BoxConstraints(maxWidth: 600),
-                    child: ElevatedButton(
-                      onPressed: controller.viewModel.haveSettingsChanged
-                          ? controller.submit
-                          : null,
-                      child: Row(
-                        mainAxisAlignment: .center,
-                        children: [Text(L10n.of(context).saveChanges)],
-                      ),
-                    ),
-                  ),
-                ),
-              ],
+            body: MaxWidthBody(
+              scrollController: controller.scrollController,
+              child: LearningSettingsTiles(
+                viewModel: controller.viewModel,
+                languageErrorNotifier: controller.languageMatchError,
+              ),
             ),
           ),
-        );
-
-        if (!controller.widget.isDialog) return dialogContent;
-        return FullWidthDialog(
-          dialogContent: dialogContent,
-          maxWidth: 600,
-          maxHeight: 800,
         );
       },
     );

--- a/lib/routes/world/right_panel/right_panel_settings_subpage.dart
+++ b/lib/routes/world/right_panel/right_panel_settings_subpage.dart
@@ -49,7 +49,7 @@ class RightPanelSettingsSubpage extends StatelessWidget {
         // own, so the panel card header is its only chrome.
         return const Settings();
       case 'learning':
-        return const SettingsLearning(isDialog: false);
+        return const SettingsLearning();
       case 'style':
         return const SettingsStyle();
       case 'notifications':


### PR DESCRIPTION
…on that saves changes

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
