### PR TITLE
chore: make default gold shimmer color darker in light mode

### DIFF
--- a/lib/pangea/common/widgets/shimmer_background.dart
+++ b/lib/pangea/common/widgets/shimmer_background.dart
@@ -4,7 +4,7 @@ import 'package:fluffychat/config/app_config.dart';
 
 class ShimmerBackground extends StatefulWidget {
   final Widget child;
-  final Color shimmerColor;
+  final Color? shimmerColor;
   final bool enabled;
   final BorderRadius? borderRadius;
   final Duration delayBetweenPulses;
@@ -13,7 +13,7 @@ class ShimmerBackground extends StatefulWidget {
   const ShimmerBackground({
     super.key,
     required this.child,
-    this.shimmerColor = AppConfig.goldLight,
+    this.shimmerColor,
     this.enabled = true,
     this.borderRadius,
     this.delayBetweenPulses = Duration.zero,
@@ -118,8 +118,16 @@ class _ShimmerBackgroundState extends State<ShimmerBackground>
       return widget.child;
     }
 
+    final theme = Theme.of(context);
+
     final borderRadius =
         widget.borderRadius ?? BorderRadius.circular(AppConfig.borderRadius);
+
+    final color =
+        widget.shimmerColor ??
+        (theme.brightness == Brightness.light
+            ? AppConfig.gold
+            : AppConfig.goldLight);
 
     return AnimatedBuilder(
       animation: _animation,
@@ -133,9 +141,7 @@ class _ShimmerBackgroundState extends State<ShimmerBackground>
                   borderRadius: borderRadius,
                   child: DecoratedBox(
                     decoration: BoxDecoration(
-                      color: widget.shimmerColor.withValues(
-                        alpha: _animation.value,
-                      ),
+                      color: color.withValues(alpha: _animation.value),
                       borderRadius: borderRadius,
                     ),
                   ),

--- a/lib/routes/chat/toolbar/word_card/lemma_reaction_picker.dart
+++ b/lib/routes/chat/toolbar/word_card/lemma_reaction_picker.dart
@@ -189,10 +189,6 @@ class LemmaReactionPickerState extends State<LemmaReactionPicker>
     final globallyEnableSelection = globallyEnable && widget.enableSelection;
     final globallyEnableReactions = globallyEnable && widget.enableReactions;
 
-    Logs().w(
-      "ENABLE REACTIONS: ${widget.enableReactions}. ENABLE SELECTION: ${widget.enableSelection}",
-    );
-
     final bool hasSentSelectedEmojiReaction =
         _selectedEmoji != null &&
         _userReactionEvents.containsKey(_selectedEmoji!);


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
