### PR TITLE
fix: once bot has been triggered to pick an activity role, disable pl…

### DIFF
--- a/lib/features/activity_sessions/bot_activty_role_room_extension.dart
+++ b/lib/features/activity_sessions/bot_activty_role_room_extension.dart
@@ -1,0 +1,11 @@
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+
+extension BotActivtyRoleRoomExtension on Room {
+  bool get botAddedToActivity =>
+      getState(PangeaEventTypes.botParticipant) != null;
+
+  Future<void> addBotToActivity() =>
+      client.setRoomStateWithKey(id, PangeaEventTypes.botParticipant, "", {});
+}

--- a/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
@@ -242,7 +242,7 @@ class _ConfirmedRoleSessionCTAButtons extends StatelessWidget {
             padding: EdgeInsetsGeometry.only(bottom: 16.0),
             child: _CTAButton(
               L10n.of(context).playWithBot,
-              controller.playWithBot,
+              controller.enablePlayWithBot ? controller.playWithBot : null,
             ),
           ),
         if (controller.showInviteOptions)

--- a/lib/routes/chat/activity_sessions/bot_join_error_dialog.dart
+++ b/lib/routes/chat/activity_sessions/bot_join_error_dialog.dart
@@ -6,6 +6,7 @@ import 'package:collection/collection.dart';
 import 'package:matrix/matrix.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import 'package:fluffychat/features/activity_sessions/bot_activty_role_room_extension.dart';
 import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/features/bot/widgets/bot_face_svg.dart';
 import 'package:fluffychat/l10n/l10n.dart';
@@ -46,12 +47,7 @@ class PlayWithBotLoadingDialogState extends State<PlayWithBotLoadingDialog> {
       // creation but stays idle until this marker lands; writing it makes the bot
       // claim the open role and start playing. Re-invite defensively in case the
       // auto-invite never landed (harmless if the bot is already joined).
-      await widget.room.client.setRoomStateWithKey(
-        widget.room.id,
-        PangeaEventTypes.botParticipant,
-        "",
-        {},
-      );
+      await widget.room.addBotToActivity();
       // The bot is invited at room creation, so it is normally already present
       // here. Only re-invite if it is genuinely absent (it left, or the
       // create-time invite failed). Look up membership from the authoritative

--- a/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
@@ -7,6 +7,7 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/bot_activty_role_room_extension.dart';
 import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
@@ -61,6 +62,9 @@ class ConfirmedRoleSessionController extends State<ConfirmedRoleSession>
   bool get showPingCourse => widget.course != null;
 
   bool get showInviteOptions => widget.room.isRoomAdmin;
+
+  bool get enablePlayWithBot =>
+      showInviteOptions && !widget.room.botAddedToActivity;
 
   @override
   String get descriptionText =>

--- a/lib/utils/client_manager.dart
+++ b/lib/utils/client_manager.dart
@@ -148,6 +148,7 @@ abstract class ClientManager {
         PangeaEventTypes.analyticsSettings,
         PangeaEventTypes.courseSettings,
         PangeaEventTypes.orchestratorAwardedGoals,
+        PangeaEventTypes.botParticipant,
         // Pangea#
       },
       logLevel: kReleaseMode ? Level.warning : Level.verbose,


### PR DESCRIPTION
…ay with bot button

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking when a bot has been added to an activity.
  * Improved bot-join handling so the app can record bot participation more reliably.

* **Bug Fixes**
  * The “Play with bot” action is now disabled when it isn’t available, preventing invalid taps.
  * Bot activity state is now loaded earlier, reducing inconsistencies when entering sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->