### PR TITLE
fix: better spacing in free trial onboarding page for small screens

### DIFF
--- a/lib/features/subscription/widgets/pro_features_card.dart
+++ b/lib/features/subscription/widgets/pro_features_card.dart
@@ -76,24 +76,19 @@ class ProFeaturesCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           ..._ProFeatureInfo.entries(L10n.of(context)).map(
-            (e) => RichText(
-              text: TextSpan(
-                children: [
-                  WidgetSpan(
-                    alignment: PlaceholderAlignment.middle,
-                    child: Padding(
-                      padding: EdgeInsets.only(right: 8.0),
-                      child: Icon(e.icon, color: gold, size: 20.0),
-                    ),
-                  ),
-                  TextSpan(
-                    text: e.text,
+            (e) => Row(
+              spacing: 8.0,
+              children: [
+                Icon(e.icon, color: gold, size: 20.0),
+                Expanded(
+                  child: Text(
+                    e.text,
                     style: theme.textTheme.titleMedium?.copyWith(
                       color: theme.colorScheme.onSurface,
                     ),
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
           ),
         ],

--- a/lib/routes/onboarding/onboarding_step_views/free_trial_step_view.dart
+++ b/lib/routes/onboarding/onboarding_step_views/free_trial_step_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/subscription/subscription_constants.dart';
 import 'package:fluffychat/features/subscription/widgets/pro_features_card.dart';
 import 'package:fluffychat/l10n/l10n.dart';
@@ -18,6 +19,16 @@ class FreeTrialStepView extends StatelessWidget {
       Theme.of(context).colorScheme.surface.withAlpha(70),
       AppConfig.gold,
     );
+
+    final isColumnMode = FluffyThemes.isColumnMode(context);
+
+    final mediumTextStyle = isColumnMode
+        ? theme.textTheme.bodyMedium
+        : theme.textTheme.bodySmall;
+
+    final largeTextStyle = isColumnMode
+        ? theme.textTheme.displayMedium
+        : theme.textTheme.headlineMedium;
 
     return Scaffold(
       appBar: AppBar(
@@ -44,7 +55,7 @@ class FreeTrialStepView extends StatelessWidget {
             child: Center(
               child: Container(
                 width: 350,
-                padding: const EdgeInsets.symmetric(vertical: 48),
+                padding: const EdgeInsets.only(bottom: 20.0),
                 child: Column(
                   children: [
                     Expanded(
@@ -68,16 +79,17 @@ class FreeTrialStepView extends StatelessWidget {
                                       children: [
                                         Text(
                                           L10n.of(context).thanksForSigningUp,
-                                          style: theme.textTheme.bodyLarge,
+                                          style: mediumTextStyle,
+                                          textAlign: TextAlign.center,
                                         ),
 
                                         Text(
                                           L10n.of(context).sevenDaysFree,
-                                          style: theme.textTheme.displayMedium
-                                              ?.copyWith(
-                                                color: gold,
-                                                fontWeight: FontWeight.w900,
-                                              ),
+                                          style: largeTextStyle?.copyWith(
+                                            color: gold,
+                                            fontWeight: FontWeight.w900,
+                                          ),
+                                          textAlign: TextAlign.center,
                                         ),
                                       ],
                                     ),
@@ -100,7 +112,7 @@ class FreeTrialStepView extends StatelessWidget {
                                     child: Text(
                                       L10n.of(context).manageTrialInSettings,
                                       textAlign: TextAlign.center,
-                                      style: theme.textTheme.bodyLarge,
+                                      style: mediumTextStyle,
                                     ),
                                   ),
                                 ],
@@ -122,7 +134,7 @@ class FreeTrialStepView extends StatelessWidget {
                     const SizedBox(height: 8),
                     Text(
                       L10n.of(context).noCreditCardRequired,
-                      style: theme.textTheme.bodyMedium,
+                      style: mediumTextStyle,
                     ),
                   ],
                 ),

--- a/lib/routes/onboarding/onboarding_step_views/pick_language_step_view.dart
+++ b/lib/routes/onboarding/onboarding_step_views/pick_language_step_view.dart
@@ -68,6 +68,8 @@ class PickLanguageStepViewState extends State<PickLanguageStepView> {
     final baseLanguage =
         _step.state.baseLanguage ?? userL1 ?? systemLanguage ?? defaultLanguage;
 
+    _selectedBaseLanguage.addListener(_onBaseLanguageChanged);
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _setBaseLanguage(baseLanguage);
       _setTargetLanguage(targetLanguage);
@@ -76,6 +78,7 @@ class PickLanguageStepViewState extends State<PickLanguageStepView> {
 
   @override
   void dispose() {
+    _selectedBaseLanguage.removeListener(_onBaseLanguageChanged);
     _searchController.dispose();
     _selectedBaseLanguage.dispose();
     _selectedTargetLanguage.dispose();
@@ -99,10 +102,6 @@ class PickLanguageStepViewState extends State<PickLanguageStepView> {
 
     _step.selectBaseLanguage(lang);
     _selectedBaseLanguage.value = lang;
-
-    if (lang != null) {
-      _setAppLanguage(lang);
-    }
   }
 
   void _setTargetLanguage(LanguageModel? lang) {
@@ -113,6 +112,13 @@ class PickLanguageStepViewState extends State<PickLanguageStepView> {
 
     _step.selectTargetLanguage(lang);
     _selectedTargetLanguage.value = lang;
+  }
+
+  void _onBaseLanguageChanged() {
+    final lang = _selectedBaseLanguage.value;
+    if (lang != null) {
+      Future.delayed(Duration(milliseconds: 500), () => _setAppLanguage(lang));
+    }
   }
 
   void _setAppLanguage(LanguageModel language) {


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
