### PR TITLE
Move compress semantics label to switch

### DIFF
--- a/lib/routes/chat/send_file_dialog.dart
+++ b/lib/routes/chat/send_file_dialog.dart
@@ -367,50 +367,55 @@ class SendFileDialogState extends State<SendFileDialog> {
                     Row(
                       crossAxisAlignment: .center,
                       children: [
-                        if ({
-                          TargetPlatform.iOS,
-                          TargetPlatform.macOS,
-                        }.contains(theme.platform))
-                          CupertinoSwitch(
-                            value: compressionSupported && compress,
-                            onChanged: compressionSupported
-                                ? (v) => setState(() => compress = v)
-                                : null,
-                          )
-                        else
-                          Switch.adaptive(
-                            value: compressionSupported && compress,
-                            onChanged: compressionSupported
-                                ? (v) => setState(() => compress = v)
-                                : null,
-                          ),
+                        Semantics(
+                          label: L10n.of(context).compress,
+                          child:
+                              {
+                                TargetPlatform.iOS,
+                                TargetPlatform.macOS,
+                              }.contains(theme.platform)
+                              ? CupertinoSwitch(
+                                  value: compressionSupported && compress,
+                                  onChanged: compressionSupported
+                                      ? (v) => setState(() => compress = v)
+                                      : null,
+                                )
+                              : Switch.adaptive(
+                                  value: compressionSupported && compress,
+                                  onChanged: compressionSupported
+                                      ? (v) => setState(() => compress = v)
+                                      : null,
+                                ),
+                        ),
                         const SizedBox(width: 16),
                         Expanded(
-                          child: Column(
-                            mainAxisSize: .min,
-                            crossAxisAlignment: .start,
-                            children: [
-                              Row(
-                                mainAxisSize: .min,
-                                children: [
+                          child: ExcludeSemantics(
+                            child: Column(
+                              mainAxisSize: .min,
+                              crossAxisAlignment: .start,
+                              children: [
+                                Row(
+                                  mainAxisSize: .min,
+                                  children: [
+                                    Text(
+                                      L10n.of(context).compress,
+                                      style: theme.textTheme.titleMedium,
+                                      textAlign: TextAlign.left,
+                                    ),
+                                  ],
+                                ),
+                                if (!compress)
                                   Text(
-                                    L10n.of(context).compress,
-                                    style: theme.textTheme.titleMedium,
-                                    textAlign: TextAlign.left,
+                                    ' ($sizeString)',
+                                    style: theme.textTheme.labelSmall,
                                   ),
-                                ],
-                              ),
-                              if (!compress)
-                                Text(
-                                  ' ($sizeString)',
-                                  style: theme.textTheme.labelSmall,
-                                ),
-                              if (!compressionSupported)
-                                Text(
-                                  L10n.of(context).notSupportedOnThisDevice,
-                                  style: theme.textTheme.labelSmall,
-                                ),
-                            ],
+                                if (!compressionSupported)
+                                  Text(
+                                    L10n.of(context).notSupportedOnThisDevice,
+                                    style: theme.textTheme.labelSmall,
+                                  ),
+                              ],
+                            ),
                           ),
                         ),
                       ],


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
