### PR TITLE
chore: drop dead _org-copilot-instructions.md gitignore line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,7 +107,6 @@ CLAUDE.md
 # E2E test artifacts
 test-results/
 
-# Claude Code team config (per-repo) — track the team hooks, ignore the rest of .claude/ and the generated org-guide copy
+# Claude Code team config (per-repo) — track the team hooks, ignore the rest of .claude/
 .claude/*
 !.claude/settings.json
-.github/_org-copilot-instructions.md


### PR DESCRIPTION
The org guide is now inlined into the generated (gitignored) CLAUDE.md by sync (pangeachat/.github#226) instead of being fanned out as .github/_org-copilot-instructions.md. That file is no longer generated, so the gitignore entry for it is dead config. Removes the line and trims the stale comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore rules for configuration files.
  * Preserved access to the shared settings file while continuing to ignore other local configuration files.
  * Removed an outdated ignore entry and refreshed the related comment text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->