### PR TITLE
Improve cluster appearance and color consistency and contrast

### DIFF
--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -197,7 +197,6 @@ class _PowerupsPill extends StatelessWidget {
   });
 
   static const double _xpStroke = 5.0;
-  static const double _xpInset = 3.0;
   static const double _innerRadius = 20.0;
 
   @override
@@ -235,16 +234,18 @@ class _PowerupsPill extends StatelessWidget {
                     CustomPaint(
                       painter: XpBorderPainter(
                         progress: progress,
-                        trackColor: const Color(0xFFBCC2CC),
+                        trackColor: const Color.fromARGB(130, 135, 135, 135),
                         progressColor: AppConfig.gold,
                         stroke: _xpStroke,
-                        radius: _innerRadius + _xpInset + _xpStroke / 2,
+                        radius: _innerRadius + _xpStroke / 2,
                       ),
                       child: Padding(
-                        padding: const EdgeInsets.all(_xpInset + _xpStroke),
+                        padding: const EdgeInsets.all(_xpStroke),
                         child: Container(
                           decoration: BoxDecoration(
-                            color: Colors.white,
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.surfaceContainer,
                             borderRadius: BorderRadius.circular(_innerRadius),
                           ),
                           clipBehavior: Clip.antiAlias,
@@ -324,10 +325,6 @@ class _TrackerButton extends StatelessWidget {
     required this.onTap,
   });
 
-  // The white inner field is a fixed colour (not theme-driven), so its content
-  // is a fixed dark — matches Figma `--text`/icon-default on white.
-  static const Color _ink = Color(0xFF1E1E1E);
-
   @override
   Widget build(BuildContext context) {
     return Tooltip(
@@ -347,7 +344,7 @@ class _TrackerButton extends StatelessWidget {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Icon(indicator.icon, size: 24, color: _ink),
+                Icon(indicator.icon, size: 24),
                 const SizedBox(height: 3),
                 Text(
                   '$count',
@@ -355,7 +352,6 @@ class _TrackerButton extends StatelessWidget {
                     fontSize: 16,
                     height: 1.1,
                     fontWeight: FontWeight.w600,
-                    color: _ink,
                   ),
                 ),
               ],
@@ -380,7 +376,7 @@ class _LevelMedal extends StatelessWidget {
       '<svg viewBox="0 0 24.6667 28.875" xmlns="http://www.w3.org/2000/svg">'
       '<path d="M4.33333 28.875V17.5656L0 10.3125L6.16667 0H18.5L24.6667 '
       '10.3125L20.3333 17.5656V28.875L12.3333 26.125L4.33333 28.875Z" '
-      'fill="#F3C141"/></svg>';
+      'fill="#FDBF01"/></svg>';
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the world map user cluster XP ring and inner padding visuals for a cleaner, more consistent appearance.
  * Improved tracker button icon and count text coloring so they better match the current theme.
  * Refreshed the level medal shield color to a brighter gold tone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->