### PR TITLE
7341 w toolbar practice options cut off at bottom

### DIFF
--- a/lib/features/overlay/overlay.dart
+++ b/lib/features/overlay/overlay.dart
@@ -95,9 +95,7 @@ class OverlayUtil {
       const horizontalPadding = 10.0;
 
       final targetSize = targetRenderBox.size;
-      final targetOffset = parentRenderBox.globalToLocal(
-        targetRenderBox.localToGlobal(Offset.zero),
-      );
+      final targetOffset = localOffset(targetRenderBox, parentRenderBox);
 
       final midpoint = targetOffset.dx + (targetSize.width / 2);
       final leftEdge = midpoint - (displayDetails.maxWidth / 2);
@@ -162,4 +160,10 @@ class OverlayUtil {
     if (renderBox == null || !renderBox.hasSize) return null;
     return renderBox;
   }
+
+  static Offset localOffset(
+    RenderBox targetRenderBox,
+    RenderBox parentRenderBox,
+  ) =>
+      parentRenderBox.globalToLocal(targetRenderBox.localToGlobal(Offset.zero));
 }

--- a/lib/routes/chat/toolbar/layout/message_selection_positioner.dart
+++ b/lib/routes/chat/toolbar/layout/message_selection_positioner.dart
@@ -181,7 +181,12 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
 
   double? get parentWidth => _parentRenderBox?.size.width;
 
-  double? get parentHeight => _parentRenderBox?.size.height;
+  double? get _adjustedParentHeight {
+    final parentHeight = _parentRenderBox?.size.height;
+    if (parentHeight == null) return null;
+    final screenPadding = _screenPadding;
+    return parentHeight - (screenPadding.top + screenPadding.bottom);
+  }
 
   Size? get _overlayMessageSize => _overlayMessageRenderBox?.size;
 
@@ -226,6 +231,8 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
       _defaultMessageSize,
     );
   }
+
+  EdgeInsets get _screenPadding => MediaQuery.paddingOf(context);
 
   double? get messageLeftOffset {
     if (ownMessage) return null;
@@ -277,13 +284,13 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
   }
 
   bool get shouldScroll {
-    final parentHeight = this.parentHeight;
+    final parentHeight = _adjustedParentHeight;
     if (parentHeight == null) return false;
     return _fullContentHeight > parentHeight;
   }
 
   bool get _hasFooterOverflow {
-    final parentHeight = this.parentHeight;
+    final parentHeight = _parentRenderBox?.size.height;
     if (parentHeight == null) return false;
 
     final offset = _originalMessageOffset;
@@ -305,19 +312,23 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
     final offset = _originalMessageOffset;
     if (offset == null) return 300;
 
-    final messageHeight = originalMessageSize.height;
-    final originalContentHeight =
-        messageHeight + _reactionsHeight + AppConfig.toolbarMenuHeight + 8.0;
-
-    final parentHeight = this.parentHeight;
+    final parentHeight = _adjustedParentHeight;
     if (parentHeight == null) return 300;
 
-    double boxHeight = parentHeight - offset.dy - originalContentHeight;
+    final contentHeight =
+        _reactionsHeight +
+        originalMessageSize.height +
+        8.0 +
+        AppConfig.toolbarMenuHeight;
+
+    final adjustedTopOffset = offset.dy - _screenPadding.top;
+
+    final boxHeight = parentHeight - (contentHeight + adjustedTopOffset);
 
     final neededSpace = boxHeight + _fullContentHeight + 4.0;
 
     if (neededSpace > parentHeight) {
-      boxHeight = parentHeight - _fullContentHeight - 4.0;
+      return parentHeight - _fullContentHeight - 4.0;
     }
 
     return boxHeight;
@@ -357,7 +368,7 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
         children: [
           SizedBox(
             width: parentRendexBox.size.width,
-            height: parentRendexBox.size.height,
+            height: _adjustedParentHeight,
             child: Stack(
               alignment: ownMessage
                   ? Alignment.centerRight

--- a/lib/routes/chat/toolbar/layout/message_selection_positioner.dart
+++ b/lib/routes/chat/toolbar/layout/message_selection_positioner.dart
@@ -193,9 +193,7 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
     if (parentRenderBox == null) return null;
 
     return _runWithLogging(
-      () => parentRenderBox.globalToLocal(
-        overlayMessageRenderBox.localToGlobal(Offset.zero),
-      ),
+      () => OverlayUtil.localOffset(overlayMessageRenderBox, parentRenderBox),
       "Error getting overlay message offset",
       null,
     );
@@ -209,9 +207,7 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
     if (parentRenderBox == null) return null;
 
     return _runWithLogging(
-      () => parentRenderBox.globalToLocal(
-        messageRenderBox.localToGlobal(Offset.zero),
-      ),
+      () => OverlayUtil.localOffset(messageRenderBox, parentRenderBox),
       "Error getting message offset",
       null,
     );

--- a/lib/routes/chat/toolbar/layout/practice_mode_transition_animation.dart
+++ b/lib/routes/chat/toolbar/layout/practice_mode_transition_animation.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/overlay/overlay.dart';
 import 'package:fluffychat/routes/chat/toolbar/layout/message_selection_positioner.dart';
 import 'package:fluffychat/routes/chat/toolbar/layout/overlay_center_content.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -37,10 +38,12 @@ class PracticeModeTransitionAnimationState
 
   Offset? get _centerMessageOffset {
     final renderBox = _centerMessageRenderBox;
-    if (renderBox == null) {
-      return null;
-    }
-    return renderBox.localToGlobal(Offset.zero);
+    if (renderBox == null) return null;
+
+    final parentRenderBox = OverlayUtil.overlayRenderBox(context);
+    if (parentRenderBox == null) return null;
+
+    return OverlayUtil.localOffset(renderBox, parentRenderBox);
   }
 
   Size? get _centerMessageSize {


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay and message selection positioning so popups and highlights stay aligned more reliably, especially around safe-area and system inset changes.
  * Fixed layout sizing so chat overlay content fits the visible screen area more consistently.
  * Made transition positioning more stable when animating centered messages, reducing misplaced overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->