### PR TITLE
Organize login and signup semantics

### DIFF
--- a/lib/routes/home/login/login_options_view.dart
+++ b/lib/routes/home/login/login_options_view.dart
@@ -45,86 +45,97 @@ class LoginOptionsViewState extends State<LoginOptionsView> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 450),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              BackButton(onPressed: Navigator.of(context).pop),
-              Text(L10n.of(context).login),
-              const SizedBox(width: 40.0),
-            ],
-          ),
-        ),
-        automaticallyImplyLeading: false,
-      ),
-      body: SafeArea(
-        child: Center(
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 300, maxHeight: 600),
-            child: Column(
-              spacing: 16.0,
-              mainAxisAlignment: MainAxisAlignment.end,
+    return Semantics(
+      label: L10n.of(context).pageLabel(L10n.of(context).login),
+      child: Scaffold(
+        appBar: AppBar(
+          centerTitle: true,
+          title: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 450),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                Text(
-                  L10n.of(context).loginToAccount,
-                  textAlign: TextAlign.center,
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                if (_prevInfo != null)
-                  Text(
-                    L10n.of(context).welcomeBackLogin(
-                      _prevInfo!.method.label(L10n.of(context)),
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                Opacity(
-                  opacity: _buttonOpacity(LoginMethod.apple),
-                  child: PangeaSsoButton(
-                    provider: SSOProvider.apple,
-                    title: "Apple",
-                  ),
-                ),
-                Opacity(
-                  opacity: _buttonOpacity(LoginMethod.google),
-                  child: PangeaSsoButton(
-                    provider: SSOProvider.google,
-                    title: "Google",
-                  ),
-                ),
-                Opacity(
-                  opacity: _buttonOpacity(LoginMethod.email),
-                  child: ElevatedButton(
-                    onPressed: () => context.go('/home/login/email'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: theme.colorScheme.primaryContainer,
-                      foregroundColor: theme.colorScheme.onPrimaryContainer,
-                    ),
-                    child: Row(
-                      spacing: 8.0,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        PangeaLogoSvg(
-                          width: 20,
-                          forceColor: Theme.of(
-                            context,
-                          ).colorScheme.onPrimaryContainer,
-                        ),
-                        Text(L10n.of(context).email),
-                      ],
-                    ),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(12.0),
-                  child: TOSIndicator(),
-                ),
+                BackButton(onPressed: Navigator.of(context).pop),
+                ExcludeSemantics(child: Text(L10n.of(context).login)),
+                const SizedBox(width: 40.0),
               ],
+            ),
+          ),
+          automaticallyImplyLeading: false,
+        ),
+        body: SafeArea(
+          child: Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 300, maxHeight: 600),
+              child: Column(
+                spacing: 16.0,
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  Semantics(
+                    container: true,
+                    child: Text(
+                      L10n.of(context).loginToAccount,
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  if (_prevInfo != null)
+                    Semantics(
+                      container: true,
+                      child: Text(
+                        L10n.of(context).welcomeBackLogin(
+                          _prevInfo!.method.label(L10n.of(context)),
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  Opacity(
+                    opacity: _buttonOpacity(LoginMethod.apple),
+                    child: PangeaSsoButton(
+                      provider: SSOProvider.apple,
+                      title: "Apple",
+                    ),
+                  ),
+                  Opacity(
+                    opacity: _buttonOpacity(LoginMethod.google),
+                    child: PangeaSsoButton(
+                      provider: SSOProvider.google,
+                      title: "Google",
+                    ),
+                  ),
+                  Opacity(
+                    opacity: _buttonOpacity(LoginMethod.email),
+                    child: ElevatedButton(
+                      onPressed: () => context.go('/home/login/email'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: theme.colorScheme.primaryContainer,
+                        foregroundColor: theme.colorScheme.onPrimaryContainer,
+                      ),
+                      child: Row(
+                        spacing: 8.0,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          ExcludeSemantics(
+                            child: PangeaLogoSvg(
+                              width: 20,
+                              forceColor: Theme.of(
+                                context,
+                              ).colorScheme.onPrimaryContainer,
+                            ),
+                          ),
+                          Text(L10n.of(context).email),
+                        ],
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(12.0),
+                    child: TOSIndicator(),
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/routes/home/login/pangea_login_view.dart
+++ b/lib/routes/home/login/pangea_login_view.dart
@@ -12,131 +12,143 @@ class PasswordLoginView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Form(
-      key: controller.formKey,
-      child: Scaffold(
-        appBar: AppBar(
-          centerTitle: true,
-          title: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 450),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                BackButton(onPressed: Navigator.of(context).pop),
-                Text(L10n.of(context).loginWithEmail),
-                const SizedBox(width: 40.0),
-              ],
-            ),
-          ),
-          automaticallyImplyLeading: false,
-        ),
-        body: SafeArea(
-          child: Center(
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 16.0),
-              constraints: const BoxConstraints(maxWidth: 300, maxHeight: 600),
-              child: Column(
-                spacing: 16.0,
-                mainAxisAlignment: MainAxisAlignment.end,
+    return Semantics(
+      label: L10n.of(context).pageLabel(L10n.of(context).loginWithEmail),
+      child: Form(
+        key: controller.formKey,
+        child: Scaffold(
+          appBar: AppBar(
+            centerTitle: true,
+            title: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 450),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  AutofillGroup(
-                    child: Column(
-                      spacing: 16.0,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        TextFormField(
-                          autofocus: true,
-                          decoration: InputDecoration(
-                            labelText: L10n.of(context).usernameOrEmail,
-                          ),
-                          autofillHints: const [AutofillHints.username],
-                          textInputAction: TextInputAction.next,
-                          validator: (value) {
-                            if (value == null || value.isEmpty) {
-                              return L10n.of(context).pleaseEnterYourUsername;
-                            }
-                            return null;
-                          },
-                          controller: controller.usernameController,
-                          onTapOutside: (_) =>
-                              FocusManager.instance.primaryFocus?.unfocus(),
-                          inputFormatters: [
-                            LengthLimitingTextInputFormatter(128),
-                          ],
-                        ),
-                        Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            TextFormField(
-                              autofillHints: const [AutofillHints.password],
-                              obscureText: !controller.showPassword,
-                              textInputAction: TextInputAction.go,
-                              onFieldSubmitted: (_) {
-                                controller.enabledSignIn
-                                    ? controller.login()
-                                    : null;
-                              },
-                              validator: (value) {
-                                if (value == null || value.isEmpty) {
-                                  return L10n.of(
-                                    context,
-                                  ).pleaseEnterYourPassword;
-                                }
-                                return null;
-                              },
-                              controller: controller.passwordController,
-                              decoration: InputDecoration(
-                                labelText: L10n.of(context).password,
-                                suffixIcon: IconButton(
-                                  tooltip: L10n.of(context).showPassword,
-                                  icon: Icon(
-                                    controller.showPassword
-                                        ? Icons.visibility_off
-                                        : Icons.visibility,
-                                  ),
-                                  onPressed: controller.toggleShowPassword,
-                                ),
-                              ),
-                              onTapOutside: (_) =>
-                                  FocusManager.instance.primaryFocus?.unfocus(),
-                              inputFormatters: [
-                                LengthLimitingTextInputFormatter(128),
-                              ],
-                            ),
-                            TextButton(
-                              onPressed:
-                                  controller.loadingSignIn ||
-                                      controller.client == null
-                                  ? () {}
-                                  : controller.passwordForgotten,
-                              style: TextButton.styleFrom(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 16.0,
-                                  vertical: 4.0,
-                                ),
-                                minimumSize: const Size(0, 0),
-                              ),
-                              child: Text(L10n.of(context).forgotPassword),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
+                  BackButton(onPressed: Navigator.of(context).pop),
+                  ExcludeSemantics(
+                    child: Text(L10n.of(context).loginWithEmail),
                   ),
-                  ElevatedButton(
-                    onPressed: controller.enabledSignIn
-                        ? controller.login
-                        : null,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: theme.colorScheme.primaryContainer,
-                      foregroundColor: theme.colorScheme.onPrimaryContainer,
-                    ),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [Text(L10n.of(context).login)],
-                    ),
-                  ),
+                  const SizedBox(width: 40.0),
                 ],
+              ),
+            ),
+            automaticallyImplyLeading: false,
+          ),
+          body: SafeArea(
+            child: Center(
+              child: Container(
+                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                constraints: const BoxConstraints(
+                  maxWidth: 300,
+                  maxHeight: 600,
+                ),
+                child: Column(
+                  spacing: 16.0,
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    AutofillGroup(
+                      child: Column(
+                        spacing: 16.0,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          TextFormField(
+                            autofocus: true,
+                            decoration: InputDecoration(
+                              labelText: L10n.of(context).usernameOrEmail,
+                            ),
+                            autofillHints: const [AutofillHints.username],
+                            textInputAction: TextInputAction.next,
+                            validator: (value) {
+                              if (value == null || value.isEmpty) {
+                                return L10n.of(context).pleaseEnterYourUsername;
+                              }
+                              return null;
+                            },
+                            controller: controller.usernameController,
+                            onTapOutside: (_) =>
+                                FocusManager.instance.primaryFocus?.unfocus(),
+                            inputFormatters: [
+                              LengthLimitingTextInputFormatter(128),
+                            ],
+                          ),
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              TextFormField(
+                                autofillHints: const [AutofillHints.password],
+                                obscureText: !controller.showPassword,
+                                textInputAction: TextInputAction.go,
+                                onFieldSubmitted: (_) {
+                                  controller.enabledSignIn
+                                      ? controller.login()
+                                      : null;
+                                },
+                                validator: (value) {
+                                  if (value == null || value.isEmpty) {
+                                    return L10n.of(
+                                      context,
+                                    ).pleaseEnterYourPassword;
+                                  }
+                                  return null;
+                                },
+                                controller: controller.passwordController,
+                                decoration: InputDecoration(
+                                  labelText: L10n.of(context).password,
+                                  suffixIcon: IconButton(
+                                    tooltip: L10n.of(context).showPassword,
+                                    icon: Icon(
+                                      controller.showPassword
+                                          ? Icons.visibility_off
+                                          : Icons.visibility,
+                                    ),
+                                    onPressed: controller.toggleShowPassword,
+                                  ),
+                                ),
+                                onTapOutside: (_) => FocusManager
+                                    .instance
+                                    .primaryFocus
+                                    ?.unfocus(),
+                                inputFormatters: [
+                                  LengthLimitingTextInputFormatter(128),
+                                ],
+                              ),
+                              MergeSemantics(
+                                child: TextButton(
+                                  onPressed:
+                                      controller.loadingSignIn ||
+                                          controller.client == null
+                                      ? () {}
+                                      : controller.passwordForgotten,
+                                  style: TextButton.styleFrom(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 16.0,
+                                      vertical: 4.0,
+                                    ),
+                                    minimumSize: const Size(0, 0),
+                                  ),
+                                  child: Text(L10n.of(context).forgotPassword),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    ElevatedButton(
+                      onPressed: controller.enabledSignIn
+                          ? controller.login
+                          : null,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: theme.colorScheme.primaryContainer,
+                        foregroundColor: theme.colorScheme.onPrimaryContainer,
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [Text(L10n.of(context).login)],
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/routes/home/p_sso_dialog.dart
+++ b/lib/routes/home/p_sso_dialog.dart
@@ -50,60 +50,77 @@ class SSODialogState extends State<SSODialog> {
     return Dialog(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12.0)),
       backgroundColor: Theme.of(context).colorScheme.surface,
-      child: Container(
-        padding: const EdgeInsets.all(12.0),
-        constraints: const BoxConstraints(maxWidth: 450),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Align(
-              alignment: Alignment.topRight,
-              child: IconButton(
-                tooltip: L10n.of(context).close,
-                onPressed: Navigator.of(context).pop,
-                icon: const Icon(Icons.close),
-              ),
-            ),
-            Text(
-              L10n.of(context).ssoDialogTitle,
-              style: Theme.of(context).textTheme.headlineMedium,
-              textAlign: TextAlign.center,
-            ),
-            Container(
-              alignment: Alignment.center,
-              constraints: const BoxConstraints(minHeight: 150),
-              padding: const EdgeInsets.all(4.0),
-              child: Column(
-                spacing: 16.0,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  SelectableLinkify(
-                    text: L10n.of(context).ssoDialogDesc,
-                    textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
-                    linkStyle: TextStyle(
-                      color: Theme.of(context).colorScheme.primary,
-                      decorationColor: Theme.of(context).colorScheme.primary,
-                    ),
-                    options: const LinkifyOptions(humanize: false),
-                    onOpen: (url) => UrlLauncher(context, url.url).launchUrl(),
-                    style: Theme.of(context).textTheme.bodyLarge,
-                    textAlign: TextAlign.center,
+      child: Semantics(
+        label: L10n.of(context).ssoDialogTitle,
+        container: true,
+        child: Container(
+          padding: const EdgeInsets.all(12.0),
+          constraints: const BoxConstraints(maxWidth: 450),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Align(
+                alignment: Alignment.topRight,
+                child: Semantics(
+                  container: true,
+                  child: IconButton(
+                    tooltip: L10n.of(context).close,
+                    onPressed: Navigator.of(context).pop,
+                    icon: const Icon(Icons.close),
                   ),
-                  _showHint
-                      ? Text(
-                          L10n.of(context).ssoDialogHelpText,
-                          style: Theme.of(context).textTheme.bodyLarge,
-                          textAlign: TextAlign.center,
-                        )
-                      : const SizedBox(
-                          height: 16.0,
-                          width: 16.0,
-                          child: CircularProgressIndicator.adaptive(),
-                        ),
-                ],
+                ),
               ),
-            ),
-          ],
+              ExcludeSemantics(
+                child: Text(
+                  L10n.of(context).ssoDialogTitle,
+                  style: Theme.of(context).textTheme.headlineMedium,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              Semantics(
+                container: true,
+                child: Container(
+                  alignment: Alignment.center,
+                  constraints: const BoxConstraints(minHeight: 150),
+                  padding: const EdgeInsets.all(4.0),
+                  child: Column(
+                    spacing: 16.0,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SelectableLinkify(
+                        text: L10n.of(context).ssoDialogDesc,
+                        textScaleFactor: MediaQuery.textScalerOf(
+                          context,
+                        ).scale(1),
+                        linkStyle: TextStyle(
+                          color: Theme.of(context).colorScheme.primary,
+                          decorationColor: Theme.of(
+                            context,
+                          ).colorScheme.primary,
+                        ),
+                        options: const LinkifyOptions(humanize: false),
+                        onOpen: (url) =>
+                            UrlLauncher(context, url.url).launchUrl(),
+                        style: Theme.of(context).textTheme.bodyLarge,
+                        textAlign: TextAlign.center,
+                      ),
+                      _showHint
+                          ? Text(
+                              L10n.of(context).ssoDialogHelpText,
+                              style: Theme.of(context).textTheme.bodyLarge,
+                              textAlign: TextAlign.center,
+                            )
+                          : const SizedBox(
+                              height: 16.0,
+                              width: 16.0,
+                              child: CircularProgressIndicator.adaptive(),
+                            ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/routes/home/signup/signup_view.dart
+++ b/lib/routes/home/signup/signup_view.dart
@@ -23,95 +23,107 @@ class SignupPageView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Form(
-      key: controller.formKey,
-      child: Scaffold(
-        appBar: AppBar(
-          centerTitle: true,
-          title: SizedBox(
-            width: 450,
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                BackButton(onPressed: Navigator.of(context).pop),
-                Text(L10n.of(context).signUp),
-                const SizedBox(width: 40.0),
-              ],
-            ),
-          ),
-          automaticallyImplyLeading: false,
-        ),
-        body: SafeArea(
-          child: Center(
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 300, maxHeight: 600),
-              child: Column(
-                spacing: 16.0,
-                mainAxisAlignment: MainAxisAlignment.end,
+    return Semantics(
+      label: L10n.of(context).pageLabel(L10n.of(context).signUp),
+      child: Form(
+        key: controller.formKey,
+        child: Scaffold(
+          appBar: AppBar(
+            centerTitle: true,
+            title: SizedBox(
+              width: 450,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(
-                    L10n.of(context).signupOption,
-                    textAlign: TextAlign.center,
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
+                  BackButton(onPressed: Navigator.of(context).pop),
+                  ExcludeSemantics(child: Text(L10n.of(context).signUp)),
+                  const SizedBox(width: 40.0),
+                ],
+              ),
+            ),
+            automaticallyImplyLeading: false,
+          ),
+          body: SafeArea(
+            child: Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(
+                  maxWidth: 300,
+                  maxHeight: 600,
+                ),
+                child: Column(
+                  spacing: 16.0,
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    Text(
+                      L10n.of(context).signupOption,
+                      textAlign: TextAlign.center,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
-                  ),
-                  if (controller.prevInfo != null)
-                    RichText(
-                      text: TextSpan(
-                        style: TextStyle(color: theme.colorScheme.onSurface),
-                        children: [
-                          TextSpan(
-                            text: L10n.of(context).welcomeBackLogin(
-                              controller.prevInfo!.method.label(
-                                L10n.of(context),
-                              ),
-                            ),
-                          ),
-                          TextSpan(text: ' '),
-                          TextSpan(
-                            text: L10n.of(context).clickToLogin,
+                    if (controller.prevInfo != null)
+                      MergeSemantics(
+                        child: RichText(
+                          text: TextSpan(
                             style: TextStyle(
-                              color: theme.colorScheme.primary,
-                              decoration: TextDecoration.underline,
+                              color: theme.colorScheme.onSurface,
                             ),
-                            recognizer: TapGestureRecognizer()
-                              ..onTap = () {
-                                context.go('/home/login');
-                              },
+                            children: [
+                              TextSpan(
+                                text: L10n.of(context).welcomeBackLogin(
+                                  controller.prevInfo!.method.label(
+                                    L10n.of(context),
+                                  ),
+                                ),
+                              ),
+                              TextSpan(text: ' '),
+                              TextSpan(
+                                text: L10n.of(context).clickToLogin,
+                                style: TextStyle(
+                                  color: theme.colorScheme.primary,
+                                  decoration: TextDecoration.underline,
+                                ),
+                                recognizer: TapGestureRecognizer()
+                                  ..onTap = () {
+                                    context.go('/home/login');
+                                  },
+                              ),
+                            ],
                           ),
+                          textAlign: TextAlign.center,
+                        ),
+                      ),
+                    PangeaSsoButton(provider: SSOProvider.apple),
+                    PangeaSsoButton(provider: SSOProvider.google),
+                    ElevatedButton(
+                      onPressed: () => context.go('/home/signup/email'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: theme.colorScheme.primaryContainer,
+                        foregroundColor: theme.colorScheme.onPrimaryContainer,
+                      ),
+                      child: Row(
+                        spacing: 8.0,
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          ExcludeSemantics(
+                            child: PangeaLogoSvg(
+                              width: 20,
+                              forceColor: Theme.of(
+                                context,
+                              ).colorScheme.onPrimaryContainer,
+                            ),
+                          ),
+                          Text(L10n.of(context).withEmail),
                         ],
                       ),
-                      textAlign: TextAlign.center,
                     ),
-                  PangeaSsoButton(provider: SSOProvider.apple),
-                  PangeaSsoButton(provider: SSOProvider.google),
-                  ElevatedButton(
-                    onPressed: () => context.go('/home/signup/email'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: theme.colorScheme.primaryContainer,
-                      foregroundColor: theme.colorScheme.onPrimaryContainer,
-                    ),
-                    child: Row(
-                      spacing: 8.0,
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        PangeaLogoSvg(
-                          width: 20,
-                          forceColor: Theme.of(
-                            context,
-                          ).colorScheme.onPrimaryContainer,
-                        ),
-                        Text(L10n.of(context).withEmail),
-                      ],
-                    ),
-                  ),
 
-                  Padding(
-                    padding: const EdgeInsets.all(12.0),
-                    child: TOSIndicator(),
-                  ),
-                ],
+                    Padding(
+                      padding: const EdgeInsets.all(12.0),
+                      child: TOSIndicator(),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/routes/home/signup/signup_with_email_view.dart
+++ b/lib/routes/home/signup/signup_with_email_view.dart
@@ -13,99 +13,107 @@ class SignupWithEmailView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Form(
-      key: controller.formKey,
-      child: Scaffold(
-        appBar: AppBar(
-          title: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 450),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                BackButton(onPressed: Navigator.of(context).pop),
-                Text(L10n.of(context).signUpWithEmail),
-                const SizedBox(width: 40.0),
-              ],
-            ),
-          ),
-          automaticallyImplyLeading: false,
-        ),
-        body: SafeArea(
-          child: Center(
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 16.0),
-              constraints: const BoxConstraints(maxWidth: 300, maxHeight: 600),
-              child: Column(
-                spacing: 24.0,
-                mainAxisAlignment: MainAxisAlignment.end,
+    return Semantics(
+      label: L10n.of(context).pageLabel(L10n.of(context).signUpWithEmail),
+      child: Form(
+        key: controller.formKey,
+        child: Scaffold(
+          appBar: AppBar(
+            title: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 450),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  TextFormField(
-                    decoration: InputDecoration(
-                      labelText: L10n.of(context).yourUsername,
-                    ),
-                    textInputAction: TextInputAction.next,
-                    validator: (text) {
-                      if (text == null || text.isEmpty) {
-                        return L10n.of(context).pleaseChooseAUsername;
-                      }
-                      return null;
-                    },
-                    controller: controller.usernameController,
-                    onTapOutside: (_) =>
-                        FocusManager.instance.primaryFocus?.unfocus(),
-                    inputFormatters: [LengthLimitingTextInputFormatter(128)],
+                  BackButton(onPressed: Navigator.of(context).pop),
+                  ExcludeSemantics(
+                    child: Text(L10n.of(context).signUpWithEmail),
                   ),
-                  TextFormField(
-                    textInputAction: TextInputAction.next,
-                    keyboardType: TextInputType.emailAddress,
-                    validator: controller.emailTextFieldValidator,
-                    controller: controller.emailController,
-                    decoration: InputDecoration(
-                      labelText: L10n.of(context).yourEmail,
-                    ),
-                    onTapOutside: (_) =>
-                        FocusManager.instance.primaryFocus?.unfocus(),
-                    inputFormatters: [LengthLimitingTextInputFormatter(254)],
-                  ),
-                  TextFormField(
-                    textInputAction: TextInputAction.done,
-                    obscureText: !controller.showPassword,
-                    validator: controller.password1TextFieldValidator,
-                    controller: controller.passwordController,
-                    onFieldSubmitted: controller.enableSignUp
-                        ? controller.signup
-                        : null,
-                    decoration: InputDecoration(
-                      labelText: L10n.of(context).password,
-                      suffixIcon: IconButton(
-                        tooltip: L10n.of(context).showPassword,
-                        icon: Icon(
-                          controller.showPassword
-                              ? Icons.visibility_off
-                              : Icons.visibility,
-                        ),
-                        onPressed: controller.toggleShowPassword,
-                      ),
-                      isDense: true,
-                    ),
-                    onTapOutside: (_) =>
-                        FocusManager.instance.primaryFocus?.unfocus(),
-                    inputFormatters: [LengthLimitingTextInputFormatter(128)],
-                  ),
-                  ElevatedButton(
-                    onPressed: controller.enableSignUp
-                        ? controller.signup
-                        : null,
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: theme.colorScheme.primaryContainer,
-                      foregroundColor: theme.colorScheme.onPrimaryContainer,
-                    ),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [Text(L10n.of(context).createAccount)],
-                    ),
-                  ),
+                  const SizedBox(width: 40.0),
                 ],
+              ),
+            ),
+            automaticallyImplyLeading: false,
+          ),
+          body: SafeArea(
+            child: Center(
+              child: Container(
+                padding: const EdgeInsets.symmetric(vertical: 16.0),
+                constraints: const BoxConstraints(
+                  maxWidth: 300,
+                  maxHeight: 600,
+                ),
+                child: Column(
+                  spacing: 24.0,
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextFormField(
+                      decoration: InputDecoration(
+                        labelText: L10n.of(context).yourUsername,
+                      ),
+                      textInputAction: TextInputAction.next,
+                      validator: (text) {
+                        if (text == null || text.isEmpty) {
+                          return L10n.of(context).pleaseChooseAUsername;
+                        }
+                        return null;
+                      },
+                      controller: controller.usernameController,
+                      onTapOutside: (_) =>
+                          FocusManager.instance.primaryFocus?.unfocus(),
+                      inputFormatters: [LengthLimitingTextInputFormatter(128)],
+                    ),
+                    TextFormField(
+                      textInputAction: TextInputAction.next,
+                      keyboardType: TextInputType.emailAddress,
+                      validator: controller.emailTextFieldValidator,
+                      controller: controller.emailController,
+                      decoration: InputDecoration(
+                        labelText: L10n.of(context).yourEmail,
+                      ),
+                      onTapOutside: (_) =>
+                          FocusManager.instance.primaryFocus?.unfocus(),
+                      inputFormatters: [LengthLimitingTextInputFormatter(254)],
+                    ),
+                    TextFormField(
+                      textInputAction: TextInputAction.done,
+                      obscureText: !controller.showPassword,
+                      validator: controller.password1TextFieldValidator,
+                      controller: controller.passwordController,
+                      onFieldSubmitted: controller.enableSignUp
+                          ? controller.signup
+                          : null,
+                      decoration: InputDecoration(
+                        labelText: L10n.of(context).password,
+                        suffixIcon: IconButton(
+                          tooltip: L10n.of(context).showPassword,
+                          icon: Icon(
+                            controller.showPassword
+                                ? Icons.visibility_off
+                                : Icons.visibility,
+                          ),
+                          onPressed: controller.toggleShowPassword,
+                        ),
+                        isDense: true,
+                      ),
+                      onTapOutside: (_) =>
+                          FocusManager.instance.primaryFocus?.unfocus(),
+                      inputFormatters: [LengthLimitingTextInputFormatter(128)],
+                    ),
+                    ElevatedButton(
+                      onPressed: controller.enableSignUp
+                          ? controller.signup
+                          : null,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: theme.colorScheme.primaryContainer,
+                        foregroundColor: theme.colorScheme.onPrimaryContainer,
+                      ),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [Text(L10n.of(context).createAccount)],
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/widgets/adaptive_dialogs/show_text_input_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/show_text_input_dialog.dart
@@ -37,89 +37,94 @@ Future<String?> showTextInputDialog({
     useRootNavigator: useRootNavigator,
     builder: (context) {
       final error = ValueNotifier<String?>(null);
-      return AlertDialog.adaptive(
-        title: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 256),
-          child: Text(title),
-        ),
-        content: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 256),
-          child: Column(
-            mainAxisSize: .min,
-            children: [
-              if (message != null)
-                SelectableLinkify(
-                  text: message,
-                  textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
-                  linkStyle: TextStyle(
-                    color: Theme.of(context).colorScheme.primary,
-                    decorationColor: Theme.of(context).colorScheme.primary,
-                  ),
-                  options: const LinkifyOptions(humanize: false),
-                  onOpen: (url) => UrlLauncher(context, url.url).launchUrl(),
-                ),
-              const SizedBox(height: 16),
-              ValueListenableBuilder<String?>(
-                valueListenable: error,
-                builder: (context, error, _) {
-                  return DialogTextField(
-                    hintText: hintText,
-                    errorText: error,
-                    labelText: labelText,
-                    controller: controller,
-                    initialText: initialText,
-                    prefixText: prefixText,
-                    suffixText: suffixText,
-                    // #Pangea
-                    // minLines: minLines,
-                    // maxLines: maxLines,
-                    minLines: autoSubmit ? 1 : minLines,
-                    maxLines: autoSubmit ? 1 : maxLines,
-                    onSubmitted: autoSubmit
-                        ? (_) {
-                            final input = controller.text;
-                            final errorText = validator?.call(input);
-                            if (errorText != null) {
-                              error = errorText;
-                              return;
-                            }
-                            Navigator.of(context).pop<String>(input);
-                          }
-                        : null,
-                    // Pangea#
-                    maxLength: maxLength,
-                    keyboardType: keyboardType,
-                    obscureText: obscureText,
-                  );
-                },
-              ),
-            ],
-          ),
-        ),
-        actions: [
-          AdaptiveDialogAction(
-            onPressed: () => Navigator.of(context).pop(null),
-            child: Text(cancelLabel ?? L10n.of(context).cancel),
-          ),
-          AdaptiveDialogAction(
-            onPressed: () {
-              final input = controller.text;
-              final errorText = validator?.call(input);
-              if (errorText != null) {
-                error.value = errorText;
-                return;
-              }
-              Navigator.of(context).pop<String>(input);
-            },
-            autofocus: true,
-            child: Text(
-              okLabel ?? L10n.of(context).ok,
-              style: isDestructive
-                  ? TextStyle(color: Theme.of(context).colorScheme.error)
-                  : null,
+      return Semantics(
+        label: title,
+        child: AlertDialog.adaptive(
+          title: ExcludeSemantics(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 256),
+              child: Text(title),
             ),
           ),
-        ],
+          content: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 256),
+            child: Column(
+              mainAxisSize: .min,
+              children: [
+                if (message != null)
+                  SelectableLinkify(
+                    text: message,
+                    textScaleFactor: MediaQuery.textScalerOf(context).scale(1),
+                    linkStyle: TextStyle(
+                      color: Theme.of(context).colorScheme.primary,
+                      decorationColor: Theme.of(context).colorScheme.primary,
+                    ),
+                    options: const LinkifyOptions(humanize: false),
+                    onOpen: (url) => UrlLauncher(context, url.url).launchUrl(),
+                  ),
+                const SizedBox(height: 16),
+                ValueListenableBuilder<String?>(
+                  valueListenable: error,
+                  builder: (context, error, _) {
+                    return DialogTextField(
+                      hintText: hintText,
+                      errorText: error,
+                      labelText: labelText,
+                      controller: controller,
+                      initialText: initialText,
+                      prefixText: prefixText,
+                      suffixText: suffixText,
+                      // #Pangea
+                      // minLines: minLines,
+                      // maxLines: maxLines,
+                      minLines: autoSubmit ? 1 : minLines,
+                      maxLines: autoSubmit ? 1 : maxLines,
+                      onSubmitted: autoSubmit
+                          ? (_) {
+                              final input = controller.text;
+                              final errorText = validator?.call(input);
+                              if (errorText != null) {
+                                error = errorText;
+                                return;
+                              }
+                              Navigator.of(context).pop<String>(input);
+                            }
+                          : null,
+                      // Pangea#
+                      maxLength: maxLength,
+                      keyboardType: keyboardType,
+                      obscureText: obscureText,
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            AdaptiveDialogAction(
+              onPressed: () => Navigator.of(context).pop(null),
+              child: Text(cancelLabel ?? L10n.of(context).cancel),
+            ),
+            AdaptiveDialogAction(
+              onPressed: () {
+                final input = controller.text;
+                final errorText = validator?.call(input);
+                if (errorText != null) {
+                  error.value = errorText;
+                  return;
+                }
+                Navigator.of(context).pop<String>(input);
+              },
+              autofocus: true,
+              child: Text(
+                okLabel ?? L10n.of(context).ok,
+                style: isDestructive
+                    ? TextStyle(color: Theme.of(context).colorScheme.error)
+                    : null,
+              ),
+            ),
+          ],
+        ),
       );
     },
   );


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [x] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added clearer screen reader labels across login, sign-up, SSO, password login, and text input dialogs.
  * Improved how titles, logos, and buttons are announced to assistive technologies.
  * Preserved the existing layout, navigation, validation, and dialog actions while making the interface easier to use with accessibility tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->