### PR TITLE
fix: unfocus input bar on show toolbar

### DIFF
--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -2644,9 +2644,7 @@ class ChatController extends State<ChatPageWithRoom>
       depressMessageButton.value = true;
     }
 
-    if (keyboardOpen) {
-      inputFocus.unfocus();
-    }
+    inputFocus.unfocus();
 
     if (delay != null) {
       OverlayUtil.showOverlay(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message selection behavior by consistently dismissing the text input before showing action options, preventing the keyboard state from affecting the toolbar experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->