### PR TITLE
fix: hide UI options for kicking the bot from activities

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_participant_list.dart
+++ b/lib/routes/chat/activity_sessions/activity_participant_list.dart
@@ -5,6 +5,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_role_model.dart';
+import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/pangea/spaces/load_participants_builder.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_participant_indicator.dart';
 import 'package:fluffychat/widgets/avatar.dart';
@@ -51,8 +52,11 @@ class ActivityParticipantList extends StatelessWidget {
         );
 
         final remainingMembers = participants.participants.where(
-          (p) => !assignedRoles.values.any((r) => r.userId == p.id),
+          (p) =>
+              !assignedRoles.values.any((r) => r.userId == p.id) &&
+              p.id != BotName.byEnvironment,
         );
+
         return Column(
           spacing: 12.0,
           mainAxisSize: MainAxisSize.min,

--- a/lib/routes/chat/chat_details/invite/pangea_invitation_selection.dart
+++ b/lib/routes/chat/chat_details/invite/pangea_invitation_selection.dart
@@ -258,37 +258,24 @@ class PangeaInvitationSelectionController
   }
 
   List<User> filteredContacts() {
-    List<User> contacts = [];
-    switch (filter) {
-      case InvitationFilter.space:
-        contacts = spaceParent?.getParticipants() ?? [];
-      case InvitationFilter.contacts:
-        contacts = getContacts(context);
-      case InvitationFilter.invited:
-        contacts =
-            participants
+    List<User> contacts = switch (filter) {
+      InvitationFilter.space => spaceParent?.getParticipants() ?? [],
+      InvitationFilter.contacts => getContacts(context),
+      InvitationFilter.invited =>
+        participants
                 ?.where((u) => u.membership == Membership.invite)
                 .toList() ??
-            [];
-      case InvitationFilter.knocking:
-        contacts =
-            participants
-                ?.where((u) => u.membership == Membership.knock)
-                .toList() ??
-            [];
-      case InvitationFilter.banned:
-        contacts =
-            participants
-                ?.where((u) => u.membership == Membership.ban)
-                .toList() ??
-            [];
-      default:
-        contacts =
-            participants
-                ?.where((p) => p.membership != Membership.ban)
-                .toList() ??
-            [];
-    }
+            [],
+      InvitationFilter.knocking =>
+        participants?.where((u) => u.membership == Membership.knock).toList() ??
+            [],
+      InvitationFilter.banned =>
+        participants?.where((u) => u.membership == Membership.ban).toList() ??
+            [],
+      InvitationFilter.participants || InvitationFilter.public =>
+        participants?.where((u) => u.membership != Membership.ban).toList() ??
+            [],
+    };
 
     final search = controller.text.toLowerCase();
     contacts = contacts
@@ -299,9 +286,11 @@ class PangeaInvitationSelectionController
         )
         .toList();
 
-    if (_room?.isSpace ?? false) {
+    final room = _room;
+    if (room != null && (room.isSpace || room.showActivityChatUI)) {
       contacts.removeWhere((u) => u.id == BotName.byEnvironment);
     }
+
     contacts.sort(_sortUsers);
     return contacts;
   }

--- a/lib/routes/chat/chat_details/room_participants_widget.dart
+++ b/lib/routes/chat/chat_details/room_participants_widget.dart
@@ -4,6 +4,7 @@ import 'package:collection/collection.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/spaces/load_participants_builder.dart';
@@ -55,6 +56,12 @@ class RoomParticipantsSection extends StatelessWidget {
 
           return rankOf(a).compareTo(rankOf(b));
         });
+
+        if (room.showActivityChatUI) {
+          filteredParticipants.removeWhere(
+            (u) => u.id == BotName.byEnvironment,
+          );
+        }
 
         return Wrap(
           spacing: 8.0,

--- a/lib/widgets/users/member_actions_popup_menu_button.dart
+++ b/lib/widgets/users/member_actions_popup_menu_button.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
+import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/features/bot/widgets/bot_chat_settings_dialog.dart';
 import 'package:fluffychat/features/join_codes/knocked_rooms_extension.dart';
@@ -51,6 +52,9 @@ void showMemberActionsPopupMenu({
     ),
     Offset.zero & overlay.size,
   );
+
+  final bool isBotInActivity =
+      user.id == BotName.byEnvironment && room?.showActivityChatUI == true;
 
   final action = await showMenu<_MemberActions>(
     // #Pangea
@@ -210,7 +214,9 @@ void showMemberActionsPopupMenu({
         ),
       // #Pangea
       // if (user.canKick)
-      if (user.canKick && user.membership != Membership.knock)
+      if (user.canKick &&
+          user.membership != Membership.knock &&
+          !isBotInActivity)
         // Pangea#
         PopupMenuItem(
           value: _MemberActions.kick,
@@ -228,7 +234,7 @@ void showMemberActionsPopupMenu({
             ],
           ),
         ),
-      if (user.canBan && user.membership != Membership.ban)
+      if (user.canBan && user.membership != Membership.ban && !isBotInActivity)
         PopupMenuItem(
           value: _MemberActions.ban,
           child: Row(
@@ -438,16 +444,4 @@ void showMemberActionsPopupMenu({
   }
 }
 
-enum _MemberActions {
-  info,
-  mention,
-  setRole,
-  kick,
-  ban,
-  approve,
-  unban,
-  // #Pangea
-  // report,
-  chat,
-  // Pangea#
-}
+enum _MemberActions { info, mention, setRole, kick, ban, approve, unban, chat }


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
