### PR TITLE
chore: use CEFR category titles in map filters

### DIFF
--- a/lib/routes/world/world_map_search_overlay.dart
+++ b/lib/routes/world/world_map_search_overlay.dart
@@ -143,7 +143,7 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
                 if (level != LanguageLevelTypeEnum.preA1) ...[
                   FilterChip(
                     selected: widget.filter.cefrFilter.contains(level),
-                    label: Text(level.string),
+                    label: Text(level.title(context)),
                     onSelected: (_) => widget.toggleCefr(level),
                   ),
                   const SizedBox(width: 6),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the text shown on language-level filter chips in the world map search overlay, so labels now display the correct context-based titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->