### PR TITLE
chore: remove stale Flutter version comment from pubspec

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -8,6 +8,8 @@ Follows the [cross-repo testing strategy](../../../.github/instructions/testing.
 
 ## Stack
 
+> **Run tests via `fvm flutter test`, not bare `flutter test`.** The repo pins the Flutter SDK in `.fvmrc`; a different `flutter` on your `PATH` can churn `pubspec.lock`. If that lockfile shows up in your diff, you used the wrong SDK — revert it and re-run under `fvm`.
+
 - **Framework**: `flutter test` (Dart test runner), Playwright Test (web E2E + axe-core a11y)
 - **Language**: Dart, TypeScript (Playwright specs)
 - **Unit/widget tests**: `test/` directory

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,6 @@ name: fluffychat
 # #Pangea
 # description: Chat with your friends.
 description: Learn a language while texting your friends.
-# !!!!!! flutter version: 3.16.9 !!!!!!
 # Pangea#
 publish_to: none
 # On version bump also increase the build number for F-Droid


### PR DESCRIPTION
Two small hygiene changes:

1. Removes the decorative `# !!!!!! flutter version: 3.16.9 !!!!!!` comment from `pubspec.yaml`. It was stale (dated March 2024) and misleading — the real Flutter SDK pin lives in `.fvmrc` (3.41.4). No functional change.
2. Adds an fvm-first note to `.github/instructions/testing.instructions.md` so `bare flutter test` under the wrong SDK stops churning `pubspec.lock`.

## TO TEST
- CI green (analyze/build/test). No runtime behavior changes.