### PR TITLE
Fix YouTube thumbnails: 16:9 poster, and show/play the video on the activity start page

### DIFF
--- a/lib/features/activity_sessions/activity_media_block.dart
+++ b/lib/features/activity_sessions/activity_media_block.dart
@@ -68,8 +68,15 @@ class ActivityMediaBlock {
   /// YouTube's own poster image for [youtubeId], or null when the id can't be
   /// parsed — so a thumbnail-less `youtube` block still shows a real poster
   /// instead of falling back to the (non-image) watch URL.
+  ///
+  /// Uses the `mqdefault` variant (320×180) because it is the smallest poster
+  /// that matches a 16:9 video with **no baked-in letterbox bars**. The 4:3
+  /// variants (`default`, `hqdefault`, `sddefault`) pad widescreen videos with
+  /// black top/bottom bars that survive our square `BoxFit.cover` crop; do not
+  /// switch back to them for resolution. `maxresdefault` is 16:9 too but 404s
+  /// for videos without an HD source, so it isn't a safe unconditional choice.
   String? get youtubeThumbnailUrl => youtubeId != null
-      ? 'https://img.youtube.com/vi/$youtubeId/hqdefault.jpg'
+      ? 'https://img.youtube.com/vi/$youtubeId/mqdefault.jpg'
       : null;
 
   /// The best displayable image URL for a render at [width] px, or null when

--- a/lib/features/activity_sessions/activity_plan_model.dart
+++ b/lib/features/activity_sessions/activity_plan_model.dart
@@ -120,6 +120,30 @@ class ActivityPlanModel {
   /// avatar).
   ActivityMediaBlock? get heroBlock => media.firstOrNull;
 
+  /// First *visible* media block (image / video / youtube) — the lead the
+  /// focused start-page hero renders. Skips non-visual (audio) blocks so an
+  /// audio-first activity doesn't try to paint an audio URL as an image.
+  ActivityMediaBlock? get visibleHeroBlock =>
+      media.firstWhereOrNull((b) => b.isImage || b.isVideo || b.isYoutube);
+
+  /// The poster the start-page hero shows: the visible lead block's image (a
+  /// video/YouTube block resolves to its poster frame, so a video-first
+  /// activity leads with its own frame instead of the generic placeholder),
+  /// falling back to [imageURL] (legacy single image → deterministic
+  /// placeholder) when there is no visible block.
+  Uri? get heroDisplayUrl {
+    final url = visibleHeroBlock?.displayUrl();
+    return url != null ? Uri.tryParse(url) : imageURL;
+  }
+
+  /// Whether the start-page hero's lead block plays — a video or YouTube clip.
+  /// Drives the hero's play badge and inline player. An image (or no media)
+  /// lead is not playable and renders as a still.
+  bool get heroIsPlayable {
+    final b = visibleHeroBlock;
+    return b != null && (b.isVideo || b.isYoutube);
+  }
+
   /// Whether the activity has any video or YouTube block — media that plays.
   /// The live session shows the inline carousel (so it can be played) only for
   /// these, and suppresses the blurred background image in that case;

--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -10,16 +10,14 @@ import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/widgets/error_indicator.dart';
-import 'package:fluffychat/routes/chat/activity_sessions/activity_goals_dropdown.dart';
-import 'package:fluffychat/routes/chat/activity_sessions/activity_participant_list.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_bottom_content.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_button_widget.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_controller.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_start_hero.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_vocab_widget.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
-import 'package:fluffychat/widgets/url_image_widget.dart';
 
 /// The location that closes a non-embedded activity plan opened as a room/
 /// session token (the chat list / a left panel): it drops ONLY that token, so
@@ -171,111 +169,10 @@ class ActivitySessionStartView extends StatelessWidget {
                           controller: controller.scrollController,
                           child: Column(
                             children: [
-                              Stack(
-                                children: [
-                                  // Background image — now Positioned with explicit height instead of
-                                  // living inside a height-constrained Container
-                                  Positioned(
-                                    top: 0,
-                                    left: 0,
-                                    right: 0,
-                                    height: 375.0,
-                                    child: LayoutBuilder(
-                                      builder: (context, constraints) =>
-                                          ImageByUrl(
-                                            imageUrl: activity.imageURL,
-                                            borderRadius: BorderRadius.zero,
-                                            width: constraints.maxWidth,
-                                            replacement: Container(
-                                              width: constraints.maxWidth,
-                                              height: 350.0,
-                                              decoration: BoxDecoration(
-                                                gradient: LinearGradient(
-                                                  begin: Alignment.topCenter,
-                                                  end: Alignment.bottomCenter,
-                                                  colors: [
-                                                    theme
-                                                        .colorScheme
-                                                        .primaryContainer,
-                                                    theme.colorScheme.surface,
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                    ),
-                                  ),
-                                  Positioned.fill(
-                                    top: 250.0,
-                                    child: Container(
-                                      decoration: BoxDecoration(
-                                        gradient: LinearGradient(
-                                          begin: Alignment.topCenter,
-                                          end: Alignment.center,
-                                          colors: [
-                                            theme.colorScheme.surface.withAlpha(
-                                              0,
-                                            ),
-                                            theme.colorScheme.surface,
-                                          ],
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                  if (sessionController.showRoleCards)
-                                    Padding(
-                                      padding: const EdgeInsets.only(
-                                        top: 250.0,
-                                      ),
-                                      child: Center(
-                                        child: Container(
-                                          padding: const EdgeInsets.symmetric(
-                                            horizontal: 16.0,
-                                          ),
-                                          constraints: const BoxConstraints(
-                                            maxWidth: 600.0,
-                                          ),
-                                          child: Opacity(
-                                            opacity: sessionController
-                                                .roleCardOpacity,
-                                            child: ActivityParticipantList(
-                                              activity: activity,
-                                              room: controller.activityRoom,
-                                              assignedRoles:
-                                                  controller.assignedRoles,
-                                              course: controller.courseParent,
-                                              onTap:
-                                                  sessionController.selectRole,
-                                              canSelect: sessionController
-                                                  .canSelectRole,
-                                              isSelected: sessionController
-                                                  .isRoleSelected,
-                                              isShimmering: sessionController
-                                                  .isRoleShimmering,
-                                              showStarsCard: sessionController
-                                                  .showStarsCard,
-                                              completedGoalsForRole:
-                                                  sessionController
-                                                      .completedGoalIdsForRole,
-                                            ),
-                                          ),
-                                        ),
-                                      ),
-                                    ),
-                                  Positioned(
-                                    top: 0,
-                                    left: 0,
-                                    right: 0,
-                                    child: ActivityGoalsDropdown(
-                                      goals:
-                                          sessionController.selectedRoleGoals,
-                                      completedGoalIds: sessionController
-                                          .selectedRoleCompletedGoalIds,
-                                      startCollapsed:
-                                          sessionController.goalsStartCollapsed,
-                                    ),
-                                  ),
-                                ],
+                              ActivityStartHero(
+                                controller: controller,
+                                sessionController: sessionController,
+                                activity: activity,
                               ),
                               if (sessionController.showDescriptionSection)
                                 Center(

--- a/lib/routes/chat/activity_sessions/activity_start_hero.dart
+++ b/lib/routes/chat/activity_sessions/activity_start_hero.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_media_block.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_goals_dropdown.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_media_play_badge.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_participant_list.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_controller.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_video_player.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_youtube_player.dart';
+import 'package:fluffychat/widgets/url_image_widget.dart';
+
+/// The activity start page's hero: a full-bleed background over which the role
+/// cards and goals dropdown float.
+///
+/// The plan page is a focused surface, so media plays in place (see
+/// activities.instructions.md). When the activity's lead media block is a video
+/// or YouTube clip, the hero shows that block's poster with a play badge, and
+/// tapping it mounts the player inline. While the clip plays, the role cards,
+/// gradient, and goals overlay fade out so the player is unobstructed; a close
+/// control returns to the poster and restores the overlays.
+///
+/// A non-playable (image) lead, or an activity with no media, renders as before:
+/// the poster/placeholder with the cards over it and no play affordance.
+class ActivityStartHero extends StatefulWidget {
+  final ActivitySessionStartState controller;
+  final ActivitySessionStateController sessionController;
+  final ActivityPlanModel activity;
+
+  const ActivityStartHero({
+    super.key,
+    required this.controller,
+    required this.sessionController,
+    required this.activity,
+  });
+
+  @override
+  State<ActivityStartHero> createState() => _ActivityStartHeroState();
+}
+
+class _ActivityStartHeroState extends State<ActivityStartHero> {
+  /// True once the learner taps play: the inline player is mounted and the
+  /// overlays fade out. The close control resets it back to the poster.
+  bool _playing = false;
+
+  static const _fadeDuration = Duration(milliseconds: 250);
+  static const _bgHeight = 375.0;
+
+  ActivitySessionStartState get _controller => widget.controller;
+  ActivitySessionStateController get _session => widget.sessionController;
+  ActivityPlanModel get _activity => widget.activity;
+  ActivityMediaBlock? get _hero => _activity.visibleHeroBlock;
+
+  void _play() => setState(() => _playing = true);
+  void _stop() => setState(() => _playing = false);
+
+  /// Fades [child] out (and back) as [_playing] toggles, and stops it capturing
+  /// taps while faded so the player underneath stays interactive.
+  Widget _overlay(Widget child) => AnimatedOpacity(
+    opacity: _playing ? 0.0 : 1.0,
+    duration: _fadeDuration,
+    child: IgnorePointer(ignoring: _playing, child: child),
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Stack(
+      children: [
+        // Background: the inline player while playing, else the poster (with a
+        // play badge when the lead block is a video/YouTube clip).
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          height: _bgHeight,
+          child: LayoutBuilder(
+            builder: (context, constraints) =>
+                _background(theme, constraints.maxWidth),
+          ),
+        ),
+        // Gradient bridge from the image into the page — an overlay, so it fades
+        // with the cards and doesn't tint the video or hide its controls.
+        Positioned.fill(
+          top: 250.0,
+          child: _overlay(
+            Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.center,
+                  colors: [
+                    theme.colorScheme.surface.withAlpha(0),
+                    theme.colorScheme.surface,
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+        if (_session.showRoleCards)
+          Padding(
+            padding: const EdgeInsets.only(top: 250.0),
+            child: Center(
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                constraints: const BoxConstraints(maxWidth: 600.0),
+                child: _overlay(
+                  Opacity(
+                    opacity: _session.roleCardOpacity,
+                    child: ActivityParticipantList(
+                      activity: _activity,
+                      room: _controller.activityRoom,
+                      assignedRoles: _controller.assignedRoles,
+                      course: _controller.courseParent,
+                      onTap: _session.selectRole,
+                      canSelect: _session.canSelectRole,
+                      isSelected: _session.isRoleSelected,
+                      isShimmering: _session.isRoleShimmering,
+                      showStarsCard: _session.showStarsCard,
+                      completedGoalsForRole: _session.completedGoalIdsForRole,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          child: _overlay(
+            ActivityGoalsDropdown(
+              goals: _session.selectedRoleGoals,
+              completedGoalIds: _session.selectedRoleCompletedGoalIds,
+              startCollapsed: _session.goalsStartCollapsed,
+            ),
+          ),
+        ),
+        if (_playing)
+          Positioned(
+            top: 8.0,
+            right: 8.0,
+            child: Material(
+              color: Colors.black54,
+              shape: const CircleBorder(),
+              clipBehavior: Clip.hardEdge,
+              child: IconButton(
+                tooltip: L10n.of(context).close,
+                icon: const Icon(Icons.close, color: Colors.white),
+                onPressed: _stop,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _background(ThemeData theme, double width) {
+    final hero = _hero;
+    if (_playing && hero != null) {
+      final player = hero.isYoutube
+          ? ActivityYoutubePlayer(url: hero.url ?? '')
+          : ActivityVideoPlayer(url: hero.resolvedUrl ?? '', autoPlay: true);
+      return ColoredBox(
+        color: Colors.black,
+        child: Center(
+          child: AspectRatio(aspectRatio: 16 / 9, child: player),
+        ),
+      );
+    }
+
+    final poster = ImageByUrl(
+      imageUrl: _activity.heroDisplayUrl,
+      borderRadius: BorderRadius.zero,
+      width: width,
+      replacement: Container(
+        width: width,
+        height: 350.0,
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [
+              theme.colorScheme.primaryContainer,
+              theme.colorScheme.surface,
+            ],
+          ),
+        ),
+      ),
+    );
+
+    if (!_activity.heroIsPlayable) return poster;
+
+    // Tap the poster (or the badge) to play in place. The badge sits above the
+    // role cards (they start 250px down), so it stays reachable.
+    return GestureDetector(
+      onTap: _play,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [poster, const ActivityMediaPlayBadge(size: 56.0)],
+      ),
+    );
+  }
+}

--- a/test/pangea/activity_media_block_youtube_thumbnail_test.dart
+++ b/test/pangea/activity_media_block_youtube_thumbnail_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_media_block.dart';
+
+void main() {
+  group('ActivityMediaBlock youtube poster', () {
+    ActivityMediaBlock yt(String url, {String? thumbnailUrl}) =>
+        ActivityMediaBlock(
+          blockType: 'youtube',
+          url: url,
+          thumbnailUrl: thumbnailUrl,
+        );
+
+    test('parses the 11-char id from watch / youtu.be / embed / shorts urls', () {
+      const id = 'dQw4w9WgXcQ';
+      expect(yt('https://www.youtube.com/watch?v=$id').youtubeId, id);
+      expect(yt('https://youtu.be/$id').youtubeId, id);
+      expect(yt('https://www.youtube.com/embed/$id').youtubeId, id);
+      expect(yt('https://www.youtube.com/shorts/$id').youtubeId, id);
+      // Extra query params around v= still resolve.
+      expect(
+        yt('https://www.youtube.com/watch?list=abc&v=$id&t=3s').youtubeId,
+        id,
+      );
+    });
+
+    test('derives a 16:9 mqdefault poster (no baked-in letterbox bars)', () {
+      final block = yt('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+      expect(
+        block.youtubeThumbnailUrl,
+        'https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg',
+      );
+      // Guard against a regression to any of the 4:3 (letterboxed) variants.
+      expect(block.youtubeThumbnailUrl, isNot(contains('hqdefault')));
+      expect(block.youtubeThumbnailUrl, isNot(contains('sddefault')));
+      expect(
+        block.youtubeThumbnailUrl,
+        isNot(endsWith('/default.jpg')),
+      );
+    });
+
+    test('displayUrl prefers an explicit thumbnailUrl over the derived poster',
+        () {
+      final block = yt(
+        'https://youtu.be/dQw4w9WgXcQ',
+        thumbnailUrl: 'https://content.pangea.chat/custom-poster.jpg',
+      );
+      expect(block.displayUrl(256), 'https://content.pangea.chat/custom-poster.jpg');
+    });
+
+    test('displayUrl falls back to the derived poster when no thumbnailUrl', () {
+      final block = yt('https://youtu.be/dQw4w9WgXcQ');
+      expect(
+        block.displayUrl(256),
+        'https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg',
+      );
+    });
+
+    test('unparseable youtube url yields no derived poster', () {
+      final block = yt('https://example.com/not-a-video');
+      expect(block.youtubeId, isNull);
+      expect(block.youtubeThumbnailUrl, isNull);
+      expect(block.displayUrl(256), isNull);
+    });
+  });
+}

--- a/test/pangea/activity_media_block_youtube_thumbnail_test.dart
+++ b/test/pangea/activity_media_block_youtube_thumbnail_test.dart
@@ -11,18 +11,21 @@ void main() {
           thumbnailUrl: thumbnailUrl,
         );
 
-    test('parses the 11-char id from watch / youtu.be / embed / shorts urls', () {
-      const id = 'dQw4w9WgXcQ';
-      expect(yt('https://www.youtube.com/watch?v=$id').youtubeId, id);
-      expect(yt('https://youtu.be/$id').youtubeId, id);
-      expect(yt('https://www.youtube.com/embed/$id').youtubeId, id);
-      expect(yt('https://www.youtube.com/shorts/$id').youtubeId, id);
-      // Extra query params around v= still resolve.
-      expect(
-        yt('https://www.youtube.com/watch?list=abc&v=$id&t=3s').youtubeId,
-        id,
-      );
-    });
+    test(
+      'parses the 11-char id from watch / youtu.be / embed / shorts urls',
+      () {
+        const id = 'dQw4w9WgXcQ';
+        expect(yt('https://www.youtube.com/watch?v=$id').youtubeId, id);
+        expect(yt('https://youtu.be/$id').youtubeId, id);
+        expect(yt('https://www.youtube.com/embed/$id').youtubeId, id);
+        expect(yt('https://www.youtube.com/shorts/$id').youtubeId, id);
+        // Extra query params around v= still resolve.
+        expect(
+          yt('https://www.youtube.com/watch?list=abc&v=$id&t=3s').youtubeId,
+          id,
+        );
+      },
+    );
 
     test('derives a 16:9 mqdefault poster (no baked-in letterbox bars)', () {
       final block = yt('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
@@ -33,28 +36,33 @@ void main() {
       // Guard against a regression to any of the 4:3 (letterboxed) variants.
       expect(block.youtubeThumbnailUrl, isNot(contains('hqdefault')));
       expect(block.youtubeThumbnailUrl, isNot(contains('sddefault')));
-      expect(
-        block.youtubeThumbnailUrl,
-        isNot(endsWith('/default.jpg')),
-      );
+      expect(block.youtubeThumbnailUrl, isNot(endsWith('/default.jpg')));
     });
 
-    test('displayUrl prefers an explicit thumbnailUrl over the derived poster',
-        () {
-      final block = yt(
-        'https://youtu.be/dQw4w9WgXcQ',
-        thumbnailUrl: 'https://content.pangea.chat/custom-poster.jpg',
-      );
-      expect(block.displayUrl(256), 'https://content.pangea.chat/custom-poster.jpg');
-    });
+    test(
+      'displayUrl prefers an explicit thumbnailUrl over the derived poster',
+      () {
+        final block = yt(
+          'https://youtu.be/dQw4w9WgXcQ',
+          thumbnailUrl: 'https://content.pangea.chat/custom-poster.jpg',
+        );
+        expect(
+          block.displayUrl(256),
+          'https://content.pangea.chat/custom-poster.jpg',
+        );
+      },
+    );
 
-    test('displayUrl falls back to the derived poster when no thumbnailUrl', () {
-      final block = yt('https://youtu.be/dQw4w9WgXcQ');
-      expect(
-        block.displayUrl(256),
-        'https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg',
-      );
-    });
+    test(
+      'displayUrl falls back to the derived poster when no thumbnailUrl',
+      () {
+        final block = yt('https://youtu.be/dQw4w9WgXcQ');
+        expect(
+          block.displayUrl(256),
+          'https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg',
+        );
+      },
+    );
 
     test('unparseable youtube url yields no derived poster', () {
       final block = yt('https://example.com/not-a-video');

--- a/test/pangea/activity_plan_model_hero_test.dart
+++ b/test/pangea/activity_plan_model_hero_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_media_block.dart';
+import 'package:fluffychat/features/activity_sessions/activity_media_enum.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_request.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+
+void main() {
+  ActivityPlanRequest req() => ActivityPlanRequest(
+    topic: 'jobs',
+    mode: 'Roleplay',
+    objective: 'introduce yourself',
+    media: MediaEnum.nan,
+    cefrLevel: LanguageLevelTypeEnum.a1,
+    languageOfInstructions: 'en',
+    targetLanguage: 'de',
+    numberOfParticipants: 2,
+  );
+
+  ActivityPlanModel plan(
+    List<ActivityMediaBlock> media, {
+    String? imageURL,
+  }) => ActivityPlanModel(
+    req: req(),
+    title: 'Speed-Dating Interview',
+    learningObjective: 'lo',
+    instructions: 'i',
+    vocab: const [],
+    activityId: 'act-1',
+    imageURL: imageURL,
+    media: media,
+  );
+
+  ActivityMediaBlock youtube(String url) =>
+      ActivityMediaBlock(blockType: 'youtube', url: url);
+  ActivityMediaBlock image(String resolvedUrl) =>
+      ActivityMediaBlock(blockType: 'image', resolvedUrl: resolvedUrl);
+  ActivityMediaBlock audio(String resolvedUrl) =>
+      ActivityMediaBlock(blockType: 'audio', resolvedUrl: resolvedUrl);
+
+  group('ActivityPlanModel start-page hero', () {
+    test('a youtube lead leads with the video poster, not the placeholder', () {
+      final p = plan([youtube('https://youtu.be/dQw4w9WgXcQ')]);
+      expect(p.visibleHeroBlock?.isYoutube, isTrue);
+      expect(p.heroIsPlayable, isTrue);
+      expect(
+        p.heroDisplayUrl.toString(),
+        'https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg',
+      );
+    });
+
+    test('an image lead is not playable and shows the image', () {
+      final p = plan([image('https://content.pangea.chat/hero.jpg')]);
+      expect(p.heroIsPlayable, isFalse);
+      expect(
+        p.heroDisplayUrl.toString(),
+        'https://content.pangea.chat/hero.jpg',
+      );
+    });
+
+    test('skips a non-visual audio lead to the first visible block', () {
+      final p = plan([
+        audio('https://content.pangea.chat/clip.mp3'),
+        youtube('https://youtu.be/dQw4w9WgXcQ'),
+      ]);
+      expect(p.visibleHeroBlock?.isYoutube, isTrue);
+      expect(p.heroIsPlayable, isTrue);
+      expect(
+        p.heroDisplayUrl.toString(),
+        'https://img.youtube.com/vi/dQw4w9WgXcQ/mqdefault.jpg',
+      );
+    });
+
+    test('no media falls back to the legacy image url', () {
+      final p = plan(
+        const [],
+        imageURL: 'https://content.pangea.chat/legacy.png',
+      );
+      expect(p.visibleHeroBlock, isNull);
+      expect(p.heroIsPlayable, isFalse);
+      expect(p.heroDisplayUrl.toString(), contains('legacy.png'));
+    });
+
+    test('no media and no image url yields a deterministic placeholder, never null', () {
+      final p = plan(const []);
+      expect(p.heroIsPlayable, isFalse);
+      expect(p.heroDisplayUrl, isNotNull);
+      // A real placeholder asset, not a broken/absent poster.
+      expect(p.heroDisplayUrl.toString(), contains('Space%20template'));
+    });
+  });
+}

--- a/test/pangea/activity_plan_model_hero_test.dart
+++ b/test/pangea/activity_plan_model_hero_test.dart
@@ -18,19 +18,17 @@ void main() {
     numberOfParticipants: 2,
   );
 
-  ActivityPlanModel plan(
-    List<ActivityMediaBlock> media, {
-    String? imageURL,
-  }) => ActivityPlanModel(
-    req: req(),
-    title: 'Speed-Dating Interview',
-    learningObjective: 'lo',
-    instructions: 'i',
-    vocab: const [],
-    activityId: 'act-1',
-    imageURL: imageURL,
-    media: media,
-  );
+  ActivityPlanModel plan(List<ActivityMediaBlock> media, {String? imageURL}) =>
+      ActivityPlanModel(
+        req: req(),
+        title: 'Speed-Dating Interview',
+        learningObjective: 'lo',
+        instructions: 'i',
+        vocab: const [],
+        activityId: 'act-1',
+        imageURL: imageURL,
+        media: media,
+      );
 
   ActivityMediaBlock youtube(String url) =>
       ActivityMediaBlock(blockType: 'youtube', url: url);
@@ -82,12 +80,15 @@ void main() {
       expect(p.heroDisplayUrl.toString(), contains('legacy.png'));
     });
 
-    test('no media and no image url yields a deterministic placeholder, never null', () {
-      final p = plan(const []);
-      expect(p.heroIsPlayable, isFalse);
-      expect(p.heroDisplayUrl, isNotNull);
-      // A real placeholder asset, not a broken/absent poster.
-      expect(p.heroDisplayUrl.toString(), contains('Space%20template'));
-    });
+    test(
+      'no media and no image url yields a deterministic placeholder, never null',
+      () {
+        final p = plan(const []);
+        expect(p.heroIsPlayable, isFalse);
+        expect(p.heroDisplayUrl, isNotNull);
+        // A real placeholder asset, not a broken/absent poster.
+        expect(p.heroDisplayUrl.toString(), contains('Space%20template'));
+      },
+    );
   });
 }


### PR DESCRIPTION
Two related fixes to how activity YouTube videos show up.

## 1. Thumbnail letterboxing

The derived YouTube poster used `hqdefault.jpg`, a 4:3 image with black bars baked in for 16:9 videos. Posters render into a square with `BoxFit.cover`, so those bars stayed visible on the activity cards and map pins. Switched to the 16:9 `mqdefault.jpg` variant: no bars, and it exists for every video, unlike `maxresdefault` which 404s for many. This fixes the bars everywhere the poster shows (cards, list tiles, map pins, and now the start page).

## 2. Video missing on the start page

The start-page hero rendered `activity.imageURL`, which only considers image blocks. A video-only activity (like Speed-Dating Interview) therefore fell through to the random placeholder illustration even though its YouTube block was present. The hero now leads with the video's poster and a play badge. Tapping plays the clip inline, since the plan page is a focused surface where media plays in place. When play starts, the role cards, gradient, and goals overlay fade out so the player is not obstructed; a close control returns to the poster and restores the overlays.

## Changes

- `ActivityMediaBlock.youtubeThumbnailUrl` builds the `mqdefault` URL, with a comment on why not to revert to a 4:3 variant.
- New `ActivityPlanModel` getters (`visibleHeroBlock`, `heroDisplayUrl`, `heroIsPlayable`) encode the hero decision and skip non-visual (audio) leads.
- The start-page hero is extracted into `ActivityStartHero`, a stateful widget that owns the play/fade state and reuses the existing `ActivityYoutubePlayer` / `ActivityVideoPlayer`.

## Tests

- `activity_media_block_youtube_thumbnail_test.dart`: the 16:9 poster, with a guard against regressing to a 4:3 variant.
- `activity_plan_model_hero_test.dart`: the hero getters (video lead, image lead, audio-skip, placeholder fallback).
- `flutter analyze` is clean on all changed files.

## Not verified here

The inline play, the fade-on-play, and the poster rendering need a visual pass against staging with a real YouTube activity. The YouTube embed is a platform view that unit and widget tests cannot exercise, so I verified the pure logic and left the interaction for a manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
