### PR TITLE
chore: set environment user property on init Google Analytics

### DIFF
--- a/lib/pangea/common/utils/firebase_analytics.dart
+++ b/lib/pangea/common/utils/firebase_analytics.dart
@@ -59,6 +59,7 @@ class GoogleAnalytics {
     analytics = FirebaseAnalytics.instanceFor(app: app);
     // Client is not automatically set on web
     await _setClientVersion();
+    await _setEnvironment();
 
     debugPrint("Firebase App Name: ${app.name}");
     debugPrint("Firebase App Options:");
@@ -79,6 +80,13 @@ class GoogleAnalytics {
     } catch (error) {
       debugPrint('Unable to set analytics client version: $error');
     }
+  }
+
+  static Future<void> _setEnvironment() async {
+    await analytics?.setUserProperty(
+      name: 'environment',
+      value: Environment.isStagingEnvironment ? 'staging' : 'prod',
+    );
   }
 
   static Future<void> analyticsUserUpdate(String? userID) async {


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
