### PR TITLE
Center email signup title

### DIFF
--- a/lib/routes/home/signup/signup_with_email_view.dart
+++ b/lib/routes/home/signup/signup_with_email_view.dart
@@ -19,6 +19,7 @@ class SignupWithEmailView extends StatelessWidget {
         key: controller.formKey,
         child: Scaffold(
           appBar: AppBar(
+            centerTitle: true,
             title: ConstrainedBox(
               constraints: const BoxConstraints(maxWidth: 450),
               child: Row(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Centered the title in the sign-up screen’s app bar for a more balanced header layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->