### PR TITLE
fix(activities): anchor hero height so a playing video leaves no empty scroll gap

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_start_hero.dart
+++ b/lib/routes/chat/activity_sessions/activity_start_hero.dart
@@ -103,10 +103,15 @@ class _ActivityStartHeroState extends State<ActivityStartHero> {
         // Background: the inline player while playing, else the poster (with a
         // play badge when the lead block is a video/YouTube clip). The player
         // carries its own close control, so nothing is stacked above it here.
-        Positioned(
-          top: 0,
-          left: 0,
-          right: 0,
+        //
+        // Non-positioned, so it anchors the Stack's height at [_bgHeight] in
+        // every state. The hero sits in a scroll view (unbounded height), so the
+        // Stack sizes to its non-positioned children. While playing the overlays
+        // are removed and the role cards were the only other non-positioned
+        // child; without this anchor the Stack would collapse to zero, unsizing
+        // the player and leaving an empty scroll gap below the video (#7490).
+        SizedBox(
+          width: double.infinity,
           height: _bgHeight,
           child: LayoutBuilder(
             builder: (context, constraints) =>


### PR DESCRIPTION
Fixes #7490 — the empty scrollable space below a playing video on the activity start page hero (`activity_start_hero.dart`, added in #7477).

## Root cause

The hero sits inside a `SingleChildScrollView`, so its `Stack` has unbounded height and sizes to its non-positioned children. The role cards were the only non-positioned child. While a video plays, #7489 fades the cards out and (correctly) removes them from the tree once faded — but with nothing non-positioned left, the `Stack` would collapse to zero height, unsizing the 16:9 player and leaving dead scroll space below it. On current staging (pre-#7489) the same region shows as the invisible, still-mounted cards.

## Fix

Anchor the background (poster or player) as a non-positioned child at a fixed `375` height, so the hero `Stack` is always at least that tall, in every state — playing or not, cards shown or not. While playing, the hero is exactly the player, and the activity details (description, vocab, join buttons) follow immediately below with no gap. This is option A from the issue.

## Testing

- `flutter analyze` clean on the changed file and the whole `activity_sessions/` module.
- Existing hero unit tests pass (`activity_plan_model_hero_test.dart`, `activity_media_block_youtube_thumbnail_test.dart`).
- Scroll layout can only be fully confirmed in a real browser, so please verify on staging: open an activity with a video/YouTube lead (e.g. Networking Salon), press play, and scroll down — the activity details should sit right below the video with no empty gap.

## Note on branch history

This PR's commit (`fix(activities): anchor hero height...`) originally shipped as the second commit on the `fix/activity-hero-player-pointer` branch, alongside the pointer-swallow fix. That branch's first commit was squash-merged as #7489, which left the branch's remaining commit looking diverged from `main` (same content, different SHA) — that surfaced as PR #7492 showing conflicts. This PR is that same commit cherry-picked cleanly onto current `main`, replacing #7492.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the hero background and inline player area layout during playback.
  * The header area now uses a more stable full-width sizing approach, reducing layout issues caused by the previous positioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->