### PR TITLE
fix(a11y): mark the large-card thumbnail decorative for the floor check

### DIFF
--- a/lib/routes/world/world_map_large_card.dart
+++ b/lib/routes/world/world_map_large_card.dart
@@ -365,6 +365,9 @@ class _Header extends StatelessWidget {
                   ? Image.network(
                       imageUrl.toString(),
                       fit: BoxFit.cover,
+                      // Decorative: the ancestor ExcludeSemantics already hides
+                      // it; stated here too for the a11y floor check.
+                      excludeFromSemantics: true,
                       errorBuilder: (context, _, _) =>
                           Container(color: Colors.black12),
                     )


### PR DESCRIPTION
## What
One line: `excludeFromSemantics: true` on the large-card thumbnail `Image.network` (it already sits inside an `ExcludeSemantics` ancestor, so this states the intent where the floor check's textual scan can see it).

## Why
The a11y floor check is currently RED on main (the last three integrate runs failed) — this image landed without a name/decorative marker. Every open PR inherits the failure.

## Testing
`python3 scripts/a11y_floor_check.py` green locally; no behavior change (the ancestor already excluded it from semantics).

## Accessibility
- [x] New or changed controls have an accessible name, and decorative images use `excludeFromSemantics: true`.

## TO TEST
No client testing needed, decorative-marker annotation only; no runtime surface.

## Deploy Notes
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility behavior for a decorative activity header image so it is consistently ignored by screen readers and other semantic tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->