### PR TITLE
Move staging info and version number into developer options

### DIFF
--- a/lib/routes/settings/settings_view.dart
+++ b/lib/routes/settings/settings_view.dart
@@ -335,55 +335,64 @@ class SettingsView extends StatelessWidget {
                       onTap: () => launchUrlString(AppConfig.termsOfServiceUrl),
                       trailing: const Icon(Icons.open_in_new_outlined),
                     ),
-                    FutureBuilder<PackageInfo>(
-                      future: PackageInfo.fromPlatform(),
-                      builder: (context, snapshot) {
-                        if (snapshot.connectionState == ConnectionState.done) {
-                          return ListTile(
-                            leading: const Icon(Icons.info_outline),
-                            trailing: const Icon(Icons.copy_outlined),
-                            onTap: () async {
-                              if (snapshot.data == null) return;
-                              await Clipboard.setData(
-                                ClipboardData(
-                                  text:
-                                      "${snapshot.data!.version}+${snapshot.data!.buildNumber}",
-                                ),
-                              );
-                              ScaffoldMessenger.of(
-                                context,
-                              ).showSnackBarAnnounced(
-                                SnackBar(
-                                  content: Text(
-                                    L10n.of(context).copiedToClipboard,
+                    if (MatrixState
+                        .pangeaController
+                        .userController
+                        .showDeveloperOptions)
+                      FutureBuilder<PackageInfo>(
+                        future: PackageInfo.fromPlatform(),
+                        builder: (context, snapshot) {
+                          if (snapshot.connectionState ==
+                              ConnectionState.done) {
+                            return ListTile(
+                              leading: const Icon(Icons.info_outline),
+                              trailing: const Icon(Icons.copy_outlined),
+                              onTap: () async {
+                                if (snapshot.data == null) return;
+                                await Clipboard.setData(
+                                  ClipboardData(
+                                    text:
+                                        "${snapshot.data!.version}+${snapshot.data!.buildNumber}",
                                   ),
-                                ),
-                              );
-                            },
-                            title: Text(
-                              snapshot.data != null
-                                  ? L10n.of(context).versionText(
-                                      snapshot.data!.version,
-                                      snapshot.data!.buildNumber,
-                                    )
-                                  : L10n.of(context).versionNotFound,
-                            ),
-                          );
-                        } else if (snapshot.hasError) {
-                          return ListTile(
-                            leading: const Icon(Icons.error_outline),
-                            title: Text(L10n.of(context).versionFetchError),
-                          );
-                        } else {
-                          return ListTile(
-                            leading: const CircularProgressIndicator(),
-                            title: Text(L10n.of(context).fetchingVersion),
-                          );
-                        }
-                      },
-                    ),
+                                );
+                                ScaffoldMessenger.of(
+                                  context,
+                                ).showSnackBarAnnounced(
+                                  SnackBar(
+                                    content: Text(
+                                      L10n.of(context).copiedToClipboard,
+                                    ),
+                                  ),
+                                );
+                              },
+                              title: Text(
+                                snapshot.data != null
+                                    ? L10n.of(context).versionText(
+                                        snapshot.data!.version,
+                                        snapshot.data!.buildNumber,
+                                      )
+                                    : L10n.of(context).versionNotFound,
+                              ),
+                            );
+                          } else if (snapshot.hasError) {
+                            return ListTile(
+                              leading: const Icon(Icons.error_outline),
+                              title: Text(L10n.of(context).versionFetchError),
+                            );
+                          } else {
+                            return ListTile(
+                              leading: const CircularProgressIndicator(),
+                              title: Text(L10n.of(context).fetchingVersion),
+                            );
+                          }
+                        },
+                      ),
                     // Conditional ListTile based on the environment (staging or not)
-                    if (Environment.isStagingEnvironment)
+                    if (Environment.isStagingEnvironment &&
+                        MatrixState
+                            .pangeaController
+                            .userController
+                            .showDeveloperOptions)
                       ListTile(
                         leading: const Icon(Icons.bug_report_outlined),
                         title: Text(L10n.of(context).connectedToStaging),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Developer-only settings details are now hidden unless developer options are enabled.
  * The app version entry is no longer shown to all users by default.

* **Bug Fixes**
  * The staging connection status now appears only in staging environments with developer options enabled, reducing unnecessary visibility for regular users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->