### PR TITLE
Remove report translation option

### DIFF
--- a/lib/routes/chat/events/utils/report_message.dart
+++ b/lib/routes/chat/events/utils/report_message.dart
@@ -30,8 +30,7 @@ void reportEvent(
     cancelLabel: L10n.of(context).cancel,
     actions: [
       AdaptiveModalAction(value: 1, label: L10n.of(context).offensive),
-      AdaptiveModalAction(value: 2, label: L10n.of(context).translationProblem),
-      AdaptiveModalAction(value: 3, label: L10n.of(context).other),
+      AdaptiveModalAction(value: 2, label: L10n.of(context).other),
     ],
   );
   if (score == null) return;


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the report-message options shown in the chat flow.
  * Removed the translation-related report option.
  * Kept the offensive-report option available and preserved the existing reporting flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->