### PR TITLE
feat(activities): fall back to embedded state plan or archived view for removed activities

### DIFF
--- a/.github/instructions/activities.instructions.md
+++ b/.github/instructions/activities.instructions.md
@@ -25,6 +25,16 @@ The activity's start page doesn't store its own state; it reads it from the room
 
 When a session counts as "ended" is the org doc's call. The client's part is firing the summary once that happens, and keeping a short-lived local cache of the room's analytics so the page doesn't re-fetch on every visit.
 
+## When the activity can't be fetched
+
+Some session rooms reference an activity that no longer exists on the backend. The fallback ladder and the view-only contract are the org doc's ([Removed or unresolvable activities](../../../.github/.github/instructions/activities.instructions.md#editing-semantics)); what the client shows on each rung:
+
+- **Legacy room with the plan embedded in state** — old rooms stored the whole plan in the `pangea.activity_plan` event, and [`ActivityPlanRepo`](../../lib/features/activity_sessions/activity_plan_repo.dart) falls back to it when the fetch confirms the activity is gone. The session page looks normal — hero media, role cards, goals with labels, description and vocab — but is **view-only**: no picking a role, no scoring, no suggestions. The session presents as ended without writing anything to the room. The summary section works: a cached summary shows, and a new one can still be generated.
+- **No plan anywhere** — instead of an error, the page shows an **archived session**: room name as the title, participants with their roles and finished status, star counts without goal labels, the conversation timeline, and the cached summary if one exists. A banner explains the activity ran on an older version of activities and is no longer supported.
+- **Transient fetch failure** (network, backend down) — a retryable error state, never the archived view or the "no longer supported" banner. Only a confirmed "this activity is gone" response walks down the ladder.
+
+The page never gates its whole render on the plan fetch — the timeline, roles, and progress always display from room state.
+
 ## Two ways in
 
 An activity opens one of two ways: as an overlay over the world map (when the learner is inside its course) or from its own shareable link (when they reach it directly). Both open the same activity surface — a side panel beside the map on a wide screen, a half-open bottom sheet on narrow with the camera settled on its map location (the Google Maps target UX), swipe-expandable to the full plan; see [routing.instructions.md](routing.instructions.md). A link can also ask to skip the lobby straight to role selection, or to reopen a specific in-progress session. The exact URL shapes are the cross-repo [deep-linking](../../../.github/.github/instructions/deep-linking.instructions.md) contract; this doc only relies on them.

--- a/lib/features/activity_sessions/activity_plan_repo.dart
+++ b/lib/features/activity_sessions/activity_plan_repo.dart
@@ -11,8 +11,29 @@ import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/base_repo.dart';
-import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
+
+/// How a plan [ActivityPlanRepo.lookup] resolved.
+enum ActivityPlanLookupStatus {
+  /// The plan was fetched, or served from the cache.
+  found,
+
+  /// The backend confirmed the activity no longer exists (HTTP 404).
+  /// Consumers fall back per the removed-activity ladder in the activities
+  /// instructions doc (embedded state plan → archived view).
+  removed,
+
+  /// Transient failure (network, timeout, 5xx); retrying may succeed. Never
+  /// treated as "removed", so an outage can't mislabel healthy activities.
+  failed,
+}
+
+class ActivityPlanLookup {
+  final ActivityPlanLookupStatus status;
+  final ActivityPlanModel? plan;
+
+  const ActivityPlanLookup(this.status, [this.plan]);
+}
 
 /// The single cached read path for activity plans.
 ///
@@ -49,6 +70,10 @@ class ActivityPlanRepo
   final Set<String> _hydrating = {};
   final Set<String> _revalidated = {};
 
+  /// Activity ids the backend confirmed removed (404) this app session, so
+  /// [ensure] stops re-fetching a known-missing id on every widget rebuild.
+  final Set<String> _confirmedRemoved = {};
+
   @override
   Future<Response> fetch(Requests req, ActivityPlanFetchRequest request) {
     final uri = Uri.parse(PApiUrls.activityById(request.activityId)).replace(
@@ -78,8 +103,27 @@ class ActivityPlanRepo
   /// The plan for [activityId], localized to [l1] (viewer L1 by default), with
   /// media resolved. Cached (TTL + in-flight dedup); null on fetch failure.
   /// [forceRefresh] re-fetches past the TTL (the cache survives until the fresh
-  /// plan lands).
+  /// plan lands). Callers that need to tell a removed activity apart from a
+  /// transient failure use [lookup].
   Future<ActivityPlanModel?> getPlan(
+    String activityId, {
+    String? l1,
+    String? version,
+    bool forceRefresh = false,
+  }) async {
+    final result = await lookup(
+      activityId,
+      l1: l1,
+      version: version,
+      forceRefresh: forceRefresh,
+    );
+    return result.plan;
+  }
+
+  /// [getPlan] with the failure kind surfaced: [ActivityPlanLookupStatus
+  /// .removed] on a confirmed 404 vs [ActivityPlanLookupStatus.failed] on a
+  /// transient error.
+  Future<ActivityPlanLookup> lookup(
     String activityId, {
     String? l1,
     String? version,
@@ -87,14 +131,26 @@ class ActivityPlanRepo
   }) async {
     final request = _request(activityId, l1, version: version);
     final result = await get(request, forceRefresh: forceRefresh);
-    final response = result.result;
-    if (response == null) return null;
+    if (result.isError) {
+      final status = classifyLookupError(result.asError!.error);
+      if (status == ActivityPlanLookupStatus.removed) {
+        _confirmedRemoved.add(activityId);
+      }
+      return ActivityPlanLookup(status);
+    }
 
-    final resolved = await _withResolvedMedia(response.plan);
+    _confirmedRemoved.remove(activityId);
+    final resolved = await resolveMedia(result.asValue!.value.plan);
     _resolved[request.storageKey] = resolved;
     notifyListeners();
-    return resolved;
+    return ActivityPlanLookup(ActivityPlanLookupStatus.found, resolved);
   }
+
+  @visibleForTesting
+  static ActivityPlanLookupStatus classifyLookupError(Object error) =>
+      error is Response && error.statusCode == 404
+      ? ActivityPlanLookupStatus.removed
+      : ActivityPlanLookupStatus.failed;
 
   /// Synchronous lookup for `room.activityPlan`: the media-resolved plan if
   /// [getPlan] has run, else the raw (TTL-checked) cached plan, else null — in
@@ -132,6 +188,9 @@ class ActivityPlanRepo
     String? version,
     bool revalidate = false,
   }) {
+    // A confirmed-removed id can't hydrate; re-fetching on every rebuild of
+    // the sync getter would loop 404s.
+    if (_confirmedRemoved.contains(activityId)) return;
     final key = _request(activityId, l1, version: version).storageKey;
     if (_hydrating.contains(key)) return;
     final doRevalidate = revalidate && _revalidated.add(key);
@@ -145,7 +204,10 @@ class ActivityPlanRepo
     ).whenComplete(() => _hydrating.remove(key));
   }
 
-  Future<ActivityPlanModel> _withResolvedMedia(ActivityPlanModel plan) async {
+  /// Resolves upload-referenced media blocks to CDN urls. Applied to every
+  /// fetched plan, and by fallback consumers to legacy plans read from room
+  /// state (which carry the same unresolved `upload_id` references).
+  Future<ActivityPlanModel> resolveMedia(ActivityPlanModel plan) async {
     final ids = plan.media
         .map((b) => b.uploadId)
         .whereType<String>()

--- a/lib/features/activity_sessions/activity_plan_repo.dart
+++ b/lib/features/activity_sessions/activity_plan_repo.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import 'package:http/http.dart' show Response;
+import 'package:sentry_flutter/sentry_flutter.dart' show SentryLevel;
 
 import 'package:fluffychat/features/activity_sessions/activity_media_repo.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_fetch_request.dart';
@@ -11,6 +12,7 @@ import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/base_repo.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 /// How a plan [ActivityPlanRepo.lookup] resolved.
@@ -207,6 +209,12 @@ class ActivityPlanRepo
   /// Resolves upload-referenced media blocks to CDN urls. Applied to every
   /// fetched plan, and by fallback consumers to legacy plans read from room
   /// state (which carry the same unresolved `upload_id` references).
+  ///
+  /// Fail-soft: a resolution failure (e.g. the CMS media read erroring)
+  /// returns the plan with its blocks unresolved, and they degrade to the
+  /// placeholder render. Media must never take down the plan itself — before
+  /// this guard a CMS 403 surfaced as "Activity not found" on a perfectly
+  /// healthy activity.
   Future<ActivityPlanModel> resolveMedia(ActivityPlanModel plan) async {
     final ids = plan.media
         .map((b) => b.uploadId)
@@ -214,7 +222,18 @@ class ActivityPlanRepo
         .toSet()
         .toList();
     if (ids.isEmpty) return plan;
-    final resolved = await ActivityMediaRepo.resolve(ids);
+    final Map<String, ResolvedMedia> resolved;
+    try {
+      resolved = await ActivityMediaRepo.resolve(ids);
+    } catch (e, s) {
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"activityId": plan.activityId},
+        level: SentryLevel.warning,
+      );
+      return plan;
+    }
     return plan.withMedia(
       plan.media.map((block) {
         final r = block.uploadId == null ? null : resolved[block.uploadId];

--- a/lib/features/activity_sessions/activity_roles_room_extension.dart
+++ b/lib/features/activity_sessions/activity_roles_room_extension.dart
@@ -14,6 +14,24 @@ import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
 
+/// Whether the session counts as started: finished sessions always are;
+/// otherwise every role in the plan is filled. With no plan (not yet hydrated,
+/// or the activity was removed from the backend), the seat math would read
+/// `0 - assigned <= 0` and misclassify every room as started — routing empty
+/// orphan rooms into the chat timeline instead of the start page. Instead, a
+/// plan-less room counts as started only when it has assigned roles (real
+/// progress worth showing in the timeline).
+@visibleForTesting
+bool activityStartedGate({
+  required bool finished,
+  required int? planRoleCount,
+  required int assignedRoleCount,
+}) {
+  if (finished) return true;
+  if (planRoleCount == null) return assignedRoleCount > 0;
+  return planRoleCount - assignedRoleCount <= 0;
+}
+
 class RoleException implements Exception {
   final String message;
   RoleException(this.message);
@@ -55,9 +73,11 @@ extension ActivityRolesRoomExtension on Room {
     return max(0, (availableRoles?.length ?? 0) - (assignedRoles?.length ?? 0));
   }
 
-  bool get isActivityStarted =>
-      isActivityFinished ||
-      (activityPlan?.roles.length ?? 0) - (assignedRoles?.length ?? 0) <= 0;
+  bool get isActivityStarted => activityStartedGate(
+    finished: isActivityFinished,
+    planRoleCount: activityPlan?.roles.length,
+    assignedRoleCount: assignedRoles?.length ?? 0,
+  );
 
   bool get isActivityFinished {
     final roles = activityRoles?.roles.values.where(

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -4247,6 +4247,8 @@
     "startNewSession": "Start new session",
     "joinOpenSession": "Join open session",
     "activityNotFound": "Activity not found",
+    "activityNoLongerSupported": "This activity ran on an older version of activities and is no longer supported. You can still review what happened in this session.",
+    "activityLoadFailed": "Couldn't load the activity. Check your connection and try again.",
     "levelUp": "Level up",
     "myActivities": "My activities",
     "openToJoin": "Open to join",

--- a/lib/pangea/common/utils/base_repo.dart
+++ b/lib/pangea/common/utils/base_repo.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
+
 import 'package:async/async.dart';
 import 'package:get_storage/get_storage.dart';
 import 'package:http/http.dart' hide BaseResponse, BaseRequest;
@@ -114,6 +116,15 @@ abstract class BaseRepo<
 
   Future<Response> fetch(Requests req, TRequest request);
 
+  /// Sentry level for a fetch failure. Timeouts and confirmed 404s are
+  /// warnings — a 404 means the resource is gone (expected for e.g. removed
+  /// activities referenced by old rooms), not that code broke.
+  @visibleForTesting
+  static SentryLevel errorLevel(Object e) =>
+      e is TimeoutException || (e is Response && e.statusCode == 404)
+      ? SentryLevel.warning
+      : SentryLevel.error;
+
   Future<Result<TResponse>> _fetch(TRequest request) async {
     try {
       final Requests req = Requests(
@@ -137,9 +148,7 @@ abstract class BaseRepo<
           e: e,
           s: s,
           data: request.toJson(),
-          level: e is TimeoutException
-              ? SentryLevel.warning
-              : SentryLevel.error,
+          level: errorLevel(e),
         );
       }
       return Result.error(e);

--- a/lib/routes/chat/activity_sessions/activity_session_start_page.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_start_page.dart
@@ -10,6 +10,7 @@ import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
 import 'package:fluffychat/features/activity_sessions/activity_role_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_session_discovery.dart';
 import 'package:fluffychat/features/activity_sessions/discovered_sessions_cache.dart';
 import 'package:fluffychat/features/room_summaries/room_summaries_model.dart';
@@ -18,6 +19,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/common/widgets/feedback_dialog.dart';
 import 'package:fluffychat/pangea/common/widgets/feedback_response_dialog.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/archived_session_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/confirmed_role_session_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/full_session_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/not_started_session_controller.dart';
@@ -37,6 +39,11 @@ enum SessionState {
 
   /// The user has confirmed their role.
   confirmedRole,
+
+  /// The backend confirmed the activity no longer exists (404). The page is
+  /// read-only: it renders the plan recovered from legacy room state when one
+  /// exists, else the archived fallback body — never role selection.
+  archived,
 }
 
 class ActivitySessionStartPage extends StatefulWidget {
@@ -66,6 +73,13 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
   bool _summariesLoading = true;
 
   Object? error;
+
+  /// The backend confirmed this activity no longer exists (404). [activity]
+  /// may still be populated from the plan embedded in legacy room state; when
+  /// it stays null the view renders the archived fallback from room state
+  /// alone. Distinct from [error], which is a transient failure worth
+  /// retrying.
+  bool activityRemoved = false;
 
   ActivityPlanModel? activity;
   late ActivitySessionSummariesModel _roomSummariesModel;
@@ -147,6 +161,7 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
       setState(() {
         loading = true;
         error = null;
+        activityRemoved = false;
       });
       // Gate `loading` on the bounded activity fetch ALONE, so the page always
       // resolves to the activity or the not-found error. The room summaries are
@@ -232,11 +247,24 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
     // v3: read the canonical activities-v2 plan directly (fetched on open, per
     // the thin-list/full-on-open contract). Localization is choreo's concern,
     // consumed later when this read swaps to a choreo endpoint.
-    final plan = await ActivityPlanRepo.instance.getPlan(widget.activityId);
-    if (plan == null) {
-      throw Exception("Activity not found");
+    final lookup = await ActivityPlanRepo.instance.lookup(widget.activityId);
+    switch (lookup.status) {
+      case ActivityPlanLookupStatus.found:
+        activity = lookup.plan;
+      case ActivityPlanLookupStatus.removed:
+        // Removed-activity fallback ladder (activities.instructions.md):
+        // legacy rooms embed the full plan in room state — render it
+        // view-only; with no plan anywhere the view shows the archived body
+        // built from role/goal state.
+        if (!mounted) return;
+        final statePlan = activityRoom?.activityPlan;
+        activity = statePlan == null
+            ? null
+            : await ActivityPlanRepo.instance.resolveMedia(statePlan);
+        activityRemoved = true;
+      case ActivityPlanLookupStatus.failed:
+        throw Exception("Activity plan fetch failed");
     }
-    activity = plan;
   }
 
   Future<void> submitActivityFeedback() async {
@@ -286,6 +314,8 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
   }
 
   SessionState get _sessionState {
+    if (activityRemoved) return SessionState.archived;
+
     final roomExists = widget.roomId != null;
     final userIsCreatingRoom = widget.launch;
 
@@ -354,6 +384,12 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
           summaries: _roomSummariesModel,
           summariesLoading: _summariesLoading,
           scrollController: scrollController,
+          controller: this,
+        );
+      case SessionState.archived:
+        return ArchivedSession(
+          room: activityRoom,
+          activity: activity,
           controller: this,
         );
     }

--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
 
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
@@ -16,7 +18,10 @@ import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_start_hero.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_vocab_widget.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
+import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
+import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 /// The location that closes a non-embedded activity plan opened as a room/
@@ -52,6 +57,13 @@ class ActivitySessionStartView extends StatelessWidget {
     required this.sessionController,
   });
 
+  String? _archivedRoomName(BuildContext context) {
+    if (!controller.activityRemoved) return null;
+    return controller.activityRoom?.getLocalizedDisplayname(
+      MatrixLocals(L10n.of(context)),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -81,10 +93,12 @@ class ActivitySessionStartView extends StatelessWidget {
         return Scaffold(
           appBar: AppBar(
             leadingWidth: 52.0,
-            title: activity == null
+            // With no plan, an archived session falls back to the room name —
+            // it was set from the plan's title at room creation.
+            title: (activity?.title ?? _archivedRoomName(context)) == null
                 ? null
                 : Text(
-                    activity.title,
+                    activity?.title ?? _archivedRoomName(context)!,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: FluffyThemes.isColumnMode(context)
@@ -156,7 +170,20 @@ class ActivitySessionStartView extends StatelessWidget {
           body: SafeArea(
             child: controller.loading
                 ? const Center(child: CircularProgressIndicator.adaptive())
-                : controller.error != null || activity == null
+                // Transient fetch failure — retryable, never the archived view
+                // or the "no longer supported" notice (the fallback ladder in
+                // activities.instructions.md engages only on a confirmed 404).
+                : controller.error != null
+                ? Center(
+                    child: ErrorIndicator(
+                      message: L10n.of(context).activityLoadFailed,
+                    ),
+                  )
+                // Confirmed removed with no plan recoverable from room state:
+                // archived body from role/goal state alone.
+                : activity == null && controller.activityRemoved
+                ? _ArchivedSessionFallbackBody(controller)
+                : activity == null
                 ? Center(
                     child: ErrorIndicator(
                       message: L10n.of(context).activityNotFound,
@@ -234,6 +261,83 @@ class ActivitySessionStartView extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+/// Archived body for a removed activity with no plan recoverable from room
+/// state (the last rung of the fallback ladder in activities.instructions.md):
+/// the "no longer supported" notice, plus whatever the room itself holds —
+/// each recorded role's occupant, role name, earned star count, and finished
+/// status — so past progress stays reviewable.
+class _ArchivedSessionFallbackBody extends StatelessWidget {
+  final ActivitySessionStartState controller;
+
+  const _ArchivedSessionFallbackBody(this.controller);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final room = controller.activityRoom;
+    // All recorded roles — not just currently-joined members — so a learner
+    // who left the room still shows in the review.
+    final roles = room?.activityRoles?.roles.values.toList() ?? [];
+    final awards = room?.orchestratorAwardedGoals;
+
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 600.0),
+        child: ListView(
+          padding: const EdgeInsets.all(24.0),
+          shrinkWrap: true,
+          children: [
+            Icon(
+              Icons.inventory_2_outlined,
+              size: 48.0,
+              color: theme.colorScheme.secondary,
+            ),
+            const SizedBox(height: 16.0),
+            Text(
+              L10n.of(context).activityNoLongerSupported,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 16.0),
+            ...roles.map((role) {
+              final user = room!.unsafeGetUserFromMemoryOrFallback(role.userId);
+              final stars = awards?.awards[role.id]?.length ?? 0;
+              return ListTile(
+                leading: Avatar(
+                  mxContent: user.avatarUrl,
+                  name: user.calcDisplayname(),
+                  userId: role.userId,
+                ),
+                title: Text(user.calcDisplayname()),
+                subtitle: role.role == null ? null : Text(role.role!),
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  spacing: 4.0,
+                  children: [
+                    if (stars > 0) ...[
+                      const Icon(
+                        Icons.star,
+                        size: 18.0,
+                        color: AppConfig.goldLight,
+                      ),
+                      Text('$stars'),
+                    ],
+                    if (role.isFinished)
+                      const Padding(
+                        padding: EdgeInsets.only(left: 8.0),
+                        child: Icon(Icons.check_circle_outline, size: 18.0),
+                      ),
+                  ],
+                ),
+              );
+            }),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/lib/routes/chat/activity_sessions/archived_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/archived_session_controller.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_controller.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_sessions_start_view.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+
+/// Read-only session page for an activity the backend no longer has — the
+/// removed-activity fallback ladder in activities.instructions.md. With a plan
+/// recovered from legacy room state the page renders fully (roles, goal
+/// labels, media); with none the view falls back to the archived body built
+/// from role/goal room state. Either way nothing can be joined, selected, or
+/// written — the CTA footer shows only the "no longer supported" notice.
+class ArchivedSession extends StatefulWidget {
+  final Room? room;
+  final ActivityPlanModel? activity;
+  final ActivitySessionStartState controller;
+
+  const ArchivedSession({
+    super.key,
+    required this.room,
+    required this.activity,
+    required this.controller,
+  });
+
+  @override
+  ArchivedSessionController createState() => ArchivedSessionController();
+}
+
+class ArchivedSessionController extends State<ArchivedSession>
+    implements ActivitySessionStateController {
+  final _goalsHandler = GoalsSubscriptionHandler();
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _goalsHandler.init(widget.room?.id, context, setState, () => mounted);
+  }
+
+  @override
+  void dispose() {
+    _goalsHandler.cancel();
+    super.dispose();
+  }
+
+  @override
+  String get descriptionText => L10n.of(context).activityNoLongerSupported;
+
+  @override
+  bool get goalsStartCollapsed => true;
+
+  @override
+  List<ActivityRoleGoal>? get selectedRoleGoals {
+    final roleId = widget.room?.ownRoleState?.id;
+    if (roleId == null) return null;
+    return widget.activity?.roles[roleId]?.allGoals;
+  }
+
+  @override
+  Set<String> get selectedRoleCompletedGoalIds {
+    final roleId = widget.room?.ownRoleState?.id;
+    if (roleId == null) return {};
+    return completedGoalIdsForRole(roleId);
+  }
+
+  @override
+  Set<String> completedGoalIdsForRole(String id) => _goalsHandler.scan(
+    id,
+    Matrix.of(context).client,
+    activityId: widget.controller.widget.activityId,
+    activity: widget.activity,
+  );
+
+  @override
+  bool isRoleSelected(String id) => widget.room?.ownRoleState?.id == id;
+
+  @override
+  bool isRoleShimmering(String id) => false;
+
+  @override
+  bool canSelectRole(String id) => false;
+
+  @override
+  void selectRole(String id) {}
+
+  /// Earned-star progress shows on every role card — reviewing past progress
+  /// is the point of the archived view.
+  @override
+  bool showStarsCard(String id) => widget.room != null;
+
+  @override
+  double get roleCardOpacity => 1.0;
+
+  @override
+  bool get showRoleCards => widget.activity != null;
+
+  @override
+  bool get showDescriptionSection => widget.activity != null;
+
+  @override
+  Widget build(BuildContext context) =>
+      ActivitySessionStartView(widget.controller, sessionController: this);
+}

--- a/lib/routes/chat/chat_view.dart
+++ b/lib/routes/chat/chat_view.dart
@@ -241,6 +241,7 @@ class ChatView extends StatelessWidget {
           builder: (BuildContext context, snapshot) {
             // #Pangea
             if (controller.room.isActivitySession &&
+                controller.room.activityId != null &&
                 !controller.room.isActivityStarted) {
               return ActivitySessionStartPage(
                 activityId: controller.room.activityId!,

--- a/test/pangea/activity_plan_lookup_test.dart
+++ b/test/pangea/activity_plan_lookup_test.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:http/http.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
+import 'package:fluffychat/pangea/common/utils/base_repo.dart';
+
+/// The 404-vs-transient split behind the removed-activity fallback ladder
+/// (activities.instructions.md): only a confirmed 404 may walk the ladder
+/// (embedded state plan → archived view) or claim "no longer supported";
+/// every other failure stays a retryable error, so an outage can never
+/// mislabel healthy activities as removed. 404s are also expected data state
+/// (old rooms referencing removed activities), not code breakage — they log
+/// as warnings, not Sentry errors.
+void main() {
+  group('ActivityPlanRepo.classifyLookupError', () {
+    test('404 is a confirmed miss — the only status that walks the ladder', () {
+      expect(
+        ActivityPlanRepo.classifyLookupError(Response('not found', 404)),
+        ActivityPlanLookupStatus.removed,
+      );
+    });
+
+    test('server errors are transient, never removed', () {
+      expect(
+        ActivityPlanRepo.classifyLookupError(Response('boom', 500)),
+        ActivityPlanLookupStatus.failed,
+      );
+      expect(
+        ActivityPlanRepo.classifyLookupError(Response('bad gateway', 502)),
+        ActivityPlanLookupStatus.failed,
+      );
+    });
+
+    test('timeouts and non-HTTP errors are transient, never removed', () {
+      expect(
+        ActivityPlanRepo.classifyLookupError(TimeoutException('slow')),
+        ActivityPlanLookupStatus.failed,
+      );
+      expect(
+        ActivityPlanRepo.classifyLookupError(Exception('offline')),
+        ActivityPlanLookupStatus.failed,
+      );
+    });
+  });
+
+  group('BaseRepo.errorLevel — Sentry severity', () {
+    test('404 logs as warning (expected data state, not breakage)', () {
+      expect(
+        BaseRepo.errorLevel(Response('not found', 404)),
+        SentryLevel.warning,
+      );
+    });
+
+    test('timeouts log as warning', () {
+      expect(
+        BaseRepo.errorLevel(TimeoutException('slow')),
+        SentryLevel.warning,
+      );
+    });
+
+    test('other failures stay errors', () {
+      expect(BaseRepo.errorLevel(Response('boom', 500)), SentryLevel.error);
+      expect(BaseRepo.errorLevel(Exception('parse')), SentryLevel.error);
+    });
+  });
+}

--- a/test/pangea/activity_plan_lookup_test.dart
+++ b/test/pangea/activity_plan_lookup_test.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:http/http.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 

--- a/test/pangea/activity_started_gate_test.dart
+++ b/test/pangea/activity_started_gate_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
+
+/// The gate ChatView uses to pick the chat timeline vs the session start page.
+/// The regression this locks (#7480): with a null plan (unhydrated, or the
+/// activity removed from the backend) the old seat math read `0 - assigned
+/// <= 0` and classified EVERY room as started — routing empty orphan rooms
+/// into the chat timeline instead of the start page's removed-activity state.
+void main() {
+  group('activityStartedGate', () {
+    test('finished sessions are always started', () {
+      expect(
+        activityStartedGate(
+          finished: true,
+          planRoleCount: null,
+          assignedRoleCount: 0,
+        ),
+        isTrue,
+      );
+    });
+
+    test('plan-less room with no assigned roles is NOT started — an empty '
+        'orphan room shows the start page, not the chat timeline', () {
+      expect(
+        activityStartedGate(
+          finished: false,
+          planRoleCount: null,
+          assignedRoleCount: 0,
+        ),
+        isFalse,
+      );
+    });
+
+    test('plan-less room with assigned roles is started — real progress '
+        'stays reviewable in the timeline even when the plan is gone', () {
+      expect(
+        activityStartedGate(
+          finished: false,
+          planRoleCount: null,
+          assignedRoleCount: 1,
+        ),
+        isTrue,
+      );
+    });
+
+    test('with a plan, started means every role is filled', () {
+      expect(
+        activityStartedGate(
+          finished: false,
+          planRoleCount: 2,
+          assignedRoleCount: 1,
+        ),
+        isFalse,
+      );
+      expect(
+        activityStartedGate(
+          finished: false,
+          planRoleCount: 2,
+          assignedRoleCount: 2,
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What
Session pages no longer hard-fail with "Activity not found" when the backend has lost an activity id. Implements the fallback ladder from the activities instructions docs (org doc PR: pangeachat/.github#237; client doc included here):

- `ActivityPlanRepo.lookup` surfaces confirmed 404 (`removed`) vs transient failure (`failed`); `ensure` stops re-fetch loops on known-missing ids
- Start page: on a confirmed miss, renders the plan embedded in legacy `pangea.activity_plan` room state (view-only `ArchivedSession` — no role picking, no CTAs, "no longer supported" notice); with no plan anywhere, renders an archived body from role/goal room state (participants, role names, star counts, finished status)
- Transient failures show a retryable "couldn't load" error, never the removed-notice
- `isActivityStarted`: null-plan seat math no longer classifies every room as started — empty orphan rooms route to the start page (removed state), rooms with assigned roles keep the chat timeline
- BaseRepo logs 404s to Sentry as warnings, not errors

## Why
Addresses #7480 — the v3 cutover re-minted/lost activity ids and old sessions became unviewable; teachers need to review past semester sessions. The star-retirement decision on #7480 stays open: the progression rollup is pure over id maps (dead ids contribute nothing, no crash), but whether to retire those stars is unresolved.

## Testing
- New: `test/pangea/activity_plan_lookup_test.dart` (404-vs-transient classification + Sentry level), `test/pangea/activity_started_gate_test.dart` (null-plan gate)
- Full suite: `fvm flutter test test/` — 996 passed
- `fvm flutter analyze` clean on touched files; `dart format` applied
- Not verified against a live orphaned room yet — needs staging QA per the issue's TO TEST

## Deploy Notes
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an archived-session view for older activity rooms that can still show read-only details, role occupants, and earned stars.
  * Added clearer handling for missing activity data, including retryable load errors and a “no longer supported” state.

* **Bug Fixes**
  * Improved session status detection so rooms aren’t marked started too early when activity data is unavailable.
  * Reduced repeated failed activity lookups and made media loading fail softly so the rest of the page still renders.

* **Tests**
  * Added coverage for activity lookup status handling and session-start detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->