### PR TITLE
fix(mobile-chrome): reopen a section sheet at a real height after drag-to-zero

### DIFF
--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -177,6 +177,15 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
   void _remember(NavCavityHeight height) {
     final key = widget.cavityKey;
     if (key == null) return;
+    // Dragging a SECTION sheet fully down is a dismissal, not a height
+    // preference: collapsed renders 0px there (no handle left to grab), so
+    // persisting it would make every reopen arrive already-dismissed and
+    // stuck (#7510). The sheet still collapses now; the memory just keeps
+    // the last real height for the reopen. A peek cavity's collapsed is a
+    // visible, draggable rest height and is remembered as before.
+    if (height == NavCavityHeight.collapsed && !widget.cavityDefaultsToPeek) {
+      return;
+    }
     MobileNavWidget._heightByKey[key] = height;
   }
 

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -269,6 +269,36 @@ void main() {
         reason: 'dragging the handle down must shrink the cavity',
       );
     });
+
+    testWidgets(
+      'a section sheet dragged fully down reopens at a real height (#7510)',
+      (tester) async {
+        await pumpNav(
+          tester,
+          activeSection: AppSection.chats,
+          cavityChild: const Text('Chat list'),
+          cavityKey: 'chats',
+          maxHeightFraction: 0.75,
+        );
+        expect(cavityHeightOf(tester), greaterThan(0.0));
+
+        // Drag the handle all the way down: the sheet dismisses to 0px (no
+        // handle left to grab) — a dismissal, not a height preference.
+        await tester.drag(handleFinder(), const Offset(0, 700));
+        await tester.pumpAndSettle();
+        expect(cavityHeightOf(tester), 0.0);
+
+        // The rail item must reopen it at a usable height, NOT the
+        // remembered zero (the #7510 stuck state).
+        await tester.tap(find.byTooltip('All chats'));
+        await tester.pumpAndSettle();
+        expect(
+          cavityHeightOf(tester),
+          greaterThan(100.0),
+          reason: 'reopening after a drag-to-zero must restore a real height',
+        );
+      },
+    );
   });
 
   group('tap-outside collapse', () {


### PR DESCRIPTION
## What
Dragging a section sheet (chats, courses, course card at full, activity plan) all the way down collapses it to 0px AND persisted that zero into the per-key height memory, so the rail item reopened it already dismissed with no handle left to grab. The stuck state from #7510.

Drag-to-zero on a section sheet is a dismissal, not a height preference: the sheet still collapses on the drag, but the memory now keeps the last real height, so reopening from the rail restores a usable sheet. Peek cavities (course card) are unchanged since their collapsed state is a visible, draggable 240px peek.

## Why
Closes #7510.

## TO TEST
- [ ] On a phone-width window, open Chats and drag the sheet handle all the way down: the sheet fully closes to just the rail
- [ ] Tap Chats in the rail: the sheet reopens at a real height (all chats visible), not stuck closed
- [ ] Drag it to full, drag to zero, reopen: it comes back at full (the last real height)
- [ ] Open a course card, drag it down to its small peek, tap away and back: the peek height is remembered as before

Run tests locally: `flutter test test/pangea/navigation/` (251 pass, includes a new regression test for the reopen).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where reopening the mobile navigation cavity could restore a collapsed zero-height state instead of the last usable height.
  * Improved cavity reopen behavior so a dismissed panel now returns to a functional non-zero height after being dragged closed.
* **Tests**
  * Added coverage for the drag-to-close and reopen flow to verify height is preserved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->