### PR TITLE
fix(workspace): closing the settings menu keeps an open settings page

### DIFF
--- a/lib/features/navigation/workspace_nav.dart
+++ b/lib/features/navigation/workspace_nav.dart
@@ -703,15 +703,18 @@ abstract class WorkspaceNav {
     );
   }
 
-  /// Close the whole settings/profile panel — the menu master AND its open page
-  /// detail — keeping the rest of the right column. Closing the master drops its
-  /// detail (it has no meaning without the menu).
+  /// Close the settings/profile MENU master, dropping only the `settings`
+  /// token — "closing a panel drops its token and nothing else"
+  /// (routing.instructions.md), the same rule [closeSection] documents for the
+  /// course family. An open `settingspage` detail therefore survives a menu
+  /// close exactly as a `coursepage` survives its `course` card closing: the
+  /// page keeps rendering (it reads its own identity from its token param, not
+  /// from the menu), just without its master beside it. The page's own close
+  /// still drops it via [closeRight]/[settingsBack] (#7493).
   static String closeSettings(Uri current) => _mutate(
     current,
     'right',
-    (tokens) => tokens
-        .where((t) => t.type != 'settings' && t.type != 'settingspage')
-        .toList(),
+    (tokens) => _remove(tokens, const PanelToken('settings')),
   );
 
   /// The settings panel's back: a leaf (`a/b`) pops to its parent page; a

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -651,23 +651,53 @@ void main() {
       expect(right.single.type, 'settings'); // menu remains
     });
 
-    test('closeSettings drops the menu AND its page, keeps the rest', () {
-      // Analytics can no longer coexist with settings (opening settings drops
-      // it, #7109), so "the rest" is a left panel. closeSettings clears the
-      // right settings panel and leaves the left column intact.
+    test('closeSettings drops only the menu, keeping an open settingspage '
+        'detail (#7493)', () {
+      // Closing the settings MENU drops only its own token — the same rule
+      // closeSection documents for the course family (a coursepage survives
+      // its course card closing, #7317). A settingspage reads its own
+      // identity from its token param, so it keeps rendering without its
+      // master beside it.
       var loc = WorkspaceNav.openSettings(
         u('/?left=room:!a'),
         page: 'learning',
       );
       loc = WorkspaceNav.closeSettings(u(loc));
       final panels = parseOpenPanels(u(loc));
+      expect(panels.right.any((t) => t.type == 'settings'), isFalse);
       expect(
-        panels.right.any(
-          (t) => t.type == 'settings' || t.type == 'settingspage',
-        ),
-        isFalse,
-      );
+        panels.right.single,
+        const PanelToken('settingspage', 'learning'),
+      ); // page survives
       expect(panels.left.single, const PanelToken('room', '!a'));
+    });
+
+    test(
+      'closeSettings on a bare menu (no open page) clears the right column',
+      () {
+        // Analytics can no longer coexist with settings (opening settings
+        // drops it, #7109), so with no settingspage open, closing the menu
+        // leaves the right column empty.
+        var loc = WorkspaceNav.openSettings(u('/?left=room:!a'));
+        loc = WorkspaceNav.closeSettings(u(loc));
+        final panels = parseOpenPanels(u(loc));
+        expect(panels.right, isEmpty);
+        expect(panels.left.single, const PanelToken('room', '!a'));
+      },
+    );
+
+    test('closing the settingspage detail keeps the settings menu master', () {
+      // The reverse case: closing the page (via closeRight, the page's own
+      // close) must not touch the menu — mirrored to the course family's
+      // coursepage close.
+      final loc = WorkspaceNav.openSettings(u('/'), page: 'learning');
+      final closed = WorkspaceNav.closeRight(
+        u(loc),
+        const PanelToken('settingspage', 'learning'),
+      );
+      final panels = parseOpenPanels(u(closed));
+      expect(panels.right.any((t) => t.type == 'settingspage'), isFalse);
+      expect(panels.right.single.type, 'settings'); // menu remains
     });
   });
 


### PR DESCRIPTION
## What
This fixes a bug where closing the settings menu also closed any open settings subpage (like Security or Learning) beside it, even though the two are meant to behave like independent panels. The settings menu's close now drops only its own token, leaving an open settings page in place. This mirrors how the course family already works: closing a course card keeps an open course management page beside it. Closing the settings page itself is unchanged and still closes just the page, leaving the menu open.

## Why
Closes #7493. Aligns settings with the course family's documented close behavior.

## TO TEST
- [ ] Open Settings from the profile avatar, then open a settings page (e.g. Learning or Security) beside it.
- [ ] Close the settings menu using its X. Confirm the settings page stays open and the menu is gone.
- [ ] With only the settings page open, confirm its own close (back arrow or X, depending on width) closes the page normally.
- [ ] Open the settings menu with no page open and close it. Confirm the whole right column clears as before.
- [ ] Repeat on a narrow/mobile viewport and confirm the settings page's close affordance still shows correctly (back arrow if the menu is open behind it, X otherwise).