### PR TITLE
feat(quests): quest-total and per-Mission star counts on the course panel

### DIFF
--- a/.github/instructions/quests.instructions.md
+++ b/.github/instructions/quests.instructions.md
@@ -24,9 +24,19 @@ Every surface that preferences by progression reads the *same* shared resolver, 
 
 - the [world map](world-map.instructions.md) — the Priority matrix raises activities carrying the anchor Mission to the top of the relevance band, decaying for Missions further along; per-activity star progress renders as a fill (see its pin-display section);
 - the **activity start page** — opens directly into play for every activity (nothing is gated), showing star progress and, where relevant, that this is a next-Mission activity;
+- the **course panel's star display** (below);
 - the course/quest list and the powerups cluster, as they are built for v3.
 
 The teacher-overridable star threshold is part of the cross-repo rule (org doc); this doc only resolves it from local state.
+
+## Star display on the course panel
+
+The course panel tells the learner how far along they are, at two grains, computed from the same resolver inputs (joined-course outlines + per-activity stars from session rooms) so the numbers can never disagree with the map:
+
+- **Per Mission**: earned stars over the satisfaction threshold (the teacher-overridable stars-to-unlock), with a progress bar. Stars past the threshold display raw (e.g. 12/7 — surplus effort shows); the bar clamps at full.
+- **Per quest (the panel header)**: a total star count summing each Mission's stars **capped at its threshold** — one over-practiced Mission can't inflate quest progress — over a bar that fills toward the sum of the quest's thresholds.
+
+A course **preview** (not joined) shows no star display — there is no learner progress to show. This builds toward the world_v2 tabbed course card (Figma "Everything outside of Chat"); until that card ships, the display lives on the existing course objectives panel.
 
 ## Future Work
 

--- a/lib/features/quests/quest_progression_resolver.dart
+++ b/lib/features/quests/quest_progression_resolver.dart
@@ -30,6 +30,25 @@ class MissionProgress {
   /// A star is one orchestrator-awarded activity goal; a Mission is satisfied
   /// once its star total reaches the (teacher-overridable) threshold.
   bool get satisfied => stars >= threshold;
+
+  /// Stars capped at the threshold — the Mission's contribution to a quest's
+  /// star total, so an over-practiced Mission can't inflate quest progress.
+  /// The per-Mission display shows the raw [stars] (surplus effort shows,
+  /// e.g. 12/7); only the quest-level sum caps. See quests.instructions.md.
+  int get cappedStars => stars > threshold ? threshold : stars;
+}
+
+/// A quest's star display summary: [earned] sums each Mission's stars capped
+/// at its threshold; [total] sums the thresholds — so earned/total is the
+/// quest header's progress fraction. See quests.instructions.md ("Star display
+/// on the course panel").
+class QuestStarSummary {
+  final int earned;
+  final int total;
+
+  const QuestStarSummary({required this.earned, required this.total});
+
+  double get fraction => total <= 0 ? 0 : (earned / total).clamp(0.0, 1.0);
 }
 
 /// One in-scope quest: its ordered Mission sequence, the resolved anchor (the
@@ -80,6 +99,22 @@ class ProgressionResolution {
   /// Missions ranks higher) and saturate at the ceiling. Outside any quest the
   /// activity's refs match nothing and this is 0 — the consumer then ranks it on
   /// plain level/L2 fit. See world-map.instructions.md Priority matrix.
+  /// The star summary for a quest given its ordered [missionIds]: per-Mission
+  /// stars capped at each threshold, summed, over the summed thresholds. A
+  /// Mission the rollup doesn't know (an outline not in scope) contributes its
+  /// default threshold and zero stars, so a partially-resolved panel still
+  /// shows a stable denominator.
+  QuestStarSummary questStars(Iterable<String> missionIds) {
+    var earned = 0;
+    var total = 0;
+    for (final id in missionIds) {
+      final progress = rollup[id];
+      earned += progress?.cappedStars ?? 0;
+      total += progress?.threshold ?? kDefaultStarsToUnlockObjective;
+    }
+    return QuestStarSummary(earned: earned, total: total);
+  }
+
   double missionGradient(Iterable<String> objectiveRefs) {
     if (quests.isEmpty) return 0;
     final refs = objectiveRefs.toSet();

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -4247,6 +4247,13 @@
     "startNewSession": "Start new session",
     "joinOpenSession": "Join open session",
     "activityNotFound": "Activity not found",
+    "starsEarnedOfTotal": "{earned} of {total} stars earned",
+    "@starsEarnedOfTotal": {
+        "placeholders": {
+            "earned": {},
+            "total": {}
+        }
+    },
     "activityNoLongerSupported": "This activity ran on an older version of activities and is no longer supported. You can still review what happened in this session.",
     "activityLoadFailed": "Couldn't load the activity. Check your connection and try again.",
     "levelUp": "Level up",

--- a/lib/routes/courses/course_objectives/course_objectives_view.dart
+++ b/lib/routes/courses/course_objectives/course_objectives_view.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
@@ -5,13 +7,17 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
+import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
 import 'package:fluffychat/features/quests/quests_client_extension.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/chat/chat_details/activity_suggestion_card.dart';
+import 'package:fluffychat/routes/world/joined_objective_cache.dart';
 
 /// The objective groups that should render: those with at least one activity.
 /// An activity-less objective would otherwise show a header over a fixed-height
@@ -67,6 +73,17 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
   late Future<List<QuestObjectiveGroup>> _groupsFuture;
   final ScrollController _scrollController = ScrollController();
 
+  /// The shared progression rollup behind the star display — same inputs and
+  /// resolver as the world map, so the numbers can never disagree
+  /// (quests.instructions.md, "Star display on the course panel"). Empty in a
+  /// preview (no room → no learner progress to show) and until the first
+  /// resolve completes.
+  final JoinedObjectiveCache _objectiveCache = JoinedObjectiveCache();
+  ProgressionResolution _progression = ProgressionResolution.empty;
+
+  /// This quest's ordered Mission ids, for the header's quest-star summary.
+  List<String> _orderedMissionIds = const [];
+
   String? get _questId => widget.questId ?? widget.room?.coursePlan?.uuid;
 
   @override
@@ -109,6 +126,7 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.questId != widget.questId ||
         oldWidget.room?.id != widget.room?.id) {
+      _progression = ProgressionResolution.empty;
       _groupsFuture = _load();
     }
   }
@@ -121,7 +139,30 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
     final questId = _questId;
     if (questId == null) return [];
     final outline = await QuestRepo.outline(questId);
+    _orderedMissionIds = outline.quest.learningObjectiveIds;
+    unawaited(_loadProgression());
     return outline.groups;
+  }
+
+  /// Resolve the star-display rollup. Joined courses only — a preview has no
+  /// learner progress to show. Fire-and-forget from [_load]: the outline
+  /// renders immediately and the star chips fill in when the resolve lands.
+  Future<void> _loadProgression() async {
+    final client = widget.room?.client;
+    if (client == null) return;
+    await _objectiveCache.rebuildFromJoinedCourses(
+      client,
+      onError: (uuid, e, s) => ErrorHandler.logError(
+        e: e,
+        s: s,
+        m: 'CourseObjectivesList: course outline failed to resolve',
+        data: {'courseUuid': uuid},
+      ),
+    );
+    if (!mounted) return;
+    setState(() {
+      _progression = _objectiveCache.resolution(client.userStarsByActivity);
+    });
   }
 
   @override
@@ -148,6 +189,9 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
             ),
           );
         }
+        // The quest-star header shows only for a joined course once the shared
+        // rollup has resolved; a preview has no learner progress to show.
+        final showStars = widget.room != null && _progression.rollup.isNotEmpty;
         final list = ListView.separated(
           controller: widget.shrinkWrap ? null : _scrollController,
           padding: const EdgeInsets.symmetric(vertical: 8.0),
@@ -155,14 +199,25 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
           physics: widget.shrinkWrap
               ? const NeverScrollableScrollPhysics()
               : null,
-          itemCount: groups.length,
+          itemCount: groups.length + (showStars ? 1 : 0),
           separatorBuilder: (_, _) => const SizedBox(height: 24.0),
-          itemBuilder: (context, i) => _ObjectiveSection(
-            index: i,
-            group: groups[i],
-            room: widget.room,
-            hasCompletedActivity: widget.hasCompletedActivity,
-          ),
+          itemBuilder: (context, i) {
+            if (showStars && i == 0) {
+              return _QuestStarsHeader(
+                summary: _progression.questStars(_orderedMissionIds),
+              );
+            }
+            final group = groups[showStars ? i - 1 : i];
+            return _ObjectiveSection(
+              index: showStars ? i - 1 : i,
+              group: group,
+              room: widget.room,
+              hasCompletedActivity: widget.hasCompletedActivity,
+              progress: showStars
+                  ? _progression.rollup[group.objective.id]
+                  : null,
+            );
+          },
         );
         // In a preview the list is embedded in an outer scroll view (shrinkWrap)
         // with no map behind it, so a wheel can't leak — return it bare. The
@@ -181,6 +236,45 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
   }
 }
 
+/// The quest-level star summary at the top of a joined course's objective
+/// list: total earned (each Mission capped at its threshold) over a bar that
+/// fills toward the sum of thresholds. See quests.instructions.md.
+class _QuestStarsHeader extends StatelessWidget {
+  final QuestStarSummary summary;
+
+  const _QuestStarsHeader({required this.summary});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Semantics(
+      label: L10n.of(context).starsEarnedOfTotal(summary.earned, summary.total),
+      child: Row(
+        children: [
+          Icon(Icons.star, size: 22.0, color: AppConfig.goldByTheme(context)),
+          const SizedBox(width: 6.0),
+          Text(
+            '${summary.earned}',
+            style: const TextStyle(fontSize: 16.0, fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(width: 12.0),
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8.0),
+              child: LinearProgressIndicator(
+                value: summary.fraction,
+                minHeight: 10.0,
+                color: AppConfig.goldByTheme(context),
+                backgroundColor: theme.colorScheme.surfaceContainerHighest,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _ObjectiveSection extends StatelessWidget {
   final int index;
   final QuestObjectiveGroup group;
@@ -191,11 +285,16 @@ class _ObjectiveSection extends StatelessWidget {
   final Room? room;
   final bool Function(String userId, String activityId)? hasCompletedActivity;
 
+  /// The Mission's rollup from the shared resolver, or null when there is
+  /// nothing to show (preview, or the rollup hasn't resolved yet).
+  final MissionProgress? progress;
+
   const _ObjectiveSection({
     required this.index,
     required this.group,
     required this.room,
     required this.hasCompletedActivity,
+    required this.progress,
   });
 
   @override
@@ -209,7 +308,8 @@ class _ObjectiveSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Objective header: placeholder icon + the can-do statement.
+        // Objective header: placeholder icon + the can-do statement, with the
+        // Mission's earned/threshold stars when the shared rollup is in.
         Row(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
@@ -224,8 +324,50 @@ class _ObjectiveSection extends StatelessWidget {
                 ),
               ),
             ),
+            if (progress != null) ...[
+              const SizedBox(width: 8.0),
+              Semantics(
+                label: L10n.of(
+                  context,
+                ).starsEarnedOfTotal(progress!.stars, progress!.threshold),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.star,
+                      size: 18.0,
+                      color: AppConfig.goldByTheme(context),
+                    ),
+                    const SizedBox(width: 4.0),
+                    Text(
+                      // Raw stars over the satisfaction threshold — surplus
+                      // shows (12/7); only the quest header caps.
+                      '${progress!.stars}/${progress!.threshold}',
+                      style: const TextStyle(
+                        fontSize: 14.0,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ],
         ),
+        if (progress != null) ...[
+          const SizedBox(height: 8.0),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(6.0),
+            child: LinearProgressIndicator(
+              value: progress!.threshold <= 0
+                  ? 0
+                  : (progress!.stars / progress!.threshold).clamp(0.0, 1.0),
+              minHeight: 6.0,
+              color: AppConfig.goldByTheme(context),
+              backgroundColor: theme.colorScheme.surfaceContainerHighest,
+            ),
+          ),
+        ],
         const SizedBox(height: 12.0),
         // The activities that satisfy this objective.
         SizedBox(

--- a/lib/routes/world/joined_objective_cache.dart
+++ b/lib/routes/world/joined_objective_cache.dart
@@ -1,6 +1,10 @@
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
 import 'package:fluffychat/features/quests/lo_progression.dart';
 import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/routes/world/world_map_client_extension.dart';
 
 /// Holds the learner's joined-course quest outlines: each course's ordered
 /// learning-objective sequence and the activities that satisfy each objective.
@@ -79,6 +83,28 @@ class JoinedObjectiveCache {
     );
     _outlines = next;
     _ids = {for (final o in next) ...o.orderedLoIds};
+  }
+
+  /// [rebuild] from the client's joined courses — each course's quest uuid with
+  /// its teacher stars-to-unlock override. The single home for that mapping:
+  /// the world map's pins manager and the course panel's star display both
+  /// rebuild through here, so every surface resolves identical outlines.
+  Future<void> rebuildFromJoinedCourses(
+    Client client, {
+    void Function(String uuid, Object error, StackTrace stack)? onError,
+  }) {
+    final thresholds = <String, int>{
+      for (final room in client.joinedCourseRooms)
+        room.coursePlan!.uuid:
+            room.teacherMode.starsToUnlockObjective ??
+            kDefaultStarsToUnlockObjective,
+    };
+    return rebuild(
+      thresholds.keys.toList(),
+      starsToUnlockOf: (uuid) =>
+          thresholds[uuid] ?? kDefaultStarsToUnlockObjective,
+      onError: onError,
+    );
   }
 
   static Future<CourseLoOutline> _outlineFromQuest(String uuid) async =>

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -321,18 +321,11 @@ class WorldMapPinsManager {
     if (_objectiveCacheRebuilding) return;
     _objectiveCacheRebuilding = true;
     try {
-      final courseRooms = client.joinedCourseRooms;
-      final uuids = courseRooms.map((r) => r.coursePlan!.uuid).toList();
-      final thresholds = <String, int>{
-        for (final r in courseRooms)
-          r.coursePlan!.uuid:
-              r.teacherMode.starsToUnlockObjective ??
-              kDefaultStarsToUnlockObjective,
-      };
-      await _objectiveCache.rebuild(
-        uuids,
-        starsToUnlockOf: (uuid) =>
-            thresholds[uuid] ?? kDefaultStarsToUnlockObjective,
+      final uuids = client.joinedCourseRooms
+          .map((r) => r.coursePlan!.uuid)
+          .toList();
+      await _objectiveCache.rebuildFromJoinedCourses(
+        client,
         onError: (uuid, e, s) => ErrorHandler.logError(
           e: e,
           s: s,

--- a/test/pangea/quest_star_summary_test.dart
+++ b/test/pangea/quest_star_summary_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/quests/lo_progression.dart';
+import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
+
+/// Star display math (quests.instructions.md, "Star display on the course
+/// panel"): per-Mission display shows raw stars over the threshold (surplus
+/// shows, e.g. 12/7), while the quest header sums each Mission's stars CAPPED
+/// at its threshold — one over-practiced Mission can't inflate quest progress
+/// — over the summed thresholds.
+void main() {
+  group('MissionProgress.cappedStars', () {
+    test('below threshold passes through', () {
+      expect(const MissionProgress(stars: 4, threshold: 7).cappedStars, 4);
+    });
+
+    test('overflow caps at the threshold', () {
+      expect(const MissionProgress(stars: 12, threshold: 7).cappedStars, 7);
+    });
+  });
+
+  group('ProgressionResolution.questStars', () {
+    ProgressionResolution resolutionWith(Map<String, MissionProgress> rollup) =>
+        ProgressionResolution(rollup: rollup, quests: const []);
+
+    test('sums capped stars over summed thresholds (mockup: 4+1 → ⭐5)', () {
+      final resolution = resolutionWith({
+        'getting-around': const MissionProgress(stars: 4, threshold: 7),
+        'introductions': const MissionProgress(stars: 1, threshold: 7),
+      });
+      final summary = resolution.questStars([
+        'getting-around',
+        'introductions',
+      ]);
+      expect(summary.earned, 5);
+      expect(summary.total, 14);
+      expect(summary.fraction, closeTo(5 / 14, 1e-9));
+    });
+
+    test('an over-practiced Mission contributes at most its threshold', () {
+      final resolution = resolutionWith({
+        'a': const MissionProgress(stars: 12, threshold: 7),
+        'b': const MissionProgress(stars: 0, threshold: 7),
+      });
+      final summary = resolution.questStars(['a', 'b']);
+      expect(summary.earned, 7);
+      expect(summary.total, 14);
+    });
+
+    test('a Mission missing from the rollup keeps a stable denominator '
+        '(default threshold, zero stars)', () {
+      final resolution = resolutionWith({
+        'known': const MissionProgress(stars: 3, threshold: 7),
+      });
+      final summary = resolution.questStars(['known', 'unknown']);
+      expect(summary.earned, 3);
+      expect(summary.total, 7 + kDefaultStarsToUnlockObjective);
+    });
+
+    test('empty quest yields zero with a safe fraction', () {
+      final summary = resolutionWith({}).questStars(const []);
+      expect(summary.earned, 0);
+      expect(summary.total, 0);
+      expect(summary.fraction, 0);
+    });
+  });
+}


### PR DESCRIPTION
## What
Surfaces learner star progress on the course objectives panel, per the world_v2 Figma mockup (Everything outside of Chat, node 12506-194645):

- Quest header: total stars earned (each Mission capped at its threshold) with a progress bar toward the sum of thresholds
- Per Mission: raw earned/threshold (surplus shows, e.g. 12/7) with a bar that clamps at full
- `MissionProgress.cappedStars` + `QuestStarSummary`/`questStars()` added to the shared progression resolver (pure)
- `JoinedObjectiveCache.rebuildFromJoinedCourses` extracted as the single home for the joined-course uuid/teacher-threshold mapping; the world map's pins manager and the panel both rebuild through it, so the numbers can never drift between surfaces
- Previews (unjoined course) show no star display; the display fills in when the shared rollup resolves
- Display semantics recorded in the client quests instructions doc (decisions from Will, 2026-07-07)

## Why
Closes #7534

## Testing
- New `test/pangea/quest_star_summary_test.dart` (capping, overflow, mockup 4+1→5 case, stable denominator, empty quest)
- Full suite: `fvm flutter test test/` — 1013 passed
- `fvm flutter analyze` clean on touched files; `dart format` + import sorter applied
- Not yet exercised against a live course with earned stars — needs staging QA per the issue's TO TEST

## Deploy Notes
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quest and course star progress display in joined courses, including earned stars, thresholds, and a progress bar.
  * Course objectives now show aggregated star progress across missions with clearer progress feedback.

* **Bug Fixes**
  * Star totals are now capped per mission, preventing extra practice from inflating quest progress.
  * Progress calculations stay stable when some missions are still unavailable.

* **Tests**
  * Added coverage for star capping and quest-level progress calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->