### PR TITLE
fix(mobile-chrome): Courses rail item opens the hub while a course is selected

### DIFF
--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -49,6 +49,19 @@ class MobileNavWidget extends StatefulWidget {
   /// is cavity-hosted (rail-only, no matter the last height).
   final Widget? cavityChild;
 
+  /// Which rail item's OWN surface the cavity hosts — [AppSection.chats] for
+  /// the chat list, [AppSection.courses] for the add-course hub, null for
+  /// anything else (a course sheet, an activity plan). Drives the
+  /// tap-the-active-item toggle: [activeSection] alone can't, because the
+  /// highlight resolves a whole course context to Courses while the cavity
+  /// hosts a specific course, and the Courses tap must then NAVIGATE to the
+  /// hub, not toggle the course sheet (#7537).
+  final AppSection? cavitySection;
+
+  /// True when the cavity hosts the shortcut's own course sheet: the shortcut
+  /// tap then toggles collapse/re-expand instead of a same-URL no-op (#7537).
+  final bool courseShortcutHostsCavity;
+
   /// Height-memory identity for the current [cavityChild]: a course space id,
   /// or a fixed key like `'chats'` / `'courses'`. A different key opens at its
   /// own default rather than inheriting the previous key's height.
@@ -84,6 +97,8 @@ class MobileNavWidget extends StatefulWidget {
     required this.onCourseShortcutTap,
     required this.onSectionTap,
     this.cavityChild,
+    this.cavitySection,
+    this.courseShortcutHostsCavity = false,
     this.cavityKey,
     this.cavityDefaultsToPeek = false,
     required this.maxHeightFraction,
@@ -285,21 +300,41 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
     });
   }
 
+  /// Collapse an expanded cavity, or re-expand a collapsed one to its
+  /// remembered height — the tap-the-active-item gesture.
+  void _toggleCavity() {
+    if (_currentFraction > 0.01) {
+      _collapseEphemeral();
+    } else {
+      _openAt(_restoreHeight());
+    }
+  }
+
   void _onRailItemTap(AppSection section) {
-    if (widget.cavityChild != null && section == widget.activeSection) {
-      // Tapping the already-active rail item while expanded collapses it;
-      // while collapsed (with content available) re-expands to the
-      // remembered height.
-      if (_currentFraction > 0.01) {
-        _collapseEphemeral();
-      } else {
-        _openAt(_restoreHeight());
-      }
+    // Toggle only when the cavity is hosting THIS rail item's own surface
+    // (the chat list for Chats, the hub for Courses) — NOT merely when the
+    // item is highlighted. The highlight ([activeSection]) resolves a whole
+    // course context to Courses, so with a course sheet hosted the Courses
+    // icon looked active and this shortcut swallowed the tap that should
+    // navigate to the hub (#7537).
+    if (widget.cavityChild != null && section == widget.cavitySection) {
+      _toggleCavity();
       return;
     }
-    // A different rail item: the shell handles token navigation and the next
+    // Any other rail item: the shell handles token navigation and the next
     // build's didUpdateWidget resolves the resulting height.
     widget.onSectionTap(section);
+  }
+
+  void _onCourseShortcutTap() {
+    // The shortcut's own toggle: when its course IS the hosted sheet, the tap
+    // collapses/re-expands like any active rail item — a same-URL navigation
+    // would be a visible no-op (#7537). Anything else navigates.
+    if (widget.cavityChild != null && widget.courseShortcutHostsCavity) {
+      _toggleCavity();
+      return;
+    }
+    widget.onCourseShortcutTap();
   }
 
   @override
@@ -424,7 +459,7 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
                                     icon: widget.courseShortcutIcon,
                                     label: widget.courseShortcutLabel,
                                     selected: widget.courseShortcutSelected,
-                                    onTap: widget.onCourseShortcutTap,
+                                    onTap: _onCourseShortcutTap,
                                   ),
                                 ],
                               ),

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -440,6 +440,16 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
         cavityToken?.type == 'course' || cavityToken?.type == 'coursepage';
     final isActivityCavity = cavityToken?.type == 'activity';
 
+    // Which rail item's OWN surface the cavity hosts, for the widget's
+    // tap-the-active-item toggle. A course sheet / activity plan is neither
+    // rail section's surface — the Courses tap must then navigate to the hub
+    // instead of toggling (#7537).
+    final cavitySection = switch (cavityToken?.type) {
+      'chats' => AppSection.chats,
+      'addcourse' => AppSection.courses,
+      _ => null,
+    };
+
     // The floating search bar (routing.instructions.md → Single-column search
     // bar), riding the widget's topAttachment slot. This PR wires the MAP
     // scope: over the bare/scoped map it drives the world map's own filter
@@ -566,6 +576,13 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
           // value falls back to home.
           _ => WorkspaceNav.clearAll(),
         }),
+        cavitySection: cavitySection,
+        // The shortcut hosts the cavity when the hosted course sheet IS the
+        // shortcut's course (course cavities key by their space id).
+        courseShortcutHostsCavity:
+            isCourseCavity &&
+            shortcutCourse != null &&
+            shortcutCourse.id == activeSpaceId,
         cavityChild: cavityToken == null
             ? null
             : WorkspaceLeftPanel(

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -27,6 +27,8 @@ void main() {
     VoidCallback? onCourseShortcutTap,
     double maxHeightFraction = 0.75,
     double? preferredCavityHeightPx,
+    AppSection? cavitySection,
+    bool courseShortcutHostsCavity = false,
   }) async {
     tester.view.physicalSize = const Size(400, 800);
     tester.view.devicePixelRatio = 1.0;
@@ -47,6 +49,8 @@ void main() {
             cavityDefaultsToPeek: cavityDefaultsToPeek,
             maxHeightFraction: maxHeightFraction,
             preferredCavityHeightPx: preferredCavityHeightPx,
+            cavitySection: cavitySection,
+            courseShortcutHostsCavity: courseShortcutHostsCavity,
           ),
         ),
       ),
@@ -276,6 +280,7 @@ void main() {
         await pumpNav(
           tester,
           activeSection: AppSection.chats,
+          cavitySection: AppSection.chats,
           cavityChild: const Text('Chat list'),
           cavityKey: 'chats',
           maxHeightFraction: 0.75,
@@ -301,6 +306,107 @@ void main() {
     );
   });
 
+  group('the toggle keys on what the cavity hosts (#7537)', () {
+    testWidgets(
+      'Courses tap NAVIGATES to the hub while a course sheet is hosted, '
+      'even though the highlight resolves to Courses',
+      (tester) async {
+        AppSection? tapped;
+        await pumpNav(
+          tester,
+          // A selected course: highlight says Courses, but the cavity hosts
+          // the COURSE sheet (cavitySection null), not the hub.
+          activeSection: AppSection.courses,
+          cavitySection: null,
+          cavityChild: const Text('Course sheet'),
+          cavityKey: 'course-a',
+          cavityDefaultsToPeek: true,
+          onSectionTap: (s) => tapped = s,
+        );
+        final before = cavityHeightOf(tester);
+
+        await tester.tap(find.byTooltip('Courses'));
+        await tester.pumpAndSettle();
+
+        expect(
+          tapped,
+          AppSection.courses,
+          reason: 'the tap must navigate to the hub, not toggle the sheet',
+        );
+        expect(cavityHeightOf(tester), closeTo(before, 1.0));
+      },
+    );
+
+    testWidgets('Courses tap toggles when the cavity hosts the hub itself', (
+      tester,
+    ) async {
+      AppSection? tapped;
+      await pumpNav(
+        tester,
+        activeSection: AppSection.courses,
+        cavitySection: AppSection.courses,
+        cavityChild: const Text('Courses hub'),
+        cavityKey: 'addcourse',
+        onSectionTap: (s) => tapped = s,
+      );
+      expect(cavityHeightOf(tester), greaterThan(0.0));
+
+      await tester.tap(find.byTooltip('Courses'));
+      await tester.pumpAndSettle();
+
+      expect(tapped, isNull, reason: 'the active hub tap is a toggle');
+      expect(cavityHeightOf(tester), 0.0);
+    });
+
+    testWidgets('the course shortcut toggles its own hosted sheet instead of a '
+        'same-URL no-op', (tester) async {
+      var shortcutTaps = 0;
+      await pumpNav(
+        tester,
+        activeSection: AppSection.courses,
+        cavitySection: null,
+        courseShortcutHostsCavity: true,
+        cavityChild: const Text('Course sheet'),
+        cavityKey: 'course-a',
+        cavityDefaultsToPeek: true,
+        onCourseShortcutTap: () => shortcutTaps++,
+      );
+      final peek = cavityHeightOf(tester);
+      expect(peek, greaterThan(0.0));
+
+      // Expanded -> tap collapses (ephemeral), no navigation.
+      await tester.tap(find.byTooltip('Add a course'));
+      await tester.pumpAndSettle();
+      expect(shortcutTaps, 0);
+      expect(cavityHeightOf(tester), 0.0);
+
+      // Collapsed -> tap re-expands to the remembered height.
+      await tester.tap(find.byTooltip('Add a course'));
+      await tester.pumpAndSettle();
+      expect(shortcutTaps, 0);
+      expect(cavityHeightOf(tester), closeTo(peek, 1.0));
+    });
+
+    testWidgets(
+      'the course shortcut navigates when its course is NOT the hosted sheet',
+      (tester) async {
+        var shortcutTaps = 0;
+        await pumpNav(
+          tester,
+          activeSection: AppSection.chats,
+          cavitySection: AppSection.chats,
+          cavityChild: const Text('Chat list'),
+          cavityKey: 'chats',
+          onCourseShortcutTap: () => shortcutTaps++,
+        );
+
+        await tester.tap(find.byTooltip('Add a course'));
+        await tester.pumpAndSettle();
+        expect(shortcutTaps, 1);
+      },
+    );
+  });
+
   group('tap-outside collapse', () {
     testWidgets(
       'tapping outside collapses (ephemeral — no navigation), and the rail '
@@ -309,6 +415,7 @@ void main() {
         await pumpNav(
           tester,
           activeSection: AppSection.chats,
+          cavitySection: AppSection.chats,
           cavityChild: const Text('Chat list'),
           cavityKey: 'chats',
           maxHeightFraction: 0.75,
@@ -346,6 +453,7 @@ void main() {
       await pumpNav(
         tester,
         activeSection: AppSection.chats,
+        cavitySection: AppSection.chats,
         cavityChild: const Text('Chat list'),
         cavityKey: 'chats',
         maxHeightFraction: 0.75,


### PR DESCRIPTION
## What
On a narrow screen with a course selected, tapping the Courses rail item did nothing except collapse or re-expand the course sheet. The rail's tap-the-active-item toggle compared AppSections, and the section highlight resolves any course surface or course context to Courses, so the Courses icon looked active while the cavity hosted a specific course and the tap short-circuited into the toggle. The toggle now keys on what the cavity actually hosts: the Courses tap toggles only when the hub itself is the sheet, and otherwise navigates to it. The course shortcut gains the mirrored behavior: tapping it while its own course sheet is hosted toggles collapse/re-expand instead of a same-URL no-op, and tapping it from any other surface navigates as before.

## Why
Closes #7537.

## TO TEST
- [ ] On a phone-width window, open a course from the rail shortcut so the course sheet shows
- [ ] Tap the Courses (map) rail item: the Courses hub opens, replacing the course sheet
- [ ] From the hub, tap the course shortcut: the course sheet returns
- [ ] With the course sheet showing, tap the course shortcut again: the sheet collapses; tap once more and it re-expands at the height you left it
- [ ] Tap Chats, then Chats again: the chats sheet still toggles collapsed/expanded as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile navigation so the expandable cavity now tracks which section it belongs to.
  * Course shortcut taps now behave differently depending on whether they control the open cavity or navigate normally.

* **Bug Fixes**
  * Fixed cases where tapping a rail item could toggle the wrong panel.
  * Made collapse/expand behavior more consistent when reopening hosted content on mobile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->