### PR TITLE
chore: don't show next button in initial stage of course course code …

### DIFF
--- a/lib/routes/onboarding/onboarding_step_views/course_code_step_view.dart
+++ b/lib/routes/onboarding/onboarding_step_views/course_code_step_view.dart
@@ -172,52 +172,51 @@ class CourseCodeStepViewState extends State<CourseCodeStepView> {
             ),
           ),
         ),
-        //     Column(
-        Column(
-          children: [
-            ValueListenableBuilder(
-              valueListenable: _showCodeInput,
-              builder: (context, showInput, _) {
-                if (!showInput) return SizedBox();
-                return Padding(
+        ValueListenableBuilder(
+          valueListenable: _showCodeInput,
+          builder: (context, showInput, _) {
+            if (!showInput) return SizedBox(height: 60.0);
+            return Column(
+              children: [
+                Padding(
                   padding: EdgeInsetsGeometry.only(bottom: 12.0),
                   child: TextButton(
                     onPressed: widget.skip,
                     child: Text(L10n.of(context).courseCodeStepSkip),
                   ),
-                );
-              },
-            ),
-            ElevatedButton(
-              onPressed: _step.enableGoForward ? widget.forward : null,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: theme.colorScheme.primaryContainer,
-                foregroundColor: theme.colorScheme.onPrimaryContainer,
-                minimumSize: const Size.fromHeight(48),
-              ),
-              child: SizedBox(
-                height: 24,
-                child: Center(
-                  child: AnimatedSwitcher(
-                    duration: const Duration(milliseconds: 200),
-                    child: widget.loading
-                        ? SizedBox(
-                            key: const ValueKey('loading'),
-                            width: double.infinity,
-                            child: const LinearProgressIndicator(),
-                          )
-                        : Text(
-                            widget.hasNextStep
-                                ? _step.nextStepText(L10n.of(context))
-                                : _step.lastStepText(L10n.of(context)),
-                            key: const ValueKey('text'),
-                            textAlign: TextAlign.center,
-                          ),
+                ),
+                ElevatedButton(
+                  onPressed: _step.enableGoForward ? widget.forward : null,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: theme.colorScheme.primaryContainer,
+                    foregroundColor: theme.colorScheme.onPrimaryContainer,
+                    minimumSize: const Size.fromHeight(48),
+                  ),
+                  child: SizedBox(
+                    height: 24,
+                    child: Center(
+                      child: AnimatedSwitcher(
+                        duration: const Duration(milliseconds: 200),
+                        child: widget.loading
+                            ? SizedBox(
+                                key: const ValueKey('loading'),
+                                width: double.infinity,
+                                child: const LinearProgressIndicator(),
+                              )
+                            : Text(
+                                widget.hasNextStep
+                                    ? _step.nextStepText(L10n.of(context))
+                                    : _step.lastStepText(L10n.of(context)),
+                                key: const ValueKey('text'),
+                                textAlign: TextAlign.center,
+                              ),
+                      ),
+                    ),
                   ),
                 ),
-              ),
-            ),
-          ],
+              ],
+            );
+          },
         ),
       ],
     );


### PR DESCRIPTION
…step

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
