### PR TITLE
fix(activities): keep activity video inline so it can't trap on landscape tablets

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_video_player.dart
+++ b/lib/routes/chat/activity_sessions/activity_video_player.dart
@@ -53,6 +53,10 @@ class _ActivityVideoPlayerState extends State<ActivityVideoPlayer> {
           autoPlay: widget.autoPlay,
           looping: false,
           showControlsOnInitialize: false,
+          // Inline only, matching the YouTube player: activity video is an
+          // in-place stimulus, and fullscreen has no in-app exit here, so it
+          // would trap the learner on a landscape tablet (#7500).
+          allowFullScreen: false,
           aspectRatio: widget.aspectRatio ?? controller.value.aspectRatio,
         );
       });

--- a/lib/routes/chat/activity_sessions/activity_youtube_player.dart
+++ b/lib/routes/chat/activity_sessions/activity_youtube_player.dart
@@ -10,6 +10,13 @@ import 'package:youtube_player_iframe/youtube_player_iframe.dart';
 /// browser permits autoplay; with sound it relies on the user's tap as the
 /// gesture. Only the carousel's active page should mount one — it owns an
 /// iframe/webview that must be torn down with [YoutubePlayerController.close].
+///
+/// The embed stays inline: fullscreen is fully disabled (no fullscreen button,
+/// no auto-fullscreen on landscape rotation, no fullscreen-on-vertical-drag).
+/// Activity video is an in-place plan-page stimulus, and the package's
+/// fullscreen has no in-app exit affordance the way we mount it, so on a
+/// landscape tablet it would otherwise take over the screen with no way out and
+/// trap the learner (#7500).
 class ActivityYoutubePlayer extends StatefulWidget {
   final String url;
   final bool muted;
@@ -37,6 +44,9 @@ class _ActivityYoutubePlayerState extends State<ActivityYoutubePlayer> {
         mute: widget.muted,
         showControls: true,
         playsInline: true,
+        // Keep it inline — see the class doc (#7500). Already the package
+        // default, but pinned so it can't silently flip back on.
+        showFullscreenButton: false,
         privacyEnhancedMode: true,
       ),
     );
@@ -59,6 +69,10 @@ class _ActivityYoutubePlayerState extends State<ActivityYoutubePlayer> {
     return YoutubePlayer(
       controller: _controller,
       aspectRatio: widget.aspectRatio,
+      // Inline only (#7500): don't auto-fullscreen on landscape rotation, and
+      // don't let a vertical drag push into fullscreen.
+      autoFullScreen: false,
+      enableFullScreenOnVerticalDrag: false,
     );
   }
 }


### PR DESCRIPTION
Closes #7500.

## Problem

On a landscape tablet, tapping an activity video takes over the whole screen with no way out (no X, no exit-fullscreen, even after the video ends) — the learner is trapped and has to rotate the device to escape.

## Root cause

The YouTube embed (`youtube_player_iframe`) enters fullscreen on its own: the `YoutubePlayer` widget defaults `autoFullScreen: true` ("automatically enter fullscreen when the device rotates to landscape") and `enableFullScreenOnVerticalDrag: true`. We mount the player inline with no fullscreen scaffold and with the fullscreen button already off, so once it auto-enters fullscreen on landscape there is no in-app control to leave it.

(My earlier note on the issue guessed the fullscreen button — that turned out to already default to off in this package. The real trigger is `autoFullScreen` on the landscape rotation.)

## Fix

Keep the activity player inline. On `ActivityYoutubePlayer`:

- `autoFullScreen: false` — no auto-fullscreen on landscape rotation.
- `enableFullScreenOnVerticalDrag: false` — a stray vertical drag can't push into fullscreen.
- `showFullscreenButton: false` pinned explicitly (already the package default) so it can't silently flip back on.

`playsInline: true` was already set. All current activity videos are YouTube, so this covers the reported case. I also set `allowFullScreen: false` on the uploaded-video (Chewie) player so the two paths behave the same and an uploaded video can't reintroduce the same trap later. Easy to revisit if we ever want true fullscreen for activity video.

## Testing

- `flutter analyze` clean on both changed files.
- No tests mount these players (they own live webview/decoder instances). Native fullscreen behavior can only be confirmed on a device, so please verify on a landscape iPad: play an activity video, rotate, and confirm it stays inline in the hero and never takes over the screen.
