### PR TITLE
Use darker gold for vocab practice +XP

### DIFF
--- a/lib/routes/analytics/construct_analytics/practice/completed_analytics_practice_exercises_view.dart
+++ b/lib/routes/analytics/construct_analytics/practice/completed_analytics_practice_exercises_view.dart
@@ -69,7 +69,7 @@ class CompletedAnalyticsPracticeExercisesView extends StatelessWidget {
             Text(
               "+ ${session.state.allXPGained} XP",
               style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                color: AppConfig.goldLight,
+                color: AppConfig.goldByTheme(context),
                 fontWeight: FontWeight.bold,
               ),
             ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated XP text to use a theme-aware gold color, improving visual consistency across themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->