### PR TITLE
Reduce gap at bottom of chat list

### DIFF
--- a/lib/routes/chat_list/chat_list_body.dart
+++ b/lib/routes/chat_list/chat_list_body.dart
@@ -305,7 +305,7 @@ class ChatListViewBody extends StatelessWidget {
                 SliverToBoxAdapter(
                   child: DMListTile(visible: !controller.isSearchMode),
                 ),
-              const SliverToBoxAdapter(child: SizedBox(height: 75.0)),
+              const SliverToBoxAdapter(child: SizedBox(height: 8.0)),
               // Pangea#
             ],
           ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reduced extra vertical spacing in the chat list when older messages are available, resulting in a tighter and more consistent layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->