### PR TITLE
Add padding around activity load error

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -186,8 +186,11 @@ class ActivitySessionStartView extends StatelessWidget {
                 // activities.instructions.md engages only on a confirmed 404).
                 : controller.error != null
                 ? Center(
-                    child: ErrorIndicator(
-                      message: L10n.of(context).activityLoadFailed,
+                    child: Padding(
+                      padding: const EdgeInsets.all(24.0),
+                      child: ErrorIndicator(
+                        message: L10n.of(context).activityLoadFailed,
+                      ),
                     ),
                   )
                 // Confirmed removed with no plan recoverable from room state:


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
