### PR TITLE
Show pre-a1 map filter

### DIFF
--- a/lib/routes/world/world_map_search_overlay.dart
+++ b/lib/routes/world/world_map_search_overlay.dart
@@ -148,15 +148,14 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
                     ),
                     const SizedBox(width: 6),
                   ],
-                  for (final level in LanguageLevelTypeEnum.values)
-                    if (level != LanguageLevelTypeEnum.preA1) ...[
-                      FilterChip(
-                        selected: widget.filter.cefrFilter.contains(level),
-                        label: Text(level.title(context)),
-                        onSelected: (_) => widget.toggleCefr(level),
-                      ),
-                      const SizedBox(width: 6),
-                    ],
+                  for (final level in LanguageLevelTypeEnum.values) ...[
+                    FilterChip(
+                      selected: widget.filter.cefrFilter.contains(level),
+                      label: Text(level.title(context)),
+                      onSelected: (_) => widget.toggleCefr(level),
+                    ),
+                    const SizedBox(width: 6),
+                  ],
                   for (final c in MapCompletionFilter.values) ...[
                     FilterChip(
                       selected: widget.filter.completionFilter.contains(c),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The language-level filter now includes the full set of available CEFR options, including the lowest level.
  * Users can now see and select the previously missing `preA1` filter chip in the search overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->