### PR TITLE
Attributions visibility

### DIFF
--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -478,6 +478,11 @@ class _WorldMapViewState extends State<WorldMapView> {
     final dark = Theme.of(context).brightness == Brightness.dark;
     final retina = dark && MediaQuery.devicePixelRatioOf(context) > 1.0;
 
+    final attributionsLeft = 0.0;
+    final attributionsBottom = FluffyThemes.isColumnMode(context)
+        ? 0.0
+        : _narrowBottomChromeInset;
+
     // Resolve which pins to draw and each one's tier/state/pinged/fill once per
     // frame, then lay out the layers from it.
     final render = _resolvePinRender(context);
@@ -543,16 +548,26 @@ class _WorldMapViewState extends State<WorldMapView> {
           MarkerLayer(markers: _exitingMarkers()),
           // Large cards (always visible): the featured cards the width affords.
           MarkerLayer(markers: _largeMarkers(render)),
-          Padding(
+          // Make a background, so attributions stand out in dark mode
+          Positioned(
+            left: attributionsLeft + 8,
+            bottom: attributionsBottom + 8,
+            child: Container(
+              height: 32,
+              width: 32,
+              decoration: BoxDecoration(
+                color: const Color.fromARGB(130, 135, 135, 135),
+                shape: BoxShape.circle,
+              ),
+            ),
+          ),
+          Positioned(
             // On a narrow screen the bottom chrome (nav widget + the search bar
             // riding above it) owns the bottom edge, so lift the attribution
             // above it — otherwise it sits unreadable UNDER the floating rail
             // (#7218 on narrow).
-            padding: EdgeInsets.only(
-              bottom: FluffyThemes.isColumnMode(context)
-                  ? 0.0
-                  : _narrowBottomChromeInset,
-            ),
+            left: attributionsLeft,
+            bottom: attributionsBottom,
             child: RichAttributionWidget(
               // #7218: bottom-LEFT so the attribution and its expand popup don't
               // sit under the bottom-right zoom/World controls (where it was

--- a/lib/widgets/navigation_rail.dart
+++ b/lib/widgets/navigation_rail.dart
@@ -93,154 +93,164 @@ class SpacesNavigationRail extends StatelessWidget {
     // world_v2: the rail floats over the persistent map in the shared dock pill
     // (rounded, surface, elevated, outline-bordered) — the same chrome as the
     // top-right cluster, one source of truth. See workspace_dock.dart.
-    return WorkspaceDock(
-      child: SafeArea(
-        child: Semantics(
-          label: L10n.of(context).navOptionsLabel,
-          child: StreamBuilder(
-            key: ValueKey(client.userID.toString()),
-            stream: client.onSync.stream
-                .where((s) => s.hasRoomUpdate)
-                .rateLimit(const Duration(seconds: 1)),
-            builder: (context, _) {
-              final allSpaces = client.rooms
-                  .where((room) => room.isSpace)
-                  .toList();
+    return SafeArea(
+      child: Padding(
+        // Leave space for attributions widget to be visible
+        padding: .only(bottom: 100),
+        child: WorkspaceDock(
+          child: Semantics(
+            label: L10n.of(context).navOptionsLabel,
+            child: StreamBuilder(
+              key: ValueKey(client.userID.toString()),
+              stream: client.onSync.stream
+                  .where((s) => s.hasRoomUpdate)
+                  .rateLimit(const Duration(seconds: 1)),
+              builder: (context, _) {
+                final allSpaces = client.rooms
+                    .where((room) => room.isSpace)
+                    .toList();
 
-              return AnimatedContainer(
-                width: naviRailWidth,
-                duration: FluffyThemes.animationDuration,
-                // world_v2 rail order (top→bottom): World · Chats · Courses ·
-                // joined spaces. (Profile/settings is no longer a rail slot;
-                // analytics opens from the top-right cluster.)
-                child: Column(
-                  // Size the rail to its items — a floating bar over the map, not
-                  // the full screen height; it still scrolls if the joined-spaces
-                  // list overflows the viewport.
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Flexible(
-                      child: ListView(
-                        shrinkWrap: true,
-                        scrollDirection: Axis.vertical,
-                        children: [
-                          // 1. World map home — the Pangea brand mark, at the top
-                          // of the rail. Chromeless and avatar-sized; the left
-                          // indicator bar conveys selection. Brand purple when
-                          // active, muted when not.
-                          NaviRailItem(
-                            isSelected: isWorld,
-                            backgroundColor: Colors.transparent,
-                            // Exclude the logo's semanticsLabel so VoiceOver reads
-                            // only the button tooltip ("world"), not the logo name.
-                            icon: ExcludeSemantics(
-                              child: PangeaLogoSvg(
-                                width: largeIconWidth,
-                                forceColor: Theme.of(
-                                  context,
-                                ).colorScheme.onSurfaceVariant,
-                              ),
-                            ),
-                            selectedIcon: ExcludeSemantics(
-                              child: PangeaLogoSvg(
-                                width: largeIconWidth,
-                                forceColor: Theme.of(
-                                  context,
-                                ).colorScheme.primary,
-                              ),
-                            ),
-                            onTap: () {
-                              // World is home: clear every panel (both columns)
-                              // and reveal the full map. See routing.instructions.md.
-                              context.go(WorkspaceNav.clearAll());
-                            },
-                            toolTip: L10n.of(context).world,
-                            naviRailWidth: naviRailWidth,
-                          ),
-                          // 2. Chats — the chat list. Chromeless (no box fill) and
-                          // icon-sized to match the brand mark / course avatars
-                          // (it used to render tiny on the default surface fill);
-                          // the left indicator bar conveys selection.
-                          NaviRailItem(
-                            isSelected: isChats,
-                            backgroundColor: Colors.transparent,
-                            icon: Icon(
-                              Icons.forum_outlined,
-                              size: smallIconWidth,
-                            ),
-                            selectedIcon: Icon(
-                              Icons.forum,
-                              size: smallIconWidth,
-                            ),
-                            onTap: () {
-                              // Token-only: the chats list is a left `chats` token
-                              // over the world path `/` (no legacy `/chats` path).
-                              context.go(
-                                WorkspaceNav.setSection(
-                                  state.uri,
-                                  const ChatsPanelToken(),
-                                  // Replace open left panels rather than stack.
-                                  keepRoom: false,
+                return AnimatedContainer(
+                  width: naviRailWidth,
+                  duration: FluffyThemes.animationDuration,
+                  // world_v2 rail order (top→bottom): World · Chats · Courses ·
+                  // joined spaces. (Profile/settings is no longer a rail slot;
+                  // analytics opens from the top-right cluster.)
+                  child: Column(
+                    // Size the rail to its items — a floating bar over the map, not
+                    // the full screen height; it still scrolls if the joined-spaces
+                    // list overflows the viewport.
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Flexible(
+                        child: ListView(
+                          shrinkWrap: true,
+                          scrollDirection: Axis.vertical,
+                          children: [
+                            // 1. World map home — the Pangea brand mark, at the top
+                            // of the rail. Chromeless and avatar-sized; the left
+                            // indicator bar conveys selection. Brand purple when
+                            // active, muted when not.
+                            NaviRailItem(
+                              isSelected: isWorld,
+                              backgroundColor: Colors.transparent,
+                              // Exclude the logo's semanticsLabel so VoiceOver reads
+                              // only the button tooltip ("world"), not the logo name.
+                              icon: ExcludeSemantics(
+                                child: PangeaLogoSvg(
+                                  width: largeIconWidth,
+                                  forceColor: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
                                 ),
-                              );
-                            },
-                            toolTip: L10n.of(context).allChats,
-                            unreadBadgeFilter: (room) =>
-                                room.firstSpaceParent == null,
-                            naviRailWidth: naviRailWidth,
-                          ),
-                          // 3. Courses — opens the Courses panel (the courses
-                          // you're in + add-course options) as a bare `addcourse`
-                          // left token. The Material map icon; chromeless, the bar
-                          // conveys selection. keepRoom:false keeps it a focused
-                          // flow with no chat floating over it. (Analytics is not a
-                          // rail section — it opens from the top-right cluster.)
-                          NaviRailItem(
-                            isSelected: isCourseFind,
-                            backgroundColor: Colors.transparent,
-                            icon: Icon(
-                              Icons.map_outlined,
-                              size: smallIconWidth,
+                              ),
+                              selectedIcon: ExcludeSemantics(
+                                child: PangeaLogoSvg(
+                                  width: largeIconWidth,
+                                  forceColor: Theme.of(
+                                    context,
+                                  ).colorScheme.primary,
+                                ),
+                              ),
+                              onTap: () {
+                                // World is home: clear every panel (both columns)
+                                // and reveal the full map. See routing.instructions.md.
+                                context.go(WorkspaceNav.clearAll());
+                              },
+                              toolTip: L10n.of(context).world,
+                              naviRailWidth: naviRailWidth,
                             ),
-                            selectedIcon: Icon(Icons.map, size: smallIconWidth),
-                            onTap: () {
-                              context.go(WorkspaceNav.openAddCourse(state.uri));
-                            },
-                            toolTip: L10n.of(context).courses,
-                            naviRailWidth: naviRailWidth,
-                          ),
-                          Semantics(
-                            label: L10n.of(context).joinedCourseListLabel,
-                            child: ListView(
-                              shrinkWrap: true,
-                              scrollDirection: Axis.vertical,
-                              children: [
-                                // 4. The course spaces you're in.
-                                for (final space in allSpaces)
-                                  // _spaceItem(context, space),
-                                  _SpaceItem(
-                                    space: space,
-                                    iconWidth: largeIconWidth,
-                                    naviRailWidth: naviRailWidth,
-                                    // Highlight the course avatar only while the course
-                                    // IS the open section — not merely because `?c=`
-                                    // persists under a chat/room (routing decision 5).
-                                    selected:
-                                        section == AppSection.courses &&
-                                        activeSpaceId == space.id,
-                                    onTap: () => _onTapSpace(context, space.id),
+                            // 2. Chats — the chat list. Chromeless (no box fill) and
+                            // icon-sized to match the brand mark / course avatars
+                            // (it used to render tiny on the default surface fill);
+                            // the left indicator bar conveys selection.
+                            NaviRailItem(
+                              isSelected: isChats,
+                              backgroundColor: Colors.transparent,
+                              icon: Icon(
+                                Icons.forum_outlined,
+                                size: smallIconWidth,
+                              ),
+                              selectedIcon: Icon(
+                                Icons.forum,
+                                size: smallIconWidth,
+                              ),
+                              onTap: () {
+                                // Token-only: the chats list is a left `chats` token
+                                // over the world path `/` (no legacy `/chats` path).
+                                context.go(
+                                  WorkspaceNav.setSection(
+                                    state.uri,
+                                    const ChatsPanelToken(),
+                                    // Replace open left panels rather than stack.
+                                    keepRoom: false,
                                   ),
-                              ],
+                                );
+                              },
+                              toolTip: L10n.of(context).allChats,
+                              unreadBadgeFilter: (room) =>
+                                  room.firstSpaceParent == null,
+                              naviRailWidth: naviRailWidth,
                             ),
-                          ),
-                        ],
+                            // 3. Courses — opens the Courses panel (the courses
+                            // you're in + add-course options) as a bare `addcourse`
+                            // left token. The Material map icon; chromeless, the bar
+                            // conveys selection. keepRoom:false keeps it a focused
+                            // flow with no chat floating over it. (Analytics is not a
+                            // rail section — it opens from the top-right cluster.)
+                            NaviRailItem(
+                              isSelected: isCourseFind,
+                              backgroundColor: Colors.transparent,
+                              icon: Icon(
+                                Icons.map_outlined,
+                                size: smallIconWidth,
+                              ),
+                              selectedIcon: Icon(
+                                Icons.map,
+                                size: smallIconWidth,
+                              ),
+                              onTap: () {
+                                context.go(
+                                  WorkspaceNav.openAddCourse(state.uri),
+                                );
+                              },
+                              toolTip: L10n.of(context).courses,
+                              naviRailWidth: naviRailWidth,
+                            ),
+                            Semantics(
+                              label: L10n.of(context).joinedCourseListLabel,
+                              child: ListView(
+                                shrinkWrap: true,
+                                scrollDirection: Axis.vertical,
+                                children: [
+                                  // 4. The course spaces you're in.
+                                  for (final space in allSpaces)
+                                    // _spaceItem(context, space),
+                                    _SpaceItem(
+                                      space: space,
+                                      iconWidth: largeIconWidth,
+                                      naviRailWidth: naviRailWidth,
+                                      // Highlight the course avatar only while the course
+                                      // IS the open section — not merely because `?c=`
+                                      // persists under a chat/room (routing decision 5).
+                                      selected:
+                                          section == AppSection.courses &&
+                                          activeSpaceId == space.id,
+                                      onTap: () =>
+                                          _onTapSpace(context, space.id),
+                                    ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
-                    ),
-                  ],
-                ),
-              );
-            },
+                    ],
+                  ),
+                );
+              },
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved map attribution positioning across different layouts and screen sizes.
  * Added a contrasting background behind map attributions for better visibility in dark mode.
  * Adjusted navigation rail spacing to prevent overlap with map attributions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->