### PR TITLE
fix: set require analytics access to true by default

### DIFF
--- a/lib/features/analytics_access/course_settings_extension.dart
+++ b/lib/features/analytics_access/course_settings_extension.dart
@@ -14,6 +14,12 @@ extension CourseSettingsExtension on Room {
     return CourseSettingsModel();
   }
 
+  Future<void> setRequireAnalyticsAccess(bool value) async {
+    final current = _courseSettings;
+    if (current.requireAnalyticsAccess == value) return;
+    await _setCourseSettings(current.copyWith(requireAnalyticsAccess: value));
+  }
+
   Future<void> toggleRequireAnalyticsAccess() async {
     final current = _courseSettings;
     await _setCourseSettings(
@@ -22,11 +28,14 @@ extension CourseSettingsExtension on Room {
   }
 
   Future<void> _setCourseSettings(CourseSettingsModel model) async {
+    if (model == _courseSettings) return;
+    final syncFuture = client.waitForRoomInSync(id);
     await client.setRoomStateWithKey(
       id,
       PangeaEventTypes.courseSettings,
       '',
       model.toJson(),
     );
+    await syncFuture;
   }
 }

--- a/lib/features/analytics_access/course_settings_model.dart
+++ b/lib/features/analytics_access/course_settings_model.dart
@@ -19,4 +19,14 @@ class CourseSettingsModel {
           requireAnalyticsAccess ?? this.requireAnalyticsAccess,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CourseSettingsModel &&
+          runtimeType == other.runtimeType &&
+          requireAnalyticsAccess == other.requireAnalyticsAccess;
+
+  @override
+  int get hashCode => Object.hashAll([requireAnalyticsAccess]);
 }

--- a/lib/routes/courses/own/invite/course_invite_page.dart
+++ b/lib/routes/courses/own/invite/course_invite_page.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/analytics_access/course_settings_extension.dart';
 import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_client_extension.dart';
@@ -125,16 +126,52 @@ class CourseInvitePageController extends State<CourseInvitePage>
     }
   }
 
+  Future<bool> get _requireAnalyticsAccess async {
+    String spaceId;
+    try {
+      spaceId = await getSpaceId();
+    } catch (e, s) {
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"created_course_id": widget.courseId},
+      );
+      return true;
+    }
+
+    final room = Matrix.of(context).client.getRoomById(spaceId);
+    if (room == null) return true;
+    return room.requireAnalyticsAccess;
+  }
+
   Future<void> _setVisibility(bool value) async {
     try {
-      debugPrint(
-        "Setting course visibility to ${value ? "public" : "private"}",
-      );
       final spaceId = await getSpaceId();
       await Matrix.of(context).client.setRoomVisibilityOnDirectory(
         spaceId,
         visibility: value ? Visibility.public : Visibility.private,
       );
+    } catch (e, s) {
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"created_course_id": widget.courseId, "visibility": value},
+      );
+      rethrow;
+    } finally {
+      if (mounted) setState(() {});
+    }
+  }
+
+  Future<void> _setRequireAnalyticsAccess(bool value) async {
+    try {
+      final spaceId = await getSpaceId();
+      final room = Matrix.of(context).client.getRoomById(spaceId);
+      if (room == null) {
+        throw Exception('Room not found');
+      }
+
+      await room.setRequireAnalyticsAccess(value);
     } catch (e, s) {
       ErrorHandler.logError(
         e: e,
@@ -263,32 +300,69 @@ class CourseInvitePageController extends State<CourseInvitePage>
                   spacing: 24.0,
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    Row(
-                      spacing: 8.0,
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Flexible(
-                          child: Text(
-                            L10n.of(context).visibilityToggleTitle,
-                            style: theme.textTheme.bodyMedium,
-                            textAlign: TextAlign.center,
-                          ),
-                        ),
-                        FutureBuilder(
-                          future: _isPublic,
-                          builder: (context, snapshot) {
-                            final value = snapshot.data ?? true;
-                            return Switch(
-                              value: value,
-                              onChanged: (v) => showFutureLoadingDialog(
-                                context: context,
-                                future: () => _setVisibility(v),
+                    Container(
+                      padding: EdgeInsets.symmetric(horizontal: 16.0),
+                      constraints: BoxConstraints(maxWidth: 400.0),
+                      child: Column(
+                        spacing: 8.0,
+                        children: [
+                          Row(
+                            spacing: 8.0,
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Flexible(
+                                child: Text(
+                                  L10n.of(context).visibilityToggleTitle,
+                                  style: theme.textTheme.bodyMedium,
+                                  textAlign: TextAlign.center,
+                                ),
                               ),
-                              activeThumbColor: AppConfig.success,
-                            );
-                          },
-                        ),
-                      ],
+                              FutureBuilder(
+                                future: _isPublic,
+                                builder: (context, snapshot) {
+                                  final value = snapshot.data ?? true;
+                                  return Switch(
+                                    value: value,
+                                    onChanged: (v) => showFutureLoadingDialog(
+                                      context: context,
+                                      future: () => _setVisibility(v),
+                                    ),
+                                    activeThumbColor: AppConfig.success,
+                                  );
+                                },
+                              ),
+                            ],
+                          ),
+                          Row(
+                            spacing: 8.0,
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Flexible(
+                                child: Text(
+                                  L10n.of(context).requireAnalyticsAccessTitle,
+                                  style: theme.textTheme.bodyMedium,
+                                  textAlign: TextAlign.center,
+                                ),
+                              ),
+                              FutureBuilder(
+                                future: _requireAnalyticsAccess,
+                                builder: (context, snapshot) {
+                                  final value = snapshot.data ?? true;
+                                  return Switch(
+                                    value: value,
+                                    onChanged: (v) => showFutureLoadingDialog(
+                                      context: context,
+                                      future: () =>
+                                          _setRequireAnalyticsAccess(v),
+                                    ),
+                                    activeThumbColor: AppConfig.success,
+                                  );
+                                },
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
                     ),
                     ElevatedButton(
                       onPressed: () async {

--- a/lib/routes/courses/own/selected_course_page.dart
+++ b/lib/routes/courses/own/selected_course_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart' as sdk;
 
+import 'package:fluffychat/features/analytics_access/course_settings_model.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_model.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
@@ -114,6 +115,12 @@ class SelectedCourseController extends State<SelectedCourse>
             sdk.StateEvent(
               type: PangeaEventTypes.coursePlan,
               content: {"uuid": courseId},
+            ),
+            sdk.StateEvent(
+              type: PangeaEventTypes.courseSettings,
+              content: CourseSettingsModel(
+                requireAnalyticsAccess: true,
+              ).toJson(),
             ),
           ],
           avatarUrl: course.imageUrl.toString(),

--- a/lib/routes/settings/settings_view.dart
+++ b/lib/routes/settings/settings_view.dart
@@ -12,6 +12,7 @@ import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/routes/settings/settings.dart';
 import 'package:fluffychat/routes/settings/support_chat_list_tile.dart';
 import 'package:fluffychat/widgets/announcing_snackbar.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 
 // #Pangea
 // Pangea#


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
