### PR TITLE
fix: on open activity with existing session, open room panel of session

### DIFF
--- a/lib/features/navigation/workspace_nav.dart
+++ b/lib/features/navigation/workspace_nav.dart
@@ -443,20 +443,22 @@ abstract class WorkspaceNav {
     bool launch = false,
     int? autoplay,
   }) {
-    final parts = WorkspaceQuery.parts(current.query);
-    WorkspaceQuery.removeKeys(parts, {'left'});
-
-    final token = ActivityPanelToken(
-      ActivityTokenParam(
-        activityId: activityId,
-        roomId: roomId,
-        launch: launch,
-        autoplay: autoplay,
-      ),
+    return _mutate(
+      current,
+      'left',
+      (_) => roomId != null
+          ? [RoomPanelToken(RoomTokenParam(id: roomId))]
+          : [
+              ActivityPanelToken(
+                ActivityTokenParam(
+                  activityId: activityId,
+                  roomId: roomId,
+                  launch: launch,
+                  autoplay: autoplay,
+                ),
+              ),
+            ],
     );
-
-    parts.add('left=${token.encode()}');
-    return WorkspaceQuery.location(PRoutes.world, parts);
   }
 
   /// Drop the open `activity` token, keeping the rest of the workspace —


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
