### PR TITLE
fix: extract shared functionality into user clutter view model, added…

### DIFF
--- a/lib/routes/chat/chat_view.dart
+++ b/lib/routes/chat/chat_view.dart
@@ -24,7 +24,7 @@ import 'package:fluffychat/routes/chat/chat_event_list.dart';
 import 'package:fluffychat/routes/chat/chat_floating_action_button.dart';
 import 'package:fluffychat/routes/chat/chat_input_bar.dart';
 import 'package:fluffychat/routes/chat/pinned_events.dart';
-import 'package:fluffychat/routes/world/world_analytics_bar.dart';
+import 'package:fluffychat/routes/world/analytics_header_avatar.dart';
 import 'package:fluffychat/utils/account_config.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
 import 'package:fluffychat/utils/navigation_util.dart';

--- a/lib/routes/world/analytics_header_avatar.dart
+++ b/lib/routes/world/analytics_header_avatar.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/analytics_data/derived_analytics_data_model.dart';
+import 'package:fluffychat/features/languages/language_model.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/circular_xp_ring_painter.dart';
+import 'package:fluffychat/routes/world/hex_level_badge.dart';
+import 'package:fluffychat/routes/world/level_up_badge_celebration.dart';
+import 'package:fluffychat/routes/world/user_cluster_view_model.dart';
+import 'package:fluffychat/routes/world/user_cluster_view_model_builder.dart';
+import 'package:fluffychat/routes/world/world_user_cluster.dart';
+
+class AnalyticsHeaderAvatar extends StatelessWidget {
+  const AnalyticsHeaderAvatar({super.key});
+
+  @override
+  Widget build(BuildContext context) => UserClusterViewModelBuilder(
+    builder: (context, viewModel) => Padding(
+      padding: const EdgeInsets.only(right: 12.0),
+      child: AnalyticsHeaderAvatarInternal(
+        viewModel: viewModel,
+        // App-bar sized: the full-size circle is built for open floating
+        // space; at 0.75 the ring + badge + flag fit the toolbar's height.
+        scale: 0.75,
+      ),
+    ),
+  );
+}
+
+/// The avatar circle wearing the XP ring, the level badge, and the small
+/// flag (Figma collapsed component) — one tap target, announced as a single
+/// button. Plain values only; [AnalyticsHeaderAvatar] is its Matrix-aware
+/// host, mounting it in a full-screen chat's app bar (routing.instructions.md
+/// → "Single-column analytics nav bar"). [scale] shrinks the whole cluster
+/// proportionally so it fits a toolbar.
+class AnalyticsHeaderAvatarInternal extends StatelessWidget {
+  final UserClusterViewModel viewModel;
+  final double scale;
+
+  const AnalyticsHeaderAvatarInternal({
+    required this.viewModel,
+    this.scale = 1.0,
+    this.flagBuilder,
+    super.key,
+  });
+
+  final Widget Function(
+    LanguageModel language,
+    VoidCallback onTap,
+    double width,
+    double height,
+    double fontSize,
+  )?
+  flagBuilder;
+
+  // Base (scale 1.0) geometry — the floating-space size the cluster was
+  // designed at; every dimension multiplies by [scale] so the proportions
+  // hold at toolbar sizes.
+  static const double _xpStrokeBase = 4.0;
+  static const double _avatarSizeBase = 44.0;
+  static const double _flagWidthBase = 28.0;
+  static const double _flagHeightBase = 20.0;
+  static const double _flagFontSizeBase = 11.0;
+
+  // Miniature hex badge pinned over the avatar's top-left, and the flag
+  // hanging under its bottom edge — the collapsed echo of the bar cluster.
+  static const double _badgeTopOffsetBase = -6.0;
+  static const double _badgeLeftOffsetBase = -10.0;
+  static const double _badgeWidthBase = 30.0;
+  static const double _badgeHeightBase = 26.0;
+  static const double _badgeFontSizeBase = 13.0;
+  static const double _flagBottomOffsetBase = -10.0;
+
+  double get _xpStroke => _xpStrokeBase * scale;
+  double get _avatarSize => _avatarSizeBase * scale;
+  double get _flagWidth => _flagWidthBase * scale;
+  double get _flagHeight => _flagHeightBase * scale;
+  double get _flagFontSize => _flagFontSizeBase * scale;
+  double get _badgeTopOffset => _badgeTopOffsetBase * scale;
+  double get _badgeLeftOffset => _badgeLeftOffsetBase * scale;
+  double get _badgeWidth => _badgeWidthBase * scale;
+  double get _badgeHeight => _badgeHeightBase * scale;
+  double get _badgeFontSize => _badgeFontSizeBase * scale;
+  double get _flagBottomOffset => _flagBottomOffsetBase * scale;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = L10n.of(context).analyticsAndSettingsLabel;
+    return StreamBuilder(
+      stream: viewModel.languageStream,
+      builder: (context, _) {
+        final l2 = viewModel.userL2;
+        return MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: Tooltip(
+            message: label,
+            // The Semantics below already names this control; exclude the Tooltip
+            // so its message isn't announced twice.
+            excludeFromSemantics: true,
+            child: Semantics(
+              button: true,
+              label: label,
+              // A bounded node of its own: without `container` the annotation
+              // merges into the stretched ancestor, so assistive tech (and the
+              // widget tests' semantics taps) target the full-width bar area
+              // instead of the circle.
+              container: true,
+              excludeSemantics: true,
+              // Expose the tap on the announced node for assistive tech (#7185).
+              onTap: () => viewModel.openAnalyticsSummary(context),
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => viewModel.openAnalyticsSummary(context),
+                child: FutureBuilder<DerivedAnalyticsDataModel>(
+                  future: viewModel.derivedAnalyticsData,
+                  builder: (context, snapshot) {
+                    final derived =
+                        snapshot.data ?? viewModel.cachedDerivedAnalyticsData;
+                    final level = derived?.level ?? 1;
+                    final progress = (derived?.levelProgress ?? 0.0).clamp(
+                      0.0,
+                      1.0,
+                    );
+                    return Stack(
+                      clipBehavior: Clip.none,
+                      alignment: Alignment.center,
+                      children: [
+                        CustomPaint(
+                          size: Size.square(_avatarSize + 2 * _xpStroke),
+                          painter: CircularXpRingPainter(
+                            progress: progress,
+                            trackColor: const Color.fromARGB(
+                              130,
+                              135,
+                              135,
+                              135,
+                            ),
+                            progressColor: AppConfig.goldByTheme(context),
+                            stroke: _xpStroke,
+                          ),
+                          child: Padding(
+                            padding: EdgeInsets.all(_xpStroke),
+                            child: ListenableBuilder(
+                              listenable: Listenable.merge([
+                                viewModel.avatarUrl,
+                                viewModel.displayName,
+                              ]),
+                              builder: (context, _) => ClusterAvatar(
+                                avatarUrl: viewModel.avatarUrl.value,
+                                name: viewModel.displayName.value,
+                                onTap: () =>
+                                    viewModel.openAnalyticsSummary(context),
+                                size: _avatarSize,
+                              ),
+                            ),
+                          ),
+                        ),
+                        Positioned(
+                          top: _badgeTopOffset,
+                          left: _badgeLeftOffset,
+                          child: IgnorePointer(
+                            child: Material(
+                              type: MaterialType.transparency,
+                              child: LevelUpBadgeCelebration(
+                                levelUpdates: viewModel.levelUpdates,
+                                child: HexLevelBadge(
+                                  level: level,
+                                  onTap: () =>
+                                      viewModel.openAnalyticsSummary(context),
+                                  width: _badgeWidth,
+                                  height: _badgeHeight,
+                                  fontSize: _badgeFontSize,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                        if (l2 != null)
+                          Positioned(
+                            bottom: _flagBottomOffset,
+                            child: IgnorePointer(
+                              child:
+                                  flagBuilder?.call(
+                                    l2,
+                                    () =>
+                                        viewModel.openAnalyticsSummary(context),
+                                    _flagWidth,
+                                    _flagHeight,
+                                    _flagFontSize,
+                                  ) ??
+                                  ClusterLanguageFlag(
+                                    language: l2,
+                                    onTap: () =>
+                                        viewModel.openAnalyticsSummary(context),
+                                    width: _flagWidth,
+                                    height: _flagHeight,
+                                    fontSize: _flagFontSize,
+                                  ),
+                            ),
+                          ),
+                      ],
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/routes/world/circular_xp_ring_painter.dart
+++ b/lib/routes/world/circular_xp_ring_painter.dart
@@ -1,0 +1,61 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// Paints the collapsed avatar's XP ring: a full gray circular track with a
+/// gold arc filling clockwise from the top for [progress] (0-1) of the way to
+/// the next level. The cluster's `XpBorderPainter` traces the powerups pill's
+/// rounded-rect outline instead, so the circular avatar needs this simpler
+/// circular counterpart rather than reusing it as-is.
+class CircularXpRingPainter extends CustomPainter {
+  final double progress;
+  final Color trackColor;
+  final Color progressColor;
+  final double stroke;
+
+  const CircularXpRingPainter({
+    required this.progress,
+    required this.trackColor,
+    required this.progressColor,
+    required this.stroke,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = size.center(Offset.zero);
+    final radius = (size.shortestSide - stroke) / 2;
+    final rect = Rect.fromCircle(center: center, radius: radius);
+
+    canvas.drawArc(
+      rect,
+      0,
+      2 * math.pi,
+      false,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = stroke
+        ..color = trackColor,
+    );
+
+    final p = progress.clamp(0.0, 1.0);
+    if (p <= 0) return;
+    canvas.drawArc(
+      rect,
+      -math.pi / 2,
+      2 * math.pi * p,
+      false,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = stroke
+        ..strokeCap = StrokeCap.round
+        ..color = progressColor,
+    );
+  }
+
+  @override
+  bool shouldRepaint(CircularXpRingPainter old) =>
+      old.progress != progress ||
+      old.progressColor != progressColor ||
+      old.trackColor != trackColor ||
+      old.stroke != stroke;
+}

--- a/lib/routes/world/hex_level_badge.dart
+++ b/lib/routes/world/hex_level_badge.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+
+/// The narrow bar's level badge: the Figma hexagon (pointy left/right, flat
+/// top/bottom) with a darker gold border and the level number centered —
+/// unlike the web cluster's tailed shield medal, which hangs its number low
+/// and carries the notched ribbon bottom the mobile design drops. Same
+/// semantics contract as [ClusterLevelMedal] (named button, tap opens Level).
+class HexLevelBadge extends StatelessWidget {
+  final int level;
+  final VoidCallback onTap;
+  final double width;
+  final double height;
+  final double fontSize;
+
+  const HexLevelBadge({
+    super.key,
+    required this.level,
+    required this.onTap,
+    this.width = 48.0,
+    this.height = 42.0,
+    this.fontSize = 18.0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final label = '${L10n.of(context).level} $level';
+    final fill = AppConfig.goldByTheme(context);
+    final hsl = HSLColor.fromColor(fill);
+    final border = hsl
+        .withLightness((hsl.lightness * 0.72).clamp(0.0, 1.0))
+        .toColor();
+    return Tooltip(
+      message: label,
+      // Semantics below names this; exclude the Tooltip so the label isn't
+      // announced twice.
+      excludeFromSemantics: true,
+      child: Semantics(
+        button: true,
+        label: label,
+        container: true,
+        excludeSemantics: true,
+        // Expose the tap on the announced node for assistive tech (#7185).
+        onTap: onTap,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: CustomPaint(
+            size: Size(width, height),
+            painter: _HexBadgePainter(fill: fill, border: border),
+            child: SizedBox(
+              width: width,
+              height: height,
+              child: Center(
+                child: Text(
+                  '$level',
+                  style: TextStyle(
+                    fontSize: fontSize,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Paints the badge hexagon: vertices at the horizontal extremes, flat top and
+/// bottom edges, gold fill with a darker gold outline (the Figma component).
+class _HexBadgePainter extends CustomPainter {
+  final Color fill;
+  final Color border;
+
+  const _HexBadgePainter({required this.fill, required this.border});
+
+  Path _hex(Size size) {
+    final w = size.width;
+    final h = size.height;
+    return Path()
+      ..moveTo(0, h / 2)
+      ..lineTo(w * 0.25, 0)
+      ..lineTo(w * 0.75, 0)
+      ..lineTo(w, h / 2)
+      ..lineTo(w * 0.75, h)
+      ..lineTo(w * 0.25, h)
+      ..close();
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final path = _hex(size);
+    canvas.drawPath(path, Paint()..color = fill);
+    canvas.drawPath(
+      path,
+      Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2.5
+        ..strokeJoin = StrokeJoin.round
+        ..color = border,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_HexBadgePainter old) =>
+      old.fill != fill || old.border != border;
+}

--- a/lib/routes/world/user_cluster_view_model.dart
+++ b/lib/routes/world/user_cluster_view_model.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+
+import 'package:go_router/go_router.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/analytics/construct_type_enum.dart';
+import 'package:fluffychat/features/analytics_data/analytics_data_service.dart';
+import 'package:fluffychat/features/analytics_data/analytics_update_dispatcher.dart';
+import 'package:fluffychat/features/analytics_data/derived_analytics_data_model.dart';
+import 'package:fluffychat/features/languages/language_model.dart';
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/features/navigation/token_params/analytics_token.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
+import 'package:fluffychat/features/user/user_controller.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+
+abstract class UserClusterViewModel {
+  ValueNotifier<Uri?> get avatarUrl;
+
+  ValueNotifier<String?> get displayName;
+
+  Stream<LevelUpdate> get levelUpdates;
+
+  Stream<LanguageUpdate> get languageStream;
+
+  Stream<AnalyticsStreamUpdate> get constructUpdateStream;
+
+  Stream<void> get starsUpdateStream;
+
+  bool get isAnalyticsInitializing;
+
+  LanguageModel? get userL2;
+
+  int get starsEarned;
+
+  int get numVocabConstructs;
+
+  int get numGrammarConstruct;
+
+  DerivedAnalyticsDataModel? get cachedDerivedAnalyticsData;
+
+  Future<DerivedAnalyticsDataModel> get derivedAnalyticsData;
+
+  void reloadProfile();
+
+  void openAnalytics(BuildContext context, AnalyticsPanelTab tab);
+
+  void openAnalyticsSummary(BuildContext context);
+
+  void openProfile(BuildContext context);
+
+  void openLevel(BuildContext context);
+
+  void openLearningSettings(BuildContext context);
+
+  void dispose();
+}
+
+class WorldUserClusterViewModel implements UserClusterViewModel {
+  final AnalyticsDataService analyticsService;
+  final Client client;
+
+  final ValueNotifier<Uri?> _avatarUrl = ValueNotifier(null);
+  final ValueNotifier<String?> _displayName = ValueNotifier(null);
+
+  late final Stream<LevelUpdate> _levelUpdates;
+
+  WorldUserClusterViewModel({
+    required this.analyticsService,
+    required this.client,
+  }) {
+    _levelUpdates = analyticsService.updateDispatcher.levelUpdateStream.stream
+        .where(
+          (_) => MatrixState
+              .pangeaController
+              .subscriptionController
+              .showSubscriptionGatedContent,
+        );
+  }
+
+  bool _profileLoaded = false;
+
+  @override
+  void dispose() {
+    _avatarUrl.dispose();
+    _displayName.dispose();
+  }
+
+  @override
+  ValueNotifier<Uri?> get avatarUrl => _avatarUrl;
+
+  @override
+  ValueNotifier<String?> get displayName => _displayName;
+
+  @override
+  Stream<LevelUpdate> get levelUpdates => _levelUpdates;
+
+  @override
+  Stream<LanguageUpdate> get languageStream =>
+      MatrixState.pangeaController.userController.languageStream.stream;
+
+  @override
+  Stream<AnalyticsStreamUpdate> get constructUpdateStream =>
+      analyticsService.updateDispatcher.constructUpdateStream.stream;
+
+  @override
+  Stream<void> get starsUpdateStream => client.onRoomState.stream.where(
+    (e) => e.state.type == PangeaEventTypes.orchestratorAwardedGoals,
+  );
+
+  @override
+  bool get isAnalyticsInitializing => analyticsService.isInitializing;
+
+  @override
+  LanguageModel? get userL2 =>
+      MatrixState.pangeaController.userController.userL2;
+
+  @override
+  int get starsEarned {
+    final userL2 = this.userL2;
+    return userL2 != null ? client.totalStarsEarned(userL2) : 0;
+  }
+
+  @override
+  int get numVocabConstructs =>
+      analyticsService.numConstructs(ConstructTypeEnum.vocab);
+
+  @override
+  int get numGrammarConstruct =>
+      analyticsService.numConstructs(ConstructTypeEnum.morph);
+
+  @override
+  DerivedAnalyticsDataModel? get cachedDerivedAnalyticsData =>
+      analyticsService.cachedDerivedData;
+
+  @override
+  Future<DerivedAnalyticsDataModel> get derivedAnalyticsData {
+    final l2 = userL2;
+    return l2 != null
+        ? analyticsService.derivedData(l2.langCodeShort)
+        : Future.value(DerivedAnalyticsDataModel());
+  }
+
+  bool _closeSections(BuildContext context) =>
+      !FluffyThemes.isColumnMode(context);
+
+  @override
+  void reloadProfile() {
+    if (_profileLoaded) return;
+    _profileLoaded = true;
+    _loadProfile();
+  }
+
+  @override
+  void openAnalytics(BuildContext context, AnalyticsPanelTab tab) => context.go(
+    WorkspaceNav.openAnalytics(
+      GoRouterState.of(context).uri,
+      subpage: tab.indicator,
+      closeSections: _closeSections(context),
+    ),
+  );
+
+  @override
+  void openAnalyticsSummary(BuildContext context) => context.go(
+    WorkspaceNav.setRight(GoRouterState.of(context).uri, [
+      AnalyticsPanelToken(
+        AnalyticsTokenParam(subpage: ProgressIndicatorEnum.wordsUsed),
+      ),
+    ], closeSections: _closeSections(context)),
+  );
+
+  @override
+  void openProfile(BuildContext context) => context.go(
+    WorkspaceNav.openSettings(
+      GoRouterState.of(context).uri,
+      closeSections: _closeSections(context),
+    ),
+  );
+
+  @override
+  void openLevel(BuildContext context) => context.go(
+    WorkspaceNav.openAnalytics(
+      GoRouterState.of(context).uri,
+      subpage: ProgressIndicatorEnum.level,
+      closeSections: _closeSections(context),
+    ),
+  );
+
+  @override
+  void openLearningSettings(BuildContext context) => context.go(
+    WorkspaceNav.openSettings(
+      GoRouterState.of(context).uri,
+      page: 'learning',
+      closeSections: _closeSections(context),
+    ),
+  );
+
+  Future<void> _loadProfile() async {
+    try {
+      final profile = await client.fetchOwnProfile();
+      _avatarUrl.value = profile.avatarUrl;
+      _displayName.value = profile.displayName;
+    } catch (_) {
+      // Avatar falls back to the initial; not worth surfacing.
+    }
+  }
+}

--- a/lib/routes/world/user_cluster_view_model_builder.dart
+++ b/lib/routes/world/user_cluster_view_model_builder.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/routes/world/user_cluster_view_model.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+
+class UserClusterViewModelBuilder extends StatefulWidget {
+  final Widget Function(BuildContext context, UserClusterViewModel viewModel)
+  builder;
+  const UserClusterViewModelBuilder({super.key, required this.builder});
+
+  @override
+  UserClusterViewModelBuilderState createState() =>
+      UserClusterViewModelBuilderState();
+}
+
+class UserClusterViewModelBuilderState
+    extends State<UserClusterViewModelBuilder> {
+  late final UserClusterViewModel _viewModel;
+
+  @override
+  void initState() {
+    super.initState();
+    final matrix = Matrix.of(context);
+    _viewModel = WorldUserClusterViewModel(
+      analyticsService: matrix.analyticsDataService,
+      client: matrix.client,
+    );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _viewModel.reloadProfile();
+  }
+
+  @override
+  void dispose() {
+    _viewModel.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.builder(context, _viewModel);
+}

--- a/lib/routes/world/world_analytics_bar.dart
+++ b/lib/routes/world/world_analytics_bar.dart
@@ -1,318 +1,19 @@
-import 'dart:async';
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 
-import 'package:go_router/go_router.dart';
 import 'package:shimmer/shimmer.dart';
 
 import 'package:fluffychat/config/app_config.dart';
-import 'package:fluffychat/config/themes.dart';
-import 'package:fluffychat/features/analytics/construct_type_enum.dart';
-import 'package:fluffychat/features/analytics_data/analytics_update_dispatcher.dart';
 import 'package:fluffychat/features/analytics_data/derived_analytics_data_model.dart';
 import 'package:fluffychat/features/languages/language_model.dart';
-import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
-import 'package:fluffychat/features/navigation/token_params/analytics_token.dart';
-import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart';
-import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/routes/world/hex_level_badge.dart';
 import 'package:fluffychat/routes/world/level_up_badge_celebration.dart';
+import 'package:fluffychat/routes/world/user_cluster_view_model.dart';
+import 'package:fluffychat/routes/world/user_cluster_view_model_builder.dart';
 import 'package:fluffychat/routes/world/world_user_cluster.dart';
 import 'package:fluffychat/routes/world/xp_border_painter.dart';
 import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
-import 'package:fluffychat/widgets/matrix.dart';
-
-/// The single-column (mobile/narrow) rendering of [WorldUserCluster] — the
-/// right column's entry point, pinned to the top of the safe area as a
-/// horizontal bar instead of the web cluster's vertical column
-/// (routing.instructions.md, "Single-column analytics nav bar"). Same data,
-/// same tokens, same tap destinations as the cluster.
-///
-/// Always the FULL bar: the shell mounts it only on surfaces where it is
-/// navigation — the map/cavity ground and the right-column panels it heads.
-/// A full-screen chat hosts [AnalyticsHeaderAvatar] in its own app bar
-/// instead (no floating chrome stacked over page content), and route-driven
-/// detail pages show nothing.
-///
-/// Content only — the caller (the workspace shell) is responsible for
-/// [Positioned] placement, width bounds (the layout is a [Row] with an
-/// [Expanded] middle, so it must be given a bounded width), and safe-area
-/// padding.
-class WorldAnalyticsBar extends StatelessWidget {
-  const WorldAnalyticsBar({super.key});
-
-  /// The bar's rendered height: the avatar column governs the Row —
-  /// avatar (56) + flag gap (6) + flag (28). The shell's
-  /// `analyticsBarAllowance` derives from this so content placed "below the
-  /// bar" actually clears it (a widget test pins the rendered height to this
-  /// constant).
-  static const double expandedHeight = 90.0;
-
-  @override
-  Widget build(BuildContext context) => _AnalyticsScope(
-    builder: (context, s) => AnalyticsBarView(
-      avatarUrl: s.avatarUrl,
-      displayName: s.displayName,
-      l2: s.l2,
-      starsCount: s.starsCount,
-      grammarCount: s.grammarCount,
-      vocabCount: s.vocabCount,
-      level: s.level,
-      xpProgress: s.xpProgress,
-      isInitializing: s.isInitializing,
-      levelUpdates: s.levelUpdates,
-      onTrackerTap: (tab) => _openAnalytics(context, tab),
-      onAvatarTap: () => _openProfile(context),
-      onLevelTap: () => _openLevel(context),
-      onFlagTap: () => _openLearningSettings(context),
-    ),
-  );
-}
-
-/// The analytics avatar as a CHAT HEADER action: the circle wearing the XP
-/// ring, level badge, and L2 flag, rendered inside the full-screen chat /
-/// session app bar (routing.instructions.md, "Single-column analytics nav
-/// bar"). A plain button — tapping it opens the analytics summary panel,
-/// whose header IS the full bar. This replaced the floating collapsed avatar
-/// (and its temporary-expansion timer): chrome stacked over page content was
-/// error-prone, and a timed control was a WCAG liability.
-class AnalyticsHeaderAvatar extends StatelessWidget {
-  const AnalyticsHeaderAvatar({super.key});
-
-  @override
-  Widget build(BuildContext context) => _AnalyticsScope(
-    builder: (context, s) => Padding(
-      padding: const EdgeInsets.only(right: 12.0),
-      child: CollapsedAvatarView(
-        avatarUrl: s.avatarUrl,
-        displayName: s.displayName,
-        l2: s.l2,
-        level: s.level,
-        xpProgress: s.xpProgress,
-        levelUpdates: s.levelUpdates,
-        // App-bar sized: the full-size circle is built for open floating
-        // space; at 0.75 the ring + badge + flag fit the toolbar's height.
-        scale: 0.75,
-        onTap: () => _openAnalyticsSummary(context),
-      ),
-    ),
-  );
-}
-
-/// Single-column: a right panel takes the section's slot, so opening one
-/// closes an open section sheet (chats list, Courses hub, course card) —
-/// otherwise X-ing the panel reveals a stale sheet instead of the map. A live
-/// room persists (the header-avatar loop returns to it). The bar renders on
-/// narrow only, but gate on the breakpoint so a mid-resize tap stays correct.
-bool _closeSections(BuildContext context) =>
-    !FluffyThemes.isColumnMode(context);
-
-/// Open the right-docked analytics panel on [tab]'s summary — identical to
-/// the web cluster's tracker taps.
-void _openAnalytics(BuildContext context, AnalyticsPanelTab tab) => context.go(
-  WorkspaceNav.openAnalytics(
-    GoRouterState.of(context).uri,
-    subpage: tab.indicator,
-    closeSections: _closeSections(context),
-  ),
-);
-
-/// The header avatar opens the analytics summary — the panel whose header is
-/// the full bar, so every bar destination is one more tap away.
-void _openAnalyticsSummary(BuildContext context) => context.go(
-  WorkspaceNav.setRight(GoRouterState.of(context).uri, [
-    AnalyticsPanelToken(
-      AnalyticsTokenParam(subpage: ProgressIndicatorEnum.wordsUsed),
-    ),
-  ], closeSections: _closeSections(context)),
-);
-
-/// The bar's avatar opens the profile + settings panel, same as the cluster.
-void _openProfile(BuildContext context) => context.go(
-  WorkspaceNav.openSettings(
-    GoRouterState.of(context).uri,
-    closeSections: _closeSections(context),
-  ),
-);
-
-/// The level badge opens the level analytics tab, same as the cluster.
-void _openLevel(BuildContext context) => context.go(
-  WorkspaceNav.openAnalytics(
-    GoRouterState.of(context).uri,
-    subpage: ProgressIndicatorEnum.level,
-    closeSections: _closeSections(context),
-  ),
-);
-
-/// The L2 flag opens the learning settings page directly, same as the
-/// cluster.
-void _openLearningSettings(BuildContext context) => context.go(
-  WorkspaceNav.openSettings(
-    GoRouterState.of(context).uri,
-    page: 'learning',
-    closeSections: _closeSections(context),
-  ),
-);
-
-/// The resolved display values every analytics-nav rendering consumes.
-class AnalyticsSnapshot {
-  final Uri? avatarUrl;
-  final String? displayName;
-  final LanguageModel? l2;
-  final int starsCount;
-  final int grammarCount;
-  final int vocabCount;
-  final int level;
-  final double xpProgress;
-  final bool isInitializing;
-
-  /// Level-change signal for the badge's celebration — the same
-  /// `levelUpdateStream` the old top-down chat snackbar listened to (#7432),
-  /// already subscription-gated. A plain stream value so the renderings below
-  /// stay Matrix-free; see [LevelUpBadgeCelebration].
-  final Stream<LevelUpdate>? levelUpdates;
-
-  const AnalyticsSnapshot({
-    required this.avatarUrl,
-    required this.displayName,
-    required this.l2,
-    required this.starsCount,
-    required this.grammarCount,
-    required this.vocabCount,
-    required this.level,
-    required this.xpProgress,
-    required this.isInitializing,
-    required this.levelUpdates,
-  });
-}
-
-/// The ONLY Matrix-aware layer of the analytics nav: subscribes to the same
-/// streams the cluster does (language, construct updates, awarded-goal room
-/// state, derived analytics, own profile) and hands the resolved
-/// [AnalyticsSnapshot] to [builder]. Everything below it renders plain values
-/// and is testable without a live Client.
-class _AnalyticsScope extends StatefulWidget {
-  final Widget Function(BuildContext, AnalyticsSnapshot) builder;
-
-  const _AnalyticsScope({required this.builder});
-
-  @override
-  State<_AnalyticsScope> createState() => _AnalyticsScopeState();
-}
-
-class _AnalyticsScopeState extends State<_AnalyticsScope> {
-  bool _profileLoaded = false;
-
-  final ValueNotifier<Uri?> _avatarUrl = ValueNotifier(null);
-  final ValueNotifier<String?> _displayName = ValueNotifier(null);
-
-  /// See [AnalyticsSnapshot.levelUpdates]. Created once so consumer rebuilds
-  /// don't churn the celebration's subscription; the subscription gate (the
-  /// old snackbar's) is applied per event.
-  Stream<LevelUpdate>? _levelUpdates;
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _levelUpdates ??= Matrix.of(context)
-        .analyticsDataService
-        .updateDispatcher
-        .levelUpdateStream
-        .stream
-        .where(
-          (_) => MatrixState
-              .pangeaController
-              .subscriptionController
-              .showSubscriptionGatedContent,
-        );
-    if (_profileLoaded) return;
-    _profileLoaded = true;
-    _loadProfile();
-  }
-
-  @override
-  void dispose() {
-    _avatarUrl.dispose();
-    _displayName.dispose();
-    super.dispose();
-  }
-
-  Future<void> _loadProfile() async {
-    try {
-      final profile = await Matrix.of(context).client.fetchOwnProfile();
-      if (!mounted) return;
-      _avatarUrl.value = profile.avatarUrl;
-      _displayName.value = profile.displayName;
-    } catch (_) {
-      // Avatar falls back to the initial; not worth surfacing.
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final matrix = Matrix.of(context);
-    final client = matrix.client;
-    final service = matrix.analyticsDataService;
-
-    // The same data wiring as the cluster's pill, nested so every update
-    // (language switch, construct counts, awarded stars, level/XP) rebuilds
-    // the consumer below with fresh plain values.
-    return StreamBuilder(
-      stream: MatrixState.pangeaController.userController.languageStream.stream,
-      builder: (context, _) {
-        final l2 = MatrixState.pangeaController.userController.userL2;
-        return StreamBuilder(
-          stream: service.updateDispatcher.constructUpdateStream.stream,
-          builder: (context, _) {
-            final vocab = service.numConstructs(ConstructTypeEnum.vocab);
-            final grammar = service.numConstructs(ConstructTypeEnum.morph);
-            return StreamBuilder(
-              stream: client.onRoomState.stream.where(
-                (e) =>
-                    e.state.type == PangeaEventTypes.orchestratorAwardedGoals,
-              ),
-              builder: (context, _) {
-                final stars = l2 != null ? client.totalStarsEarned(l2) : 0;
-                return FutureBuilder<DerivedAnalyticsDataModel>(
-                  future: l2 != null
-                      ? service.derivedData(l2.langCodeShort)
-                      : Future.value(DerivedAnalyticsDataModel()),
-                  builder: (context, snapshot) {
-                    final derived = snapshot.data ?? service.cachedDerivedData;
-                    return ListenableBuilder(
-                      listenable: Listenable.merge([_avatarUrl, _displayName]),
-                      builder: (context, _) => widget.builder(
-                        context,
-                        AnalyticsSnapshot(
-                          avatarUrl: _avatarUrl.value,
-                          displayName: _displayName.value,
-                          l2: l2,
-                          starsCount: stars,
-                          grammarCount: grammar,
-                          vocabCount: vocab,
-                          level: derived?.level ?? 1,
-                          xpProgress: (derived?.levelProgress ?? 0.0).clamp(
-                            0.0,
-                            1.0,
-                          ),
-                          isInitializing: service.isInitializing,
-                          levelUpdates: _levelUpdates,
-                        ),
-                      ),
-                    );
-                  },
-                );
-              },
-            );
-          },
-        );
-      },
-    );
-  }
-}
 
 /// The full bar's plain-values rendering, isolated from the Matrix/analytics
 /// data plumbing above so it is unit-testable without a live Client: every
@@ -323,30 +24,7 @@ class _AnalyticsScopeState extends State<_AnalyticsScope> {
 /// state machine — collapsed rendering, ~3s timer, focus suspension — is
 /// gone: full-screen surfaces host [AnalyticsHeaderAvatar] in their own app
 /// bar instead of a floating collapsed bar.)
-class AnalyticsBarView extends StatelessWidget {
-  final Uri? avatarUrl;
-  final String? displayName;
-  final LanguageModel? l2;
-  final int starsCount;
-  final int grammarCount;
-  final int vocabCount;
-  final int level;
-
-  /// 0-1 progress toward the next level, drawn as the avatar's XP ring.
-  final double xpProgress;
-
-  /// True while analytics are still loading; the trackers shimmer.
-  final bool isInitializing;
-
-  /// Level-change signal for the badge's celebration (a plain stream value;
-  /// see [AnalyticsSnapshot.levelUpdates]). Null renders no celebration.
-  final Stream<LevelUpdate>? levelUpdates;
-
-  final void Function(AnalyticsPanelTab) onTrackerTap;
-  final VoidCallback onAvatarTap;
-  final VoidCallback onLevelTap;
-  final VoidCallback onFlagTap;
-
+class WorldAnalyticsBar extends StatelessWidget {
   /// Builds the L2 flag chip at the requested size. Null uses the real
   /// [ClusterLanguageFlag]; tests inject a plain stand-in because the real
   /// chip loads a network SVG whose async parse throws into the test zone.
@@ -359,68 +37,21 @@ class AnalyticsBarView extends StatelessWidget {
   )?
   flagBuilder;
 
-  const AnalyticsBarView({
-    required this.avatarUrl,
-    required this.displayName,
-    required this.l2,
-    required this.starsCount,
-    required this.grammarCount,
-    required this.vocabCount,
-    required this.level,
-    required this.xpProgress,
-    required this.isInitializing,
-    required this.onTrackerTap,
-    required this.onAvatarTap,
-    required this.onLevelTap,
-    required this.onFlagTap,
-    this.levelUpdates,
-    this.flagBuilder,
-    super.key,
-  });
+  const WorldAnalyticsBar({this.flagBuilder, super.key});
+
+  static const double expandedHeight = 90.0;
 
   @override
-  Widget build(BuildContext context) => _ExpandedAnalyticsBar(
-    avatarUrl: avatarUrl,
-    displayName: displayName,
-    l2: l2,
-    starsCount: starsCount,
-    grammarCount: grammarCount,
-    vocabCount: vocabCount,
-    level: level,
-    xpProgress: xpProgress,
-    isInitializing: isInitializing,
-    levelUpdates: levelUpdates,
-    onTrackerTap: onTrackerTap,
-    onAvatarTap: onAvatarTap,
-    onLevelTap: onLevelTap,
-    onFlagTap: onFlagTap,
-    flagBuilder: flagBuilder,
+  Widget build(BuildContext context) => UserClusterViewModelBuilder(
+    builder: (context, viewModel) => WorldAnalyticsBarInternal(
+      viewModel: viewModel,
+      flagBuilder: flagBuilder,
+    ),
   );
 }
 
-/// The full horizontal bar: level badge at the left end, the gold powerups
-/// pill (Stars / Grammar / Vocabulary) in the middle, the avatar with its XP
-/// ring at the right, and the L2 flag below the avatar
-/// (routing.instructions.md, "Single-column analytics nav bar"). Reuses the
-/// cluster's visual atoms ([ClusterAvatar], [ClusterTrackerButton],
-/// [ClusterLevelMedal], [ClusterLanguageFlag]) so the look and the
-/// tooltip/semantics labels stay identical to web. Plain values only — no
-/// Matrix or router reads (see [AnalyticsBarView]).
-class _ExpandedAnalyticsBar extends StatelessWidget {
-  final Uri? avatarUrl;
-  final String? displayName;
-  final LanguageModel? l2;
-  final int starsCount;
-  final int grammarCount;
-  final int vocabCount;
-  final int level;
-  final double xpProgress;
-  final bool isInitializing;
-  final Stream<LevelUpdate>? levelUpdates;
-  final void Function(AnalyticsPanelTab) onTrackerTap;
-  final VoidCallback onAvatarTap;
-  final VoidCallback onLevelTap;
-  final VoidCallback onFlagTap;
+class WorldAnalyticsBarInternal extends StatelessWidget {
+  final UserClusterViewModel viewModel;
   final Widget Function(
     LanguageModel language,
     VoidCallback onTap,
@@ -430,21 +61,9 @@ class _ExpandedAnalyticsBar extends StatelessWidget {
   )?
   flagBuilder;
 
-  const _ExpandedAnalyticsBar({
-    required this.avatarUrl,
-    required this.displayName,
-    required this.l2,
-    required this.starsCount,
-    required this.grammarCount,
-    required this.vocabCount,
-    required this.level,
-    required this.xpProgress,
-    required this.isInitializing,
-    required this.levelUpdates,
-    required this.onTrackerTap,
-    required this.onAvatarTap,
-    required this.onLevelTap,
-    required this.onFlagTap,
+  const WorldAnalyticsBarInternal({
+    super.key,
+    required this.viewModel,
     required this.flagBuilder,
   });
 
@@ -460,65 +79,72 @@ class _ExpandedAnalyticsBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l2 = this.l2;
-    return Semantics(
-      label: L10n.of(context).analyticsAndSettingsLabel,
-      child: Row(
-        mainAxisSize: MainAxisSize.max,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Expanded(
-            // Right-justified, up against the avatar — the pill and avatar
-            // read as one cluster at the bar's right end, like the web
-            // cluster's tight column.
-            child: Align(
-              alignment: Alignment.centerRight,
-              // The medal + XP-bordered pill are ONE unit, exactly like the web
-              // cluster rotated horizontal: the pill's frame IS the XP ring
-              // (gold growing from the badge's top, clockwise, meeting at its
-              // bottom) and the level medal overhangs the pill's LEFT end —
-              // the mirror of web's bottom-center overhang.
-              child: _PowerupsRow(
-                onTap: onTrackerTap,
-                onLevelTap: () => onLevelTap(),
-                l2: l2,
-                levelUpdates: levelUpdates,
-              ),
-            ),
-          ),
-          const SizedBox(width: _pillAvatarGap),
-          Column(
-            mainAxisSize: MainAxisSize.min,
+    return StreamBuilder(
+      stream: viewModel.languageStream,
+      builder: (context, _) {
+        final l2 = viewModel.userL2;
+        return Semantics(
+          label: L10n.of(context).analyticsAndSettingsLabel,
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              ClusterAvatar(
-                avatarUrl: avatarUrl,
-                name: displayName,
-                onTap: onAvatarTap,
-                size: _avatarSize,
-              ),
-              if (l2 != null)
-                Padding(
-                  padding: const EdgeInsets.only(top: 6),
-                  child:
-                      flagBuilder?.call(
-                        l2,
-                        onFlagTap,
-                        _flagWidth,
-                        _flagHeight,
-                        _flagFontSize,
-                      ) ??
-                      ClusterLanguageFlag(
-                        language: l2,
-                        onTap: onFlagTap,
-                        width: _flagWidth,
-                        height: _flagHeight,
-                        fontSize: _flagFontSize,
-                      ),
+              Expanded(
+                // Right-justified, up against the avatar — the pill and avatar
+                // read as one cluster at the bar's right end, like the web
+                // cluster's tight column.
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  // The medal + XP-bordered pill are ONE unit, exactly like the web
+                  // cluster rotated horizontal: the pill's frame IS the XP ring
+                  // (gold growing from the badge's top, clockwise, meeting at its
+                  // bottom) and the level medal overhangs the pill's LEFT end —
+                  // the mirror of web's bottom-center overhang.
+                  child: _PowerupsRow(viewModel: viewModel),
                 ),
+              ),
+              const SizedBox(width: _pillAvatarGap),
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  ListenableBuilder(
+                    listenable: Listenable.merge([
+                      viewModel.avatarUrl,
+                      viewModel.displayName,
+                    ]),
+                    builder: (context, _) => ClusterAvatar(
+                      avatarUrl: viewModel.avatarUrl.value,
+                      name: viewModel.displayName.value,
+                      onTap: () => viewModel.openProfile(context),
+                      size: _avatarSize,
+                    ),
+                  ),
+                  if (l2 != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 6),
+                      child:
+                          flagBuilder?.call(
+                            l2,
+                            () => viewModel.openLearningSettings(context),
+                            _flagWidth,
+                            _flagHeight,
+                            _flagFontSize,
+                          ) ??
+                          ClusterLanguageFlag(
+                            language: l2,
+                            onTap: () =>
+                                viewModel.openLearningSettings(context),
+                            width: _flagWidth,
+                            height: _flagHeight,
+                            fontSize: _flagFontSize,
+                          ),
+                    ),
+                ],
+              ),
             ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }
@@ -528,20 +154,9 @@ class _ExpandedAnalyticsBar extends StatelessWidget {
 /// labels, same shimmer-while-initializing as the cluster's pill, so the two
 /// surfaces never disagree — but all values arrive as plain fields.
 class _PowerupsRow extends StatelessWidget {
-  final void Function(AnalyticsPanelTab) onTap;
-  final VoidCallback onLevelTap;
-  final LanguageModel? l2;
+  final UserClusterViewModel viewModel;
 
-  /// Level-change signal for the medal's celebration; see
-  /// [LevelUpBadgeCelebration].
-  final Stream<LevelUpdate>? levelUpdates;
-
-  const _PowerupsRow({
-    required this.onTap,
-    required this.onLevelTap,
-    required this.l2,
-    required this.levelUpdates,
-  });
+  const _PowerupsRow({required this.viewModel});
 
   static const double _xpStroke = 5.0;
   static const double _innerRadius = 20.0;
@@ -564,468 +179,140 @@ class _PowerupsRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final matrix = Matrix.of(context);
-    final client = matrix.client;
-    final service = matrix.analyticsDataService;
-    final l2 = this.l2;
-
     return StreamBuilder(
-      stream: service.updateDispatcher.constructUpdateStream.stream,
+      stream: viewModel.languageStream,
       builder: (context, _) {
-        final vocab = service.numConstructs(ConstructTypeEnum.vocab);
-        final grammar = service.numConstructs(ConstructTypeEnum.morph);
+        return StreamBuilder(
+          stream: viewModel.constructUpdateStream,
+          builder: (context, _) {
+            final vocab = viewModel.numVocabConstructs;
+            final grammar = viewModel.numGrammarConstruct;
 
-        final content = FutureBuilder<DerivedAnalyticsDataModel>(
-          future: l2 != null
-              ? service.derivedData(l2.langCodeShort)
-              : Future.value(DerivedAnalyticsDataModel()),
-          builder: (context, snapshot) {
-            final derived = snapshot.data ?? service.cachedDerivedData;
-            final level = derived?.level ?? 1;
-            final progress = (derived?.levelProgress ?? 0.0).clamp(0.0, 1.0);
+            final content = FutureBuilder<DerivedAnalyticsDataModel>(
+              future: viewModel.derivedAnalyticsData,
+              builder: (context, snapshot) {
+                final derived =
+                    snapshot.data ?? viewModel.cachedDerivedAnalyticsData;
 
-            return Stack(
-              alignment: Alignment.centerLeft,
-              // The badge's level-up celebration paints just outside the
-              // pill unit's bounds (pulse + chip); don't clip it. The
-              // celebration is decoration-only (IgnorePointer), so the
-              // hit-test caveat below still only concerns the badge itself.
-              clipBehavior: Clip.none,
-              children: [
-                Padding(
-                  padding: EdgeInsets.only(left: _hexBadgeOverhang),
-                  child: CustomPaint(
-                    painter: XpBorderPainter(
-                      progress: progress,
-                      trackColor: const Color.fromARGB(130, 135, 135, 135),
-                      progressColor: AppConfig.goldByTheme(context),
-                      stroke: _xpStroke,
-                      radius: _innerRadius + _xpStroke / 2,
-                      anchor: XpBorderAnchor.leftCenter,
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(_xpStroke),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.surfaceContainer,
-                          borderRadius: BorderRadius.circular(_innerRadius),
+                final level = derived?.level ?? 1;
+                final progress = (derived?.levelProgress ?? 0.0).clamp(
+                  0.0,
+                  1.0,
+                );
+
+                return Stack(
+                  alignment: Alignment.centerLeft,
+                  // The badge's level-up celebration paints just outside the
+                  // pill unit's bounds (pulse + chip); don't clip it. The
+                  // celebration is decoration-only (IgnorePointer), so the
+                  // hit-test caveat below still only concerns the badge itself.
+                  clipBehavior: Clip.none,
+                  children: [
+                    Padding(
+                      padding: EdgeInsets.only(left: _hexBadgeOverhang),
+                      child: CustomPaint(
+                        painter: XpBorderPainter(
+                          progress: progress,
+                          trackColor: const Color.fromARGB(130, 135, 135, 135),
+                          progressColor: AppConfig.goldByTheme(context),
+                          stroke: _xpStroke,
+                          radius: _innerRadius + _xpStroke / 2,
+                          anchor: XpBorderAnchor.leftCenter,
                         ),
-                        clipBehavior: Clip.antiAlias,
-                        padding: EdgeInsets.fromLTRB(
-                          _hexBadgeOverhang + _pillTrackerClearance,
-                          _pillVerticalPadding,
-                          _pillRightPadding,
-                          _pillVerticalPadding,
-                        ),
-                        child: Material(
-                          type: MaterialType.transparency,
-                          child: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              StreamBuilder(
-                                stream: client.onRoomState.stream.where(
-                                  (e) =>
-                                      e.state.type ==
-                                      PangeaEventTypes.orchestratorAwardedGoals,
-                                ),
-                                builder: (context, _) {
-                                  final stars = l2 != null
-                                      ? client.totalStarsEarned(l2)
-                                      : 0;
-
-                                  return ClusterTrackerButton(
-                                    indicator: ProgressIndicatorEnum.stars,
-                                    count: stars,
-                                    onTap: () =>
-                                        onTap(AnalyticsPanelTab.sessions),
-                                  );
-                                },
+                        child: Padding(
+                          padding: const EdgeInsets.all(_xpStroke),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: Theme.of(
+                                context,
+                              ).colorScheme.surfaceContainer,
+                              borderRadius: BorderRadius.circular(_innerRadius),
+                            ),
+                            clipBehavior: Clip.antiAlias,
+                            padding: EdgeInsets.fromLTRB(
+                              _hexBadgeOverhang + _pillTrackerClearance,
+                              _pillVerticalPadding,
+                              _pillRightPadding,
+                              _pillVerticalPadding,
+                            ),
+                            child: Material(
+                              type: MaterialType.transparency,
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  StreamBuilder(
+                                    stream: viewModel.starsUpdateStream,
+                                    builder: (context, _) {
+                                      final stars = viewModel.starsEarned;
+                                      return ClusterTrackerButton(
+                                        indicator: ProgressIndicatorEnum.stars,
+                                        count: stars,
+                                        onTap: () => viewModel.openAnalytics(
+                                          context,
+                                          AnalyticsPanelTab.sessions,
+                                        ),
+                                      );
+                                    },
+                                  ),
+                                  ClusterTrackerButton(
+                                    indicator: ProgressIndicatorEnum.morphsUsed,
+                                    count: grammar,
+                                    onTap: () => viewModel.openAnalytics(
+                                      context,
+                                      AnalyticsPanelTab.grammar,
+                                    ),
+                                  ),
+                                  ClusterTrackerButton(
+                                    indicator: ProgressIndicatorEnum.wordsUsed,
+                                    count: vocab,
+                                    onTap: () => viewModel.openAnalytics(
+                                      context,
+                                      AnalyticsPanelTab.vocab,
+                                    ),
+                                  ),
+                                ],
                               ),
-                              ClusterTrackerButton(
-                                indicator: ProgressIndicatorEnum.morphsUsed,
-                                count: grammar,
-                                onTap: () => onTap(AnalyticsPanelTab.grammar),
-                              ),
-                              ClusterTrackerButton(
-                                indicator: ProgressIndicatorEnum.wordsUsed,
-                                count: vocab,
-                                onTap: () => onTap(AnalyticsPanelTab.vocab),
-                              ),
-                            ],
+                            ),
                           ),
                         ),
                       ),
                     ),
-                  ),
-                ),
-                // Half-overlapping the pill's left end, vertically centered
-                // (the Figma hexagon). Kept INSIDE the Stack's bounds — a
-                // negative Positioned paints but does not hit-test, which
-                // silently killed the badge's tap (test-caught).
-                Positioned(
-                  left: 0,
-                  child: Material(
-                    type: MaterialType.transparency,
-                    child: LevelUpBadgeCelebration(
-                      levelUpdates: levelUpdates,
-                      child: _HexLevelBadge(
-                        level: level,
-                        onTap: onLevelTap,
-                        width: _badgeWidth,
-                        height: _badgeHeight,
-                        fontSize: _badgeFontSize,
+                    // Half-overlapping the pill's left end, vertically centered
+                    // (the Figma hexagon). Kept INSIDE the Stack's bounds — a
+                    // negative Positioned paints but does not hit-test, which
+                    // silently killed the badge's tap (test-caught).
+                    Positioned(
+                      left: 0,
+                      child: Material(
+                        type: MaterialType.transparency,
+                        child: LevelUpBadgeCelebration(
+                          levelUpdates: viewModel.levelUpdates,
+                          child: HexLevelBadge(
+                            level: level,
+                            onTap: () => viewModel.openLevel(context),
+                            width: _badgeWidth,
+                            height: _badgeHeight,
+                            fontSize: _badgeFontSize,
+                          ),
+                        ),
                       ),
                     ),
-                  ),
-                ),
-              ],
+                  ],
+                );
+              },
             );
+            return viewModel.isAnalyticsInitializing
+                ? Shimmer.fromColors(
+                    baseColor: Theme.of(
+                      context,
+                    ).colorScheme.surfaceContainerHighest,
+                    highlightColor: Theme.of(context).colorScheme.surface,
+                    child: content,
+                  )
+                : content;
           },
         );
-        return service.isInitializing
-            ? Shimmer.fromColors(
-                baseColor: Theme.of(
-                  context,
-                ).colorScheme.surfaceContainerHighest,
-                highlightColor: Theme.of(context).colorScheme.surface,
-                child: content,
-              )
-            : content;
       },
     );
   }
-}
-
-/// The narrow bar's level badge: the Figma hexagon (pointy left/right, flat
-/// top/bottom) with a darker gold border and the level number centered —
-/// unlike the web cluster's tailed shield medal, which hangs its number low
-/// and carries the notched ribbon bottom the mobile design drops. Same
-/// semantics contract as [ClusterLevelMedal] (named button, tap opens Level).
-class _HexLevelBadge extends StatelessWidget {
-  final int level;
-  final VoidCallback onTap;
-  final double width;
-  final double height;
-  final double fontSize;
-
-  const _HexLevelBadge({
-    required this.level,
-    required this.onTap,
-    this.width = 48.0,
-    this.height = 42.0,
-    this.fontSize = 18.0,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final label = '${L10n.of(context).level} $level';
-    final fill = AppConfig.goldByTheme(context);
-    final hsl = HSLColor.fromColor(fill);
-    final border = hsl
-        .withLightness((hsl.lightness * 0.72).clamp(0.0, 1.0))
-        .toColor();
-    return Tooltip(
-      message: label,
-      // Semantics below names this; exclude the Tooltip so the label isn't
-      // announced twice.
-      excludeFromSemantics: true,
-      child: Semantics(
-        button: true,
-        label: label,
-        container: true,
-        excludeSemantics: true,
-        // Expose the tap on the announced node for assistive tech (#7185).
-        onTap: onTap,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: onTap,
-          child: CustomPaint(
-            size: Size(width, height),
-            painter: _HexBadgePainter(fill: fill, border: border),
-            child: SizedBox(
-              width: width,
-              height: height,
-              child: Center(
-                child: Text(
-                  '$level',
-                  style: TextStyle(
-                    fontSize: fontSize,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.black,
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Paints the badge hexagon: vertices at the horizontal extremes, flat top and
-/// bottom edges, gold fill with a darker gold outline (the Figma component).
-class _HexBadgePainter extends CustomPainter {
-  final Color fill;
-  final Color border;
-
-  const _HexBadgePainter({required this.fill, required this.border});
-
-  Path _hex(Size size) {
-    final w = size.width;
-    final h = size.height;
-    return Path()
-      ..moveTo(0, h / 2)
-      ..lineTo(w * 0.25, 0)
-      ..lineTo(w * 0.75, 0)
-      ..lineTo(w, h / 2)
-      ..lineTo(w * 0.75, h)
-      ..lineTo(w * 0.25, h)
-      ..close();
-  }
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final path = _hex(size);
-    canvas.drawPath(path, Paint()..color = fill);
-    canvas.drawPath(
-      path,
-      Paint()
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = 2.5
-        ..strokeJoin = StrokeJoin.round
-        ..color = border,
-    );
-  }
-
-  @override
-  bool shouldRepaint(_HexBadgePainter old) =>
-      old.fill != fill || old.border != border;
-}
-
-/// The avatar circle wearing the XP ring, the level badge, and the small
-/// flag (Figma collapsed component) — one tap target, announced as a single
-/// button. Plain values only; [AnalyticsHeaderAvatar] is its Matrix-aware
-/// host, mounting it in a full-screen chat's app bar (routing.instructions.md
-/// → "Single-column analytics nav bar"). [scale] shrinks the whole cluster
-/// proportionally so it fits a toolbar.
-class CollapsedAvatarView extends StatelessWidget {
-  final Uri? avatarUrl;
-  final String? displayName;
-  final LanguageModel? l2;
-  final int level;
-  final double xpProgress;
-  final VoidCallback onTap;
-  final double scale;
-
-  /// Level-change signal for the mini badge's celebration (a plain stream
-  /// value; see [AnalyticsSnapshot.levelUpdates]). Null renders no
-  /// celebration.
-  final Stream<LevelUpdate>? levelUpdates;
-
-  const CollapsedAvatarView({
-    required this.avatarUrl,
-    required this.displayName,
-    required this.l2,
-    required this.level,
-    required this.xpProgress,
-    required this.onTap,
-    this.scale = 1.0,
-    this.levelUpdates,
-    this.flagBuilder,
-    super.key,
-  });
-
-  final Widget Function(
-    LanguageModel language,
-    VoidCallback onTap,
-    double width,
-    double height,
-    double fontSize,
-  )?
-  flagBuilder;
-
-  // Base (scale 1.0) geometry — the floating-space size the cluster was
-  // designed at; every dimension multiplies by [scale] so the proportions
-  // hold at toolbar sizes.
-  static const double _xpStrokeBase = 4.0;
-  static const double _avatarSizeBase = 44.0;
-  static const double _flagWidthBase = 28.0;
-  static const double _flagHeightBase = 20.0;
-  static const double _flagFontSizeBase = 11.0;
-
-  // Miniature hex badge pinned over the avatar's top-left, and the flag
-  // hanging under its bottom edge — the collapsed echo of the bar cluster.
-  static const double _badgeTopOffsetBase = -6.0;
-  static const double _badgeLeftOffsetBase = -10.0;
-  static const double _badgeWidthBase = 30.0;
-  static const double _badgeHeightBase = 26.0;
-  static const double _badgeFontSizeBase = 13.0;
-  static const double _flagBottomOffsetBase = -10.0;
-
-  double get _xpStroke => _xpStrokeBase * scale;
-  double get _avatarSize => _avatarSizeBase * scale;
-  double get _flagWidth => _flagWidthBase * scale;
-  double get _flagHeight => _flagHeightBase * scale;
-  double get _flagFontSize => _flagFontSizeBase * scale;
-  double get _badgeTopOffset => _badgeTopOffsetBase * scale;
-  double get _badgeLeftOffset => _badgeLeftOffsetBase * scale;
-  double get _badgeWidth => _badgeWidthBase * scale;
-  double get _badgeHeight => _badgeHeightBase * scale;
-  double get _badgeFontSize => _badgeFontSizeBase * scale;
-  double get _flagBottomOffset => _flagBottomOffsetBase * scale;
-
-  @override
-  Widget build(BuildContext context) {
-    final l2 = this.l2;
-    final label = L10n.of(context).analyticsAndSettingsLabel;
-
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: Tooltip(
-        message: label,
-        // The Semantics below already names this control; exclude the Tooltip
-        // so its message isn't announced twice.
-        excludeFromSemantics: true,
-        child: Semantics(
-          button: true,
-          label: label,
-          // A bounded node of its own: without `container` the annotation
-          // merges into the stretched ancestor, so assistive tech (and the
-          // widget tests' semantics taps) target the full-width bar area
-          // instead of the circle.
-          container: true,
-          excludeSemantics: true,
-          // Expose the tap on the announced node for assistive tech (#7185).
-          onTap: onTap,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: onTap,
-            child: Stack(
-              clipBehavior: Clip.none,
-              alignment: Alignment.center,
-              children: [
-                CustomPaint(
-                  size: Size.square(_avatarSize + 2 * _xpStroke),
-                  painter: CircularXpRingPainter(
-                    progress: xpProgress,
-                    trackColor: const Color.fromARGB(130, 135, 135, 135),
-                    progressColor: AppConfig.goldByTheme(context),
-                    stroke: _xpStroke,
-                  ),
-                  child: Padding(
-                    padding: EdgeInsets.all(_xpStroke),
-                    child: ClusterAvatar(
-                      avatarUrl: avatarUrl,
-                      name: displayName,
-                      onTap: onTap,
-                      size: _avatarSize,
-                    ),
-                  ),
-                ),
-                Positioned(
-                  top: _badgeTopOffset,
-                  left: _badgeLeftOffset,
-                  child: IgnorePointer(
-                    child: Material(
-                      type: MaterialType.transparency,
-                      child: LevelUpBadgeCelebration(
-                        levelUpdates: levelUpdates,
-                        child: _HexLevelBadge(
-                          level: level,
-                          onTap: onTap,
-                          width: _badgeWidth,
-                          height: _badgeHeight,
-                          fontSize: _badgeFontSize,
-                        ),
-                      ),
-                    ),
-                  ),
-                ),
-                if (l2 != null)
-                  Positioned(
-                    bottom: _flagBottomOffset,
-                    child: IgnorePointer(
-                      child:
-                          flagBuilder?.call(
-                            l2,
-                            onTap,
-                            _flagWidth,
-                            _flagHeight,
-                            _flagFontSize,
-                          ) ??
-                          ClusterLanguageFlag(
-                            language: l2,
-                            onTap: onTap,
-                            width: _flagWidth,
-                            height: _flagHeight,
-                            fontSize: _flagFontSize,
-                          ),
-                    ),
-                  ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Paints the collapsed avatar's XP ring: a full gray circular track with a
-/// gold arc filling clockwise from the top for [progress] (0-1) of the way to
-/// the next level. The cluster's `XpBorderPainter` traces the powerups pill's
-/// rounded-rect outline instead, so the circular avatar needs this simpler
-/// circular counterpart rather than reusing it as-is.
-class CircularXpRingPainter extends CustomPainter {
-  final double progress;
-  final Color trackColor;
-  final Color progressColor;
-  final double stroke;
-
-  const CircularXpRingPainter({
-    required this.progress,
-    required this.trackColor,
-    required this.progressColor,
-    required this.stroke,
-  });
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final center = size.center(Offset.zero);
-    final radius = (size.shortestSide - stroke) / 2;
-    final rect = Rect.fromCircle(center: center, radius: radius);
-
-    canvas.drawArc(
-      rect,
-      0,
-      2 * math.pi,
-      false,
-      Paint()
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = stroke
-        ..color = trackColor,
-    );
-
-    final p = progress.clamp(0.0, 1.0);
-    if (p <= 0) return;
-    canvas.drawArc(
-      rect,
-      -math.pi / 2,
-      2 * math.pi * p,
-      false,
-      Paint()
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = stroke
-        ..strokeCap = StrokeCap.round
-        ..color = progressColor,
-    );
-  }
-
-  @override
-  bool shouldRepaint(CircularXpRingPainter old) =>
-      old.progress != progress ||
-      old.progressColor != progressColor ||
-      old.trackColor != trackColor ||
-      old.stroke != stroke;
 }

--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -1,26 +1,19 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:go_router/go_router.dart';
 import 'package:shimmer/shimmer.dart';
 
 import 'package:fluffychat/config/app_config.dart';
-import 'package:fluffychat/features/analytics/construct_type_enum.dart';
-import 'package:fluffychat/features/analytics_data/analytics_update_dispatcher.dart';
 import 'package:fluffychat/features/analytics_data/derived_analytics_data_model.dart';
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
-import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart';
-import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
 import 'package:fluffychat/routes/world/level_up_badge_celebration.dart';
+import 'package:fluffychat/routes/world/user_cluster_view_model.dart';
+import 'package:fluffychat/routes/world/user_cluster_view_model_builder.dart';
 import 'package:fluffychat/routes/world/xp_border_painter.dart';
 import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
 import 'package:fluffychat/widgets/avatar.dart';
-import 'package:fluffychat/widgets/matrix.dart';
 
 /// The persistent top-right cluster over the world map (world_v2): the user's
 /// avatar wrapped in a clockwise XP ring (gray track that fills gold toward the
@@ -32,97 +25,26 @@ import 'package:fluffychat/widgets/matrix.dart';
 /// analytics-system.instructions.md); the cluster listens to the analytics
 /// update streams so counts/level/XP stay live. Look follows Figma
 /// `AvatarLangFlags` (12935:46894). See routing.instructions.md.
-class WorldUserCluster extends StatefulWidget {
+class WorldUserCluster extends StatelessWidget {
   const WorldUserCluster({super.key});
 
   @override
-  State<WorldUserCluster> createState() => _WorldUserClusterState();
+  Widget build(BuildContext context) => UserClusterViewModelBuilder(
+    builder: (context, viewModel) =>
+        WorldUserClusterInternal(viewModel: viewModel),
+  );
 }
 
-class _WorldUserClusterState extends State<WorldUserCluster> {
-  bool _profileLoaded = false;
-
-  final ValueNotifier<Uri?> _avatarUrl = ValueNotifier(null);
-  final ValueNotifier<String?> _displayName = ValueNotifier(null);
-
-  /// The level-up celebration signal for the medal — the same
-  /// `levelUpdateStream` the old top-down chat snackbar listened to (#7432),
-  /// with the snackbar's subscription gate applied at event time. Created
-  /// once so rebuilds don't churn the celebration's subscription.
-  Stream<LevelUpdate>? _levelUpdates;
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _levelUpdates ??= Matrix.of(context)
-        .analyticsDataService
-        .updateDispatcher
-        .levelUpdateStream
-        .stream
-        .where(
-          (_) => MatrixState
-              .pangeaController
-              .subscriptionController
-              .showSubscriptionGatedContent,
-        );
-    if (_profileLoaded) return;
-    _profileLoaded = true;
-    _loadProfile();
-  }
-
-  @override
-  void dispose() {
-    _avatarUrl.dispose();
-    _displayName.dispose();
-    super.dispose();
-  }
-
-  Future<void> _loadProfile() async {
-    try {
-      final profile = await Matrix.of(context).client.fetchOwnProfile();
-      if (!mounted) return;
-      _avatarUrl.value = profile.avatarUrl;
-      _displayName.value = profile.displayName;
-    } catch (_) {
-      // Avatar falls back to the initial; not worth surfacing.
-    }
-  }
-
-  /// Open the right-docked analytics panel on [tab]'s summary by writing the
-  /// `?right=analytics:<tab>` token (the URL is the source of truth for open
-  /// panels). `setRight` replaces the whole right list, so switching trackers
-  /// lands on the new tab's summary and drops any open construct detail.
-  void _openAnalytics(AnalyticsPanelTab tab) => context.go(
-    WorkspaceNav.openAnalytics(
-      GoRouterState.of(context).uri,
-      subpage: tab.indicator,
-    ),
-  );
-
-  /// Open the profile + settings panel on the right (its menu), keeping any
-  /// other open panels — world_v2 moved settings/profile to the right column.
-  void _openProfile() =>
-      context.go(WorkspaceNav.openSettings(GoRouterState.of(context).uri));
-
-  /// The level medal opens the level analytics tab on the right.
-  void _openLevel() => context.go(
-    WorkspaceNav.openAnalytics(
-      GoRouterState.of(context).uri,
-      subpage: ProgressIndicatorEnum.level,
-    ),
-  );
-
-  /// The L2 flag opens the learning settings page on the right directly.
-  void _openLearningSettings() => context.go(
-    WorkspaceNav.openSettings(GoRouterState.of(context).uri, page: 'learning'),
-  );
+class WorldUserClusterInternal extends StatelessWidget {
+  final UserClusterViewModel viewModel;
+  const WorldUserClusterInternal({super.key, required this.viewModel});
 
   @override
   Widget build(BuildContext context) {
     return StreamBuilder(
-      stream: MatrixState.pangeaController.userController.languageStream.stream,
+      stream: viewModel.languageStream,
       builder: (context, _) {
-        final l2 = MatrixState.pangeaController.userController.userL2;
+        final l2 = viewModel.userL2;
         return Semantics(
           label: L10n.of(context).analyticsAndSettingsLabel,
           child: Column(
@@ -130,26 +52,24 @@ class _WorldUserClusterState extends State<WorldUserCluster> {
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
               ListenableBuilder(
-                listenable: Listenable.merge([_avatarUrl, _displayName]),
+                listenable: Listenable.merge([
+                  viewModel.avatarUrl,
+                  viewModel.displayName,
+                ]),
                 builder: (context, _) => ClusterAvatar(
-                  avatarUrl: _avatarUrl.value,
-                  name: _displayName.value,
-                  onTap: _openProfile,
+                  avatarUrl: viewModel.avatarUrl.value,
+                  name: viewModel.displayName.value,
+                  onTap: () => viewModel.openProfile(context),
                 ),
               ),
               const SizedBox(height: 8),
-              _PowerupsPill(
-                onTap: _openAnalytics,
-                onLevelTap: _openLevel,
-                l2: l2,
-                levelUpdates: _levelUpdates,
-              ),
+              _PowerupsPill(viewModel: viewModel),
               if (l2 != null)
                 Padding(
                   padding: const EdgeInsets.only(top: 20),
                   child: ClusterLanguageFlag(
                     language: l2,
-                    onTap: _openLearningSettings,
+                    onTap: () => viewModel.openLearningSettings(context),
                   ),
                 ),
             ],
@@ -223,43 +143,25 @@ class ClusterAvatar extends StatelessWidget {
 /// The gold "powerups" pill: a white inner stack of the three trackers with the
 /// level medal overhanging its base. Follows Figma `AvatarLangFlags`.
 class _PowerupsPill extends StatelessWidget {
-  final void Function(AnalyticsPanelTab) onTap;
-  final VoidCallback onLevelTap;
-  final LanguageModel? l2;
-
-  /// Level-change signal for the medal's celebration; see
-  /// [LevelUpBadgeCelebration].
-  final Stream<LevelUpdate>? levelUpdates;
-
-  const _PowerupsPill({
-    required this.onTap,
-    required this.onLevelTap,
-    required this.l2,
-    required this.levelUpdates,
-  });
+  final UserClusterViewModel viewModel;
+  const _PowerupsPill({required this.viewModel});
 
   static const double _xpStroke = 5.0;
   static const double _innerRadius = 20.0;
 
   @override
   Widget build(BuildContext context) {
-    final matrix = Matrix.of(context);
-    final client = matrix.client;
-    final service = matrix.analyticsDataService;
-    final l2 = this.l2;
-
     return StreamBuilder(
-      stream: service.updateDispatcher.constructUpdateStream.stream,
+      stream: viewModel.constructUpdateStream,
       builder: (context, _) {
-        final vocab = service.numConstructs(ConstructTypeEnum.vocab);
-        final grammar = service.numConstructs(ConstructTypeEnum.morph);
+        final vocab = viewModel.numVocabConstructs;
+        final grammar = viewModel.numGrammarConstruct;
 
         final content = FutureBuilder<DerivedAnalyticsDataModel>(
-          future: l2 != null
-              ? service.derivedData(l2.langCodeShort)
-              : Future.value(DerivedAnalyticsDataModel()),
+          future: viewModel.derivedAnalyticsData,
           builder: (context, snapshot) {
-            final derived = snapshot.data ?? service.cachedDerivedData;
+            final derived =
+                snapshot.data ?? viewModel.cachedDerivedAnalyticsData;
             final level = derived?.level ?? 1;
             final progress = (derived?.levelProgress ?? 0.0).clamp(0.0, 1.0);
 
@@ -301,34 +203,34 @@ class _PowerupsPill extends StatelessWidget {
                               mainAxisSize: MainAxisSize.min,
                               children: [
                                 StreamBuilder(
-                                  stream: client.onRoomState.stream.where(
-                                    (e) =>
-                                        e.state.type ==
-                                        PangeaEventTypes
-                                            .orchestratorAwardedGoals,
-                                  ),
+                                  stream: viewModel.starsUpdateStream,
                                   builder: (context, _) {
-                                    final stars = l2 != null
-                                        ? client.totalStarsEarned(l2)
-                                        : 0;
-
+                                    final stars = viewModel.starsEarned;
                                     return ClusterTrackerButton(
                                       indicator: ProgressIndicatorEnum.stars,
                                       count: stars,
-                                      onTap: () =>
-                                          onTap(AnalyticsPanelTab.sessions),
+                                      onTap: () => viewModel.openAnalytics(
+                                        context,
+                                        AnalyticsPanelTab.sessions,
+                                      ),
                                     );
                                   },
                                 ),
                                 ClusterTrackerButton(
                                   indicator: ProgressIndicatorEnum.morphsUsed,
                                   count: grammar,
-                                  onTap: () => onTap(AnalyticsPanelTab.grammar),
+                                  onTap: () => viewModel.openAnalytics(
+                                    context,
+                                    AnalyticsPanelTab.grammar,
+                                  ),
                                 ),
                                 ClusterTrackerButton(
                                   indicator: ProgressIndicatorEnum.wordsUsed,
                                   count: vocab,
-                                  onTap: () => onTap(AnalyticsPanelTab.vocab),
+                                  onTap: () => viewModel.openAnalytics(
+                                    context,
+                                    AnalyticsPanelTab.vocab,
+                                  ),
                                 ),
                               ],
                             ),
@@ -344,8 +246,11 @@ class _PowerupsPill extends StatelessWidget {
                   child: Material(
                     type: MaterialType.transparency,
                     child: LevelUpBadgeCelebration(
-                      levelUpdates: levelUpdates,
-                      child: ClusterLevelMedal(level: level, onTap: onLevelTap),
+                      levelUpdates: viewModel.levelUpdates,
+                      child: ClusterLevelMedal(
+                        level: level,
+                        onTap: () => viewModel.openLevel(context),
+                      ),
                     ),
                   ),
                 ),
@@ -354,7 +259,7 @@ class _PowerupsPill extends StatelessWidget {
           },
         );
 
-        return service.isInitializing
+        return viewModel.isAnalyticsInitializing
             ? Shimmer.fromColors(
                 baseColor: Theme.of(
                   context,

--- a/test/pangea/navigation/mock_user_cluster_view_model.dart
+++ b/test/pangea/navigation/mock_user_cluster_view_model.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/cupertino.dart';
+
+import 'package:fluffychat/features/analytics_data/analytics_data_service.dart';
+import 'package:fluffychat/features/analytics_data/analytics_update_dispatcher.dart';
+import 'package:fluffychat/features/analytics_data/derived_analytics_data_model.dart';
+import 'package:fluffychat/features/languages/language_model.dart';
+import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/features/user/user_controller.dart';
+import 'package:fluffychat/routes/world/user_cluster_view_model.dart';
+
+class MockUserClusterViewModel implements UserClusterViewModel {
+  late final Stream<LevelUpdate> _levelUpdates;
+  MockUserClusterViewModel({Stream<LevelUpdate>? levelUpdates})
+    : _levelUpdates = levelUpdates ?? const Stream.empty();
+
+  int taps = 0;
+  int avatarTaps = 0;
+  int levelTaps = 0;
+  int flagTaps = 0;
+  AnalyticsPanelTab? tappedTab;
+
+  @override
+  ValueNotifier<Uri?> get avatarUrl => ValueNotifier(null);
+
+  @override
+  ValueNotifier<String?> get displayName => ValueNotifier(null);
+
+  @override
+  Stream<LevelUpdate> get levelUpdates => _levelUpdates;
+
+  @override
+  Stream<LanguageUpdate> get languageStream => Stream.empty();
+
+  @override
+  Stream<AnalyticsStreamUpdate> get constructUpdateStream => Stream.empty();
+
+  @override
+  Stream<void> get starsUpdateStream => Stream.empty();
+
+  @override
+  bool get isAnalyticsInitializing => false;
+
+  @override
+  LanguageModel? get userL2 =>
+      LanguageModel(langCode: 'es', displayName: 'Spanish');
+
+  @override
+  int get starsEarned => 0;
+
+  @override
+  int get numVocabConstructs => 0;
+
+  @override
+  int get numGrammarConstruct => 0;
+
+  @override
+  DerivedAnalyticsDataModel? get cachedDerivedAnalyticsData =>
+      DerivedAnalyticsDataModel();
+
+  @override
+  Future<DerivedAnalyticsDataModel> get derivedAnalyticsData =>
+      Future.value(DerivedAnalyticsDataModel());
+
+  @override
+  void reloadProfile() {}
+
+  @override
+  void openAnalytics(BuildContext context, AnalyticsPanelTab tab) =>
+      tappedTab = tab;
+
+  @override
+  void openAnalyticsSummary(BuildContext context) => taps++;
+
+  @override
+  void openProfile(BuildContext context) => avatarTaps++;
+
+  @override
+  void openLevel(BuildContext context) => levelTaps++;
+
+  @override
+  void openLearningSettings(BuildContext context) => flagTaps++;
+
+  @override
+  void dispose() {}
+}

--- a/test/pangea/navigation/token_grammar_test.dart
+++ b/test/pangea/navigation/token_grammar_test.dart
@@ -298,26 +298,22 @@ void main() {
   });
 
   group('WorkspaceNav.openActivity / dropActivityOverlay', () {
-    test(
-      'openActivity keeps the context by default and seats a sole token',
-      () {
-        final loc = WorkspaceNav.openActivity(
-          u('/?c=!s&left=course&right=analytics:vocab'),
-          'act-1',
-          roomId: '!sess',
-        );
-        final uri = u(loc);
-        expect(activeSpaceIdFor(uri), '!s');
-        expect(parseOpenPanels(uri).left.map((t) => t.type), [
-          PanelTypesEnum.activity,
-        ]);
-        expect(parseOpenPanels(uri).right.map((t) => t.type), [
-          PanelTypesEnum.analytics,
-        ]);
-        expect(activityInfoFor(uri)?.roomId, '!sess');
-        expect(uri.queryParameters['roomid'], isNull);
-      },
-    );
+    test('openActivity opens a room panel when roomId is provided', () {
+      final loc = WorkspaceNav.openActivity(
+        u('/?c=!s&left=course&right=analytics:vocab'),
+        'act-1',
+        roomId: '!sess',
+      );
+      final uri = u(loc);
+      expect(activeSpaceIdFor(uri), '!s');
+      expect(parseOpenPanels(uri).left, [
+        RoomPanelToken(RoomTokenParam(id: '!sess')),
+      ]);
+      expect(parseOpenPanels(uri).right.map((t) => t.type), [
+        PanelTypesEnum.analytics,
+      ]);
+      expect(uri.queryParameters['roomid'], isNull);
+    });
 
     test('a world-map pin (no context) opens with none, so it closes to the '
         'map', () {

--- a/test/pangea/navigation/world_analytics_bar_test.dart
+++ b/test/pangea/navigation/world_analytics_bar_test.dart
@@ -9,15 +9,18 @@ import 'package:fluffychat/features/analytics_data/analytics_update_dispatcher.d
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/analytics_header_avatar.dart';
 import 'package:fluffychat/routes/world/level_up_badge_celebration.dart';
+import 'package:fluffychat/routes/world/user_cluster_view_model.dart';
 import 'package:fluffychat/routes/world/world_analytics_bar.dart';
+import 'mock_user_cluster_view_model.dart';
 
 /// Coverage for the world_v2 single-column analytics NAV BAR
 /// (routing.instructions.md, "Single-column analytics nav bar").
 /// [WorldAnalyticsBar] / [AnalyticsHeaderAvatar] read live Matrix/analytics
 /// streams (mirroring `WorldUserCluster`'s data sourcing), which have no
 /// lightweight test double here, so this file drives their plain-values
-/// renderings — [AnalyticsBarView] (the full bar) and [CollapsedAvatarView]
+/// renderings — [WorldAnalyticsBar] (the full bar) and [AnalyticsHeaderAvatarInternal]
 /// (the chat-header avatar) — directly. The old temporary-expansion state
 /// machine (collapsed rendering, ~3s timer, WCAG focus suspension) is gone:
 /// full-screen chats host the avatar in their own app bar as a plain button.
@@ -76,30 +79,10 @@ void main() {
 
   Future<void> pumpBar(
     WidgetTester tester, {
-    void Function(AnalyticsPanelTab)? onTrackerTap,
-    VoidCallback? onAvatarTap,
-    VoidCallback? onLevelTap,
-    VoidCallback? onFlagTap,
-    Stream<LevelUpdate>? levelUpdates,
+    required UserClusterViewModel viewModel,
   }) => pumpShellMounted(
     tester,
-    AnalyticsBarView(
-      avatarUrl: null,
-      displayName: 'Ada',
-      l2: es,
-      starsCount: 0,
-      grammarCount: 0,
-      vocabCount: 0,
-      level: 1,
-      xpProgress: 0.0,
-      isInitializing: false,
-      levelUpdates: levelUpdates,
-      onTrackerTap: onTrackerTap ?? (_) {},
-      onAvatarTap: onAvatarTap ?? () {},
-      onLevelTap: onLevelTap ?? () {},
-      onFlagTap: onFlagTap ?? () {},
-      flagBuilder: flagStandIn,
-    ),
+    WorldAnalyticsBarInternal(flagBuilder: flagStandIn, viewModel: viewModel),
   );
 
   setUpAll(() {
@@ -115,7 +98,7 @@ void main() {
   group('full bar (AnalyticsBarView)', () {
     testWidgets('renders the full bar with all named controls', (tester) async {
       final semantics = tester.ensureSemantics();
-      await pumpBar(tester);
+      await pumpBar(tester, viewModel: MockUserClusterViewModel());
       final l10n = l10nOf(tester);
 
       expect(find.bySemanticsLabel(l10n.settings), findsOneWidget);
@@ -143,8 +126,8 @@ void main() {
         // place right panels and the search bar BELOW the bar — if the bar's
         // implicit layout grows past the declared constant, that content
         // slides back underneath it.
-        await pumpBar(tester);
-        final size = tester.getSize(find.byType(AnalyticsBarView));
+        await pumpBar(tester, viewModel: MockUserClusterViewModel());
+        final size = tester.getSize(find.byType(WorldAnalyticsBarInternal));
         expect(
           size.height,
           lessThanOrEqualTo(WorldAnalyticsBar.expandedHeight),
@@ -156,35 +139,26 @@ void main() {
       tester,
     ) async {
       final semantics = tester.ensureSemantics();
-      AnalyticsPanelTab? tappedTab;
-      var avatarTaps = 0;
-      var levelTaps = 0;
-      var flagTaps = 0;
+      final viewModel = MockUserClusterViewModel();
 
-      await pumpBar(
-        tester,
-        onTrackerTap: (tab) => tappedTab = tab,
-        onAvatarTap: () => avatarTaps++,
-        onLevelTap: () => levelTaps++,
-        onFlagTap: () => flagTaps++,
-      );
+      await pumpBar(tester, viewModel: viewModel);
       final l10n = l10nOf(tester);
 
       await tester.tap(find.bySemanticsLabel('${l10n.vocab}: 0'));
-      expect(tappedTab, AnalyticsPanelTab.vocab);
+      expect(viewModel.tappedTab, AnalyticsPanelTab.vocab);
 
       await tester.tap(find.bySemanticsLabel(l10n.settings));
-      expect(avatarTaps, 1);
+      expect(viewModel.avatarTaps, 1);
 
       await tester.tap(find.bySemanticsLabel('${l10n.level} 1'));
-      expect(levelTaps, 1);
+      expect(viewModel.levelTaps, 1);
 
       await tester.tap(
         find.bySemanticsLabel(
           '${es.getDisplayName(l10n)}, ${l10n.learningSettings}',
         ),
       );
-      expect(flagTaps, 1);
+      expect(viewModel.flagTaps, 1);
 
       semantics.dispose();
     });
@@ -196,7 +170,10 @@ void main() {
       // top-down snackbar consumed, #7432) into the badge's
       // LevelUpBadgeCelebration.
       final controller = StreamController<LevelUpdate>.broadcast();
-      await pumpBar(tester, levelUpdates: controller.stream);
+      final viewModel = MockUserClusterViewModel(
+        levelUpdates: controller.stream,
+      );
+      await pumpBar(tester, viewModel: viewModel);
       final chipText = l10nOf(tester).levelUpChip(2);
 
       expect(find.text(chipText), findsNothing);
@@ -220,22 +197,15 @@ void main() {
   group('chat-header avatar (CollapsedAvatarView)', () {
     Future<void> pumpAvatar(
       WidgetTester tester, {
-      required VoidCallback onTap,
+      required UserClusterViewModel viewModel,
       double scale = 1.0,
-      Stream<LevelUpdate>? levelUpdates,
     }) => pumpShellMounted(
       tester,
       Align(
         alignment: Alignment.centerRight,
-        child: CollapsedAvatarView(
-          avatarUrl: null,
-          displayName: 'Ada',
-          l2: es,
-          level: 1,
-          xpProgress: 0.0,
+        child: AnalyticsHeaderAvatarInternal(
+          viewModel: viewModel,
           scale: scale,
-          onTap: onTap,
-          levelUpdates: levelUpdates,
           flagBuilder: flagStandIn,
         ),
       ),
@@ -245,7 +215,7 @@ void main() {
       tester,
     ) async {
       final semantics = tester.ensureSemantics();
-      await pumpAvatar(tester, onTap: () {});
+      await pumpAvatar(tester, viewModel: MockUserClusterViewModel());
       final l10n = l10nOf(tester);
 
       expect(
@@ -265,13 +235,13 @@ void main() {
       tester,
     ) async {
       final semantics = tester.ensureSemantics();
-      var taps = 0;
-      await pumpAvatar(tester, onTap: () => taps++);
+      final viewModel = MockUserClusterViewModel();
+      await pumpAvatar(tester, viewModel: viewModel);
 
       await tester.tap(
         find.bySemanticsLabel(l10nOf(tester).analyticsAndSettingsLabel),
       );
-      expect(taps, 1);
+      expect(viewModel.taps, 1);
       // A plain button: nothing expands, nothing is pending.
       await tester.pump(const Duration(seconds: 5));
       expect(find.bySemanticsLabel(l10nOf(tester).settings), findsNothing);
@@ -283,12 +253,10 @@ void main() {
       'a level-up event pops the celebration chip at the mini badge',
       (tester) async {
         final controller = StreamController<LevelUpdate>.broadcast();
-        await pumpAvatar(
-          tester,
-          onTap: () {},
-          scale: 0.75,
+        final viewModel = MockUserClusterViewModel(
           levelUpdates: controller.stream,
         );
+        await pumpAvatar(tester, scale: 0.75, viewModel: viewModel);
         final chipText = l10nOf(tester).levelUpChip(2);
 
         expect(find.text(chipText), findsNothing);
@@ -314,8 +282,12 @@ void main() {
       // AnalyticsHeaderAvatar mounts it at 0.75 inside a kToolbarHeight (56)
       // app bar: ring box (44+8)*0.75 = 39, badge overhang 4.5, flag hang
       // 7.5 — the whole cluster must stay comfortably inside the toolbar.
-      await pumpAvatar(tester, onTap: () {}, scale: 0.75);
-      final box = tester.getSize(find.byType(CollapsedAvatarView));
+      await pumpAvatar(
+        tester,
+        scale: 0.75,
+        viewModel: MockUserClusterViewModel(),
+      );
+      final box = tester.getSize(find.byType(AnalyticsHeaderAvatarInternal));
       expect(box.height, lessThanOrEqualTo(kToolbarHeight));
     });
   });


### PR DESCRIPTION
… mock view model to fix broken user cluster tests

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
