### PR TITLE
spike: collapse large pin cards to dots below city zoom

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -239,6 +239,18 @@ class WorldMapController extends State<WorldMap>
 
   MapController get mapController => widget.controller ?? _ownController;
 
+  /// The live camera zoom, or null before the map is laid out (reading the
+  /// camera throws until the first frame). The single reader of the raw zoom so
+  /// the pin-budget zoom gate ([budgetForView]) and the on-map +/- controls
+  /// share one null-safe access.
+  double? get liveZoom {
+    try {
+      return mapController.camera.zoom;
+    } catch (_) {
+      return null;
+    }
+  }
+
   bool get isWorld => MapContextController.notifier.value is! CourseMapContext;
 
   /// The id of the activity the detail panel is focused on, or null. Focus is

--- a/lib/routes/world/world_map_pin_budget.dart
+++ b/lib/routes/world/world_map_pin_budget.dart
@@ -93,6 +93,36 @@ PinBudget budgetForWidth(double width) {
   return kPinBudgetBreakpoints.last.budget;
 }
 
+/// PARKED SPIKE (#7245, draft): below this camera zoom the map frames a region /
+/// country / continent rather than a city, so a full-size large card reads as
+/// clutter splayed across the map. The proposal: at that zoom the large tier
+/// collapses back to compact dots. Zoom `3` is the whole world, `~10` roughly
+/// city level, `18` a street.
+const double kLargeCardMinZoom = 10.0;
+
+/// PARKED SPIKE (#7245, draft): the width-driven [budgetForWidth] with a **zoom
+/// gate** applied. Below [kLargeCardMinZoom] the large tier is emptied and its
+/// slots roll into `small`, so zooming out returns those activities to dots
+/// without dropping them or shrinking the on-screen count `N`. Mid pins are
+/// unaffected — only the large tier is zoom-gated, and a focused card degrades
+/// with the rest. A null [zoom] (camera not laid out yet) leaves the width
+/// budget untouched so a first frame never spuriously collapses.
+///
+/// NOT wired into world-map.instructions.md yet — the doc still says caps are
+/// width-driven only. If this ships, the doc revision lands with it.
+PinBudget budgetForView(double width, double? zoom) {
+  final base = budgetForWidth(width);
+  if (zoom == null || zoom >= kLargeCardMinZoom || base.large == 0) {
+    return base;
+  }
+  return PinBudget(
+    large: 0,
+    mid: base.mid,
+    small: base.small + base.large,
+    trail: base.trail,
+  );
+}
+
 /// Tier pixel sizes — also tuned here so all pin-density knobs live in one file.
 abstract class PinSize {
   /// Small dot — intentionally tiny, Google-Maps style (was 18px before the

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -180,9 +180,12 @@ class _WorldMapViewState extends State<WorldMapView> {
 
     // The available visible-map width (viewport minus open panels) picks the
     // budget row: a total cap `N` split into large/mid/small caps + a trail
-    // reservation (world-map.instructions.md, "Pin display").
-    final budget = budgetForWidth(
+    // reservation (world-map.instructions.md, "Pin display"); the zoom gate then
+    // empties the large tier when zoomed out past city level (#7245, parked
+    // spike — see budgetForView).
+    final budget = budgetForView(
       widget.controller.widget.availableVisibleMapWidth,
+      widget.controller.liveZoom,
     );
     final ranking = _getRankings(
       visible: visible,


### PR DESCRIPTION
Addresses #7245 — parked spike, not for merge as-is.

## What this is

A minimal working spike for returning open activity cards to dots when zoomed out. Parked by decision: not yet convinced it's worth adding a second axis (zoom) to the pin-display logic, which today is deliberately width-driven only.

## What it does

- `budgetForView(width, zoom)` wraps the existing `budgetForWidth`: below `kLargeCardMinZoom` (10.0, ~city level) the large tier empties and its slots roll into `small`, so `N` is unchanged — cards degrade to dots, nothing disappears.
- Mid pins are untouched; only the large tier is zoom-gated. A focused card degrades with the rest (focus ring still marks it).
- `WorldMapController.liveZoom` — null-safe camera-zoom getter shared with the render path.
- Compiles clean (`dart analyze`); not manually tested, no widget tests yet.

## If we pick this up

- Revise `world-map.instructions.md` ("Pin display" / "Priority matrix"), which currently states caps are width-driven only — the doc change lands with this, per repo convention.
- Reuse `liveZoom` in `_MapZoomControls._currentZoom()` (duplicate logic today).
- Add unit tests for `budgetForView` and manual zoom-out verification.
- Tune `kLargeCardMinZoom` by feel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)