### PR TITLE
fix(world): abbreviate cluster tracker counts above 999

### DIFF
--- a/lib/routes/world/compact_count.dart
+++ b/lib/routes/world/compact_count.dart
@@ -1,0 +1,28 @@
+/// Abbreviates a tracker count for width-bounded display: counts above 999
+/// render as `1.2k` / `12k` / `999k` / `1.2M` so the cluster's powerups pill
+/// (and the narrow analytics bar reusing the same tracker button) never grows
+/// past the allocator's fixed `clusterGutter` — raw 4-5 digit vocab counts
+/// overlapped the right column's card (#7508). The displayed string never
+/// exceeds 4 characters for any count a learner can reach.
+///
+/// Deliberately NOT locale-aware (`NumberFormat.compact` renders e.g. Spanish
+/// `1,2 mil`, which is wider than the raw digits and defeats the width bound);
+/// the fixed `k`/`M` suffix is the games-convention compromise. Exact counts
+/// stay available to assistive tech via the tracker's semantics label.
+///
+/// Values are floored, never rounded up, so a count is never overstated
+/// (999,999 is `999k`, not `1M`).
+String compactCount(int count) {
+  if (count < 1000) return '$count';
+  if (count < 1000000) return _abbreviate(count, 1000, 'k');
+  return _abbreviate(count, 1000000, 'M');
+}
+
+String _abbreviate(int count, int unit, String suffix) {
+  final whole = count ~/ unit;
+  // Two-plus whole units: no room (or need) for a decimal — "12k", "999k".
+  if (whole >= 10) return '$whole$suffix';
+  // One decimal place, floored — "1.2k"; drop a zero decimal — "2k".
+  final tenth = (count * 10 ~/ unit) % 10;
+  return tenth == 0 ? '$whole$suffix' : '$whole.$tenth$suffix';
+}

--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -8,6 +8,7 @@ import 'package:fluffychat/features/analytics_data/derived_analytics_data_model.
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/compact_count.dart';
 import 'package:fluffychat/routes/world/level_up_badge_celebration.dart';
 import 'package:fluffychat/routes/world/user_cluster_view_model.dart';
 import 'package:fluffychat/routes/world/user_cluster_view_model_builder.dart';
@@ -276,6 +277,9 @@ class _PowerupsPill extends StatelessWidget {
 /// One tracker in the powerups pill: a dark icon over its count, on the white
 /// inner field. Tapping opens that metric's analytics tab. Public so
 /// [WorldAnalyticsBar] can lay the same three trackers out horizontally.
+/// The displayed count abbreviates above 999 ([compactCount]) so the pill
+/// never outgrows the allocator's fixed cluster gutter; the semantics label
+/// carries the exact count.
 class ClusterTrackerButton extends StatelessWidget {
   final ProgressIndicatorEnum indicator;
   final int count;
@@ -310,6 +314,7 @@ class ClusterTrackerButton extends StatelessWidget {
         borderRadius: BorderRadius.circular(100),
         child: Semantics(
           button: true,
+          // The exact count — assistive tech is never given the abbreviation.
           label: '${indicator.tooltip(context)}: $count',
           excludeSemantics: true,
           child: Padding(
@@ -323,7 +328,7 @@ class ClusterTrackerButton extends StatelessWidget {
                 Icon(indicator.icon, size: iconSize),
                 const SizedBox(height: 3),
                 Text(
-                  '$count',
+                  compactCount(count),
                   style: TextStyle(
                     fontSize: fontSize,
                     height: 1.1,

--- a/test/pangea/world/cluster_tracker_count_test.dart
+++ b/test/pangea/world/cluster_tracker_count_test.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/compact_count.dart';
+import 'package:fluffychat/routes/world/world_user_cluster.dart';
+import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
+
+/// Pins the width contract that keeps the world user cluster's powerups pill
+/// inside the allocator's fixed `PanelAllocator.clusterGutter` (#7508): raw
+/// 4-5 digit tracker counts grew the pill past the gutter and under the right
+/// column's card, so [ClusterTrackerButton] displays [compactCount]'s
+/// abbreviation (never more than 4 glyphs) while its semantics label keeps
+/// the exact count for assistive tech.
+void main() {
+  group('compactCount', () {
+    test('passes counts below 1000 through exactly', () {
+      expect(compactCount(0), '0');
+      expect(compactCount(42), '42');
+      expect(compactCount(999), '999');
+    });
+
+    test('abbreviates thousands, floored, dropping a zero decimal', () {
+      expect(compactCount(1000), '1k');
+      expect(compactCount(1049), '1k');
+      expect(compactCount(1250), '1.2k');
+      expect(compactCount(9999), '9.9k');
+      expect(compactCount(10000), '10k');
+      expect(compactCount(99999), '99k');
+      expect(compactCount(999999), '999k', reason: 'floored, never 1M early');
+    });
+
+    test('abbreviates millions the same way', () {
+      expect(compactCount(1000000), '1M');
+      expect(compactCount(1234567), '1.2M');
+      expect(compactCount(999999999), '999M');
+    });
+
+    test('never exceeds 4 glyphs for any reachable count', () {
+      for (final n in [0, 9, 99, 999, 1000, 9999, 99999, 999999, 999999999]) {
+        expect(
+          compactCount(n).length,
+          lessThanOrEqualTo(4),
+          reason: '$n must render width-bounded',
+        );
+      }
+    });
+  });
+
+  group('ClusterTrackerButton', () {
+    Future<void> pumpTracker(WidgetTester tester, int count) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          supportedLocales: L10n.supportedLocales,
+          home: Scaffold(
+            body: Center(
+              child: ClusterTrackerButton(
+                indicator: ProgressIndicatorEnum.wordsUsed,
+                count: count,
+                onTap: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+      // The L10n delegates load asynchronously (same as the analytics bar
+      // tests); one pump isn't enough for the tracker to mount.
+      await tester.pumpAndSettle();
+    }
+
+    double trackerWidth(WidgetTester tester) =>
+        tester.getSize(find.byType(ClusterTrackerButton)).width;
+
+    testWidgets('a 5-digit count renders no wider than a 3-digit count', (
+      tester,
+    ) async {
+      await pumpTracker(tester, 999);
+      final threeDigitWidth = trackerWidth(tester);
+
+      await pumpTracker(tester, 99999);
+      expect(
+        trackerWidth(tester),
+        threeDigitWidth,
+        reason:
+            'abbreviation ("99k") must keep a 5-digit count at 3 glyphs, so '
+            'the pill stays inside PanelAllocator.clusterGutter',
+      );
+    });
+
+    testWidgets('the displayed count never exceeds 4 glyphs of width', (
+      tester,
+    ) async {
+      // Measure one glyph's advance from the trackers themselves (the test
+      // font's digits aren't exactly 1em wide), then cap every abbreviated
+      // count at four advances — the widest string compactCount can emit.
+      // Production fonts render '.'/'k' narrower than digits, so real widths
+      // sit below this cap, inside the gutter budget (88 clusterGutter - 12
+      // chrome margin - 18 pill chrome around the widest tracker).
+      await pumpTracker(tester, 99);
+      final twoGlyphs = trackerWidth(tester);
+      await pumpTracker(tester, 999);
+      final threeGlyphs = trackerWidth(tester);
+      final maxWidth = threeGlyphs + (threeGlyphs - twoGlyphs);
+
+      for (final count in [9999, 99999, 999999, 1234567]) {
+        await pumpTracker(tester, count);
+        expect(
+          trackerWidth(tester),
+          lessThanOrEqualTo(maxWidth),
+          reason: 'count $count must render at most 4 glyphs',
+        );
+      }
+    });
+
+    testWidgets('shows the abbreviation but announces the exact count', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      await pumpTracker(tester, 99999);
+
+      expect(find.text('99k'), findsOneWidget);
+      expect(find.text('99999'), findsNothing);
+
+      final l10n = L10n.of(tester.element(find.byType(Scaffold)));
+      expect(
+        find.bySemanticsLabel('${l10n.vocab}: 99999'),
+        findsOneWidget,
+        reason: 'assistive tech must get the exact count, not "99k"',
+      );
+
+      semantics.dispose();
+    });
+  });
+}


### PR DESCRIPTION
Closes #7508

## What

`ClusterTrackerButton` (the powerups pill on the world cluster, reused by the narrow `WorldAnalyticsBar`) now displays `compactCount(count)`: exact through 999, then floored `1.2k` / `12k` / `999k` / `1.2M` — never more than 4 glyphs, so the pill stays inside the allocator's fixed 88px `clusterGutter` at any reachable count. The semantics label keeps the exact number; only the visual abbreviates.

Design notes (also answering the `999+` suggestion on the issue — see the reply there):

- **Deliberately not locale-aware**: `NumberFormat.compact` renders e.g. Spanish `1,2 mil`, wider than the raw digits, defeating the width bound. Fixed `k`/`M` is the games-convention compromise.
- **Floored, never rounded up**: a count is never overstated (999,999 → `999k`, not `1M`).
- `999+` was considered and rejected: it freezes the display forever at 1,000 while these counts are motivational and should keep visibly growing.

## Testing

- New `cluster_tracker_count_test.dart`: exact-through-999, flooring/decimal rules, a 4-glyph cap sweep, widget-measured width contract (5-digit count renders no wider than 3-digit), and a semantics test pinning that assistive tech gets `99999` while the visual shows `99k`.
- `dart analyze` clean; `dart format` + import sorter run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large tracker counts now display in compact formats such as `1.2k` and `1M`.
  * Count displays remain within a consistent, space-efficient width.

* **Accessibility**
  * Screen readers continue to receive the exact underlying count, even when a shortened value is shown visually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->