### PR TITLE
fix(world): stop suppressing the nav widget for an open activity plan on narrow

### DIFF
--- a/lib/features/navigation/panel_registry.dart
+++ b/lib/features/navigation/panel_registry.dart
@@ -89,9 +89,10 @@ sealed class PanelDef {
   /// Whether this panel is **map content** — a selection on the world map (a
   /// course, an activity plan, the add-course flow). On a narrow screen the
   /// section surfaces (the chat list, the add-course hub, the course family)
-  /// ride the nav widget's expandable cavity over the (scoped) map (`MobileNavWidget`,
-  /// via the shell's `cavityIndex`); the activity plan is a start/join flow and
-  /// renders full-screen instead. See `routing.instructions.md`.
+  /// AND the activity plan ride the nav widget's expandable cavity over the
+  /// (scoped) map (`MobileNavWidget`, via the shell's `cavityIndex`) — the
+  /// plan as a half-open sheet with the camera on its pin, the Google Maps
+  /// UX. See `routing.instructions.md`.
   final bool mapContent;
 
   const PanelDef({

--- a/lib/features/navigation/route_facts.dart
+++ b/lib/features/navigation/route_facts.dart
@@ -208,11 +208,14 @@ MapFocus? mapFocusFor(GoRouterState state) {
 /// deep detail views (a room/space leaf, a construct drilldown).
 bool showNavRail(GoRouterState state, bool isColumnMode) {
   if (isColumnMode) return true;
-  // An in-progress activity is immersive: on a narrow screen the bottom nav is
-  // suppressed so a stray tap (World/Chats/Avatar) can't abandon the activity
-  // mid-task — the design marks an activity the exclusive surface, and it carries
-  // its own exit. See `routing.instructions.md`.
-  if (activityFor(state) != null) return false;
+  // NOTE: an open `activity` token must NOT suppress the nav widget. The plan
+  // stage rides the widget's expandable cavity on narrow (a half-open sheet,
+  // pin visible — routing.instructions.md), so hiding the widget here left the
+  // activity with no host at all: a bare map with every control gone (#7530).
+  // The immersive case — a LAUNCHED session — is a `room`/`session` token,
+  // which hides the chrome through the focused-full-screen path instead; the
+  // liveView sibling rule drops the plan token at launch, so the two never
+  // coexist. (The suppression predated the panel/cavity model, #7385.)
   final roomId = state.pathParameters['roomid'];
   final spaceId = state.pathParameters['spaceid'];
   if (roomId == null && spaceId == null) {

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -874,9 +874,9 @@ class _ShellLayout {
     final hasCavity = cavityIndex != null;
 
     // The floating nav widget shows wherever the narrow chrome does — the bare
-    // map or a cavity surface — and is covered by a focused full-screen surface
-    // (a room/activity, a center-detail page, or a right panel expanding over
-    // it).
+    // map or a cavity surface (which includes the activity plan's half-open
+    // sheet, #7530) — and is covered by a focused full-screen surface (a
+    // room/session, a center-detail page, or a right panel expanding over it).
     final navWidgetVisible =
         !isColumnMode &&
         navRail &&
@@ -884,10 +884,11 @@ class _ShellLayout {
         (focusedNarrowType == null || hasCavity);
 
     // The analytics NAV BAR mounts only where it is navigation: over the map,
-    // a cavity, and an open right panel (which it heads). A full-screen LEFT
-    // surface (a chat, an activity) hosts the header avatar in its own app
-    // bar instead, and a center-detail page shows nothing — no floating
-    // chrome stacked over page content.
+    // a cavity (including the activity plan's sheet), and an open right panel
+    // (which it heads). A full-screen LEFT surface (a chat, a launched
+    // session) hosts the header avatar in its own app bar instead, and a
+    // center-detail page shows nothing — no floating chrome stacked over page
+    // content.
     final analyticsBarVisible =
         !isColumnMode &&
         navRail &&

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -670,10 +670,11 @@ class _ShellLayout {
 
   /// Index into [leftTokens] of the panel hosted in the nav widget's expandable
   /// **cavity** on a narrow screen — the chat list, the Courses/add-course hub,
-  /// or the course family (card + coursepage detail). Null when nothing
-  /// cavity-hosted is the narrow focus; [hasCavity] is its presence. Full-screen
-  /// surfaces (a room, an activity, a session, any right panel) never ride the
-  /// cavity. See `routing.instructions.md` → Single-column bottom nav.
+  /// the course family (card + coursepage detail), or the activity plan (a
+  /// half-open sheet with the camera on its pin — the Google Maps UX). Null
+  /// when nothing cavity-hosted is the narrow focus; [hasCavity] is its
+  /// presence. Full-screen surfaces (a room, a session, any right panel) never
+  /// ride the cavity. See `routing.instructions.md` → Single-column bottom nav.
   final int? cavityIndex;
   final bool hasCavity;
 


### PR DESCRIPTION
Closes #7530

## Root cause

Two rules collided on narrow screens:

- The activity plan is a **cavity** surface — it rides the mobile nav widget's expandable cavity as a half-open sheet with the camera on its pin (the Google Maps UX; `routing.instructions.md`, and `cavityTypes`/`isCavity` has always included `activity`).
- `showNavRail` returned **false** whenever an activity token was open ("an in-progress activity is immersive") — a rule from #7028, written when an open activity was a full-screen canvas surface. After #7385 moved the plan into the cavity, this rule hid the nav widget — the cavity's only host — exactly when it had an activity to show.

Net effect: tapping a pin (or a course-plan activity) on narrow seated the token, the shell treated it as the focused surface (hiding the analytics bar and search), the panel-layer loop skipped it (cavity-hosted), and the nav widget that would host it never mounted. A bare map with every control gone: "stuck on map."

## Fix

Remove the stale suppression in `showNavRail` (narrow-only — column mode returns early). The genuinely immersive case, a **launched session**, is unaffected: launching swaps the plan token for a `room`/`session` token (the liveView sibling rule), which hides the chrome through the focused-full-screen path. Also corrected the two stale comments (`workspace_shell.dart` cavity doc, `panel_registry.dart` mapContent doc) that claimed the activity renders full-screen — the routing doc and the code now agree.

## Verification

Reproduced and verified fixed on the local stack with a scratch Playwright run at 390×844 (real pointer click on a map pin):

- **Before**: URL seats `left=activity:<id>`, semantics tree collapses to 8 nodes (map only), no panel, no nav, no search — bare map.
- **After**: half-open cavity sheet with the plan (title, X, Start), pin visible above, bottom nav + search bar + analytics bar all present; 55 semantics nodes. Wide (1280px) control unchanged (full left panel).
- `flutter test test/pangea/navigation/ test/pangea/world/` + ranking/placement suites: 345/345 green; analyzer clean.

Noticed in passing (separate issue to follow): map pin dots are unactivatable via assistive tech — `Semantics(excludeSemantics: true)` on the dot swallows the inner `GestureDetector`'s tap action, so semantics/screen-reader taps no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Activity plans now remain accessible alongside the mobile navigation interface instead of incorrectly hiding it.
  * Activity plans display in an expandable half-screen panel with the map centered on the relevant pin.
  * Full-screen session and room views continue to use immersive layouts without navigation controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->