### PR TITLE
fix(courses): class-code join survives sync lag; consume inbound code at completion

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -22,7 +22,10 @@ test("authenticate", async ({ page }) => {
   test.setTimeout(120000); 
 
   // If button can't be found, requirements of test may not be met.
-  await expect(page.getByRole("button", { name: intl.loginToAccount }), { message: 'Ensure the system language is english, and the account is not already authenticated.' }).toBeEnabled();
+  // A debug-mode cold boot can take well over a minute (thousands of DDC
+  // module loads on a cache-less Playwright context), so give the landing
+  // page a boot-scale window rather than the 5s expect default.
+  await expect(page.getByRole("button", { name: intl.loginToAccount }), { message: 'Ensure the system language is english, and the account is not already authenticated.' }).toBeEnabled({ timeout: 120000 });
 
   await page.getByRole("button", { name: intl.loginToAccount }).click();
 

--- a/lib/features/analytics_access/join_room_analytics_access_extension.dart
+++ b/lib/features/analytics_access/join_room_analytics_access_extension.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/analytics/client_analytics_extension.dart';
@@ -36,7 +38,7 @@ extension JoinRoomAnalyticsAccessClientExtension on Client {
     final room = await _loadRoom(resp);
     final joinResp = JoinResponse(
       roomId: resp,
-      shouldShowNotice: room.shouldShowAnalyticsAccessNotice,
+      shouldShowNotice: room?.shouldShowAnalyticsAccessNotice ?? false,
     );
     return joinResp;
   }
@@ -54,26 +56,31 @@ extension JoinRoomAnalyticsAccessClientExtension on Client {
     final room = await _loadRoom(resp);
     final joinResp = JoinResponse(
       roomId: roomId,
-      shouldShowNotice: room.shouldShowAnalyticsAccessNotice,
+      shouldShowNotice: room?.shouldShowAnalyticsAccessNotice ?? false,
     );
     return joinResp;
   }
 
-  Future<Room> _loadRoom(String roomId) async {
-    Room? room = getRoomById(roomId);
+  /// The joined room from local state, waiting briefly for sync to surface it.
+  /// Null when sync is still lagging — NOT a failure: every caller runs after
+  /// a join API call that already succeeded, so the membership is real and the
+  /// local room list just hasn't caught up. A freshly-booted client (a class
+  /// join link IS a fresh page load) routinely takes longer than this to chew
+  /// through its initial sync; failing the flow here stranded the user on the
+  /// join page as a secret member of the course (#7579).
+  Future<Room?> _loadRoom(String roomId) async {
+    final room = getRoomById(roomId);
     if (room == null || room.membership != Membership.join) {
-      await waitForRoomInSync(
-        roomId,
-        join: true,
-      ).timeout(Duration(seconds: 10));
+      try {
+        await waitForRoomInSync(
+          roomId,
+          join: true,
+        ).timeout(const Duration(seconds: 10));
+      } on TimeoutException {
+        // Sync lag, not a failed join — proceed without the local room.
+      }
     }
-
-    room = getRoomById(roomId);
-    if (room == null) {
-      throw "Room not found after joining";
-    }
-
-    return room;
+    return getRoomById(roomId);
   }
 
   Future<LanguageModel?> _getCourseLanguage(String courseId) async {
@@ -183,7 +190,7 @@ extension JoinRoomAnalyticsAccessRoomExtension on Room {
     final room = await client._loadRoom(id);
     final joinResp = JoinResponse(
       roomId: id,
-      shouldShowNotice: room.shouldShowAnalyticsAccessNotice,
+      shouldShowNotice: room?.shouldShowAnalyticsAccessNotice ?? false,
     );
     return joinResp;
   }

--- a/lib/features/join_codes/space_code_controller.dart
+++ b/lib/features/join_codes/space_code_controller.dart
@@ -6,25 +6,95 @@ import 'package:flutter/material.dart';
 
 import 'package:async/async.dart';
 import 'package:collection/collection.dart';
+import 'package:go_router/go_router.dart';
 import 'package:http/http.dart' hide Client;
 import 'package:matrix/matrix.dart' hide Result;
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'package:fluffychat/features/analytics_access/join_room_analytics_access_extension.dart';
+import 'package:fluffychat/features/analytics_access/join_room_analytics_consent_handler.dart';
 import 'package:fluffychat/features/join_codes/knock_with_code_extension.dart';
 import 'package:fluffychat/features/join_codes/space_code_repo.dart';
 import 'package:fluffychat/features/join_codes/too_many_requests_dialog.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
+import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 
 class NotFoundException implements Exception {}
 
 class SpaceCodeController {
-  static Completer<Result<JoinResponse>>? _joinCompleter;
+  /// In-flight joins keyed by code, so a double-tap on the same code awaits
+  /// the one join — while a DIFFERENT code (a second class link arriving
+  /// mid-join) runs its own, instead of being handed the first code's result
+  /// (#7579).
+  static final Map<String, Future<Result<JoinResponse>>> _inFlightJoins = {};
 
   static StreamController spaceCodeStream = StreamController.broadcast();
+
+  /// The one post-join hop, shared by every code entry point (the coded-link
+  /// page, the public course preview, the legacy cached-code path): run the
+  /// analytics-consent step where the room is available locally, then open
+  /// the course. When sync hasn't surfaced the room yet the join is STILL
+  /// done (the join API call succeeded), so navigate to the course anyway —
+  /// its panel renders a loading state until sync catches up — instead of
+  /// silently stranding the user on the join page as a secret member of the
+  /// course (#7579). Class codes only attach to course spaces, so the course
+  /// route is the right target for the not-yet-local case; the consent
+  /// notice, skipped here, resurfaces through the course-settings listener.
+  static Future<void> navigateAfterJoin(
+    BuildContext context,
+    Client client,
+    JoinResponse joinResp,
+  ) async {
+    final target = await resolveJoinedTarget(context, client, joinResp);
+    if (target == null || !context.mounted) return;
+    goToJoinedTarget(context, target);
+  }
+
+  /// The async half of the post-join hop: run the analytics-consent step where
+  /// the room is available locally, and resolve where to land. Null means the
+  /// learner declined consent — don't navigate. When sync hasn't surfaced the
+  /// room yet the join is STILL done (the join API call succeeded), so resolve
+  /// to the course anyway — its panel renders a loading state until sync
+  /// catches up — instead of silently stranding the user on the join page as a
+  /// secret member of the course (#7579). Class codes only attach to course
+  /// spaces, so the course route is the right default for the not-yet-local
+  /// case; the consent notice, skipped there, resurfaces through the
+  /// course-settings listener.
+  static Future<({String roomId, bool isSpace})?> resolveJoinedTarget(
+    BuildContext context,
+    Client client,
+    JoinResponse joinResp,
+  ) async {
+    final room = client.getRoomById(joinResp.roomId);
+    if (room == null) return (roomId: joinResp.roomId, isSpace: true);
+
+    final handler = JoinRoomAnalyticsConsentHandler(joinResp, room);
+    final joinedRoomId = await handler.handle(context);
+    if (joinedRoomId == null) return null;
+    return (roomId: joinedRoomId, isSpace: room.isSpace);
+  }
+
+  /// The synchronous half of the post-join hop, split from
+  /// [resolveJoinedTarget] so a caller that must rewrite its own URL first
+  /// (the inbound-coded join page consuming its trigger, #7579) can do both
+  /// in one tick — before the rebuild the rewrite schedules can dispose it.
+  static void goToJoinedTarget(
+    BuildContext context,
+    ({String roomId, bool isSpace}) target,
+  ) {
+    target.isSpace
+        ? context.go(
+            WorkspaceNav.openCourse(
+              GoRouterState.of(context).uri,
+              target.roomId,
+            ),
+          )
+        : NavigationUtil.goToSpaceRoute(target.roomId, const [], context);
+  }
 
   static Future<void> cacheRoomCodeToJoin(String code) async {
     await SpaceCodeRepo.setSpaceCode(code);
@@ -58,9 +128,11 @@ class SpaceCodeController {
     BuildContext? context,
     bool showLoading = true,
   }) async {
+    final inFlight = _inFlightJoins[spaceCode];
+    if (inFlight != null) return inFlight;
+    final completer = Completer<Result<JoinResponse>>();
+    _inFlightJoins[spaceCode] = completer.future;
     try {
-      if (_joinCompleter != null) return _joinCompleter!.future;
-      _joinCompleter = Completer<Result<JoinResponse>>();
       await SpaceCodeRepo.setRecentCode(spaceCode);
 
       // TODO this should throw error if failed
@@ -75,10 +147,10 @@ class SpaceCodeController {
 
       GoogleAnalytics.joinClass(spaceCode);
       final result = Result.value(roomId);
-      _joinCompleter?.complete(result);
+      completer.complete(result);
       return result;
     } catch (e, s) {
-      _joinCompleter?.complete(Result.error(e, s));
+      completer.complete(Result.error(e, s));
       ErrorHandler.logError(e: e, s: s, data: {"spaceCode": spaceCode});
       if (e is StreamedResponse && e.statusCode == 429 && context != null) {
         await showDialog(
@@ -88,7 +160,7 @@ class SpaceCodeController {
       }
       return Result.error(e, s);
     } finally {
-      _joinCompleter = null;
+      _inFlightJoins.remove(spaceCode);
     }
   }
 
@@ -155,25 +227,23 @@ class SpaceCodeController {
         }
       }
 
-      roomIdToJoin ??= resp.roomIds.firstOrNull;
+      // A room the server says we're already in can be absent from the LOCAL
+      // list on a cold boot (initial sync still running); joining it again is
+      // idempotent server-side, so fall through to a join rather than a
+      // not-found (#7579 — re-clicking a link for a class you're in).
+      roomIdToJoin ??= resp.roomIds.firstOrNull ?? alreadyJoined.firstOrNull;
       if (roomIdToJoin == null) {
         throw NotFoundException();
       }
 
       final joinResp = await client.joinRoomByIdWithAccessCheck(roomIdToJoin);
-      Room? room = client.getRoomById(roomIdToJoin);
+      final room = client.getRoomById(roomIdToJoin);
 
-      if (room == null) {
-        await client.waitForRoomInSync(roomIdToJoin, join: true);
-        room = client.getRoomById(roomIdToJoin);
-        if (room == null) {
-          throw Exception("Failed to join space with id $roomIdToJoin");
-        }
-      }
-
-      if (room.membership != Membership.join) {
-        await room.client.waitForRoomInSync(room.id, join: true);
-      }
+      // The join API call above succeeded — the membership is real. A null or
+      // stale local room only means sync hasn't caught up (a class-link click
+      // is a fresh page load, so the client may still be mid-initial-sync);
+      // don't fail a join that happened, and never wait unboundedly (#7579).
+      if (room == null) return joinResp;
 
       // Sometimes, the invite event comes through after the join event and
       // replaces it, so membership gets out of sync. In this case,
@@ -182,7 +252,7 @@ class SpaceCodeController {
       if (room.membership !=
           room
               .getParticipants()
-              .firstWhereOrNull((u) => u.id == room?.client.userID)
+              .firstWhereOrNull((u) => u.id == room.client.userID)
               ?.membership) {
         await room.requestParticipants();
       }

--- a/lib/features/join_codes/space_code_controller.dart
+++ b/lib/features/join_codes/space_code_controller.dart
@@ -72,7 +72,17 @@ class SpaceCodeController {
     final room = client.getRoomById(joinResp.roomId);
     if (room == null) return (roomId: joinResp.roomId, isSpace: true);
 
-    final handler = JoinRoomAnalyticsConsentHandler(joinResp, room);
+    // Recompute the notice from the room as it stands NOW: when the join-time
+    // sync-wait timed out, [joinResp.shouldShowNotice] is a false fallback,
+    // and running the handler with it would record consent that was never
+    // asked for. The room may have landed in the meantime.
+    final handler = JoinRoomAnalyticsConsentHandler(
+      JoinResponse(
+        roomId: joinResp.roomId,
+        shouldShowNotice: room.shouldShowAnalyticsAccessNotice,
+      ),
+      room,
+    );
     final joinedRoomId = await handler.handle(context);
     if (joinedRoomId == null) return null;
     return (roomId: joinedRoomId, isSpace: room.isSpace);
@@ -230,8 +240,10 @@ class SpaceCodeController {
       // A room the server says we're already in can be absent from the LOCAL
       // list on a cold boot (initial sync still running); joining it again is
       // idempotent server-side, so fall through to a join rather than a
-      // not-found (#7579 — re-clicking a link for a class you're in).
-      roomIdToJoin ??= resp.roomIds.firstOrNull ?? alreadyJoined.firstOrNull;
+      // not-found (#7579 — re-clicking a link for a class you're in). The
+      // server's already-joined room is authoritative, so it outranks any
+      // other joinable candidate for the same code.
+      roomIdToJoin ??= alreadyJoined.firstOrNull ?? resp.roomIds.firstOrNull;
       if (roomIdToJoin == null) {
         throw NotFoundException();
       }

--- a/lib/routes/chat_list/chat_list.dart
+++ b/lib/routes/chat_list/chat_list.dart
@@ -1158,21 +1158,7 @@ class ChatListController extends State<ChatList>
     final joinResp = result.result;
     if (joinResp == null) return;
 
-    final room = client.getRoomById(joinResp.roomId);
-    if (room == null) return;
-
-    final handler = JoinRoomAnalyticsConsentHandler(joinResp, room);
-    final joinedRoomId = await handler.handle(context);
-    if (joinedRoomId == null) return;
-
-    room.isSpace
-        ? context.go(
-            WorkspaceNav.openCourse(
-              GoRouterState.of(context).uri,
-              joinedRoomId,
-            ),
-          )
-        : NavigationUtil.goToSpaceRoute(joinedRoomId, const [], context);
+    await SpaceCodeController.navigateAfterJoin(context, client, joinResp);
   }
 
   Future<void> _startDMWithCachedUserId(Client client) async {

--- a/lib/routes/courses/preview/public_course_preview.dart
+++ b/lib/routes/courses/preview/public_course_preview.dart
@@ -17,7 +17,6 @@ import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/courses/preview/public_course_preview_view.dart';
-import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -150,21 +149,7 @@ class PublicCoursePreviewController extends State<PublicCoursePreview>
     final joinResp = result.result;
     if (joinResp == null) return;
 
-    final room = client.getRoomById(joinResp.roomId);
-    if (room == null) return;
-
-    final handler = JoinRoomAnalyticsConsentHandler(joinResp, room);
-    final joinedRoomId = await handler.handle(context);
-    if (joinedRoomId == null) return;
-
-    room.isSpace
-        ? context.go(
-            WorkspaceNav.openCourse(
-              GoRouterState.of(context).uri,
-              joinedRoomId,
-            ),
-          )
-        : NavigationUtil.goToSpaceRoute(joinedRoomId, const [], context);
+    await SpaceCodeController.navigateAfterJoin(context, client, joinResp);
   }
 
   Future<void> joinCourse() async {

--- a/lib/routes/courses/private/course_code_page.dart
+++ b/lib/routes/courses/private/course_code_page.dart
@@ -6,24 +6,25 @@ import 'package:go_router/go_router.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
-import 'package:fluffychat/features/analytics_access/join_room_analytics_consent_handler.dart';
 import 'package:fluffychat/features/join_codes/space_code_controller.dart';
 import 'package:fluffychat/features/navigation/token_params/add_course_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/spaces/space_constants.dart';
-import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 class CourseCodePage extends StatefulWidget {
   /// A code delivered by an inbound join link (the `addcourse` token's
   /// `private/<code>` leaf — see LegacyRedirects, #7524). Prefilled and
-  /// submitted once, running the exact join a manual entry performs; on
-  /// failure the page stays up with the code in the field. The trigger is
-  /// consumed before the submit: the coded URL is history-REPLACED with the
-  /// manual `private` page, so browser back or a refresh never re-fires the
-  /// join.
+  /// submitted once, running the exact join a manual entry performs. The
+  /// trigger is consumed when the submit COMPLETES (the coded URL is
+  /// history-REPLACED with the manual `private` page), so back or refresh
+  /// after the flow never re-fires it. Consuming it up front looked safer but
+  /// remounted this page mid-join — the URL rewrite changes the panel's
+  /// identity key — orphaning the post-join navigation and stranding the user
+  /// on the join page as a secret member of the course (#7579). A refresh
+  /// MID-join re-fires harmlessly: the knock+join are idempotent server-side.
   final String? initialCode;
   final Widget closeButton;
 
@@ -74,22 +75,27 @@ class CourseCodePageState extends State<CourseCodePage> {
     }
   }
 
-  /// One-shot inbound-code submit. Consumes its trigger first: the coded URL
-  /// is history-REPLACED with the manual `private` page, so back after a
-  /// successful join and refresh after a failed one both land on the manual
-  /// page without resubmitting.
+  /// One-shot inbound-code submit; the trigger is consumed at completion
+  /// (see [CourseCodePage.initialCode]).
   void _autoSubmit() {
     _codeController.text = widget.initialCode!.trim();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
-      context.replace(
-        WorkspaceNav.openAddCoursePage(
-          GoRouterState.of(context).uri,
-          AddCourseSubpageEnum.private,
-        ),
-      );
-      _submit();
+      _submit(consumeInboundCode: true);
     });
+  }
+
+  /// History-replace the inbound-coded URL with the manual `private` page so
+  /// back/refresh never re-fire the join. Rewriting this panel's own URL
+  /// changes its identity key and remounts it, so any follow-up navigation
+  /// must happen in the SAME tick (#7579).
+  void _consumeInboundCode() {
+    context.replace(
+      WorkspaceNav.openAddCoursePage(
+        GoRouterState.of(context).uri,
+        AddCourseSubpageEnum.private,
+      ),
+    );
   }
 
   @override
@@ -100,7 +106,7 @@ class CourseCodePageState extends State<CourseCodePage> {
 
   String get _code => _codeController.text.trim();
 
-  Future<void> _submit() async {
+  Future<void> _submit({bool consumeInboundCode = false}) async {
     if (_code.isEmpty) {
       return;
     }
@@ -114,23 +120,25 @@ class CourseCodePageState extends State<CourseCodePage> {
     if (!mounted) return;
 
     final joinResp = result.result;
-    if (joinResp == null) return;
+    if (joinResp == null) {
+      // Failed join (error already surfaced by the loading dialog): consume
+      // the trigger so a refresh lands on the manual page, not a re-fire.
+      if (consumeInboundCode) _consumeInboundCode();
+      return;
+    }
 
-    final room = client.getRoomById(joinResp.roomId);
-    if (room == null) return;
-
-    final handler = JoinRoomAnalyticsConsentHandler(joinResp, room);
-    final joinedRoomId = await handler.handle(context);
-    if (!mounted || joinedRoomId == null) return;
-
-    room.isSpace
-        ? context.go(
-            WorkspaceNav.openCourse(
-              GoRouterState.of(context).uri,
-              joinedRoomId,
-            ),
-          )
-        : NavigationUtil.goToSpaceRoute(joinedRoomId, const [], context);
+    final target = await SpaceCodeController.resolveJoinedTarget(
+      context,
+      client,
+      joinResp,
+    );
+    if (!mounted) return;
+    // Consume, then hop, in one tick: the consume's rebuild remounts this
+    // page, so a navigation scheduled any later would be orphaned (#7579).
+    if (consumeInboundCode) _consumeInboundCode();
+    if (target != null) {
+      SpaceCodeController.goToJoinedTarget(context, target);
+    }
   }
 
   @override


### PR DESCRIPTION
Closes #7579

## Root cause (full diagnosis on the issue)

Reproduced on the local stack with two coded knock-spaces driven by Playwright, each link a fresh page load. Two stacked defects:

1. **The join succeeded server-side but the client refused to believe it.** After `joinRoomById` returns, `_loadRoom` waited on `waitForRoomInSync(...).timeout(10s)` and **threw** on timeout. A freshly-booted client (which is what a link click produces) routinely takes longer than that to chew through its initial sync — so the flow errored out, stranding the user on the join-with-code page as a secret member of the class.
2. **The consume-first URL replace killed the page mid-flight.** The inbound-code page history-replaced its own coded URL before submitting; that rewrite changes the panel's identity key, remounting the page, so the post-join navigation ran on a defunct context and silently vanished.

## Fix

- **Join response is the source of truth; sync-wait is best-effort UX.** `_loadRoom` no longer throws on timeout — it returns the room if local, else null, and callers proceed (`shouldShowNotice` falls back to false; the consent notice resurfaces via the course-settings listener). `_joinSpace`'s unbounded `waitForRoomInSync` + throw are gone.
- **Consume the inbound code at completion, not up front.** The coded URL is replaced with the manual page when the submit finishes (success or failure), in the SAME tick as the course hop so the remount can't orphan it. Back/refresh after the flow still never re-fire; a refresh mid-join re-fires harmlessly (knock+join are idempotent, and the `alreadyJoined` path now works cold).
- **`alreadyJoined` works on a cold boot**: falls through to an (idempotent) join when the local room list hasn't caught up, instead of throwing not-found when re-clicking a link for a class you're in.
- **In-flight join dedup keyed by code**: a second class link arriving mid-join runs its own join instead of receiving the first code's result.
- **One shared post-join hop** (`resolveJoinedTarget`/`goToJoinedTarget` + `navigateAfterJoin`): the coded page, the public course preview, and the legacy cached-code path all ran the same copy-pasted block with the same silent `room == null` hole; now there's one implementation.
- e2e harness: the auth setup's first assert gets a boot-scale timeout (debug cold boots on a cache-less context far exceed the 5s expect default).

## Verification

- Local-stack e2e (Playwright, release build, two knock spaces with real access codes): both consecutive class links now join AND land on their respective courses (`?c=<spaceA>&left=course` then `?c=<spaceB>&left=course`); server-side membership verified `join` for both. Before the fix: second link parked on the code page while membership was secretly `join`.
- `flutter test test/pangea/`: 1068 passing; the one failure (`choreo_endpoint_test` activity feedback, live local choreo 500) reproduces identically on main and is not in CI's bucket.
- `dart analyze` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when joining rooms while local synchronization is delayed.
  * Prevented duplicate join attempts for the same space code.
  * Ensured failed or completed join-code submissions are not retriggered by refresh or back navigation.
  * Increased authentication setup wait time to support slower startup conditions.

* **Improvements**
  * Centralized post-join handling and navigation.
  * Added consistent routing for course spaces and regular spaces.
  * Preserved analytics consent handling when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->