### PR TITLE
fix(a11y): make world map pins activatable by screen readers

### DIFF
--- a/lib/routes/world/world_map_state_dot.dart
+++ b/lib/routes/world/world_map_state_dot.dart
@@ -89,6 +89,11 @@ class _WorldMapDotState extends State<WorldMapDot>
           label: widget.dying
               ? ''
               : L10n.of(context).activityLabel(widget.card.title),
+          // excludeSemantics drops the DESCENDANT tree — including the
+          // GestureDetector's implicit tap action — so this node must carry
+          // its own onTap, or assistive tech can name the pin but never
+          // activate it (#7591).
+          onTap: widget.dying ? null : widget.onTap,
           excludeSemantics: true,
           child: GestureDetector(
             onTap: widget.dying ? null : widget.onTap,

--- a/test/pangea/world/world_map_semantics_activation_test.dart
+++ b/test/pangea/world/world_map_semantics_activation_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_state_dot.dart';
+import 'package:fluffychat/routes/world/world_user_cluster.dart';
+import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
+
+/// Covers #7591: a control that names itself to assistive tech must also be
+/// ACTIVATABLE through it. `Semantics(excludeSemantics: true)` drops the
+/// descendant tree — including a wrapped GestureDetector/InkWell's implicit
+/// tap action — so such nodes must carry their own `onTap`. These tests
+/// perform the real [SemanticsAction.tap] (what a screen-reader double-tap
+/// sends), not a pointer tap.
+void main() {
+  const card = QuestActivityCard(
+    activityId: 'a1',
+    title: 'Test Activity',
+    l2: 'es',
+    coordinates: [0, 0],
+    learningObjectiveRefs: [],
+  );
+
+  Future<void> pump(WidgetTester tester, Widget child) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(body: Center(child: child)),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// Send the screen-reader activation to the node found by [label].
+  void performSemanticsTap(WidgetTester tester, String label) {
+    final node = tester.getSemantics(find.bySemanticsLabel(label));
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(
+      node.id,
+      SemanticsAction.tap,
+    );
+  }
+
+  for (final tier in [PinTier.small, PinTier.mid]) {
+    testWidgets('a ${tier.name} pin activates via the semantics tap action', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      var tapped = false;
+      await pump(
+        tester,
+        WorldMapDot(
+          card: card,
+          state: ActivityPinState.available,
+          tier: tier,
+          onTap: () => tapped = true,
+          pinged: false,
+        ),
+      );
+
+      performSemanticsTap(tester, 'Activity: Test Activity');
+      expect(
+        tapped,
+        isTrue,
+        reason:
+            'a screen-reader double-tap on the ${tier.name} pin must open '
+            'the activity (#7591)',
+      );
+      semantics.dispose();
+    });
+  }
+
+  testWidgets('a cluster tracker activates via the semantics tap action', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    var tapped = false;
+    await pump(
+      tester,
+      ClusterTrackerButton(
+        indicator: ProgressIndicatorEnum.wordsUsed,
+        count: 42,
+        onTap: () => tapped = true,
+      ),
+    );
+
+    final l10n = L10n.of(tester.element(find.byType(Scaffold)));
+    performSemanticsTap(tester, '${l10n.vocab}: 42');
+    expect(
+      tapped,
+      isTrue,
+      reason:
+          'a screen-reader double-tap on a tracker must open its analytics '
+          'tab (#7591)',
+    );
+    semantics.dispose();
+  });
+}

--- a/test/pangea/world/world_map_semantics_activation_test.dart
+++ b/test/pangea/world/world_map_semantics_activation_test.dart
@@ -39,7 +39,11 @@ void main() {
   /// Send the screen-reader activation to the node found by [label].
   void performSemanticsTap(WidgetTester tester, String label) {
     final node = tester.getSemantics(find.bySemanticsLabel(label));
-    tester.binding.rootPipelineOwner.semanticsOwner!.performAction(
+    // The deprecated owner is the one that actually holds the test view's
+    // semantics tree; rootPipelineOwner carries no SemanticsOwner in the test
+    // binding, so actions sent there go nowhere.
+    // ignore: deprecated_member_use
+    tester.binding.pipelineOwner.semanticsOwner!.performAction(
       node.id,
       SemanticsAction.tap,
     );

--- a/test/pangea/world/world_map_semantics_activation_test.dart
+++ b/test/pangea/world/world_map_semantics_activation_test.dart
@@ -39,7 +39,7 @@ void main() {
   /// Send the screen-reader activation to the node found by [label].
   void performSemanticsTap(WidgetTester tester, String label) {
     final node = tester.getSemantics(find.bySemanticsLabel(label));
-    tester.binding.pipelineOwner.semanticsOwner!.performAction(
+    tester.binding.rootPipelineOwner.semanticsOwner!.performAction(
       node.id,
       SemanticsAction.tap,
     );


### PR DESCRIPTION
Closes #7591

## What

Map pin dots/mid pins named themselves to assistive tech but could not be **activated**: `Semantics(excludeSemantics: true)` drops the descendant tree, including the wrapped `GestureDetector`'s implicit tap action, so a screen-reader double-tap (or any synthetic semantics tap) no-oped. Found while diagnosing #7530 — a semantics click did nothing while a pointer click at the same coordinates worked.

Fix: the pin's semantics node now carries its own `onTap` (null while dying), matching the pattern the rest of the world chrome already follows (`world_user_cluster`, `hex_level_badge`).

Swept every other `excludeSemantics: true` in `lib/routes/world/`: all either already carry their own `onTap` or are non-interactive announcements (`level_up_badge_celebration`). `ClusterTrackerButton` looked suspicious (tap on the `InkWell` outside the excluding node) but proves activatable — now locked by test.

## Testing

New `world_map_semantics_activation_test.dart` performs the real `SemanticsAction.tap` (what a screen-reader double-tap sends, not a pointer tap) against the small pin, mid pin, and cluster tracker — red before the fix for the pins, green after. Full world suite: 37/37. Analyzer clean.

Manual VoiceOver/TalkBack steps are on the issue's TO TEST checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accessibility for world map pins so screen-reader users can activate interactive pins through semantic tap actions.
  - Prevented pins marked as unavailable or disappearing from exposing an activation action.
  - Improved semantic activation reliability for clustered map controls.

- **Tests**
  - Added accessibility coverage verifying screen-reader activation for map pins and cluster controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->