### PR TITLE
feat(ui): use the gold ribbon as the level symbol everywhere

### DIFF
--- a/lib/routes/analytics/level/level_analytics_details_content.dart
+++ b/lib/routes/analytics/level/level_analytics_details_content.dart
@@ -12,6 +12,7 @@ import 'package:fluffychat/pangea/morphs/grammar_constructs_provider.dart';
 import 'package:fluffychat/widgets/analytics_summary/learning_progress_indicators.dart';
 import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
 import 'package:fluffychat/widgets/matrix.dart';
+import 'package:fluffychat/widgets/users/level_ribbon.dart';
 
 class LevelAnalyticsDetailsContent extends StatelessWidget {
   /// When hosted inside the world map's right-docked analytics panel, hide the
@@ -60,13 +61,20 @@ class LevelAnalyticsDetailsContent extends StatelessWidget {
                       return Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Text(
-                            "⭐ ${L10n.of(context).levelShort(level)}",
-                            style: TextStyle(
-                              fontSize: isColumnMode ? 24 : 16,
-                              fontWeight: FontWeight.w900,
-                              color: AppConfig.gold,
-                            ),
+                          Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              LevelRibbon(height: isColumnMode ? 28.0 : 20.0),
+                              const SizedBox(width: 6.0),
+                              Text(
+                                L10n.of(context).levelShort(level),
+                                style: TextStyle(
+                                  fontSize: isColumnMode ? 24 : 16,
+                                  fontWeight: FontWeight.w900,
+                                  color: AppConfig.gold,
+                                ),
+                              ),
+                            ],
                           ),
                           Text(
                             L10n.of(context).xpIntoLevel(totalXP, maxLevelXP),

--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -15,6 +15,7 @@ import 'package:fluffychat/routes/world/user_cluster_view_model_builder.dart';
 import 'package:fluffychat/routes/world/xp_border_painter.dart';
 import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
 import 'package:fluffychat/widgets/avatar.dart';
+import 'package:fluffychat/widgets/users/level_ribbon.dart';
 
 /// The persistent top-right cluster over the world map (world_v2): the user's
 /// avatar wrapped in a clockwise XP ring (gray track that fills gold toward the
@@ -356,15 +357,6 @@ class ClusterLevelMedal extends StatelessWidget {
     super.key,
   });
 
-  // The outer shield shape from Figma (icon/warning-secondary fill #F3C141 ==
-  // AppConfig.goldMedal); the level number is overlaid.
-
-  String _shieldSvg(String hexcode) =>
-      '<svg viewBox="0 0 24.6667 28.875" xmlns="http://www.w3.org/2000/svg">'
-      '<path d="M4.33333 28.875V17.5656L0 10.3125L6.16667 0H18.5L24.6667 '
-      '10.3125L20.3333 17.5656V28.875L12.3333 26.125L4.33333 28.875Z" '
-      'fill="$hexcode"/></svg>';
-
   @override
   Widget build(BuildContext context) {
     final label = '${L10n.of(context).level} $level';
@@ -383,34 +375,8 @@ class ClusterLevelMedal extends StatelessWidget {
           // Expose the tap on the announced node for assistive tech (#7185).
           onTap: onTap,
           child: Padding(
-            padding: EdgeInsets.all(4.0),
-            child: SizedBox(
-              width: 38,
-              height: 44,
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  SvgPicture.string(
-                    _shieldSvg(AppConfig.goldHexByTheme(context)),
-                    width: 38,
-                    height: 44,
-                    fit: BoxFit.contain,
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 5),
-                    child: Text(
-                      '$level',
-                      style: const TextStyle(
-                        fontSize: 17,
-                        height: 1.0,
-                        fontWeight: FontWeight.bold,
-                        color: Colors.black,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
+            padding: const EdgeInsets.all(4.0),
+            child: LevelRibbon(height: 44, level: level),
           ),
         ),
       ),

--- a/lib/widgets/analytics_summary/learning_progress_indicators.dart
+++ b/lib/widgets/analytics_summary/learning_progress_indicators.dart
@@ -15,6 +15,7 @@ import 'package:fluffychat/widgets/analytics_summary/progress_indicator.dart';
 import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
 import 'package:fluffychat/widgets/hover_builder.dart';
 import 'package:fluffychat/widgets/matrix.dart';
+import 'package:fluffychat/widgets/users/level_ribbon.dart';
 
 /// A summary of "My Analytics" shown at the top of the chat list
 /// It shows a variety of progress indicators such as
@@ -241,17 +242,9 @@ class LearningProgressIndicators extends StatelessWidget {
                                             ),
                                           ),
                                           if (data != null)
-                                            Text(
-                                              "⭐ ${data.level}",
-                                              style: Theme.of(context)
-                                                  .textTheme
-                                                  .titleLarge
-                                                  ?.copyWith(
-                                                    fontWeight: FontWeight.bold,
-                                                    color: Theme.of(
-                                                      context,
-                                                    ).colorScheme.primary,
-                                                  ),
+                                            LevelRibbon(
+                                              level: data.level,
+                                              height: 28.0,
                                             ),
                                         ],
                                       );

--- a/lib/widgets/users/level_display_name.dart
+++ b/lib/widgets/users/level_display_name.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
 import 'package:fluffychat/widgets/matrix.dart';
+import 'package:fluffychat/widgets/users/level_ribbon.dart';
 
 class LevelDisplayName extends StatelessWidget {
   final String userId;
@@ -104,18 +105,11 @@ class LevelDisplayName extends StatelessWidget {
                       ),
                     ],
                     const SizedBox(width: 4.0),
-                    if (level != null) ...[
-                      Text("⭐", style: textStyle),
-                      Text(
-                        "$level",
-                        style:
-                            textStyle ??
-                            TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: Theme.of(context).colorScheme.primary,
-                            ),
+                    if (level != null)
+                      LevelRibbon(
+                        level: level,
+                        height: (iconSize ?? 16.0) + 2.0,
                       ),
-                    ],
                   ],
                 ),
             ],

--- a/lib/widgets/users/level_ribbon.dart
+++ b/lib/widgets/users/level_ribbon.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_svg/svg.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+
+/// The gold ribbon/shield that represents a learner's level across the app —
+/// the single source of the level symbol, so the right-nav cluster medal
+/// ([ClusterLevelMedal]) and the inline level chips (profile cards, analytics
+/// headers) all render the same mark instead of a bare `⭐`.
+///
+/// [level] is overlaid on the shield when non-null; pass null for a plain
+/// level glyph beside its own text label. [height] drives the shield size and
+/// the number scales from it. Presentational only — wrap it in an `InkWell` /
+/// `Semantics` where it needs to be tappable.
+class LevelRibbon extends StatelessWidget {
+  final int? level;
+  final double height;
+
+  const LevelRibbon({required this.height, this.level, super.key});
+
+  /// The shield outline from Figma (icon/warning-secondary), filled [hexcode].
+  static String _shieldSvg(String hexcode) =>
+      '<svg viewBox="0 0 24.6667 28.875" xmlns="http://www.w3.org/2000/svg">'
+      '<path d="M4.33333 28.875V17.5656L0 10.3125L6.16667 0H18.5L24.6667 '
+      '10.3125L20.3333 17.5656V28.875L12.3333 26.125L4.33333 28.875Z" '
+      'fill="$hexcode"/></svg>';
+
+  @override
+  Widget build(BuildContext context) {
+    // Shield aspect ratio from the viewBox (24.6667 x 28.875).
+    final width = height * (24.6667 / 28.875);
+    final ribbon = SvgPicture.string(
+      _shieldSvg(AppConfig.goldHexByTheme(context)),
+      width: width,
+      height: height,
+      fit: BoxFit.contain,
+    );
+    final level = this.level;
+    if (level == null) return ribbon;
+
+    return SizedBox(
+      width: width,
+      height: height,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          ribbon,
+          // The number sits slightly above the ribbon's notched base.
+          Padding(
+            padding: EdgeInsets.only(bottom: height * 0.11),
+            child: Text(
+              '$level',
+              style: TextStyle(
+                fontSize: height * 0.42,
+                height: 1.0,
+                fontWeight: FontWeight.bold,
+                color: Colors.black,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/pangea/widgets/level_ribbon_test.dart
+++ b/test/pangea/widgets/level_ribbon_test.dart
@@ -11,7 +11,9 @@ import 'package:fluffychat/widgets/users/level_ribbon.dart';
 /// beside it).
 void main() {
   Future<void> pump(WidgetTester tester, Widget child) => tester.pumpWidget(
-    MaterialApp(home: Scaffold(body: Center(child: child))),
+    MaterialApp(
+      home: Scaffold(body: Center(child: child)),
+    ),
   );
 
   testWidgets('renders the ribbon SVG with the level number overlaid', (

--- a/test/pangea/widgets/level_ribbon_test.dart
+++ b/test/pangea/widgets/level_ribbon_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/widgets/users/level_ribbon.dart';
+
+/// The level symbol is the gold ribbon (was a bare `⭐`). These lock the two
+/// modes the app uses: number-inside (profile card, cluster medal, progress
+/// row) and plain glyph (the analytics header, where the level text sits
+/// beside it).
+void main() {
+  Future<void> pump(WidgetTester tester, Widget child) => tester.pumpWidget(
+    MaterialApp(home: Scaffold(body: Center(child: child))),
+  );
+
+  testWidgets('renders the ribbon SVG with the level number overlaid', (
+    tester,
+  ) async {
+    await pump(tester, const LevelRibbon(height: 44, level: 7));
+    expect(find.byType(SvgPicture), findsOneWidget);
+    expect(find.text('7'), findsOneWidget);
+  });
+
+  testWidgets('renders a plain ribbon glyph when level is null', (
+    tester,
+  ) async {
+    await pump(tester, const LevelRibbon(height: 20));
+    expect(find.byType(SvgPicture), findsOneWidget);
+    expect(find.byType(Text), findsNothing);
+  });
+
+  testWidgets('keeps the shield aspect ratio for the given height', (
+    tester,
+  ) async {
+    await pump(tester, const LevelRibbon(height: 28.875, level: 1));
+    final size = tester.getSize(find.byType(SvgPicture).first);
+    expect(size.height, closeTo(28.875, 0.01));
+    expect(size.width, closeTo(24.6667, 0.01));
+  });
+}


### PR DESCRIPTION
Closes #7595

## What

The learner level rendered as a bare `⭐` in several places while the right-nav cluster medal already used the gold ribbon/shield. This standardizes on the ribbon everywhere and extracts one shared widget so there's a single source of the level symbol.

- New `LevelRibbon` widget (`lib/widgets/users/level_ribbon.dart`): the gold shield with an optional number overlaid, size-parameterized. `ClusterLevelMedal` was refactored to use it (its inline shield SVG is now the widget's, so no duplicated path data).
- Swapped the three genuine level-star sites:
  - **Profile card** (`LevelDisplayName`, the `EN › DE ⭐1` from the report) → ribbon with the number inside.
  - **Analytics summary row** (`LearningProgressIndicators`, the `⭐ N` beside the progress bar) → ribbon with the number inside.
  - **Level analytics header** (`LevelAnalyticsDetailsContent`, `⭐ LVL N`) → ribbon glyph + the existing "LVL N" label (number stays in the text, so the ribbon is a plain glyph there to avoid showing the number twice).
- The decorative scattered `⭐` on the subscription paywall (`unsubscribed_practice_page`) is not a level symbol and is left as-is.

## Verification

Ran on the local stack and confirmed all three surfaces render the gold ribbon (screenshots): profile card `EN › ES [ribbon 3]`, cluster medal unchanged, Level header `[ribbon] LVL 3`. New `level_ribbon_test.dart` locks both modes (number-inside / plain glyph) and the shield aspect ratio; the world suite (cluster medal) stays green — 40/40. Analyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)