### PR TITLE
feat(world): align course plan panel with designs — shared header, overall-only progress bar, collapsed mobile peek

### DIFF
--- a/lib/routes/chat/chat_details/space_details_content.dart
+++ b/lib/routes/chat/chat_details/space_details_content.dart
@@ -9,7 +9,6 @@ import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/analytics_access/course_settings_extension.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
-import 'package:fluffychat/features/course_plans/map_clipper.dart';
 import 'package:fluffychat/features/instructions/instructions_enum.dart';
 import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dart';
 import 'package:fluffychat/features/join_codes/join_rule_extension.dart';
@@ -33,7 +32,6 @@ import 'package:fluffychat/routes/courses/course_objectives/course_objectives_vi
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
-import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 
 enum SpaceSettingsTabs {
@@ -316,216 +314,205 @@ class SpaceDetailsContent extends StatelessWidget {
     ];
   }
 
+  /// Below this incoming height the course card renders only its header and
+  /// progress bar — the collapsed mobile peek (the nav cavity clips there). The
+  /// wide/web panel and the expanded sheet are always well above it. See
+  /// [build].
+  static const double _kCompactCardMaxHeight = 168.0;
+
   @override
   Widget build(BuildContext context) {
     final isColumnMode = FluffyThemes.isColumnMode(context);
     final displayname = room.getLocalizedDisplayname(
       MatrixLocals(L10n.of(context)),
     );
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        // world_v2: a space has no AppBar (PangeaRoomDetailsView passes null for
-        // spaces), so the left-panel close control — an X on desktop, a back
-        // arrow on mobile — rides at the leading edge of the card header,
-        // matching the right column's leading close affordance. Dropping it
-        // would leave the course card with no way to close. See
-        // routing.instructions.md.
-        //
-        // NARROW: one row — [X | title | share] — so the nav widget's peek
-        // shows the course identity immediately (the Figma MOBILE-Course
-        // frame); the title block below then renders without repeating the
-        // name. Column mode keeps the two-row header with the large avatar.
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          crossAxisAlignment: .center,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // The collapsed mobile peek gives the card just enough height for the
+        // header + progress bar and the nav cavity clips there. The Expanded
+        // tab body can't shrink into that short box (it overflows), so below
+        // the threshold we render ONLY the header + bar; the tabs and content
+        // slide in when the learner drags the sheet up (#7597, the Figma
+        // mobile-default frame).
+        final compact =
+            constraints.maxHeight.isFinite &&
+            constraints.maxHeight < _kCompactCardMaxHeight;
+        return Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            if (controller.widget.embeddedCloseButton != null)
-              controller.widget.embeddedCloseButton!,
-            if (isColumnMode)
-              const SizedBox()
-            else
-              Expanded(
-                child: Text(
-                  displayname,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.center,
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-              ),
-            if (room.joinCode != null)
-              Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: ShareRoomButton(
-                  room: room,
-                  tooltip: L10n.of(context).shareCourse,
-                  child: const Icon(Icons.share_outlined),
-                ),
-              ),
-          ],
-        ),
-        SizedBox(height: 8),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Flexible(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (isColumnMode) ...[
-                    ClipPath(
-                      clipper: MapClipper(),
-                      child: Avatar(
-                        mxContent: room.avatar,
-                        name: displayname,
-                        userId: room.directChatMatrixID,
-                        size: 80.0,
-                        borderRadius: BorderRadius.circular(0.0),
-                      ),
-                    ),
-                    const SizedBox(width: 16.0),
-                  ],
-                  Flexible(
-                    child: Column(
-                      spacing: isColumnMode ? 12.0 : 6.0,
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        // Narrow shows the name in the header row above (the
-                        // Figma peek) — repeating it here would double it.
-                        if (isColumnMode)
-                          Text(
-                            displayname,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: Theme.of(context).textTheme.titleLarge,
-                          ),
-                        if (room.coursePlan != null)
-                          CourseInfoChips(
-                            room.coursePlan!.uuid,
-                            fontSize: 12.0,
-                            iconSize: 12.0,
-                          ),
-                      ],
+            // world_v2: a space has no AppBar (PangeaRoomDetailsView passes null
+            // for spaces), so the left-panel close control — an X on desktop, a
+            // back arrow on mobile — rides at the leading edge of the card
+            // header. Dropping it would leave the course card with no way to
+            // close. See routing.instructions.md.
+            //
+            // Shared header (web + mobile, #7597): [X · title · share]. The one
+            // web/mobile difference is the tab labels below — RoomDetailsButton's
+            // width-driven `mini`. No large course avatar (removed), and the
+            // language/level/module chips moved to the top of the More tab.
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                if (controller.widget.embeddedCloseButton != null)
+                  controller.widget.embeddedCloseButton!,
+                Expanded(
+                  child: Text(
+                    displayname,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
                     ),
                   ),
-                ],
-              ),
+                ),
+                if (room.joinCode != null)
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: ShareRoomButton(
+                      room: room,
+                      tooltip: L10n.of(context).shareCourse,
+                      child: const Icon(Icons.share_outlined),
+                    ),
+                  ),
+              ],
             ),
-          ],
-        ),
-        SizedBox(height: isColumnMode ? 24.0 : 12.0),
-        SpaceDetailsButtonRow(
-          controller: controller,
-          room: room,
-          selectedTab: tab(context),
-          onTabSelected: (tab) => setSelectedTab(tab, context),
-          buttons: _buttons(context),
-        ),
-        SizedBox(height: isColumnMode ? 30.0 : 14.0),
-        Expanded(
-          child: Builder(
-            builder: (context) {
-              switch (tab(context)) {
-                case SpaceSettingsTabs.chat:
-                  return CourseChats(
-                    room.id,
-                    activeChat: null,
-                    client: room.client,
-                  );
-                case SpaceSettingsTabs.course:
-                  // world_v2: the course plan is a sequence of learning
-                  // objectives, each satisfied by interchangeable activities
-                  // (no longer grouped by city).
-                  return CourseObjectivesList(
-                    room: room,
-                    hasCompletedActivity:
-                        controller.roomSummariesModel.hasCompletedActivity,
-                  );
-                case SpaceSettingsTabs.participants:
-                  return SingleChildScrollView(
-                    child: Column(
-                      children: [
-                        const InstructionsInlineTooltip(
-                          instructionsEnum:
-                              InstructionsEnum.courseParticipantTooltip,
-                          padding: EdgeInsets.only(
-                            bottom: 16.0,
-                            left: 16.0,
-                            right: 16.0,
+            const SizedBox(height: 12.0),
+            // The overall course progress bar rides ABOVE the tabs so it shows on
+            // every tab and survives the collapsed mobile peek (the objective list,
+            // where it used to live, isn't mounted then). Only the course has a
+            // bar; per-Mission rows show just their stars (#7597).
+            CourseProgressBar(room: room),
+            if (!compact) ...[
+              SizedBox(height: isColumnMode ? 24.0 : 12.0),
+              SpaceDetailsButtonRow(
+                controller: controller,
+                room: room,
+                selectedTab: tab(context),
+                onTabSelected: (tab) => setSelectedTab(tab, context),
+                buttons: _buttons(context),
+              ),
+              SizedBox(height: isColumnMode ? 30.0 : 14.0),
+              Expanded(
+                child: Builder(
+                  builder: (context) {
+                    switch (tab(context)) {
+                      case SpaceSettingsTabs.chat:
+                        return CourseChats(
+                          room.id,
+                          activeChat: null,
+                          client: room.client,
+                        );
+                      case SpaceSettingsTabs.course:
+                        // world_v2: the course plan is a sequence of learning
+                        // objectives, each satisfied by interchangeable activities
+                        // (no longer grouped by city).
+                        return CourseObjectivesList(
+                          room: room,
+                          hasCompletedActivity: controller
+                              .roomSummariesModel
+                              .hasCompletedActivity,
+                        );
+                      case SpaceSettingsTabs.participants:
+                        return SingleChildScrollView(
+                          child: Column(
+                            children: [
+                              const InstructionsInlineTooltip(
+                                instructionsEnum:
+                                    InstructionsEnum.courseParticipantTooltip,
+                                padding: EdgeInsets.only(
+                                  bottom: 16.0,
+                                  left: 16.0,
+                                  right: 16.0,
+                                ),
+                              ),
+                              RoomParticipantsSection(room: room),
+                            ],
                           ),
-                        ),
-                        RoomParticipantsSection(room: room),
-                      ],
-                    ),
-                  );
-                case SpaceSettingsTabs.analytics:
-                  return SingleChildScrollView(
-                    child: Center(child: SpaceAnalytics(roomId: room.id)),
-                  );
-                case SpaceSettingsTabs.more:
-                  final buttons = _buttons(
-                    context,
-                  ).where((b) => !b.showInMainView && b.visible).toList();
+                        );
+                      case SpaceSettingsTabs.analytics:
+                        return SingleChildScrollView(
+                          child: Center(child: SpaceAnalytics(roomId: room.id)),
+                        );
+                      case SpaceSettingsTabs.more:
+                        final buttons = _buttons(
+                          context,
+                        ).where((b) => !b.showInMainView && b.visible).toList();
 
-                  return SingleChildScrollView(
-                    child: Column(
-                      children: [
-                        if (room.topic.isNotEmpty) ...[
-                          Text(
-                            room.topic,
-                            style: TextStyle(
-                              fontSize: isColumnMode ? 16.0 : 12.0,
-                            ),
-                          ),
-                          SizedBox(height: isColumnMode ? 30.0 : 14.0),
-                        ],
-                        Column(
-                          spacing: 10.0,
-                          mainAxisSize: MainAxisSize.min,
-                          children: buttons.map((b) {
-                            return Opacity(
-                              opacity: b.enabled ? 1.0 : 0.5,
-                              child: b.isToggle
-                                  ? SwitchListTile(
-                                      title: Text(b.title),
-                                      subtitle: b.description != null
-                                          ? Text(b.description!)
-                                          : null,
-                                      secondary: b.icon,
-                                      value: b.value,
-                                      onChanged: b.enabled
-                                          ? (value) {
-                                              b.onPressed?.call();
-                                            }
-                                          : null,
-                                      activeThumbColor:
-                                          AppConfig.activeToggleColor,
-                                    )
-                                  : ListTile(
-                                      title: Text(b.title),
-                                      subtitle: b.description != null
-                                          ? Text(b.description!)
-                                          : null,
-                                      leading: b.icon,
-                                      onTap: b.enabled
-                                          ? () => b.onPressed?.call()
-                                          : null,
-                                      trailing: b.trailing,
+                        return SingleChildScrollView(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              // Course meta at the top of More: the description, then
+                              // the language/level/module chips in a row beneath it
+                              // (moved out of the header, #7597).
+                              if (room.topic.isNotEmpty)
+                                Padding(
+                                  padding: const EdgeInsets.only(bottom: 12.0),
+                                  child: Text(
+                                    room.topic,
+                                    style: TextStyle(
+                                      fontSize: isColumnMode ? 16.0 : 12.0,
                                     ),
-                            );
-                          }).toList(),
-                        ),
-                      ],
-                    ),
-                  );
-              }
-            },
-          ),
-        ),
-      ],
+                                  ),
+                                ),
+                              if (room.coursePlan != null)
+                                Padding(
+                                  padding: EdgeInsets.only(
+                                    bottom: isColumnMode ? 30.0 : 14.0,
+                                  ),
+                                  child: CourseInfoChips(
+                                    room.coursePlan!.uuid,
+                                    fontSize: 12.0,
+                                    iconSize: 12.0,
+                                  ),
+                                ),
+                              Column(
+                                spacing: 10.0,
+                                mainAxisSize: MainAxisSize.min,
+                                children: buttons.map((b) {
+                                  return Opacity(
+                                    opacity: b.enabled ? 1.0 : 0.5,
+                                    child: b.isToggle
+                                        ? SwitchListTile(
+                                            title: Text(b.title),
+                                            subtitle: b.description != null
+                                                ? Text(b.description!)
+                                                : null,
+                                            secondary: b.icon,
+                                            value: b.value,
+                                            onChanged: b.enabled
+                                                ? (value) {
+                                                    b.onPressed?.call();
+                                                  }
+                                                : null,
+                                            activeThumbColor:
+                                                AppConfig.activeToggleColor,
+                                          )
+                                        : ListTile(
+                                            title: Text(b.title),
+                                            subtitle: b.description != null
+                                                ? Text(b.description!)
+                                                : null,
+                                            leading: b.icon,
+                                            onTap: b.enabled
+                                                ? () => b.onPressed?.call()
+                                                : null,
+                                            trailing: b.trailing,
+                                          ),
+                                  );
+                                }).toList(),
+                              ),
+                            ],
+                          ),
+                        );
+                    }
+                  },
+                ),
+              ),
+            ],
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/routes/courses/course_objectives/course_objectives_view.dart
+++ b/lib/routes/courses/course_objectives/course_objectives_view.dart
@@ -87,11 +87,7 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
   /// (quests.instructions.md, "Star display on the course panel"). Empty in a
   /// preview (no room → no learner progress to show) and until the first
   /// resolve completes.
-  final JoinedObjectiveCache _objectiveCache = JoinedObjectiveCache();
   ProgressionResolution _progression = ProgressionResolution.empty;
-
-  /// This quest's ordered Mission ids, for the header's quest-star summary.
-  List<String> _orderedMissionIds = const [];
 
   @override
   void initState() {
@@ -165,7 +161,6 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
       return;
     }
 
-    _orderedMissionIds = outline.quest.learningObjectiveIds;
     unawaited(_loadProgression());
 
     final filtered = objectiveGroupsWithActivities(outline.groups);
@@ -182,19 +177,9 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
   Future<void> _loadProgression() async {
     final client = widget.room?.client;
     if (client == null) return;
-    await _objectiveCache.rebuildFromJoinedCourses(
-      client,
-      onError: (uuid, e, s) => ErrorHandler.logError(
-        e: e,
-        s: s,
-        m: 'CourseObjectivesList: course outline failed to resolve',
-        data: {'courseUuid': uuid},
-      ),
-    );
+    final resolved = await resolveJoinedProgression(client);
     if (!mounted) return;
-    setState(() {
-      _progression = _objectiveCache.resolution(client.userStarsByActivity);
-    });
+    setState(() => _progression = resolved);
   }
 
   @override
@@ -262,9 +247,12 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
               child: ErrorIndicator(message: error.toLocalizedString(context)),
             );
           case AsyncLoaded(value: final groups):
-            // The quest-star header shows only for a joined course once the shared
-            // rollup has resolved; a preview has no learner progress to show.
-            final showStars =
+            // The overall quest-star bar now lives in the course card header
+            // (above the tabs — [CourseProgressBar]), so it shows on every tab
+            // and in the collapsed mobile peek; the list is just the Missions.
+            // Per-Mission stars still show once the shared rollup resolves; a
+            // preview has no learner progress.
+            final hasProgress =
                 widget.room != null && _progression.rollup.isNotEmpty;
             final list = ListView.separated(
               controller: widget.shrinkWrap ? null : _scrollController,
@@ -276,18 +264,13 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
               itemCount: groups.length,
               separatorBuilder: (_, _) => const SizedBox(height: 24.0),
               itemBuilder: (context, i) {
-                if (showStars && i == 0) {
-                  return _QuestStarsHeader(
-                    summary: _progression.questStars(_orderedMissionIds),
-                  );
-                }
-                final group = groups[showStars ? i - 1 : i];
+                final group = groups[i];
                 return _ObjectiveSection(
-                  index: showStars ? i - 1 : i,
+                  index: i,
                   group: group,
                   room: widget.room,
                   hasCompletedActivity: widget.hasCompletedActivity,
-                  progress: showStars
+                  progress: hasProgress
                       ? _progression.rollup[group.objective.id]
                       : null,
                 );
@@ -311,42 +294,156 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
   }
 }
 
-/// The quest-level star summary at the top of a joined course's objective
-/// list: total earned (each Mission capped at its threshold) over a bar that
-/// fills toward the sum of thresholds. See quests.instructions.md.
-class _QuestStarsHeader extends StatelessWidget {
-  final QuestStarSummary summary;
+/// Resolve the learner's shared joined-course progression — the SAME inputs and
+/// resolver as the world map, so the star numbers can never disagree
+/// (quests.instructions.md). Called by both the header's [CourseProgressBar] and
+/// the objective list's per-Mission chips; identical cached inputs (the quest
+/// outline cache + `client.userStarsByActivity`) mean the two can't drift, so a
+/// second resolve is safe rather than a re-derivation risk.
+Future<ProgressionResolution> resolveJoinedProgression(Client client) async {
+  final cache = JoinedObjectiveCache();
+  await cache.rebuildFromJoinedCourses(
+    client,
+    onError: (uuid, e, s) => ErrorHandler.logError(
+      e: e,
+      s: s,
+      m: 'course progression failed to resolve',
+      data: {'courseUuid': uuid},
+    ),
+  );
+  return cache.resolution(client.userStarsByActivity);
+}
 
-  const _QuestStarsHeader({required this.summary});
+/// The overall course progress bar for the course-card HEADER (above the tabs,
+/// #7597): the quest's earned-over-threshold stars and a bar. Lives in the
+/// header so it shows on every tab and in the collapsed mobile peek — where the
+/// objective list (and its old in-list header) isn't even mounted, since the
+/// card opens on the chat tab on narrow. Self-resolves the shared progression
+/// ([resolveJoinedProgression]); renders a muted empty bar until it lands so the
+/// header height (and the peek) stays stable.
+class CourseProgressBar extends StatefulWidget {
+  final Room room;
+
+  const CourseProgressBar({required this.room, super.key});
+
+  @override
+  State<CourseProgressBar> createState() => _CourseProgressBarState();
+}
+
+class _CourseProgressBarState extends State<CourseProgressBar> {
+  QuestStarSummary? _summary;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void didUpdateWidget(covariant CourseProgressBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.room.id != widget.room.id) {
+      setState(() => _summary = null);
+      _load();
+    }
+  }
+
+  Future<void> _load() async {
+    final questId = widget.room.coursePlan?.uuid;
+    if (questId == null) return;
+    final outlineResult = await QuestRepo.outline(questId);
+    final orderedMissionIds =
+        outlineResult.result?.quest.learningObjectiveIds ?? const [];
+    final progression = await resolveJoinedProgression(widget.room.client);
+    if (!mounted) return;
+    setState(() => _summary = progression.questStars(orderedMissionIds));
+  }
+
+  @override
+  Widget build(BuildContext context) => _ProgressBarRow(summary: _summary);
+}
+
+/// The overall course progress bar: a rounded gold fill over a gray track with
+/// a star sitting INSIDE the bar at the goal (right) end — no number. Learners
+/// read progress from the fill and tap/hover the bar for the exact
+/// earned/threshold (#7597, the Figma course-plan frame). A null [summary]
+/// renders the muted empty state (pre-resolve), keeping the header height
+/// stable.
+class _ProgressBarRow extends StatelessWidget {
+  final QuestStarSummary? summary;
+
+  static const double _barHeight = 20.0;
+
+  const _ProgressBarRow({required this.summary});
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Semantics(
-      label: L10n.of(context).starsEarnedOfTotal(summary.earned, summary.total),
-      child: Row(
+    final summary = this.summary;
+    final gold = AppConfig.goldByTheme(context);
+    final fraction = (summary?.fraction ?? 0.0).clamp(0.0, 1.0);
+    final label = summary == null
+        ? null
+        : L10n.of(context).starsEarnedOfTotal(summary.earned, summary.total);
+
+    final bar = SizedBox(
+      height: _barHeight,
+      child: Stack(
+        alignment: Alignment.centerLeft,
         children: [
-          Icon(Icons.star, size: 22.0, color: AppConfig.goldByTheme(context)),
-          const SizedBox(width: 6.0),
-          Text(
-            '${summary.earned}',
-            style: const TextStyle(fontSize: 16.0, fontWeight: FontWeight.w700),
+          // Gray track.
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(_barHeight / 2),
+            ),
+            child: const SizedBox.expand(),
           ),
-          const SizedBox(width: 12.0),
-          Expanded(
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(8.0),
-              child: LinearProgressIndicator(
-                value: summary.fraction,
-                minHeight: 10.0,
-                color: AppConfig.goldByTheme(context),
-                backgroundColor: theme.colorScheme.surfaceContainerHighest,
+          // Gold fill — the learner's progress toward the goal.
+          FractionallySizedBox(
+            widthFactor: fraction,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: gold,
+                borderRadius: BorderRadius.circular(_barHeight / 2),
+              ),
+            ),
+          ),
+          // The goal star, inside the bar at the right end. A surface-coloured
+          // outline star sits behind it so it reads on both the gold fill (full
+          // progress) and the gray track.
+          Positioned(
+            right: 5.0,
+            child: SizedBox(
+              width: _barHeight - 4,
+              height: _barHeight - 4,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  Icon(
+                    Icons.star,
+                    size: _barHeight - 3,
+                    color: theme.colorScheme.surface,
+                  ),
+                  Icon(Icons.star, size: _barHeight - 6, color: gold),
+                ],
               ),
             ),
           ),
         ],
       ),
     );
+
+    final result = Semantics(label: label, value: label, child: bar);
+
+    // Tap (mobile) and hover (desktop) both surface the exact count.
+    return label == null
+        ? result
+        : Tooltip(
+            message: label,
+            triggerMode: TooltipTriggerMode.tap,
+            child: result,
+          );
   }
 }
 
@@ -429,20 +526,8 @@ class _ObjectiveSection extends StatelessWidget {
             ],
           ],
         ),
-        if (progress != null) ...[
-          const SizedBox(height: 8.0),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(6.0),
-            child: LinearProgressIndicator(
-              value: progress!.threshold <= 0
-                  ? 0
-                  : (progress!.stars / progress!.threshold).clamp(0.0, 1.0),
-              minHeight: 6.0,
-              color: AppConfig.goldByTheme(context),
-              backgroundColor: theme.colorScheme.surfaceContainerHighest,
-            ),
-          ),
-        ],
+        // No per-Mission progress bar — only the overall course has a bar (in
+        // the header). A Mission shows just its star count above (#7597).
         const SizedBox(height: 12.0),
         // The activities that satisfy this objective.
         SizedBox(

--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -128,7 +128,15 @@ class MobileNavWidget extends StatefulWidget {
 
 class _MobileNavWidgetState extends State<MobileNavWidget> {
   static const double _railHeight = MobileNavWidget.railRowHeight;
-  static const double _peekHeight = 240.0;
+
+  /// The collapsed peek height for a course sheet (the only cavity that peeks).
+  /// Sized to the course card's compact header — the drag handle plus the
+  /// [X · title · share] row and the overall progress bar — so the collapsed
+  /// default shows exactly the course identity + progress. The card itself
+  /// drops its tabs/content below `_kCompactCardMaxHeight` (168px) so this short
+  /// box never overflows; the tabs slide in as the learner drags up (#7597, the
+  /// Figma mobile-default frame). Kept a touch under that threshold.
+  static const double _peekHeight = 128.0;
   static const Duration _animationDuration = Duration(milliseconds: 240);
 
   /// The rest stop the cavity currently sits at. Non-null means the drawn

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -214,11 +214,12 @@ void main() {
 
       final maxHeightPx = 800.0 * 0.75;
       final height = cavityHeightOf(tester);
-      // The designed 240px peek (the MobileCourseSheet-style inset): above 0
-      // (rail-only) and clearly short of half. Before the rest state was
-      // derived per-build, a cold mount resolved against a zero max height
-      // and rendered the 0.2 fallback (120px) instead.
-      expect(height, closeTo(240.0, 1.0));
+      // The designed 128px peek — the compact course header (title + progress
+      // bar), tabs below the fold (#7597): above 0 (rail-only) and clearly
+      // short of half. Before the rest state was derived per-build, a cold
+      // mount resolved against a zero max height and rendered the 0.2 fallback
+      // (120px) instead.
+      expect(height, closeTo(128.0, 1.0));
       expect(height, lessThan(maxHeightPx * 0.5));
     });
   });
@@ -540,7 +541,7 @@ void main() {
       final height = cavityHeightOf(tester);
       expect(
         height,
-        closeTo(240.0, 1.0), // the course peek, NOT the chats key's full
+        closeTo(128.0, 1.0), // the course peek, NOT the chats key's full
         reason: 'a different key must not inherit the previous key\'s height',
       );
       expect(height, lessThan(maxHeightPx));


### PR DESCRIPTION
Closes #7597

Aligns the course plan panel (the `course:` left panel / mobile bottom sheet, hosted by `SpaceDetailsContent`) with the Figma designs.

Figma: [course plan panel](https://www.figma.com/design/n2qX4WsnVhYqT2KV6pMVbl/Everything-outside-of-Chat?node-id=12506-194645) · [mobile collapsed default](https://www.figma.com/design/n2qX4WsnVhYqT2KV6pMVbl/Everything-outside-of-Chat?node-id=13394-61069)

## Changes

1. **One shared header (web + mobile).** Dropped the `isColumnMode` divergence — both now render `[X · title · share]`, the overall progress bar, then the tabs. The only web/mobile difference is the tab labels (`RoomDetailsButton`'s width-driven `mini`). Removed the web-only large `MapClipper` course avatar. The language/level/module chips moved to the top of the **More** tab, in a row beneath the description.

2. **Overall-only progress bar, lifted into the header.** The quest-star bar (`_QuestStarsHeader`) moved out of the objective-list tab body and into the shared header as a self-resolving `CourseProgressBar`, so it shows on every tab and survives the collapsed mobile peek (the objective list isn't mounted there — the card opens on the chat tab on narrow). Its resolve is extracted into a shared `resolveJoinedProgression` used by both the header bar and the per-Mission chips (identical cached inputs → the numbers can't disagree). Per-Mission progress bars removed — each Mission shows just its star count. (Also fixes a latent bug that dropped the last objective when stars were shown.)

3. **New progress-bar look.** A rounded gold-fill bar with a star **inside** at the goal end, **no number**; learners read progress from the fill and tap (mobile) / hover (desktop) for the exact earned/total (tooltip + semantics). An outline star behind keeps it legible on both the fill and the track.

4. **Collapsed mobile peek.** The nav cavity clips the course sheet at a short peek; the card's `Expanded` tab body can't shrink into that box (it overflowed by 59px), so the card now gates its tabs/body on incoming height via `LayoutBuilder` (`_kCompactCardMaxHeight` = 168) — below that it renders only the header + progress bar. The course peek is tuned to 128px. Tabs slide in when the learner drags the sheet up.

## Verification

- **Web (local):** confirmed the shared header (`[X · title · share]` + progress bar + labeled tabs, no avatar), the new star-in-bar progress bar (no number), and the More tab (description then chips) across several courses.
- Analyzer clean; affected suites green (29): `courses/`, `joined_objective_cache`, `mobile_nav_widget` (peek assertions updated to 128px).
- **Not verifiable locally:** the per-Mission activity list — the local Synapse account's token is rejected by the staging CMS (`/cms/api/activities-v2` → 403), so quest outlines don't resolve locally. Covered by the issue's TO TEST for staging QA. The collapsed mobile peek couldn't get a live narrow-viewport screenshot (browser resize wouldn't render narrow mode); the fix is logic + test-covered but should get a device check — it's in the TO TEST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact course details view for collapsed sheets, showing course identity and progress while keeping additional content hidden until expanded.
  * Introduced a course progress bar in the course card header.
  * Simplified the course details header with a cleaner title and optional sharing action.

* **Improvements**
  * Reduced the collapsed course sheet height for a more compact mobile experience.
  * Streamlined course objective progress displays while retaining per-mission star counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->