### PR TITLE
docs(skill): env routing is per-service; link local-stack wiring

### DIFF
--- a/.github/skills/run-flutter-web-local/SKILL.md
+++ b/.github/skills/run-flutter-web-local/SKILL.md
@@ -187,6 +187,8 @@ There should be exactly **one** real `flutter run` (a `dartvm … flutter_tools`
 
 ## Env — which stack the build talks to
 
+**Which Synapse / CMS / choreo the build points at is a per-service choice, not a package deal** — `client/.env` routes each independently, and mixing is normal (e.g. local Synapse + local CMS + staging choreo to smoke-test a deployed language tool). One hard rule constrains the mix: **`SYNAPSE_URL` and `CMS_API` must be the same environment** — the client authenticates to the CMS with the Matrix bearer token, and a cross-homeserver token gets **403** with course/activity content silently missing. `CHOREO_API` mixes freely. The full wiring, base-path shapes, and the other cross-service contracts that bite live in [local-stack.instructions.md](../../../../.github/.github/instructions/local-stack.instructions.md) — read it before debugging any "content not loading" symptom.
+
 The web app fetches its config from `GET /.env` at the dev-server root (served from repo-root `client/.env`; no `assets/.env` since #6975). It is fetched once at app startup and the dev server caches it per process, so **neither a hot reload nor a browser reload picks up an edited `client/.env`** — clean-restart to serve the new values.
 
 ```bash


### PR DESCRIPTION
Doc-only. The run-flutter-web-local skill now states up front that which Synapse / CMS / choreo the build points at is a per-service choice (mixing is normal), names the one hard rule (`SYNAPSE_URL` + `CMS_API` same environment or CMS reads 403 with content silently missing), and links the org local-stack.instructions.md for the full wiring. Motivated by a session that burned an hour rediscovering the 403 rule and the `/cms/api` base path that were already documented there but not routed to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to configure target backends for local Flutter web builds.
  * Added guidance to keep `SYNAPSE_URL` and `CMS_API` aligned to prevent authentication errors and missing course or activity content.
  * Linked to additional cross-service configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->