### PR TITLE
Fix non-lemma POS distractors in grammar practice

### DIFF
--- a/lib/pangea/morphs/parts_of_speech_enum.dart
+++ b/lib/pangea/morphs/parts_of_speech_enum.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 /// list ordered by priority
 enum PartOfSpeechEnum {
   //Content tokens
@@ -37,4 +39,28 @@ enum PartOfSpeechEnum {
   };
 
   bool get isContentWord => _contentPartsOfSpeech.contains(this);
+
+  /// categories that describe non-lemma tokens (punctuation, symbols,
+  /// whitespace, affixes, unclassified) rather than a real word a learner
+  /// could produce. No lemma should ever be tagged with one of these, so
+  /// they must never surface as practice targets or distractors.
+  static final Set<PartOfSpeechEnum> _neverALemma = {
+    PartOfSpeechEnum.affix,
+    PartOfSpeechEnum.punct,
+    PartOfSpeechEnum.space,
+    PartOfSpeechEnum.sym,
+    PartOfSpeechEnum.x,
+  };
+
+  bool get isEligibleLemmaCategory => !_neverALemma.contains(this);
+
+  /// same check as [isEligibleLemmaCategory], but for a raw UD POS tag
+  /// string (case-insensitive). Unrecognized tags are treated as eligible
+  /// so this only ever excludes known non-lemma categories.
+  static bool isEligibleLemmaTag(String tag) {
+    final pos = PartOfSpeechEnum.values.firstWhereOrNull(
+      (p) => p.name.toLowerCase() == tag.toLowerCase(),
+    );
+    return pos?.isEligibleLemmaCategory ?? true;
+  }
 }

--- a/lib/routes/analytics/construct_analytics/practice/morph_category_practice_exercise_generator.dart
+++ b/lib/routes/analytics/construct_analytics/practice/morph_category_practice_exercise_generator.dart
@@ -1,4 +1,5 @@
 import 'package:fluffychat/pangea/morphs/grammar_constructs_provider.dart';
+import 'package:fluffychat/pangea/morphs/parts_of_speech_enum.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/practice/analytics_practice_session_model.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/practice/analytics_practice_session_repo.dart';
 import 'package:fluffychat/routes/chat/toolbar/practice_exercises/message_practice_exercise_request.dart';
@@ -26,7 +27,11 @@ class MorphCategoryPracticeExerciseGenerator {
     );
     final allTags = tags.map((t) => t.value);
     final List<String> possibleDistractors = allTags
-        .where((tag) => tag.toLowerCase() != morphTag.toLowerCase())
+        .where(
+          (tag) =>
+              tag.toLowerCase() != morphTag.toLowerCase() &&
+              PartOfSpeechEnum.isEligibleLemmaTag(tag),
+        )
         .toList();
 
     if (possibleDistractors.isEmpty) {

--- a/lib/routes/chat/toolbar/practice_exercises/morph_practice_exercise_generator.dart
+++ b/lib/routes/chat/toolbar/practice_exercises/morph_practice_exercise_generator.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 
 import 'package:fluffychat/pangea/morphs/grammar_constructs_provider.dart';
 import 'package:fluffychat/pangea/morphs/morph_features_enum.dart';
+import 'package:fluffychat/pangea/morphs/parts_of_speech_enum.dart';
 import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
 import 'package:fluffychat/routes/chat/toolbar/message_practice/message_morph_choice.dart';
 import 'package:fluffychat/routes/chat/toolbar/practice_exercises/message_practice_exercise_request.dart';
@@ -33,7 +34,9 @@ class MorphPracticeExerciseGenerator {
     final allTags = tags.map((t) => t.value);
     final List<String> possibleDistractors = allTags
         .where(
-          (tag) => tag.toLowerCase() != morphTag.toLowerCase() && tag != "X",
+          (tag) =>
+              tag.toLowerCase() != morphTag.toLowerCase() &&
+              PartOfSpeechEnum.isEligibleLemmaTag(tag),
         )
         .toList();
 

--- a/test/pangea/morphs/parts_of_speech_enum_test.dart
+++ b/test/pangea/morphs/parts_of_speech_enum_test.dart
@@ -5,8 +5,19 @@ import 'package:fluffychat/pangea/morphs/parts_of_speech_enum.dart';
 void main() {
   group('PartOfSpeechEnum.isEligibleLemmaTag', () {
     test('excludes non-lemma UD categories regardless of case', () {
-      for (final tag in ['punct', 'PUNCT', 'sym', 'SYM', 'space', 'SPACE',
-          'affix', 'AFFIX', 'x', 'X']) {
+      const nonLemmaTags = [
+        'punct',
+        'PUNCT',
+        'sym',
+        'SYM',
+        'space',
+        'SPACE',
+        'affix',
+        'AFFIX',
+        'x',
+        'X',
+      ];
+      for (final tag in nonLemmaTags) {
         expect(
           PartOfSpeechEnum.isEligibleLemmaTag(tag),
           isFalse,

--- a/test/pangea/morphs/parts_of_speech_enum_test.dart
+++ b/test/pangea/morphs/parts_of_speech_enum_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/morphs/parts_of_speech_enum.dart';
+
+void main() {
+  group('PartOfSpeechEnum.isEligibleLemmaTag', () {
+    test('excludes non-lemma UD categories regardless of case', () {
+      for (final tag in ['punct', 'PUNCT', 'sym', 'SYM', 'space', 'SPACE',
+          'affix', 'AFFIX', 'x', 'X']) {
+        expect(
+          PartOfSpeechEnum.isEligibleLemmaTag(tag),
+          isFalse,
+          reason: '$tag should never be eligible as a lemma category',
+        );
+      }
+    });
+
+    test('allows real word categories', () {
+      for (final tag in ['noun', 'VERB', 'adj', 'PRON', 'det']) {
+        expect(PartOfSpeechEnum.isEligibleLemmaTag(tag), isTrue);
+      }
+    });
+
+    test('treats unrecognized tags as eligible', () {
+      expect(PartOfSpeechEnum.isEligibleLemmaTag('Pres'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Grammar practice's POS multiple-choice question could offer punctuation/symbol/space/affix as wrong answers, which no real word can ever be tagged as; the raw UD tag value leaked through unlocalized since those tags are intentionally excluded from the display-eligible title lookup.
- The actual practice target token was already filtered to a real word (`lemma.saveVocab`), but distractor sampling in `MorphPracticeExerciseGenerator` and `MorphCategoryPracticeExerciseGenerator` pulled from the raw tag list without the same exclusion.
- Adds `PartOfSpeechEnum.isEligibleLemmaTag`/`isEligibleLemmaCategory` as one shared source of truth (affix, punct, space, sym, x are never a lemma category) and reuses it in both generators, replacing the ad-hoc case-sensitive `tag != "X"` check in one of them.

Closes #7600 (client-side recreation of pangeachat/2-step-choreographer#2655).

## Test plan
- [ ] `flutter test test/pangea/morphs/parts_of_speech_enum_test.dart` (added unit test covering the new helper)
- [ ] Toolbar grammar practice: switch through several POS questions per language, confirm no punctuation/symbol/space/affix option ever appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved morphology practice exercises by filtering out unsuitable part-of-speech tags from suggested distractors.
  * Applied consistent, case-insensitive handling for lemma eligibility.
  * Preserved support for valid and unrecognized tags while excluding non-lemma categories.

* **Tests**
  * Added coverage for eligible, ineligible, case-variant, and unknown part-of-speech tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->