### PR TITLE
Fix course progress bar gold fill rendering at zero height

### DIFF
--- a/lib/routes/courses/course_objectives/course_objectives_view.dart
+++ b/lib/routes/courses/course_objectives/course_objectives_view.dart
@@ -360,7 +360,7 @@ class _CourseProgressBarState extends State<CourseProgressBar> {
   }
 
   @override
-  Widget build(BuildContext context) => _ProgressBarRow(summary: _summary);
+  Widget build(BuildContext context) => ProgressBarRow(summary: _summary);
 }
 
 /// The overall course progress bar: a rounded gold fill over a gray track with
@@ -369,12 +369,12 @@ class _CourseProgressBarState extends State<CourseProgressBar> {
 /// earned/threshold (#7597, the Figma course-plan frame). A null [summary]
 /// renders the muted empty state (pre-resolve), keeping the header height
 /// stable.
-class _ProgressBarRow extends StatelessWidget {
+class ProgressBarRow extends StatelessWidget {
   final QuestStarSummary? summary;
 
   static const double _barHeight = 20.0;
 
-  const _ProgressBarRow({required this.summary});
+  const ProgressBarRow({required this.summary, super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -399,7 +399,10 @@ class _ProgressBarRow extends StatelessWidget {
             ),
             child: const SizedBox.expand(),
           ),
-          // Gold fill — the learner's progress toward the goal.
+          // Gold fill — the learner's progress toward the goal. The
+          // SizedBox.expand child is load-bearing: a childless DecoratedBox in
+          // a loose Stack sizes to constraints.smallest (zero height) and
+          // paints nothing (#7603).
           FractionallySizedBox(
             widthFactor: fraction,
             child: DecoratedBox(
@@ -407,6 +410,7 @@ class _ProgressBarRow extends StatelessWidget {
                 color: gold,
                 borderRadius: BorderRadius.circular(_barHeight / 2),
               ),
+              child: const SizedBox.expand(),
             ),
           ),
           // The goal star, inside the bar at the right end. A surface-coloured

--- a/test/pangea/courses/course_progress_bar_test.dart
+++ b/test/pangea/courses/course_progress_bar_test.dart
@@ -27,9 +27,7 @@ void main() {
     ) async {
       await tester.pumpWidget(
         wrap(
-          const ProgressBarRow(
-            summary: QuestStarSummary(earned: 3, total: 40),
-          ),
+          const ProgressBarRow(summary: QuestStarSummary(earned: 3, total: 40)),
         ),
       );
       // The async L10n delegate load gates MaterialApp's first real frame.

--- a/test/pangea/courses/course_progress_bar_test.dart
+++ b/test/pangea/courses/course_progress_bar_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/courses/course_objectives/course_objectives_view.dart';
+
+void main() {
+  Widget wrap(Widget child) => MaterialApp(
+    localizationsDelegates: L10n.localizationsDelegates,
+    supportedLocales: L10n.supportedLocales,
+    home: Scaffold(
+      body: SizedBox(width: 400, child: Center(child: child)),
+    ),
+  );
+
+  /// The gold fill: the FractionallySizedBox's DecoratedBox.
+  Finder fillFinder() => find.descendant(
+    of: find.byType(FractionallySizedBox),
+    matching: find.byType(DecoratedBox),
+  );
+
+  group('ProgressBarRow', () {
+    testWidgets('gold fill has nonzero size for partial progress (#7603)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        wrap(
+          const ProgressBarRow(
+            summary: QuestStarSummary(earned: 3, total: 40),
+          ),
+        ),
+      );
+      // The async L10n delegate load gates MaterialApp's first real frame.
+      await tester.pumpAndSettle();
+
+      final fillSize = tester.getSize(fillFinder().first);
+      expect(fillSize.height, greaterThan(0));
+      expect(fillSize.width, greaterThan(0));
+
+      // The fill spans the summary's fraction of the track (the row itself —
+      // FractionallySizedBox shrink-wraps its child, so it can't measure it).
+      final trackWidth = tester.getSize(find.byType(ProgressBarRow)).width;
+      expect(fillSize.width, moreOrLessEquals(trackWidth * 3 / 40, epsilon: 1));
+    });
+
+    testWidgets('null summary renders an empty (zero-width) fill', (
+      tester,
+    ) async {
+      await tester.pumpWidget(wrap(const ProgressBarRow(summary: null)));
+      await tester.pumpAndSettle();
+      expect(tester.getSize(fillFinder().first).width, 0);
+    });
+
+    testWidgets('full progress fills the whole track', (tester) async {
+      await tester.pumpWidget(
+        wrap(
+          const ProgressBarRow(
+            summary: QuestStarSummary(earned: 40, total: 40),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final fillSize = tester.getSize(fillFinder().first);
+      final trackWidth = tester.getSize(find.byType(ProgressBarRow)).width;
+      expect(fillSize.width, moreOrLessEquals(trackWidth, epsilon: 0.01));
+      expect(fillSize.height, greaterThan(0));
+    });
+  });
+}


### PR DESCRIPTION
Closes #7603

The header progress bar's gold fill was a `FractionallySizedBox` wrapping a childless `DecoratedBox`. In the bar's loose `Stack`, a childless `DecoratedBox` sizes to `constraints.smallest`, so the fill laid out at fraction-width x 0 height and painted nothing — a learner with 3/40 stars saw an empty track while the tooltip reported the right count.

- Give the fill the same `SizedBox.expand` child the gray track already has.
- Make `ProgressBarRow` public and add widget tests: partial progress paints a nonzero fill at the right fraction, null summary paints zero width, full progress spans the track.

## Test

`flutter test test/pangea/courses/course_progress_bar_test.dart` (3 passing), `dart analyze` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved course progress bar rendering so the gold progress fill displays at the correct size, including for partial, empty, and complete progress.

* **Tests**
  * Added coverage to verify progress bar dimensions across different progress states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->