### PR TITLE
Read canonical activity rows only in QuestRepo; dedupe by activity_id

### DIFF
--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:async/async.dart';
 import 'package:http/http.dart';
 
@@ -90,8 +92,17 @@ class QuestRepo {
     'learningObjectiveRefs': true,
   };
 
-  /// `where` matching any activity that satisfies one of [loIds] at [l2].
-  static Map<String, dynamic> _loAtL2Where(List<String> loIds, String l2) => {
+  /// `where` matching any CANONICAL activity that satisfies one of [loIds] at
+  /// [l2]. `activities-v2` is a shared canonical+translation collection — a
+  /// row is a translation iff `req.source_request_hash` is set, and
+  /// translation rows share the canonical's `activity_id` — so without the
+  /// canonical-only clause every translation row matches too and each renders
+  /// as its own card/pin (#7604). The contract requires selecting canonicals
+  /// via `exists: false` — an equals-null test matches nothing (choreo
+  /// llm-base-handler-localization.instructions.md; same clause as the choreo
+  /// bbox read).
+  @visibleForTesting
+  static Map<String, dynamic> loAtL2Where(List<String> loIds, String l2) => {
     'and': [
       {
         'or': [
@@ -104,8 +115,28 @@ class QuestRepo {
       {
         'res.plan.l2': {'equals': l2},
       },
+      {
+        'req.source_request_hash': {'exists': false},
+      },
     ],
   };
+
+  /// Keep the first row per `activity_id`. Degraded data (a duplicate
+  /// canonical, or an orphaned translation slipping past a filter) must never
+  /// surface the same activity twice: duplicate ids render duplicate cards
+  /// and, worse, duplicate `ValueKey`s in the world-map marker Stack — a hard
+  /// crash (#7604). Last line of defense; [loAtL2Where] is the primary filter.
+  @visibleForTesting
+  static List<T> dedupeByActivityId<T>(
+    List<T> rows,
+    String Function(T) idOf,
+  ) {
+    final seen = <String>{};
+    return [
+      for (final row in rows)
+        if (seen.add(idOf(row))) row,
+    ];
+  }
 
   static PayloadClient _client() => PayloadClient(
     baseUrl: Environment.cmsApi,
@@ -202,13 +233,13 @@ class QuestRepo {
       final resp = await _client().find(
         _activitiesKey,
         (json) => QuestActivityCard.fromJson(json),
-        where: _loAtL2Where(learningObjectiveIds, targetLanguage),
+        where: loAtL2Where(learningObjectiveIds, targetLanguage),
         select: _pinSelect,
         limit: 200,
         depth: 0,
       );
       final filtered = resp.docs.where((card) => card.point != null).toList();
-      return Result.value(filtered);
+      return Result.value(dedupeByActivityId(filtered, (c) => c.activityId));
     } catch (e, s) {
       ErrorHandler.logError(
         e: e,
@@ -232,20 +263,23 @@ class QuestRepo {
       final resp = await _client().find<Map<String, dynamic>>(
         _activitiesKey,
         (json) => json,
-        where: _loAtL2Where(loIds, quest.targetLanguage),
+        where: loAtL2Where(loIds, quest.targetLanguage),
         limit: 200,
         depth: 0,
       );
-      final entries = resp.docs
-          .map(
-            (doc) => (
-              plan: activityPlanFromV2(doc),
-              refs: ((doc['learningObjectiveRefs'] as List? ?? const [])
-                  .map((e) => e is Map ? e['id'] as String : e as String)
-                  .toList()),
-            ),
-          )
-          .toList();
+      final entries = dedupeByActivityId(
+        resp.docs
+            .map(
+              (doc) => (
+                plan: activityPlanFromV2(doc),
+                refs: ((doc['learningObjectiveRefs'] as List? ?? const [])
+                    .map((e) => e is Map ? e['id'] as String : e as String)
+                    .toList()),
+              ),
+            )
+            .toList(),
+        (e) => e.plan.activityId,
+      );
 
       // Resolve all plans' media upload_ids → CDN URLs in one batched read.
       final resolved = await _withResolvedMedia(

--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -127,10 +127,7 @@ class QuestRepo {
   /// and, worse, duplicate `ValueKey`s in the world-map marker Stack — a hard
   /// crash (#7604). Last line of defense; [loAtL2Where] is the primary filter.
   @visibleForTesting
-  static List<T> dedupeByActivityId<T>(
-    List<T> rows,
-    String Function(T) idOf,
-  ) {
+  static List<T> dedupeByActivityId<T>(List<T> rows, String Function(T) idOf) {
     final seen = <String>{};
     return [
       for (final row in rows)

--- a/test/pangea/quests/quest_repo_canonical_test.dart
+++ b/test/pangea/quests/quest_repo_canonical_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+
+void main() {
+  group('QuestRepo.loAtL2Where', () {
+    test('selects canonical rows only (#7604)', () {
+      final where = QuestRepo.loAtL2Where(['lo-1', 'lo-2'], 'es');
+      final clauses = where['and'] as List;
+
+      // activities-v2 is a shared canonical+translation collection; without
+      // this clause every translation row of an activity matches too and each
+      // renders as its own card/pin. The contract requires `exists`, not
+      // equals-null (llm-base-handler-localization.instructions.md).
+      expect(
+        clauses,
+        anyElement(
+          equals({
+            'req.source_request_hash': {'exists': false},
+          }),
+        ),
+      );
+    });
+
+    test('keeps the LO and l2 constraints', () {
+      final where = QuestRepo.loAtL2Where(['lo-1'], 'es');
+      final clauses = where['and'] as List;
+      expect(
+        clauses,
+        anyElement(
+          equals({
+            'or': [
+              {
+                'learningObjectiveRefs': {'contains': 'lo-1'},
+              },
+            ],
+          }),
+        ),
+      );
+      expect(
+        clauses,
+        anyElement(
+          equals({
+            'res.plan.l2': {'equals': 'es'},
+          }),
+        ),
+      );
+    });
+  });
+
+  group('QuestRepo.dedupeByActivityId', () {
+    test('keeps the first row per activity_id', () {
+      final rows = [
+        (id: 'a', tag: 1),
+        (id: 'b', tag: 2),
+        (id: 'a', tag: 3),
+        (id: 'c', tag: 4),
+        (id: 'b', tag: 5),
+      ];
+      final unique = QuestRepo.dedupeByActivityId(rows, (r) => r.id);
+      expect(unique.map((r) => r.tag), [1, 2, 4]);
+    });
+
+    test('passes unique rows through unchanged', () {
+      final rows = [(id: 'a'), (id: 'b')];
+      expect(QuestRepo.dedupeByActivityId(rows, (r) => r.id), rows);
+    });
+  });
+}


### PR DESCRIPTION
Closes #7604

## What

`activities-v2` is a shared canonical+translation collection: a row is a translation iff `req.source_request_hash` is set, and translation rows share the canonical's `activity_id`. `QuestRepo`'s shared where-builder filtered only by LO refs + `l2`, so every translation row matched too — each rendering as its own card in the course plan tab (same activity in Spanish/English/German) and as its own course-scoped map pin, where two pins sharing an `activity_id` produced duplicate `ValueKey`s in the marker Stack and a hard red-screen crash.

- `loAtL2Where` now selects canonical rows via `req.source_request_hash exists: false` — the clause the collection contract requires (equals-null matches nothing; see choreo `llm-base-handler-localization.instructions.md`) and the same one the choreo bbox read already uses (`activity_fetch.py`). This matches `QuestRepo`'s existing docstring ("canonical only — localization is choreo's concern").
- `dedupeByActivityId` guards both reads as a last line of defense so degraded data can never crash the map again.

## Due diligence

- The choreo bbox endpoint (world-scoped pins) already filters canonical-only — this brings the client's interim direct-CMS reads in line with it.
- The local seeder copies every content-collection page from staging unfiltered, so the observed data is a faithful staging mirror: three `activity_id`s exist whose rows are ALL translation rows (their canonical's `request_hash` matches nothing) — orphans left behind when canonicals were deleted (canonical deletion doesn't cascade to translation rows).
- Verified the fixed query against live local Payload for the three affected LOs: 9 rows, all canonical, one per `activity_id`, zero duplicates. LO coverage survives via regenerated canonicals; one orphaned concept ("Giving Directions at San Antonio") is hidden until data repair — tracked separately.

## Test

`flutter test test/pangea/quests/ test/pangea/world/ test/pangea/courses/` — 44 passing. New tests cover the canonical-only clause and the dedupe helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)