### PR TITLE
Course sheet on mobile always opens at peek

### DIFF
--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -188,6 +188,10 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
   };
 
   NavCavityHeight _restoreHeight() {
+    // A peek cavity (course card) always opens at its default peek — a
+    // deterministic entry state, not the height it was left at (#7609). The
+    // height memory exists for SECTION sheets (#7510) and stays theirs.
+    if (widget.cavityDefaultsToPeek) return _defaultHeight();
     final key = widget.cavityKey;
     if (key == null) return NavCavityHeight.collapsed;
     return MobileNavWidget._heightByKey[key] ?? _defaultHeight();
@@ -198,17 +202,17 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
       : NavCavityHeight.half;
 
   void _remember(NavCavityHeight height) {
+    // A peek cavity never reads the memory ([_restoreHeight]) — it always
+    // reopens at peek (#7609) — so don't write it either.
+    if (widget.cavityDefaultsToPeek) return;
     final key = widget.cavityKey;
     if (key == null) return;
     // Dragging a SECTION sheet fully down is a dismissal, not a height
     // preference: collapsed renders 0px there (no handle left to grab), so
     // persisting it would make every reopen arrive already-dismissed and
     // stuck (#7510). The sheet still collapses now; the memory just keeps
-    // the last real height for the reopen. A peek cavity's collapsed is a
-    // visible, draggable rest height and is remembered as before.
-    if (height == NavCavityHeight.collapsed && !widget.cavityDefaultsToPeek) {
-      return;
-    }
+    // the last real height for the reopen.
+    if (height == NavCavityHeight.collapsed) return;
     MobileNavWidget._heightByKey[key] = height;
   }
 

--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -421,6 +421,18 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
                                   : ClipRect(
                                       child: _NavCavity(
                                         onHandleTap: _toggleHandle,
+                                        // At peek, a tap anywhere on the sheet
+                                        // (not claimed by an inner button)
+                                        // expands to full — the peek is an
+                                        // entry point, not a surface to
+                                        // interact with (#7609).
+                                        onBodyTap:
+                                            widget.cavityDefaultsToPeek &&
+                                                _restState ==
+                                                    NavCavityHeight.collapsed
+                                            ? () =>
+                                                  _openAt(NavCavityHeight.full)
+                                            : null,
                                         onDragStart: _onDragStart,
                                         onDragUpdate: _onDragUpdate,
                                         onDragEnd: _onDragEnd,
@@ -578,6 +590,13 @@ class _CourseShortcutButton extends StatelessWidget {
 /// content brings its own header/close.
 class _NavCavity extends StatelessWidget {
   final VoidCallback onHandleTap;
+
+  /// Non-null while the sheet rests at peek: a tap anywhere on the cavity not
+  /// claimed by a deeper hitbox (the X, share, the progress-bar tooltip)
+  /// expands the sheet. Null once expanded — the detector then only absorbs
+  /// stray taps so they can't fall through to the map behind and deselect the
+  /// course (#7609).
+  final VoidCallback? onBodyTap;
   final GestureDragStartCallback onDragStart;
   final GestureDragUpdateCallback onDragUpdate;
   final GestureDragEndCallback onDragEnd;
@@ -585,6 +604,7 @@ class _NavCavity extends StatelessWidget {
 
   const _NavCavity({
     required this.onHandleTap,
+    required this.onBodyTap,
     required this.onDragStart,
     required this.onDragUpdate,
     required this.onDragEnd,
@@ -596,6 +616,23 @@ class _NavCavity extends StatelessWidget {
     final theme = Theme.of(context);
     final l10n = L10n.of(context);
 
+    // The whole cavity resizes by drag, not just the 36px handle — deeper
+    // scrollables (an expanded tab's list) still win their own drags in the
+    // gesture arena, so this only claims drags the content doesn't. Opaque so
+    // the cavity is always a hit target: without it, taps on the sheet's dead
+    // space fell through to the world map behind and deselected the course
+    // (#7609).
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onBodyTap,
+      onVerticalDragStart: onDragStart,
+      onVerticalDragUpdate: onDragUpdate,
+      onVerticalDragEnd: onDragEnd,
+      child: _cavityColumn(theme, l10n),
+    );
+  }
+
+  Widget _cavityColumn(ThemeData theme, L10n l10n) {
     return Column(
       children: [
         // Grab handle: drag to resize, tap to toggle half/full. Exposed to

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -235,8 +235,8 @@ void main() {
         );
         final peek = cavityHeightOf(tester);
 
-        // Expand to full via the handle's tap toggle, then leave.
-        await tester.tap(handleFinder());
+        // Expand to full (tap-the-body, #7609), then leave.
+        await tester.tap(find.text('Course card'));
         await tester.pumpAndSettle();
         expect(cavityHeightOf(tester), greaterThan(peek));
         await unmountNav(tester);
@@ -253,6 +253,66 @@ void main() {
         expect(cavityHeightOf(tester), closeTo(peek, 1.0));
       },
     );
+
+    testWidgets('tapping the sheet body at peek expands to full (#7609)', (
+      tester,
+    ) async {
+      await pumpNav(
+        tester,
+        activeSection: AppSection.courses,
+        cavityChild: const Text('Course card'),
+        cavityKey: 'course-a',
+        cavityDefaultsToPeek: true,
+      );
+      final peek = cavityHeightOf(tester);
+
+      // The tap lands on the card content, not the handle or a button —
+      // the cavity-wide detector claims it.
+      await tester.tap(find.text('Course card'));
+      await tester.pumpAndSettle();
+
+      expect(cavityHeightOf(tester), closeTo(800.0 * 0.75, 1.0));
+      expect(cavityHeightOf(tester), greaterThan(peek));
+    });
+
+    testWidgets(
+      'tapping the sheet body while expanded does NOT collapse or fall '
+      'through (#7609)',
+      (tester) async {
+        await pumpNav(
+          tester,
+          activeSection: AppSection.courses,
+          cavityChild: const Text('Course card'),
+          cavityKey: 'course-a',
+          cavityDefaultsToPeek: true,
+        );
+        await tester.tap(find.text('Course card'));
+        await tester.pumpAndSettle();
+        final full = cavityHeightOf(tester);
+
+        await tester.tap(find.text('Course card'));
+        await tester.pumpAndSettle();
+
+        expect(cavityHeightOf(tester), closeTo(full, 1.0));
+      },
+    );
+
+    testWidgets('dragging the sheet body resizes, not just the handle '
+        '(#7609)', (tester) async {
+      await pumpNav(
+        tester,
+        activeSection: AppSection.courses,
+        cavityChild: const Text('Course card'),
+        cavityKey: 'course-a',
+        cavityDefaultsToPeek: true,
+      );
+      final peek = cavityHeightOf(tester);
+
+      await tester.drag(find.text('Course card'), const Offset(0, -400));
+      await tester.pumpAndSettle();
+
+      expect(cavityHeightOf(tester), greaterThan(peek));
+    });
   });
 
   group('handle', () {

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -222,6 +222,37 @@ void main() {
       expect(height, closeTo(128.0, 1.0));
       expect(height, lessThan(maxHeightPx * 0.5));
     });
+
+    testWidgets(
+      'a course cavity reopens at peek, not the height it was left at (#7609)',
+      (tester) async {
+        await pumpNav(
+          tester,
+          activeSection: AppSection.courses,
+          cavityChild: const Text('Course card'),
+          cavityKey: 'course-a',
+          cavityDefaultsToPeek: true,
+        );
+        final peek = cavityHeightOf(tester);
+
+        // Expand to full via the handle's tap toggle, then leave.
+        await tester.tap(handleFinder());
+        await tester.pumpAndSettle();
+        expect(cavityHeightOf(tester), greaterThan(peek));
+        await unmountNav(tester);
+
+        // Reopening the same course arrives at the default peek — a
+        // deterministic entry state; the height memory is section sheets'.
+        await pumpNav(
+          tester,
+          activeSection: AppSection.courses,
+          cavityChild: const Text('Course card'),
+          cavityKey: 'course-a',
+          cavityDefaultsToPeek: true,
+        );
+        expect(cavityHeightOf(tester), closeTo(peek, 1.0));
+      },
+    );
   });
 
   group('handle', () {


### PR DESCRIPTION
Closes #7609

Opening a course on mobile restored the sheet to whatever height it was left at (half/full) via the per-key cavity height memory. That memory exists for section sheets (#7510); a course card inheriting it made the entry state nondeterministic.

- `_restoreHeight` now returns the default peek for peek cavities (`cavityDefaultsToPeek`) instead of consulting the memory; `_remember` skips writing for them (the memory is never read).
- Section sheets keep their memory unchanged.
- New test: a course cavity expanded to full and closed reopens at the 128px peek.

## Test

`flutter test test/pangea/navigation/mobile_nav_widget_test.dart` — 20 passing. `dart format` + `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tapping the body of a course card while it is minimized now expands it to full height.
  * Course cards reopen at their default preview height instead of restoring a previous expanded height.
  * Dragging the card body continues to resize the sheet as expected.

* **Bug Fixes**
  * Prevented taps on an already expanded card from unexpectedly collapsing it or triggering underlying content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->