### PR TITLE
Pan, don't zoom, on activity focus

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -563,20 +563,19 @@ class WorldMapController extends State<WorldMap>
           64.0,
         );
 
-        // A specific focus target is zoomed IN on within the exposed canvas:
-        // opening an activity glides the camera down to its pin at a close
-        // (neighborhood/building) zoom, never zooming out past where we already
-        // are. Today that is an activity; new focus kinds resolve in
-        // [_focusPoint].
+        // A specific focus target PANS into the exposed canvas at the current
+        // zoom — a pure glide, no zoom change in either direction (#7496: the
+        // zoom-to-16 jump was disorienting). The single-point fit resolves the
+        // center within the padded area; capping maxZoom at the current zoom
+        // pins the zoom in place. Today that is an activity; new focus kinds
+        // resolve in [_focusPoint].
         final point = _pinsManager.focusPoint(widget.focus);
         if (point != null) {
           _animateFit(
             CameraFit.coordinates(
               coordinates: [point],
               padding: padding,
-              maxZoom: mapController.camera.zoom > WorldMapConstants.focusZoom
-                  ? mapController.camera.zoom
-                  : WorldMapConstants.focusZoom,
+              maxZoom: mapController.camera.zoom,
             ),
           );
           return;

--- a/lib/routes/world/world_map_constants.dart
+++ b/lib/routes/world/world_map_constants.dart
@@ -13,10 +13,6 @@ class WorldMapConstants {
   static bool canZoomIn(double zoom) => zoom < maxZoom;
   static bool canZoomOut(double zoom) => zoom > minZoom;
 
-  /// The zoom the camera glides to when an activity is focused (opened) — close
-  /// enough to read it as "this specific spot" (neighborhood/building level).
-  static const double focusZoom = 16.0;
-
   static const Duration fitSettleDelay = Duration(seconds: 2);
   static const Duration camGlideDuration = Duration(milliseconds: 600);
 


### PR DESCRIPTION
Addresses the activity-selection half of #7496 ("Pan to center but don't zoom on activity focus/selection").

Focusing an activity used to glide the camera to its pin AND raise the zoom to 16 whenever the view was wider. Now the focus fit caps `maxZoom` at the current camera zoom, so the glide is a pure pan that still centers the pin within the exposed map area (the padding-inset region outside open panels), on web and mobile alike. The now-unused `focusZoom` constant is removed.

The course-selection half of #7496 (zoom+pan to fit the course) is existing behavior and is unchanged, so this closes the issue.

Closes #7496

## Test

`flutter test test/pangea/world/` — 37 passing; `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)