### PR TITLE
Add focus buttons; stop auto-zooming on course selection

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -4336,6 +4336,11 @@
         "type": "String",
         "placeholders": {}
     },
+    "focusOnMap": "Focus on map",
+    "@focusOnMap": {
+        "type": "String",
+        "placeholders": {}
+    },
     "addCourse": "Add a course",
     "addNewCourse": "Add new course",
     "world": "World",

--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -18,6 +18,7 @@ import 'package:fluffychat/routes/chat/activity_sessions/activity_session_bottom
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_button_widget.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_controller.dart';
+import 'package:fluffychat/routes/world/map_context.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_start_hero.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_vocab_widget.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
@@ -170,6 +171,13 @@ class ActivitySessionStartView extends StatelessWidget {
               ),
             ),
             actions: [
+              // The one camera path that zooms (#7616): selection only pans,
+              // so this button zoom+pans the map to the activity's pin.
+              IconButton(
+                tooltip: L10n.of(context).focusOnMap,
+                icon: const Icon(Icons.filter_center_focus),
+                onPressed: MapCameraFocusRequests.request,
+              ),
               IconButton(
                 tooltip: L10n.of(context).feedbackButton,
                 icon: const Icon(Icons.flag_outlined),

--- a/lib/routes/chat/chat_details/space_details_content.dart
+++ b/lib/routes/chat/chat_details/space_details_content.dart
@@ -29,6 +29,7 @@ import 'package:fluffychat/routes/chat/chat_details/space_details_button_row.dar
 import 'package:fluffychat/routes/chat_list/course_chats_page.dart';
 import 'package:fluffychat/routes/courses/course_info_chip_widget.dart';
 import 'package:fluffychat/routes/courses/course_objectives/course_objectives_view.dart';
+import 'package:fluffychat/routes/world/map_context.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
@@ -364,6 +365,14 @@ class SpaceDetailsContent extends StatelessWidget {
                       fontWeight: FontWeight.w600,
                     ),
                   ),
+                ),
+                // The one camera path that zooms (#7616): course selection
+                // only pans, so this button zoom+pan-fits the map to all of
+                // the course's activities.
+                IconButton(
+                  tooltip: L10n.of(context).focusOnMap,
+                  icon: const Icon(Icons.filter_center_focus),
+                  onPressed: MapCameraFocusRequests.request,
                 ),
                 if (room.joinCode != null)
                   Padding(

--- a/lib/routes/world/map_context.dart
+++ b/lib/routes/world/map_context.dart
@@ -42,3 +42,15 @@ abstract class MapContextController {
     if (notifier.value != context) notifier.value = context;
   }
 }
+
+/// The deliberate "bring the camera to my selection" request — the focus
+/// button on the activity plan page and the course card header (#7616).
+/// Selecting an activity or course only PANS the camera (the automatic zoom
+/// was jarring — #7496, #7616); this button is the one path that zooms: in on
+/// a focused activity's pin, or to fit a course's activities. A one-shot tick
+/// the persistent map listens to; fired with no map alive it does nothing.
+abstract class MapCameraFocusRequests {
+  static final ValueNotifier<int> notifier = ValueNotifier<int>(0);
+
+  static void request() => notifier.value++;
+}

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -162,6 +162,7 @@ class WorldMapController extends State<WorldMap>
     _loadForContext();
 
     MapContextController.notifier.addListener(_onContextChange);
+    MapCameraFocusRequests.notifier.addListener(_onCameraFocusRequest);
 
     // Rebuild when a featured large card's full plan hydrates (image + goals).
     ActivityPlanRepo.instance.addListener(_onPlanHydrate);
@@ -256,6 +257,7 @@ class WorldMapController extends State<WorldMap>
     _zoomSettleTimer?.cancel();
     _cameraAnimationController.dispose();
     MapContextController.notifier.removeListener(_onContextChange);
+    MapCameraFocusRequests.notifier.removeListener(_onCameraFocusRequest);
     ActivityPlanRepo.instance.removeListener(_onPlanHydrate);
     // Reset the process-global so a pin selected at teardown (e.g. logging out
     // with a pin sheet up) can't strand a stale `true` that would hide the bottom
@@ -554,15 +556,6 @@ class WorldMapController extends State<WorldMap>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       try {
-        // Inset the left edge by the overlay so content lands in the uncovered
-        // area to the right of the column/panel, not behind it.
-        final padding = EdgeInsets.fromLTRB(
-          widget.leftOverlayWidth + 64.0,
-          64.0,
-          widget.rightOverlayWidth + 64.0,
-          64.0,
-        );
-
         // A specific focus target PANS into the exposed canvas at the current
         // zoom — a pure glide, no zoom change in either direction (#7496: the
         // zoom-to-16 jump was disorienting). The single-point fit resolves the
@@ -574,29 +567,79 @@ class WorldMapController extends State<WorldMap>
           _animateFit(
             CameraFit.coordinates(
               coordinates: [point],
-              padding: padding,
+              padding: _exposedCanvasPadding,
               maxZoom: mapController.camera.zoom,
             ),
           );
           return;
         }
 
-        // Otherwise a course context fits all of its activities.
+        // A course context likewise PANS — to the center of its activities'
+        // bounds — at the current zoom. The automatic bounds fit zoomed on
+        // every course selection, which fired too often to feel deliberate
+        // (#7616); the zoomful fit moved to the explicit focus button
+        // ([_onCameraFocusRequest]).
         if (MapContextController.notifier.value is! CourseMapContext) return;
 
         final points = _pinsManager.focusPoints;
         if (points.isEmpty) return;
         _animateFit(
-          CameraFit.bounds(
-            bounds: LatLngBounds.fromPoints(points),
-            padding: padding,
-            maxZoom: 12.0,
+          CameraFit.coordinates(
+            coordinates: [LatLngBounds.fromPoints(points).center],
+            padding: _exposedCanvasPadding,
+            maxZoom: mapController.camera.zoom,
           ),
         );
       } catch (_) {
         // Controller/camera not ready yet; the next change will refit.
       }
     });
+  }
+
+  /// Inset the left/right edges by the overlays so camera targets land in the
+  /// uncovered map area beside the column/panel, not behind it.
+  EdgeInsets get _exposedCanvasPadding => EdgeInsets.fromLTRB(
+    widget.leftOverlayWidth + 64.0,
+    64.0,
+    widget.rightOverlayWidth + 64.0,
+    64.0,
+  );
+
+  /// The focus button (#7616) — the ONE camera path that zooms. A focused
+  /// activity glides in to [WorldMapConstants.focusZoom] (never zooming out
+  /// past the current view); a course context zoom+pan-fits all its
+  /// activities' bounds. Fired via [MapCameraFocusRequests] from the activity
+  /// plan page and the course card header.
+  void _onCameraFocusRequest() {
+    if (!mounted) return;
+    try {
+      final point = _pinsManager.focusPoint(widget.focus);
+      if (point != null) {
+        _animateFit(
+          CameraFit.coordinates(
+            coordinates: [point],
+            padding: _exposedCanvasPadding,
+            maxZoom: mapController.camera.zoom > WorldMapConstants.focusZoom
+                ? mapController.camera.zoom
+                : WorldMapConstants.focusZoom,
+          ),
+        );
+        return;
+      }
+
+      if (MapContextController.notifier.value is! CourseMapContext) return;
+      final points = _pinsManager.focusPoints;
+      if (points.isEmpty) return;
+      _animateFit(
+        CameraFit.bounds(
+          bounds: LatLngBounds.fromPoints(points),
+          padding: _exposedCanvasPadding,
+          maxZoom: WorldMapConstants.courseFitMaxZoom,
+        ),
+      );
+    } catch (_) {
+      // Controller/camera not ready yet; the button can simply be pressed again.
+    }
   }
 
   /// Glide the camera to where [fit] would place it (instead of snapping via

--- a/lib/routes/world/world_map_constants.dart
+++ b/lib/routes/world/world_map_constants.dart
@@ -13,6 +13,15 @@ class WorldMapConstants {
   static bool canZoomIn(double zoom) => zoom < maxZoom;
   static bool canZoomOut(double zoom) => zoom > minZoom;
 
+  /// The zoom the DELIBERATE focus button glides to for an activity (#7616) —
+  /// close enough to read it as "this specific spot" (neighborhood/building
+  /// level). Selection itself never zooms; only the button uses this.
+  static const double focusZoom = 16.0;
+
+  /// The zoom cap for the focus button's course fit (#7616): fitting a
+  /// one-location course never dives below city level.
+  static const double courseFitMaxZoom = 12.0;
+
   static const Duration fitSettleDelay = Duration(seconds: 2);
   static const Duration camGlideDuration = Duration(milliseconds: 600);
 


### PR DESCRIPTION
Closes #7616

Course selection still ran the zoomful bounds fit on every hop, which fired too often to feel deliberate (activity selection was already pan-only, #7496). Now no selection zooms; an explicit focus button owns the zoomful move.

- **Course selection pans only**: the camera glides to the center of the course's activities' bounds within the exposed map area, at the current zoom.
- **`MapCameraFocusRequests`** — an app-wide one-shot channel (same pattern as `MapContextController`) that panels fire and the persistent map consumes.
- **Focus button on the activity plan page** (beside the flag): pans and zooms in on the pin (`focusZoom` 16, never zooming out past the current view).
- **Focus button on the course card header** (beside share): zoom+pan fit of all the course's activities (`courseFitMaxZoom` 12).
- New `focusOnMap` l10n string.

## Test

`flutter test test/pangea/world/ test/pangea/courses/` — 43 passing; `dart analyze` clean; `flutter gen-l10n` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)