### PR TITLE
Fix import order from #7617

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -18,10 +18,10 @@ import 'package:fluffychat/routes/chat/activity_sessions/activity_session_bottom
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_button_widget.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_controller.dart';
-import 'package:fluffychat/routes/world/map_context.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_start_hero.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_vocab_widget.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
+import 'package:fluffychat/routes/world/map_context.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/avatar.dart';


### PR DESCRIPTION
#7617 was merged with its `code_tests` check red — the only failure was `import_sorter --exit-if-changed` on the new import in `activity_sessions_start_view.dart`. This is the mechanical `dart run import_sorter:main` fix to get main green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)