### PR TITLE
Leaving a chat closes only its panel, keeping the chat list

### DIFF
--- a/lib/features/navigation/room_close_location.dart
+++ b/lib/features/navigation/room_close_location.dart
@@ -1,0 +1,34 @@
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/room_id_url.dart';
+import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/features/navigation/token_params/room_token.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
+
+/// The location that closes an open room-panel token for [roomId]: it drops
+/// ONLY that token, so the rest of the workspace — notably the chat list —
+/// survives. Closing an activity plan (#7156) and leaving a chat (#7561) must
+/// not also clear the chat list. Returns null when no such token is open (e.g.
+/// the standalone `/<activityId>` route) — the caller pops or falls back.
+String? roomTokenCloseLocation(Uri uri, String? roomId) {
+  if (roomId == null || roomId.isEmpty) return null;
+
+  bool matches(PanelToken t) {
+    if (!t.type.isRoomPanel) return false;
+
+    final param = t.param;
+    if (param == null || param is! RoomTokenParam) return false;
+    return shortRoomId(param.id) == shortRoomId(roomId);
+  }
+
+  final panels = parseOpenPanels(uri);
+
+  for (final t in panels.left) {
+    if (matches(t)) return WorkspaceNav.closeLeft(uri, t);
+  }
+
+  for (final t in panels.right) {
+    if (matches(t)) return WorkspaceNav.closeRight(uri, t);
+  }
+
+  return null;
+}

--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -5,12 +5,10 @@ import 'package:go_router/go_router.dart';
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
-import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/panel_types_enum.dart';
-import 'package:fluffychat/features/navigation/room_id_url.dart';
+import 'package:fluffychat/features/navigation/room_close_location.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/route_paths.dart';
-import 'package:fluffychat/features/navigation/token_params/room_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/widgets/error_indicator.dart';
@@ -27,36 +25,9 @@ import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
-/// The location that closes a non-embedded activity plan opened as a room/
-/// session token (the chat list / a left panel): it drops ONLY that token, so
-/// the rest of the workspace — notably the chat list — survives. Closing an
-/// activity (e.g. one stuck on an "activity not found" error) must not also
-/// clear the chat list (#7156). Returns null when no such token is open — the
-/// standalone `/<activityId>` route — so the caller pops or falls back to home.
-@visibleForTesting
-String? activityRoomCloseLocation(Uri uri, String? roomId) {
-  if (roomId == null || roomId.isEmpty) return null;
-
-  bool matches(PanelToken t) {
-    if (!t.type.isRoomPanel) return false;
-
-    final param = t.param;
-    if (param == null || param is! RoomTokenParam) return false;
-    return shortRoomId(param.id) == shortRoomId(roomId);
-  }
-
-  final panels = parseOpenPanels(uri);
-
-  for (final t in panels.left) {
-    if (matches(t)) return WorkspaceNav.closeLeft(uri, t);
-  }
-
-  for (final t in panels.right) {
-    if (matches(t)) return WorkspaceNav.closeRight(uri, t);
-  }
-
-  return null;
-}
+// The close-only-this-room-token location moved to the navigation layer
+// (`roomTokenCloseLocation`) once leaving a chat needed the same semantic
+// (#7561); the activity plan's close (#7156) reads it from there.
 
 class ActivitySessionStartView extends StatelessWidget {
   final ActivitySessionStartState controller;
@@ -155,7 +126,7 @@ class ActivitySessionStartView extends StatelessWidget {
                         tooltip: L10n.of(context).close,
                         icon: const Icon(Icons.close),
                         onPressed: () {
-                          final close = activityRoomCloseLocation(
+                          final close = roomTokenCloseLocation(
                             uri,
                             controller.widget.roomId,
                           );

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -40,6 +40,7 @@ import 'package:fluffychat/features/languages/language_service.dart';
 import 'package:fluffychat/features/languages/p_language_store.dart';
 import 'package:fluffychat/features/navigation/panel_focus.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/room_close_location.dart';
 import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/token_params/room_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
@@ -396,8 +397,23 @@ class ChatController extends State<ChatPageWithRoom>
     if (success.error != null) return;
     // #Pangea
     // context.go('/rooms');
-    NavigationUtil.goToSpaceRoute(null, [], context);
+    _closeLeftRoom();
     // Pangea#
+  }
+
+  /// Close ONLY the left room's token after the user leaves it — the rest of
+  /// the workspace, notably the chat list, survives (#7561). Falls back to the
+  /// bare exit when the room isn't open as a token (a pushed route).
+  void _closeLeftRoom() {
+    final close = roomTokenCloseLocation(
+      GoRouterState.of(context).uri,
+      room.id,
+    );
+    if (close != null) {
+      context.go(close);
+    } else {
+      NavigationUtil.goToSpaceRoute(null, [], context);
+    }
   }
 
   // #Pangea
@@ -3106,7 +3122,8 @@ class ChatController extends State<ChatPageWithRoom>
       ).client.waitForRoomInSync(widget.room.id, leave: true);
     }
 
-    NavigationUtil.goToSpaceRoute(null, [], context);
+    if (!mounted) return;
+    _closeLeftRoom();
   }
 
   Future<void> requestRegeneration(String eventId) async {

--- a/test/pangea/navigation/activity_room_close_test.dart
+++ b/test/pangea/navigation/activity_room_close_test.dart
@@ -1,19 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fluffychat/features/navigation/panel_types_enum.dart';
+import 'package:fluffychat/features/navigation/room_close_location.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
-import 'package:fluffychat/routes/chat/activity_sessions/activity_sessions_start_view.dart';
 
 void main() {
   Uri u(String s) => Uri.parse(s);
 
-  group('activityRoomCloseLocation (#7156)', () {
+  group('roomTokenCloseLocation (#7156, #7561)', () {
     test('closing a room-token activity drops only the room, keeping the '
         'chat list', () {
-      final loc = activityRoomCloseLocation(
-        u('/?left=chats,room:!abc'),
-        '!abc',
-      );
+      final loc = roomTokenCloseLocation(u('/?left=chats,room:!abc'), '!abc');
       expect(loc, isNotNull);
       final left = parseOpenPanels(u(loc!)).left;
       expect(
@@ -27,7 +24,7 @@ void main() {
     });
 
     test('other open panels survive (e.g. an analytics summary)', () {
-      final loc = activityRoomCloseLocation(
+      final loc = roomTokenCloseLocation(
         u('/?left=chats,room:!abc&right=analytics:vocab'),
         '!abc',
       );
@@ -39,9 +36,23 @@ void main() {
       );
     });
 
+    test('leaving a chat opened from the chat list keeps the list and the '
+        'course context (#7561)', () {
+      final loc = roomTokenCloseLocation(
+        u('/?c=!course&left=chats,room:!abc'),
+        '!abc',
+      );
+      expect(loc, isNotNull);
+      final closed = u(loc!);
+      expect(parseOpenPanels(closed).left.map((t) => t.type), [
+        PanelTypesEnum.chats,
+      ]);
+      expect(activeSpaceIdFor(closed), '!course'); // map scope survives
+    });
+
     test('the standalone /<activityId> route has no room token, so it returns '
         'null (caller pops or falls back to home)', () {
-      expect(activityRoomCloseLocation(u('/abc123'), '!abc'), isNull);
+      expect(roomTokenCloseLocation(u('/abc123'), '!abc'), isNull);
     });
   });
 }


### PR DESCRIPTION
Closes #7561

Both leave paths (`leaveChat` from the chat menu and `onLeave` from details) navigated to the bare exit (`goToSpaceRoute(null, ...)`), which clears the whole left token list — leaving a chat also closed the chat list.

They now use the "drop only this room's token" location: the #7156 helper generalized out of the activity start view into the navigation layer as `roomTokenCloseLocation` (the activity plan's X now reads it from there). After leaving, the chat panel closes while the chat list, course context, and any open right panel survive. Falls back to the old bare exit when the room isn't open as a token (a pushed route).

**TO TEST**
- Open the chat list, open a chat, leave it via the chat menu → the chat closes, the chat list stays.
- Same via chat details → Leave.
- Leave a chat while a course is selected → the course scope and list survive.

## Test

`flutter test test/pangea/navigation/activity_room_close_test.dart` — 4 passing (incl. a new leave-specific case asserting list + course scope survive); `dart analyze` + `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room-closing navigation when leaving activities or chats.
  * Closing a room now removes only the matching room panel while preserving other open panels and chat lists.
  * Added safer fallback navigation when no matching room token is available.

* **Tests**
  * Expanded coverage for room-panel closing, preserved context, and standalone activity routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->