### PR TITLE
fix: close confetti overlay on start new round of analytics practice

### DIFF
--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_page.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_page.dart
@@ -250,6 +250,10 @@ class AnalyticsPracticeState extends State<AnalyticsPractice>
 
   Future<void> startSession() async {
     _clearState();
+
+    // if starting one round after another, hide the confetti from the previous round
+    MatrixState.pAnyState.closeOverlay(StarRainWidget.practiceCompleteKey);
+
     final analyticsService = Matrix.of(context).analyticsDataService;
     if (analyticsService.hasInitError) {
       // Trigger reinit so this retry attempt uses a fresh init. If reinit also


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
