### PR TITLE
7621 hide course zoom button in spaces without course plans

### DIFF
--- a/lib/features/quests/quest_objectives_loader.dart
+++ b/lib/features/quests/quest_objectives_loader.dart
@@ -31,9 +31,13 @@ class QuestObjectivesLoader {
     ProgressionResolution.empty,
   );
 
+  int _loadGeneration = 0;
+  bool _disposed = false;
+
   void dispose() {
     _questLoader.dispose();
     _progression.dispose();
+    _disposed = true;
   }
 
   QuestLoader get questLoader => _questLoader;
@@ -55,33 +59,54 @@ class QuestObjectivesLoader {
         _ => const [],
       };
 
+  void _updateProgression(ProgressionResolution value, int loadGen) {
+    if (!_disposed && loadGen == _loadGeneration) {
+      _progression.value = value;
+    }
+  }
+
+  void _updateQuest(AsyncState<QuestOutline> value, int loadGen) {
+    if (!_disposed && loadGen == _loadGeneration) {
+      _questLoader.value = value;
+    }
+  }
+
   Future<void> loadOutline(String? questId) async {
-    _progression.value = ProgressionResolution.empty;
+    if (_disposed) return;
+
+    _loadGeneration++;
+    final loadGen = _loadGeneration;
+    _updateProgression(ProgressionResolution.empty, loadGen);
 
     // world_v2 → v3: the course space's coursePlan.uuid (or the previewed
     // plan's uuid) points at a quest-plans id. The outline (Missions + their
     // activities) comes from the v3 quest read layer; the v1
     // course-plans/topics fan-out is retired.
     if (questId == null) {
-      _questLoader.value = AsyncError(MissingQuestException());
+      if (!_disposed && loadGen == _loadGeneration) {
+        _updateQuest(AsyncError(MissingQuestException()), loadGen);
+      }
       return;
     }
 
-    _questLoader.value = AsyncLoading();
+    _updateQuest(AsyncLoading(), loadGen);
     final outlineResult = await QuestRepo.outline(questId);
     final outline = outlineResult.result;
 
+    if (_disposed) return;
+
     if (outline == null) {
-      _questLoader.value = AsyncError(
-        outlineResult.error ?? MissingQuestException(),
+      _updateQuest(
+        AsyncError(outlineResult.error ?? MissingQuestException()),
+        loadGen,
       );
       return;
     }
 
-    _questLoader.value = AsyncLoaded(outline);
+    _updateQuest(AsyncLoaded(outline), loadGen);
 
     ProgressionResolution.resolveJoinedProgression(
       client,
-    ).then((p) => _progression.value = p);
+    ).then((p) => _updateProgression(p, loadGen));
   }
 }

--- a/lib/features/quests/quest_objectives_loader.dart
+++ b/lib/features/quests/quest_objectives_loader.dart
@@ -11,6 +11,17 @@ import 'package:fluffychat/widgets/future_loading_dialog.dart';
 
 typedef QuestLoader = ValueNotifier<AsyncState<QuestOutline>>;
 
+/// The objective groups that should render: those with at least one activity.
+/// An activity-less objective would otherwise show a header over a fixed-height
+/// activity-card row that is all empty space, so it is dropped (#7114). Null
+/// (still loading / no data) maps to an empty list.
+@visibleForTesting
+List<QuestObjectiveGroup> objectiveGroupsWithActivities(
+  List<QuestObjectiveGroup>? groups,
+) => (groups ?? const <QuestObjectiveGroup>[])
+    .where((g) => g.activities.isNotEmpty)
+    .toList();
+
 class QuestObjectivesLoader {
   final Client client;
   QuestObjectivesLoader({required this.client});
@@ -35,6 +46,14 @@ class QuestObjectivesLoader {
     };
     return progression.value.questStars(objectiveIds);
   }
+
+  List<QuestObjectiveGroup> get filteredObjectiveGroups =>
+      switch (_questLoader.value) {
+        AsyncLoaded(value: final outline) => objectiveGroupsWithActivities(
+          outline.groups,
+        ),
+        _ => const [],
+      };
 
   Future<void> loadOutline(String? questId) async {
     _progression.value = ProgressionResolution.empty;

--- a/lib/features/quests/quest_objectives_loader.dart
+++ b/lib/features/quests/quest_objectives_loader.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/pangea/common/utils/async_state.dart';
+import 'package:fluffychat/widgets/future_loading_dialog.dart';
+
+typedef QuestLoader = ValueNotifier<AsyncState<QuestOutline>>;
+
+class QuestObjectivesLoader {
+  final Client client;
+  QuestObjectivesLoader({required this.client});
+
+  final QuestLoader _questLoader = QuestLoader(AsyncLoading());
+  final ValueNotifier<ProgressionResolution> _progression = ValueNotifier(
+    ProgressionResolution.empty,
+  );
+
+  void dispose() {
+    _questLoader.dispose();
+    _progression.dispose();
+  }
+
+  QuestLoader get questLoader => _questLoader;
+  ValueNotifier<ProgressionResolution> get progression => _progression;
+
+  QuestStarSummary get questStars {
+    final List<String> objectiveIds = switch (_questLoader.value) {
+      AsyncLoaded(value: final value) => value.quest.learningObjectiveIds,
+      _ => const [],
+    };
+    return progression.value.questStars(objectiveIds);
+  }
+
+  Future<void> loadOutline(String? questId) async {
+    _progression.value = ProgressionResolution.empty;
+
+    // world_v2 → v3: the course space's coursePlan.uuid (or the previewed
+    // plan's uuid) points at a quest-plans id. The outline (Missions + their
+    // activities) comes from the v3 quest read layer; the v1
+    // course-plans/topics fan-out is retired.
+    if (questId == null) {
+      _questLoader.value = AsyncError(MissingQuestException());
+      return;
+    }
+
+    _questLoader.value = AsyncLoading();
+    final outlineResult = await QuestRepo.outline(questId);
+    final outline = outlineResult.result;
+
+    if (outline == null) {
+      _questLoader.value = AsyncError(
+        outlineResult.error ?? MissingQuestException(),
+      );
+      return;
+    }
+
+    _questLoader.value = AsyncLoaded(outline);
+
+    ProgressionResolution.resolveJoinedProgression(
+      client,
+    ).then((p) => _progression.value = p);
+  }
+}

--- a/lib/features/quests/quest_progression_resolver.dart
+++ b/lib/features/quests/quest_progression_resolver.dart
@@ -5,7 +5,12 @@
 // activity start page). Pure logic — no Matrix or network — so it stays
 // unit-testable. Design: quests.instructions.md, world-map.instructions.md.
 
+import 'package:matrix/matrix.dart';
+
 import 'package:fluffychat/features/quests/lo_progression.dart';
+import 'package:fluffychat/features/quests/quests_client_extension.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/routes/world/joined_objective_cache.dart';
 
 /// How far along a quest the next-Mission gradient reaches before decaying to
 /// zero. The anchor Mission scores 1.0; each Mission further along loses
@@ -137,6 +142,28 @@ class ProgressionResolution {
       }
     }
     return total.clamp(0.0, kBandCeiling);
+  }
+
+  /// Resolve the learner's shared joined-course progression — the SAME inputs and
+  /// resolver as the world map, so the star numbers can never disagree
+  /// (quests.instructions.md). Called by both the header's [CourseProgressBar] and
+  /// the objective list's per-Mission chips; identical cached inputs (the quest
+  /// outline cache + `client.userStarsByActivity`) mean the two can't drift, so a
+  /// second resolve is safe rather than a re-derivation risk.
+  static Future<ProgressionResolution> resolveJoinedProgression(
+    Client client,
+  ) async {
+    final cache = JoinedObjectiveCache();
+    await cache.rebuildFromJoinedCourses(
+      client,
+      onError: (uuid, e, s) => ErrorHandler.logError(
+        e: e,
+        s: s,
+        m: 'course progression failed to resolve',
+        data: {'courseUuid': uuid},
+      ),
+    );
+    return cache.resolution(client.userStarsByActivity);
   }
 }
 

--- a/lib/routes/chat/chat_details/chat_details.dart
+++ b/lib/routes/chat/chat_details/chat_details.dart
@@ -8,9 +8,9 @@ import 'package:image_picker/image_picker.dart';
 import 'package:matrix/matrix.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
 import 'package:fluffychat/features/join_codes/join_rule_extension.dart';
+import 'package:fluffychat/features/quests/quest_objectives_loader.dart';
 import 'package:fluffychat/features/room_summaries/room_summaries_model.dart';
 import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
@@ -61,18 +61,20 @@ class ChatDetails extends StatefulWidget {
 // #Pangea
 // class ChatDetailsController extends State<ChatDetails> {
 class ChatDetailsController extends State<ChatDetails>
-    with CoursePlanProvider, ChatDownloadProvider {
+    with ChatDownloadProvider {
   bool loadingCourseInfo = true;
   bool loadingCourseSummary = true;
 
-  // listen to language updates to refresh course info
-  StreamSubscription? _languageSubscription;
-
   late CourseInfoSummariesModel roomSummariesModel;
+  late final QuestObjectivesLoader _objectivesProvider;
 
   @override
   void initState() {
     super.initState();
+
+    _objectivesProvider = QuestObjectivesLoader(
+      client: Matrix.of(context).client,
+    );
 
     final room = Matrix.of(context).client.getRoomById(widget.roomId);
     roomSummariesModel = CourseInfoSummariesModel(
@@ -80,19 +82,8 @@ class ChatDetailsController extends State<ChatDetails>
       activitiesToCompleteOverride: room?.teacherMode.activitiesToUnlockTopic,
     );
 
-    _loadCourseInfo();
+    _objectivesProvider.loadOutline(_questId);
     _loadSummaries();
-
-    _languageSubscription = MatrixState
-        .pangeaController
-        .userController
-        .languageStream
-        .stream
-        .listen((update) {
-          if (update.prevBaseLang != update.baseLang) {
-            _loadCourseInfo();
-          }
-        });
 
     if (room?.isSpace == true) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -104,10 +95,8 @@ class ChatDetailsController extends State<ChatDetails>
   @override
   void didUpdateWidget(covariant ChatDetails oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final room = Matrix.of(context).client.getRoomById(widget.roomId);
-    if (oldWidget.roomId != widget.roomId ||
-        course?.uuid != room?.coursePlan?.uuid) {
-      _loadCourseInfo();
+    if (oldWidget.roomId != widget.roomId) {
+      _objectivesProvider.loadOutline(_questId);
       _loadSummaries();
     }
 
@@ -119,17 +108,21 @@ class ChatDetailsController extends State<ChatDetails>
 
   @override
   void dispose() {
-    _languageSubscription?.cancel();
+    _objectivesProvider.dispose();
     super.dispose();
   }
 
-  // Pangea#
   bool displaySettings = false;
 
   void toggleDisplaySettings() =>
       setState(() => displaySettings = !displaySettings);
 
   String? get roomId => widget.roomId;
+
+  String? get _questId =>
+      Matrix.of(context).client.getRoomById(widget.roomId)?.coursePlan?.uuid;
+
+  QuestObjectivesLoader get objectivesProvider => _objectivesProvider;
 
   void setDisplaynameAction() async {
     final room = Matrix.of(context).client.getRoomById(roomId!)!;
@@ -370,22 +363,6 @@ class ChatDetailsController extends State<ChatDetails>
 
     if (resp.isError || resp.result == null || !mounted) return;
     NavigationUtil.goToSpaceRoute(resp.result, ['invite'], context);
-  }
-
-  Future<void> _loadCourseInfo() async {
-    final room = Matrix.of(context).client.getRoomById(roomId!);
-    if (room == null || !room.isSpace || room.coursePlan == null) {
-      setState(() {
-        course = null;
-        loadingCourse = false;
-        loadingCourseInfo = false;
-      });
-      return;
-    }
-
-    if (mounted) setState(() => loadingCourseInfo = true);
-    await loadCourse(room.coursePlan!.uuid);
-    if (mounted) setState(() => loadingCourseInfo = false);
   }
 
   Future<void> _loadSummaries() async {

--- a/lib/routes/chat/chat_details/space_details_content.dart
+++ b/lib/routes/chat/chat_details/space_details_content.dart
@@ -370,11 +370,15 @@ class SpaceDetailsContent extends StatelessWidget {
                 // The one camera path that zooms (#7616): course selection
                 // only pans, so this button zoom+pan-fits the map to all of
                 // the course's activities.
-                IconButton(
-                  tooltip: L10n.of(context).focusOnMap,
-                  icon: const Icon(Icons.filter_center_focus),
-                  onPressed: MapCameraFocusRequests.request,
-                ),
+                if (controller
+                    .objectivesProvider
+                    .filteredObjectiveGroups
+                    .isNotEmpty)
+                  IconButton(
+                    tooltip: L10n.of(context).focusOnMap,
+                    icon: const Icon(Icons.filter_center_focus),
+                    onPressed: MapCameraFocusRequests.request,
+                  ),
                 if (room.joinCode != null)
                   Padding(
                     padding: const EdgeInsets.all(8.0),

--- a/lib/routes/chat/chat_details/space_details_content.dart
+++ b/lib/routes/chat/chat_details/space_details_content.dart
@@ -370,15 +370,22 @@ class SpaceDetailsContent extends StatelessWidget {
                 // The one camera path that zooms (#7616): course selection
                 // only pans, so this button zoom+pan-fits the map to all of
                 // the course's activities.
-                if (controller
-                    .objectivesProvider
-                    .filteredObjectiveGroups
-                    .isNotEmpty)
-                  IconButton(
-                    tooltip: L10n.of(context).focusOnMap,
-                    icon: const Icon(Icons.filter_center_focus),
-                    onPressed: MapCameraFocusRequests.request,
-                  ),
+                ValueListenableBuilder(
+                  valueListenable: controller.objectivesProvider.questLoader,
+                  builder: (context, _, _) {
+                    if (controller
+                        .objectivesProvider
+                        .filteredObjectiveGroups
+                        .isNotEmpty) {
+                      return IconButton(
+                        tooltip: L10n.of(context).focusOnMap,
+                        icon: const Icon(Icons.filter_center_focus),
+                        onPressed: MapCameraFocusRequests.request,
+                      );
+                    }
+                    return const SizedBox.shrink();
+                  },
+                ),
                 if (room.joinCode != null)
                   Padding(
                     padding: const EdgeInsets.all(8.0),

--- a/lib/routes/chat/chat_details/space_details_content.dart
+++ b/lib/routes/chat/chat_details/space_details_content.dart
@@ -29,6 +29,7 @@ import 'package:fluffychat/routes/chat/chat_details/space_details_button_row.dar
 import 'package:fluffychat/routes/chat_list/course_chats_page.dart';
 import 'package:fluffychat/routes/courses/course_info_chip_widget.dart';
 import 'package:fluffychat/routes/courses/course_objectives/course_objectives_view.dart';
+import 'package:fluffychat/routes/courses/course_objectives/course_progress_bar.dart';
 import 'package:fluffychat/routes/world/map_context.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
@@ -390,7 +391,9 @@ class SpaceDetailsContent extends StatelessWidget {
             // every tab and survives the collapsed mobile peek (the objective list,
             // where it used to live, isn't mounted then). Only the course has a
             // bar; per-Mission rows show just their stars (#7597).
-            CourseProgressBar(room: room),
+            CourseProgressBar(
+              objectivesProvider: controller.objectivesProvider,
+            ),
             if (!compact) ...[
               SizedBox(height: isColumnMode ? 24.0 : 12.0),
               SpaceDetailsButtonRow(
@@ -415,11 +418,18 @@ class SpaceDetailsContent extends StatelessWidget {
                         // world_v2: the course plan is a sequence of learning
                         // objectives, each satisfied by interchangeable activities
                         // (no longer grouped by city).
-                        return CourseObjectivesList(
-                          room: room,
-                          hasCompletedActivity: controller
-                              .roomSummariesModel
-                              .hasCompletedActivity,
+                        return ListenableBuilder(
+                          listenable: Listenable.merge([
+                            controller.objectivesProvider.questLoader,
+                            controller.objectivesProvider.progression,
+                          ]),
+                          builder: (context, _) => CourseObjectivesList(
+                            room: room,
+                            hasCompletedActivity: controller
+                                .roomSummariesModel
+                                .hasCompletedActivity,
+                            objectivesProvider: controller.objectivesProvider,
+                          ),
                         );
                       case SpaceSettingsTabs.participants:
                         return SingleChildScrollView(

--- a/lib/routes/courses/course_objectives/course_objectives_view.dart
+++ b/lib/routes/courses/course_objectives/course_objectives_view.dart
@@ -20,17 +20,6 @@ import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/chat_details/activity_suggestion_card.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
 
-/// The objective groups that should render: those with at least one activity.
-/// An activity-less objective would otherwise show a header over a fixed-height
-/// activity-card row that is all empty space, so it is dropped (#7114). Null
-/// (still loading / no data) maps to an empty list.
-@visibleForTesting
-List<QuestObjectiveGroup> objectiveGroupsWithActivities(
-  List<QuestObjectiveGroup>? groups,
-) => (groups ?? const <QuestObjectiveGroup>[])
-    .where((g) => g.activities.isNotEmpty)
-    .toList();
-
 /// The Activities / Course-plan tab of a selected course (world_v2): the
 /// course's learning objectives, each with the activities that satisfy it.
 /// Objectives are the unlockable unit; activities are interchangeable
@@ -119,13 +108,13 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
               error,
               showAddCourse: widget.room?.isRoomAdmin == true,
             );
-          case AsyncLoaded(value: final outline):
+          case AsyncLoaded():
             // The overall quest-star bar now lives in the course card header
             // (above the tabs — [CourseProgressBar]), so it shows on every tab
             // and in the collapsed mobile peek; the list is just the Missions.
             // Per-Mission stars still show once the shared rollup resolves; a
             // preview has no learner progress.
-            final groups = objectiveGroupsWithActivities(outline.groups);
+            final groups = widget.objectivesProvider.filteredObjectiveGroups;
             if (groups.isEmpty) {
               return _QuestLoadErrorView(
                 MissingQuestException(),

--- a/lib/routes/courses/course_objectives/course_objectives_view.dart
+++ b/lib/routes/courses/course_objectives/course_objectives_view.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
@@ -9,24 +7,18 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
-import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
 import 'package:fluffychat/features/navigation/token_params/room_subpage_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
+import 'package:fluffychat/features/quests/quest_objectives_loader.dart';
 import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
 import 'package:fluffychat/features/quests/quests_client_extension.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/async_state.dart';
-import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/common/widgets/error_indicator.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/chat_details/activity_suggestion_card.dart';
-import 'package:fluffychat/routes/world/joined_objective_cache.dart';
 import 'package:fluffychat/utils/localized_exception_extension.dart';
-import 'package:fluffychat/widgets/future_loading_dialog.dart';
-
-typedef _ObjectivesLoader =
-    ValueNotifier<AsyncState<List<QuestObjectiveGroup>>>;
 
 /// The objective groups that should render: those with at least one activity.
 /// An activity-less objective would otherwise show a header over a fixed-height
@@ -66,7 +58,10 @@ class CourseObjectivesList extends StatefulWidget {
   /// `Expanded`).
   final bool shrinkWrap;
 
+  final QuestObjectivesLoader objectivesProvider;
+
   const CourseObjectivesList({
+    required this.objectivesProvider,
     this.room,
     this.questId,
     this.hasCompletedActivity,
@@ -79,30 +74,13 @@ class CourseObjectivesList extends StatefulWidget {
 }
 
 class _CourseObjectivesListState extends State<CourseObjectivesList> {
-  final _ObjectivesLoader _objectivesLoader = _ObjectivesLoader(AsyncLoading());
   final ScrollController _scrollController = ScrollController();
-
-  /// The shared progression rollup behind the star display — same inputs and
-  /// resolver as the world map, so the numbers can never disagree
-  /// (quests.instructions.md, "Star display on the course panel"). Empty in a
-  /// preview (no room → no learner progress to show) and until the first
-  /// resolve completes.
-  ProgressionResolution _progression = ProgressionResolution.empty;
-
-  @override
-  void initState() {
-    super.initState();
-    _load();
-  }
 
   @override
   void dispose() {
-    _objectivesLoader.dispose();
     _scrollController.dispose();
     super.dispose();
   }
-
-  String? get _questId => widget.questId ?? widget.room?.coursePlan?.uuid;
 
   /// Scroll this list from a vertical mouse wheel anywhere over the panel —
   /// including the gaps between cards and the objective headers. Those areas are
@@ -128,326 +106,77 @@ class _CourseObjectivesListState extends State<CourseObjectivesList> {
   }
 
   @override
-  void didUpdateWidget(covariant CourseObjectivesList oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.questId != widget.questId ||
-        oldWidget.room?.id != widget.room?.id) {
-      _progression = ProgressionResolution.empty;
-      _load();
-    }
-  }
-
-  Future<void> _load() async {
-    // world_v2 → v3: the course space's coursePlan.uuid (or the previewed
-    // plan's uuid) points at a quest-plans id. The outline (Missions + their
-    // activities) comes from the v3 quest read layer; the v1
-    // course-plans/topics fan-out is retired.
-    final questId = _questId;
-    if (questId == null) {
-      _objectivesLoader.value = AsyncError(MissingQuestException());
-      return;
-    }
-
-    _objectivesLoader.value = AsyncLoading();
-    final outlineResult = await QuestRepo.outline(questId);
-    final outline = outlineResult.result;
-
-    if (!mounted) return;
-
-    if (outline == null) {
-      _objectivesLoader.value = AsyncError(
-        outlineResult.error ?? MissingQuestException(),
-      );
-      return;
-    }
-
-    unawaited(_loadProgression());
-
-    final filtered = objectiveGroupsWithActivities(outline.groups);
-    if (filtered.isEmpty) {
-      _objectivesLoader.value = AsyncError(MissingQuestException());
-      return;
-    }
-    _objectivesLoader.value = AsyncLoaded(filtered);
-  }
-
-  /// Resolve the star-display rollup. Joined courses only — a preview has no
-  /// learner progress to show. Fire-and-forget from [_load]: the outline
-  /// renders immediately and the star chips fill in when the resolve lands.
-  Future<void> _loadProgression() async {
-    final client = widget.room?.client;
-    if (client == null) return;
-    final resolved = await resolveJoinedProgression(client);
-    if (!mounted) return;
-    setState(() => _progression = resolved);
-  }
-
-  @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
-      valueListenable: _objectivesLoader,
+      valueListenable: widget.objectivesProvider.questLoader,
       builder: (context, state, _) {
         switch (state) {
           case AsyncLoading():
           case AsyncIdle():
             return const Center(child: CircularProgressIndicator.adaptive());
           case AsyncError(error: final error):
-            if (error is MissingQuestException) {
-              final showAddCourse = widget.room?.isRoomAdmin == true;
-              return Center(
-                child: Padding(
-                  padding: const EdgeInsets.all(24.0),
-                  child: Column(
-                    spacing: 12.0,
-                    children: [
-                      Text(
-                        showAddCourse
-                            ? L10n.of(context).missingCourseOutlineCta
-                            : L10n.of(context).missingCourseOutline,
-                        textAlign: TextAlign.center,
-                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                          color: Theme.of(context).colorScheme.outline,
-                        ),
-                      ),
-                      if (showAddCourse)
-                        SizedBox(
-                          width: double.infinity,
-                          child: FilledButton.tonalIcon(
-                            onPressed: () => context.go(
-                              WorkspaceNav.openCoursePage(
-                                GoRouterState.of(context).uri,
-                                RoomSubpageEnum.addcourse,
-                              ),
-                            ),
-                            icon: Icon(Icons.map_outlined, size: 20.0),
-                            label: Text(L10n.of(context).addCoursePlan),
-                            style: FilledButton.styleFrom(
-                              backgroundColor: Theme.of(
-                                context,
-                              ).colorScheme.primaryContainer,
-                              foregroundColor: Theme.of(
-                                context,
-                              ).colorScheme.onPrimaryContainer,
-                              padding: const EdgeInsets.symmetric(
-                                vertical: 14.0,
-                              ),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(10.0),
-                              ),
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
-              );
-            }
-
-            return Center(
-              child: ErrorIndicator(message: error.toLocalizedString(context)),
+            return _QuestLoadErrorView(
+              error,
+              showAddCourse: widget.room?.isRoomAdmin == true,
             );
-          case AsyncLoaded(value: final groups):
+          case AsyncLoaded(value: final outline):
             // The overall quest-star bar now lives in the course card header
             // (above the tabs — [CourseProgressBar]), so it shows on every tab
             // and in the collapsed mobile peek; the list is just the Missions.
             // Per-Mission stars still show once the shared rollup resolves; a
             // preview has no learner progress.
-            final hasProgress =
-                widget.room != null && _progression.rollup.isNotEmpty;
-            final list = ListView.separated(
-              controller: widget.shrinkWrap ? null : _scrollController,
-              padding: const EdgeInsets.symmetric(vertical: 8.0),
-              shrinkWrap: widget.shrinkWrap,
-              physics: widget.shrinkWrap
-                  ? const NeverScrollableScrollPhysics()
-                  : null,
-              itemCount: groups.length,
-              separatorBuilder: (_, _) => const SizedBox(height: 24.0),
-              itemBuilder: (context, i) {
-                final group = groups[i];
-                return _ObjectiveSection(
-                  index: i,
-                  group: group,
-                  room: widget.room,
-                  hasCompletedActivity: widget.hasCompletedActivity,
-                  progress: hasProgress
-                      ? _progression.rollup[group.objective.id]
+            final groups = objectiveGroupsWithActivities(outline.groups);
+            if (groups.isEmpty) {
+              return _QuestLoadErrorView(
+                MissingQuestException(),
+                showAddCourse: widget.room?.isRoomAdmin == true,
+              );
+            }
+
+            return ValueListenableBuilder(
+              valueListenable: widget.objectivesProvider.progression,
+              builder: (context, progression, _) {
+                final hasProgress =
+                    widget.room != null && progression.rollup.isNotEmpty;
+                final list = ListView.separated(
+                  controller: widget.shrinkWrap ? null : _scrollController,
+                  padding: const EdgeInsets.symmetric(vertical: 8.0),
+                  shrinkWrap: widget.shrinkWrap,
+                  physics: widget.shrinkWrap
+                      ? const NeverScrollableScrollPhysics()
                       : null,
+                  itemCount: groups.length,
+                  separatorBuilder: (_, _) => const SizedBox(height: 24.0),
+                  itemBuilder: (context, i) {
+                    final group = groups[i];
+                    return _ObjectiveSection(
+                      index: i,
+                      group: group,
+                      room: widget.room,
+                      hasCompletedActivity: widget.hasCompletedActivity,
+                      progress: hasProgress
+                          ? progression.rollup[group.objective.id]
+                          : null,
+                    );
+                  },
+                );
+                // In a preview the list is embedded in an outer scroll view (shrinkWrap)
+                // with no map behind it, so a wheel can't leak — return it bare. The
+                // standalone course-card panel floats over the map, so capture the wheel
+                // OPAQUELY across the whole panel: the gaps between cards and the
+                // objective headers are hit-transparent, and a wheel there would zoom the
+                // map instead of scrolling the list. See [_claimVerticalScroll].
+                if (widget.shrinkWrap) return list;
+                return Listener(
+                  behavior: HitTestBehavior.opaque,
+                  onPointerSignal: _claimVerticalScroll,
+                  child: list,
                 );
               },
-            );
-            // In a preview the list is embedded in an outer scroll view (shrinkWrap)
-            // with no map behind it, so a wheel can't leak — return it bare. The
-            // standalone course-card panel floats over the map, so capture the wheel
-            // OPAQUELY across the whole panel: the gaps between cards and the
-            // objective headers are hit-transparent, and a wheel there would zoom the
-            // map instead of scrolling the list. See [_claimVerticalScroll].
-            if (widget.shrinkWrap) return list;
-            return Listener(
-              behavior: HitTestBehavior.opaque,
-              onPointerSignal: _claimVerticalScroll,
-              child: list,
             );
         }
       },
     );
-  }
-}
-
-/// Resolve the learner's shared joined-course progression — the SAME inputs and
-/// resolver as the world map, so the star numbers can never disagree
-/// (quests.instructions.md). Called by both the header's [CourseProgressBar] and
-/// the objective list's per-Mission chips; identical cached inputs (the quest
-/// outline cache + `client.userStarsByActivity`) mean the two can't drift, so a
-/// second resolve is safe rather than a re-derivation risk.
-Future<ProgressionResolution> resolveJoinedProgression(Client client) async {
-  final cache = JoinedObjectiveCache();
-  await cache.rebuildFromJoinedCourses(
-    client,
-    onError: (uuid, e, s) => ErrorHandler.logError(
-      e: e,
-      s: s,
-      m: 'course progression failed to resolve',
-      data: {'courseUuid': uuid},
-    ),
-  );
-  return cache.resolution(client.userStarsByActivity);
-}
-
-/// The overall course progress bar for the course-card HEADER (above the tabs,
-/// #7597): the quest's earned-over-threshold stars and a bar. Lives in the
-/// header so it shows on every tab and in the collapsed mobile peek — where the
-/// objective list (and its old in-list header) isn't even mounted, since the
-/// card opens on the chat tab on narrow. Self-resolves the shared progression
-/// ([resolveJoinedProgression]); renders a muted empty bar until it lands so the
-/// header height (and the peek) stays stable.
-class CourseProgressBar extends StatefulWidget {
-  final Room room;
-
-  const CourseProgressBar({required this.room, super.key});
-
-  @override
-  State<CourseProgressBar> createState() => _CourseProgressBarState();
-}
-
-class _CourseProgressBarState extends State<CourseProgressBar> {
-  QuestStarSummary? _summary;
-
-  @override
-  void initState() {
-    super.initState();
-    _load();
-  }
-
-  @override
-  void didUpdateWidget(covariant CourseProgressBar oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.room.id != widget.room.id) {
-      setState(() => _summary = null);
-      _load();
-    }
-  }
-
-  Future<void> _load() async {
-    final questId = widget.room.coursePlan?.uuid;
-    if (questId == null) return;
-    final outlineResult = await QuestRepo.outline(questId);
-    final orderedMissionIds =
-        outlineResult.result?.quest.learningObjectiveIds ?? const [];
-    final progression = await resolveJoinedProgression(widget.room.client);
-    if (!mounted) return;
-    setState(() => _summary = progression.questStars(orderedMissionIds));
-  }
-
-  @override
-  Widget build(BuildContext context) => ProgressBarRow(summary: _summary);
-}
-
-/// The overall course progress bar: a rounded gold fill over a gray track with
-/// a star sitting INSIDE the bar at the goal (right) end — no number. Learners
-/// read progress from the fill and tap/hover the bar for the exact
-/// earned/threshold (#7597, the Figma course-plan frame). A null [summary]
-/// renders the muted empty state (pre-resolve), keeping the header height
-/// stable.
-class ProgressBarRow extends StatelessWidget {
-  final QuestStarSummary? summary;
-
-  static const double _barHeight = 20.0;
-
-  const ProgressBarRow({required this.summary, super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final summary = this.summary;
-    final gold = AppConfig.goldByTheme(context);
-    final fraction = (summary?.fraction ?? 0.0).clamp(0.0, 1.0);
-    final label = summary == null
-        ? null
-        : L10n.of(context).starsEarnedOfTotal(summary.earned, summary.total);
-
-    final bar = SizedBox(
-      height: _barHeight,
-      child: Stack(
-        alignment: Alignment.centerLeft,
-        children: [
-          // Gray track.
-          DecoratedBox(
-            decoration: BoxDecoration(
-              color: theme.colorScheme.surfaceContainerHighest,
-              borderRadius: BorderRadius.circular(_barHeight / 2),
-            ),
-            child: const SizedBox.expand(),
-          ),
-          // Gold fill — the learner's progress toward the goal. The
-          // SizedBox.expand child is load-bearing: a childless DecoratedBox in
-          // a loose Stack sizes to constraints.smallest (zero height) and
-          // paints nothing (#7603).
-          FractionallySizedBox(
-            widthFactor: fraction,
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                color: gold,
-                borderRadius: BorderRadius.circular(_barHeight / 2),
-              ),
-              child: const SizedBox.expand(),
-            ),
-          ),
-          // The goal star, inside the bar at the right end. A surface-coloured
-          // outline star sits behind it so it reads on both the gold fill (full
-          // progress) and the gray track.
-          Positioned(
-            right: 5.0,
-            child: SizedBox(
-              width: _barHeight - 4,
-              height: _barHeight - 4,
-              child: Stack(
-                alignment: Alignment.center,
-                children: [
-                  Icon(
-                    Icons.star,
-                    size: _barHeight - 3,
-                    color: theme.colorScheme.surface,
-                  ),
-                  Icon(Icons.star, size: _barHeight - 6, color: gold),
-                ],
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-
-    final result = Semantics(label: label, value: label, child: bar);
-
-    // Tap (mobile) and hover (desktop) both surface the exact count.
-    return label == null
-        ? result
-        : Tooltip(
-            message: label,
-            triggerMode: TooltipTriggerMode.tap,
-            child: result,
-          );
   }
 }
 
@@ -647,6 +376,68 @@ class _ObjectivePlaceholderIcon extends StatelessWidget {
         borderRadius: BorderRadius.circular(10.0),
       ),
       child: Icon(Icons.flag_outlined, size: 22.0, color: scheme.onSurface),
+    );
+  }
+}
+
+class _QuestLoadErrorView extends StatelessWidget {
+  final Object error;
+  final bool showAddCourse;
+
+  const _QuestLoadErrorView(this.error, {required this.showAddCourse});
+
+  @override
+  Widget build(BuildContext context) {
+    if (error is MissingQuestException) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            spacing: 12.0,
+            children: [
+              Text(
+                showAddCourse
+                    ? L10n.of(context).missingCourseOutlineCta
+                    : L10n.of(context).missingCourseOutline,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: Theme.of(context).colorScheme.outline,
+                ),
+              ),
+              if (showAddCourse)
+                SizedBox(
+                  width: double.infinity,
+                  child: FilledButton.tonalIcon(
+                    onPressed: () => context.go(
+                      WorkspaceNav.openCoursePage(
+                        GoRouterState.of(context).uri,
+                        RoomSubpageEnum.addcourse,
+                      ),
+                    ),
+                    icon: Icon(Icons.map_outlined, size: 20.0),
+                    label: Text(L10n.of(context).addCoursePlan),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: Theme.of(
+                        context,
+                      ).colorScheme.primaryContainer,
+                      foregroundColor: Theme.of(
+                        context,
+                      ).colorScheme.onPrimaryContainer,
+                      padding: const EdgeInsets.symmetric(vertical: 14.0),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(10.0),
+                      ),
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return Center(
+      child: ErrorIndicator(message: error.toLocalizedString(context)),
     );
   }
 }

--- a/lib/routes/courses/course_objectives/course_progress_bar.dart
+++ b/lib/routes/courses/course_objectives/course_progress_bar.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/quests/quest_objectives_loader.dart';
+import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+
+/// The overall course progress bar for the course-card HEADER (above the tabs,
+/// #7597): the quest's earned-over-threshold stars and a bar. Lives in the
+/// header so it shows on every tab and in the collapsed mobile peek — where the
+/// objective list (and its old in-list header) isn't even mounted, since the
+/// card opens on the chat tab on narrow. Self-resolves the shared progression
+/// ([resolveJoinedProgression]); renders a muted empty bar until it lands so the
+/// header height (and the peek) stays stable.
+class CourseProgressBar extends StatelessWidget {
+  final QuestObjectivesLoader objectivesProvider;
+  const CourseProgressBar({required this.objectivesProvider, super.key});
+
+  @override
+  Widget build(BuildContext context) => ValueListenableBuilder(
+    valueListenable: objectivesProvider.progression,
+    builder: (context, progression, _) =>
+        ProgressBarRow(summary: objectivesProvider.questStars),
+  );
+}
+
+/// The overall course progress bar: a rounded gold fill over a gray track with
+/// a star sitting INSIDE the bar at the goal (right) end — no number. Learners
+/// read progress from the fill and tap/hover the bar for the exact
+/// earned/threshold (#7597, the Figma course-plan frame). A null [summary]
+/// renders the muted empty state (pre-resolve), keeping the header height
+/// stable.
+class ProgressBarRow extends StatelessWidget {
+  final QuestStarSummary? summary;
+
+  static const double _barHeight = 20.0;
+
+  const ProgressBarRow({required this.summary, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final summary = this.summary;
+    final gold = AppConfig.goldByTheme(context);
+    final fraction = (summary?.fraction ?? 0.0).clamp(0.0, 1.0);
+    final label = summary == null
+        ? null
+        : L10n.of(context).starsEarnedOfTotal(summary.earned, summary.total);
+
+    final bar = SizedBox(
+      height: _barHeight,
+      child: Stack(
+        alignment: Alignment.centerLeft,
+        children: [
+          // Gray track.
+          DecoratedBox(
+            decoration: BoxDecoration(
+              color: theme.colorScheme.surfaceContainerHighest,
+              borderRadius: BorderRadius.circular(_barHeight / 2),
+            ),
+            child: const SizedBox.expand(),
+          ),
+          // Gold fill — the learner's progress toward the goal. The
+          // SizedBox.expand child is load-bearing: a childless DecoratedBox in
+          // a loose Stack sizes to constraints.smallest (zero height) and
+          // paints nothing (#7603).
+          FractionallySizedBox(
+            widthFactor: fraction,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: gold,
+                borderRadius: BorderRadius.circular(_barHeight / 2),
+              ),
+              child: const SizedBox.expand(),
+            ),
+          ),
+          // The goal star, inside the bar at the right end. A surface-coloured
+          // outline star sits behind it so it reads on both the gold fill (full
+          // progress) and the gray track.
+          Positioned(
+            right: 5.0,
+            child: SizedBox(
+              width: _barHeight - 4,
+              height: _barHeight - 4,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  Icon(
+                    Icons.star,
+                    size: _barHeight - 3,
+                    color: theme.colorScheme.surface,
+                  ),
+                  Icon(Icons.star, size: _barHeight - 6, color: gold),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+
+    final result = Semantics(label: label, value: label, child: bar);
+
+    // Tap (mobile) and hover (desktop) both surface the exact count.
+    return label == null
+        ? result
+        : Tooltip(
+            message: label,
+            triggerMode: TooltipTriggerMode.tap,
+            child: result,
+          );
+  }
+}

--- a/lib/routes/courses/own/selected_course_page.dart
+++ b/lib/routes/courses/own/selected_course_page.dart
@@ -6,11 +6,11 @@ import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart' as sdk;
 
 import 'package:fluffychat/features/analytics_access/course_settings_model.dart';
-import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
-import 'package:fluffychat/features/course_plans/courses/course_plan_model.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
 import 'package:fluffychat/features/navigation/token_params/add_course_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
+import 'package:fluffychat/features/quests/models/quest_plan_model.dart';
+import 'package:fluffychat/features/quests/quest_objectives_loader.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/spaces/client_spaces_extension.dart';
 import 'package:fluffychat/routes/chat/chat_details/space_details_content.dart';
@@ -42,21 +42,33 @@ class SelectedCourse extends StatefulWidget {
   SelectedCourseController createState() => SelectedCourseController();
 }
 
-class SelectedCourseController extends State<SelectedCourse>
-    with CoursePlanProvider {
+class SelectedCourseController extends State<SelectedCourse> {
+  late final QuestObjectivesLoader _objectivesProvider;
+
   @override
   initState() {
     super.initState();
-    loadCourse(widget.courseId);
+    _objectivesProvider = QuestObjectivesLoader(
+      client: Matrix.of(context).client,
+    );
+    _objectivesProvider.loadOutline(widget.courseId);
   }
 
   @override
   void didUpdateWidget(covariant SelectedCourse oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.courseId != widget.courseId) {
-      loadCourse(widget.courseId);
+      _objectivesProvider.loadOutline(widget.courseId);
     }
   }
+
+  @override
+  void dispose() {
+    _objectivesProvider.dispose();
+    super.dispose();
+  }
+
+  QuestObjectivesLoader get objectivesProvider => _objectivesProvider;
 
   String get title {
     switch (widget.mode) {
@@ -76,7 +88,7 @@ class SelectedCourseController extends State<SelectedCourse>
     }
   }
 
-  Future<void> submit(CoursePlanModel course) async {
+  Future<void> submit(QuestPlan course) async {
     switch (widget.mode) {
       case SelectedCourseMode.launch:
         return launchCourse(widget.courseId, course);
@@ -85,12 +97,12 @@ class SelectedCourseController extends State<SelectedCourse>
     }
   }
 
-  Future<void> launchCourse(String courseId, CoursePlanModel course) async {
+  Future<void> launchCourse(String courseId, QuestPlan course) async {
     final client = Matrix.of(context).client;
     final Completer<String> completer = Completer<String>();
     client
         .createPangeaSpace(
-          name: course.title,
+          name: course.name,
           topic: course.description,
           visibility: sdk.Visibility.public,
           joinRules: sdk.JoinRules.knock,
@@ -106,7 +118,6 @@ class SelectedCourseController extends State<SelectedCourse>
               ).toJson(),
             ),
           ],
-          avatarUrl: course.imageUrl.toString(),
           spaceChild: 0,
         )
         .then((spaceId) => completer.complete(spaceId))
@@ -123,7 +134,7 @@ class SelectedCourseController extends State<SelectedCourse>
     );
   }
 
-  Future<void> addCourseToSpace(CoursePlanModel course) async {
+  Future<void> addCourseToSpace(QuestPlan course) async {
     if (widget.spaceId == null) {
       throw Exception("Space ID is null");
     }
@@ -137,7 +148,7 @@ class SelectedCourseController extends State<SelectedCourse>
     await space.addCourseToSpace(widget.courseId);
 
     if (space.name.isEmpty) {
-      await space.setName(course.title);
+      await space.setName(course.name);
     }
 
     if (space.topic.isEmpty) {

--- a/lib/routes/courses/own/selected_course_view.dart
+++ b/lib/routes/courses/own/selected_course_view.dart
@@ -4,15 +4,16 @@ import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/course_plans/map_clipper.dart';
 import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/utils/async_state.dart';
 import 'package:fluffychat/pangea/common/widgets/error_indicator.dart';
 import 'package:fluffychat/routes/courses/cefr_level_match.dart';
 import 'package:fluffychat/routes/courses/course_info_chip_widget.dart';
 import 'package:fluffychat/routes/courses/course_objectives/course_objectives_view.dart';
 import 'package:fluffychat/routes/courses/own/selected_course_page.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
-import 'package:fluffychat/widgets/url_image_widget.dart';
 
 class SelectedCourseView extends StatelessWidget {
   final SelectedCourseController controller;
@@ -28,19 +29,6 @@ class SelectedCourseView extends StatelessWidget {
     const double largeIconSize = 24.0;
     const double mediumIconSize = 16.0;
     const double smallIconSize = 12.0;
-
-    final course = controller.course;
-
-    final userController = MatrixState.pangeaController.userController;
-    final cefrMatch = course == null
-        ? CefrMatchResult.none
-        : computeCefrMatch(
-            context: context,
-            userLevel: userController.userCefrLevel,
-            courseLevel: course.cefrLevel,
-            courseLanguage: course.targetLanguage,
-            userLanguage: userController.userL2Code,
-          );
 
     return Scaffold(
       appBar: AppBar(
@@ -61,41 +49,59 @@ class SelectedCourseView extends StatelessWidget {
           alignment: Alignment.topCenter,
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 500.0),
-            child: controller.loadingCourse
-                ? const Center(child: CircularProgressIndicator.adaptive())
-                : controller.courseError != null || course == null
-                ? Center(
+            child: ValueListenableBuilder(
+              valueListenable: controller.objectivesProvider.questLoader,
+              builder: (context, state, _) {
+                return switch (state) {
+                  AsyncLoading() || AsyncIdle() => const Center(
+                    child: CircularProgressIndicator.adaptive(),
+                  ),
+                  AsyncError() => Center(
                     child: ErrorIndicator(
                       message: L10n.of(context).oopsSomethingWentWrong,
                     ),
-                  )
-                : Column(
-                    children: [
-                      Expanded(
-                        child: Padding(
-                          padding: const EdgeInsets.only(
-                            top: 12.0,
-                            left: 12.0,
-                            right: 12.0,
-                          ),
-                          child: ListView.builder(
-                            itemCount: 2,
-                            itemBuilder: (context, index) {
-                              final String displayname = course.title;
+                  ),
+                  AsyncLoaded(value: final outline) => () {
+                    final course = outline.quest;
+                    final cefrEntry = course.targetCefr;
+                    final courseCefr = cefrEntry != null
+                        ? LanguageLevelTypeEnum.fromString(cefrEntry)
+                        : null;
 
-                              if (index == 0) {
-                                return Column(
-                                  spacing: 8.0,
-                                  children: [
-                                    ClipPath(
-                                      clipper: MapClipper(),
-                                      child: ImageByUrl(
-                                        imageUrl: course.imageUrl,
-                                        width: 100.0,
-                                        borderRadius: BorderRadius.circular(
-                                          0.0,
-                                        ),
-                                        replacement: Avatar(
+                    final userController =
+                        MatrixState.pangeaController.userController;
+
+                    final cefrMatch = courseCefr == null
+                        ? CefrMatchResult.none
+                        : computeCefrMatch(
+                            context: context,
+                            userLevel: userController.userCefrLevel,
+                            courseLevel: courseCefr,
+                            courseLanguage: course.targetLanguage,
+                            userLanguage: userController.userL2Code,
+                          );
+
+                    final String displayname = course.name;
+
+                    return Column(
+                      children: [
+                        Expanded(
+                          child: Padding(
+                            padding: const EdgeInsets.only(
+                              top: 12.0,
+                              left: 12.0,
+                              right: 12.0,
+                            ),
+                            child: ListView.builder(
+                              itemCount: 2,
+                              itemBuilder: (context, index) {
+                                if (index == 0) {
+                                  return Column(
+                                    spacing: 8.0,
+                                    children: [
+                                      ClipPath(
+                                        clipper: MapClipper(),
+                                        child: Avatar(
                                           name: displayname,
                                           size: 100.0,
                                           borderRadius: BorderRadius.circular(
@@ -103,60 +109,165 @@ class SelectedCourseView extends StatelessWidget {
                                           ),
                                         ),
                                       ),
-                                    ),
-                                    Text(
-                                      displayname,
-                                      style: const TextStyle(
-                                        fontSize: titleFontSize,
+                                      Text(
+                                        displayname,
+                                        style: const TextStyle(
+                                          fontSize: titleFontSize,
+                                        ),
                                       ),
-                                    ),
-                                    Text(
-                                      course.description,
+                                      Text(
+                                        course.description,
+                                        style: const TextStyle(
+                                          fontSize: descFontSize,
+                                        ),
+                                      ),
+                                      Wrap(
+                                        spacing: 8.0,
+                                        runSpacing: 8.0,
+                                        children: [
+                                          CourseInfoChip(
+                                            icon: Icons.language,
+                                            text: course.targetLanguage
+                                                .toUpperCase(),
+                                            fontSize: descFontSize,
+                                            iconSize: smallIconSize,
+                                          ),
+                                          if (courseCefr != null)
+                                            CourseInfoChip(
+                                              icon: Icons.school,
+                                              text: courseCefr.title(context),
+                                              fontSize: descFontSize,
+                                              iconSize: smallIconSize,
+                                              highlightColor:
+                                                  cefrMatch.chipColor,
+                                            ),
+                                          CourseInfoChip(
+                                            icon: Icons.location_on,
+                                            text: L10n.of(context).numModules(
+                                              course.sequence.length,
+                                            ),
+                                            fontSize: descFontSize,
+                                            iconSize: smallIconSize,
+                                          ),
+                                        ],
+                                      ),
+                                      Padding(
+                                        padding: const EdgeInsets.only(
+                                          top: 4.0,
+                                          bottom: 8.0,
+                                        ),
+                                        child: Row(
+                                          spacing: 4.0,
+                                          children: [
+                                            const Icon(
+                                              Icons.map,
+                                              size: largeIconSize,
+                                            ),
+                                            Text(
+                                              L10n.of(context).coursePlan,
+                                              style: const TextStyle(
+                                                fontSize: titleFontSize,
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ],
+                                  );
+                                }
+
+                                // world_v2: all courses are v3 quests — render the
+                                // plan from the quest outline (no room yet, so a
+                                // read-only preview). shrinkWrap: this sits inside
+                                // the page's outer ListView. See routing.instructions.md.
+                                return CourseObjectivesList(
+                                  questId: course.id,
+                                  shrinkWrap: true,
+                                  objectivesProvider:
+                                      controller.objectivesProvider,
+                                );
+                              },
+                            ),
+                          ),
+                        ),
+                        Container(
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surface,
+                            border: Border(
+                              top: BorderSide(
+                                color: theme.dividerColor,
+                                width: 1.0,
+                              ),
+                            ),
+                          ),
+                          padding: const EdgeInsets.all(12.0),
+                          child: Column(
+                            spacing: 8.0,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              if (cefrMatch.message != null)
+                                InlineTooltip(
+                                  message: cefrMatch.message!,
+                                  isClosed: false,
+                                  backgroundColor: cefrMatch.chipColor,
+                                  icon: cefrMatch.icon,
+                                ),
+                              Row(
+                                spacing: 12.0,
+                                children: [
+                                  const Icon(Icons.edit, size: mediumIconSize),
+                                  Flexible(
+                                    child: Text(
+                                      L10n.of(context).editCourseLater,
                                       style: const TextStyle(
                                         fontSize: descFontSize,
                                       ),
                                     ),
-                                    Wrap(
-                                      spacing: 8.0,
-                                      runSpacing: 8.0,
-                                      children: [
-                                        CourseInfoChip(
-                                          icon: Icons.language,
-                                          text: course.targetLanguageDisplay,
-                                          fontSize: descFontSize,
-                                          iconSize: smallIconSize,
-                                        ),
-                                        CourseInfoChip(
-                                          icon: Icons.school,
-                                          text: course.cefrLevel.title(context),
-                                          fontSize: descFontSize,
-                                          iconSize: smallIconSize,
-                                          highlightColor: cefrMatch.chipColor,
-                                        ),
-                                        CourseInfoChip(
-                                          icon: Icons.location_on,
-                                          text: L10n.of(
-                                            context,
-                                          ).numModules(course.topicIds.length),
-                                          fontSize: descFontSize,
-                                          iconSize: smallIconSize,
-                                        ),
-                                      ],
+                                  ),
+                                ],
+                              ),
+                              Row(
+                                spacing: 12.0,
+                                children: [
+                                  const Icon(
+                                    Icons.shield,
+                                    size: mediumIconSize,
+                                  ),
+                                  Flexible(
+                                    child: Text(
+                                      L10n.of(context).newCourseAccess,
+                                      style: const TextStyle(
+                                        fontSize: descFontSize,
+                                      ),
                                     ),
-                                    Padding(
-                                      padding: const EdgeInsets.only(
-                                        top: 4.0,
-                                        bottom: 8.0,
+                                  ),
+                                ],
+                              ),
+                              Padding(
+                                padding: const EdgeInsets.only(top: 8.0),
+                                child: Column(
+                                  spacing: 8.0,
+                                  children: [
+                                    ElevatedButton(
+                                      style: ElevatedButton.styleFrom(
+                                        backgroundColor:
+                                            theme.colorScheme.primaryContainer,
+                                        foregroundColor: theme
+                                            .colorScheme
+                                            .onPrimaryContainer,
+                                      ),
+                                      onPressed: () => showFutureLoadingDialog(
+                                        context: context,
+                                        future: () => controller.submit(course),
                                       ),
                                       child: Row(
-                                        spacing: 4.0,
+                                        spacing: 8.0,
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.center,
                                         children: [
-                                          const Icon(
-                                            Icons.map,
-                                            size: largeIconSize,
-                                          ),
+                                          const Icon(Icons.map_outlined),
                                           Text(
-                                            L10n.of(context).coursePlan,
+                                            controller.buttonText,
                                             style: const TextStyle(
                                               fontSize: titleFontSize,
                                             ),
@@ -165,110 +276,17 @@ class SelectedCourseView extends StatelessWidget {
                                       ),
                                     ),
                                   ],
-                                );
-                              }
-
-                              // world_v2: all courses are v3 quests — render the
-                              // plan from the quest outline (no room yet, so a
-                              // read-only preview). shrinkWrap: this sits inside
-                              // the page's outer ListView. See routing.instructions.md.
-                              return CourseObjectivesList(
-                                questId: course.uuid,
-                                shrinkWrap: true,
-                              );
-                            },
+                                ),
+                              ),
+                            ],
                           ),
                         ),
-                      ),
-                      Container(
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.surface,
-                          border: Border(
-                            top: BorderSide(
-                              color: theme.dividerColor,
-                              width: 1.0,
-                            ),
-                          ),
-                        ),
-                        padding: const EdgeInsets.all(12.0),
-                        child: Column(
-                          spacing: 8.0,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            if (cefrMatch.message != null)
-                              InlineTooltip(
-                                message: cefrMatch.message!,
-                                isClosed: false,
-                                backgroundColor: cefrMatch.chipColor,
-                                icon: cefrMatch.icon,
-                              ),
-                            Row(
-                              spacing: 12.0,
-                              children: [
-                                const Icon(Icons.edit, size: mediumIconSize),
-                                Flexible(
-                                  child: Text(
-                                    L10n.of(context).editCourseLater,
-                                    style: const TextStyle(
-                                      fontSize: descFontSize,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                            Row(
-                              spacing: 12.0,
-                              children: [
-                                const Icon(Icons.shield, size: mediumIconSize),
-                                Flexible(
-                                  child: Text(
-                                    L10n.of(context).newCourseAccess,
-                                    style: const TextStyle(
-                                      fontSize: descFontSize,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                            Padding(
-                              padding: const EdgeInsets.only(top: 8.0),
-                              child: Column(
-                                spacing: 8.0,
-                                children: [
-                                  ElevatedButton(
-                                    style: ElevatedButton.styleFrom(
-                                      backgroundColor:
-                                          theme.colorScheme.primaryContainer,
-                                      foregroundColor:
-                                          theme.colorScheme.onPrimaryContainer,
-                                    ),
-                                    onPressed: () => showFutureLoadingDialog(
-                                      context: context,
-                                      future: () => controller.submit(course),
-                                    ),
-                                    child: Row(
-                                      spacing: 8.0,
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.center,
-                                      children: [
-                                        const Icon(Icons.map_outlined),
-                                        Text(
-                                          controller.buttonText,
-                                          style: const TextStyle(
-                                            fontSize: titleFontSize,
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
+                      ],
+                    );
+                  }(),
+                };
+              },
+            ),
           ),
         ),
       ),

--- a/lib/routes/courses/preview/public_course_preview.dart
+++ b/lib/routes/courses/preview/public_course_preview.dart
@@ -7,14 +7,16 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/analytics_access/join_room_analytics_access_extension.dart';
 import 'package:fluffychat/features/analytics_access/join_room_analytics_consent_handler.dart';
-import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
 import 'package:fluffychat/features/join_codes/knocked_rooms_extension.dart';
 import 'package:fluffychat/features/join_codes/space_code_controller.dart';
 import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/token_params/add_course_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
+import 'package:fluffychat/features/quests/models/quest_plan_model.dart';
+import 'package:fluffychat/features/quests/quest_objectives_loader.dart';
 import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/utils/async_state.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/courses/preview/public_course_preview_view.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
@@ -36,15 +38,19 @@ class PublicCoursePreview extends StatefulWidget {
       PublicCoursePreviewController();
 }
 
-class PublicCoursePreviewController extends State<PublicCoursePreview>
-    with CoursePlanProvider {
+class PublicCoursePreviewController extends State<PublicCoursePreview> {
   RoomSummaryResponse? roomSummary;
   Object? roomSummaryError;
   bool loadingRoomSummary = false;
 
+  late final QuestObjectivesLoader _objectivesProvider;
+
   @override
   initState() {
     super.initState();
+    _objectivesProvider = QuestObjectivesLoader(
+      client: Matrix.of(context).client,
+    );
     _loadSummary();
   }
 
@@ -55,6 +61,14 @@ class PublicCoursePreviewController extends State<PublicCoursePreview>
       _loadSummary();
     }
   }
+
+  @override
+  void dispose() {
+    _objectivesProvider.dispose();
+    super.dispose();
+  }
+
+  QuestObjectivesLoader get objectivesProvider => _objectivesProvider;
 
   /// world_v2: the public course preview is route-driven
   /// (`/courses/preview/:courseroomid`) because its parent `/courses…` segments
@@ -71,9 +85,22 @@ class PublicCoursePreviewController extends State<PublicCoursePreview>
     );
   }
 
-  bool get loading => loadingCourse || loadingRoomSummary;
+  bool get _loadingCourse =>
+      _objectivesProvider.questLoader.value is AsyncLoading;
+
+  Object? get _courseError => switch (_objectivesProvider.questLoader.value) {
+    AsyncError(error: final error) => error,
+    _ => null,
+  };
+
+  QuestPlan? get course => switch (_objectivesProvider.questLoader.value) {
+    AsyncLoaded(value: final value) => value.quest,
+    _ => null,
+  };
+
+  bool get loading => _loadingCourse || loadingRoomSummary;
   bool get hasError =>
-      (courseError != null || (!loadingCourse && course == null)) ||
+      (_courseError != null || (!_loadingCourse && course == null)) ||
       (roomSummaryError != null ||
           (!loadingRoomSummary && roomSummary == null));
 
@@ -104,8 +131,6 @@ class PublicCoursePreviewController extends State<PublicCoursePreview>
       this.roomSummary = roomSummary;
     } catch (e, s) {
       roomSummaryError = e;
-      loadingCourse = false;
-
       ErrorHandler.logError(
         e: e,
         s: s,
@@ -120,7 +145,7 @@ class PublicCoursePreviewController extends State<PublicCoursePreview>
     }
 
     if (roomSummary?.coursePlan != null) {
-      await loadCourse(roomSummary!.coursePlan!.uuid);
+      await _objectivesProvider.loadOutline(roomSummary!.coursePlan!.uuid);
     } else {
       ErrorHandler.logError(
         e: Exception("No course plan found in room summary"),
@@ -129,7 +154,6 @@ class PublicCoursePreviewController extends State<PublicCoursePreview>
       if (mounted) {
         setState(() {
           roomSummaryError = Exception("No course plan found in room summary");
-          loadingCourse = false;
         });
       }
     }

--- a/lib/routes/courses/preview/public_course_preview_view.dart
+++ b/lib/routes/courses/preview/public_course_preview_view.dart
@@ -14,6 +14,7 @@ import 'package:fluffychat/routes/courses/cefr_level_match.dart';
 import 'package:fluffychat/routes/courses/course_info_chip_widget.dart';
 import 'package:fluffychat/routes/courses/course_objectives/course_objectives_view.dart';
 import 'package:fluffychat/routes/courses/preview/public_course_preview.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/user_dialog.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -55,8 +56,9 @@ class PublicCoursePreviewView extends StatelessWidget {
           alignment: Alignment.topCenter,
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 500.0),
-            child: Builder(
-              builder: (context) {
+            child: ValueListenableBuilder(
+              valueListenable: controller.objectivesProvider.questLoader,
+              builder: (context, state, _) {
                 if (controller.loading) {
                   return const Center(
                     child: CircularProgressIndicator.adaptive(),
@@ -74,22 +76,30 @@ class PublicCoursePreviewView extends StatelessWidget {
                 final course = controller.course!;
                 final summary = controller.roomSummary!;
 
-                Uri? avatarUrl = course.imageUrl;
-                if (summary.avatarUrl != null) {
-                  avatarUrl = Uri.tryParse(summary.avatarUrl!);
-                }
+                final roomAvatar = summary.avatarUrl;
+                final avatarUrl = roomAvatar != null
+                    ? Uri.tryParse(roomAvatar)
+                    : null;
 
-                final displayname = summary.displayName ?? course.title;
+                final displayname = summary.displayName ?? course.name;
 
                 final userController =
                     MatrixState.pangeaController.userController;
-                final cefrMatch = computeCefrMatch(
-                  context: context,
-                  userLevel: userController.userCefrLevel,
-                  courseLevel: course.cefrLevel,
-                  courseLanguage: course.targetLanguage,
-                  userLanguage: userController.userL2Code,
-                );
+
+                final cefrEntry = course.targetCefr;
+                final courseCefr = cefrEntry != null
+                    ? LanguageLevelTypeEnum.fromString(cefrEntry)
+                    : null;
+
+                final cefrMatch = courseCefr == null
+                    ? CefrMatchResult.none
+                    : computeCefrMatch(
+                        context: context,
+                        userLevel: userController.userCefrLevel,
+                        courseLevel: courseCefr,
+                        courseLanguage: course.targetLanguage,
+                        userLanguage: userController.userL2Code,
+                      );
 
                 return Column(
                   children: [
@@ -145,22 +155,24 @@ class PublicCoursePreviewView extends StatelessWidget {
                                     children: [
                                       CourseInfoChip(
                                         icon: Icons.language,
-                                        text: course.targetLanguageDisplay,
+                                        text: course.targetLanguage
+                                            .toUpperCase(),
                                         fontSize: descFontSize,
                                         iconSize: smallIconSize,
                                       ),
-                                      CourseInfoChip(
-                                        icon: Icons.school,
-                                        text: course.cefrLevel.title(context),
-                                        fontSize: descFontSize,
-                                        iconSize: smallIconSize,
-                                        highlightColor: cefrMatch.chipColor,
-                                      ),
+                                      if (courseCefr != null)
+                                        CourseInfoChip(
+                                          icon: Icons.school,
+                                          text: courseCefr.title(context),
+                                          fontSize: descFontSize,
+                                          iconSize: smallIconSize,
+                                          highlightColor: cefrMatch.chipColor,
+                                        ),
                                       CourseInfoChip(
                                         icon: Icons.location_on,
                                         text: L10n.of(
                                           context,
-                                        ).numModules(course.topicIds.length),
+                                        ).numModules(course.sequence.length),
                                         fontSize: descFontSize,
                                         iconSize: smallIconSize,
                                       ),
@@ -204,8 +216,9 @@ class PublicCoursePreviewView extends StatelessWidget {
                             // outline (read-only preview, no room). shrinkWrap:
                             // embedded in the page's outer scroll view.
                             return CourseObjectivesList(
-                              questId: course.uuid,
+                              questId: course.id,
                               shrinkWrap: true,
+                              objectivesProvider: controller.objectivesProvider,
                             );
                           },
                         ),

--- a/test/pangea/courses/course_objectives_filter_test.dart
+++ b/test/pangea/courses/course_objectives_filter_test.dart
@@ -4,8 +4,8 @@ import 'package:fluffychat/features/activity_sessions/activity_media_enum.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_request.dart';
 import 'package:fluffychat/features/quests/models/learning_objective_model.dart';
+import 'package:fluffychat/features/quests/quest_objectives_loader.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
-import 'package:fluffychat/routes/courses/course_objectives/course_objectives_view.dart';
 import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
 
 /// Regression coverage for #7114 ("Remove extra space for course modules

--- a/test/pangea/courses/course_progress_bar_test.dart
+++ b/test/pangea/courses/course_progress_bar_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
 import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/routes/courses/course_objectives/course_objectives_view.dart';
+import 'package:fluffychat/routes/courses/course_objectives/course_progress_bar.dart';
 
 void main() {
   Widget wrap(Widget child) => MaterialApp(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified quest-based objective loading and progress tracking across course pages, previews, and chat details.
  * Added a course progress bar with star totals, visual completion progress, accessibility labels, and tooltips.
  * Course objectives now update automatically as outline and progression data loads.

* **Bug Fixes**
  * Improved handling and display of missing or failed quest outlines.
  * Updated course details to use current quest language, level, module, and naming information.

* **Tests**
  * Updated objective filtering and progress bar tests for the new course experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->