### PR TITLE
fix: exclude finished activities from list of active activity instanc…

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -772,7 +772,7 @@ class WorldMapController extends State<WorldMap>
     // a pin on the world map has none and closes with an X. A held session
     // resumes via the token's session-binding field (#7257). The map focuses
     // the activity's pin via the token (`mapFocusFor` → `ActivityFocus`).
-    final myRoom = client?.myActivityInstance(card.activityId);
+    final myRoom = client?.activeActivityInstance(card.activityId);
     context.go(
       WorkspaceNav.openActivity(uri, card.activityId, roomId: myRoom?.id),
     );

--- a/lib/routes/world/world_map_client_extension.dart
+++ b/lib/routes/world/world_map_client_extension.dart
@@ -16,13 +16,17 @@ extension WorldMapClientExtension on Client {
   /// *another* learner's open session): here we resolve "my started/joined
   /// session" so a map-pin tap reopens it (binding the overlay via `roomid=`)
   /// instead of spawning a fresh instance (#7257).
-  Room? myActivityInstance(String activityId) {
+  Room? activeActivityInstance(String activityId) {
     Room? best;
     var bestHasRole = false;
     for (final r in rooms) {
       if (r.activityId != activityId) continue;
       if (r.membership != Membership.join) continue;
-      final hasRole = r.ownRole != null;
+
+      final ownRole = r.ownRoleState;
+      final hasRole = ownRole != null;
+      if (ownRole != null && ownRole.isFinished) continue;
+
       final ms = r.lastEvent?.originServerTs.millisecondsSinceEpoch ?? 0;
       final bestMs =
           best?.lastEvent?.originServerTs.millisecondsSinceEpoch ?? 0;


### PR DESCRIPTION
…es on click activity pin

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
