### PR TITLE
chore: only animate goal transitions in in-chat activity dropdown

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_dropdown_header.dart
+++ b/lib/routes/chat/activity_sessions/activity_dropdown_header.dart
@@ -10,6 +10,7 @@ class ActivityDropdownHeader extends StatelessWidget {
   final bool isGoalCompleted;
   final VoidCallback toggleShowDropdown;
   final Widget? trailing;
+  final bool animateGoalTransitions;
 
   const ActivityDropdownHeader({
     super.key,
@@ -17,11 +18,30 @@ class ActivityDropdownHeader extends StatelessWidget {
     required this.isGoalCompleted,
     required this.toggleShowDropdown,
     this.trailing,
+    this.animateGoalTransitions = true,
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final goalIndicator = Row(
+      key: ValueKey(goal.id),
+      children: [
+        Expanded(
+          child: GoalStatusWidget(
+            goal: goal,
+            complete: isGoalCompleted,
+            starTarget: ActivitySessionConstants.goalMenuStarTargetId(goal.id),
+            textStyle: const TextStyle(
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+        ?trailing,
+      ],
+    );
+
     return InkWell(
       onTap: toggleShowDropdown,
       child: Container(
@@ -30,56 +50,40 @@ class ActivityDropdownHeader extends StatelessWidget {
           border: Border(top: BorderSide(color: theme.dividerColor)),
           color: theme.colorScheme.surface,
         ),
-        child: AnimatedSwitcher(
-          duration: FluffyThemes.animationDuration,
-          transitionBuilder: (child, animation) {
-            final isCurrent = child.key == ValueKey(goal.id);
+        child: animateGoalTransitions
+            ? AnimatedSwitcher(
+                duration: FluffyThemes.animationDuration,
+                transitionBuilder: (child, animation) {
+                  final isCurrent = child.key == ValueKey(goal.id);
 
-            return ClipRect(
-              child: AnimatedBuilder(
-                animation: animation,
-                child: child,
-                builder: (context, child) {
-                  final offset = isCurrent
-                      // New item: 1 -> 0
-                      ? Offset(0, 1 - animation.value)
-                      // Old item: 0 -> -1
-                      : Offset(0, animation.value - 1);
+                  return ClipRect(
+                    child: AnimatedBuilder(
+                      animation: animation,
+                      child: child,
+                      builder: (context, child) {
+                        final offset = isCurrent
+                            // New item: 1 -> 0
+                            ? Offset(0, 1 - animation.value)
+                            // Old item: 0 -> -1
+                            : Offset(0, animation.value - 1);
 
-                  return FractionalTranslation(
-                    translation: offset,
-                    child: child,
+                        return FractionalTranslation(
+                          translation: offset,
+                          child: child,
+                        );
+                      },
+                    ),
                   );
                 },
-              ),
-            );
-          },
-          layoutBuilder: (currentChild, previousChildren) {
-            return Stack(
-              alignment: Alignment.centerLeft,
-              children: [...previousChildren, ?currentChild],
-            );
-          },
-          child: Row(
-            key: ValueKey(goal.id),
-            children: [
-              Expanded(
-                child: GoalStatusWidget(
-                  goal: goal,
-                  complete: isGoalCompleted,
-                  starTarget: ActivitySessionConstants.goalMenuStarTargetId(
-                    goal.id,
-                  ),
-                  textStyle: const TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-              ?trailing,
-            ],
-          ),
-        ),
+                layoutBuilder: (currentChild, previousChildren) {
+                  return Stack(
+                    alignment: Alignment.centerLeft,
+                    children: [...previousChildren, ?currentChild],
+                  );
+                },
+                child: goalIndicator,
+              )
+            : goalIndicator,
       ),
     );
   }

--- a/lib/routes/chat/activity_sessions/activity_goals_dropdown.dart
+++ b/lib/routes/chat/activity_sessions/activity_goals_dropdown.dart
@@ -87,6 +87,7 @@ class _ActivityGoalsDropdownState extends State<ActivityGoalsDropdown> {
                 trailing: remainingGoals.isNotEmpty
                     ? Icon(showDropdown ? Icons.expand_less : Icons.expand_more)
                     : null,
+                animateGoalTransitions: false,
               ),
             if (remainingGoals.isNotEmpty)
               ActivityDropdownContentContainer(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
