### PR TITLE
chore: move grammar construct flag button into appbar

### DIFF
--- a/lib/routes/analytics/activities/activity_archive.dart
+++ b/lib/routes/analytics/activities/activity_archive.dart
@@ -17,7 +17,6 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/analytics_navigation_util.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
 import 'package:fluffychat/widgets/activity_star_row.dart';
-import 'package:fluffychat/widgets/analytics_summary/learning_progress_indicators.dart';
 import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
 import 'package:fluffychat/widgets/hover_builder.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
@@ -26,11 +25,8 @@ import '../../../config/themes.dart';
 import '../../../widgets/avatar.dart';
 
 class ActivityArchive extends StatelessWidget {
-  /// When hosted inside the world map's right-docked analytics panel, hide the
-  /// cross-metric [LearningProgressIndicators] header (its tabs navigate to the
-  /// old left-column section routes). See routing.instructions.md.
-  final bool embedded;
-  const ActivityArchive({super.key, this.embedded = false});
+  final Widget closeButton;
+  const ActivityArchive({super.key, required this.closeButton});
 
   @override
   Widget build(BuildContext context) {
@@ -48,16 +44,25 @@ class ActivityArchive extends StatelessWidget {
           context,
         ).pathParameters['roomid'];
         return Scaffold(
+          appBar: AppBar(
+            leading: Center(child: closeButton),
+            title: Text(
+              L10n.of(context).stars,
+              style: FluffyThemes.isColumnMode(context)
+                  ? Theme.of(context).textTheme.titleLarge
+                  : Theme.of(context).textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+            ),
+            centerTitle: false,
+            titleSpacing: 0,
+          ),
           body: SafeArea(
             child: Padding(
               padding: const EdgeInsetsGeometry.all(16.0),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  if (!embedded)
-                    const LearningProgressIndicators(
-                      selected: ProgressIndicatorEnum.activities,
-                    ),
                   if (!analyticsService.hasInitError)
                     MaxWidthBody(
                       showBorder: false,

--- a/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
+++ b/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:async/async.dart';
@@ -8,6 +9,7 @@ import 'package:go_router/go_router.dart';
 import 'package:material_symbols_icons/symbols.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/analytics/construct_identifier.dart';
 import 'package:fluffychat/features/analytics/construct_level_enum.dart';
 import 'package:fluffychat/features/analytics/construct_type_enum.dart';
@@ -17,9 +19,12 @@ import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/pangea/common/widgets/feedback_dialog.dart';
+import 'package:fluffychat/pangea/common/widgets/feedback_response_dialog.dart';
 import 'package:fluffychat/pangea/lemmas/lemma_info_response.dart';
 import 'package:fluffychat/pangea/morphs/grammar_constructs_provider.dart';
 import 'package:fluffychat/pangea/morphs/morph_features_and_tags.dart';
+import 'package:fluffychat/routes/analytics/construct_analytics/analytics_download_button.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/construct_analytics_details/morph_details_view.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/construct_analytics_details/vocab_analytics_details_view.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/morph_analytics_list_view.dart';
@@ -35,16 +40,18 @@ import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 class ConstructAnalyticsView extends StatefulWidget {
-  const ConstructAnalyticsView({
-    super.key,
-    required this.view,
-    this.construct,
-    this.showPracticeButton = false,
-  });
-
   final ConstructTypeEnum view;
   final ConstructIdentifier? construct;
   final bool showPracticeButton;
+  final Widget closeButton;
+
+  const ConstructAnalyticsView({
+    super.key,
+    required this.view,
+    required this.closeButton,
+    this.construct,
+    this.showPracticeButton = false,
+  });
 
   @override
   ConstructAnalyticsViewState createState() => ConstructAnalyticsViewState();
@@ -246,7 +253,7 @@ class ConstructAnalyticsViewState extends State<ConstructAnalyticsView> {
 
   bool get selectMode => selectedConstructs.isNotEmpty;
 
-  Future<void> onFlagTokenInfo(
+  Future<void> onFlagVocabDetails(
     PangeaToken token,
     LemmaInfoResponse lemmaInfo,
     PTRequest ptRequest,
@@ -273,10 +280,81 @@ class ConstructAnalyticsViewState extends State<ConstructAnalyticsView> {
     );
   }
 
+  Future<void> onFlagGrammarDetails() async {
+    if (widget.view != ConstructTypeEnum.morph) return;
+
+    final construct = widget.construct;
+    final feature = construct?.category;
+    if (feature == null) return;
+
+    final l10n = L10n.of(context);
+    await showDialog(
+      context: context,
+      builder: (dialogContext) => FeedbackDialog(
+        title: l10n.grammarFeedbackDialogTitle,
+        onSubmit: (feedback) async {
+          Navigator.of(dialogContext).pop();
+          final result = await showFutureLoadingDialog(
+            context: context,
+            future: () => GrammarConstructsProvider.submitTagFeedback(
+              feature: feature,
+              feedback: feedback,
+            ),
+          );
+          if (!mounted || result.isError) return;
+          setState(() {});
+          await showDialog(
+            context: context,
+            builder: (context) => FeedbackResponseDialog(
+              title: l10n.grammarFeedbackDialogTitle,
+              feedback: L10n.of(context).grammarFeedbackSubmittedDesc,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final analyticsService = Matrix.of(context).analyticsDataService;
+    final title = widget.construct != null
+        ? null
+        : switch (widget.view) {
+            ConstructTypeEnum.morph => L10n.of(context).grammar,
+            ConstructTypeEnum.vocab => L10n.of(context).vocab,
+          };
+
+    final showDownload = kIsWeb && widget.construct == null;
+    final showReport =
+        widget.view == ConstructTypeEnum.morph && widget.construct != null;
+
     return Scaffold(
+      appBar: AppBar(
+        leading: Center(child: widget.closeButton),
+        title: title != null
+            ? Text(
+                title,
+                style: FluffyThemes.isColumnMode(context)
+                    ? Theme.of(context).textTheme.titleLarge
+                    : Theme.of(context).textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+              )
+            : null,
+        centerTitle: false,
+        titleSpacing: 0,
+        actions: [
+          if (showDownload) DownloadAnalyticsButton(),
+          if (showReport)
+            IconButton(
+              color: Theme.of(context).iconTheme.color,
+              icon: const Icon(Icons.flag_outlined),
+              tooltip: L10n.of(context).reportGrammarIssueTooltip,
+              onPressed: onFlagGrammarDetails,
+            ),
+        ],
+      ),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsetsGeometry.all(16.0),

--- a/lib/routes/analytics/construct_analytics/construct_analytics_details/morph_details_view.dart
+++ b/lib/routes/analytics/construct_analytics/construct_analytics_details/morph_details_view.dart
@@ -3,9 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:fluffychat/features/analytics/construct_identifier.dart';
 import 'package:fluffychat/features/analytics/construct_level_enum.dart';
 import 'package:fluffychat/features/analytics/construct_use_model.dart';
-import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/pangea/common/widgets/feedback_dialog.dart';
-import 'package:fluffychat/pangea/common/widgets/feedback_response_dialog.dart';
 import 'package:fluffychat/pangea/morphs/grammar_construct_example.dart';
 import 'package:fluffychat/pangea/morphs/grammar_constructs_provider.dart';
 import 'package:fluffychat/pangea/morphs/morph_features_enum.dart';
@@ -13,57 +10,12 @@ import 'package:fluffychat/pangea/morphs/morph_icon.dart';
 import 'package:fluffychat/pangea/morphs/morph_meaning_widget.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/construct_analytics_details/analytics_details_usage_content.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/construct_analytics_details/construct_xp_progress_bar.dart';
-import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
-class MorphDetailsView extends StatefulWidget {
+class MorphDetailsView extends StatelessWidget {
   final ConstructIdentifier constructId;
-
   const MorphDetailsView({required this.constructId, super.key});
-
-  @override
-  State<MorphDetailsView> createState() => _MorphDetailsViewState();
-}
-
-class _MorphDetailsViewState extends State<MorphDetailsView> {
-  /// Bumped after a feedback regen so the meaning content remounts and
-  /// re-reads the (now updated) grammar constructs cache.
-  int _regenCount = 0;
-
-  ConstructIdentifier get constructId => widget.constructId;
-
-  /// The flag flow (#6839): collect feedback, send it to the choreographer
-  /// (which regenerates the feature's meaning bundle in place — choreo
-  /// #2548), then remount the meaning content to show the corrected copy.
-  Future<void> _flagMeaning(String feature) async {
-    final l10n = L10n.of(context);
-    await showDialog(
-      context: context,
-      builder: (dialogContext) => FeedbackDialog(
-        title: l10n.grammarFeedbackDialogTitle,
-        onSubmit: (feedback) async {
-          Navigator.of(dialogContext).pop();
-          final result = await showFutureLoadingDialog(
-            context: context,
-            future: () => GrammarConstructsProvider.submitTagFeedback(
-              feature: feature,
-              feedback: feedback,
-            ),
-          );
-          if (!mounted || result.isError) return;
-          setState(() => _regenCount++);
-          await showDialog(
-            context: context,
-            builder: (context) => FeedbackResponseDialog(
-              title: l10n.grammarFeedbackDialogTitle,
-              feedback: L10n.of(context).grammarFeedbackSubmittedDesc,
-            ),
-          );
-        },
-      ),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -107,75 +59,59 @@ class _MorphDetailsViewState extends State<MorphDetailsView> {
         return MaxWidthBody(
           maxWidth: 600.0,
           showBorder: false,
-          child: Stack(
+          child: Column(
+            spacing: 16.0,
             children: [
-              Column(
-                key: ValueKey('morph-details-$_regenCount'),
-                spacing: 16.0,
-                children: [
-                  if (localizedTag != null)
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        SizedBox(
-                          width: 32.0,
-                          height: 32.0,
-                          child: MorphIcon(feature: featureEnum, tag: tag),
-                        ),
-                        const SizedBox(width: 10.0),
-                        Text(
-                          localizedTag.title,
-                          style: Theme.of(
-                            context,
-                          ).textTheme.titleLarge?.copyWith(color: textColor),
-                        ),
-                      ],
+              if (localizedTag != null)
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    SizedBox(
+                      width: 32.0,
+                      height: 32.0,
+                      child: MorphIcon(feature: featureEnum, tag: tag),
                     ),
-                  if (localizedFeature != null)
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        SizedBox(
-                          width: 24.0,
-                          height: 24.0,
-                          child: MorphIcon(feature: featureEnum),
-                        ),
-                        const SizedBox(width: 10.0),
-                        Text(
-                          localizedFeature.title,
-                          style: Theme.of(context).textTheme.titleMedium,
-                        ),
-                      ],
-                    ),
-                  MorphMeaningWidget(
-                    feature: feature,
-                    tag: tag,
-                    style: Theme.of(context).textTheme.bodyLarge,
-                  ),
-                  if (localizedTag != null)
-                    GrammarConstructExample(tag: localizedTag),
-                  const Divider(),
-                  if (construct != null) ...[
-                    ConstructXPProgressBar(construct: construct.id),
-                    Padding(
-                      padding: const EdgeInsets.all(20.0),
-                      child: AnalyticsDetailsUsageContent(construct: construct),
+                    const SizedBox(width: 10.0),
+                    Text(
+                      localizedTag.title,
+                      style: Theme.of(
+                        context,
+                      ).textTheme.titleLarge?.copyWith(color: textColor),
                     ),
                   ],
-                ],
-              ),
-              // Flag in the top right, like the vocab word card (#6839).
-              Positioned(
-                top: 0.0,
-                right: 0.0,
-                child: IconButton(
-                  color: Theme.of(context).iconTheme.color,
-                  icon: const Icon(Icons.flag_outlined),
-                  tooltip: L10n.of(context).reportGrammarIssueTooltip,
-                  onPressed: () => _flagMeaning(feature),
                 ),
+              if (localizedFeature != null)
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    SizedBox(
+                      width: 24.0,
+                      height: 24.0,
+                      child: MorphIcon(feature: featureEnum),
+                    ),
+                    const SizedBox(width: 10.0),
+                    Text(
+                      localizedFeature.title,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                  ],
+                ),
+              MorphMeaningWidget(
+                feature: feature,
+                tag: tag,
+                style: Theme.of(context).textTheme.bodyLarge,
               ),
+              if (localizedTag != null)
+                GrammarConstructExample(tag: localizedTag),
+              const Divider(),
+              if (construct != null) ...[
+                ConstructXPProgressBar(construct: construct.id),
+                Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: AnalyticsDetailsUsageContent(construct: construct),
+                ),
+              ],
             ],
           ),
         );

--- a/lib/routes/analytics/construct_analytics/construct_analytics_details/vocab_analytics_details_view.dart
+++ b/lib/routes/analytics/construct_analytics/construct_analytics_details/vocab_analytics_details_view.dart
@@ -98,7 +98,7 @@ class VocabDetailsView extends StatelessWidget {
                         LemmaInfoResponse lemmaInfo,
                         PTRequest ptRequest,
                         PTResponse ptResponse,
-                      ) => controller.onFlagTokenInfo(
+                      ) => controller.onFlagVocabDetails(
                         token,
                         lemmaInfo,
                         ptRequest,

--- a/lib/routes/analytics/level/level_analytics_details_content.dart
+++ b/lib/routes/analytics/level/level_analytics_details_content.dart
@@ -9,19 +9,12 @@ import 'package:fluffychat/features/instructions/instructions_enum.dart';
 import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/morphs/grammar_constructs_provider.dart';
-import 'package:fluffychat/widgets/analytics_summary/learning_progress_indicators.dart';
-import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/users/level_ribbon.dart';
 
 class LevelAnalyticsDetailsContent extends StatelessWidget {
-  /// When hosted inside the world map's right-docked analytics panel, hide the
-  /// cross-metric [LearningProgressIndicators] header — the panel card already
-  /// carries the title and close control, and the metric switcher belongs to the
-  /// cluster, not the docked tab. Mirrors `ConstructAnalyticsView.embedded`.
-  final bool embedded;
-
-  const LevelAnalyticsDetailsContent({super.key, this.embedded = false});
+  final Widget closeButton;
+  const LevelAnalyticsDetailsContent({super.key, required this.closeButton});
 
   @override
   Widget build(BuildContext context) {
@@ -31,6 +24,19 @@ class LevelAnalyticsDetailsContent extends StatelessWidget {
         MatrixState.pangeaController.userController.userL2?.langCodeShort;
 
     return Scaffold(
+      appBar: AppBar(
+        leading: Center(child: closeButton),
+        title: Text(
+          L10n.of(context).level,
+          style: FluffyThemes.isColumnMode(context)
+              ? Theme.of(context).textTheme.titleLarge
+              : Theme.of(
+                  context,
+                ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        centerTitle: false,
+        titleSpacing: 0,
+      ),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsetsGeometry.all(16.0),
@@ -40,11 +46,6 @@ class LevelAnalyticsDetailsContent extends StatelessWidget {
             builder: (context, _) {
               return Column(
                 children: [
-                  if (!embedded)
-                    const LearningProgressIndicators(
-                      selected: ProgressIndicatorEnum.level,
-                      canSelect: false,
-                    ),
                   FutureBuilder(
                     future: language != null
                         ? analyticsService.derivedData(language)

--- a/lib/routes/world/right_panel/right_panel_analytics_subpage.dart
+++ b/lib/routes/world/right_panel/right_panel_analytics_subpage.dart
@@ -1,14 +1,11 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/features/analytics/construct_type_enum.dart';
 import 'package:fluffychat/features/navigation/token_params/analytics_token.dart';
-import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/activities/activity_archive.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/analytics_details_popup.dart';
-import 'package:fluffychat/routes/analytics/construct_analytics/analytics_download_button.dart';
 import 'package:fluffychat/routes/analytics/level/level_analytics_details_content.dart';
-import 'package:fluffychat/routes/world/right_panel/panel_card_with_header.dart';
+import 'package:fluffychat/routes/world/panel_card.dart';
 import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
 
 class RightPanelAnalyticsSubpage extends StatelessWidget {
@@ -27,46 +24,35 @@ class RightPanelAnalyticsSubpage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final l10n = L10n.of(context);
-
     final tab = param?.subpage;
-    final title = switch (tab) {
-      ProgressIndicatorEnum.morphsUsed => l10n.grammar,
-      ProgressIndicatorEnum.activities => l10n.stars,
-      ProgressIndicatorEnum.level => l10n.level,
-      _ => l10n.vocab,
-    };
-
-    final child = switch (tab) {
-      ProgressIndicatorEnum.morphsUsed => ConstructAnalyticsView(
-        view: ConstructTypeEnum.morph,
-        // The Practice FAB (→ /practice/morph). Without this the panel had
-        // no way to reach practice — the entry point the world_v2 migration
-        // dropped. See routing.instructions.md.
-        showPracticeButton: true,
-      ),
-      ProgressIndicatorEnum.activities => const ActivityArchive(embedded: true),
-      ProgressIndicatorEnum.level => const LevelAnalyticsDetailsContent(
-        embedded: true,
-      ),
-      _ => const ConstructAnalyticsView(
-        view: ConstructTypeEnum.vocab,
-        showPracticeButton: true, // the Practice FAB (→ /practice/vocab)
-      ),
-    };
-
-    final showDownload =
-        kIsWeb &&
-        (tab == ProgressIndicatorEnum.morphsUsed ||
-            tab == ProgressIndicatorEnum.wordsUsed);
-
-    return PanelCardWithHeader(
-      title: title,
-      icon: icon,
-      onLeading: onLeading,
-      trailing: showDownload ? DownloadAnalyticsButton() : null,
+    final closeButton = IconButton(
       tooltip: tooltip,
-      child: child,
+      icon: Icon(icon),
+      onPressed: onLeading,
+    );
+
+    return PanelCard(
+      child: switch (tab) {
+        ProgressIndicatorEnum.morphsUsed => ConstructAnalyticsView(
+          view: ConstructTypeEnum.morph,
+          // The Practice FAB (→ /practice/morph). Without this the panel had
+          // no way to reach practice — the entry point the world_v2 migration
+          // dropped. See routing.instructions.md.
+          showPracticeButton: true,
+          closeButton: closeButton,
+        ),
+        ProgressIndicatorEnum.activities => ActivityArchive(
+          closeButton: closeButton,
+        ),
+        ProgressIndicatorEnum.level => LevelAnalyticsDetailsContent(
+          closeButton: closeButton,
+        ),
+        _ => ConstructAnalyticsView(
+          view: ConstructTypeEnum.vocab,
+          showPracticeButton: true, // the Practice FAB (→ /practice/vocab)
+          closeButton: closeButton,
+        ),
+      },
     );
   }
 }

--- a/lib/routes/world/right_panel/workspace_right_panel.dart
+++ b/lib/routes/world/right_panel/workspace_right_panel.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
@@ -11,7 +10,6 @@ import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/analytics_details_popup.dart';
-import 'package:fluffychat/routes/analytics/construct_analytics/analytics_download_button.dart';
 import 'package:fluffychat/routes/world/panel_card.dart';
 import 'package:fluffychat/routes/world/right_panel/panel_card_with_header.dart';
 import 'package:fluffychat/routes/world/right_panel/right_panel_analytics_practice_subpage.dart';
@@ -143,31 +141,27 @@ class WorkspaceRightPanel extends StatelessWidget {
                 ),
               );
       case VocabAnalyticsPanelToken(param: final param):
-        return PanelCardWithHeader(
-          title: '',
-          icon: leadingIcon,
-          onLeading: onLeading,
-          tooltip: leadingTooltip,
-          trailing: kIsWeb && param?.constructId == null
-              ? DownloadAnalyticsButton()
-              : null,
+        return PanelCard(
           child: ConstructAnalyticsView(
             view: ConstructTypeEnum.vocab,
             construct: param?.constructId,
+            closeButton: IconButton(
+              tooltip: leadingTooltip,
+              icon: Icon(leadingIcon),
+              onPressed: onLeading,
+            ),
           ),
         );
       case GrammarAnalyticsPanelToken(param: final param):
-        return PanelCardWithHeader(
-          title: '',
-          icon: leadingIcon,
-          onLeading: onLeading,
-          tooltip: leadingTooltip,
-          trailing: kIsWeb && param?.constructId == null
-              ? DownloadAnalyticsButton()
-              : null,
+        return PanelCard(
           child: ConstructAnalyticsView(
             view: ConstructTypeEnum.morph,
             construct: param?.constructId,
+            closeButton: IconButton(
+              tooltip: leadingTooltip,
+              icon: Icon(leadingIcon),
+              onPressed: onLeading,
+            ),
           ),
         );
       case AnalyticsPracticePanelToken(param: final param):


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
