### PR TITLE
Keep the chat list open when leaving/deleting a chat; reset to home when leaving a course (#7561)

### DIFF
--- a/.github/instructions/routing.instructions.md
+++ b/.github/instructions/routing.instructions.md
@@ -133,11 +133,16 @@ token over the course-scoped map.
 switching panels — closing the course card itself, tapping an activity pin,
 moving to Chats or Settings — all leave `?c=` untouched; closing panels is
 precisely how you get a clear look at the scoped map (#7087). The context
-changes in exactly two ways: selecting another **course** replaces it, and the
-**World/home** control clears it — the one deliberate full reset, dropping every
-open panel *and* the context together in one history step so the back button
-restores both. Surfaces that carry no context of their own (the Courses hub,
-Chats, Settings) overlay the map you left without changing it.
+changes in three ways: selecting another **course** replaces it; the
+**World/home** control clears it; and **leaving or deleting the course you are
+in** clears it. The latter two are the same deliberate full reset — dropping
+every open panel *and* the context together in one history step (so the back
+button restores both) and revealing the world map at its personal default.
+Leaving or deleting a *course* is the only membership change that resets scope:
+leaving or deleting a chat, DM, or activity just drops that one panel and leaves
+the rest of the workspace — notably the list it sat in — standing (#7561).
+Surfaces that carry no context of their own (the Courses hub, Chats, Settings)
+overlay the map you left without changing it.
 
 Pure **map filters** (region, language, activity kind) are a future, separate
 `?m=` list — display refinement, not workspace context. Nothing uses it today.

--- a/lib/features/navigation/room_close_location.dart
+++ b/lib/features/navigation/room_close_location.dart
@@ -1,8 +1,13 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:go_router/go_router.dart';
+
 import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/token_params/room_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
+import 'package:fluffychat/utils/navigation_util.dart';
 
 /// The location that closes an open room-panel token for [roomId]: it drops
 /// ONLY that token, so the rest of the workspace — notably the chat list —
@@ -31,4 +36,32 @@ String? roomTokenCloseLocation(Uri uri, String? roomId) {
   }
 
   return null;
+}
+
+/// Close the open room panel for [roomId] after leaving or deleting it from a
+/// surface that is NOT the room itself — a chat-list (or course-chat-list) row's
+/// context menu. Drops ONLY that room's token, so the list it sits in stays open
+/// and the surviving `?c=` scope decides which is revealed beneath: the chat
+/// list, or the course card of a course-scoped list (#7561). When the room isn't
+/// open as a panel there is nothing to close, so the workspace is left untouched
+/// and the list drops the row reactively — navigating unconditionally here is
+/// what closed the list before. See `routing.instructions.md`.
+void closeRoomPanelFromList(BuildContext context, String roomId) {
+  final close = roomTokenCloseLocation(GoRouterState.of(context).uri, roomId);
+  if (close != null) context.go(close);
+}
+
+/// Close the open room panel for [roomId] after leaving or deleting it from the
+/// room's OWN surface — its in-chat menu or its details page. Drops that room's
+/// token so what's beneath survives (the chat list, or the course card it was
+/// opened over) (#7561). Falls back to the bare workspace exit only when the room
+/// isn't a token panel (a legacy pushed route), so the user is never stranded on
+/// the surface of the room they just left. See `routing.instructions.md`.
+void closeOwnRoomPanel(BuildContext context, String roomId) {
+  final close = roomTokenCloseLocation(GoRouterState.of(context).uri, roomId);
+  if (close != null) {
+    context.go(close);
+  } else {
+    NavigationUtil.goToSpaceRoute(null, const [], context);
+  }
 }

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -404,17 +404,7 @@ class ChatController extends State<ChatPageWithRoom>
   /// Close ONLY the left room's token after the user leaves it — the rest of
   /// the workspace, notably the chat list, survives (#7561). Falls back to the
   /// bare exit when the room isn't open as a token (a pushed route).
-  void _closeLeftRoom() {
-    final close = roomTokenCloseLocation(
-      GoRouterState.of(context).uri,
-      room.id,
-    );
-    if (close != null) {
-      context.go(close);
-    } else {
-      NavigationUtil.goToSpaceRoute(null, [], context);
-    }
-  }
+  void _closeLeftRoom() => closeOwnRoomPanel(context, room.id);
 
   // #Pangea
   // void requestHistory([dynamic _]) async {

--- a/lib/routes/chat/chat_details/chat_context_menu_action.dart
+++ b/lib/routes/chat/chat_details/chat_context_menu_action.dart
@@ -6,7 +6,6 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/features/navigation/room_close_location.dart';
-import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
@@ -294,8 +293,11 @@ void chatContextMenuAction(
       }
 
       if (!resp.isError) {
+        // Leaving a whole course is the World/home reset: drop every panel and
+        // the `?c=` scope, back to the world map at its personal default. A
+        // chat/DM/activity instead just drops its own panel (closeRoomPanelFromList).
         isSpace
-            ? context.go(PRoutes.chatsList)
+            ? outerContext.go(WorkspaceNav.clearAll())
             : closeRoomPanelFromList(outerContext, room.id);
       }
 

--- a/lib/routes/chat/chat_details/chat_context_menu_action.dart
+++ b/lib/routes/chat/chat_details/chat_context_menu_action.dart
@@ -5,6 +5,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/features/navigation/room_close_location.dart';
 import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
@@ -13,7 +14,6 @@ import 'package:fluffychat/routes/chat/chat_details/delete_room_extension.dart';
 import 'package:fluffychat/routes/chat/chat_details/delete_space_dialog.dart';
 import 'package:fluffychat/routes/chat_list/chat_list.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
-import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
@@ -296,7 +296,7 @@ void chatContextMenuAction(
       if (!resp.isError) {
         isSpace
             ? context.go(PRoutes.chatsList)
-            : NavigationUtil.goToSpaceRoute(null, [], outerContext);
+            : closeRoomPanelFromList(outerContext, room.id);
       }
 
       return;
@@ -318,7 +318,7 @@ void chatContextMenuAction(
           future: room.delete,
         );
         if (!resp.isError) {
-          NavigationUtil.goToSpaceRoute(null, [], outerContext);
+          closeRoomPanelFromList(outerContext, room.id);
         }
       }
       return;

--- a/lib/routes/chat/chat_details/chat_details_button_row.dart
+++ b/lib/routes/chat/chat_details/chat_details_button_row.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/navigation/room_close_location.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/chat_details/chat_details.dart';
@@ -150,7 +151,7 @@ class ChatDetailsButtonRowState extends State<ChatDetailsButtonRow> {
             future: room.leave,
           );
           if (!resp.isError) {
-            NavigationUtil.goToSpaceRoute(null, [], context);
+            closeOwnRoomPanel(context, room.id);
           }
         },
         enabled: room.membership == Membership.join,
@@ -175,7 +176,7 @@ class ChatDetailsButtonRowState extends State<ChatDetailsButtonRow> {
             future: room.delete,
           );
           if (resp.isError) return;
-          NavigationUtil.goToSpaceRoute(null, [], context);
+          closeOwnRoomPanel(context, room.id);
         },
         enabled: room.isRoomAdmin,
         visible: !room.isDirectChat,

--- a/lib/routes/chat/chat_details/delete_space_dialog.dart
+++ b/lib/routes/chat/chat_details/delete_space_dialog.dart
@@ -4,7 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/themes.dart';
-import 'package:fluffychat/features/navigation/route_paths.dart';
+import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/chat_details/delete_room_extension.dart';
@@ -51,7 +51,9 @@ class DeleteSpaceDialog extends StatefulWidget {
     );
 
     if (!result.isError) {
-      context.go(PRoutes.chatsList);
+      // Deleting a course is the World/home reset (parity with leaving one):
+      // drop every panel and the `?c=` scope, back to the world map.
+      context.go(WorkspaceNav.clearAll());
     }
   }
 

--- a/lib/routes/chat/chat_details/space_details_content.dart
+++ b/lib/routes/chat/chat_details/space_details_content.dart
@@ -13,7 +13,6 @@ import 'package:fluffychat/features/instructions/instructions_enum.dart';
 import 'package:fluffychat/features/instructions/instructions_inline_tooltip.dart';
 import 'package:fluffychat/features/join_codes/join_rule_extension.dart';
 import 'package:fluffychat/features/join_codes/share_room_button.dart';
-import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/features/navigation/token_params/room_subpage_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
@@ -299,7 +298,9 @@ class SpaceDetailsContent extends StatelessWidget {
             future: room.leaveSpace,
           );
           if (!resp.isError) {
-            context.go(PRoutes.chatsList);
+            // Leaving a course is the World/home reset: drop every panel and the
+            // `?c=` scope, back to the world map at its personal default.
+            context.go(WorkspaceNav.clearAll());
           }
         },
         enabled: room.membership == Membership.join,

--- a/test/pangea/navigation/leave_delete_close_test.dart
+++ b/test/pangea/navigation/leave_delete_close_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:fluffychat/features/navigation/panel_types_enum.dart';
+import 'package:fluffychat/features/navigation/room_close_location.dart';
+import 'package:fluffychat/features/navigation/route_facts.dart';
+
+/// Behavioral coverage for the leave/delete close helpers (#7561): leaving or
+/// deleting a chat must close ONLY that chat's panel and never the list it sits
+/// in. `closeRoomPanelFromList` drives the chat-list / course-chat-list context
+/// menus; `closeOwnRoomPanel` drives the chat's own in-view menu and details
+/// page. Both delegate to `roomTokenCloseLocation` (unit-tested separately in
+/// activity_room_close_test.dart) — here we pin the navigate-vs-no-op contract
+/// that the earlier bug got wrong.
+void main() {
+  /// Pump a GoRouter at [initialLocation], invoke [onTap] with the button's
+  /// (in-shell) context, and return the resulting location after it settles.
+  Future<Uri> tapClose(
+    WidgetTester tester,
+    String initialLocation,
+    void Function(BuildContext) onTap,
+  ) async {
+    final router = GoRouter(
+      initialLocation: initialLocation,
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => Scaffold(
+            body: TextButton(
+              onPressed: () => onTap(context),
+              child: const Text('close'),
+            ),
+          ),
+        ),
+      ],
+    );
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('close'));
+    await tester.pumpAndSettle();
+    return router.routerDelegate.currentConfiguration.uri;
+  }
+
+  group('closeRoomPanelFromList — leaving from a list row (#7561)', () {
+    testWidgets('leaving an open chat keeps the chat list', (tester) async {
+      final uri = await tapClose(
+        tester,
+        '/?left=chats,room:!abc',
+        (c) => closeRoomPanelFromList(c, '!abc'),
+      );
+      final left = parseOpenPanels(uri).left.map((t) => t.type);
+      expect(left, [PanelTypesEnum.chats]); // list survives, room dropped
+    });
+
+    testWidgets('leaving an open chat from a course-scoped list keeps the '
+        'course card and the course context', (tester) async {
+      final uri = await tapClose(
+        tester,
+        '/?c=!course&left=course,room:!abc',
+        (c) => closeRoomPanelFromList(c, '!abc'),
+      );
+      expect(parseOpenPanels(uri).left.map((t) => t.type), [
+        PanelTypesEnum.course,
+      ]);
+      expect(activeSpaceIdFor(uri), '!course'); // scope survives
+    });
+
+    testWidgets('leaving a chat that is NOT open does not navigate — the chat '
+        'list stays exactly as it was', (tester) async {
+      final uri = await tapClose(
+        tester,
+        '/?left=chats',
+        (c) => closeRoomPanelFromList(c, '!notopen'),
+      );
+      // The pre-fix bug: an unconditional goToSpaceRoute here cleared the list
+      // to the bare world map. There is nothing to close, so nothing moves.
+      expect(uri.toString(), '/?left=chats');
+    });
+
+    testWidgets('leaving a chat that is NOT open from a course-scoped list '
+        'leaves that list untouched', (tester) async {
+      final uri = await tapClose(
+        tester,
+        '/?c=!course&left=course',
+        (c) => closeRoomPanelFromList(c, '!notopen'),
+      );
+      expect(parseOpenPanels(uri).left.map((t) => t.type), [
+        PanelTypesEnum.course,
+      ]);
+      expect(activeSpaceIdFor(uri), '!course');
+    });
+  });
+
+  group('closeOwnRoomPanel — leaving from the chat\'s own surface (#7561)', () {
+    testWidgets('leaving the open chat drops its panel, keeping the chat list', (
+      tester,
+    ) async {
+      final uri = await tapClose(
+        tester,
+        '/?left=chats,room:!abc',
+        (c) => closeOwnRoomPanel(c, '!abc'),
+      );
+      expect(parseOpenPanels(uri).left.map((t) => t.type), [
+        PanelTypesEnum.chats,
+      ]);
+    });
+
+    testWidgets('falls back to the bare workspace exit when the room is not a '
+        'token panel', (tester) async {
+      final uri = await tapClose(
+        tester,
+        '/?left=chats',
+        (c) => closeOwnRoomPanel(c, '!notopen'),
+      );
+      // No matching room token -> the defensive fallback exits to the world map
+      // rather than stranding the user on the room they just left.
+      expect(uri.path, '/');
+      expect(parseOpenPanels(uri).left, isEmpty);
+      expect(activeSpaceIdFor(uri), isNull);
+    });
+  });
+}


### PR DESCRIPTION
Fixes #7561.

## Problem

The earlier fix (#7620) routed only the in-chat and activity-session leave paths through the token-preserving close. Three other entry points still called `NavigationUtil.goToSpaceRoute(null, [], ...)`, which with no course context clears the whole workspace to the world map, taking the chat list with it:

- the chat-list (and course-chat-list) row "More options" menu: Leave and Delete
- the chat details page: Leave and Delete

## Fix

Two small shared helpers in `room_close_location.dart`, both delegating to the existing `roomTokenCloseLocation`:

- `closeRoomPanelFromList` for list context menus: drops the room's token if it is open, otherwise does nothing. Leaving a chat that is not open as a panel should not navigate at all, which was the core bug.
- `closeOwnRoomPanel` for the chat's own surfaces (details page, in-chat menu): drops the token, with the existing defensive exit fallback. `_closeLeftRoom` now delegates to it, so there is one implementation.

This satisfies the reported requirements straight from the routing model (closing a panel just drops its token, never from remembering where the user came from):

- Leaving a chat opened from the chat list keeps the chat list.
- Leaving a chat opened from the course chat list keeps the course card and the `?c=` scope.
- Leave and delete now share the same closure behavior.

Leaving or deleting a whole **course** is different, and is now correct too: it resets to the home world map (drops every panel and the `?c=` scope, revealing the personal default), the same reset as the World/home control, instead of dumping you on the chat list. That decision is captured in `routing.instructions.md`.

## Testing

- New widget tests in `test/pangea/navigation/leave_delete_close_test.dart` drive a real GoRouter through every case, including the "not open, so no navigation" case. Full navigation suite passes (280 tests); `dart analyze` clean.
- Verified live in the web client (local stack, throwaway rooms):
  - Details-page Leave: `?left=chats,room:x/details` collapses to `?left=chats`, room gone, list stays.
  - Context-menu Leave on a chat that is not open: URL stays `?left=chats` (no navigation), row removed, list stays.
  - No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved navigation when leaving or deleting courses, chats, direct messages, and activities.
  * Leaving or deleting a course now clears its context and all open panels in one step.
  * Leaving or deleting an individual room closes only that panel while preserving surrounding lists and workspace context.

* **Bug Fixes**
  * Corrected fallback navigation to the World/home workspace when no room panel is open.

* **Tests**
  * Added coverage for panel-closing and workspace navigation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->