### PR TITLE
fix: remove options to manually edit grammar construct descriptions

### DIFF
--- a/lib/pangea/morphs/grammar_constructs_provider.dart
+++ b/lib/pangea/morphs/grammar_constructs_provider.dart
@@ -88,50 +88,6 @@ class GrammarConstructsProvider {
     return defaultFeaturesAndTags;
   }
 
-  static Future<void> setTagDescription({
-    required String feature,
-    required String tag,
-    required String description,
-  }) async {
-    final request = _request;
-    final constructsResult = await GrammarConstructsRepo.instance.get(request);
-    final constructs = constructsResult.result;
-    if (constructs == null) {
-      Logs().w("Failed to fetch grammar constructs in setTagDescription");
-      return;
-    }
-
-    final features = constructs.features;
-    final featureIndex = features.indexWhere((f) => f.value == feature);
-    if (featureIndex == -1) {
-      Logs().w("Feature $feature not found in setTagDescription");
-      return;
-    }
-
-    final tags = features[featureIndex].tags;
-    final tagIndex = tags.indexWhere((t) => t.value == tag);
-    if (tagIndex == -1) {
-      Logs().w("Tag $tag not found in setTagDescription");
-      return;
-    }
-
-    final currentTag = tags[tagIndex];
-    final updatedTag = currentTag.copyWith(description: description);
-
-    final updatedTags = List<GrammarTag>.from(tags);
-    updatedTags[tagIndex] = updatedTag;
-
-    final currentFeature = features[featureIndex];
-    final updatedFeature = currentFeature.copyWith(tags: updatedTags);
-
-    final updatedFeatures = List<GrammarFeature>.from(features);
-    updatedFeatures[featureIndex] = updatedFeature;
-
-    final updatedConstructs = constructs.copyWith(features: updatedFeatures);
-    await GrammarConstructsRepo.instance.setCached(request, updatedConstructs);
-    MorphFeaturesAndTags.clearLookupCache();
-  }
-
   /// Flag a grammar meaning (#6839): send the user's feedback to the
   /// choreographer, which regenerates the feature's meaning bundle in
   /// place and returns it (choreo #2548). The regenerated titles and

--- a/lib/pangea/morphs/morph_meaning_widget.dart
+++ b/lib/pangea/morphs/morph_meaning_widget.dart
@@ -2,9 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
-import 'package:sentry_flutter/sentry_flutter.dart';
-
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/utils/async_state.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/morphs/grammar_constructs_provider.dart';
 import 'package:fluffychat/pangea/morphs/grammar_constructs_response.dart';
@@ -29,9 +28,11 @@ class MorphMeaningWidget extends StatefulWidget {
 }
 
 class MorphMeaningWidgetState extends State<MorphMeaningWidget> {
-  GrammarTag? _tag;
-  bool _isLoading = true;
-  bool _editMode = false;
+  final ValueNotifier<AsyncState<GrammarTag>> _loader = ValueNotifier(
+    AsyncLoading(),
+  );
+
+  int _generation = 0;
 
   @override
   void initState() {
@@ -49,152 +50,54 @@ class MorphMeaningWidgetState extends State<MorphMeaningWidget> {
 
   @override
   void dispose() {
-    _controller.dispose();
+    _loader.dispose();
     super.dispose();
   }
 
-  final _controller = TextEditingController();
-
-  String get _blankDescription =>
-      widget.blankErrorFeedback ? '' : L10n.of(context).meaningNotFound;
-
-  void _setEditMode(bool value) => setState(() => _editMode = value);
+  void _setLoaderValue(AsyncState<GrammarTag> value, int generation) {
+    if (mounted && _generation == generation) {
+      _loader.value = value;
+    }
+  }
 
   Future<void> _loadMorphMeaning() async {
-    if (mounted) {
-      setState(() {
-        _isLoading = true;
-        _tag = null;
-      });
-    }
+    _generation++;
+    final generation = _generation;
 
-    final tag = await GrammarConstructsProvider.fetchTag(
-      feature: widget.feature,
-      tag: widget.tag,
-    );
-
-    final description = tag?.description ?? _blankDescription;
-    _controller.text = description;
-
-    if (mounted) {
-      setState(() {
-        _isLoading = false;
-        _tag = tag;
-      });
-    }
-  }
-
-  Future<void> _setMorphMeaning() async {
-    final text = _controller.text;
-    if (text.isEmpty || text == _tag?.description) {
-      return;
-    }
+    _setLoaderValue(AsyncLoading(), generation);
 
     try {
-      await GrammarConstructsProvider.setTagDescription(
+      final tag = await GrammarConstructsProvider.fetchTag(
         feature: widget.feature,
         tag: widget.tag,
-        description: text,
-      ).timeout(Duration(seconds: 10));
-    } catch (e, s) {
-      if (e is TimeoutException) {
-        ErrorHandler.logError(e: e, s: s, data: {}, level: SentryLevel.warning);
-      }
-    }
-
-    if (mounted) {
-      _setEditMode(false);
-      _loadMorphMeaning();
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (_isLoading) {
-      return const TextLoadingShimmer();
-    }
-
-    if (_editMode && _tag != null) {
-      return MorphEditView(
-        tag: _tag!,
-        controller: _controller,
-        exit: () => _setEditMode(false),
-        save: _setMorphMeaning,
       );
+
+      if (tag == null) throw 'Tag not found';
+      _setLoaderValue(AsyncLoaded(tag), generation);
+    } catch (e, s) {
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {'feature': widget.feature, 'tag': widget.tag},
+      );
+      _setLoaderValue(AsyncError(e), generation);
     }
-
-    return Tooltip(
-      triggerMode: TooltipTriggerMode.tap,
-      message: L10n.of(context).doubleClickToEdit,
-      child: GestureDetector(
-        onLongPress: () => _setEditMode(true),
-        onDoubleTap: () => _setEditMode(true),
-        child: Text(
-          textAlign: TextAlign.center,
-          _tag?.description ?? L10n.of(context).meaningNotFound,
-          style: widget.style,
-        ),
-      ),
-    );
   }
-}
-
-class MorphEditView extends StatelessWidget {
-  final GrammarTag tag;
-  final VoidCallback exit;
-  final VoidCallback save;
-  final TextEditingController controller;
-
-  const MorphEditView({
-    required this.tag,
-    required this.exit,
-    required this.save,
-    required this.controller,
-    super.key,
-  });
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      spacing: 10.0,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Text(
-          "${L10n.of(context).pangeaBotIsFallible} ${L10n.of(context).whatIsMeaning(tag.title, '')}",
-          textAlign: TextAlign.center,
-          style: const TextStyle(fontStyle: FontStyle.italic),
-        ),
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: TextField(minLines: 1, maxLines: 3, controller: controller),
-        ),
-        Row(
-          spacing: 10.0,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ElevatedButton(
-              onPressed: exit,
-              style: ElevatedButton.styleFrom(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.0),
-                ),
-                padding: const EdgeInsets.symmetric(horizontal: 10),
-              ),
-              child: Text(L10n.of(context).cancel),
-            ),
-            ElevatedButton(
-              onPressed: save,
-              style: ElevatedButton.styleFrom(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.0),
-                ),
-                padding: const EdgeInsets.symmetric(horizontal: 10),
-              ),
-              child: Text(L10n.of(context).saveChanges),
-            ),
-          ],
-        ),
-      ],
-    );
+    return switch (_loader.value) {
+      AsyncLoading() || AsyncIdle() => const TextLoadingShimmer(),
+      AsyncError() => Text(
+        textAlign: TextAlign.center,
+        L10n.of(context).meaningNotFound,
+        style: widget.style,
+      ),
+      AsyncLoaded(value: final tag) => Text(
+        textAlign: TextAlign.center,
+        tag.description,
+        style: widget.style,
+      ),
+    };
   }
 }

--- a/test/pangea/navigation/leave_delete_close_test.dart
+++ b/test/pangea/navigation/leave_delete_close_test.dart
@@ -94,18 +94,19 @@ void main() {
   });
 
   group('closeOwnRoomPanel — leaving from the chat\'s own surface (#7561)', () {
-    testWidgets('leaving the open chat drops its panel, keeping the chat list', (
-      tester,
-    ) async {
-      final uri = await tapClose(
-        tester,
-        '/?left=chats,room:!abc',
-        (c) => closeOwnRoomPanel(c, '!abc'),
-      );
-      expect(parseOpenPanels(uri).left.map((t) => t.type), [
-        PanelTypesEnum.chats,
-      ]);
-    });
+    testWidgets(
+      'leaving the open chat drops its panel, keeping the chat list',
+      (tester) async {
+        final uri = await tapClose(
+          tester,
+          '/?left=chats,room:!abc',
+          (c) => closeOwnRoomPanel(c, '!abc'),
+        );
+        expect(parseOpenPanels(uri).left.map((t) => t.type), [
+          PanelTypesEnum.chats,
+        ]);
+      },
+    );
 
     testWidgets('falls back to the bare workspace exit when the room is not a '
         'token panel', (tester) async {


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
