### PR TITLE
Show situation specific error when try join banned course

### DIFF
--- a/lib/features/join_codes/space_code_controller.dart
+++ b/lib/features/join_codes/space_code_controller.dart
@@ -183,7 +183,9 @@ class SpaceCodeController {
     final resp = await showFutureLoadingDialog(
       context: context,
       future: () => _joinSpaceWithCodeWithoutLoading(spaceCode, client: client),
-      onError: (e, s) => notFoundError ?? L10n.of(context).unableToFindRoom,
+      onError: (e, s) => e is! StreamedResponse || e.statusCode == 403
+          ? L10n.of(context).bannedCourseError
+          : notFoundError ?? L10n.of(context).unableToFindRoom,
       showError: (err) => err is! StreamedResponse || err.statusCode != 429,
     );
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -5076,5 +5076,6 @@
             }
         }
     },
+    "bannedCourseError": "You've been removed from this course. Contact your teacher.",
     "closeAddCoursePage": "Close add course page"
 }


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Joining a course with an invalid or restricted code now displays a more accurate error message.
  - Users removed from a course are informed that they should contact their teacher.

- **Localization**
  - Added English text for the course access restriction message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->