### PR TITLE
Star semantics: clamp Mission threshold to earnable stars; card star totals; Activity Card UI docs

### DIFF
--- a/.github/instructions/quests.instructions.md
+++ b/.github/instructions/quests.instructions.md
@@ -38,6 +38,33 @@ The course panel tells the learner how far along they are, at two grains, comput
 
 A course **preview** (not joined) shows no star display — there is no learner progress to show. This builds toward the world_v2 tabbed course card (Figma "Everything outside of Chat"); until that card ships, the display lives on the existing course objectives panel.
 
+# Panel > Chats
+This panel
+
+# Panel > Course Plan
+This panel listing group of Activity Cards in multiple row.
+
+## Various Activity Card UI
+To help users easily scan and search for the right activity in Course listing, we design various Activity Card UI to help differentiate:
+
+1. **Normal Activity Plan**
+:🔘 Light Gray Card showing from top down: the large Activity image, the large Activity name, the row of star, and small Activity type next to number of role.
+
+2. **Joinable/Open Activity**
+:🟢 Green Card with an overlay tag [Open (number of open session/instance)] on the top right, and White text color. The tag will convey clearly that this Activity is Open and how many open sessions to choose. The tag also make it easy for screen reader, accessibility check. The color choice align with design of Green Joinable Map Pin V6. 
+
+3. **Ongoing Activity**
+:🟣 Purple Card with overlay tag [Ongoing]on the top right, and White text color. The tag will convey clearly that this Activity is Ongoing. The tag also make it easy for screen reader, accessibility check. The color choice align with design of Purple Ongoing Map Pin V6. 
+
+4. **Need to invite more participant to start** 
+:🔘 Light Gray Card with 30% Opacity, this convey that the Activity is still clickable but de-emphasized. If users want to know why, they can click on the card and see the "Uh oh, you need to invite NN people...".
+
+[Figma link to design mockup](https://www.figma.com/design/n2qX4WsnVhYqT2KV6pMVbl/Everything-outside-of-Chat?node-id=13765-270419&t=pnytLg8wuPthDfDt-11)
+
+# Panel > Participants
+
+# Panel > More
+
 ## Future Work
 
 File GitHub issues for these and link them here (use the `update-future-work` skill).

--- a/.github/instructions/quests.instructions.md
+++ b/.github/instructions/quests.instructions.md
@@ -12,7 +12,7 @@ A **Quest** is the learner's ordered journey through **Learning Objectives** (le
 Nothing is locked, so the question is not "is this allowed?" but "where should the learner go next?" — and that is asked by many surfaces, so it is resolved **once** into a single shared answer, never re-derived per surface (re-deriving invites two surfaces drifting on the same question). It is built from two inputs the client already holds:
 
 - **The ordered Mission sequences** of the learner's in-scope quests — their joined courses by default, or whatever the world map's quest filter selects — each quest's outline (ordered Mission ids + the activities under each), cached and rebuilt on course join/leave.
-- **The per-Mission star rollup** — a **star** is one orchestrator-awarded activity goal, read from awarded-goal state on the learner's own session rooms and summed per Mission across all its activities. No server-side progression endpoint is needed: every session that earned a star is a room the client can read. (Same collectible pattern as vocab/grammar — see [analytics-system.instructions.md](analytics-system.instructions.md).)
+- **The per-Mission star rollup** — a **star** is one orchestrator-awarded activity goal, read from awarded-goal state on the learner's own session rooms. Per activity, the learner's stars are their **best single session** (the most goals awarded to them in any one session of it — repeat sessions do not accumulate); the Mission total sums those per-activity bests across the Mission's distinct activities. Both rules are the org doc's satisfaction model. No server-side progression endpoint is needed: every session that earned a star is a room the client can read. (Same collectible pattern as vocab/grammar — see [analytics-system.instructions.md](analytics-system.instructions.md).)
 
 From those, the resolver finds each quest's **anchor (next) Mission**: the **first Mission in quest order whose star total is below the satisfaction threshold**; once every Mission is satisfied, the anchor falls back to the **lowest-star Mission**, so a completed quest keeps pointing at the learner's weakest area instead of going silent. When several quests are in scope it yields an anchor **per quest** plus the global per-Mission star totals; consumers preference still-unsatisfied Missions and **accumulate** across quests (so an activity advancing several quests' unfinished Missions ranks higher) — the resolver just supplies the anchors and totals, the weighting lives in the consumer (see the [world map](world-map.instructions.md) Priority matrix).
 
@@ -31,39 +31,27 @@ The teacher-overridable star threshold is part of the cross-repo rule (org doc);
 
 ## Star display on the course panel
 
-The course panel tells the learner how far along they are, at two grains, computed from the same resolver inputs (joined-course outlines + per-activity stars from session rooms) so the numbers can never disagree with the map:
+The course panel tells the learner how far along they are, at two grains, computed from the same resolver inputs (joined-course outlines + per-activity stars from session rooms) so the numbers can never disagree with the map.
 
-- **Per Mission**: earned stars over the satisfaction threshold (the teacher-overridable stars-to-unlock), with a progress bar. Stars past the threshold display raw (e.g. 12/7 — surplus effort shows); the bar clamps at full.
-- **Per quest (the panel header)**: a total star count summing each Mission's stars **capped at its threshold** — one over-practiced Mission can't inflate quest progress — over a bar that fills toward the sum of the quest's thresholds.
+Every displayed threshold is the **effective threshold**: the configured stars-to-unlock (teacher-overridable, default 10) clamped to the sum of earnable stars across the Mission's activities — the org doc's invariant that a Mission is always satisfiable from its content ([client#7663](https://github.com/pangeachat/client/issues/7663)). Earnable per activity is its goals-per-role count, falling back to the min across roles for plans predating the uniform-count generation invariant (org [`activities`](../../../.github/.github/instructions/activities.instructions.md) doc). The resolver computes the clamp; displays never re-derive it.
+
+- **Per Mission**: earned stars over the effective threshold, with a progress bar. Stars past the threshold display raw (e.g. 12/7 — surplus effort shows); the bar clamps at full.
+- **Per quest (the panel header)**: a total star count summing each Mission's stars **capped at its effective threshold** — one over-practiced Mission can't inflate quest progress — over a bar that fills toward the sum of the quest's effective thresholds. The clamp is what keeps this denominator honest: it can never exceed the stars the course's activities actually offer.
 
 A course **preview** (not joined) shows no star display — there is no learner progress to show. This builds toward the world_v2 tabbed course card (Figma "Everything outside of Chat"); until that card ships, the display lives on the existing course objectives panel.
 
-# Panel > Chats
-This panel
+## Activity cards on the course plan panel
 
-# Panel > Course Plan
-This panel listing group of Activity Cards in multiple row.
+The course plan panel lists the course's activities as cards, in rows. Each card carries the activity image, name, a **star row**, and the activity type next to the role count.
 
-## Various Activity Card UI
-To help users easily scan and search for the right activity in Course listing, we design various Activity Card UI to help differentiate:
+**The star row**: the learner's earned stars for that activity (best single session, per the rollup above) out of the activity's earnable count — its goals-per-role count, falling back to the min across roles (org [`activities`](../../../.github/.github/instructions/activities.instructions.md) doc owns that number).
 
-1. **Normal Activity Plan**
-:🔘 Light Gray Card showing from top down: the large Activity image, the large Activity name, the row of star, and small Activity type next to number of role.
+**Card states** — so a learner can scan a course listing and tell what each activity is doing right now ([Figma mockup](https://www.figma.com/design/n2qX4WsnVhYqT2KV6pMVbl/Everything-outside-of-Chat?node-id=13765-270419&t=pnytLg8wuPthDfDt-11)):
 
-2. **Joinable/Open Activity**
-:🟢 Green Card with an overlay tag [Open (number of open session/instance)] on the top right, and White text color. The tag will convey clearly that this Activity is Open and how many open sessions to choose. The tag also make it easy for screen reader, accessibility check. The color choice align with design of Green Joinable Map Pin V6. 
-
-3. **Ongoing Activity**
-:🟣 Purple Card with overlay tag [Ongoing]on the top right, and White text color. The tag will convey clearly that this Activity is Ongoing. The tag also make it easy for screen reader, accessibility check. The color choice align with design of Purple Ongoing Map Pin V6. 
-
-4. **Need to invite more participant to start** 
-:🔘 Light Gray Card with 30% Opacity, this convey that the Activity is still clickable but de-emphasized. If users want to know why, they can click on the card and see the "Uh oh, you need to invite NN people...".
-
-[Figma link to design mockup](https://www.figma.com/design/n2qX4WsnVhYqT2KV6pMVbl/Everything-outside-of-Chat?node-id=13765-270419&t=pnytLg8wuPthDfDt-11)
-
-# Panel > Participants
-
-# Panel > More
+1. **Normal (not started)** — 🔘 light gray card: image, name, star row, activity type + role count.
+2. **Joinable/Open** — 🟢 green card with an overlay tag "Open (N)" on the top right in white text, where N is the number of open sessions to choose from. The tag states the meaning in text (screen-reader friendly rather than color-only); the green matches the joinable map pin (V6).
+3. **Ongoing** — 🟣 purple card with an "Ongoing" overlay tag on the top right in white text; same text-not-color-only rationale; the purple matches the ongoing map pin (V6).
+4. **Needs more participants to start** — 🔘 light gray card at 30% opacity: still clickable but de-emphasized. Tapping it explains why ("Uh oh, you need to invite N people…").
 
 ## Future Work
 
@@ -71,3 +59,5 @@ File GitHub issues for these and link them here (use the `update-future-work` sk
 
 - A persisted per-Mission star total (server-side rollup) once reading every session room client-side becomes too costly at catalog scale.
 - Teacher-set **hard** restrictions (an opt-in gate on top of the soft default), if classroom demand appears — deliberately not built today (see the org doc).
+- Implement the joinable/open activity card design — [pangeachat/client#7669](https://github.com/pangeachat/client/issues/7669).
+- Design hint indicating an activity needs more people to start — [pangeachat/client#6810](https://github.com/pangeachat/client/issues/6810).

--- a/lib/features/activity_sessions/activity_plan_model.dart
+++ b/lib/features/activity_sessions/activity_plan_model.dart
@@ -172,6 +172,20 @@ class ActivityPlanModel {
   /// must surface (the parse sites log it loudly) — return empty, not fakes.
   Map<String, ActivityRole> get roles => _roles ?? const {};
 
+  /// The stars ONE player can earn in this activity: their role's goal count.
+  /// Generation guarantees the count is uniform across roles; plans predating
+  /// that rule may differ, so this takes the min across roles — permissive
+  /// (org activities doc, goal-progression invariants). The single home for
+  /// the rule: card star rows, the map's large card, and the Mission threshold
+  /// ceiling (quest_progression_resolver.dart) all read this. 0 when the plan
+  /// has no roles (degraded data — surfaces elsewhere).
+  int get earnableStars {
+    if (roles.isEmpty) return 0;
+    return roles.values
+        .map((r) => r.allGoals.length)
+        .reduce((a, b) => b < a ? b : a);
+  }
+
   factory ActivityPlanModel.fromJson(Map<String, dynamic> json) {
     final req = ActivityPlanRequest.fromJson(
       json[ActivitySessionConstants.activityPlanRequest],

--- a/lib/features/quests/lo_progression.dart
+++ b/lib/features/quests/lo_progression.dart
@@ -17,9 +17,17 @@ class CourseLoOutline {
   final Map<String, Set<String>> activityIdsByLo;
   final int starsToUnlock;
 
+  /// Stars ONE player can earn per activity (ActivityPlanModel.earnableStars),
+  /// keyed by activity id. Feeds the resolver's threshold clamp: an objective's
+  /// effective threshold never exceeds the sum of earnable stars across its
+  /// activities (quests.instructions.md). Empty when the builder had no plans
+  /// in hand — the resolver then leaves the configured threshold unclamped.
+  final Map<String, int> earnableByActivity;
+
   const CourseLoOutline({
     required this.orderedLoIds,
     required this.activityIdsByLo,
     this.starsToUnlock = kDefaultStarsToUnlockObjective,
+    this.earnableByActivity = const {},
   });
 }

--- a/lib/features/quests/quest_progression_resolver.dart
+++ b/lib/features/quests/quest_progression_resolver.dart
@@ -180,12 +180,21 @@ ProgressionResolution resolveProgression({
   // Mission is shared.
   final activitiesByMission = <String, Set<String>>{};
   final thresholdByMission = <String, int>{};
+  final earnableByActivity = <String, int>{};
   final sequences = <List<String>>[];
 
   for (final outline in outlines) {
     final seq = outline.orderedLoIds;
     if (seq.isEmpty) continue;
     sequences.add(seq);
+    outline.earnableByActivity.forEach((activityId, earnable) {
+      // Outlines carry the same plan, so values agree; min keeps a
+      // disagreement permissive (the lower ceiling clamps the threshold lower).
+      final existing = earnableByActivity[activityId];
+      earnableByActivity[activityId] = existing == null || earnable < existing
+          ? earnable
+          : existing;
+    });
     for (final missionId in seq) {
       (activitiesByMission[missionId] ??= <String>{}).addAll(
         outline.activityIdsByLo[missionId] ?? const <String>{},
@@ -202,13 +211,24 @@ ProgressionResolution resolveProgression({
   final rollup = <String, MissionProgress>{};
   activitiesByMission.forEach((missionId, activities) {
     var stars = 0;
+    var earnableCeiling = 0;
     for (final activityId in activities) {
       stars += starsByActivity[activityId] ?? 0;
+      earnableCeiling += earnableByActivity[activityId] ?? 0;
     }
+    final configured =
+        thresholdByMission[missionId] ?? kDefaultStarsToUnlockObjective;
+    // Effective threshold: the configured stars-to-unlock clamped to the sum of
+    // earnable stars across the Mission's activities, so a Mission is always
+    // satisfiable from its content and displays never advertise stars the
+    // learner cannot earn (org quests doc invariant; #7663). A ceiling of 0
+    // means no goal data reached the outline (degraded/legacy plans) — leave
+    // the configured threshold rather than marking the Mission satisfied at 0.
     rollup[missionId] = MissionProgress(
       stars: stars,
-      threshold:
-          thresholdByMission[missionId] ?? kDefaultStarsToUnlockObjective,
+      threshold: earnableCeiling > 0 && earnableCeiling < configured
+          ? earnableCeiling
+          : configured,
     );
   });
 

--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -59,6 +59,11 @@ class QuestOutline {
         group.objective.id: group.activities.map((a) => a.activityId).toSet(),
     },
     starsToUnlock: starsToUnlock,
+    earnableByActivity: {
+      for (final group in groups)
+        for (final a in group.activities)
+          a.activityId: a.plan.earnableStars,
+    },
   );
 }
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -4643,6 +4643,17 @@
     "screenSizeWarning": "For the best experience using this application, please expand your screen size.",
     "activitiesToUnlockTopicTitle": "Activities to Unlock Next Topic",
     "activitiesToUnlockTopicDesc": "Set the number of activities to unlock the next course topic",
+    "starsToUnlockObjectiveTitle": "Stars per Mission",
+    "starsToUnlockObjectiveDesc": "Set the number of stars needed to complete each mission",
+    "maxStarsPerMissionWarning": "This course has missions where only {maxValue} stars can be earned. Please enter a number less than or equal to {maxValue}.",
+    "@maxStarsPerMissionWarning": {
+        "type": "integer",
+        "placeholders": {
+            "maxValue": {
+                "type": "int"
+            }
+        }
+    },
     "activitySettingsOverrideWarning": "Language and language level determined by activity plan",
     "voice": "Voice",
     "youLeftTheChat": "🚪 You left the chat",

--- a/lib/routes/chat/chat_details/activity_suggestion_card.dart
+++ b/lib/routes/chat/chat_details/activity_suggestion_card.dart
@@ -31,9 +31,9 @@ class ActivitySuggestionCard extends StatelessWidget {
     this.starsEarned = 0,
   });
 
-  int get _starsTotal => activity.roles.values
-      .map((r) => r.allGoals.length)
-      .fold(0, (a, b) => b > a ? b : a);
+  // One player's earnable stars — uniform across roles by generation, min
+  // across roles for older plans (see ActivityPlanModel.earnableStars).
+  int get _starsTotal => activity.earnableStars;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/chat/chat_details/space_details_content.dart
+++ b/lib/routes/chat/chat_details/space_details_content.dart
@@ -15,6 +15,7 @@ import 'package:fluffychat/features/join_codes/join_rule_extension.dart';
 import 'package:fluffychat/features/join_codes/share_room_button.dart';
 import 'package:fluffychat/features/navigation/token_params/room_subpage_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
+import 'package:fluffychat/features/quests/lo_progression.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
@@ -174,72 +175,76 @@ class SpaceDetailsContent extends StatelessWidget {
         value: room.isTeacherMode,
       ),
       ButtonDetails(
-        title: L10n.of(context).activitiesToUnlockTopicTitle,
-        description: L10n.of(context).activitiesToUnlockTopicDesc,
-        icon: const Icon(Icons.lock_open_outlined, size: 30.0),
+        title: L10n.of(context).starsToUnlockObjectiveTitle,
+        description: L10n.of(context).starsToUnlockObjectiveDesc,
+        icon: const Icon(Icons.star_outline, size: 30.0),
         onPressed: () async {
-          int minActivities = 0;
+          // The cap is the lowest-content Mission's earnable stars — the sum
+          // of one player's earnable stars (goals per role) across its
+          // activities. A value above it could never be satisfied there; the
+          // resolver also clamps at resolve time as content changes
+          // (quests.instructions.md; #7663).
+          int maxStars = 0;
           if (room.coursePlan != null) {
-            // world_v2: the cap is the fewest activities in any mission of the
-            // v3 quest outline (replaces the v1 per-topic activity count).
             final resp = await showFutureLoadingDialog(
               context: context,
               future: () async {
                 final outline = await QuestRepo.outline(room.coursePlan!.uuid);
                 return outline.result?.groups
-                    .map((g) => g.activities.length)
+                    .map(
+                      (g) => g.activities.fold(
+                        0,
+                        (sum, a) => sum + a.plan.earnableStars,
+                      ),
+                    )
                     .min;
               },
               showError: (e) => false,
             );
 
             if (resp.result != null) {
-              minActivities = resp.result!;
+              maxStars = resp.result!;
             }
           }
-          final current = room.teacherMode.activitiesToUnlockTopic;
+          final current =
+              room.teacherMode.starsToUnlockObjective ??
+              kDefaultStarsToUnlockObjective;
           final resp = await showTextInputDialog(
             context: context,
-            title: L10n.of(context).activitiesToUnlockTopicTitle,
+            title: L10n.of(context).starsToUnlockObjectiveTitle,
             keyboardType: TextInputType.number,
             maxLength: 2,
             maxLines: 1,
             validator: (input) {
               final value = int.tryParse(input);
-              if (value == null || value < 0) {
+              if (value == null || value < 1) {
                 return L10n.of(context).enterNumber;
               }
-              if (value > minActivities) {
-                return L10n.of(
-                  context,
-                ).minActivitiesPerTopicWarning(value, minActivities);
+              if (maxStars > 0 && value > maxStars) {
+                return L10n.of(context).maxStarsPerMissionWarning(maxStars);
               }
               return null;
             },
-            initialText: current != null ? "$current" : null,
+            initialText: "$current",
           );
 
           if (resp == null) return;
           await showFutureLoadingDialog(
             context: context,
             future: () => room.setTeacherMode(
-              room.teacherMode.copyWith(
-                activitiesToUnlockTopic: int.parse(resp),
-              ),
+              room.teacherMode.copyWith(starsToUnlockObjective: int.parse(resp)),
             ),
           );
         },
         enabled: room.isRoomAdmin,
         showInMainView: false,
-        trailing: room.teacherMode.activitiesToUnlockTopic != null
-            ? Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                child: Text(
-                  "${room.teacherMode.activitiesToUnlockTopic}",
-                  style: Theme.of(context).textTheme.labelLarge,
-                ),
-              )
-            : null,
+        trailing: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Text(
+            "${room.teacherMode.starsToUnlockObjective ?? kDefaultStarsToUnlockObjective}",
+            style: Theme.of(context).textTheme.labelLarge,
+          ),
+        ),
       ),
       ButtonDetails(
         title: l10n.requireAnalyticsAccessTitle,

--- a/lib/routes/world/joined_objective_cache.dart
+++ b/lib/routes/world/joined_objective_cache.dart
@@ -72,6 +72,7 @@ class JoinedObjectiveCache {
               activityIdsByLo: o.activityIdsByLo,
               starsToUnlock:
                   starsToUnlockOf?.call(uuid) ?? kDefaultStarsToUnlockObjective,
+              earnableByActivity: o.earnableByActivity,
             ),
           );
         } catch (e, s) {

--- a/lib/routes/world/world_map_large_card.dart
+++ b/lib/routes/world/world_map_large_card.dart
@@ -68,15 +68,10 @@ class WorldMapLargeCard extends StatelessWidget {
     this.openSlots = 0,
   });
 
-  /// The most-goal role's goal count stands in for the activity's star total: a
-  /// learner plays one role, and the richest role bounds the progress bar.
-  int get _starsTotal {
-    final plan = this.plan;
-    if (plan == null) return 0;
-    return plan.roles.values
-        .map((r) => r.allGoals.length)
-        .fold(0, (a, b) => b > a ? b : a);
-  }
+  /// One player's earnable stars stands in for the activity's star total —
+  /// uniform across roles by generation, min across roles for older plans
+  /// (see ActivityPlanModel.earnableStars).
+  int get _starsTotal => plan?.earnableStars ?? 0;
 
   /// "Done": a full star total on an inProgress pin — the inProgress state at
   /// 100% (world-map.instructions.md, "Pin state"). A pin with a live session

--- a/test/pangea/activity_plan_earnable_stars_test.dart
+++ b/test/pangea/activity_plan_earnable_stars_test.dart
@@ -1,0 +1,73 @@
+// One player's earnable stars per activity: their role's goal count. Uniform
+// across roles by generation; min across roles for older plans (permissive).
+// The single home is ActivityPlanModel.earnableStars — card star rows, the
+// map's large card, and the Mission threshold clamp all read it. Design:
+// quests.instructions.md + org activities doc (goal-progression invariants).
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_media_enum.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_request.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+
+void main() {
+  ActivityPlanRequest req() => ActivityPlanRequest(
+    topic: 'jobs',
+    mode: 'Roleplay',
+    objective: 'introduce yourself',
+    media: MediaEnum.nan,
+    cefrLevel: LanguageLevelTypeEnum.a1,
+    languageOfInstructions: 'en',
+    targetLanguage: 'de',
+    numberOfParticipants: 2,
+  );
+
+  ActivityRole role(String id, int goalCount) => ActivityRole(
+    id: id,
+    name: id,
+    goal: null,
+    goals: [
+      for (var i = 0; i < goalCount; i++)
+        ActivityRoleGoal(id: '$id-g$i', description: 'goal $i'),
+    ],
+  );
+
+  ActivityPlanModel plan(Map<String, ActivityRole> roles) => ActivityPlanModel(
+    req: req(),
+    title: 'Speed-Dating Interview',
+    learningObjective: 'lo',
+    instructions: 'i',
+    vocab: const [],
+    activityId: 'act-1',
+    roles: roles,
+  );
+
+  group('ActivityPlanModel.earnableStars', () {
+    test('uniform goal counts read that count', () {
+      final p = plan({'a': role('a', 4), 'b': role('b', 4)});
+      expect(p.earnableStars, 4);
+    });
+
+    test('differing counts (pre-uniform plans) take the min across roles', () {
+      final p = plan({'a': role('a', 4), 'b': role('b', 3)});
+      expect(p.earnableStars, 3);
+    });
+
+    test('a plan with no roles earns nothing', () {
+      final p = plan(const {});
+      expect(p.earnableStars, 0);
+    });
+
+    test('a legacy single-string goal counts as one', () {
+      final legacy = ActivityRole(
+        id: 'a',
+        name: 'a',
+        goal: 'say hi',
+        goals: const [],
+      );
+      final p = plan({'a': legacy, 'b': role('b', 3)});
+      expect(p.earnableStars, 1);
+    });
+  });
+}

--- a/test/pangea/quest_progression_resolver_test.dart
+++ b/test/pangea/quest_progression_resolver_test.dart
@@ -8,10 +8,12 @@ void main() {
     List<String> seq,
     Map<String, Set<String>> acts, {
     int threshold = kDefaultStarsToUnlockObjective,
+    Map<String, int> earnable = const {},
   }) => CourseLoOutline(
     orderedLoIds: seq,
     activityIdsByLo: acts,
     starsToUnlock: threshold,
+    earnableByActivity: earnable,
   );
 
   group('resolveProgression — rollup', () {
@@ -68,6 +70,102 @@ void main() {
         starsByActivity: {'a': 6},
       );
       expect(r.rollup['m1']!.stars, 6); // unioned, not 12
+    });
+  });
+
+  group('resolveProgression — effective threshold clamp', () {
+    test('threshold clamps to the sum of earnable stars across activities', () {
+      final r = resolveProgression(
+        outlines: [
+          outline(
+            ['m1'],
+            {
+              'm1': {'a', 'b'},
+            },
+            earnable: {'a': 3, 'b': 4},
+          ),
+        ],
+        starsByActivity: {},
+      );
+      // configured 10, content offers 3 + 4 = 7
+      expect(r.rollup['m1']!.threshold, 7);
+    });
+
+    test('a configured threshold below the ceiling is kept as-is', () {
+      final r = resolveProgression(
+        outlines: [
+          outline(
+            ['m1'],
+            {
+              'm1': {'a', 'b'},
+            },
+            threshold: 5,
+            earnable: {'a': 3, 'b': 4},
+          ),
+        ],
+        starsByActivity: {},
+      );
+      expect(r.rollup['m1']!.threshold, 5);
+    });
+
+    test('a zero ceiling (no goal data) leaves the configured threshold', () {
+      final r = resolveProgression(
+        outlines: [
+          outline(
+            ['m1'],
+            {
+              'm1': {'a'},
+            },
+          ),
+        ],
+        starsByActivity: {},
+      );
+      // no earnable data — do NOT clamp to 0 (a Mission must not read
+      // satisfied-at-zero off degraded/legacy plans)
+      expect(r.rollup['m1']!.threshold, kDefaultStarsToUnlockObjective);
+      expect(r.rollup['m1']!.satisfied, isFalse);
+    });
+
+    test('a Mission satisfiable only via the clamp reads satisfied', () {
+      final r = resolveProgression(
+        outlines: [
+          outline(
+            ['m1', 'm2'],
+            {
+              'm1': {'a'},
+              'm2': {'b'},
+            },
+            earnable: {'a': 4, 'b': 4},
+          ),
+        ],
+        starsByActivity: {'a': 4}, // full marks on m1's only activity
+      );
+      expect(r.rollup['m1']!.satisfied, isTrue);
+      // and the anchor advances past it
+      expect(r.quests.single.anchorMissionId, 'm2');
+    });
+
+    test('disagreeing earnable values across outlines take the min', () {
+      final r = resolveProgression(
+        outlines: [
+          outline(
+            ['m1'],
+            {
+              'm1': {'a'},
+            },
+            earnable: {'a': 4},
+          ),
+          outline(
+            ['m1'],
+            {
+              'm1': {'a'},
+            },
+            earnable: {'a': 3},
+          ),
+        ],
+        starsByActivity: {},
+      );
+      expect(r.rollup['m1']!.threshold, 3);
     });
   });
 


### PR DESCRIPTION
Closes #7663. Extends @KhueDao1's quests-doc PR (and folds in #7674) with the design consensus and its implementation.

**Design (docs)** — org SOT in pangeachat/.github#252; client quests doc updated here:
- Per-activity stars are the learner's best single session; repeat sessions don't accumulate. Stars sum only across a Mission's distinct activities.
- An activity's earnable star count for one player is its goals-per-role (uniform by generation; min across roles for older plans).
- A Mission's effective threshold never exceeds the sum of earnable stars across its activities — clamped at resolve time.
- Activity Card UI states (normal / open / ongoing / needs-participants) documented with the Figma link.

**Implementation**
- `ActivityPlanModel.earnableStars` — single home for the per-player earnable count; card star rows and the map large card now use it (was max-across-roles).
- Resolver clamp: `resolveProgression` caps each Mission's threshold at its content ceiling (zero ceiling = no goal data leaves the configured threshold unclamped, so degraded plans can't mark a Mission satisfied at 0).
- Course settings: the old "Activities to Unlock Next Topic" control is replaced by **Stars per Mission** (writes `stars_to_unlock_objective`, default 10, validated against the lowest-content Mission's earnable stars).
- Tests: earnable-stars unit tests, resolver clamp tests. Full `test/pangea/` suite green (2 pre-existing live-env choreo endpoint flakes unrelated to this diff).

**TO TEST**
- [ ] Open a course's objectives panel: each Mission shows earned/threshold where the threshold never exceeds the total stars earnable from that Mission's activities (e.g. a 2-activity Mission with 4-goal roles shows /8, not /10).
- [ ] The course header's total star denominator equals the sum of those per-Mission (clamped) thresholds — no more 50 when only 35 is earnable.
- [ ] An activity card's star row shows earned/goals-per-role; replaying an activity does not increase earned stars beyond your best session.
- [ ] Complete all goals in every activity of a Mission: the Mission reads complete and the next Mission becomes the suggested one.
- [ ] Course settings (admin): "Stars per Mission" shows 10 by default; entering a number above the lowest-content Mission's earnable stars is rejected with a warning naming the max.

### Accessibility

- [x] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. (The settings row reuses the existing ButtonDetails pattern; no new bare controls.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mission star requirements now reflect the best session for each activity and total across distinct activities.
  * Mission thresholds are automatically capped at the stars learners can earn.
  * Teacher settings now support configuring stars required to unlock objectives, with validation against the course maximum.
  * Course and activity cards display updated star totals and progress states.
  * Added localized labels, descriptions, and warnings for mission star objectives.

* **Bug Fixes**
  * Corrected mission progress and completion calculations for varied activity goals and legacy plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->