### PR TITLE
Quest instruction, add link to Activity Card UI tickets and activities instruction

### DIFF
--- a/.github/instructions/quests.instructions.md
+++ b/.github/instructions/quests.instructions.md
@@ -38,9 +38,16 @@ The course panel tells the learner how far along they are, at two grains, comput
 
 A course **preview** (not joined) shows no star display — there is no learner progress to show. This builds toward the world_v2 tabbed course card (Figma "Everything outside of Chat"); until that card ships, the display lives on the existing course objectives panel.
 
+## Star display on Activity Card
+Follow the logic for how many star to show in [activities.instruction.md](.github/instructions/activities.instructions.md)
+
+## Star display on each LO
+
 ## Future Work
 
 File GitHub issues for these and link them here (use the `update-future-work` skill).
 
 - A persisted per-Mission star total (server-side rollup) once reading every session room client-side becomes too costly at catalog scale.
 - Teacher-set **hard** restrictions (an opt-in gate on top of the soft default), if classroom demand appears — deliberately not built today (see the org doc).
+- [ ] Implement designs of Joinabel and Open Activity https://github.com/pangeachat/client/issues/7669
+- [ ] Implement design hint to indicate Activity that need more people to start https://github.com/pangeachat/client/issues/6810


### PR DESCRIPTION
Added sections for star display logic on Activity Card with link to activities instruction on defining how many start to show

In Future Work, listed 2 tickets related to the updating of Activity Card UI

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
