### PR TITLE
ci: gate main on code_tests and pin local dart format to the .fvmrc Flutter

### DIFF
--- a/.github/instructions/ci-caching.instructions.md
+++ b/.github/instructions/ci-caching.instructions.md
@@ -57,7 +57,7 @@ Wall-clock ≈ 12m50s (parallel; APK was the critical path). `build_debug_linux`
 
 ### Gotchas for future edits
 
-- **No required status checks are configured on `main`** (verified via the branch-protection API), so gating APK/iOS to push-only strands nothing. If required checks are added later, do **not** mark the native jobs required, or PRs will wait on checks that never run.
+- **`main` requires the `code_tests` check** (branch protection; pangeachat/client#7680) — the format / import-sort / analyze / test gate. The native jobs (`build_debug_apk`, `build_debug_ios`) run push-only (`if: github.event_name == 'push'`), so they must **never** be added as required checks, or PRs will wait on checks that never run. `build_debug_web` and `accessibility_floor_check` do run on PRs but are intentionally left un-required.
 - **Keep the PR and main-push builds using identical debug steps.** The cache key is derived from the build; if the main-push web build diverges from the PR web build (e.g. profile vs debug, like `main_deploy.yaml`), the key stops matching and PRs miss again.
 - **No cache purge was needed.** The stale per-PR rust entries self-evict on GitHub's 7-day / 10 GB LRU, and the new `main`-scope debug key does not collide with the existing profile-build key.
 

--- a/.github/instructions/code-style.instructions.md
+++ b/.github/instructions/code-style.instructions.md
@@ -26,3 +26,7 @@ Conventions for Dart/Flutter code in this repo, beyond what `dart format` and `f
 - Don't write pointless tests. Tests should confirm that the explicit functionalities of the given class are working, and that edge cases do not cause error. Prefer to write tests first and then write code that makes those tests pass. This ensures that tests are targeting the correct functionality, and that tests don't know about any of the internal workings of the code they're testing.
 - Keep widgets well encapsulated. Child classes / widgets shouldn't need to know too much information about their parents. Only pass necessary information into widgets.
 - Cache the results of heavy computations.
+
+## Formatting toolchain
+
+The `code_tests` gate rejects any `dart format` diff, and it formats with the Flutter version pinned in `.fvmrc` — not whatever Flutter is on your PATH. Different Flutter versions format Dart differently, so code that looks clean under a newer or older local Flutter can still fail the gate, while `dart format` on that machine reports no changes — which is why the person who introduced a formatting failure often can't reproduce it. Format with the pinned version so local output matches CI; the simplest way is to install [FVM](https://fvm.app) and run `dart format` through it. The gate also verifies `.fvmrc` and the CI Flutter version stay in sync, so the two toolchains can't silently drift.

--- a/.github/instructions/code-style.instructions.md
+++ b/.github/instructions/code-style.instructions.md
@@ -29,4 +29,4 @@ Conventions for Dart/Flutter code in this repo, beyond what `dart format` and `f
 
 ## Formatting toolchain
 
-The `code_tests` gate rejects any `dart format` diff, and it formats with the Flutter version pinned in `.fvmrc` — not whatever Flutter is on your PATH. Different Flutter versions format Dart differently, so code that looks clean under a newer or older local Flutter can still fail the gate, while `dart format` on that machine reports no changes — which is why the person who introduced a formatting failure often can't reproduce it. Format with the pinned version so local output matches CI; the simplest way is to install [FVM](https://fvm.app) and run `dart format` through it. The gate also verifies `.fvmrc` and the CI Flutter version stay in sync, so the two toolchains can't silently drift.
+`dart format` output depends on the Flutter version, so format with the one pinned in `.fvmrc` — otherwise the `code_tests` gate can reject code that looks clean under a different local Flutter. Setup and the one-command formatter (`scripts/format.sh`) live in [CONTRIBUTING.md](../../CONTRIBUTING.md#flutter-version-fvm).

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "dart.flutterSdkPath": ".fvm/flutter_sdk",
     "dart.previewLsp": true,
     "editor.codeActionsOnSave": {
         "source.fixAll": "explicit",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,8 +174,11 @@ CI fails if the two ever disagree.
 We use [FVM (Flutter Version Management)](https://fvm.app) to consume that pin:
 
 ```sh
-# one-time: install FVM (see https://fvm.app/documentation/getting-started/installation)
-dart pub global activate fvm
+# one-time: install FVM. Homebrew is simplest and puts fvm on your PATH:
+brew install fvm
+# Alternatively `dart pub global activate fvm`, then add ~/.pub-cache/bin to your PATH
+# (e.g. in ~/.zshenv) so editors and Claude Code sessions can find fvm too — otherwise
+# they fall back to your system Flutter and format differently from CI.
 
 # from the repo root: install the pinned version recorded in .fvmrc
 fvm install
@@ -185,15 +188,19 @@ fvm flutter pub get
 fvm dart format lib/ test/
 ```
 
-Tip: point your IDE's Flutter SDK at `.fvm/flutter_sdk` (created by `fvm install`) so
-editor formatting matches CI. To bump the version, change it in **both** `.fvmrc` and
-`versions.env` in the same PR.
+Or just run [`scripts/format.sh`](scripts/format.sh) — it formats `lib/` and `test/` with the
+pinned SDK, locates fvm even when it isn't on your PATH, and runs `fvm install` on first use.
+
+This repo's tracked [`.vscode/settings.json`](.vscode/settings.json) points the Dart/Flutter
+extension at `.fvm/flutter_sdk`, so once you've run `fvm install`, VS Code's format-on-save and
+analyzer use the pinned version automatically. To bump the version, change it in **both**
+`.fvmrc` and `versions.env` in the same PR.
 
 ### Formatting
 
-We do not allow code with wrong formatting. Please run `fvm dart format lib/ test/`
-(or `dart format lib/ test/` if you already run the pinned Flutter) if your IDE
-doesn't do this automatically. CI runs `dart format lib/ test/ --set-exit-if-changed`.
+We do not allow code with wrong formatting. Run [`scripts/format.sh`](scripts/format.sh)
+(or `fvm dart format lib/ test/`) if your IDE doesn't do this automatically.
+`scripts/format.sh --check` mirrors CI, which runs `dart format lib/ test/ --set-exit-if-changed`.
 
 ### Code Analyzis
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Format lib/ and test/ with the Flutter version pinned in .fvmrc, so local output
+# matches the CI `code_tests` format gate. System `dart format` uses whatever Flutter is
+# on your PATH and formats Dart differently, so it can report "0 changed" on code that CI
+# then rejects. See CONTRIBUTING.md#flutter-version-fvm.
+#
+#   ./scripts/format.sh          format lib/ and test/ in place
+#   ./scripts/format.sh --check  verify only; non-zero exit if anything would change (CI parity)
+#
+# Import sorting is a separate CI check; run `fvm dart run import_sorter:main --no-comments`
+# for that (it resolves packages, so it can touch pubspec.lock).
+#
+# Locates fvm even when ~/.pub-cache/bin isn't on PATH — the common reason editor and
+# Claude Code sessions "can't find fvm" despite it being installed.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fvm_bin="$(command -v fvm || true)"
+if [ -z "$fvm_bin" ]; then
+  for cand in "$HOME/.pub-cache/bin/fvm" /opt/homebrew/bin/fvm /usr/local/bin/fvm; do
+    [ -x "$cand" ] && fvm_bin="$cand" && break
+  done
+fi
+if [ -z "$fvm_bin" ]; then
+  echo "error: fvm not found. Install it — 'brew install fvm', or 'dart pub global activate fvm'" >&2
+  echo "       then add ~/.pub-cache/bin to your PATH. See CONTRIBUTING.md#flutter-version-fvm." >&2
+  exit 1
+fi
+
+if [ "${1:-}" = "--check" ]; then
+  exec "$fvm_bin" dart format lib/ test/ --set-exit-if-changed
+else
+  exec "$fvm_bin" dart format lib/ test/
+fi


### PR DESCRIPTION
## What

Two halves that stop red `dart format` from reaching `main` and stop it slipping past local checks:

- **Merge gate** (applied via the branch-protection API, not a repo file): require the `code_tests` check on `main`, non-strict. Push-only native jobs stay un-required.
- **Local parity** (this PR): make `dart format` use the `.fvmrc`-pinned Flutter everywhere —
  - `.vscode/settings.json`: `dart.flutterSdkPath: .fvm/flutter_sdk` so format-on-save/analyzer use the pin.
  - `scripts/format.sh`: one command formatting `lib/`+`test/` with the pinned SDK, locating `fvm` even when it isn't on PATH; `--check` mirrors the CI gate.
  - `CONTRIBUTING.md`: brew-install recommendation + the `~/.pub-cache/bin` PATH gotcha; `code-style.instructions.md` links to it (SOT); `ci-caching.instructions.md` corrected for the now-required check.

## Why

Closes #7680. PRs merged red because `main` had **no required status checks**. And local `dart format` ran system Flutter (3.41.4 pinned, but `fvm` wasn't on PATH, `formatOnSave` wasn't pinned, and the `dart-format` alias used system `dart`), so authors saw `0 changes` and couldn't reproduce the CI diff.

## Testing

`./scripts/format.sh --check` → "Formatted 1098 files (0 changed)" under the pinned 3.41.4, exit 0; confirmed non-mutating (no `pubspec.lock`/`.fvmrc` churn). `code_tests` runs on this PR. Branch-protection verified via `GET .../protection/required_status_checks`.

Heads-up for reviewers: `dart.flutterSdkPath` makes the Dart extension require `.fvm/flutter_sdk`, so each dev runs `fvm install` once (documented in CONTRIBUTING). Drop that one file if the team prefers docs-only.

## Deploy Notes

None.
