### PR TITLE
fix(course-plans): distinguish error from empty state in the new-course picker

### DIFF
--- a/lib/features/course_plans/new_course_page.dart
+++ b/lib/features/course_plans/new_course_page.dart
@@ -339,53 +339,31 @@ class NewCoursePageState extends State<NewCoursePage> {
                 ValueListenableBuilder(
                   valueListenable: _courses,
                   builder: (context, value, _) {
-                    final loading = value == null;
-                    if (loading || value.isError || value.result!.isEmpty) {
-                      return Center(
+                    if (value == null) {
+                      return const Center(
                         child: Padding(
-                          padding: const EdgeInsets.all(32.0),
-                          child: loading
-                              ? const CircularProgressIndicator.adaptive()
-                              : Center(
-                                  child: Column(
-                                    spacing: 12.0,
-                                    children: [
-                                      const BotFace(
-                                        expression: BotExpression.addled,
-                                        width: Avatar.defaultSize * 1.5,
-                                      ),
-                                      Text(
-                                        L10n.of(context).noCourseTemplatesFound,
-                                        textAlign: TextAlign.center,
-                                        style: theme.textTheme.bodyLarge,
-                                      ),
-                                      ElevatedButton(
-                                        onPressed: () =>
-                                            context.go(PRoutes.chatsList),
-                                        style: ElevatedButton.styleFrom(
-                                          backgroundColor: theme
-                                              .colorScheme
-                                              .primaryContainer,
-                                          foregroundColor: theme
-                                              .colorScheme
-                                              .onPrimaryContainer,
-                                        ),
-                                        child: Row(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.center,
-                                          children: [
-                                            Text(L10n.of(context).continueText),
-                                          ],
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ),
+                          padding: EdgeInsets.all(32.0),
+                          child: CircularProgressIndicator.adaptive(),
                         ),
                       );
                     }
 
+                    if (value.isError) {
+                      return _CoursePickerMessage(
+                        message: L10n.of(context).oopsSomethingWentWrong,
+                        buttonLabel: L10n.of(context).tryAgain,
+                        onPressed: _loadCourses,
+                      );
+                    }
+
                     final courses = value.result!;
+                    if (courses.isEmpty) {
+                      return _CoursePickerMessage(
+                        message: L10n.of(context).noCourseTemplatesFound,
+                        buttonLabel: L10n.of(context).continueText,
+                        onPressed: () => context.go(PRoutes.chatsList),
+                      );
+                    }
                     return Expanded(
                       child: ListView.builder(
                         controller: _scrollController,
@@ -433,6 +411,54 @@ class NewCoursePageState extends State<NewCoursePage> {
               ],
             ),
           ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Empty- and error-state message for the course picker: an addled bot face, a
+/// message, and a single action button. Used for both the "no courses" and the
+/// "something went wrong" states, which differ only in copy and action.
+class _CoursePickerMessage extends StatelessWidget {
+  final String message;
+  final String buttonLabel;
+  final VoidCallback onPressed;
+
+  const _CoursePickerMessage({
+    required this.message,
+    required this.buttonLabel,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 12.0,
+          children: [
+            const BotFace(
+              expression: BotExpression.addled,
+              width: Avatar.defaultSize * 1.5,
+            ),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyLarge,
+            ),
+            ElevatedButton(
+              onPressed: onPressed,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: theme.colorScheme.primaryContainer,
+                foregroundColor: theme.colorScheme.onPrimaryContainer,
+              ),
+              child: Text(buttonLabel),
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
## What

Split the new-course picker's collapsed `loading || error || empty` branch so a **failed** load shows "Oops, something went wrong…" + a **Try again** button, while a genuinely empty successful result keeps the "no courses" copy + Continue. Loading still shows the spinner.

## Why

Closes #7678. `NewCoursePage` rendered `Result.error` and an empty result identically (both `noCourseTemplatesFound`), so a failed quest-plans request — e.g. the slow 403 when the Matrix token doesn't validate — looked like an empty catalog. That misleads teachers/learners and masks real auth/infra incidents.

Reuses the app-standard `oopsSomethingWentWrong` / `tryAgain` strings (already used by other error states) rather than adding l10n, and extracts the shared bot-face + message + button into one `_CoursePickerMessage` used by both the empty and error states. Error retry re-runs `_loadCourses`. The existing Sentry logging in `_fetchAndAppend` is unchanged.

## Testing

- `fvm dart format lib/ test/ --set-exit-if-changed` (pinned 3.41.4): **0 changed**.
- `fvm flutter analyze lib/features/course_plans/new_course_page.dart`: **No issues found**.
- No new automated test: the picker is a network-backed page (static `QuestPlansRepo.searchByFilter` over `PayloadClient`, plus `MatrixState`/routing) and the repo has no page-level mock harness; this is a presentational branch split. Manual QA per the issue's TO TEST — key step: offline → error + Try again, **not** the "no courses" copy.

## Deploy Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer course-picker states for loading, errors, and empty results.
  * Added a “Try again” action when course templates fail to load.
  * Added a “Continue” action when no course templates are available.

* **UI Improvements**
  * Updated empty and error messages with a more consistent, streamlined presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->