### PR TITLE
docs(quests): extend applyTo to the v3 course_plans picker path

### DIFF
--- a/.github/instructions/quests.instructions.md
+++ b/.github/instructions/quests.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "lib/features/quests/**"
+applyTo: "lib/features/quests/**,lib/features/course_plans/**"
 description: "Client-side next-Mission resolver — the one shared answer to 'which Mission should this learner work on next, per quest?', its inputs (joined-course Mission sequences + per-Mission star rollup), and the ranking surfaces that read it."
 ---
 


### PR DESCRIPTION
## What

Extend `quests.instructions.md`'s `applyTo` to also match `lib/features/course_plans/**`, so the doc governs the v3 quest picker/model/`courses` code that lives under that (legacily named) directory. Frontmatter only — no content or design change.

## Why

`course_plans` is the v3 **quests** domain, but the doc's `applyTo` was `lib/features/quests/**` only. So the governing doc never auto-loaded for `lib/features/course_plans/**`: Copilot's `applyTo` matching skipped it, the Claude doc-coverage hook pointed at the generic codebase-organization map, and a session working on `new_course_page.dart` (#7678 / #7682) read the **deprecated** v1 `course-plans.instructions.md` instead (which globs the unrelated `lib/pangea/course_plans/**`). Extending the glob makes the doc reach the code the team says it governs.

Docs-only governance fix; no issue per issues.instructions.md. Renaming the directory `course_plans` → `quests` is the cleaner long-term reconciliation but a much larger refactor, so deferred.

## Testing

N/A — instruction-doc frontmatter only, no runtime surface.

## Deploy Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal instruction targeting to cover both quest and course plan features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->