### PR TITLE
feat(orchestrator): refresh suggestions on every output, discard reaction buckets, exclude suggestion XP

### DIFF
--- a/lib/routes/chat/choreographer/activity_orchestrator/active_suggestion_model.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/active_suggestion_model.dart
@@ -1,0 +1,28 @@
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_role_suggestions.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_suggestion.dart';
+
+class ActiveSuggestionModel {
+  final OrchestratorRoleSuggestions suggestion;
+  final List<OrchestratorSuggestion> shuffledChoices;
+
+  final OrchestratorSuggestion? selectedChoice;
+  final OrchestratorSuggestion? acceptedChoice;
+
+  ActiveSuggestionModel({
+    required this.suggestion,
+    this.selectedChoice,
+    this.acceptedChoice,
+    List<OrchestratorSuggestion>? shuffledChoices,
+  }) : shuffledChoices =
+           shuffledChoices ?? (List.from(suggestion.suggestions)..shuffle());
+
+  ActiveSuggestionModel copyWith({
+    OrchestratorSuggestion? selectedChoice,
+    OrchestratorSuggestion? acceptedChoice,
+  }) => ActiveSuggestionModel(
+    suggestion: suggestion,
+    selectedChoice: selectedChoice ?? this.selectedChoice,
+    acceptedChoice: acceptedChoice ?? this.acceptedChoice,
+    shuffledChoices: shuffledChoices,
+  );
+}

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart
@@ -119,9 +119,13 @@ class OrchestratorController {
         return;
       }
 
-      if (_activeSuggestion != null) {
+      // Re-fire (choreo#2761): the orchestrator runs after every message, so
+      // fresh outputs replace the active suggestion — EXCEPT mid-interaction.
+      // Once the user has tapped a choice, don't yank the card out from under
+      // them; the next re-fire supplies a fresher output anyway.
+      if (_activeSuggestion?.selectedChoice != null) {
         _log(
-          "Received orchestrator output event but already have active suggestion, ignoring",
+          "Received orchestrator output while a choice is selected, ignoring",
         );
         return;
       }
@@ -131,6 +135,13 @@ class OrchestratorController {
       // bot's own role.
       final botUserId = event.senderId;
       final timeline = await room.getTimeline();
+      // Staleness key: the latest visible message of ANY sender (choreo#2761
+      // rule 6) — under re-fire the freshest output is legitimately based on
+      // a bot reply. Out-of-order arrivals resolve here too: an older
+      // in-flight output fails this check regardless of arrival order.
+      final latestMessage = timeline.events.firstWhereOrNull(
+        (e) => e.type == EventTypes.Message && e.isVisibleInGui,
+      );
       final latestHumanMessage = timeline.events.firstWhereOrNull(
         (e) =>
             e.type == EventTypes.Message &&
@@ -145,22 +156,29 @@ class OrchestratorController {
               .length ??
           0;
 
+      // A stale output decides nothing — keep whatever is showing.
+      if (output.basedOnEventId != latestMessage?.eventId) {
+        _log("Received stale orchestrator output, ignoring");
+        return;
+      }
+
       final suggestion = suggestionToShow(
         output: output,
         ownRoleId: roleId,
         currentUserId: room.client.userID,
-        latestHumanMessageEventId: latestHumanMessage?.eventId,
+        latestMessageEventId: latestMessage?.eventId,
         latestHumanMessageSenderId: latestHumanMessage?.senderId,
         humanRoleCount: humanRoleCount,
       );
-      if (suggestion == null) return;
 
-      if (suggestion.suggestions.isEmpty) {
-        Logs().w("Suggestion without choices received");
-        return;
-      }
-
-      _setActiveSuggestion(ActiveSuggestionModel(suggestion: suggestion));
+      // A fresh output fully wins: it sets OR clears the active suggestion.
+      // Clearing matters — without it a chip from an earlier turn would
+      // linger after an output that carries no bucket for this role.
+      _setActiveSuggestion(
+        suggestion == null
+            ? null
+            : ActiveSuggestionModel(suggestion: suggestion),
+      );
     } catch (e, s) {
       ErrorHandler.logError(e: e, s: s, data: event.content);
     }
@@ -170,27 +188,28 @@ class OrchestratorController {
   /// current user for an orchestrator output, or null if they should not be
   /// prompted. Extracted from [_onOrchestratorOutputEvent] for unit testing.
   ///
-  /// The orchestrator broadcasts a single event (triggered by whoever spoke
-  /// last) carrying a bucket per role; the recommendation goes to the responder,
-  /// not the speaker:
+  /// The orchestrator re-fires on every message (choreo#2761), so outputs are
+  /// legitimately based on bot replies too; the recommendation goes to the
+  /// responder, not the speaker:
   /// - multi-human (>= 2 human roles): prompt the user who did NOT send the
   ///   latest human message — after A's message B is prompted; after B's, A.
   /// - single-human (participant mode, bot holds a role): prompt the lone human
-  ///   right after their own message.
-  /// Stale outputs — not based on the latest human message — are dropped.
+  ///   right after their own message OR after the bot's reply to them.
+  /// Stale outputs — not based on the latest visible message of ANY sender —
+  /// are dropped (the caller also checks this before deciding to clear).
   @visibleForTesting
   static OrchestratorRoleSuggestions? suggestionToShow({
     required OrchestratorOutput output,
     required String ownRoleId,
     required String? currentUserId,
-    required String? latestHumanMessageEventId,
+    required String? latestMessageEventId,
     required String? latestHumanMessageSenderId,
     required int humanRoleCount,
   }) {
     final roleSuggestion = output.suggestionsByRoleId(ownRoleId).firstOrNull;
     if (roleSuggestion == null) return null;
 
-    if (output.basedOnEventId != latestHumanMessageEventId) return null;
+    if (output.basedOnEventId != latestMessageEventId) return null;
 
     final isMultiHumanActivity = humanRoleCount >= 2;
     final currentUserSpokeLast = latestHumanMessageSenderId == currentUserId;

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart
@@ -8,38 +8,13 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/active_suggestion_model.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_output.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_role_suggestions.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_suggestion.dart';
 import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/filtered_timeline_extension.dart';
-
-class ActiveSuggestionModel {
-  final OrchestratorRoleSuggestions suggestion;
-  final List<OrchestratorSuggestion> shuffledChoices;
-
-  final OrchestratorSuggestion? selectedChoice;
-  final OrchestratorSuggestion? acceptedChoice;
-
-  ActiveSuggestionModel({
-    required this.suggestion,
-    this.selectedChoice,
-    this.acceptedChoice,
-    List<OrchestratorSuggestion>? shuffledChoices,
-  }) : shuffledChoices =
-           shuffledChoices ?? (List.from(suggestion.suggestions)..shuffle());
-
-  ActiveSuggestionModel copyWith({
-    OrchestratorSuggestion? selectedChoice,
-    OrchestratorSuggestion? acceptedChoice,
-  }) => ActiveSuggestionModel(
-    suggestion: suggestion,
-    selectedChoice: selectedChoice ?? this.selectedChoice,
-    acceptedChoice: acceptedChoice ?? this.acceptedChoice,
-    shuffledChoices: shuffledChoices,
-  );
-}
 
 class OrchestratorController {
   final Room room;
@@ -119,10 +94,8 @@ class OrchestratorController {
         return;
       }
 
-      // Re-fire (choreo#2761): the orchestrator runs after every message, so
-      // fresh outputs replace the active suggestion — EXCEPT mid-interaction.
-      // Once the user has tapped a choice, don't yank the card out from under
-      // them; the next re-fire supplies a fresher output anyway.
+      // Re-fire (choreo#2761): fresh outputs replace the active suggestion —
+      // except mid-interaction; a tapped card is never yanked from the user.
       if (_activeSuggestion?.selectedChoice != null) {
         _log(
           "Received orchestrator output while a choice is selected, ignoring",
@@ -135,10 +108,8 @@ class OrchestratorController {
       // bot's own role.
       final botUserId = event.senderId;
       final timeline = await room.getTimeline();
-      // Staleness key: the latest visible message of ANY sender (choreo#2761
-      // rule 6) — under re-fire the freshest output is legitimately based on
-      // a bot reply. Out-of-order arrivals resolve here too: an older
-      // in-flight output fails this check regardless of arrival order.
+      // Staleness key (choreo#2761 rule 6): the latest visible message of ANY
+      // sender — recency against the timeline decides, never arrival order.
       final latestMessage = timeline.events.firstWhereOrNull(
         (e) => e.type == EventTypes.Message && e.isVisibleInGui,
       );
@@ -171,8 +142,7 @@ class OrchestratorController {
         humanRoleCount: humanRoleCount,
       );
 
-      // A fresh output fully wins: it sets OR clears the active suggestion.
-      // Clearing matters — without it a chip from an earlier turn would
+      // Null clears on purpose — otherwise a chip from an earlier turn would
       // linger after an output that carries no bucket for this role.
       _setActiveSuggestion(
         suggestion == null

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_output.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_output.dart
@@ -32,10 +32,9 @@ class OrchestratorOutput {
           ),
         )
         .toList(),
-    // v2 (choreo#2761): Reaction buckets and turn-0 null buckets arrive from
-    // the bot's adapter as empty options lists — they are emitted for
-    // uniformity and deliberately never rendered, so drop them here along
-    // with malformed buckets. Valid sibling buckets are kept.
+    // v2 (choreo#2761): reaction and turn-0 null buckets arrive as empty
+    // options lists, deliberately never rendered — drop them and malformed
+    // buckets.
     suggestions: List.from(json["suggestions"] ?? [])
         .whereType<Map>()
         .where((s) => s["role_id"] is String)

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_output.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_output.dart
@@ -32,12 +32,19 @@ class OrchestratorOutput {
           ),
         )
         .toList(),
-    suggestions: List.from(json["suggestions"])
+    // v2 (choreo#2761): Reaction buckets and turn-0 null buckets arrive from
+    // the bot's adapter as empty options lists — they are emitted for
+    // uniformity and deliberately never rendered, so drop them here along
+    // with malformed buckets. Valid sibling buckets are kept.
+    suggestions: List.from(json["suggestions"] ?? [])
+        .whereType<Map>()
+        .where((s) => s["role_id"] is String)
         .map(
           (s) => OrchestratorRoleSuggestions.fromJson(
             Map<String, dynamic>.from(s),
           ),
         )
+        .where((s) => s.suggestions.isNotEmpty)
         .toList(),
     flag: json["flag"] != null
         ? OrchestratorFlag.fromJson(Map<String, dynamic>.from(json["flag"]))

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_role_suggestions.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_role_suggestions.dart
@@ -10,9 +10,22 @@ class OrchestratorRoleSuggestions {
   });
 
   static OrchestratorRoleSuggestions fromJson(Map<String, dynamic> json) {
+    // Under the v2 contract (choreo#2761) a bucket's options list may be
+    // empty (the bot adapts Reaction and turn-0 null buckets to empty lists)
+    // and unknown option shapes may appear during rollout. Skip malformed
+    // entries instead of throwing — one bad entry must not discard the
+    // whole orchestrator output.
     return OrchestratorRoleSuggestions(
       roleId: json["role_id"],
-      suggestions: List.from(json["suggestions"])
+      suggestions: List.from(json["suggestions"] ?? [])
+          .whereType<Map>()
+          .where(
+            (s) =>
+                s["text"] is String &&
+                OrchestratorSuggestionType.values.any(
+                  (v) => v.name == s["type"],
+                ),
+          )
           .map(
             (s) =>
                 OrchestratorSuggestion.fromJson(Map<String, dynamic>.from(s)),

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_role_suggestions.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_role_suggestions.dart
@@ -10,11 +10,8 @@ class OrchestratorRoleSuggestions {
   });
 
   static OrchestratorRoleSuggestions fromJson(Map<String, dynamic> json) {
-    // Under the v2 contract (choreo#2761) a bucket's options list may be
-    // empty (the bot adapts Reaction and turn-0 null buckets to empty lists)
-    // and unknown option shapes may appear during rollout. Skip malformed
-    // entries instead of throwing — one bad entry must not discard the
-    // whole orchestrator output.
+    // v2 (choreo#2761): options may be empty (adapted Reaction / turn-0 null
+    // buckets) or malformed during rollout — skip bad entries, never throw.
     return OrchestratorRoleSuggestions(
       roleId: json["role_id"],
       suggestions: List.from(json["suggestions"] ?? [])

--- a/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/common/widgets/choice_array.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/active_suggestion_model.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_suggestion.dart';
 import 'package:fluffychat/routes/chat/choreographer/igc/writing_assistance_popup.dart';
@@ -35,9 +36,8 @@ class SuggestionCardState extends State<SuggestionCard> {
   @override
   void initState() {
     super.initState();
-    // Under re-fire the active suggestion can be replaced or cleared while
-    // this card is open. Rebuild on replace (so taps never hit a swapped-out
-    // model) and close on clear.
+    // Under re-fire the active suggestion can change while the card is open:
+    // rebuild on replace (taps never hit a swapped-out model), close on clear.
     _suggestionSubscription = widget.controller.suggestionStream.stream.listen((
       suggestion,
     ) {

--- a/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
@@ -38,16 +38,16 @@ class SuggestionCardState extends State<SuggestionCard> {
     // Under re-fire the active suggestion can be replaced or cleared while
     // this card is open. Rebuild on replace (so taps never hit a swapped-out
     // model) and close on clear.
-    _suggestionSubscription = widget.controller.suggestionStream.stream.listen(
-      (suggestion) {
-        if (!mounted) return;
-        if (suggestion == null) {
-          _close();
-        } else {
-          setState(() {});
-        }
-      },
-    );
+    _suggestionSubscription = widget.controller.suggestionStream.stream.listen((
+      suggestion,
+    ) {
+      if (!mounted) return;
+      if (suggestion == null) {
+        _close();
+      } else {
+        setState(() {});
+      }
+    });
   }
 
   @override

--- a/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/suggestion_card.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
@@ -27,6 +29,40 @@ class SuggestionCard extends StatefulWidget {
 class SuggestionCardState extends State<SuggestionCard> {
   ActiveSuggestionModel? get suggestionsModel =>
       widget.controller.activeSuggestion;
+
+  StreamSubscription<ActiveSuggestionModel?>? _suggestionSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    // Under re-fire the active suggestion can be replaced or cleared while
+    // this card is open. Rebuild on replace (so taps never hit a swapped-out
+    // model) and close on clear.
+    _suggestionSubscription = widget.controller.suggestionStream.stream.listen(
+      (suggestion) {
+        if (!mounted) return;
+        if (suggestion == null) {
+          _close();
+        } else {
+          setState(() {});
+        }
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _suggestionSubscription?.cancel();
+    // Closing the card without accepting releases the mid-interaction pin
+    // (a tapped distractor otherwise blocks every future replacement).
+    final model = widget.controller.activeSuggestion;
+    if (model != null &&
+        model.acceptedChoice == null &&
+        model.selectedChoice != null) {
+      widget.controller.resetSuggestionState();
+    }
+    super.dispose();
+  }
 
   void _close() {
     widget.popupManager.close();

--- a/lib/routes/chat/choreographer/choreo_record_model.dart
+++ b/lib/routes/chat/choreographer/choreo_record_model.dart
@@ -24,8 +24,7 @@ class ChoreoRecordModel {
   final Set<String> pastedStrings = {};
 
   /// Texts inserted by accepting an orchestrator suggestion chip. Like
-  /// [pastedStrings], in-memory only (not serialized): send-time scoring
-  /// reads the live record, and suggestion tokens must not score as
+  /// [pastedStrings], in-memory only — suggestion tokens must not score as
   /// self-written language (#7665).
   final Set<String> suggestionStrings = {};
 

--- a/lib/routes/chat/choreographer/choreo_record_model.dart
+++ b/lib/routes/chat/choreographer/choreo_record_model.dart
@@ -23,6 +23,12 @@ class ChoreoRecordModel {
 
   final Set<String> pastedStrings = {};
 
+  /// Texts inserted by accepting an orchestrator suggestion chip. Like
+  /// [pastedStrings], in-memory only (not serialized): send-time scoring
+  /// reads the live record, and suggestion tokens must not score as
+  /// self-written language (#7665).
+  final Set<String> suggestionStrings = {};
+
   ChoreoRecordModel({
     required this.choreoSteps,
     required this.openMatches,

--- a/lib/routes/chat/choreographer/choreographer.dart
+++ b/lib/routes/chat/choreographer/choreographer.dart
@@ -6,6 +6,7 @@ import 'package:async/async.dart';
 import 'package:matrix/matrix.dart' hide Result;
 
 import 'package:fluffychat/features/subscription/utils/subscription_status_enum.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/active_suggestion_model.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart';
 import 'package:fluffychat/routes/chat/choreographer/assistance_state_enum.dart';
 import 'package:fluffychat/routes/chat/choreographer/choreo_constants.dart';
@@ -374,8 +375,8 @@ class Choreographer extends ChangeNotifier {
     final acceptedChoice = suggestion?.acceptedChoice;
     if (acceptedChoice != null) {
       // Record BEFORE setSystemText so the lazily-created record snapshots
-      // the pre-suggestion input as its originalText. Accepted-suggestion
-      // tokens are excluded from XP like pastes (#7665).
+      // pre-suggestion input as originalText; excluded from XP like pastes
+      // (#7665).
       _record.suggestionStrings.add(acceptedChoice.text);
       textController.setSystemText(
         acceptedChoice.text,

--- a/lib/routes/chat/choreographer/choreographer.dart
+++ b/lib/routes/chat/choreographer/choreographer.dart
@@ -373,6 +373,10 @@ class Choreographer extends ChangeNotifier {
   void _onUpdateSuggestion(ActiveSuggestionModel? suggestion) {
     final acceptedChoice = suggestion?.acceptedChoice;
     if (acceptedChoice != null) {
+      // Record BEFORE setSystemText so the lazily-created record snapshots
+      // the pre-suggestion input as its originalText. Accepted-suggestion
+      // tokens are excluded from XP like pastes (#7665).
+      _record.suggestionStrings.add(acceptedChoice.text);
       textController.setSystemText(
         acceptedChoice.text,
         EditTypeEnum.suggestion,

--- a/lib/routes/chat/events/models/representation_content_model.dart
+++ b/lib/routes/chat/events/models/representation_content_model.dart
@@ -152,15 +152,21 @@ class PangeaRepresentation {
         .where((token) => token.lemma.saveVocab)
         .toList();
 
-    final pastedStrings = choreo?.pastedStrings ?? <String>{};
+    // Accepted-suggestion text is excluded exactly like pasted text: neither
+    // is self-written language, so neither should generate construct uses
+    // (#7665).
+    final excludedStrings = {
+      ...?choreo?.pastedStrings,
+      ...?choreo?.suggestionStrings,
+    };
 
     final openMatches = choreo?.openMatches ?? [];
 
     return tokensToSave
         .where(
           (token) =>
-              !pastedStrings.any(
-                (pasted) => pasted.toLowerCase().contains(
+              !excludedStrings.any(
+                (excluded) => excluded.toLowerCase().contains(
                   token.text.content.toLowerCase(),
                 ),
               ) &&

--- a/lib/routes/chat/events/models/representation_content_model.dart
+++ b/lib/routes/chat/events/models/representation_content_model.dart
@@ -152,9 +152,8 @@ class PangeaRepresentation {
         .where((token) => token.lemma.saveVocab)
         .toList();
 
-    // Accepted-suggestion text is excluded exactly like pasted text: neither
-    // is self-written language, so neither should generate construct uses
-    // (#7665).
+    // Accepted-suggestion text is excluded like pasted text — neither is
+    // self-written language, so neither generates construct uses (#7665).
     final excludedStrings = {
       ...?choreo?.pastedStrings,
       ...?choreo?.suggestionStrings,

--- a/test/pangea/choreo_record_test.dart
+++ b/test/pangea/choreo_record_test.dart
@@ -80,6 +80,24 @@ void main() async {
       );
     });
 
+    test("suggestionStrings is in-memory only, like pastedStrings", () {
+      // Send-time scoring reads the live record (#7665); neither exclusion
+      // set is serialized.
+      final record = ChoreoRecordModel(
+        originalText: "",
+        choreoSteps: [],
+        openMatches: [],
+      );
+
+      expect(record.suggestionStrings, isEmpty);
+      record.suggestionStrings.add("quiero un café");
+      record.pastedStrings.add("hola");
+
+      final received = ChoreoRecordModel.fromJson(record.toJson());
+      expect(received.suggestionStrings, isEmpty);
+      expect(received.pastedStrings, isEmpty);
+    });
+
     test("Test that fromJSON converts old version correctly", () {
       final List<String> steps = [];
 

--- a/test/pangea/orchestrator_controller_suggestion_test.dart
+++ b/test/pangea/orchestrator_controller_suggestion_test.dart
@@ -189,43 +189,37 @@ void main() {
   group('OrchestratorController.suggestionToShow — any-sender staleness', () {
     const botEvent = r'$botReply';
 
-    test(
-      'output based on the bot reply (the latest message) is shown to the '
-      'lone human',
-      () {
-        // Re-fire (choreo#2761): after the bot replies to the lone human, the
-        // fresh output is based on the bot's message. The human still sent the
-        // latest HUMAN message, so they are prompted.
-        final output = outputWithBothRoles(botEvent);
-        final result = OrchestratorController.suggestionToShow(
-          output: output,
-          ownRoleId: roleA,
-          currentUserId: userA,
-          latestMessageEventId: botEvent,
-          latestHumanMessageSenderId: userA,
-          humanRoleCount: 1,
-        );
-        expect(result, isNotNull);
-        expect(result!.roleId, roleA);
-      },
-    );
+    test('output based on the bot reply (the latest message) is shown to the '
+        'lone human', () {
+      // Re-fire (choreo#2761): after the bot replies to the lone human, the
+      // fresh output is based on the bot's message. The human still sent the
+      // latest HUMAN message, so they are prompted.
+      final output = outputWithBothRoles(botEvent);
+      final result = OrchestratorController.suggestionToShow(
+        output: output,
+        ownRoleId: roleA,
+        currentUserId: userA,
+        latestMessageEventId: botEvent,
+        latestHumanMessageSenderId: userA,
+        humanRoleCount: 1,
+      );
+      expect(result, isNotNull);
+      expect(result!.roleId, roleA);
+    });
 
-    test(
-      'output based on an older human message is dropped once a bot reply '
-      'is the latest message',
-      () {
-        final output = outputWithBothRoles(eventA);
-        final result = OrchestratorController.suggestionToShow(
-          output: output,
-          ownRoleId: roleA,
-          currentUserId: userA,
-          latestMessageEventId: botEvent, // the bot has since replied
-          latestHumanMessageSenderId: userA,
-          humanRoleCount: 1,
-        );
-        expect(result, isNull);
-      },
-    );
+    test('output based on an older human message is dropped once a bot reply '
+        'is the latest message', () {
+      final output = outputWithBothRoles(eventA);
+      final result = OrchestratorController.suggestionToShow(
+        output: output,
+        ownRoleId: roleA,
+        currentUserId: userA,
+        latestMessageEventId: botEvent, // the bot has since replied
+        latestHumanMessageSenderId: userA,
+        humanRoleCount: 1,
+      );
+      expect(result, isNull);
+    });
   });
 
   group('OrchestratorOutput.fromJson — v2 bucket tolerance', () {
@@ -248,57 +242,63 @@ void main() {
       expect(output.suggestions.single.roleId, roleB);
     });
 
-    test('null options list and missing role_id are dropped, siblings kept', () {
-      final output = OrchestratorOutput.fromJson({
-        'based_on_event_id': eventA,
-        'goal_completion': [
-          {
-            'role_id': roleA,
-            'goal_ids': ['goal-1'],
-          },
-        ],
-        'suggestions': [
-          {'role_id': roleA, 'suggestions': null},
-          {
-            'suggestions': [
-              {'text': 'no-role', 'type': 'best'},
-            ],
-          },
-          {
-            'role_id': roleB,
-            'suggestions': [
-              {'text': 'B-best', 'type': 'best'},
-            ],
-          },
-        ],
-        'flag': null,
-      });
-      expect(output.suggestions, hasLength(1));
-      expect(output.suggestions.single.roleId, roleB);
-      // goal_completion survives malformed sibling buckets.
-      expect(output.goalCompletion, hasLength(1));
-    });
+    test(
+      'null options list and missing role_id are dropped, siblings kept',
+      () {
+        final output = OrchestratorOutput.fromJson({
+          'based_on_event_id': eventA,
+          'goal_completion': [
+            {
+              'role_id': roleA,
+              'goal_ids': ['goal-1'],
+            },
+          ],
+          'suggestions': [
+            {'role_id': roleA, 'suggestions': null},
+            {
+              'suggestions': [
+                {'text': 'no-role', 'type': 'best'},
+              ],
+            },
+            {
+              'role_id': roleB,
+              'suggestions': [
+                {'text': 'B-best', 'type': 'best'},
+              ],
+            },
+          ],
+          'flag': null,
+        });
+        expect(output.suggestions, hasLength(1));
+        expect(output.suggestions.single.roleId, roleB);
+        // goal_completion survives malformed sibling buckets.
+        expect(output.goalCompletion, hasLength(1));
+      },
+    );
 
-    test('unknown option type or null text skips the entry, keeps valid ones', () {
-      final output = OrchestratorOutput.fromJson({
-        'based_on_event_id': eventA,
-        'goal_completion': [],
-        'suggestions': [
-          {
-            'role_id': roleA,
-            'suggestions': [
-              {'text': null, 'type': 'best'},
-              {'text': 'valid', 'type': 'best'},
-              {'text': 'weird', 'type': 'emoji'},
-            ],
-          },
-        ],
-        'flag': null,
-      });
-      expect(output.suggestions, hasLength(1));
-      expect(output.suggestions.single.suggestions, hasLength(1));
-      expect(output.suggestions.single.suggestions.single.text, 'valid');
-    });
+    test(
+      'unknown option type or null text skips the entry, keeps valid ones',
+      () {
+        final output = OrchestratorOutput.fromJson({
+          'based_on_event_id': eventA,
+          'goal_completion': [],
+          'suggestions': [
+            {
+              'role_id': roleA,
+              'suggestions': [
+                {'text': null, 'type': 'best'},
+                {'text': 'valid', 'type': 'best'},
+                {'text': 'weird', 'type': 'emoji'},
+              ],
+            },
+          ],
+          'flag': null,
+        });
+        expect(output.suggestions, hasLength(1));
+        expect(output.suggestions.single.suggestions, hasLength(1));
+        expect(output.suggestions.single.suggestions.single.text, 'valid');
+      },
+    );
 
     test('missing suggestions key parses to an empty list', () {
       final output = OrchestratorOutput.fromJson({

--- a/test/pangea/orchestrator_controller_suggestion_test.dart
+++ b/test/pangea/orchestrator_controller_suggestion_test.dart
@@ -47,7 +47,7 @@ void main() {
         output: output,
         ownRoleId: roleB,
         currentUserId: userB,
-        latestHumanMessageEventId: eventA,
+        latestMessageEventId: eventA,
         latestHumanMessageSenderId: userA,
         humanRoleCount: 2,
       );
@@ -61,7 +61,7 @@ void main() {
         output: output,
         ownRoleId: roleA,
         currentUserId: userA,
-        latestHumanMessageEventId: eventA,
+        latestMessageEventId: eventA,
         latestHumanMessageSenderId: userA,
         humanRoleCount: 2,
       );
@@ -74,7 +74,7 @@ void main() {
         output: output,
         ownRoleId: roleA,
         currentUserId: userA,
-        latestHumanMessageEventId: eventB,
+        latestMessageEventId: eventB,
         latestHumanMessageSenderId: userB,
         humanRoleCount: 2,
       );
@@ -88,7 +88,7 @@ void main() {
         output: output,
         ownRoleId: roleB,
         currentUserId: userB,
-        latestHumanMessageEventId: eventB,
+        latestMessageEventId: eventB,
         latestHumanMessageSenderId: userB,
         humanRoleCount: 2,
       );
@@ -105,7 +105,7 @@ void main() {
           output: output,
           ownRoleId: roleA,
           currentUserId: userA,
-          latestHumanMessageEventId: eventA,
+          latestMessageEventId: eventA,
           latestHumanMessageSenderId: userA, // the lone human spoke last
           humanRoleCount: 1,
         );
@@ -121,7 +121,7 @@ void main() {
             output: output,
             ownRoleId: roleA,
             currentUserId: userA,
-            latestHumanMessageEventId: eventB,
+            latestMessageEventId: eventB,
             latestHumanMessageSenderId: userB,
             humanRoleCount: 1,
           );
@@ -140,7 +140,7 @@ void main() {
         output: output,
         ownRoleId: roleB,
         currentUserId: userB,
-        latestHumanMessageEventId: eventB, // a newer human message exists
+        latestMessageEventId: eventB, // a newer human message exists
         latestHumanMessageSenderId: userA,
         humanRoleCount: 2,
       );
@@ -165,7 +165,7 @@ void main() {
         output: output,
         ownRoleId: roleB, // no bucket for roleB in this output
         currentUserId: userB,
-        latestHumanMessageEventId: eventA,
+        latestMessageEventId: eventA,
         latestHumanMessageSenderId: userA,
         humanRoleCount: 2,
       );
@@ -178,11 +178,135 @@ void main() {
         output: output,
         ownRoleId: roleB,
         currentUserId: userB,
-        latestHumanMessageEventId: null,
+        latestMessageEventId: null,
         latestHumanMessageSenderId: null,
         humanRoleCount: 2,
       );
       expect(result, isNull);
+    });
+  });
+
+  group('OrchestratorController.suggestionToShow — any-sender staleness', () {
+    const botEvent = r'$botReply';
+
+    test(
+      'output based on the bot reply (the latest message) is shown to the '
+      'lone human',
+      () {
+        // Re-fire (choreo#2761): after the bot replies to the lone human, the
+        // fresh output is based on the bot's message. The human still sent the
+        // latest HUMAN message, so they are prompted.
+        final output = outputWithBothRoles(botEvent);
+        final result = OrchestratorController.suggestionToShow(
+          output: output,
+          ownRoleId: roleA,
+          currentUserId: userA,
+          latestMessageEventId: botEvent,
+          latestHumanMessageSenderId: userA,
+          humanRoleCount: 1,
+        );
+        expect(result, isNotNull);
+        expect(result!.roleId, roleA);
+      },
+    );
+
+    test(
+      'output based on an older human message is dropped once a bot reply '
+      'is the latest message',
+      () {
+        final output = outputWithBothRoles(eventA);
+        final result = OrchestratorController.suggestionToShow(
+          output: output,
+          ownRoleId: roleA,
+          currentUserId: userA,
+          latestMessageEventId: botEvent, // the bot has since replied
+          latestHumanMessageSenderId: userA,
+          humanRoleCount: 1,
+        );
+        expect(result, isNull);
+      },
+    );
+  });
+
+  group('OrchestratorOutput.fromJson — v2 bucket tolerance', () {
+    test('reaction bucket (empty options + reaction key) is dropped', () {
+      final output = OrchestratorOutput.fromJson({
+        'based_on_event_id': eventA,
+        'goal_completion': [],
+        'suggestions': [
+          {'role_id': roleA, 'suggestions': [], 'reaction': '👍'},
+          {
+            'role_id': roleB,
+            'suggestions': [
+              {'text': 'B-best', 'type': 'best'},
+            ],
+          },
+        ],
+        'flag': null,
+      });
+      expect(output.suggestions, hasLength(1));
+      expect(output.suggestions.single.roleId, roleB);
+    });
+
+    test('null options list and missing role_id are dropped, siblings kept', () {
+      final output = OrchestratorOutput.fromJson({
+        'based_on_event_id': eventA,
+        'goal_completion': [
+          {
+            'role_id': roleA,
+            'goal_ids': ['goal-1'],
+          },
+        ],
+        'suggestions': [
+          {'role_id': roleA, 'suggestions': null},
+          {
+            'suggestions': [
+              {'text': 'no-role', 'type': 'best'},
+            ],
+          },
+          {
+            'role_id': roleB,
+            'suggestions': [
+              {'text': 'B-best', 'type': 'best'},
+            ],
+          },
+        ],
+        'flag': null,
+      });
+      expect(output.suggestions, hasLength(1));
+      expect(output.suggestions.single.roleId, roleB);
+      // goal_completion survives malformed sibling buckets.
+      expect(output.goalCompletion, hasLength(1));
+    });
+
+    test('unknown option type or null text skips the entry, keeps valid ones', () {
+      final output = OrchestratorOutput.fromJson({
+        'based_on_event_id': eventA,
+        'goal_completion': [],
+        'suggestions': [
+          {
+            'role_id': roleA,
+            'suggestions': [
+              {'text': null, 'type': 'best'},
+              {'text': 'valid', 'type': 'best'},
+              {'text': 'weird', 'type': 'emoji'},
+            ],
+          },
+        ],
+        'flag': null,
+      });
+      expect(output.suggestions, hasLength(1));
+      expect(output.suggestions.single.suggestions, hasLength(1));
+      expect(output.suggestions.single.suggestions.single.text, 'valid');
+    });
+
+    test('missing suggestions key parses to an empty list', () {
+      final output = OrchestratorOutput.fromJson({
+        'based_on_event_id': eventA,
+        'goal_completion': [],
+        'flag': null,
+      });
+      expect(output.suggestions, isEmpty);
     });
   });
 }

--- a/test/pangea/vocab_and_morph_uses_test.dart
+++ b/test/pangea/vocab_and_morph_uses_test.dart
@@ -45,28 +45,30 @@ void main() {
     expect(uses.first.xp, ConstructUseTypeEnum.wa.pointValue);
   });
 
-  test('accepted-suggestion tokens produce zero uses; typed tokens still score',
-      () {
-    final choreo = _record()..suggestionStrings.add('quiero un café');
+  test(
+    'accepted-suggestion tokens produce zero uses; typed tokens still score',
+    () {
+      final choreo = _record()..suggestionStrings.add('quiero un café');
 
-    final suggestionUses = representation.vocabAndMorphUses(
-      tokens: [_token('quiero', 5), _token('café', 15)],
-      metadata: metadata,
-      choreo: choreo,
-    );
-    expect(suggestionUses, isEmpty);
+      final suggestionUses = representation.vocabAndMorphUses(
+        tokens: [_token('quiero', 5), _token('café', 15)],
+        metadata: metadata,
+        choreo: choreo,
+      );
+      expect(suggestionUses, isEmpty);
 
-    final typedUses = representation.vocabAndMorphUses(
-      tokens: [_token('hola', 0)],
-      metadata: metadata,
-      choreo: choreo,
-    );
-    expect(typedUses, isNotEmpty);
-    expect(
-      typedUses.every((u) => u.useType == ConstructUseTypeEnum.wa),
-      isTrue,
-    );
-  });
+      final typedUses = representation.vocabAndMorphUses(
+        tokens: [_token('hola', 0)],
+        metadata: metadata,
+        choreo: choreo,
+      );
+      expect(typedUses, isNotEmpty);
+      expect(
+        typedUses.every((u) => u.useType == ConstructUseTypeEnum.wa),
+        isTrue,
+      );
+    },
+  );
 
   test('pasted tokens stay excluded (regression pin)', () {
     final choreo = _record()..pastedStrings.add('quiero un café');

--- a/test/pangea/vocab_and_morph_uses_test.dart
+++ b/test/pangea/vocab_and_morph_uses_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/analytics/construct_use_type_enum.dart';
+import 'package:fluffychat/features/analytics/constructs_model.dart';
+import 'package:fluffychat/pangea/lemmas/lemma.dart';
+import 'package:fluffychat/routes/chat/choreographer/choreo_record_model.dart';
+import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
+import 'package:fluffychat/routes/chat/events/models/pangea_token_text_model.dart';
+import 'package:fluffychat/routes/chat/events/models/representation_content_model.dart';
+
+/// XP-integrity tests for [PangeaRepresentation.vocabAndMorphUses] token
+/// filtering (#7665): text inserted by accepting an orchestrator suggestion
+/// chip must be excluded from construct-use scoring exactly like pasted text,
+/// while genuinely typed tokens keep scoring as written-active (`wa`).
+PangeaToken _token(String content, int offset) => PangeaToken(
+  text: PangeaTokenText.fromJson({'content': content, 'offset': offset}),
+  lemma: Lemma(text: content, saveVocab: true, form: content),
+  pos: 'NOUN',
+  morph: const {},
+);
+
+ChoreoRecordModel _record() =>
+    ChoreoRecordModel(choreoSteps: [], openMatches: [], originalText: '');
+
+void main() {
+  final representation = PangeaRepresentation(
+    langCode: 'es',
+    text: 'hola quiero un café',
+    originalSent: true,
+    originalWritten: true,
+  );
+  final metadata = ConstructUseMetaData(
+    roomId: '!room:test',
+    eventId: r'$event',
+    timeStamp: DateTime(2026, 7, 15),
+  );
+
+  test('without choreo, tokens score as written-active (wa)', () {
+    final uses = representation.vocabAndMorphUses(
+      tokens: [_token('hola', 0)],
+      metadata: metadata,
+    );
+    expect(uses, isNotEmpty);
+    expect(uses.every((u) => u.useType == ConstructUseTypeEnum.wa), isTrue);
+    expect(uses.first.xp, ConstructUseTypeEnum.wa.pointValue);
+  });
+
+  test('accepted-suggestion tokens produce zero uses; typed tokens still score',
+      () {
+    final choreo = _record()..suggestionStrings.add('quiero un café');
+
+    final suggestionUses = representation.vocabAndMorphUses(
+      tokens: [_token('quiero', 5), _token('café', 15)],
+      metadata: metadata,
+      choreo: choreo,
+    );
+    expect(suggestionUses, isEmpty);
+
+    final typedUses = representation.vocabAndMorphUses(
+      tokens: [_token('hola', 0)],
+      metadata: metadata,
+      choreo: choreo,
+    );
+    expect(typedUses, isNotEmpty);
+    expect(
+      typedUses.every((u) => u.useType == ConstructUseTypeEnum.wa),
+      isTrue,
+    );
+  });
+
+  test('pasted tokens stay excluded (regression pin)', () {
+    final choreo = _record()..pastedStrings.add('quiero un café');
+
+    final uses = representation.vocabAndMorphUses(
+      tokens: [_token('quiero', 5)],
+      metadata: metadata,
+      choreo: choreo,
+    );
+    expect(uses, isEmpty);
+  });
+}


### PR DESCRIPTION
Closes #7665. Client side of the v2 trigger model (epic pangeachat/2-step-choreographer#2761); pairs with pangeachat/pangea-bot#1407 (re-fire trigger).

## Changes

1. **Ignore-if-active → replace.** A fresh (non-stale) output sets OR clears the active suggestion — newest wins; clearing prevents a chip from an earlier turn lingering forever under re-fire. Mid-interaction guard: once the user has tapped a choice the output is dropped (the next re-fire supplies a fresher one). Closing the card without accepting calls `resetSuggestionState()` so a tapped distractor can't pin the card indefinitely, and `SuggestionCard` now subscribes to the suggestion stream (rebuild on replace, close on clear) so taps never hit a swapped-out model.
2. **Any-sender staleness key.** `based_on_event_id` is compared against the latest visible message of ANY sender (was: latest human message) — under re-fire the freshest output is legitimately based on a bot reply. This also resolves out-of-order arrivals by recency, never arrival order; stale outputs keep the current chip.
3. **Reaction/null bucket tolerance.** The bot adapts v2 `Reaction {emoji}` and turn-0 `null` buckets to empty options lists (+ a `reaction` key) before broadcasting; those buckets are parsed and silently discarded — never rendered (the deliberate cost of the #2664 anonymity principle). Malformed buckets/entries are skipped so one bad bucket no longer discards the whole output (previously the parse threw and everything was dropped).
4. **XP rider.** Accepted-suggestion text goes into `ChoreoRecordModel.suggestionStrings` (in-memory only, parallel to `pastedStrings`) and is excluded from construct-use scoring in `vocabAndMorphUses`. Tapped chips previously scored as `wa` (3 pts/construct) — full self-written credit. **Pedagogy call flagged for review:** the default here treats suggestions like paste (excluded entirely, 0 XP), per the issue's default proposal; routing to a distinct low-value use type is the alternative.

## TO TEST

- [ ] In a 1:1 activity, send a message — after the bot replies, your suggestion chip appears/updates based on the bot's actual reply (needs bot#1407 deployed)
- [ ] Send two messages quickly — the chip shown matches the latest state of the conversation, with no flicker of outdated suggestions
- [ ] Tap a suggestion and send it — the message sends normally
- [ ] Open analytics after tapping several suggestions through an activity — the tapped words do not appear as high-value uses

## Tests

`flutter analyze` clean; the 3 touched test files (24 tests incl. new any-sender staleness, bucket-tolerance, and XP-exclusion cases) pass. Full local suite: 2 unrelated files (`world_map_zoom_test`, `widget_test`) flaked under full-suite parallelism and pass in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Suggestions now update live while the suggestion card remains open, including replacement and clearing of active suggestions.
  * Accepted suggestion text is now tracked separately to prevent it from being treated as user-written input.

* **Bug Fixes**
  * Stale suggestions are dropped sooner using the latest message from any sender.
  * More resilient parsing for incoming suggestion payloads (tolerates empty, partial, or malformed data).

* **Tests**
  * Added/extended tests covering live refresh, any-sender staleness, suggestion parsing tolerance, serialization behavior, and vocabulary/scoring exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->