### PR TITLE
Use same popup for add email as signup

### DIFF
--- a/lib/routes/settings/settings_security/settings_3pid/settings_3pid.dart
+++ b/lib/routes/settings/settings_security/settings_3pid/settings_3pid.dart
@@ -1,12 +1,12 @@
-import 'package:flutter/material.dart';
-
-import 'package:matrix/matrix.dart';
-
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/home/signup/registration_email_popup.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
+import 'package:flutter/material.dart';
+import 'package:matrix/matrix.dart';
+
 import 'settings_3pid_view.dart';
 
 class Settings3Pid extends StatefulWidget {
@@ -44,31 +44,37 @@ class Settings3PidController extends State<Settings3Pid> {
       ),
     );
     if (response.error != null) return;
-    final ok = await showOkAlertDialog(
-      useRootNavigator: false,
-      context: context,
-      title: L10n.of(context).weSentYouAnEmail,
-      // #Pangea
-      // message: L10n.of(context).pleaseClickOnLink,
-      message: L10n.of(context).clickOnEmailLinkDesc,
-      // Pangea#
-      okLabel: L10n.of(context).iHaveClickedOnLink,
-    );
-    if (ok != OkCancelResult.ok) return;
-    final success = await showFutureLoadingDialog(
-      context: context,
-      delay: false,
-      future: () => Matrix.of(context).client.uiaRequestBackground(
-        (auth) => Matrix.of(
-          context,
-        ).client.add3PID(clientSecret, response.result!.sid, auth: auth),
-      ),
-      // #Pangea
-      showError: (e) => !e.toString().contains("Request has been canceled"),
-      // Pangea#
-    );
-    if (success.error != null) return;
-    setState(() => request = null);
+    if (OkCancelResult.ok ==
+        await showDialog<OkCancelResult?>(
+          useRootNavigator: false,
+          barrierDismissible: false,
+          context: context,
+          builder: (context) => RegistrationEmailPopup(
+            onResendEmail: () async {
+              Settings3Pid.sendAttempt++;
+              await Matrix.of(context).client.requestTokenToRegisterEmail(
+                clientSecret,
+                input,
+                Settings3Pid.sendAttempt,
+              );
+            },
+          ),
+        )) {
+      final success = await showFutureLoadingDialog(
+        context: context,
+        delay: false,
+        future: () => Matrix.of(context).client.uiaRequestBackground(
+          (auth) => Matrix.of(
+            context,
+          ).client.add3PID(clientSecret, response.result!.sid, auth: auth),
+        ),
+        // #Pangea
+        showError: (e) => !e.toString().contains("Request has been canceled"),
+        // Pangea#
+      );
+      if (success.error != null) return;
+      setState(() => request = null);
+    }
   }
 
   Future<List<ThirdPartyIdentifier>?>? request;

--- a/lib/routes/settings/settings_security/settings_3pid/settings_3pid.dart
+++ b/lib/routes/settings/settings_security/settings_3pid/settings_3pid.dart
@@ -1,12 +1,13 @@
+import 'package:flutter/material.dart';
+
+import 'package:matrix/matrix.dart';
+
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/home/signup/registration_email_popup.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
-import 'package:flutter/material.dart';
-import 'package:matrix/matrix.dart';
-
 import 'settings_3pid_view.dart';
 
 class Settings3Pid extends StatefulWidget {


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a registration email popup when adding an email address.
  * Added an option to resend the registration email directly from the popup.

* **Bug Fixes**
  * Preserved the existing confirmation and cancellation handling while completing email registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->