### PR TITLE
Group focus items to keep tab order logical

### DIFF
--- a/lib/routes/courses/private/course_code_page.dart
+++ b/lib/routes/courses/private/course_code_page.dart
@@ -183,35 +183,39 @@ class CourseCodePageState extends State<CourseCodePage> {
                     BlendMode.srcIn,
                   ),
                 ),
-                Column(
-                  spacing: 16.0,
-                  children: [
-                    Text(
-                      L10n.of(context).enterCodeToJoin,
-                      style: theme.textTheme.titleMedium?.copyWith(
-                        fontWeight: FontWeight.bold,
+
+                FocusTraversalGroup(
+                  policy: OrderedTraversalPolicy(),
+                  child: Column(
+                    spacing: 16.0,
+                    children: [
+                      Text(
+                        L10n.of(context).enterCodeToJoin,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
                       ),
-                    ),
-                    TextFormField(
-                      controller: _codeController,
-                      decoration: InputDecoration(
-                        hintText: L10n.of(context).courseCodeHint,
+                      TextFormField(
+                        controller: _codeController,
+                        decoration: InputDecoration(
+                          hintText: L10n.of(context).courseCodeHint,
+                        ),
+                        onFieldSubmitted: (_) => _submit(),
+                        inputFormatters: [LengthLimitingTextInputFormatter(10)],
                       ),
-                      onFieldSubmitted: (_) => _submit(),
-                      inputFormatters: [LengthLimitingTextInputFormatter(10)],
-                    ),
-                    ElevatedButton(
-                      onPressed: _code.isNotEmpty ? _submit : null,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: theme.colorScheme.primaryContainer,
-                        foregroundColor: theme.colorScheme.onPrimaryContainer,
+                      ElevatedButton(
+                        onPressed: _code.isNotEmpty ? _submit : null,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: theme.colorScheme.primaryContainer,
+                          foregroundColor: theme.colorScheme.onPrimaryContainer,
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [Text(L10n.of(context).submit)],
+                        ),
                       ),
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [Text(L10n.of(context).submit)],
-                      ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ],
             ),

--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -49,32 +49,35 @@ class WorldUserClusterInternal extends StatelessWidget {
         final l2 = viewModel.userL2;
         return Semantics(
           label: L10n.of(context).analyticsAndSettingsLabel,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              ListenableBuilder(
-                listenable: Listenable.merge([
-                  viewModel.avatarUrl,
-                  viewModel.displayName,
-                ]),
-                builder: (context, _) => ClusterAvatar(
-                  avatarUrl: viewModel.avatarUrl.value,
-                  name: viewModel.displayName.value,
-                  onTap: () => viewModel.openProfile(context),
-                ),
-              ),
-              const SizedBox(height: 8),
-              _PowerupsPill(viewModel: viewModel),
-              if (l2 != null)
-                Padding(
-                  padding: const EdgeInsets.only(top: 20),
-                  child: ClusterLanguageFlag(
-                    language: l2,
-                    onTap: () => viewModel.openLearningSettings(context),
+          child: FocusTraversalGroup(
+            policy: OrderedTraversalPolicy(),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                ListenableBuilder(
+                  listenable: Listenable.merge([
+                    viewModel.avatarUrl,
+                    viewModel.displayName,
+                  ]),
+                  builder: (context, _) => ClusterAvatar(
+                    avatarUrl: viewModel.avatarUrl.value,
+                    name: viewModel.displayName.value,
+                    onTap: () => viewModel.openProfile(context),
                   ),
                 ),
-            ],
+                const SizedBox(height: 8),
+                _PowerupsPill(viewModel: viewModel),
+                if (l2 != null)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 20),
+                    child: ClusterLanguageFlag(
+                      language: l2,
+                      onTap: () => viewModel.openLearningSettings(context),
+                    ),
+                  ),
+              ],
+            ),
           ),
         );
       },

--- a/lib/widgets/layouts/left_panel_layer.dart
+++ b/lib/widgets/layouts/left_panel_layer.dart
@@ -46,12 +46,15 @@ class LeftPanelLayer extends StatelessWidget {
         ? state.extra as Completer<String>
         : null;
 
-    final panel = WorkspaceLeftPanel(
-      token: token,
-      currentUri: state.uri,
-      foldedOver: foldedOver,
-      shareItems: shareItems,
-      courseCreationCompleter: courseCreationCompleter,
+    final panel = FocusTraversalGroup(
+      policy: OrderedTraversalPolicy(),
+      child: WorkspaceLeftPanel(
+        token: token,
+        currentUri: state.uri,
+        foldedOver: foldedOver,
+        shareItems: shareItems,
+        courseCreationCompleter: courseCreationCompleter,
+      ),
     );
 
     final type = token.type;

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -338,10 +338,13 @@ class WorkspaceShell extends StatelessWidget {
                     bottom: 0,
                     left: l.allocation.right[i].left,
                     width: l.allocation.right[i].width,
-                    child: WorkspaceRightPanel(
-                      token: l.rightTokens[i],
-                      currentUri: state.uri,
-                      foldedOver: l.allocation.right[i].foldedOver,
+                    child: FocusTraversalGroup(
+                      policy: OrderedTraversalPolicy(),
+                      child: WorkspaceRightPanel(
+                        token: l.rightTokens[i],
+                        currentUri: state.uri,
+                        foldedOver: l.allocation.right[i].foldedOver,
+                      ),
                     ),
                   ),
             ],
@@ -593,10 +596,13 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
             shortcutCourse.id == activeSpaceId,
         cavityChild: cavityToken == null
             ? null
-            : WorkspaceLeftPanel(
-                token: cavityToken,
-                currentUri: uri,
-                bare: true,
+            : FocusTraversalGroup(
+                policy: OrderedTraversalPolicy(),
+                child: WorkspaceLeftPanel(
+                  token: cavityToken,
+                  currentUri: uri,
+                  bare: true,
+                ),
               ),
         cavityKey: cavityKey,
         // A course card opens at peek (the map leads); sections and the

--- a/lib/widgets/navigation_rail.dart
+++ b/lib/widgets/navigation_rail.dart
@@ -100,156 +100,159 @@ class SpacesNavigationRail extends StatelessWidget {
         child: WorkspaceDock(
           child: Semantics(
             label: L10n.of(context).navOptionsLabel,
-            child: StreamBuilder(
-              key: ValueKey(client.userID.toString()),
-              stream: client.onSync.stream
-                  .where((s) => s.hasRoomUpdate)
-                  .rateLimit(const Duration(seconds: 1)),
-              builder: (context, _) {
-                final allSpaces = client.rooms
-                    .where((room) => room.isSpace)
-                    .toList();
+            child: FocusTraversalGroup(
+              policy: OrderedTraversalPolicy(),
+              child: StreamBuilder(
+                key: ValueKey(client.userID.toString()),
+                stream: client.onSync.stream
+                    .where((s) => s.hasRoomUpdate)
+                    .rateLimit(const Duration(seconds: 1)),
+                builder: (context, _) {
+                  final allSpaces = client.rooms
+                      .where((room) => room.isSpace)
+                      .toList();
 
-                return AnimatedContainer(
-                  width: naviRailWidth,
-                  duration: FluffyThemes.animationDuration,
-                  // world_v2 rail order (top→bottom): World · Chats · Courses ·
-                  // joined spaces. (Profile/settings is no longer a rail slot;
-                  // analytics opens from the top-right cluster.)
-                  child: Column(
-                    // Size the rail to its items — a floating bar over the map, not
-                    // the full screen height; it still scrolls if the joined-spaces
-                    // list overflows the viewport.
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Flexible(
-                        child: ListView(
-                          shrinkWrap: true,
-                          scrollDirection: Axis.vertical,
-                          children: [
-                            // 1. World map home — the Pangea brand mark, at the top
-                            // of the rail. Chromeless and avatar-sized; the left
-                            // indicator bar conveys selection. Brand purple when
-                            // active, muted when not.
-                            NaviRailItem(
-                              isSelected: isWorld,
-                              backgroundColor: Colors.transparent,
-                              // Exclude the logo's semanticsLabel so VoiceOver reads
-                              // only the button tooltip ("world"), not the logo name.
-                              icon: ExcludeSemantics(
-                                child: PangeaLogoSvg(
-                                  width: largeIconWidth,
-                                  forceColor: Theme.of(
-                                    context,
-                                  ).colorScheme.onSurfaceVariant,
-                                ),
-                              ),
-                              selectedIcon: ExcludeSemantics(
-                                child: PangeaLogoSvg(
-                                  width: largeIconWidth,
-                                  forceColor: Theme.of(
-                                    context,
-                                  ).colorScheme.primary,
-                                ),
-                              ),
-                              onTap: () {
-                                // World is home: clear every panel (both columns)
-                                // and reveal the full map. See routing.instructions.md.
-                                context.go(WorkspaceNav.clearAll());
-                              },
-                              toolTip: L10n.of(context).world,
-                              naviRailWidth: naviRailWidth,
-                            ),
-                            // 2. Chats — the chat list. Chromeless (no box fill) and
-                            // icon-sized to match the brand mark / course avatars
-                            // (it used to render tiny on the default surface fill);
-                            // the left indicator bar conveys selection.
-                            NaviRailItem(
-                              isSelected: isChats,
-                              backgroundColor: Colors.transparent,
-                              icon: Icon(
-                                Icons.forum_outlined,
-                                size: smallIconWidth,
-                              ),
-                              selectedIcon: Icon(
-                                Icons.forum,
-                                size: smallIconWidth,
-                              ),
-                              onTap: () {
-                                // Token-only: the chats list is a left `chats` token
-                                // over the world path `/` (no legacy `/chats` path).
-                                context.go(
-                                  WorkspaceNav.setSection(
-                                    state.uri,
-                                    const ChatsPanelToken(),
-                                    // Replace open left panels rather than stack.
-                                    keepRoom: false,
+                  return AnimatedContainer(
+                    width: naviRailWidth,
+                    duration: FluffyThemes.animationDuration,
+                    // world_v2 rail order (top→bottom): World · Chats · Courses ·
+                    // joined spaces. (Profile/settings is no longer a rail slot;
+                    // analytics opens from the top-right cluster.)
+                    child: Column(
+                      // Size the rail to its items — a floating bar over the map, not
+                      // the full screen height; it still scrolls if the joined-spaces
+                      // list overflows the viewport.
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Flexible(
+                          child: ListView(
+                            shrinkWrap: true,
+                            scrollDirection: Axis.vertical,
+                            children: [
+                              // 1. World map home — the Pangea brand mark, at the top
+                              // of the rail. Chromeless and avatar-sized; the left
+                              // indicator bar conveys selection. Brand purple when
+                              // active, muted when not.
+                              NaviRailItem(
+                                isSelected: isWorld,
+                                backgroundColor: Colors.transparent,
+                                // Exclude the logo's semanticsLabel so VoiceOver reads
+                                // only the button tooltip ("world"), not the logo name.
+                                icon: ExcludeSemantics(
+                                  child: PangeaLogoSvg(
+                                    width: largeIconWidth,
+                                    forceColor: Theme.of(
+                                      context,
+                                    ).colorScheme.onSurfaceVariant,
                                   ),
-                                );
-                              },
-                              toolTip: L10n.of(context).allChats,
-                              unreadBadgeFilter: (room) =>
-                                  room.firstSpaceParent == null,
-                              naviRailWidth: naviRailWidth,
-                            ),
-                            // 3. Courses — opens the Courses panel (the courses
-                            // you're in + add-course options) as a bare `addcourse`
-                            // left token. The Material map icon; chromeless, the bar
-                            // conveys selection. keepRoom:false keeps it a focused
-                            // flow with no chat floating over it. (Analytics is not a
-                            // rail section — it opens from the top-right cluster.)
-                            NaviRailItem(
-                              isSelected: isCourseFind,
-                              backgroundColor: Colors.transparent,
-                              icon: Icon(
-                                Icons.map_outlined,
-                                size: smallIconWidth,
+                                ),
+                                selectedIcon: ExcludeSemantics(
+                                  child: PangeaLogoSvg(
+                                    width: largeIconWidth,
+                                    forceColor: Theme.of(
+                                      context,
+                                    ).colorScheme.primary,
+                                  ),
+                                ),
+                                onTap: () {
+                                  // World is home: clear every panel (both columns)
+                                  // and reveal the full map. See routing.instructions.md.
+                                  context.go(WorkspaceNav.clearAll());
+                                },
+                                toolTip: L10n.of(context).world,
+                                naviRailWidth: naviRailWidth,
                               ),
-                              selectedIcon: Icon(
-                                Icons.map,
-                                size: smallIconWidth,
-                              ),
-                              onTap: () {
-                                context.go(
-                                  WorkspaceNav.openAddCourse(state.uri),
-                                );
-                              },
-                              toolTip: L10n.of(context).courses,
-                              naviRailWidth: naviRailWidth,
-                            ),
-                            Semantics(
-                              label: L10n.of(context).joinedCourseListLabel,
-                              child: ListView(
-                                shrinkWrap: true,
-                                scrollDirection: Axis.vertical,
-                                children: [
-                                  // 4. The course spaces you're in.
-                                  for (final space in allSpaces)
-                                    // _spaceItem(context, space),
-                                    _SpaceItem(
-                                      space: space,
-                                      iconWidth: largeIconWidth,
-                                      naviRailWidth: naviRailWidth,
-                                      // Highlight the course avatar only while the course
-                                      // IS the open section — not merely because `?c=`
-                                      // persists under a chat/room (routing decision 5).
-                                      selected:
-                                          section == AppSection.courses &&
-                                          activeSpaceId == space.id,
-                                      onTap: () =>
-                                          _onTapSpace(context, space.id),
+                              // 2. Chats — the chat list. Chromeless (no box fill) and
+                              // icon-sized to match the brand mark / course avatars
+                              // (it used to render tiny on the default surface fill);
+                              // the left indicator bar conveys selection.
+                              NaviRailItem(
+                                isSelected: isChats,
+                                backgroundColor: Colors.transparent,
+                                icon: Icon(
+                                  Icons.forum_outlined,
+                                  size: smallIconWidth,
+                                ),
+                                selectedIcon: Icon(
+                                  Icons.forum,
+                                  size: smallIconWidth,
+                                ),
+                                onTap: () {
+                                  // Token-only: the chats list is a left `chats` token
+                                  // over the world path `/` (no legacy `/chats` path).
+                                  context.go(
+                                    WorkspaceNav.setSection(
+                                      state.uri,
+                                      const ChatsPanelToken(),
+                                      // Replace open left panels rather than stack.
+                                      keepRoom: false,
                                     ),
-                                ],
+                                  );
+                                },
+                                toolTip: L10n.of(context).allChats,
+                                unreadBadgeFilter: (room) =>
+                                    room.firstSpaceParent == null,
+                                naviRailWidth: naviRailWidth,
                               ),
-                            ),
-                          ],
+                              // 3. Courses — opens the Courses panel (the courses
+                              // you're in + add-course options) as a bare `addcourse`
+                              // left token. The Material map icon; chromeless, the bar
+                              // conveys selection. keepRoom:false keeps it a focused
+                              // flow with no chat floating over it. (Analytics is not a
+                              // rail section — it opens from the top-right cluster.)
+                              NaviRailItem(
+                                isSelected: isCourseFind,
+                                backgroundColor: Colors.transparent,
+                                icon: Icon(
+                                  Icons.map_outlined,
+                                  size: smallIconWidth,
+                                ),
+                                selectedIcon: Icon(
+                                  Icons.map,
+                                  size: smallIconWidth,
+                                ),
+                                onTap: () {
+                                  context.go(
+                                    WorkspaceNav.openAddCourse(state.uri),
+                                  );
+                                },
+                                toolTip: L10n.of(context).courses,
+                                naviRailWidth: naviRailWidth,
+                              ),
+                              Semantics(
+                                label: L10n.of(context).joinedCourseListLabel,
+                                child: ListView(
+                                  shrinkWrap: true,
+                                  scrollDirection: Axis.vertical,
+                                  children: [
+                                    // 4. The course spaces you're in.
+                                    for (final space in allSpaces)
+                                      // _spaceItem(context, space),
+                                      _SpaceItem(
+                                        space: space,
+                                        iconWidth: largeIconWidth,
+                                        naviRailWidth: naviRailWidth,
+                                        // Highlight the course avatar only while the course
+                                        // IS the open section — not merely because `?c=`
+                                        // persists under a chat/room (routing decision 5).
+                                        selected:
+                                            section == AppSection.courses &&
+                                            activeSpaceId == space.id,
+                                        onTap: () =>
+                                            _onTapSpace(context, space.id),
+                                      ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                );
-              },
+                      ],
+                    ),
+                  );
+                },
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard focus traversal across course code entry, navigation rails, workspace panels, and world clusters.
  * Established a predictable focus order for desktop and mobile navigation areas.
  * Preserved existing controls, layouts, and interactions while making keyboard navigation more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->