### PR TITLE
Hide the in-app course Stats page (#7709)

### DIFF
--- a/lib/routes/chat/chat_details/space_details_content.dart
+++ b/lib/routes/chat/chat_details/space_details_content.dart
@@ -109,16 +109,19 @@ class SpaceDetailsContent extends StatelessWidget {
             setSelectedTab(SpaceSettingsTabs.participants, context),
         tab: SpaceSettingsTabs.participants,
       ),
-      ButtonDetails(
-        title: l10n.stats,
-        icon: const Icon(Symbols.bar_chart_4_bars, size: 30.0),
-        onPressed: () => setSelectedTab(SpaceSettingsTabs.analytics, context),
-        enabled: room.isRoomAdmin,
-        tab: SpaceSettingsTabs.analytics,
-        // world_v2: the card has 4 primary tabs (chats / course plan /
-        // participants / more); course stats live inside More for admins.
-        showInMainView: false,
-      ),
+      // #7709: the in-app course Stats page is hidden — the admin dashboard
+      // (admin.pangea.chat) now owns course analytics. Left commented (not
+      // deleted) so it's trivially reversible while the admin dash matures.
+      // ButtonDetails(
+      //   title: l10n.stats,
+      //   icon: const Icon(Symbols.bar_chart_4_bars, size: 30.0),
+      //   onPressed: () => setSelectedTab(SpaceSettingsTabs.analytics, context),
+      //   enabled: room.isRoomAdmin,
+      //   tab: SpaceSettingsTabs.analytics,
+      //   // world_v2: the card has 4 primary tabs (chats / course plan /
+      //   // participants / more); course stats live inside More for admins.
+      //   showInMainView: false,
+      // ),
       ButtonDetails(
         title: l10n.invite,
         description: l10n.inviteDesc,


### PR DESCRIPTION
Closes #7709. Supersedes #7698.

The in-app course **Stats** page (the `analytics` tab in the course card's More list) is retired: the admin dashboard at admin.pangea.chat now owns course/student analytics, so a parallel in-app surface is redundant and risks divergence.

Per the issue, this **comments out** the Stats `ButtonDetails` rather than deleting it — the underlying tab/page stays in place, so re-enabling is a one-line revert while the admin dash matures.

## TO TEST
- [ ] Open a course card as an admin -> More: the Stats entry is gone
- [ ] Remaining More entries (invite, edit course, etc.) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)