### PR TITLE
Logic fixes: opener suggestion chip, join-code ban error, onboarding CEFR reset, grammar-practice blank (#7703, #7592, #7583, #7360)

### DIFF
--- a/lib/features/join_codes/knock_with_code_extension.dart
+++ b/lib/features/join_codes/knock_with_code_extension.dart
@@ -12,14 +12,21 @@ extension on Api {
     request.headers['authorization'] = 'Bearer ${bearerToken!}';
     request.bodyBytes = utf8.encode(jsonEncode({'access_code': code}));
     final response = await httpClient.send(request);
+    // Read the body up front — the stream can only be consumed once, and the
+    // error path now needs it too (to detect the banned-from-every-room 403).
+    final responseString = utf8.decode(await response.stream.toBytes());
     if (response.statusCode != 200) {
+      // A valid code where the user is banned from every matched room comes
+      // back as 403 ORG.PANGEA.BANNED_FROM_ROOM: surface it as a typed
+      // exception so the join flow can show a ban-specific message instead of
+      // the generic "code not found" (#7592). Anything else keeps throwing the
+      // raw response (downstream 429 handling still reads its statusCode).
+      final banned = BannedFromRoomException.fromErrorBody(responseString);
+      if (banned != null) throw banned;
       throw response;
     }
 
-    final responseBody = await response.stream.toBytes();
-    final responseString = utf8.decode(responseBody);
-    final json = jsonDecode(responseString);
-    return KnockSpaceResponse.fromJson(json);
+    return KnockSpaceResponse.fromJson(jsonDecode(responseString));
   }
 }
 
@@ -31,16 +38,64 @@ class KnockSpaceResponse {
   final List<String> roomIds;
   final List<String> alreadyJoined;
 
-  KnockSpaceResponse({required this.roomIds, required this.alreadyJoined});
+  /// Rooms the code matched but the user is banned from — present on a mixed
+  /// 200 outcome alongside [roomIds] / [alreadyJoined] (#7592).
+  final List<String> banned;
+
+  KnockSpaceResponse({
+    required this.roomIds,
+    required this.alreadyJoined,
+    this.banned = const [],
+  });
 
   factory KnockSpaceResponse.fromJson(Map<String, dynamic> json) {
     return KnockSpaceResponse(
       roomIds: List<String>.from(json['rooms'] ?? []),
       alreadyJoined: List<String>.from(json['already_joined'] ?? []),
+      banned: List<String>.from(json['banned'] ?? []),
     );
   }
 
   Map<String, dynamic> toJson() {
-    return {'rooms': roomIds, 'already_joined': alreadyJoined};
+    return {
+      'rooms': roomIds,
+      'already_joined': alreadyJoined,
+      'banned': banned,
+    };
   }
+}
+
+/// Thrown when `/knock_with_code` reports the code is valid but the user is
+/// banned from every matched room (403 `ORG.PANGEA.BANNED_FROM_ROOM`). The join
+/// flow maps this to a ban-specific message rather than "code not found"
+/// (#7592).
+class BannedFromRoomException implements Exception {
+  /// The room ids the user is banned from, from the error body's `banned` list.
+  final List<String> banned;
+
+  BannedFromRoomException({this.banned = const []});
+
+  /// The server errcode that signals this case.
+  static const String errcode = 'ORG.PANGEA.BANNED_FROM_ROOM';
+
+  /// Parse a non-200 `/knock_with_code` body: returns a [BannedFromRoomException]
+  /// when the body carries [errcode], else null (the caller then falls back to
+  /// throwing the raw response). Never throws — a non-JSON or unexpected body
+  /// yields null. Pure, so it can be unit-tested directly.
+  static BannedFromRoomException? fromErrorBody(String body) {
+    try {
+      final json = jsonDecode(body);
+      if (json is Map<String, dynamic> && json['errcode'] == errcode) {
+        return BannedFromRoomException(
+          banned: List<String>.from(json['banned'] ?? const []),
+        );
+      }
+    } catch (_) {
+      // Non-JSON or unexpected shape — fall through to the raw-response path.
+    }
+    return null;
+  }
+
+  @override
+  String toString() => 'BannedFromRoomException(banned: $banned)';
 }

--- a/lib/features/join_codes/space_code_controller.dart
+++ b/lib/features/join_codes/space_code_controller.dart
@@ -183,7 +183,9 @@ class SpaceCodeController {
     final resp = await showFutureLoadingDialog(
       context: context,
       future: () => _joinSpaceWithCodeWithoutLoading(spaceCode, client: client),
-      onError: (e, s) => notFoundError ?? L10n.of(context).unableToFindRoom,
+      onError: (e, s) => e is BannedFromRoomException
+          ? L10n.of(context).removedFromCourseError
+          : (notFoundError ?? L10n.of(context).unableToFindRoom),
       showError: (err) => err is! StreamedResponse || err.statusCode != 429,
     );
 

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -4720,6 +4720,7 @@
     "banFromSpace": "Ban from course",
     "unbanFromSpace": "Unban from course",
     "cannotJoinBannedRoom": "Banned. Unable to join.",
+    "removedFromCourseError": "You've been removed from this course. Contact your teacher.",
     "sessionFull": "Too late! This activity is full.",
     "returnToCourse": "Return to course",
     "returnHome": "Return home",

--- a/lib/routes/analytics/construct_analytics/practice/grammar_error_example_widget.dart
+++ b/lib/routes/analytics/construct_analytics/practice/grammar_error_example_widget.dart
@@ -14,58 +14,74 @@ class GrammarErrorExampleWidget extends StatelessWidget {
     required this.showTranslation,
   });
 
-  @override
-  Widget build(BuildContext context) {
-    final text = analyticsPracticeExercise.text;
-    final errorOffset = analyticsPracticeExercise.errorOffset;
-    final errorLength = analyticsPracticeExercise.errorLength;
-
-    const maxContextChars = 50;
-
+  /// The sentence split around the blanked error span, as (before, after) plus
+  /// whether either side was context-trimmed. Grapheme-based (matching
+  /// [SpanData.errorSpan]), so the blank aligns exactly with
+  /// `text.characters[errorOffset .. errorOffset + errorLength)` — the true
+  /// error word once the offsets index the right base string (#7360). Pure and
+  /// static so the alignment is unit-testable without pumping the widget.
+  @visibleForTesting
+  static ({String before, String after, bool trimmedBefore, bool trimmedAfter})
+  splitAroundBlank(
+    String text,
+    int errorOffset,
+    int errorLength, {
+    int maxContextChars = 50,
+  }) {
     final chars = text.characters;
     final totalLength = chars.length;
 
-    // ---------- BEFORE ----------
     int beforeStart = 0;
     bool trimmedBefore = false;
-
     if (errorOffset > maxContextChars) {
       int desiredStart = errorOffset - maxContextChars;
-
-      // Snap left to nearest whitespace to avoid cutting words
+      // Snap left to nearest whitespace to avoid cutting words.
       while (desiredStart > 0 && chars.elementAt(desiredStart) != ' ') {
         desiredStart--;
       }
-
       beforeStart = desiredStart;
       trimmedBefore = true;
     }
-
     final before = chars
         .skip(beforeStart)
         .take(errorOffset - beforeStart)
         .toString();
 
-    // ---------- AFTER ----------
     int afterEnd = totalLength;
     bool trimmedAfter = false;
-
     final errorEnd = errorOffset + errorLength;
-    final afterChars = totalLength - errorEnd;
-
-    if (afterChars > maxContextChars) {
+    if (totalLength - errorEnd > maxContextChars) {
       int desiredEnd = errorEnd + maxContextChars;
-
-      // Snap right to nearest whitespace
+      // Snap right to nearest whitespace.
       while (desiredEnd < totalLength && chars.elementAt(desiredEnd) != ' ') {
         desiredEnd++;
       }
-
       afterEnd = desiredEnd;
       trimmedAfter = true;
     }
-
     final after = chars.skip(errorEnd).take(afterEnd - errorEnd).toString();
+
+    return (
+      before: before,
+      after: after,
+      trimmedBefore: trimmedBefore,
+      trimmedAfter: trimmedAfter,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final errorLength = analyticsPracticeExercise.errorLength;
+
+    final split = splitAroundBlank(
+      analyticsPracticeExercise.text,
+      analyticsPracticeExercise.errorOffset,
+      errorLength,
+    );
+    final before = split.before;
+    final after = split.after;
+    final trimmedBefore = split.trimmedBefore;
+    final trimmedAfter = split.trimmedAfter;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),

--- a/lib/routes/analytics/construct_analytics/practice/grammar_error_practice_generator.dart
+++ b/lib/routes/analytics/construct_analytics/practice/grammar_error_practice_generator.dart
@@ -25,21 +25,24 @@ class GrammarErrorPracticeGenerator {
     final correctChoice = igcMatch!.bestChoice!.value;
     final choices = igcMatch.choices!.map((c) => c.value).toList();
 
-    final stepText = choreo.stepText(stepIndex: stepIndex - 1);
-    final errorSpan = stepText.characters
-        .skip(igcMatch.offset)
-        .take(igcMatch.length)
-        .toString();
+    // The offset/length index the match's own fullText — the exact IGC input
+    // the server measured against (the same base SpanData.errorSpan uses) — NOT
+    // a client-side stepText reconstruction. Pairing the offsets with stepText
+    // slid the blank a few characters into the following word whenever the two
+    // strings differed, so display both the sentence and the blank off fullText
+    // (#7360).
+    final baseText = igcMatch.fullText;
+    final errorSpan = igcMatch.errorSpan;
 
     if (!req.grammarErrorInfo!.translation.contains(errorSpan)) {
       choices.add(errorSpan);
     }
 
-    if (igcMatch.offset + igcMatch.length > stepText.characters.length) {
+    if (igcMatch.offset + igcMatch.length > baseText.characters.length) {
       // Sometimes choreo records turn out weird when users edit the message
       // mid-IGC. If the offsets / lengths don't make sense, skip this target.
       throw Exception(
-        "IGC match offset and length exceed step text length. Step text: '$stepText', match offset: ${igcMatch.offset}, match length: ${igcMatch.length}",
+        "IGC match offset and length exceed base text length. Base text: '$baseText', match offset: ${igcMatch.offset}, match length: ${igcMatch.length}",
       );
     }
 
@@ -52,7 +55,7 @@ class GrammarErrorPracticeGenerator {
           choices: choices.toSet(),
           answers: {correctChoice},
         ),
-        text: stepText,
+        text: baseText,
         errorOffset: igcMatch.offset,
         errorLength: igcMatch.length,
         eventID: eventID,

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_controller.dart
@@ -164,7 +164,10 @@ class OrchestratorController {
   /// - multi-human (>= 2 human roles): prompt the user who did NOT send the
   ///   latest human message — after A's message B is prompted; after B's, A.
   /// - single-human (participant mode, bot holds a role): prompt the lone human
-  ///   right after their own message OR after the bot's reply to them.
+  ///   whenever a fresh own-role bucket exists — after their own message, after
+  ///   the bot's reply, and on the bot's turn-0 opener before they have spoken
+  ///   (#7703; under v2 the sender's own role is omitted and empty buckets are
+  ///   dropped, so a surviving own-role bucket already means it is their turn).
   /// Stale outputs — not based on the latest visible message of ANY sender —
   /// are dropped (the caller also checks this before deciding to clear).
   @visibleForTesting
@@ -183,9 +186,12 @@ class OrchestratorController {
 
     final isMultiHumanActivity = humanRoleCount >= 2;
     final currentUserSpokeLast = latestHumanMessageSenderId == currentUserId;
-    final shouldPrompt = isMultiHumanActivity
-        ? !currentUserSpokeLast
-        : currentUserSpokeLast;
+    // Single-human: reaching here already means a fresh own-role bucket exists
+    // (the guards above), and under v2 the sender's own role is omitted from
+    // outputs — so a surviving own-role bucket means it is the human's turn.
+    // Prompt regardless of whether they have spoken yet, so the bot's turn-0
+    // opener gets a chip too (#7703). Multi-human still prompts the responder.
+    final shouldPrompt = isMultiHumanActivity ? !currentUserSpokeLast : true;
     return shouldPrompt ? roleSuggestion : null;
   }
 

--- a/lib/routes/onboarding/onboarding_state_controller.dart
+++ b/lib/routes/onboarding/onboarding_state_controller.dart
@@ -58,7 +58,14 @@ class OnboardingStateController {
   void setAvatarInfo(AvatarInfo info) => _avatarInfo = info;
   void setDisplayName(String displayName) => _displayName = displayName;
 
-  void setUserType(UserType type) => _userType = type;
+  void setUserType(UserType type) {
+    // Switching teacher <-> learner starts the CEFR pick over: the level is a
+    // single shared field, so without this a teacher-picked level leaks onto
+    // the learner's CEFR page — nothing highlighted, yet Next enabled (#7583).
+    // Re-tapping the same role keeps the existing pick.
+    if (_userType != type) _languageLevel = null;
+    _userType = type;
+  }
 
   void setBaseLanguage(LanguageModel? lang) => _baseLanguage = lang;
   void setTargetLanguage(LanguageModel? lang) => _targetLanguage = lang;

--- a/lib/routes/onboarding/onboarding_step_views/pick_cefr_level_step_view.dart
+++ b/lib/routes/onboarding/onboarding_step_views/pick_cefr_level_step_view.dart
@@ -35,9 +35,13 @@ class PickCefrLevelStepViewState extends State<PickCefrLevelStepView> {
     super.initState();
     _step = widget.step;
     final userLevel = MatrixState.pangeaController.userController.userCefrLevel;
-    if (_step.state.languageLevel == null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) => _setLevel(userLevel));
-    }
+    // Seed the highlight from the persisted selection (or the profile default)
+    // so it always reflects state.languageLevel: on re-entry the local notifier
+    // is a fresh null, and without this the page showed nothing selected while
+    // Next stayed enabled off the still-set state (#7583).
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _setLevel(_step.state.languageLevel ?? userLevel),
+    );
   }
 
   @override

--- a/test/pangea/grammar_error_example_split_test.dart
+++ b/test/pangea/grammar_error_example_split_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/analytics/construct_analytics/practice/grammar_error_example_widget.dart';
+
+/// Unit coverage for the grammar-practice cloze split (#7360): the blank must
+/// land exactly on the target word — grapheme-aligned — not slide into the
+/// following one. The generator now feeds this the match's own fullText, the
+/// string the offset/length were measured against.
+void main() {
+  group('GrammarErrorExampleWidget.splitAroundBlank', () {
+    test('blanks exactly the target word, not the next one', () {
+      // "El gato come" — target "gato" at grapheme offset 3, length 4.
+      final s = GrammarErrorExampleWidget.splitAroundBlank('El gato come', 3, 4);
+      expect(s.before, 'El ');
+      expect(s.after, ' come');
+      expect(s.trimmedBefore, isFalse);
+      expect(s.trimmedAfter, isFalse);
+    });
+
+    test('handles a target at the very start', () {
+      final s = GrammarErrorExampleWidget.splitAroundBlank('gato come', 0, 4);
+      expect(s.before, isEmpty);
+      expect(s.after, ' come');
+    });
+
+    test('handles a target at the very end', () {
+      final s = GrammarErrorExampleWidget.splitAroundBlank('come gato', 5, 4);
+      expect(s.before, 'come ');
+      expect(s.after, isEmpty);
+    });
+
+    test(
+      'grapheme-based: a multi-code-unit char before the target keeps the '
+      'blank aligned',
+      () {
+        // The emoji is one grapheme but two UTF-16 code units; a code-unit
+        // split would land mid-character. Graphemes: ['🙂',' ','g','a','t','o'].
+        final s = GrammarErrorExampleWidget.splitAroundBlank('🙂 gato', 2, 4);
+        expect(s.before, '🙂 ');
+        expect(s.after, isEmpty);
+      },
+    );
+  });
+}

--- a/test/pangea/knock_space_response_test.dart
+++ b/test/pangea/knock_space_response_test.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/join_codes/knock_with_code_extension.dart';
+
+/// Unit coverage for the `/knock_with_code` response + error parsing (#7592):
+/// the new `banned` field on mixed 200 outcomes, and the typed
+/// banned-from-every-room exception derived from a 403 body.
+void main() {
+  group('KnockSpaceResponse.fromJson', () {
+    test('parses rooms, already_joined, and banned', () {
+      final response = KnockSpaceResponse.fromJson({
+        'rooms': ['!a:server'],
+        'already_joined': ['!b:server'],
+        'banned': ['!c:server'],
+      });
+      expect(response.roomIds, ['!a:server']);
+      expect(response.alreadyJoined, ['!b:server']);
+      expect(response.banned, ['!c:server']);
+    });
+
+    test('defaults banned to empty when the key is absent (back-compat)', () {
+      final response = KnockSpaceResponse.fromJson({
+        'rooms': ['!a:server'],
+      });
+      expect(response.banned, isEmpty);
+      expect(response.roomIds, ['!a:server']);
+    });
+
+    test('round-trips banned through toJson', () {
+      final response = KnockSpaceResponse(
+        roomIds: const [],
+        alreadyJoined: const [],
+        banned: const ['!c:server'],
+      );
+      expect(response.toJson()['banned'], ['!c:server']);
+    });
+  });
+
+  group('BannedFromRoomException.fromErrorBody', () {
+    test('returns a typed exception with the banned list on the ban errcode', () {
+      final exception = BannedFromRoomException.fromErrorBody(
+        jsonEncode({
+          'errcode': 'ORG.PANGEA.BANNED_FROM_ROOM',
+          'error': 'You are banned from every matched room.',
+          'banned': ['!room:server'],
+        }),
+      );
+      expect(exception, isNotNull);
+      expect(exception!.banned, ['!room:server']);
+    });
+
+    test('tolerates a missing banned list', () {
+      final exception = BannedFromRoomException.fromErrorBody(
+        jsonEncode({'errcode': 'ORG.PANGEA.BANNED_FROM_ROOM'}),
+      );
+      expect(exception, isNotNull);
+      expect(exception!.banned, isEmpty);
+    });
+
+    test('returns null for a different errcode', () {
+      final exception = BannedFromRoomException.fromErrorBody(
+        jsonEncode({'errcode': 'M_FORBIDDEN', 'error': 'nope'}),
+      );
+      expect(exception, isNull);
+    });
+
+    test('returns null (never throws) for a non-JSON body', () {
+      expect(
+        BannedFromRoomException.fromErrorBody('<html>502 Bad Gateway</html>'),
+        isNull,
+      );
+    });
+  });
+}

--- a/test/pangea/onboarding_tests/onboarding_step_transition_test.dart
+++ b/test/pangea/onboarding_tests/onboarding_step_transition_test.dart
@@ -190,4 +190,31 @@ void main() async {
   test("Test backward navigation through teacher without course code", () {
     testBackwardNavigationWithoutCode(teacherWithoutCode, UserType.teacher);
   });
+
+  test("Switching role clears a stale CEFR selection (#7583)", () {
+    final state = getInitialOnboardingStep(client).state;
+
+    // Pick a CEFR level as a teacher.
+    state.setUserType(UserType.teacher);
+    state.setLanguageLevel(LanguageLevelTypeEnum.a1);
+    expect(state.languageLevel, LanguageLevelTypeEnum.a1);
+
+    // Switching to learner must NOT carry the teacher's level over — otherwise
+    // the learner CEFR page shows nothing selected while Next stays enabled.
+    state.setUserType(UserType.student);
+    expect(state.languageLevel, isNull);
+
+    final levelStep = PickCefrLevelOnboardingStep(
+      client: client,
+      state: state,
+      maxRemainingSteps: 0,
+    );
+    expect(levelStep.enableGoForward, isFalse);
+
+    // Re-tapping the same role keeps a real selection.
+    state.setLanguageLevel(LanguageLevelTypeEnum.b1);
+    state.setUserType(UserType.student);
+    expect(state.languageLevel, LanguageLevelTypeEnum.b1);
+    expect(levelStep.enableGoForward, isTrue);
+  });
 }

--- a/test/pangea/orchestrator_controller_suggestion_test.dart
+++ b/test/pangea/orchestrator_controller_suggestion_test.dart
@@ -114,18 +114,27 @@ void main() {
       });
 
       test(
-        'not prompted when the latest message is not the current user\'s',
+        'lone human is prompted on the bot\'s opener, before their first '
+        'message (#7703)',
         () {
-          final output = outputWithBothRoles(eventB);
+          // v2 re-fires on the bot's turn-0 opener (choreo#2761): the output is
+          // based on the bot's message and carries the human role's bucket (the
+          // sender's own role is omitted), so the lone human is prompted even
+          // though they have not spoken yet (latestHumanMessageSenderId null).
+          // The old currentUserSpokeLast gate dropped this — the moment
+          // forced-choice suggestions matter most for the PreA1-B1 audience.
+          const botOpener = r'$botOpener';
+          final output = outputWithBothRoles(botOpener);
           final result = OrchestratorController.suggestionToShow(
             output: output,
             ownRoleId: roleA,
             currentUserId: userA,
-            latestMessageEventId: eventB,
-            latestHumanMessageSenderId: userB,
+            latestMessageEventId: botOpener,
+            latestHumanMessageSenderId: null, // no human has spoken yet
             humanRoleCount: 1,
           );
-          expect(result, isNull);
+          expect(result, isNotNull);
+          expect(result!.roleId, roleA);
         },
       );
     },


### PR DESCRIPTION
## Summary

A batch of clear, unit-tested logic/parsing fixes.

- **Orchestrator suggestion chip on the bot's opener — closes #7703.** `OrchestratorController.suggestionToShow`'s single-human branch only prompted when the current user sent the latest human message, so the bot's turn-0 opener produced no chip (`latestHumanMessageSenderId` is null before the human's first message). Under v2 the guards above already ensure a fresh own-role bucket exists and the sender's own role is omitted from outputs, so a surviving own-role bucket means it's the human's turn — prompt unconditionally in the single-human case. Multi-human is unchanged.

- **Ban-specific course-code join error — closes #7592.** `/knock_with_code` now returns `403 ORG.PANGEA.BANNED_FROM_ROOM` when a code is valid but the user is banned from every matched room. The client threw the raw response on any non-200 and dropped unknown keys, so a banned user saw the generic "code not found." Now `knockSpace` parses the body and throws a typed `BannedFromRoomException` (else keeps throwing the raw response so 429 handling is unchanged), the join flow maps it to a new `removedFromCourseError` message, and `KnockSpaceResponse` gains a `banned` field.

- **Onboarding CEFR selection reset on role switch — closes #7583.** The CEFR level is a single shared field, so picking one as a teacher and switching to learner left it set: the learner CEFR page showed nothing selected yet Next was enabled. `setUserType` now clears the level on an actual role change (same-role re-tap keeps it), and the view seeds its highlight from the persisted selection so display and the enable guard always agree.

- **Grammar-practice fill-in-the-blank alignment — #7360 (partial).** The cloze offsets index the IGC match's `fullText` (the base `SpanData.errorSpan` uses), but the generator paired them with a separately reconstructed `choreo.stepText(stepIndex-1)`; when the strings differed by a few chars the blank slid into the next word. It now displays and blanks off `igcMatch.fullText`/`igcMatch.errorSpan`. **This fixes the blank placement only** — the issue's secondary note (repeat sentences / 24h cooldown, `ConstructUses.shouldSkipForRecentPractice`) is a separate code path and is left as a follow-up, so #7360 stays open.

## Tests

Every fix ships a unit test (all pure, no app run required):
- `test/pangea/orchestrator_controller_suggestion_test.dart` — opener case (repurposed the now-invalid gate test).
- `test/pangea/knock_space_response_test.dart` (new) — `banned` parsing + the pure error-body → exception helper.
- `test/pangea/onboarding_tests/onboarding_step_transition_test.dart` — role-switch clears the level and disables Next; same-role re-tap keeps it.
- `test/pangea/grammar_error_example_split_test.dart` (new) — the blank lands exactly on the target word, grapheme-aligned.

> Note: authored without a Flutter toolchain in the environment, so these tests haven't been run locally — they're written to run under CI. The #7360 test guards the render-split alignment; the base-string swap itself rests on the `SpanData.errorSpan` contract (a full generator test would need a deep choreo fixture).

---

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md).

### Pull Request has been tested on:

_Not run in this environment — logic is covered by the unit tests above, which CI runs._

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

### Accessibility

- [x] No new or changed interactive controls in this batch (logic/parsing + a decorative blank span), so no new accessible names are required. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSQX5Y55ycHjcZkaJhc15W

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSQX5Y55ycHjcZkaJhc15W)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer handling when users are removed from a course, including a localized message.
  * Preserved information about rooms where access is banned during join-by-code flows.
  * Single-participant activities now show suggestions from the opening prompt.

* **Bug Fixes**
  * Corrected onboarding language-level selection when changing roles or returning to a step.
  * Improved grammar practice text and error-span handling, including emoji-safe formatting.

* **Tests**
  * Added coverage for banned-room responses, onboarding transitions, grammar formatting, and activity suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->