### PR TITLE
chore(l10n): remove 169 unused FluffyChat base translation keys

### DIFF
--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -63,11 +63,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "هل يُسمح للزوار الدخول",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "أمتأكد؟",
     "@areYouSure": {
         "type": "String",
@@ -323,11 +318,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "دعيَ المراسل للمجموعة",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "copiedToClipboard": "نُسخ للحافظة",
     "@copiedToClipboard": {
         "type": "String",
@@ -462,11 +452,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "لن يمكنك تعطيل التشفير أبدا، أمتأكد؟",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encryption": "التشفير",
     "@encryption": {
         "type": "String",
@@ -513,11 +498,6 @@
     },
     "group": "المجموعة",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "المجموعة عامة",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -581,15 +561,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "أدعو مراسلا الى {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "دُعيَ",
     "@invited": {
@@ -697,15 +668,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "حمِّل {count} منتسبًا إضافيًا",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "يحمّل… يرجى الانتظار.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -720,15 +682,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "لِج ل {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "اخرج",
     "@logout": {
@@ -767,11 +720,6 @@
     },
     "noEmotesFound": "لم يُعثر على انفعالة. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "يبدو أن خدمة Firebase Cloud Messaging غير متاحة على جهازك. لمواصلة تلقي الإشعارات، نوصي بتثبيت ntfy. باستخدام ntfy أو أي مزود خدمة Unified Push آخر، يمكنك تلقي إشعارات الدفع بطريقة آمنة للبيانات. يمكنك تنزيل ntfy من PlayStore أو من F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -915,11 +863,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "أزل جهازا",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "فك حجبه من المحادثة",
     "@unbanFromChat": {
@@ -1150,15 +1093,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unreadChats": "{unreadCount, plural, =1{1 محادثة غير مقروءة} other{{unreadCount} محادثات غير مقروءة}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "userAndOthersAreTyping": "{username} و {count} أخرون يكتبون…",
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -1238,16 +1172,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "مكالمة فيديو",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "مرئية تأريخ المحادثة",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "مرئي لكل المنتسبين",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1285,11 +1209,6 @@
     },
     "warning": "تحذير!",
     "@warning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "من يسمح له الانضمام للمجموعة",
-    "@whoIsAllowedToJoinThisGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1397,11 +1316,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "everythingReady": "كل شيء جاهز!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "homeserver": "الخادم",
     "@homeserver": {},
     "enterAnEmailAddress": "أدخل عنوان بريد إلكتروني",
@@ -1446,11 +1360,6 @@
     },
     "deviceId": "معرّف الجهاز",
     "@deviceId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "createNewSpace": "مساحة جديدة",
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1662,11 +1571,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "يتم تأمين رسائلك القديمة باستخدام مفتاح الاسترداد. يرجى التأكد من أنك لا تضيعه.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "shareLocation": "شارك الموقع",
     "@shareLocation": {
         "type": "String",
@@ -1679,11 +1583,6 @@
     },
     "pleaseChoose": "اختر رجاء",
     "@pleaseChoose": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "استعادة كلمة السر",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1711,8 +1610,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableMultiAccounts": "(ميزة تجربية) فعّل تعدد الحسابات",
-    "@enableMultiAccounts": {},
     "bundleName": "اسم الحزمة",
     "@bundleName": {},
     "removeFromBundle": "أزله من الحزمة",
@@ -1721,8 +1618,6 @@
     "@addToBundle": {},
     "editBundlesForAccount": "عدّل حزم هذا الحساب",
     "@editBundlesForAccount": {},
-    "addAccount": "أضف حسابًا",
-    "@addAccount": {},
     "online": "متصل",
     "@online": {
         "type": "String",
@@ -1741,11 +1636,6 @@
                 "type": "int"
             }
         }
-    },
-    "spaceIsPublic": "عام في المساحة",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
     },
     "unavailable": "غير متوفر",
     "@unavailable": {
@@ -1772,11 +1662,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceName": "اسم المساحة",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "synchronizingPleaseWait": "يُزامن… يرجى الانتظار.",
     "@synchronizingPleaseWait": {
         "type": "String",
@@ -1799,16 +1684,6 @@
     },
     "status": "الحالة",
     "@status": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "transferFromAnotherDevice": "أنقله من جهاز آخر",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "مسح نسخة المحادثة الاحتياطية لإنشاء مفتاح استرداد جديد؟",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1861,11 +1736,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "تعيين مستوى الأذونات",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "oneClientLoggedOut": "أُ خرج أحد العملاء الذي تسختدمها",
     "@oneClientLoggedOut": {},
     "pleaseEnter4Digits": "أدخل 4 أرقام أو أتركه فارغ لتعطيل القفل.",
@@ -1890,15 +1760,8 @@
     },
     "repeatPassword": "كرّر كلمة السر",
     "@repeatPassword": {},
-    "removeFromSpace": "أزل من المساحة",
-    "@removeFromSpace": {},
     "unverified": "غير مؤكد",
     "@unverified": {},
-    "whoCanPerformWhichAction": "من يستطيع القيام بأي عمل",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "messageInfo": "معلومات الرسالة",
     "@messageInfo": {},
     "messageType": "نوع الرسالة",
@@ -1951,17 +1814,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "تم إعداد النسخ الاحتياطي لمحادثاتك.",
-    "@yourChatBackupHasBeenSetUp": {},
-    "noEncryptionForPublicRooms": "يمكنك فقط تفعيل التشفير عندما تصبح الغرفة غير متاحة للعامة.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "emojis": "إيموجي",
     "@emojis": {},
-    "voiceCall": "مكالمة صوتية",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "نسخة أندرويد غير مدعومة",
     "@unsupportedAndroidVersion": {},
     "unsupportedAndroidVersionLong": "تتطلب هذه الميزة إصدار Android أحدث. يرجى التحقق من وجود تحديثات أو دعم Lineage OS.",
@@ -1993,12 +1847,8 @@
         "type": "String",
         "description": "Usage hint for the command /myroomavatar"
     },
-    "videoCallsBetaWarning": "يرجى ملاحظة أن مكالمات الفيديو حالياً في مرحلة تجريبية. قد لا تعمل كما هو متوقع أو تعمل على الإطلاق على جميع المنصات.",
-    "@videoCallsBetaWarning": {},
     "placeCall": "إجراء مكالمة",
     "@placeCall": {},
-    "emailOrUsername": "البريد الإلكتروني أو اسم المستخدم",
-    "@emailOrUsername": {},
     "dismiss": "رفض",
     "@dismiss": {},
     "setAsCanonicalAlias": "تعيين كاسم مستعار رئيسي",
@@ -2076,10 +1926,6 @@
     },
     "widgetVideo": "فيديو",
     "@widgetVideo": {},
-    "recoveryKeyLost": "هل فقدت مفتاح الاسترداد؟",
-    "@recoveryKeyLost": {},
-    "pleaseEnterRecoveryKeyDescription": "لإلغاء قفل رسائلك القديمة ، يرجى إدخال مفتاح الاسترداد الذي تم إنشاؤه في جلسة سابقة. مفتاح الاسترداد ليس كلمة المرور الخاصة بك.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "confirmMatrixId": "يرجى تأكيد معرف Matrix الخاص بك من أجل حذف حسابك.",
     "@confirmMatrixId": {},
     "supposedMxid": "يجب أن يكون هذا {mxid}",
@@ -2106,8 +1952,6 @@
             }
         }
     },
-    "unlockOldMessages": "إلغاء قفل الرسائل القديمة",
-    "@unlockOldMessages": {},
     "commandHint_markasdm": "وضع علامة على أنها غرفة رسائل مباشرة لمعرف المصفوفة",
     "@commandHint_markasdm": {},
     "dehydrate": "تصدير الجلسة ومسح الجهاز",
@@ -2116,10 +1960,6 @@
     "@dehydrateWarning": {},
     "hydrate": "استعادة من ملف النسخ الاحتياطي",
     "@hydrate": {},
-    "pleaseEnterRecoveryKey": "الرجاء إدخال مفتاح الاسترداد:",
-    "@pleaseEnterRecoveryKey": {},
-    "recoveryKey": "مفتاح الاسترداد",
-    "@recoveryKey": {},
     "widgetCustom": "مُخصّص",
     "@widgetCustom": {},
     "widgetNameError": "يرجى تقديم اسم العرض.",
@@ -2156,12 +1996,6 @@
             }
         }
     },
-    "storeInAndroidKeystore": "تخزين في سجل مفاتيح اندرويد",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "تخزين في سلسلة مفاتيح ابل",
-    "@storeInAppleKeyChain": {},
-    "storeSecurlyOnThisDevice": "احفظه بأمان على هذا الجهاز",
-    "@storeSecurlyOnThisDevice": {},
     "countFiles": "ملفات {count}",
     "@countFiles": {
         "placeholders": {
@@ -2170,20 +2004,10 @@
             }
         }
     },
-    "foregroundServiceRunning": "يظهر هذا الإشعار عند تشغيل الخدمة الأمامية.",
-    "@foregroundServiceRunning": {},
-    "screenSharingTitle": "مشاركة الشاشة",
-    "@screenSharingTitle": {},
-    "enterSpace": "أدخل المساحة",
-    "@enterSpace": {},
     "deviceKeys": "مفاتيح الجهاز:",
     "@deviceKeys": {},
     "whyIsThisMessageEncrypted": "لماذا هذه الرسالة غير قابلة للقراءة؟",
     "@whyIsThisMessageEncrypted": {},
-    "encryptThisChat": "تشفير هذه المحادثة",
-    "@encryptThisChat": {},
-    "screenSharingDetail": "أنت تشارك شاشتك في FuffyChat",
-    "@screenSharingDetail": {},
     "newGroup": "مجموعة جديدة",
     "@newGroup": {},
     "youKicked": "👞 لقد ركلت {user}",
@@ -2234,8 +2058,6 @@
             }
         }
     },
-    "saveKeyManuallyDescription": "احفظ هذا المفتاح يدويا عن طريق تشغيل مربع حوار مشاركة النظام أو الحافظة.",
-    "@saveKeyManuallyDescription": {},
     "widgetJitsi": "اجتماعات جيتسي",
     "@widgetJitsi": {},
     "youInvitedUser": "📩 قمت بدعوة {user}",
@@ -2246,8 +2068,6 @@
             }
         }
     },
-    "storeInSecureStorageDescription": "قم بتخزين مفتاح الاسترداد في التخزين الآمن لهذا الجهاز.",
-    "@storeInSecureStorageDescription": {},
     "widgetName": "الاسم",
     "@widgetName": {},
     "users": "المستخدمون",
@@ -2271,14 +2091,8 @@
             }
         }
     },
-    "disableEncryptionWarning": "لأسباب أمنية ، لا يمكنك تعطيل التشفير في المحادثة ، حيث تم تمكينه من قبل.",
-    "@disableEncryptionWarning": {},
     "reportErrorDescription": "😭 أوه لا. هناك خطأ ما. إذا كنت تريد، يمكنك الإبلاغ عن هذا الخطأ إلى المطورين.",
     "@reportErrorDescription": {},
-    "newSpaceDescription": "يسمح لك تطبيق المساحات بتوحيد دردشاتك وبناء مجتمعات خاصة أو عامة.",
-    "@newSpaceDescription": {},
-    "sorryThatsNotPossible": "معذرة... هذا غير ممكن",
-    "@sorryThatsNotPossible": {},
     "openLinkInBrowser": "فتح الرابط في المتصفح",
     "@openLinkInBrowser": {},
     "reopenChat": "إعادة فتح المحادثة",
@@ -2313,8 +2127,6 @@
     "@messagesStyle": {},
     "shareInviteLink": "شارك رابط الدعوة",
     "@shareInviteLink": {},
-    "setTheme": "تعيين السمة:",
-    "@setTheme": {},
     "setColorTheme": "تعيين لون السمة:",
     "@setColorTheme": {},
     "tryAgain": "أعد المحاولة",
@@ -2348,8 +2160,6 @@
     "@invite": {},
     "chatPermissions": "صلاحيات المحادثة",
     "@chatPermissions": {},
-    "chatDescription": "وصف المحادثة",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "تغير وصف المجموعة",
     "@chatDescriptionHasBeenChanged": {},
     "noChatDescriptionYet": "لم يتم إنشاء وصف للمحادثة حتى الآن.",
@@ -2406,10 +2216,6 @@
     "@roomUpgradeDescription": {},
     "kickUserDescription": "يتم طرد المستخدم من المحادثة ولكن لا يتم حظره. في المحادثات العامة، يمكن للمستخدم الانضمام مرة أخرى في أي وقت.",
     "@kickUserDescription": {},
-    "createGroupAndInviteUsers": "إنشاء مجموعة ودعوة المستخدمين",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "يمكن العثور على المجموعة عبر البحث",
-    "@groupCanBeFoundViaSearch": {},
     "noUsersFoundWithQuery": "لسوء الحظ، لا يمكن العثور على مستخدم لديه \"{query}\". يرجى التحقق مما إذا كنت قد ارتكبت خطأ كتابي.",
     "@noUsersFoundWithQuery": {
         "type": "String",
@@ -2423,8 +2229,6 @@
     "@yourGlobalUserIdIs": {},
     "groupName": "أسم المجموعة",
     "@groupName": {},
-    "searchChatsRooms": "ابحث عن #الدردشات، @المستخدمين...",
-    "@searchChatsRooms": {},
     "startConversation": "بدء محادثة",
     "@startConversation": {},
     "commandHint_sendraw": "إرسال جيسون الخام",
@@ -2465,8 +2269,6 @@
     "@select": {},
     "pleaseChooseAStrongPassword": "الرجاء اختيار كلمة مرور قوية",
     "@pleaseChooseAStrongPassword": {},
-    "addChatOrSubSpace": "إضافة دردشة أو مساحة فرعية",
-    "@addChatOrSubSpace": {},
     "leaveEmptyToClearStatus": "اتركه فارغًا لمسح حالتك.",
     "@leaveEmptyToClearStatus": {},
     "joinSpace": "انضم إلى المساحة",
@@ -2475,30 +2277,6 @@
     "@searchForUsers": {},
     "initAppError": "حدث خطأ بداخل التطبيق",
     "@initAppError": {},
-    "sessionLostBody": "جلستك مفقودة يرجى إبلاغ المطورين بهذا الخطأ في {url}. رسالة الخطأ هي: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "يحاول التطبيق الآن استعادة جلستك من النسخة الاحتياطية. الرجاء الإبلاغ عن هذا الخطأ للمطورين على {url}. رسالة الخطأ هي:{error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "completedKeyVerification": "أكمل {sender} عملية التحقق من المفتاح",
     "@completedKeyVerification": {
         "type": "String",
@@ -2521,8 +2299,6 @@
     "@transparent": {},
     "formattedMessagesDescription": "عرض محتوى الرسالة الغنية مثل النص الغامق باستخدام الماركداون.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUserDescription": "إذا قمت بالتحقق من مستخدم آخر، فيمكنك التأكد من أنك تعرف من تكتب إليه حقًا. 💪\n\nعند بدء عملية التحقق، سترى أنت والمستخدم الآخر نافذة منبثقة في التطبيق. هناك سترى بعد ذلك سلسلة من الرموز التعبيرية أو الأرقام التي يتعين عليك مقارنتها مع بعضها البعض.\n\nأفضل طريقة للقيام بذلك هي الالتقاء أو بدء مكالمة فيديو. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDeviceDescription": "عند التحقق من جهاز آخر، يمكن لهذه الأجهزة تبادل المفاتيح، مما يزيد من أمانك بشكل عام. 💪 عند بدء عملية التحقق، ستظهر نافذة منبثقة في التطبيق على كلا الجهازين. هناك سترى بعد ذلك سلسلة من الرموز التعبيرية أو الأرقام التي يتعين عليك مقارنتها مع بعضها البعض. من الأفضل أن يكون كلا الجهازين في متناول يديك قبل بدء عملية التحقق. 🤳",
     "@verifyOtherDeviceDescription": {},
     "formattedMessages": "رسائل منسقة",
@@ -2535,8 +2311,6 @@
     "@sendTypingNotificationsDescription": {},
     "sendReadReceiptsDescription": "يمكن للمشاركين الآخرين في المحادثة معرفة متى قرأت الرسالة.",
     "@sendReadReceiptsDescription": {},
-    "verifyOtherUser": "🔐 التحقق من المستخدم الآخر",
-    "@verifyOtherUser": {},
     "acceptedKeyVerification": "وافق {sender} على التحقق من المفتاح",
     "@acceptedKeyVerification": {
         "type": "String",
@@ -2606,8 +2380,6 @@
     "@noDatabaseEncryption": {},
     "appLockDescription": "قفل التطبيق عند عدم استخدامه بالرمز السري",
     "@appLockDescription": {},
-    "accessAndVisibility": "الوصول والرؤية",
-    "@accessAndVisibility": {},
     "calls": "المكالمات",
     "@calls": {},
     "customEmojisAndStickers": "الرموز التعبيرية والملصقات المخصصة",
@@ -2620,27 +2392,10 @@
     "@overview": {},
     "passwordRecoverySettings": "إعدادات استعادة كلمة المرور",
     "@passwordRecoverySettings": {},
-    "globalChatId": "معرف المحادثة العامة",
-    "@globalChatId": {},
-    "accessAndVisibilityDescription": "من المسموح له بالانضمام إلى هذه المحادثة وكيف يمكن اكتشاف المحادثة.",
-    "@accessAndVisibilityDescription": {},
     "customEmojisAndStickersBody": "قم بإضافة أو مشاركة الرموز التعبيرية أو الملصقات المخصصة التي يمكن استخدامها في أي دردشة.",
     "@customEmojisAndStickersBody": {},
     "hideRedactedMessages": "إخفاء الرسائل المكررة",
     "@hideRedactedMessages": {},
-    "usersMustKnock": "المستخدم يجب أن يطرق الباب",
-    "@usersMustKnock": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "يمكن اكتشاف الشات عن طريق البحث في {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "noOneCanJoin": "لا أحد يستطيع الانضمام",
-    "@noOneCanJoin": {},
     "knocking": "طرق",
     "@knocking": {},
     "knock": "دق",
@@ -2650,10 +2405,6 @@
         "type": "String",
         "count": {}
     },
-    "publicChatAddresses": "عناوين المحادثة العامة",
-    "@publicChatAddresses": {},
-    "createNewAddress": "إنشاء عنوان جديد",
-    "@createNewAddress": {},
     "searchIn": "بحث في {chat}...",
     "@searchIn": {
         "type": "String",
@@ -2762,14 +2513,6 @@
     "@sendCanceled": {},
     "noChatsFoundHere": "لم يتم العثور على دردشات هنا حتى الآن. ابدأ محادثة جديدة مع شخص ما باستخدام الزر أدناه. ⤵️",
     "@noChatsFoundHere": {},
-    "loginWithMatrixId": "تسجيل الدخول باستخدام معرف ماتريكس",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "اكتشف الخوادم المنزلية",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "ما هو خادم المنزل ؟",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "يتم تخزين جميع بياناتك على خادم المنزل، تمامًا مثل مزود خدمة البريد الإلكتروني. يمكنك اختيار خادم البيت الذي تريد استخدامه، بينما لا يزال بإمكانك التواصل مع الجميع. اعرف المزيد على https://matrix.org.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "لا يبدو أنه خادم منزلي متوافق. عنوان URL غير صحيح ؟",
     "@doesNotSeemToBeAValidHomeserver": {},
     "calculatingFileSize": "جارٍ حساب حجم الملف...",
@@ -2809,16 +2552,12 @@
     "@noticeChatBackupDeviceVerification": {},
     "continueText": "استمرار",
     "@continueText": {},
-    "welcomeText": "مرحبًا، 👋 معك FluffyChat. يمكنك تسجيل الدخول إلى أي خادم منزلي، وهو متوافق مع https://matrix.org. ثم دردش مع أي شخص. إنها شبكة مراسلة لا مركزية ضخمة!",
-    "@welcomeText": {},
     "blur": "الضبابية:",
     "@blur": {},
     "setWallpaper": "تعيين الخلفية",
     "@setWallpaper": {},
     "opacity": "التعتيم:",
     "@opacity": {},
-    "manageAccount": "‫إدارة الحساب‬",
-    "@manageAccount": {},
     "noContactInformationProvided": "لا يقدم السيرفر أي معلومات اتصال صحيحة",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "اتصل بمسؤول الخادم",
@@ -2880,13 +2619,9 @@
     "normalUser": "مستخدم عادي",
     "commandHint_roomupgrade": "ترقية هذه الغرفة إلى إصدار الغرفة المعطى",
     "checkList": "قائمة التحقق",
-    "countInvited": "{count} مدعو",
     "synchronizingPleaseWaitCounter": "جارٍ المزامنة… ({percentage}%)",
-    "appWantsToUseForLogin": "استخدم '{server}' لتسجيل الدخول",
-    "appWantsToUseForLoginDescription": "تسمح الآن للتطبيق والموقع الإلكتروني بمشاركة معلومات عنك.",
     "open": "افتح",
     "waitingForServer": "انتظار الخادم...",
-    "appIntroduction": "يتيح لك FluffyChat الدردشة مع أصدقائك عبر تطبيقات المراسلة المختلفة. تعرف على المزيد على https://matrix.org أو فقط اضغط على *متابعة*.",
     "newChatRequest": "📩 طلب دردشة جديد",
     "contentNotificationSettings": "إعدادات إشعارات المحتوى",
     "generalNotificationSettings": "إعدادات الإشعارات العامة",
@@ -2961,11 +2696,9 @@
     "taTooltip": "استخدام المستوى 2 مع المساعدة في الترجمة",
     "interactiveTranslatorSliderHeader": "مترجم تفاعلي",
     "interactiveGrammarSliderHeader": "مدقق قواعد تفاعلي",
-    "interactiveTranslatorRequired": "مطلوب",
     "waTooltip": "استخدام المستوى 2 بدون مساعدة",
     "interactiveTranslator": "مساعدة في الترجمة",
     "noIdenticalLanguages": "يرجى اختيار لغتين أساسيتين مختلفتين",
-    "searchBy": "البحث حسب البلد واللغات",
     "joinWithClassCode": "انضم إلى الدورة",
     "languageLevelPreA1": "مبتدئ منخفض (ما قبل A1)",
     "languageLevelA1": "مبتدئ متوسط (A1)",
@@ -2986,19 +2719,14 @@
     "saveChanges": "حفظ التغييرات",
     "publicProfileTitle": "السماح بعثور الآخرين على ملفي الشخصي في البحث",
     "publicProfileDesc": "عن طريق تفعيل ذلك، يمكنك تمكين المستخدمين الآخرين من العثور على ملفك الشخصي في شريط البحث العالمي وإرسال طلبات للدردشة. في هذه المرحلة، يمكنك اختيار قبول أو رفض الطلب.",
-    "errorDisableIT": "تم إيقاف مساعدة الترجمة.",
-    "errorDisableIGC": "تم إيقاف مساعدة القواعد.",
     "errorDisableITUserDesc": "انقر هنا لتحديث إعدادات مساعدة الترجمة",
     "errorDisableIGCUserDesc": "انقر هنا لتحديث إعدادات مساعدة القواعد",
     "errorDisableITClassDesc": "تم إيقاف مساعدة الترجمة للفصل الذي يوجد فيه هذا الدردشة.",
     "errorDisableIGCClassDesc": "تم إيقاف مساعدة القواعد للفصل الذي يوجد فيه هذا الدردشة.",
-    "error405Title": "لم يتم تعيين اللغات",
     "error405Desc": "يرجى تعيين لغاتك في القائمة الرئيسية > إعدادات التعلم.",
     "termsAndConditions": "الشروط والأحكام",
     "andCertifyIAmAtLeast13YearsOfAge": " وأشهد أن عمري لا يقل عن 16 عامًا.",
-    "error502504Title": "واو، هناك الكثير من الطلاب عبر الإنترنت!",
     "error502504Desc": "قد تكون أدوات الترجمة والقواعد بطيئة أو غير متاحة أثناء متابعة بوتات بانجيا.",
-    "error404Title": "خطأ في الترجمة!",
     "error404Desc": "بوت بانجيا غير متأكد من كيفية ترجمة ذلك...",
     "errorPleaseRefresh": "نحن نبحث في الأمر! يرجى إعادة التحميل والمحاولة مرة أخرى.",
     "connectedToStaging": "متصل ببيئة الاختبار",
@@ -3036,13 +2764,9 @@
     "definitionsToolName": "تعريفات الكلمات",
     "definitionsToolDescription": "عند التفعيل، يمكن النقر على الكلمات المسطرة باللون الأزرق للحصول على تعريفاتها. انقر على الرسائل للوصول إلى التعريفات.",
     "welcomeBack": "مرحبًا بعودتك! إذا كنت جزءًا من تجربة 2023-2024، يرجى الاتصال بنا للحصول على اشتراك التجربة الخاص بك. إذا كنت معلمًا قام (أو مؤسستك قامت) بشراء تراخيص لفصلك، اتصل بنا للحصول على اشتراك المعلم.",
-    "downloadTxtFile": "تحميل ملف نصي",
-    "downloadCSVFile": "تحميل ملف CSV",
     "promotionalSubscriptionDesc": "لديك حاليًا اشتراك ترويجي مدى الحياة. راسل support@pangea.chat للمساعدة في تغيير اشتراكك.",
     "originalSubscriptionPlatform": "تم شراء الاشتراك عبر {purchasePlatform}",
     "oneWeekTrial": "تجربة لمدة أسبوع واحد",
-    "downloadXLSXFile": "تحميل ملف إكسل",
-    "unkDisplayName": "غير معروف",
     "wwCountryDisplayName": "عالمياً",
     "afCountryDisplayName": "أفغانستان",
     "axCountryDisplayName": "جزر آلاند",
@@ -3337,7 +3061,6 @@
     "chatCapacityHasBeenChanged": "تم تغيير سعة الدردشة",
     "chatCapacitySetTooLow": "يجب أن تكون سعة الدردشة على الأقل {count}.",
     "chatCapacityExplanation": "تحدد سعة الدردشة عدد الأعضاء المسموح بهم في الدردشة.",
-    "tooManyRequest": "طلبات كثيرة جدًا، يرجى المحاولة مرة أخرى لاحقًا.",
     "enterNumber": "يرجى إدخال قيمة رقم صحيح.",
     "practice": "ممارسة",
     "versionNotFound": "لم يتم العثور على الإصدار",
@@ -3347,7 +3070,6 @@
     "deleteSubscriptionWarningTitle": "لديك اشتراك نشط",
     "deleteSubscriptionWarningBody": "حذف حسابك لن يلغي اشتراكك تلقائيًا.",
     "manageSubscription": "إدارة الاشتراك",
-    "error520Title": "يرجى المحاولة مرة أخرى.",
     "error520Desc": "عذرًا، لم نتمكن من فهم رسالتك...",
     "wordsUsed": "الكلمات المستخدمة",
     "level": "المستوى",
@@ -3365,7 +3087,6 @@
     "other": "آخر",
     "levelShort": "المستوى {level}",
     "noCapacityLimit": "بدون حد سعة",
-    "downloadGroupText": "تحميل نص المجموعة",
     "notificationsOn": "الإشعارات مفعلة",
     "notificationsOff": "إيقاف الإشعارات",
     "joinWithCode": "الانضمام باستخدام رمز",
@@ -3429,24 +3150,12 @@
     "whatIsTheMorphTag": "ما هو {morphologicalFeature} لـ '{wordForm}'؟",
     "dataAvailable": "توفر البيانات",
     "available": "متاح",
-    "pangeaBotIsFallible": "بوت بانجيا يخطئ أيضًا!",
-    "whatIsMeaning": "ماذا يعني '{lemma}'؟",
     "chooseLemmaMeaningInstructionsBody": "طابق المعاني مع الكلمات في الرسالة!",
-    "doubleClickToEdit": "انقر نقرًا مزدوجًا للتحرير.",
-    "topicLabel": "الموضوع",
-    "topicPlaceholder": "اختر موضوعًا...",
-    "modePlaceholder": "اختر وضعًا...",
-    "learningObjectiveLabel": "هدف التعلم",
-    "learningObjectivePlaceholder": "اختر هدف التعلم...",
-    "targetLanguageLabel": "اللغة المستهدفة",
     "cefrLevelLabel": "مستوى CEFR",
     "image": "صورة",
     "video": "فيديو",
     "nan": "غير قابل للتطبيق",
-    "addVocabulary": "إضافة مفردات",
     "instructions": "تعليمات",
-    "numberOfLearners": "عدد المتعلمين",
-    "mustBeInteger": "يجب أن يكون عددًا صحيحًا مثل 1، 2، 3، ...",
     "constructUsePvmDesc": "تم الإنتاج في رسالة صوتية",
     "leaveSpaceDescription": "عند مغادرة الدورة، ستترك جميع الدردشات داخلها. سيلاحظ المستخدمون الآخرون أنك غادرت الدورة.",
     "constructUseCorMmDesc": "تصحيح معنى الرسالة",
@@ -3461,7 +3170,6 @@
     "ttsDisabledBody": "يمكنك تفعيل تحويل النص إلى كلام في إعدادات التعلم الخاصة بك",
     "noSpaceDescriptionYet": "لم يتم إنشاء وصف للدورة بعد.",
     "tooLargeToSend": "هذه الرسالة كبيرة جدًا لإرسالها",
-    "exitWithoutSaving": "هل أنت متأكد أنك تريد الخروج بدون حفظ؟",
     "enableAutocorrectPopupTitle": "أضف لوحة مفاتيح اللغة المستهدفة الخاصة بك عن طريق الذهاب إلى:",
     "enableAutocorrectPopupSteps": "  • الإعدادات\n  • عام\n  • لوحة المفاتيح\n  • لوحات المفاتيح\n  • أضف لوحة مفاتيح جديدة",
     "enableAutocorrectPopupDescription": "بمجرد اختيار اللغة، يمكنك النقر على أيقونة الكرة الأرضية الصغيرة في أسفل يسار لوحة المفاتيح لتفعيل لوحة المفاتيح المثبتة حديثًا.",
@@ -3472,11 +3180,8 @@
     "displayName": "اسم العرض",
     "leaveRoomDescription": "أنت على وشك مغادرة هذه الدردشة. سيرى المستخدمون الآخرون أنك غادرت الدردشة.",
     "confirmUserId": "يرجى تأكيد اسم مستخدم Pangea Chat الخاص بك من أجل حذف حسابك.",
-    "startingToday": "ابتداءً من اليوم",
-    "oneWeekFreeTrial": "تجربة مجانية لمدة أسبوع واحد",
     "paidSubscriptionStarts": "ابتداءً من {startDate}",
     "cancelInSubscriptionSettings": "• إلغاء في أي وقت في إعدادات الاشتراك",
-    "cancelToAvoidCharges": "• إلغاء قبل {trialEnds} لتجنب الرسوم",
     "downloadGboard": "قم بتنزيل Gboard",
     "autocorrectNotAvailable": "للأسف، منصتك غير مدعومة حاليًا لهذه الميزة. ترقب المزيد من التطوير!",
     "pleaseUpdateApp": "يرجى تحديث التطبيق للمتابعة.",
@@ -3486,17 +3191,12 @@
     "knockSpaceSuccess": "لقد طلبت الانضمام إلى هذه الدورة! سيرد مسؤول على طلبك عندما يتلقاه 😊",
     "chooseWordAudioInstructionsBody": "استمع إلى الرسالة الكاملة. ثم قم بمطابقة الأصوات مع الكلمات.",
     "chooseMorphsInstructionsBody": "انقر على قطع الألغاز لأسئلة القواعد!",
-    "pleaseEnterInt": "يرجى إدخال رقم",
     "home": "الصفحة الرئيسية",
     "join": "انضم",
     "resetInstructionTooltipsTitle": "إعادة تعيين تلميحات التعليمات",
     "resetInstructionTooltipsDesc": "انقر لعرض تلميحات التعليمات مثل للمستخدم الجديد تمامًا.",
-    "randomize": "عشوائي",
     "clear": "مسح",
-    "featuredActivities": "المميز",
     "save": "حفظ",
-    "startChat": "ابدأ دردشة",
-    "translationProblem": "مشكلة في الترجمة",
     "askToJoin": "اطلب الانضمام",
     "emptyChatWarningTitle": "الدردشة فارغة",
     "emptyChatWarningDesc": "لم تدعُ أحدًا إلى دردشتك. انتقل إلى إعدادات الدردشة لدعوة جهات الاتصال الخاصة بك أو البوت. يمكنك أيضًا القيام بذلك لاحقًا.",
@@ -3526,17 +3226,13 @@
     "timesUsedIndependently": "مرات الاستخدام بشكل مستقل",
     "timesUsedWithAssistance": "مرات الاستخدام بمساعدة",
     "shareInviteCode": "مشاركة رمز الدعوة: {code}",
-    "leaderboard": "لوحة المتصدرين",
     "skipForNow": "تخطي الآن",
     "permissions": "الأذونات",
     "spaceChildPermission": "من يمكنه إضافة محادثات جديدة إلى هذه الدورة",
-    "addEnvironmentOverride": "إضافة تجاوز البيئة",
     "defaultOption": "افتراضي",
     "deleteChatDesc": "هل أنت متأكد أنك تريد حذف هذه الدردشة؟ سيتم حذفها لجميع المشاركين ولن تتوفر جميع الرسائل داخل الدردشة للممارسة أو تحليلات التعلم.",
     "deleteSpaceDesc": "سيتم حذف الدورة وأي دردشات مختارة لجميع المشاركين ولن تتوفر جميع الرسائل داخل الدردشة للممارسة أو تحليلات التعلم. لا يمكن التراجع عن هذا الإجراء.",
     "launch": "إطلاق",
-    "searchChats": "البحث في الدردشات",
-    "maxFifty": "حد أقصى 50",
     "configureSpace": "تكوين الدورة",
     "pinMessages": "تثبيت الرسائل",
     "setJoinRules": "تحديد قواعد الانضمام",
@@ -3570,9 +3266,6 @@
     "failedToFetchTranscription": "فشل في جلب النسخ النصي",
     "deleteEmptySpaceDesc": "سيتم حذف الدورة لجميع المشاركين. لا يمكن التراجع عن هذا الإجراء.",
     "regenerate": "إعادة الإنشاء",
-    "mySavedActivities": "أنشطتي المحفوظة",
-    "noSavedActivities": "لا توجد أنشطة محفوظة",
-    "saveActivity": "حفظ هذا النشاط",
     "failedToPlayVideo": "فشل في تشغيل الفيديو",
     "done": "تم",
     "inThisSpace": "في هذه الدورة",
@@ -3583,13 +3276,9 @@
     "numInvited": "{count} مدعو",
     "saved": "محفوظ",
     "reset": "إعادة تعيين",
-    "errorFetchingActivitiesMessage": "فشل في جلب الأنشطة",
     "errorFetchingDefinition": "فشل في جلب التعريف",
     "errorProcessAnalytics": "فشل في معالجة التحليلات",
     "errorDownloading": "فشل التنزيل",
-    "errorLoadingSpaceChildren": "فشل في تحميل الدردشات داخل هذه الدورة",
-    "unexpectedError": "خطأ غير متوقع.",
-    "pleaseReload": "يرجى إعادة التحميل والمحاولة مرة أخرى.",
     "translationError": "خطأ في الترجمة",
     "check": "تحقق",
     "unableToFindRoom": "لم يتم العثور على دردشة أو دورة بهذا الرمز. يرجى المحاولة مرة أخرى.",
@@ -3598,19 +3287,14 @@
     "request": "طلب",
     "requestAll": "طلب الكل",
     "confirmMessageUnpin": "هل أنت متأكد من أنك تريد إلغاء تثبيت هذه الرسالة؟",
-    "saveAndLaunch": "حفظ وإطلاق",
-    "launchToSpace": "إطلاق إلى الدورة",
     "pending": "قيد الانتظار",
     "inactive": "غير نشط",
-    "confirmRole": "تأكيد الدور",
     "openRoleLabel": "مفتوح",
     "finishedTheActivity": "🎯 {username} أنهى هذا النشاط",
     "activitySummaryError": "ملخصات النشاط غير متوفرة",
     "requestSummaries": "طلب الملخصات",
-    "generatingNewActivities": "أنت المستخدم الأول لهذا الزوج من اللغات! يرجى الانتظار دقيقة، نحن نعد أنشطة خصيصًا لك.",
     "requestAccessTitle": "طلب الوصول إلى التحليلات؟",
     "requestAccessDesc": "هل تود طلب الوصول لعرض تحليلات المشاركين؟\n\nإذا وافق المشاركون، سيتمكن مسؤولو هذه الدورة من عرض:\n    • إجمالي المفردات\n    • إجمالي مفاهيم القواعد\n    • إجمالي جلسات النشاط المكتملة\n    • المفاهيم النحوية المستخدمة، بشكل صحيح وخاطئ\n\nلن يتمكنوا من عرض:\n    • الرسائل في الدردشات خارج الدورة\n    • قائمة المفردات",
-    "requestAccess": "طلب الوصول ({count})",
     "analyticsInactiveTitle": "لم يمكن إرسال الطلبات للمستخدمين غير النشطين",
     "analyticsInactiveDesc": "المستخدمون غير النشطين الذين لم يسجلوا الدخول منذ تقديم هذه الميزة لن يروا طلبك.\n\nسيظهر زر الطلب بمجرد عودتهم. يمكنك إعادة إرسال الطلب لاحقًا بالنقر على زر الطلب تحت اسمهم عندما يكون متاحًا.",
     "accessRequestedTitle": "طلب الوصول إلى التحليلات",
@@ -3633,8 +3317,6 @@
     "accessDesc": "يمكنك جعل دورتك مفتوحة للعالم! أو، جعل دورتك خاصة وآمنة.",
     "createGroupChatDesc": "بينما تبدأ وتنتهي جلسات النشاط، ستظل الدردشات الجماعية مفتوحة للتواصل الروتيني.",
     "deleteDesc": "يمكن للمسؤولين فقط حذف الدورة. هذا إجراء تدميري يزيل جميع المستخدمين ويحذف جميع الدردشات المختارة داخل الدورة. تابع بحذر.",
-    "noCourseFound": "أوه، هذه الدورة بحاجة إلى خطة!\n\nخطط الدورة هي سلسلة من المواضيع وأنشطة المحادثة.",
-    "additionalParticipants": "+ {num} آخرون",
     "whatNow": "ماذا الآن؟",
     "chooseNextActivity": "اختر نشاطك التالي!",
     "letsGo": "لننطلق",
@@ -3647,13 +3329,11 @@
     "waitNotDone": "انتظر، لم أنتهِ بعد!",
     "waitingForOthersToFinish": "انتظار باقي المشاركين لإنهاء المهمة...",
     "generatingSummary": "تحليل الدردشة وتوليد النتائج",
-    "findCourse": "ابحث عن دورة",
     "pingParticipantsNotification": "{user} يبحث عن مستخدمين للانضمام إلى جلسة النشاط في {room}",
     "course": "دورة",
     "courses": "دورات",
     "goToCourse": "اذهب إلى الدورة: {course}",
     "activityComplete": "تم إكمال هذا النشاط. يجب أن تتوفر ملخص النشاط أدناه.",
-    "startNewSession": "ابدأ جلسة جديدة",
     "joinOpenSession": "انضم إلى جلسة مفتوحة",
     "activityNotFound": "النشاط غير موجود",
     "myActivities": "أنشطتي",
@@ -3716,14 +3396,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@synchronizingPleaseWaitCounter": {
         "type": "String",
         "placeholders": {
@@ -3732,27 +3404,11 @@
             }
         }
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4070,10 +3726,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4083,10 +3735,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4174,14 +3822,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4198,10 +3838,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4214,15 +3850,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4374,14 +4002,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4395,14 +4015,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5625,10 +5237,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5669,10 +5277,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5745,10 +5349,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6018,47 +5618,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6078,19 +5638,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6154,10 +5702,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6198,14 +5742,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6217,14 +5753,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6262,10 +5790,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6282,27 +5806,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6426,10 +5934,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6439,10 +5943,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6459,14 +5959,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6606,18 +6098,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6666,10 +6146,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6679,18 +6155,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6733,23 +6197,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6773,10 +6225,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6784,14 +6232,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6896,18 +6336,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6960,10 +6388,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6990,10 +6414,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7174,7 +6594,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "تحقق مرة أخرى غدًا للحصول على تحديثات النشاط.",
-    "activityDropdownDesc": "عندما تنتهي من هذا النشاط، انقر أدناه",
     "languageMismatchTitle": "عدم تطابق اللغة",
     "languageMismatchDesc": "اللغة المستهدفة الخاصة بك لا تتطابق مع لغة هذا النشاط. هل تريد تحديث لغتك المستهدفة؟",
     "reportWordIssueTooltip": "الإبلاغ عن مشكلة في معلومات الكلمة",
@@ -7187,10 +6606,6 @@
     "selectAll": "اختر الكل",
     "deselectAll": "إلغاء تحديد الكل",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7239,17 +6654,11 @@
         "placeholders": {}
     },
     "startOwn": "ابدأ خاصتي",
-    "joinCourseDesc": "كل دورة تحتوي على 8-10 مواضيع متسلسلة مع مجموعة من أنشطة تعلم اللغة القائمة على المهام.",
     "newMessageInPangeaChat": "📩 رسالة جديدة في دردشة بانجيا",
     "shareCourse": "مشاركة الدورة",
     "addCourse": "إضافة دورة",
-    "joinPublicCourse": "الانضمام إلى دورة عامة",
     "vocabLevelsDesc": "هذا هو المكان الذي ستذهب إليه كلمات المفردات بمجرد ترقيتها!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7262,10 +6671,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7284,7 +6689,6 @@
     "emojiView": "عرض الرموز التعبيرية",
     "feedbackDialogDesc": "أرتكب أخطاء أيضًا! هل هناك أي شيء يمكنني فعله لتحسين نفسي؟",
     "contactHasBeenInvitedToTheCourse": "تمت دعوة جهة الاتصال إلى الدورة",
-    "activityStatsButtonTooltip": "معلومات النشاط",
     "allow": "السماح",
     "deny": "رفض",
     "enabledRenewal": "تفعيل تجديد الاشتراك",
@@ -7552,10 +6956,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8611,16 +8011,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "الأنشطة لفتح الموضوع التالي",
-    "activitiesToUnlockTopicDesc": "حدد عدد الأنشطة لفتح موضوع الدورة التالي",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "ممارسة تعريف المفردات الصحيحة",
     "constructUseIncLMDesc": "ممارسة تعريف المفردات غير الصحيحة",
     "constructUseCorLADesc": "ممارسة الصوت للمفردات الصحيحة",
@@ -8628,7 +8018,6 @@
     "constructUseBonus": "مكافأة أثناء ممارسة المفردات",
     "practiceVocab": "ممارسة المفردات",
     "selectMeaning": "اختر المعنى",
-    "selectAudio": "اختر الصوت المطابق",
     "anotherRound": "جولة أخرى",
     "activitySettingsOverrideWarning": "اللغة ومستوى اللغة محددان بواسطة خطة النشاط",
     "voice": "صوت",
@@ -8660,10 +8049,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8681,12 +8066,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "تم بدء التنزيل",
     "webDownloadPermissionMessage": "إذا كان متصفحك يمنع التنزيلات، يرجى تمكين التنزيلات لهذا الموقع.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8781,11 +8161,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "حدث خطأ ما، ونحن نعمل بجد على إصلاحه. تحقق مرة أخرى لاحقًا.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "تفعيل مساعدة الكتابة",
     "autoIGCToolDescription": "تشغيل أدوات دردشة بانجيا تلقائيًا لتصحيح الرسائل المرسلة إلى اللغة المستهدفة.",
     "@autoIGCToolName": {
@@ -8841,24 +8216,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "قواعد اللغة",
-    "spanTypeWordChoice": "اختيار الكلمات",
     "spanTypeSpelling": "التهجئة",
     "spanTypePunctuation": "علامات الترقيم",
     "spanTypeStyle": "الأسلوب",
     "spanTypeFluency": "الطلاقة",
     "spanTypeAccents": "اللكنات",
     "spanTypeCapitalization": "حروف الجر",
-    "spanTypeCorrection": "تصحيح",
     "spanFeedbackTitle": "الإبلاغ عن مشكلة تصحيح",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8883,10 +8247,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8899,13 +8259,7 @@
     "longPressToRecordVoiceMessage": "اضغط مطولاً لتسجيل رسالة صوتية.",
     "pause": "إيقاف مؤقت",
     "resume": "استئناف",
-    "newSubSpace": "مساحة فرعية جديدة",
-    "moveToDifferentSpace": "الانتقال إلى مساحة مختلفة",
-    "removeFromSpaceDescription": "سيتم إزالة الدردشة من المساحة ولكن ستظل تظهر في قائمة الدردشات الخاصة بك.",
     "countChats": "{chats} دردشات",
-    "spaceMemberOf": "عضو في المساحة {spaces}",
-    "spaceMemberOfCanKnock": "عضو في المساحة {spaces} يمكنه الطرق",
-    "donate": "تبرع",
     "startedAPoll": "{username} بدأ استطلاع رأي.",
     "poll": "استطلاع رأي",
     "startPoll": "ابدأ استطلاع رأي",
@@ -8929,23 +8283,15 @@
     "newStickerPack": "حزمة ملصقات جديدة",
     "stickerPackName": "اسم حزمة الملصقات",
     "attribution": "نسبة",
-    "skipChatBackup": "تخطي نسخ الدردشة الاحتياطي",
-    "skipChatBackupWarning": "هل أنت متأكد؟ بدون تفعيل نسخ الدردشة الاحتياطي قد تفقد الوصول إلى رسائلك إذا قمت بتغيير جهازك.",
-    "loadingMessages": "جارٍ تحميل الرسائل",
-    "setupChatBackup": "إعداد نسخ الدردشة الاحتياطي",
     "noMoreResultsFound": "لم يتم العثور على المزيد من النتائج",
     "chatSearchedUntil": "تم البحث في الدردشة حتى {time}",
     "federationBaseUrl": "عنوان URL الأساسي للاتحاد",
     "clientWellKnownInformation": "معلومات العميل المعروفة:",
     "baseUrl": "عنوان URL الأساسي",
     "identityServer": "خادم الهوية:",
-    "versionWithNumber": "الإصدار: {version}",
     "logs": "السجلات",
-    "advancedConfigs": "الإعدادات المتقدمة",
     "advancedConfigurations": "التكوينات المتقدمة",
-    "signInWithLabel": "تسجيل الدخول باستخدام:",
     "selectAllWords": "اختر جميع الكلمات التي تسمعها في الصوت",
-    "joinCourseForActivities": "انضم إلى دورة لتجربة الأنشطة.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -8982,18 +8328,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9001,26 +8335,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9126,22 +8440,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9170,19 +8468,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9190,15 +8476,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9399,11 +8677,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "في فصل دراسي؟ ضع رمز الانضمام الخاص بك هنا.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "تمييز الرسائل الصوتية تلقائيًا",
     "selectAudioMessagesOnPlayDescription": "تمييز الرسائل الصوتية تلقائيًا عند تشغيلها",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9447,18 +8720,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "تحتوي هذه الدورة على مواضيع بها أقل من {input} نشاطات. يرجى إدخال رقم أقل من أو يساوي {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "انقر هنا لتسجيل الدخول مرة أخرى.",
     "@clickToLogin": {
@@ -9875,17 +9136,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "دب أصفر كرتوني يرفع ذراعيه في حماس.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "اختر الكلمات لتتعلم المزيد عنها",
     "requireAnalyticsAccessTitle": "يتطلب الوصول إلى التحليلات للانضمام",
     "requireAnalyticsAccessDesc": "يجب على المشاركين منح الوصول إلى تحليلات التعلم الخاصة بهم للانضمام إلى هذه الدورة",
     "analyticsAccessNoticeTitle": "يتطلب الوصول إلى التحليلات",
     "analyticsAccessNoticeDesc": "من خلال الانضمام إلى هذه الدورة، فإنك توافق على منح المسؤولين الوصول إلى تحليلات التعلم الخاصة بك.",
-    "skipOnboardingClassCodeDesc": "تتعلم بشكل مستقل؟ لا تقلق، يمكنك:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9903,10 +9158,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9935,7 +9186,6 @@
     "pickCefrLevelTeacherStepTitle": "ما المستوى الذي تقوم بتعليمه؟",
     "pickCefrLevelStudentStepTitle": "ما مستواك؟",
     "customCourseStepTitle": "املأ هذا النموذج للحصول على دورة مخصصة",
-    "aboutYourClass": "حول صفك",
     "courseCodeStepErrorMessage": "يرجى التحقق من الرمز الخاص بك والمحاولة مرة أخرى",
     "institution": "المؤسسة",
     "courseGoals": "أهداف الدورة",
@@ -9978,10 +9228,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10098,12 +9344,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "شعار دردشة بانجيا",
     "introChatDetails": "قل مرحبًا! قدم نفسك لمشاركي الدورة الآخرين، وابحث عن أصدقاء، وتحدث خارج الأنشطة.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10147,11 +9388,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "إجراءات النشاط",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "أدوات النطق",
     "audioTranscription": "نسخ صوتي بالذكاء الاصطناعي",
     "visualLearnerSupport": "دعم المتعلمين البصريين",
@@ -10192,7 +9428,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "انضم إلى دورة تتضمن هذا النشاط للعبه.",
     "resizeCoursePanel": "تغيير حجم لوحة الدورة",
     "undo": "تراجع",
     "unlock": "فتح",
@@ -10206,7 +9441,6 @@
     "addCourseBrowsePublic": "تصفح الدورات العامة",
     "browsePublicCourses": "تصفح الدورات العامة",
     "editProfile": "تعديل الملف الشخصي",
-    "numObjectives": "{count} أهداف",
     "mapSearchHint": "ابحث عن الأنشطة",
     "mapSearchNoResults": "لا توجد تطابقات في العرض",
     "mapFilterAllLanguages": "جميع اللغات",
@@ -10215,7 +9449,6 @@
     "mapFilterCompleted": "مكتمل",
     "mapFilterReset": "إعادة تعيين",
     "activityTypeConversation": "محادثة",
-    "lockedMissionRequirement": "أكمل المهمة السابقة لفتحها",
     "playAgain": "العب مرة أخرى",
     "reviewActivity": "مراجعة",
     "mapEmptyInView": "لا شيء هنا بمستواك أو لغتك. قم بتوسيع الفلاتر أو قم بالتكبير للخارج.",
@@ -10230,14 +9463,9 @@
     "scrollToBottom": "التمرير إلى الأسفل",
     "courseImage": "صورة الدورة",
     "avatarPreview": "معاينة الصورة الرمزية",
-    "activityPhoto": "صورة النشاط",
     "emotePreview": "معاينة الإيموجي: {name}",
     "activityLabel": "النشاط: {title}",
     "resetMapView": "إعادة تعيين عرض الخريطة",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10290,14 +9518,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10327,10 +9547,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10387,10 +9603,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_be.arb
+++ b/lib/l10n/intl_be.arb
@@ -168,11 +168,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Ці дазволена карыстальнікам-гасцям далучыцца",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Вы ўпэўнены?",
     "@areYouSure": {
         "type": "String",
@@ -464,15 +459,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "Рэзервовае капіраванне чатаў было наладжана.",
-    "@yourChatBackupHasBeenSetUp": {},
     "chatBackup": "Рэзервовае капіраванне чатаў",
     "@chatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "Вашы паведамленні абаронены ключом аднаўлення. Калі ласка, пераканайцеся ў тым, што вы яго не згубіце.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -631,11 +619,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Кантакт быў запрошаны ў групу",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Пра кантэнт было паведамлена адміністратарам сервера",
     "@contentHasBeenReported": {
         "type": "String",
@@ -676,15 +659,6 @@
             }
         }
     },
-    "countInvited": "Запрошана {count}",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "create": "Стварыць",
     "@create": {
         "type": "String",
@@ -701,11 +675,6 @@
     },
     "createGroup": "Стварыць групу",
     "@createGroup": {},
-    "createNewSpace": "Новая прастора",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "currentlyActive": "Зараз актыўны",
     "@currentlyActive": {
         "type": "String",
@@ -835,12 +804,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "globalChatId": "ID габальнага чату",
-    "@globalChatId": {},
-    "accessAndVisibility": "Даступнасць і бачнасць",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Каму дазволена далучацца да гэтага чату і як ён можа быць знойдзены.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Выклікі",
     "@calls": {},
     "customEmojisAndStickers": "Карыстальніцкія эмодзі і стыкеры",
@@ -864,11 +827,6 @@
     },
     "enableEncryption": "Уключыць шыфраванне",
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "enableEncryptionWarning": "Вы больш не зможаце адключыць шыфраванне. Вы ўпэўнены?",
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -896,8 +854,6 @@
             }
         }
     },
-    "enableMultiAccounts": "(БЭТА) Уключыць некалькі ўліковых запісаў на гэтай прыладзе",
-    "@enableMultiAccounts": {},
     "enterAnEmailAddress": "Увядзіце электроную пошту (email)",
     "@enterAnEmailAddress": {
         "type": "String",
@@ -913,11 +869,6 @@
                 "type": "String"
             }
         }
-    },
-    "everythingReady": "Усё гатова!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
     },
     "extremeOffensive": "Занадта абражальны",
     "@extremeOffensive": {
@@ -959,15 +910,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatDescription": "Апісанне чату",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "Апісанне чату зменена",
     "@chatDescriptionHasBeenChanged": {},
-    "groupIsPublic": "Група публічная",
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "groups": "Групы",
     "@groups": {
         "type": "String",
@@ -1062,15 +1006,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Запрасіць кантакт да {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "noChatDescriptionYet": "Апісанне чату яшчэ няма.",
     "@noChatDescriptionYet": {},
@@ -1193,15 +1128,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Загрузіць яшчэ {count} удзельнікаў",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "dehydrate": "Экспарт сеансу і ачыстка прылады",
     "@dehydrate": {},
     "dehydrateWarning": "Гэта дзеянне не можа быць адменена. Пераканайцеся, што вы бяспечна захавалі файл рэзервовай копіі.",
@@ -1232,15 +1158,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Увайсці ў {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Выйсці",
     "@logout": {
@@ -1309,16 +1226,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "noEncryptionForPublicRooms": "Вы зможаце актывіраваць шыфраванне як толькі пакой перастане быць агульнадаступным.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Здаецца, на вашай прыладзе няма ці недаступны Firebase Cloud Messaging. Каб далей атрымліваць паведамленні, мы прапануем усталяваць ntfy ці іншы правайдар паведамленняў, каб атрымліваць іх бяспечна. Вы можаце спампаваць ntfy з PlayStore ці F-Droid.",
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "noMatrixServer": "{server1} не з'яўляецца серверам matrix. Выкарыстоўваць {server2} замест яго?",
     "@noMatrixServer": {
         "type": "String",
@@ -1362,11 +1269,6 @@
     },
     "setChatDescription": "Задаць апісанне чату",
     "@setChatDescription": {},
-    "setPermissionsLevel": "Задаць ўзровееь дазволаў",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Задаць статус",
     "@setStatus": {
         "type": "String",
@@ -1413,16 +1315,6 @@
     },
     "sourceCode": "Зыходны код",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Прастора публічна",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Назва прасторы",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1525,23 +1417,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Хто якія дзеянні можа выконваць",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Каму дазволена далучацца да гэтай группы",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Чаму вы хаціце паскардзіцца?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Ачысціць рэзервовую копію чата, каб стварыць новы ключ аднаўлення?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1590,12 +1467,8 @@
     "@sender": {},
     "openGallery": "Адкрыць галерэю",
     "@openGallery": {},
-    "removeFromSpace": "Выдаліць з прасторы",
-    "@removeFromSpace": {},
     "start": "Пачаць",
     "@start": {},
-    "pleaseEnterRecoveryKeyDescription": "Каб разблакіраваць вашы мінулыя паведамленні, калі ласка, увядзіце ключ аднаўлення, што быў згенерыраваны ў мінулай сесіі. Ключ аднаўлення гэта НЕ ваш пароль.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "publish": "Апублікаваць",
     "@publish": {},
     "openChat": "Адкрыць чат",
@@ -1626,18 +1499,12 @@
     "@emojis": {},
     "placeCall": "Здзейсніць выклік",
     "@placeCall": {},
-    "voiceCall": "Галасавы выклік",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "Непадтрымліваемая версія Android",
     "@unsupportedAndroidVersion": {},
     "unsupportedAndroidVersionLong": "Гэта функцыя патрабуе навейшай версіі Android. Калі ласка, праверце наяўнасць абнаўленняў ці падтрымку Linage OS.",
     "@unsupportedAndroidVersionLong": {},
-    "videoCallsBetaWarning": "Звярніце ўвагу, што відэа выклікі знаходзяцца ў бэце. Яны могуць працаваць некарэктна ці не на ўсіх платформах.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "Эксперыментальныя відэа выклікі",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "Email ці імя карыстальніка",
-    "@emailOrUsername": {},
     "addWidget": "Дадаць віджэт",
     "@addWidget": {},
     "widgetVideo": "Відэа",
@@ -1734,26 +1601,10 @@
             }
         }
     },
-    "usersMustKnock": "Карыстальнікі абавязаны пагрукацца",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Ніхто не можа далучыцца",
-    "@noOneCanJoin": {},
     "knock": "Пагрукацца",
     "@knock": {},
     "users": "Карыстальнікі",
     "@users": {},
-    "unlockOldMessages": "Адкрыць старыя паведамленні",
-    "@unlockOldMessages": {},
-    "storeInSecureStorageDescription": "Захаваць код аднаўлення ў бяспечным месцы на прыладзе.",
-    "@storeInSecureStorageDescription": {},
-    "saveKeyManuallyDescription": "Захаваць гэты ключ самастойна, выклікам сістэмнага акна Падзяліцца ці праз буфер.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "Захаваць у Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Захаваць у Apple KeyChain",
-    "@storeInAppleKeyChain": {},
-    "storeSecurlyOnThisDevice": "Захаваць на гэтай прыладзе",
-    "@storeSecurlyOnThisDevice": {},
     "countFiles": "{count} файлаў",
     "@countFiles": {
         "placeholders": {
@@ -1766,12 +1617,6 @@
     "@user": {},
     "custom": "Карыстальніцкае",
     "@custom": {},
-    "foregroundServiceRunning": "Гэта паведамленне з'явіцца, калі асноўныя службы запрацуюць.",
-    "@foregroundServiceRunning": {},
-    "screenSharingTitle": "падзяліцца экранам",
-    "@screenSharingTitle": {},
-    "screenSharingDetail": "Вы дзеліцеся экранам у FluffyChat",
-    "@screenSharingDetail": {},
     "whyIsThisMessageEncrypted": "Чаму гэта паведамленне нельга прачытаць?",
     "@whyIsThisMessageEncrypted": {},
     "noKeyForThisMessage": "Гэта можа здарыцца з-за таго, што паведамленне было даслана да таго, як вы увайшлі ў уліковы запіс на гэтай прыладзе.\n\nТаксама верагодна, што адпраўшчык заблакіраваў вашу прыладу ці ў вас хібы з інтэрнэтам.\n\nВы можаце чытаць гэта паведамленне з іншага сеансу? Тад дашліце паведамленне адтуль! Перайдзіце ў Налады > Прылады і пераканайцеся ў тым, што вашы прылады верыфікавалі адна адну. Калі вы адкрыеце пакой наступны раз і абодве сэсіі будуць запушчаны, ключы павінны сінхранізавацца аўтаматычна.\n\nВы не хаціце згубіць клбчы, калі будзеце выходзіць ці змяняць прылады? Пераканайцеся ў тым, што вы уключылі рэзервовае капіраванне чатаў у наладах.",
@@ -1780,8 +1625,6 @@
     "@newGroup": {},
     "newSpace": "Новая прастора",
     "@newSpace": {},
-    "enterSpace": "Увайсці ў прастору",
-    "@enterSpace": {},
     "allSpaces": "Усе прасторы",
     "@allSpaces": {},
     "hidePresences": "Хаваць спіс статусаў?",
@@ -1797,14 +1640,6 @@
             }
         }
     },
-    "newSpaceDescription": "Прасторы дазваляюць аб'ядноўваць вашы чаты і ствараць агульныя ці асобныя супольнасці.",
-    "@newSpaceDescription": {},
-    "encryptThisChat": "Шыфраваць гэты чат",
-    "@encryptThisChat": {},
-    "disableEncryptionWarning": "У мэтах бяспекі, вы не можаце адклбчауь шыфраванне ў гэтым чаце, дзе яно было ўключана.",
-    "@disableEncryptionWarning": {},
-    "sorryThatsNotPossible": "Прабачце... Гэта немагчыма",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "Ключы прылад:",
     "@deviceKeys": {},
     "reopenChat": "Адкрыць чат зноў",
@@ -1843,8 +1678,6 @@
     "@reportErrorDescription": {},
     "report": "паскардзіцца",
     "@report": {},
-    "manageAccount": "Кіраванне ўліковым запісам",
-    "@manageAccount": {},
     "noContactInformationProvided": "Сервер не мае ніякай вернай кантактнай інфармацыі",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "Звязацца з адміністратарам сервера",
@@ -1881,23 +1714,10 @@
     "@previous": {},
     "otherPartyNotLoggedIn": "Іншы бок зараз не увайшоў, таму не можа атрымліваць паведамленні!",
     "@otherPartyNotLoggedIn": {},
-    "appWantsToUseForLogin": "Выкарыстоўваць '{server}' для ўвахода",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Тым самым, вы дазваляеце праграме і сайту дзяліцца інфармацыяй пра вас.",
-    "@appWantsToUseForLoginDescription": {},
     "open": "Адкрыць",
     "@open": {},
     "waitingForServer": "Чаканне сервера...",
     "@waitingForServer": {},
-    "appIntroduction": "FluffyChat дазваляе вам і вашым сябрам размаўляць скрозь розныя мэсэнджары. Даведайцеся болей на https://matrix.org ці націсніце *Працягнуць*.",
-    "@appIntroduction": {},
     "newChatRequest": "📩 Запыт новага чату",
     "@newChatRequest": {},
     "contentNotificationSettings": "Налады паведамленняў кантэнту",
@@ -2028,8 +1848,6 @@
     },
     "oneClientLoggedOut": "Адзін з вашых кліентаў выйшаў",
     "@oneClientLoggedOut": {},
-    "addAccount": "Дадаць уліковы запіс",
-    "@addAccount": {},
     "editBundlesForAccount": "Змяніць пакеты для гэтага ўліковага запісу",
     "@editBundlesForAccount": {},
     "addToBundle": "Дадаць у пакет",
@@ -2081,11 +1899,6 @@
     "@overview": {},
     "passwordRecoverySettings": "Налады скіду пароля",
     "@passwordRecoverySettings": {},
-    "passwordRecovery": "Аднаўленне пароля",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "people": "Людзі",
     "@people": {
         "type": "String",
@@ -2130,8 +1943,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "pleaseEnterRecoveryKey": "Увядзіце ключ аднаўлення:",
-    "@pleaseEnterRecoveryKey": {},
     "pleaseEnterYourPassword": "Калі ласка, увядзіце ваш пароль",
     "@pleaseEnterYourPassword": {
         "type": "String",
@@ -2247,11 +2058,6 @@
             }
         }
     },
-    "removeDevice": "Выдаліць прыладу",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "unbanFromChat": "Разблакіраваць у чаце",
     "@unbanFromChat": {
         "type": "String",
@@ -2307,10 +2113,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKey": "Ключ аднаўлення",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Ключ абнаўлення страчаны?",
-    "@recoveryKeyLost": {},
     "send": "Даслаць",
     "@send": {
         "type": "String",
@@ -2428,11 +2230,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Перанесці з іншай прылады",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Паспрабуйце даслаць зноў",
     "@tryToSendAgain": {
         "type": "String",
@@ -2488,15 +2285,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 непрачытаны чат} other{{unreadCount} непрачытаных чатаў}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} і {count} іншых удзельнікаў пішуць…",
     "@userAndOthersAreTyping": {
@@ -2584,53 +2372,23 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Відэа выклік",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "verifyOtherUserDescription": "Калі вы спраўдзілі іншага карыстальніка, вы можаце быць упэўненым з кім вы сапраўды перапісваецеся.💪\n\nКалі вы пачнеце спраўджванне, вы і іншы карыстальнік, убачыце ўсплывальнае акно ў праграме. У ім вы ўбачыце некалькі эмодзі ці лічб, якія вы павінны параўнаць адзін з адным.\n\nЛепшы метад зрабіць гэта - пачаць відэа выклік. 👭",
-    "@verifyOtherUserDescription": {},
     "pleaseEnterANumber": "Калі ласка, увядзіце лічбу большую за 0",
     "@pleaseEnterANumber": {},
     "verifyOtherDeviceDescription": "Калі вы спраўдзіце другую прыладу, яны абмяняюцца ключамі, якія ўзмоцняць вашу бяспеку. 💪 Калі вы пачнеце спраўджванне, у праграмах прылад з'явіцца ўсплывальнае паведамленне. Потым, вы ўбачыце некалькі эмодзі ці лічбаў, якія вы павінны параўнаць паміж сабой. Прасцей за ўсё гэта зрабіць, маючы дзве прылады побач. 🤳",
     "@verifyOtherDeviceDescription": {},
-    "verifyOtherUser": "🔐 Спраўдзіць іншага карыстальніка",
-    "@verifyOtherUser": {},
     "verifyOtherDevice": "🔐 Спраўдзіць іншую прыладу",
     "@verifyOtherDevice": {},
     "changeTheCanonicalRoomAlias": "Змяніць публічны адрас чату",
     "@changeTheCanonicalRoomAlias": {},
     "wrongRecoveryKey": "Прабачце... гэта не выглядае як ключ аднаўлення.",
     "@wrongRecoveryKey": {},
-    "restoreSessionBody": "Праграма спрабуе аднавіць вашу сесію з рэзервовай копіі. Калі ласка, паведаміце пра памылку распрацоўшчыкам па спасылцы {url}. Паведамленне памылкі: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "homeserverDescription": "Вашыя даныя захоўваюцца на дамашнім серверы, як у правайдара электронай пошты. Вы можаце самастойна абраць дамашні сервер, захоўвая пры тым магчымасць размаўляць. Даведайцеся болей на https://matrix.org.",
-    "@homeserverDescription": {},
     "longPressToRecordVoiceMessage": "Доўга цісніце, каб запісаць галасавое паведамленне.",
     "@longPressToRecordVoiceMessage": {},
-    "visibilityOfTheChatHistory": "Бачнасць гісторыі чату",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Бачна для ўсіх удзельнікаў",
     "@visibleForAllParticipants": {
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "Тэма:",
-    "@setTheme": {},
     "setColorTheme": "Каляровая схема:",
     "@setColorTheme": {},
     "invite": "Запрасіць",
@@ -2685,34 +2443,10 @@
     "@knocking": {},
     "knockRestricted": "Грук абмежаваны",
     "@knockRestricted": {},
-    "spaceMemberOfCanKnock": "Удзельнікі прасторы з {spaces} могуць грукацца",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "chatCanBeDiscoveredViaSearchOnServer": "Чат можа быць знойдзены праз пошук у {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "searchChatsRooms": "Пошук #чатаў, @карыстальнікаў...",
-    "@searchChatsRooms": {},
     "nothingFound": "Нічога не знойдзена...",
     "@nothingFound": {},
     "groupName": "Назва групы",
     "@groupName": {},
-    "createGroupAndInviteUsers": "Стварыць групу і запрасіць карыстальнікаў",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "Група можа быць знойдзена праз пошук",
-    "@groupCanBeFoundViaSearch": {},
     "startConversation": "Пачаць размову",
     "@startConversation": {},
     "commandHint_sendraw": "Даслаць толькі json",
@@ -2737,16 +2471,10 @@
     "@passwordsDoNotMatch": {},
     "passwordIsWrong": "Вы ўвялі няверны пароль",
     "@passwordIsWrong": {},
-    "publicChatAddresses": "Публічныя адрасы чату",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Стварыць новы адрас",
-    "@createNewAddress": {},
     "joinSpace": "Далучыцца да прасторы",
     "@joinSpace": {},
     "publicSpaces": "Публічныя прасторы",
     "@publicSpaces": {},
-    "addChatOrSubSpace": "Дадаць чат ці пад-прастору",
-    "@addChatOrSubSpace": {},
     "subspace": "Пад-прастора",
     "@subspace": {},
     "decline": "Адхіліць",
@@ -2770,18 +2498,6 @@
     "@gallery": {},
     "files": "Файлы",
     "@files": {},
-    "sessionLostBody": "Ваш сеанс страчаны. Калі ласка, паведаміце пра гэта распрацоўшчыкам: {url}. Паведамленне памылкі: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendReadReceipts": "Дасылаць адзнаку аб чытанні",
     "@sendReadReceipts": {},
     "sendReadReceiptsDescription": "Іншыя карыстальнікі чатаў будуць бачыць, калі вы прачыталі паведамленні.",
@@ -2938,12 +2654,6 @@
     "@changelog": {},
     "sendCanceled": "Адпраўка скасавана",
     "@sendCanceled": {},
-    "loginWithMatrixId": "Увайсці з Matrix-ID",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Даследаваць дамашнія сервера",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Што такое дамашні сервер?",
-    "@whatIsAHomeserver": {},
     "doesNotSeemToBeAValidHomeserver": "Гэта не выглядае як дамашні сервер. Няслушны URL?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "calculatingFileSize": "Вылічэнне памеру файла...",
@@ -2981,8 +2691,6 @@
     "@oneOfYourDevicesIsNotVerified": {},
     "noticeChatBackupDeviceVerification": "Заўвага: Калі вы падключыце ўсе свае прылады да рэзервовага капіравання, яны аўтаматычна спраўдзяцца.",
     "@noticeChatBackupDeviceVerification": {},
-    "welcomeText": "Вітаначкі 👋 Гэта FluffyChat. Вы можаце ўвайсці на любы дамашні сервер, што сумяшчальны з https://matrix.org, а потым паразмаўляць з кім-небудзь. Гэта вялізная дэцэнтралізаваная сетка абмену паведамленнямі!",
-    "@welcomeText": {},
     "blur": "Размыццё:",
     "@blur": {},
     "opacity": "Празрыстасць:",
@@ -3086,12 +2794,6 @@
     "@pause": {},
     "resume": "Працягнуць",
     "@resume": {},
-    "newSubSpace": "Новая пад-прастора",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Перамясціцца ў іншую прастору",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "Гэты чат будзе выдалены з прасторы, але з'явіцца ў вашым спісе чатаў.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} чатаў",
     "@countChats": {
         "type": "String",
@@ -3101,17 +2803,6 @@
             }
         }
     },
-    "spaceMemberOf": "Удзельнік прасторы {spaces}",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "Даць грошы",
-    "@donate": {},
     "startedAPoll": "{username} пачаў апытанне.",
     "@startedAPoll": {
         "type": "String",
@@ -3181,14 +2872,6 @@
     "@stickerPackName": {},
     "attribution": "Атрыбуцыя",
     "@attribution": {},
-    "skipChatBackup": "Прапусціць рэзервовае капіраванне чатаў",
-    "@skipChatBackup": {},
-    "skipChatBackupWarning": "Вы ўпэўнены? Без наладжвання рэзервовага капіравання чатаў, вы можаце згубіць доступ да ўсіх вашых чатаў, калі вы зменіце прыладу.",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "Загрузка паведамленняў",
-    "@loadingMessages": {},
-    "setupChatBackup": "Наладзіць рэзервовае капіраванне чатаў",
-    "@setupChatBackup": {},
     "ignore": "Блакаваць",
     "ignoredUsers": "Блакаваные карыстальнікі",
     "writeAMessageLangCodes": "Пішыце на {l1} або {l2}...",
@@ -3197,11 +2880,9 @@
     "taTooltip": "Выкарыстанне L2 з дапамогай перакладчыцкай падтрымкі",
     "interactiveTranslatorSliderHeader": "Інтэрактыўны перакладчык",
     "interactiveGrammarSliderHeader": "Інтэрактыўны праверка граматыкі",
-    "interactiveTranslatorRequired": "Абавязкова",
     "waTooltip": "Выкарыстанне L2 без дапамогі",
     "interactiveTranslator": "Дапамога з перакладам",
     "noIdenticalLanguages": "Калі ласка, выберыце розныя базавыя і мэтавыя мовы",
-    "searchBy": "Пошук па краіне і мовах",
     "joinWithClassCode": "Далучыцца да курса",
     "languageLevelPreA1": "Навічок Нізкі (Папярэдні A1)",
     "languageLevelA1": "Навічок Сярэдні (A1)",
@@ -3221,19 +2902,14 @@
     "whatIsYourBaseLanguage": "Якая ваша асноўная мова?",
     "publicProfileTitle": "Дазволіць знаходзіць мой профіль у пошуку",
     "publicProfileDesc": "Уключыўшы гэта, вы дазваляеце іншым карыстальнікам знаходзіць ваш профіль у глабальнай пошукавай радку і адпраўляць запыты на чат. На гэтым этапе вы можаце выбраць прыняць або адхіліць запыт.",
-    "errorDisableIT": "Дапамога з перакладам выключана.",
-    "errorDisableIGC": "Дапамога з граматыкай выключана.",
     "errorDisableITUserDesc": "Націсніце тут, каб абнавіць налады дапамогі з перакладам",
     "errorDisableIGCUserDesc": "Націсніце тут, каб абнавіць налады дапамогі з граматыкай",
     "errorDisableITClassDesc": "Дапамога з перакладам выключана для курса, у якім знаходзіцца гэты чат.",
     "errorDisableIGCClassDesc": "Дапамога з граматыкай выключана для курса, у якім знаходзіцца гэты чат.",
-    "error405Title": "Мовы не ўсталяваны",
     "error405Desc": "Калі ласка, усталюйце свае мовы ў галоўным меню > Налады навучання.",
     "termsAndConditions": "Умовамі і палажэннямі",
     "andCertifyIAmAtLeast13YearsOfAge": " і пацвярджаю, што мне не менш за 16 гадоў.",
-    "error502504Title": "Вау, шмат студэнтаў у сетцы!",
     "error502504Desc": "Інструменты перакладу і граматыкі могуць працаваць павольна або быць недаступнымі, пакуль боты Pangea не навядуць парадак.",
-    "error404Title": "Памылка перакладу!",
     "error404Desc": "Бот Pangea не ўпэўнены, як гэта перакласці...",
     "errorPleaseRefresh": "Мы разглядаем гэта! Калі ласка, перазагрузіце і паспрабуйце зноў.",
     "connectedToStaging": "Падключана да Staging",
@@ -3271,13 +2947,9 @@
     "definitionsToolName": "Вызначэнні слоў",
     "definitionsToolDescription": "Калі ўключана, падкрэсленыя сінім словы можна націснуць для атрымання вызначэнняў. Націсніце на паведамленні, каб атрымаць доступ да вызначэнняў.",
     "welcomeBack": "Вітаем зноў! Калі вы ўдзельнічалі ў пілотным праекце 2023-2024 гадоў, звяжыцеся з намі для атрымання спецыяльнай пілотнай падпіскі. Калі вы настаўнік, які набыў (або яго ўстанова набыла) ліцэнзіі для вашага класа, звяжыцеся з намі для атрымання настаўніцкай падпіскі.",
-    "downloadTxtFile": "Загрузіць тэкставы файл",
-    "downloadCSVFile": "Загрузіць CSV-файл",
     "promotionalSubscriptionDesc": "У вас цяпер бестэрміновая прамоцыйная падпіска. Пішыце support@pangea.chat для дапамогі ў змене вашай падпіскі.",
     "originalSubscriptionPlatform": "Падпіска, набытая праз {purchasePlatform}",
     "oneWeekTrial": "Прабная пробная версія на адзін тыдзень",
-    "downloadXLSXFile": "Загрузіць файл Excel",
-    "unkDisplayName": "Невядома",
     "wwCountryDisplayName": "Сусвет",
     "afCountryDisplayName": "Афганістан",
     "axCountryDisplayName": "Аленскія астравы",
@@ -3572,7 +3244,6 @@
     "chatCapacityHasBeenChanged": "Ёмістасць чата была зменена",
     "chatCapacitySetTooLow": "Ёмістасць чата павінна быць не менш за {count}.",
     "chatCapacityExplanation": "Ёмістасць чата абмяжоўвае колькасць удзельнікаў у чаце.",
-    "tooManyRequest": "Занадта шмат запытаў, паспрабуйце пазней.",
     "enterNumber": "Калі ласка, увядзіце цэлае лік.",
     "practice": "Практыка",
     "versionNotFound": "Версія не знойдзена",
@@ -3582,7 +3253,6 @@
     "deleteSubscriptionWarningTitle": "У вас ёсць актыўная падпіска",
     "deleteSubscriptionWarningBody": "Выдаленне вашага акаўнта не аўтаматычна адмяняе вашу падпіску.",
     "manageSubscription": "Кіраванне падпіскай",
-    "error520Title": "Паспрабуйце яшчэ раз.",
     "error520Desc": "Прабачце, мы не змаглі зразумець ваша паведамленне...",
     "wordsUsed": "Колькасць слоў",
     "level": "Узровень",
@@ -3600,7 +3270,6 @@
     "other": "Іншае",
     "levelShort": "УЗРОВЕНЬ {level}",
     "noCapacityLimit": "Абмежаванняў па ёмістасці няма",
-    "downloadGroupText": "Загрузіць тэкст групы",
     "notificationsOn": "Паведамленні ўключаны",
     "notificationsOff": "Паведамленні выключаны",
     "joinWithCode": "Далучыцца з кодам",
@@ -3664,24 +3333,12 @@
     "whatIsTheMorphTag": "Што такое {morphologicalFeature} у '{wordForm}'?",
     "dataAvailable": "Даступнасць дадзеных",
     "available": "Даступна",
-    "pangeaBotIsFallible": "Pangea Bot таксама памыляецца!",
-    "whatIsMeaning": "Што азначае '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Згаджайце значэнні з словамі ў паведамленні!",
-    "doubleClickToEdit": "Два разы клікніце, каб рэдагаваць.",
-    "topicLabel": "Тэма",
-    "topicPlaceholder": "Выберыце тэму...",
-    "modePlaceholder": "Выберыце тып...",
-    "learningObjectiveLabel": "Мэта навучання",
-    "learningObjectivePlaceholder": "Выберыце мэту навучання...",
-    "targetLanguageLabel": "Мэтавая мова",
     "cefrLevelLabel": "Узровень CEFR",
     "image": "Выява",
     "video": "Відэа",
     "nan": "Ня прымяняецца",
-    "addVocabulary": "Дадаць слоўнік",
     "instructions": "Інструкцыі",
-    "numberOfLearners": "Колькасць навучэнцаў",
-    "mustBeInteger": "Павінна быць цэлым лікам, напрыклад, 1, 2, 3, ...",
     "constructUsePvmDesc": "Выраблена ў галасавым паведамленні",
     "leaveSpaceDescription": "Пакінуўшы курс, вы пакінеце ўсе чаты ў ім. Іншыя карыстальнікі ўбачаць, што вы пакінулі курс.",
     "constructUseCorMmDesc": "Правільнае значэнне паведамлення",
@@ -3696,7 +3353,6 @@
     "ttsDisabledBody": "Вы можаце ўключыць тэкст у гаварэнне ў наладках навучання",
     "noSpaceDescriptionYet": "Пакуль не створана апісанне курса.",
     "tooLargeToSend": "Гэтае паведамленне занадта вялікае для адпраўкі",
-    "exitWithoutSaving": "Ці ўпэўнены, што хочаце пакінуць без захавання?",
     "enableAutocorrectPopupTitle": "Дадайце клавіятуру мовы мэты, перайшоўшы ў:",
     "enableAutocorrectPopupSteps": "  • Налады\n  • Агульныя\n  • Клавіятура\n  • Клавіятуры\n  • Дадаць новую клавіятуру",
     "enableAutocorrectPopupDescription": "Пасля выбару мовы вы можаце націснуць на маленькую ікону глобуса ў ніжнім левым куце вашай клавіятуры, каб актываваць новую ўсталяваную клавіятуру.",
@@ -3707,11 +3363,8 @@
     "displayName": "Імя для паказу",
     "leaveRoomDescription": "Вы збіраецеся пакінуць гэты чат. Іншыя карыстальнікі ўбачаць, што вы пакінулі чат.",
     "confirmUserId": "Калі ласка, пацвердзіце імя карыстальніка ў Pangea Chat, каб выдаліць свой рахунак.",
-    "startingToday": "Пачынаючы з сённяшняга дня",
-    "oneWeekFreeTrial": "Бясплатны пробны перыяд на адзін тыдзень",
     "paidSubscriptionStarts": "Пачынаецца {startDate}",
     "cancelInSubscriptionSettings": "• Адмяніць у любы час у наладах падпіскі",
-    "cancelToAvoidCharges": "• Адмяніце перад {trialEnds}, каб пазбегнуць плацяжоў",
     "downloadGboard": "Загрузіце Gboard",
     "autocorrectNotAvailable": "На жаль, ваша платформа ў цяперашні час не падтрымліваецца для гэтай функцыі. Сачыце за навінамі!",
     "pleaseUpdateApp": "Калі ласка, абновіце прыкладанне, каб працягнуць.",
@@ -3721,17 +3374,12 @@
     "knockSpaceSuccess": "Вы запыталі далучыцца да гэтага курса! Адміністратар адказвае на ваш запыт, калі атрымае яго 😀",
     "chooseWordAudioInstructionsBody": "Паслухайце поўнае паведамленне. Потым супастаўце аўдыё з словамі.",
     "chooseMorphsInstructionsBody": "Націсніце на часткі пазаў для граматычных пытанняў!",
-    "pleaseEnterInt": "Калі ласка, увядзіце лік",
     "home": "Галоўная",
     "join": "Далучыцца",
     "resetInstructionTooltipsTitle": "Скінуць падказкі інструкцый",
     "resetInstructionTooltipsDesc": "Націсніце, каб паказаць падказкі інструкцый, як для новага карыстальніка.",
-    "randomize": "Выпадковасць",
     "clear": "Ачысціць",
-    "featuredActivities": "Рэкамендаваныя",
     "save": "Захаваць",
-    "startChat": "Пачаць чат",
-    "translationProblem": "Праблема з перакладам",
     "askToJoin": "Пытацца далучыцца",
     "emptyChatWarningTitle": "Чат пусты",
     "emptyChatWarningDesc": "Вы не запрасілі нікога ў свой чат. Перайдзіце ў налады чата, каб запрасіць кантакты або бота. Таксама можна зрабіць гэта пазней.",
@@ -3761,17 +3409,13 @@
     "timesUsedIndependently": "Колькасць выкарыстанняў самастойна",
     "timesUsedWithAssistance": "Колькасць выкарыстанняў з дапамогай",
     "shareInviteCode": "Падзяліцеся кодам запрашэння: {code}",
-    "leaderboard": "Лідарская дошка",
     "skipForNow": "Прапусціць пакуль",
     "permissions": "Дазволы",
     "spaceChildPermission": "Хто можа дадаваць новыя чаты ў гэты курс",
-    "addEnvironmentOverride": "Дадаць пераключальнік асяроддзя",
     "defaultOption": "Па змаўчанні",
     "deleteChatDesc": "Вы ўпэўнены, што хочаце выдаліць гэты чат? Ён будзе выдалены для ўсіх удзельнікаў, і ўсе паведамленні ў чаце больш не будуць даступныя для практыкі або аналітыкі навучання.",
     "deleteSpaceDesc": "Курс і любыя выбраныя чаты будуць выдалены для ўсіх удзельнікаў, і ўсе паведамленні ў чаце больш не будуць даступныя для практыкі або аналітыкі навучання. Гэту дзею нельга адмяніць.",
     "launch": "Запусціць",
-    "searchChats": "Пошук чатаў",
-    "maxFifty": "Максімум 50",
     "configureSpace": "Налада курса",
     "pinMessages": "Закрэпіць паведамленні",
     "setJoinRules": "Усталяваць правілы далучэння",
@@ -3805,9 +3449,6 @@
     "failedToFetchTranscription": "Не ўдалося атрымаць транскрыпцыю",
     "deleteEmptySpaceDesc": "Курс будзе выдалены для ўсіх удзельнікаў. Гэты дзеянне нельга адмяніць.",
     "regenerate": "Регенераваць",
-    "mySavedActivities": "Мае захаваныя мерапрыемствы",
-    "noSavedActivities": "Захаваныя мерапрыемствы адсутнічаюць",
-    "saveActivity": "Захаваць гэтае мерапрыемства",
     "failedToPlayVideo": "Не ўдалося прайграць відэа",
     "done": "Гатова",
     "inThisSpace": "У гэтым курсе",
@@ -3818,13 +3459,9 @@
     "numInvited": "{count} запрошана",
     "saved": "Захавана",
     "reset": "Скінуць",
-    "errorFetchingActivitiesMessage": "Не ўдалося атрымаць мерапрыемствы",
     "errorFetchingDefinition": "Не ўдалося атрымаць вызначэнне",
     "errorProcessAnalytics": "Не ўдалося апрацаваць аналітыку",
     "errorDownloading": "Немагчыма загрузіць",
-    "errorLoadingSpaceChildren": "Не ўдалося загрузіць чаты ў гэтым курсе",
-    "unexpectedError": "Неспадзяваная памылка.",
-    "pleaseReload": "Калі ласка, перазагрузіце і паспрабуйце зноў.",
     "translationError": "Памылка перакладу",
     "check": "Праверыць",
     "unableToFindRoom": "Чат або курс з гэтым кодам не знойдзены. Калі ласка, паспрабуйце зноў.",
@@ -3833,19 +3470,14 @@
     "request": "Запыт",
     "requestAll": "Запытаць усё",
     "confirmMessageUnpin": "Вы ўпэўнены, што хочаце скасаваць фіксацыю гэтага паведамлення?",
-    "saveAndLaunch": "Захаваць і запусціць",
-    "launchToSpace": "Запусціць у курс",
     "pending": "Чакае",
     "inactive": "Неактыўны",
-    "confirmRole": "Пацвердзіць ролю",
     "openRoleLabel": "АДКРЫТА",
     "finishedTheActivity": "🎯 {username} завяршыў гэтую дзейнасць",
     "activitySummaryError": "Зводкі дзейнасці недаступныя",
     "requestSummaries": "Запытаць зводкі",
-    "generatingNewActivities": "Вы першы карыстальнік гэтай пары моў! Калі ласка, пачакайце хвіліну, мы рыхтуем дзейнасці спецыяльна для вас.",
     "requestAccessTitle": "Запытаць доступ да аналітыкі?",
     "requestAccessDesc": "Ці хацелі б вы папрасіць доступ да прагляду аналітыкі ўдзельнікаў?\n\nКалі ўдзельнікі пагодзяцца, адміністратара гэтага курса змогуць праглядаць іх:\n    • агульны слоўнік\n    • агульныя граматычныя канцэпцыі\n    • агульную колькасць завершаных сесій дзейнасці\n    • канкрэтныя граматычныя канцэпцыі, выкарыстаныя правільна і няправільна\n\nЯны не змогуць праглядаць іх:\n    • паведамленні ў чатах за межамі курса\n    • спіс слоўніка",
-    "requestAccess": "Папрасіць доступ ({count})",
     "analyticsInactiveTitle": "Запыты да неактыўных карыстальнікаў не маглі быць адпраўлены",
     "analyticsInactiveDesc": "Неактыўныя карыстальнікі, якія не ўвайшлі з моманту ўвядзення гэтай функцыі, не ўбачаць ваш запыт.\n\nКнопка Запытаць з'явіцца, калі яны вернуцца. Вы можаце паўторна адпраўляць запыты пазней, націснуўшы кнопку Запытаць пад іх імем, калі яна будзе даступная.",
     "accessRequestedTitle": "Запыт доступу да аналітыкі",
@@ -3868,8 +3500,6 @@
     "accessDesc": "Вы можаце зрабіць свой курс адкрытым для свету! Або зрабіць яго прыватным і бяспечным.",
     "createGroupChatDesc": "У той час як пачынаюцца і заканчваюцца сесіі дзейнасці, групавыя чаты застануцца адкрытымі для звычайнай камунікацыі.",
     "deleteDesc": "Толькі адміністратары могуць выдаліць курс. Гэта деструктыўная дзея, якая выдаляе ўсіх карыстальнікаў і ўсе выбраныя чаты ў межах курса. Выконвайце асцярожна.",
-    "noCourseFound": "О, гэты курс патрабуе плану!\n\nПланы курса — гэта паслядоўнасць тэм і мерапрыемстваў для размовы.",
-    "additionalParticipants": "+ {num} іншых",
     "whatNow": "Што цяпер?",
     "chooseNextActivity": "Выберыце сваю наступную дзейнасць!",
     "letsGo": "Пачнем",
@@ -3882,13 +3512,11 @@
     "waitNotDone": "Пачакай, я яшчэ не скончыў!",
     "waitingForOthersToFinish": "Чакаю, пакуль астатнія скончаць...",
     "generatingSummary": "Аналізуючы чат і генеруючы вынікі",
-    "findCourse": "Знайсці курс",
     "pingParticipantsNotification": "{user} шукае карыстальнікаў для далучэння да сесіі мерапрыемства ў {room}",
     "course": "Курс",
     "courses": "Курсы",
     "goToCourse": "Перайсці да курса: {course}",
     "activityComplete": "Гэтае мерапрыемства завершана. Вынікі мерапрыемства павінны быць даступныя ніжэй.",
-    "startNewSession": "Пачаць новую сесію",
     "joinOpenSession": "Далучыцца да адкрытай сесіі",
     "activityNotFound": "Дзея не знойдзена",
     "myActivities": "Мае дзейнасці",
@@ -3972,10 +3600,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3985,10 +3609,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4072,14 +3692,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4096,10 +3708,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4112,15 +3720,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4272,14 +3872,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4293,14 +3885,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5523,10 +5107,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5567,10 +5147,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5643,10 +5219,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5916,47 +5488,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5976,19 +5508,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6052,10 +5572,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6096,14 +5612,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6115,14 +5623,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6160,10 +5660,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6180,27 +5676,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6324,10 +5804,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6337,10 +5813,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6357,14 +5829,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6504,18 +5968,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6564,10 +6016,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6577,18 +6025,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6631,23 +6067,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6671,10 +6095,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6682,14 +6102,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6794,18 +6206,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6858,10 +6258,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6888,10 +6284,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7072,7 +6464,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Паглядзіце заўтра абнаўленні мерапрыемстваў.",
-    "activityDropdownDesc": "Калі вы скончыце з гэтым мерапрыемствам, націсніце ніжэй",
     "languageMismatchTitle": "Несумяшчальнасць моў",
     "languageMismatchDesc": "Мэтавая мова не адпавядае мове гэтага мерапрыемства. Хацелі б абнавіць мэту мовы?",
     "reportWordIssueTooltip": "Паведаміць пра праблему з інфармацыяй пра слова",
@@ -7085,10 +6476,6 @@
     "selectAll": "Выбраць усё",
     "deselectAll": "Адмяніць выбар усяго",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7137,17 +6524,11 @@
         "placeholders": {}
     },
     "startOwn": "Пачніце свой уласны",
-    "joinCourseDesc": "Кожны курс складаецца з 8-10 паслядоўных тэм з рознымі моўнымі заданнямі, заснаванымі на дзейнасці.",
     "newMessageInPangeaChat": "💬 Новае паведамленне ў чатзе Pangea",
     "shareCourse": "Падзяліцца курсам",
     "addCourse": "Дадаць курс",
-    "joinPublicCourse": "Далучыцца да публічнага курса",
     "vocabLevelsDesc": "Тут будуць размяшчацца словы слоўніка, калі вы іх узнясеце ўзровень!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7160,10 +6541,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7182,7 +6559,6 @@
     "emojiView": "Від эмодзі",
     "feedbackDialogDesc": "Я таксама памыляюся! Што-небудзь, што дапаможа мне палепшыцца?",
     "contactHasBeenInvitedToTheCourse": "Кантакт быў запрошаны на курс",
-    "activityStatsButtonTooltip": "Інфармацыя аб актыўнасці",
     "allow": "Дазволіць",
     "deny": "Адмовіць",
     "enabledRenewal": "Уключыць аднаўленне падпіскі",
@@ -7450,10 +6826,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8509,16 +7881,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Дзеянні для адкрыцця наступнай тэмы",
-    "activitiesToUnlockTopicDesc": "Усталюйце колькасць дзеянняў для адкрыцця наступнай тэмы курса",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Правільная практыка вызначэння слоўнікавага запасу",
     "constructUseIncLMDesc": "Неправільная практыка вызначэння слоўнікавага запасу",
     "constructUseCorLADesc": "Правільная практыка аўдыё слоўнікавага запасу",
@@ -8526,7 +7888,6 @@
     "constructUseBonus": "Бонус падчас практыкі слоўнікавага запасу",
     "practiceVocab": "Практыкаваць слоўнік",
     "selectMeaning": "Выберыце значэнне",
-    "selectAudio": "Выберыце адпаведнае аўдыё",
     "anotherRound": "Яшчэ адзін раунд",
     "activitySettingsOverrideWarning": "Мова і ўзровень мовы вызначаюцца планам актыўнасці",
     "voice": "Голас",
@@ -8558,10 +7919,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8579,12 +7936,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Спампоўка ініцыявана",
     "webDownloadPermissionMessage": "Калі ваш браўзер блакуе спампоўкі, калі ласка, уключыце спампоўкі для гэтага сайта.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8679,11 +8031,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Што-то пайшло не так, і мы актыўна працуем над выпраўленнем. Праверце пазней.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Уключыць дапамогу ў напісанні",
     "autoIGCToolDescription": "Аўтаматычна запускаць інструменты Pangea Chat для выпраўлення адпраўленых паведамленняў на мэтавую мову.",
     "@autoIGCToolName": {
@@ -8719,20 +8066,14 @@
     "clientWellKnownInformation": "Інфармацыя, вядомая кліенту:",
     "baseUrl": "Базавы URL",
     "identityServer": "Сервер ідэнтычнасці:",
-    "versionWithNumber": "Версія: {version}",
     "logs": "Журналы",
-    "advancedConfigs": "Пашыраныя налады",
     "advancedConfigurations": "Пашыраныя канфігурацыі",
-    "signInWithLabel": "Увайсці з:",
-    "spanTypeGrammar": "Граматыка",
-    "spanTypeWordChoice": "Выбар слова",
     "spanTypeSpelling": "Правільнасць напісання",
     "spanTypePunctuation": "Пунктацыя",
     "spanTypeStyle": "Стыль",
     "spanTypeFluency": "Бегласць",
     "spanTypeAccents": "Наклонкі",
     "spanTypeCapitalization": "Вялікія літары",
-    "spanTypeCorrection": "Карэкцыя",
     "spanFeedbackTitle": "Звярнуць увагу на выпраўленне памылкі",
     "selectAllWords": "Выберыце ўсе словы, якія вы чулі ў аўдыё",
     "aboutMeHint": "Пра мяне",
@@ -8743,7 +8084,6 @@
     "greatPractice": "Выдатная практыка!",
     "usedNoHints": "Малайцы, што не выкарыстоўвалі падказкі!",
     "youveCompletedPractice": "Вы скончылі практыку, працягвайце, каб палепшыць свае навыкі!",
-    "joinCourseForActivities": "Далучайцеся да курса, каб паспрабаваць дзейнасці.",
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8772,35 +8112,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
         "type": "String",
         "placeholders": {}
     },
-    "@advancedConfigs": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@advancedConfigurations": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
         "type": "String",
         "placeholders": {}
     },
@@ -8825,10 +8141,6 @@
         "placeholders": {}
     },
     "@spanTypeCapitalization": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeCorrection": {
         "type": "String",
         "placeholders": {}
     },
@@ -8869,10 +8181,6 @@
         "placeholders": {}
     },
     "@youveCompletedPractice": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9073,11 +8381,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "У класе? Увядзіце свой код для далучэння сюды.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Аўтаматычнае выдзяленне аўдыяпаведамленняў",
     "selectAudioMessagesOnPlayDescription": "Аўтаматычна выдзяляць аўдыяпаведамленні падчас прайгравання",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9121,18 +8424,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Гэты курс мае тэмы з менш чым {input} актыўнасцямі. Калі ласка, увядзіце лік, які менш або роўны {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Націсніце тут, каб зноў увайсці.",
     "@clickToLogin": {
@@ -9549,17 +8840,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Мультфільмны жоўты мядзведзь з паднятымі рукамі ў захапленні.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Выберыце словы, каб даведацца пра іх больш",
     "requireAnalyticsAccessTitle": "Патрабуецца доступ да аналітыкі для ўдзелу",
     "requireAnalyticsAccessDesc": "Удзельнікі павінны даць доступ да сваёй навучальнай аналітыкі, каб далучыцца да гэтага курса",
     "analyticsAccessNoticeTitle": "Патрабуецца доступ да аналітыкі",
     "analyticsAccessNoticeDesc": "Далучаючыся да гэтага курса, вы згаджаецеся даць адміністратарам доступ да вашай навучальнай аналітыкі.",
-    "skipOnboardingClassCodeDesc": "Навучаецеся самастойна? Не хвалюйцеся, вы можаце:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9577,10 +8862,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9609,7 +8890,6 @@
     "pickCefrLevelTeacherStepTitle": "Які ўзровень вы выкладаеце?",
     "pickCefrLevelStudentStepTitle": "Які ў вас узровень?",
     "customCourseStepTitle": "Запоўніце гэтую форму, каб атрымаць індывідуальны курс",
-    "aboutYourClass": "Пра ваш клас",
     "courseCodeStepErrorMessage": "Калі ласка, праверце свой код і паспрабуйце яшчэ раз",
     "institution": "Установа",
     "courseGoals": "Мэты курса",
@@ -9652,10 +8932,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9772,12 +9048,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Лагатып Pangea Chat",
     "introChatDetails": "Скажыце прывітанне! Пазнаёмцеся з вашымі калегамі па курсу, знайдзіце сяброў і размаўляйце па-за межамі мерапрыемстваў.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9821,11 +9092,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Дзеянні актыўнасці",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Інструменты вымаўлення",
     "audioTranscription": "Аўдыё транскрыпцыя AI",
     "visualLearnerSupport": "Падтрымка візуальных вучняў",
@@ -9866,7 +9132,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Далучайцеся да курса, які ўключае гэтую дзейнасць, каб яе прайграць.",
     "resizeCoursePanel": "Змяніць памер панэлі курса",
     "undo": "Скасаваць",
     "unlock": "Разблакаваць",
@@ -9880,7 +9145,6 @@
     "addCourseBrowsePublic": "Прагляд публічных курсаў",
     "browsePublicCourses": "Прагляд публічных курсаў",
     "editProfile": "Рэдагаваць профіль",
-    "numObjectives": "{count} мэтаў",
     "mapSearchHint": "Шукаць актыўнасці",
     "mapSearchNoResults": "Супадзенняў не знойдзена",
     "mapFilterAllLanguages": "Усе мовы",
@@ -9889,7 +9153,6 @@
     "mapFilterCompleted": "Завершана",
     "mapFilterReset": "Скінуць",
     "activityTypeConversation": "Размова",
-    "lockedMissionRequirement": "Завяршыце папярэднюю місію, каб разблакаваць",
     "playAgain": "Пагуляць яшчэ раз",
     "reviewActivity": "Агляд",
     "mapEmptyInView": "Тут нічога няма на вашым узроўні або мове. Распашыце фільтры або аддаляйцеся.",
@@ -9904,14 +9167,9 @@
     "scrollToBottom": "Пракруціць уніз",
     "courseImage": "Выява курса",
     "avatarPreview": "Папярэдні прагляд аватара",
-    "activityPhoto": "Фота актыўнасці",
     "emotePreview": "Папярэдні прагляд эмоцыі: {name}",
     "activityLabel": "Дзейнасць: {title}",
     "resetMapView": "Скінуць выгляд карты",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9964,14 +9222,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10001,10 +9251,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10061,10 +9307,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_bn.arb
+++ b/lib/l10n/intl_bn.arb
@@ -222,28 +222,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@reportErrorDescription": {},
     "@directChats": {
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
-    "@addAccount": {},
     "@configureChat": {
         "type": "String",
         "placeholders": {}
@@ -367,10 +350,6 @@
             }
         }
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youAcceptedTheInvitation": {},
     "@banFromChat": {
         "type": "String",
@@ -476,10 +455,6 @@
         "placeholders": {}
     },
     "@tryAgain": {},
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blocked": {
         "type": "String",
         "placeholders": {}
@@ -490,10 +465,6 @@
                 "type": "String"
             }
         }
-    },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "@unbanUserDescription": {},
     "@userAndUserAreTyping": {
@@ -540,9 +511,6 @@
     },
     "@link": {},
     "@widgetUrlError": {},
-    "@emailOrUsername": {},
-    "@newSpaceDescription": {},
-    "@chatDescription": {},
     "@next": {
         "type": "String",
         "placeholders": {}
@@ -563,8 +531,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@enterSpace": {},
-    "@encryptThisChat": {},
     "@fileName": {
         "type": "String",
         "placeholders": {}
@@ -590,7 +556,6 @@
         "placeholders": {}
     },
     "@reopenChat": {},
-    "@pleaseEnterRecoveryKey": {},
     "@no": {
         "type": "String",
         "placeholders": {}
@@ -606,10 +571,6 @@
     },
     "@addToBundle": {},
     "@reportMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -634,10 +595,6 @@
         }
     },
     "@noKeyForThisMessage": {},
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@inviteText": {
         "type": "String",
         "placeholders": {
@@ -667,11 +624,6 @@
         }
     },
     "@pushNotificationsNotAvailable": {},
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {},
     "@replaceRoomWithNewerVersion": {
         "type": "String",
         "placeholders": {}
@@ -694,10 +646,6 @@
             }
         }
     },
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@cantOpenUri": {
         "type": "String",
         "placeholders": {
@@ -707,7 +655,6 @@
         }
     },
     "@sender": {},
-    "@storeInAndroidKeystore": {},
     "@hideRedactedEvents": {
         "type": "String",
         "placeholders": {}
@@ -764,10 +711,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@passwordHasBeenChanged": {
         "type": "String",
         "placeholders": {}
@@ -784,7 +727,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveKeyManuallyDescription": {},
     "@none": {
         "type": "String",
         "placeholders": {}
@@ -812,10 +754,6 @@
             }
         }
     },
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@importFromZipFile": {},
     "@or": {
         "type": "String",
@@ -823,15 +761,10 @@
     },
     "@dehydrateWarning": {},
     "@noOtherDevicesFound": {},
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@emptyChat": {
         "type": "String",
         "placeholders": {}
     },
-    "@yourChatBackupHasBeenSetUp": {},
     "@chatBackup": {
         "type": "String",
         "placeholders": {}
@@ -848,7 +781,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {},
     "@unmuteChat": {
         "type": "String",
         "placeholders": {}
@@ -880,14 +812,6 @@
     "@participant": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@yes": {
         "type": "String",
@@ -964,7 +888,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@unlockOldMessages": {},
     "@changedTheJoinRulesTo": {
         "type": "String",
         "placeholders": {
@@ -1113,7 +1036,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterRecoveryKeyDescription": {},
     "@guestsAreForbidden": {
         "type": "String",
         "placeholders": {}
@@ -1254,7 +1176,6 @@
         "description": "State that {command} is not a valid /command."
     },
     "@redactMessageDescription": {},
-    "@recoveryKey": {},
     "@redactMessage": {
         "type": "String",
         "placeholders": {}
@@ -1321,10 +1242,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@verifyStart": {
         "type": "String",
         "placeholders": {}
@@ -1339,7 +1256,6 @@
         "placeholders": {}
     },
     "@serverRequiresEmail": {},
-    "@screenSharingTitle": {},
     "@widgetCustom": {},
     "@sentCallInformations": {
         "type": "String",
@@ -1431,7 +1347,6 @@
         "placeholders": {}
     },
     "@messageInfo": {},
-    "@disableEncryptionWarning": {},
     "@directChat": {},
     "@encryptionNotEnabled": {
         "type": "String",
@@ -1455,21 +1370,15 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {},
     "@enterAnEmailAddress": {
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {},
     "@commandHint_kick": {
         "type": "String",
         "description": "Usage hint for the command /kick"
     },
     "@copiedToClipboard": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1512,10 +1421,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@confirmMatrixId": {},
     "@learnMore": {},
     "@iHaveClickedOnLink": {
@@ -1535,7 +1440,6 @@
     },
     "@newGroup": {},
     "@bundleName": {},
-    "@removeFromSpace": {},
     "@dateAndTimeOfDay": {
         "type": "String",
         "placeholders": {
@@ -1577,10 +1481,6 @@
     },
     "@scanQrCode": {},
     "@pleaseEnterANumber": {},
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youKicked": {
         "placeholders": {
             "user": {
@@ -1627,22 +1527,12 @@
             }
         }
     },
-    "@sorryThatsNotPossible": {},
     "@oopsSomethingWentWrong": {
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@shareInviteLink": {},
     "@commandHint_markasdm": {},
-    "@recoveryKeyLost": {},
     "@cuddleContent": {
         "type": "String",
         "placeholders": {
@@ -1665,14 +1555,6 @@
     },
     "@deviceKeys": {},
     "@waitingPartnerNumbers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -1704,15 +1586,10 @@
         "type": "String",
         "placeholders": {}
     },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@settings": {
         "type": "String",
         "placeholders": {}
     },
-    "@setTheme": {},
     "@changeTheHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -1733,10 +1610,6 @@
                 "type": "String"
             }
         }
-    },
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
     },
     "@changeDeviceName": {
         "type": "String",
@@ -1873,7 +1746,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@storeInSecureStorageDescription": {},
     "@openChat": {},
     "@kickUserDescription": {},
     "@sendAMessage": {
@@ -1895,7 +1767,6 @@
         "placeholders": {}
     },
     "@invite": {},
-    "@enableMultiAccounts": {},
     "@anyoneCanJoin": {
         "type": "String",
         "placeholders": {}
@@ -1913,7 +1784,6 @@
         }
     },
     "@unsupportedAndroidVersionLong": {},
-    "@storeSecurlyOnThisDevice": {},
     "@ok": {
         "type": "String",
         "placeholders": {}
@@ -1930,7 +1800,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@screenSharingDetail": {},
     "@changedTheDisplaynameTo": {
         "type": "String",
         "placeholders": {
@@ -1939,14 +1808,6 @@
             },
             "displayname": {
                 "type": "String"
-            }
-        }
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
             }
         }
     },
@@ -1987,7 +1848,6 @@
     "anyoneCanJoin": "কেউ যোগ দিতে পারে! তবে, অ্যাডমিন যে কেউকে বহিষ্কার ও নিষিদ্ধ করতে পারেন। যারা নিষিদ্ধ, তারা ফিরে আসতে পারবেন না!",
     "appLock": "অ্যাপ লক",
     "appLockDescription": "পিন কোড দিয়ে ব্যবহার না করলে অ্যাপটি লক করুন",
-    "areGuestsAllowedToJoin": "অতিথি ব্যবহারকারীরা যোগ দিতে পারবে?",
     "areYouSure": "আপনি কি নিশ্চিত?",
     "areYouSureYouWantToLogout": "আপনি কি নিশ্চিত যে আপনি লগ আউট করতে চান?",
     "askSSSSSign": "অন্য ব্যক্তির স্বাক্ষর করতে, দয়া করে আপনার নিরাপদ স্টোর পাসফ্রেজ বা পুনরুদ্ধার কী প্রবেশ করুন।",
@@ -2029,9 +1889,7 @@
     "changeTheNameOfTheGroup": "গ্রুপের নাম পরিবর্তন করুন",
     "changeYourAvatar": "আপনার অবতার পরিবর্তন করুন",
     "channelCorruptedDecryptError": "এনক্রিপশন ক্ষতিগ্রস্ত হয়েছে",
-    "yourChatBackupHasBeenSetUp": "আপনার চ্যাট ব্যাকআপ সেটআপ করা হয়েছে।",
     "chatBackup": "চ্যাট ব্যাকআপ",
-    "chatBackupDescription": "আপনার পুরানো বার্তা গুলি একটি পুনরুদ্ধার কী দিয়ে সুরক্ষিত। দয়া করে নিশ্চিত করুন যে আপনি এটি হারাবেন না।",
     "chatDetails": "চ্যাটের বিবরণ",
     "chats": "চ্যাট",
     "chooseAStrongPassword": "একটি শক্তিশালী পাসওয়ার্ড নির্বাচন করুন",
@@ -2061,17 +1919,14 @@
     "compareEmojiMatch": "অনুগ্রহ করে ইমোজিগুলি তুলনা করুন",
     "compareNumbersMatch": "অনুগ্রহ করে সংখ্যাগুলি তুলনা করুন",
     "configureChat": "চ্যাট কনফিগার করুন",
-    "contactHasBeenInvitedToTheGroup": "যোগাযোগকে গ্রুপে আমন্ত্রণ জানানো হয়েছে",
     "contentHasBeenReported": "বিষয়বস্তু সার্ভার অ্যাডমিনদের কাছে রিপোর্ট করা হয়েছে",
     "copiedToClipboard": "ক্লিপবোর্ডে কপি করা হয়েছে",
     "copyToClipboard": "ক্লিপবোর্ডে কপি করুন",
     "couldNotDecryptMessage": "বার্তা ডিক্রিপ্ট করতে পারিনি: {error}",
     "checkList": "তালিকা পরীক্ষা করুন",
     "countParticipants": "{count} অংশগ্রহণকারী",
-    "countInvited": "{count} আমন্ত্রিত",
     "createdTheChat": "💬 {username} চ্যাটটি তৈরি করেছেন",
     "createGroup": "গ্রুপ তৈরি করুন",
-    "createNewSpace": "নতুন স্থান",
     "currentlyActive": "বর্তমানে সক্রিয়",
     "darkTheme": "অন্ধকার",
     "dateAndTimeOfDay": "{date}, {timeOfDay}",
@@ -2093,9 +1948,6 @@
     "emoteKeyboardNoRecents": "সাম্প্রতিক ব্যবহৃত ইমোটগুলি এখানে দেখাবে...",
     "emotePacks": "রুমের জন্য ইমোট প্যাক",
     "emoteSettings": "ইমোট সেটিংস",
-    "globalChatId": "গ্লোবাল চ্যাট আইডি",
-    "accessAndVisibility": "অ্যাক্সেস এবং দৃশ্যমানতা",
-    "accessAndVisibilityDescription": "কে এই চ্যাটে যোগ দিতে পারবে এবং কিভাবে চ্যাটটি আবিষ্কৃত হবে।",
     "calls": "কল",
     "customEmojisAndStickers": "কাস্টম ইমোজি এবং স্টিকার",
     "customEmojisAndStickersBody": "কাস্টম ইমোজি বা স্টিকার যোগ করুন বা শেয়ার করুন যা যে কোনও চ্যাটে ব্যবহার করা যেতে পারে।",
@@ -2103,21 +1955,17 @@
     "emptyChat": "খালি চ্যাট",
     "enableEmotesGlobally": "গ্লোবালি ইমোট প্যাক সক্রিয় করুন",
     "enableEncryption": "এনক্রিপশন সক্রিয় করুন",
-    "enableEncryptionWarning": "আপনি আর এনক্রিপশন বন্ধ করতে পারবেন না। আপনি কি নিশ্চিত?",
     "encryptionNotEnabled": "এনক্রিপশন সক্রিয় নয়",
     "endedTheCall": "{senderName} কল শেষ করেছেন",
     "enterAnEmailAddress": "একটি ইমেল ঠিকানা লিখুন",
     "homeserver": "হোমসার্ভার",
     "errorObtainingLocation": "অবস্থান পাওয়ার ত্রুটি: {error}",
-    "everythingReady": "সব কিছু প্রস্তুত!",
     "extremeOffensive": "অত্যন্ত আপত্তিজনক",
     "fileName": "ফাইলের নাম",
     "fontSize": "ফন্টের আকার",
     "fromJoining": "যোগদান থেকে",
     "fromTheInvitation": "নিমন্ত্রণ থেকে",
-    "chatDescription": "চ্যাট বিবরণ",
     "chatDescriptionHasBeenChanged": "চ্যাট বিবরণ পরিবর্তিত হয়েছে",
-    "groupIsPublic": "গ্রুপটি পাবলিক",
     "groups": "গ্রুপসমূহ",
     "groupWith": "{displayname} এর সাথে গ্রুপ",
     "guestsAreForbidden": "অতিথিদের নিষিদ্ধ করা হয়েছে",
@@ -2136,7 +1984,6 @@
     "incorrectPassphraseOrKey": "ভুল পাসফ্রেজ বা পুনরুদ্ধার কী",
     "inoffensive": "অপ্রতিবন্ধক",
     "inviteContact": "যোগাযোগ আমন্ত্রণ করুন",
-    "inviteContactToGroup": "যোগাযোগকে {groupName} এ আমন্ত্রণ জানান",
     "noChatDescriptionYet": "এখনো কোনও চ্যাট বিবরণ তৈরি হয়নি।",
     "tryAgain": "আবার চেষ্টা করুন",
     "invalidServerName": "অবৈধ সার্ভার নাম",
@@ -2155,7 +2002,6 @@
     "lastActiveAgo": "শেষ সক্রিয়তা: {localizedTimeShort}",
     "leftTheChat": "চ্যাট থেকে প্রস্থান করেছেন",
     "lightTheme": "আলো",
-    "loadCountMoreParticipants": "আরও {count} অংশগ্রহণকারী লোড করুন",
     "dehydrate": "সেশন এক্সপোর্ট করুন এবং ডিভাইসটি মুছে ফেলুন",
     "dehydrateWarning": "এই ক্রিয়া পূর্বে ফিরে আসবে না। নিশ্চিত করুন যে আপনি ব্যাকআপ ফাইলটি নিরাপদে সংরক্ষণ করেছেন।",
     "hydrate": "ব্যাকআপ ফাইল থেকে পুনরুদ্ধার করুন",
@@ -2163,7 +2009,6 @@
     "loadMore": "আরও লোড করুন…",
     "locationDisabledNotice": "অবস্থান পরিষেবা নিষ্ক্রিয়। দয়া করে এগুলি সক্ষম করুন যাতে আপনি আপনার অবস্থান শেয়ার করতে পারেন।",
     "locationPermissionDeniedNotice": "অবস্থান অনুমতি অস্বীকৃত। দয়া করে অনুমতি দিন যাতে আপনি আপনার অবস্থান শেয়ার করতে পারেন।",
-    "logInTo": "{homeserver} এ লগইন করুন",
     "mention": "উল্লেখ করুন",
     "messages": "বার্তা",
     "messagesStyle": "বার্তা:",
@@ -2177,8 +2022,6 @@
     "no": "না",
     "noConnectionToTheServer": "সার্ভারের সাথে সংযোগ নেই",
     "noEmotesFound": "কোন ইমোট পাওয়া যায়নি। 😕",
-    "noEncryptionForPublicRooms": "আপনি কেবল তখনই এনক্রিপশন সক্রিয় করতে পারেন যখন রুমটি আর পাবলিক অ্যাক্সেসযোগ্য নয়।",
-    "noGoogleServicesWarning": "ফায়ারবেস ক্লাউড মেসেজিং আপনার ডিভাইসে উপলব্ধ নয় বলে মনে হচ্ছে। এখনও পুশ নোটিফিকেশন পেতে, আমরা ntfy ইনস্টল করার সুপারিশ করি। ntfy বা অন্য কোনও ইউনিফাইড পুশ প্রোভাইডার দিয়ে আপনি ডেটা সুরক্ষিত উপায়ে পুশ নোটিফিকেশন পেতে পারেন। আপনি PlayStore বা F-Droid থেকে ntfy ডাউনলোড করতে পারেন।",
     "noMatrixServer": "{server1} কোনও ম্যাট্রিক্স সার্ভার নয়, এর পরিবর্তে {server2} ব্যবহার করবেন?",
     "shareInviteLink": "আমন্ত্রণ লিঙ্ক শেয়ার করুন",
     "scanQrCode": "QR কোড স্ক্যান করুন",
@@ -2199,12 +2042,10 @@
     "openCamera": "ক্যামেরা খুলুন",
     "openVideoCamera": "ভিডিওর জন্য ক্যামেরা খুলুন",
     "oneClientLoggedOut": "আপনার এক ক্লায়েন্ট লগআউট হয়েছে",
-    "addAccount": "অ্যাকাউন্ট যোগ করুন",
     "editBundlesForAccount": "এই অ্যাকাউন্টের জন্য বান্ডিল সম্পাদনা করুন",
     "addToBundle": "বান্ডিলে যোগ করুন",
     "removeFromBundle": "এই বান্ডিল থেকে সরান",
     "bundleName": "বান্ডিলের নাম",
-    "enableMultiAccounts": "(BETA) এই ডিভাইসে মাল্টি অ্যাকাউন্ট সক্ষম করুন",
     "openInMaps": "ম্যাপে খুলুন",
     "link": "লিঙ্ক",
     "serverRequiresEmail": "এই সার্ভারটি নিবন্ধনের জন্য আপনার ইমেল ঠিকানা যাচাই করতে চায়।",
@@ -2216,7 +2057,6 @@
     "passwordHasBeenChanged": "পাসওয়ার্ড পরিবর্তন করা হয়েছে",
     "overview": "সারাংশ",
     "passwordRecoverySettings": "পাসওয়ার্ড পুনরুদ্ধার সেটিংস",
-    "passwordRecovery": "পাসওয়ার্ড পুনরুদ্ধার",
     "people": "মানুষ",
     "pickImage": "একটি ছবি নির্বাচন করুন",
     "pin": "পিন",
@@ -2225,7 +2065,6 @@
     "pleaseChooseAPasscode": "একটি পাসকোড নির্বাচন করুন",
     "pleaseClickOnLink": "অনুগ্রহ করে ইমেইলে লিঙ্কে ক্লিক করুন এবং তারপর এগিয়ে যান।",
     "pleaseEnter4Digits": "অনুগ্রহ করে ৪ অঙ্ক লিখুন বা অ্যাপ লক নিষ্ক্রিয় করতে খালি রাখুন।",
-    "pleaseEnterRecoveryKey": "অনুগ্রহ করে আপনার পুনরুদ্ধার কী লিখুন:",
     "pleaseEnterYourPassword": "অনুগ্রহ করে আপনার পাসওয়ার্ড লিখুন",
     "pleaseEnterYourPin": "অনুগ্রহ করে আপনার পিন লিখুন",
     "pleaseEnterYourUsername": "অনুগ্রহ করে আপনার ব্যবহারকারীর নাম লিখুন",
@@ -2245,7 +2084,6 @@
     "rejectedTheInvitation": "{username} আমন্ত্রণ প্রত্যাখ্যান করেছেন",
     "removeAllOtherDevices": "অন্য সব ডিভাইস সরান",
     "removedBy": "{username} দ্বারা সরানো হয়েছে",
-    "removeDevice": "ডিভাইস সরান",
     "unbanFromChat": "চ্যাট থেকে আনব্যান করুন",
     "removeYourAvatar": "আপনার অবতার সরান",
     "replaceRoomWithNewerVersion": "কক্ষটি নতুন সংস্করণে প্রতিস্থাপন করুন",
@@ -2257,8 +2095,6 @@
     "saveFile": "ফাইল সংরক্ষণ করুন",
     "search": "অনুসন্ধান",
     "security": "নিরাপত্তা",
-    "recoveryKey": "পুনরুদ্ধার কী",
-    "recoveryKeyLost": "পুনরুদ্ধার কী হারিয়ে গেছে?",
     "send": "পাঠান",
     "sendAMessage": "একটি বার্তা পাঠান",
     "sendAsText": "টেক্সট হিসেবে পাঠান",
@@ -2277,7 +2113,6 @@
     "separateChatTypes": "সরাসরি চ্যাট এবং গ্রুপ আলাদা করুন",
     "setAsCanonicalAlias": "প্রধান উপনাম হিসেবে সেট করুন",
     "setChatDescription": "চ্যাট বিবরণ সেট করুন",
-    "setPermissionsLevel": "অনুমতি স্তর সেট করুন",
     "setStatus": "অবস্থা সেট করুন",
     "settings": "সেটিংস",
     "share": "শেয়ার করুন",
@@ -2287,8 +2122,6 @@
     "presencesToggle": "অন্য ব্যবহারকারীদের স্ট্যাটাস বার্তা দেখান",
     "skip": "এড়িয়ে যান",
     "sourceCode": "উৎস কোড",
-    "spaceIsPublic": "স্থানটি পাবলিক",
-    "spaceName": "স্থান নাম",
     "startedACall": "{senderName} একটি কল শুরু করেছেন",
     "status": "অবস্থা",
     "statusExampleMessage": "আজ আপনি কেমন আছেন?",
@@ -2300,7 +2133,6 @@
     "theyMatch": "তারা মেলে",
     "title": "ফ্লাফি চ্যাট",
     "tooManyRequestsWarning": "অনেক অনুরোধ। দয়া করে পরে আবার চেষ্টা করুন!",
-    "transferFromAnotherDevice": "অন্য ডিভাইস থেকে স্থানান্তর করুন",
     "tryToSendAgain": "আবার পাঠানোর চেষ্টা করুন",
     "unavailable": "অপ্রাপ্য",
     "unbannedUser": "{username} {targetName} এর থেকে নিষেধাজ্ঞা প্রত্যাহার করেছেন",
@@ -2310,7 +2142,6 @@
     "unknownEvent": "অজানা ঘটনা '{type}'",
     "unmuteChat": "চ্যাট আনমিউট করুন",
     "unpin": "অপিন করুন",
-    "unreadChats": "{unreadCount, plural, =1{1টি পড়া বাকি চ্যাট} other{{unreadCount}টি পড়া বাকি চ্যাট}}",
     "userAndOthersAreTyping": "{username} এবং {count} অন্যরা টাইপ করছে…",
     "userAndUserAreTyping": "{username} এবং {username2} টাইপ করছে…",
     "userIsTyping": "{username} টাইপ করছে…",
@@ -2323,8 +2154,6 @@
     "verifyStart": "প্রমাণীকরণ শুরু করুন",
     "verifySuccess": "আপনি সফলভাবে প্রমাণিত হয়েছেন!",
     "verifyTitle": "অন্য অ্যাকাউন্ট যাচাই করা হচ্ছে",
-    "videoCall": "ভিডিও কল",
-    "visibilityOfTheChatHistory": "চ্যাট ইতিহাসের দৃশ্যমানতা",
     "visibleForAllParticipants": "সকল অংশগ্রহণকারীর জন্য দৃশ্যমান",
     "visibleForEveryone": "সবার জন্য দৃশ্যমান",
     "voiceMessage": "কণ্ঠ বার্তা",
@@ -2334,10 +2163,7 @@
     "wallpaper": "ওয়ালপেপার:",
     "warning": "সতর্কতা!",
     "weSentYouAnEmail": "আমরা আপনাকে একটি ইমেল পাঠিয়েছি",
-    "whoCanPerformWhichAction": "কেউ কোন কাজ করতে পারে",
-    "whoIsAllowedToJoinThisGroup": "এই গ্রুপে যোগদানের অনুমতি কার?",
     "whyDoYouWantToReportThis": "আপনি এটি রিপোর্ট করতে চান কেন?",
-    "wipeChatBackup": "আপনার চ্যাট ব্যাকআপ মুছে ফেলুন এবং একটি নতুন পুনরুদ্ধার কী তৈরি করুন?",
     "withTheseAddressesRecoveryDescription": "এই ঠিকানাগুলির মাধ্যমে আপনি আপনার পাসওয়ার্ড পুনরুদ্ধার করতে পারেন।",
     "writeAMessage": "একটি বার্তা লিখুন…",
     "yes": "হ্যাঁ",
@@ -2350,9 +2176,7 @@
     "messageType": "বার্তার ধরণ",
     "sender": "প্রেরক",
     "openGallery": "গ্যালারী খুলুন",
-    "removeFromSpace": "স্থান থেকে সরান",
     "start": "শুরু করুন",
-    "pleaseEnterRecoveryKeyDescription": "আপনার পুরোনো বার্তা আনলক করতে, দয়া করে আপনার পুনরুদ্ধার কী প্রবেশ করুন যা পূর্ববর্তী সেশনে তৈরি করা হয়েছে। আপনার পুনরুদ্ধার কী আপনার পাসওয়ার্ড নয়।",
     "publish": "প্রকাশ করুন",
     "openChat": "চ্যাট খুলুন",
     "markAsRead": "পড়া হিসেবে চিহ্নিত করুন",
@@ -2363,12 +2187,9 @@
     "confirmEventUnpin": "আপনি কি নিশ্চিত যে আপনি ইভেন্টটি স্থায়ীভাবে আনপিন করতে চান?",
     "emojis": "ইমোজি",
     "placeCall": "কল করুন",
-    "voiceCall": "ভয়েস কল",
     "unsupportedAndroidVersion": "অপ্রোড Android সংস্করণ",
     "unsupportedAndroidVersionLong": "এই বৈশিষ্ট্যটি একটি নতুন Android সংস্করণ প্রয়োজন। অনুগ্রহ করে আপডেট বা Lineage OS সমর্থনের জন্য চেক করুন।",
-    "videoCallsBetaWarning": "দয়া করে মনে রাখবেন যে ভিডিও কল বর্তমানে বিটা পর্যায়ে। এটি প্রত্যাশিত মতো কাজ নাও করতে পারে বা সব প্ল্যাটফর্মে কাজ নাও করতে পারে।",
     "experimentalVideoCalls": "প্রায়োগিক ভিডিও কল",
-    "emailOrUsername": "ইমেল বা ব্যবহারকারীর নাম",
     "addWidget": "উইজেট যোগ করুন",
     "widgetVideo": "ভিডিও",
     "widgetEtherpad": "টেক্সট নোট",
@@ -2390,35 +2211,19 @@
     "youKickedAndBanned": "🙅 আপনি {user} কে বহিষ্কার ও নিষিদ্ধ করেছেন",
     "youUnbannedUser": "আপনি {user} এর নিষেধাজ্ঞা প্রত্যাহার করেছেন",
     "hasKnocked": "🚪 {user} Knock করেছেন",
-    "usersMustKnock": "ব্যবহারকারীদের Knock করতে হবে",
-    "noOneCanJoin": "কেউ যোগ দিতে পারবে না",
     "knock": "Knock",
     "users": "ব্যবহারকারীরা",
-    "unlockOldMessages": "পুরানো বার্তা আনলক করুন",
-    "storeInSecureStorageDescription": "এই ডিভাইসের সুরক্ষিত স্টোরেজে পুনরুদ্ধার কী সংরক্ষণ করুন।",
-    "saveKeyManuallyDescription": "সিস্টেম শেয়ার ডায়ালগ বা ক্লিপবোর্ড ট্রিগার করে এই কী ম্যানুয়ালি সংরক্ষণ করুন।",
-    "storeInAndroidKeystore": "Android KeyStore-এ সংরক্ষণ করুন",
-    "storeInAppleKeyChain": "Apple KeyChain-এ সংরক্ষণ করুন",
-    "storeSecurlyOnThisDevice": "এই ডিভাইসে নিরাপদে সংরক্ষণ করুন",
     "countFiles": "{count} ফাইল",
     "user": "ব্যবহারকারী",
     "custom": "কাস্টম",
-    "foregroundServiceRunning": "এই বিজ্ঞপ্তিটি তখন প্রদর্শিত হয় যখন সামনের সারির পরিষেবা চলমান থাকে।",
-    "screenSharingTitle": "স্ক্রীন শেয়ারিং",
-    "screenSharingDetail": "আপনি FuffyChat-এ আপনার স্ক্রীন শেয়ার করছেন",
     "whyIsThisMessageEncrypted": "এই বার্তা unreadable কেন?",
     "noKeyForThisMessage": "এটি ঘটতে পারে যদি বার্তাটি আপনি এই ডিভাইসে সাইন ইন করার আগে পাঠানো হয়।\n\nএছাড়াও সম্ভব যে প্রেরক আপনার ডিভাইস ব্লক করেছে বা ইন্টারনেট সংযোগে কিছু ভুল হয়েছে।\n\nআপনি কি অন্য সেশনে বার্তাটি পড়তে পারছেন? তাহলে আপনি এটি থেকে বার্তাটি ট্রান্সফার করতে পারেন! সেটিংস > ডিভাইস এ যান এবং নিশ্চিত করুন যে আপনার ডিভাইসগুলো একে অপরকে ভেরিফাই করেছে। যখন আপনি পরবর্তী বার রুমটি খুলবেন এবং উভয় সেশন ফ্রন্টে থাকবে, তখন কী স্বয়ংক্রিয়ভাবে ট্রান্সমিট হবে।\n\nলগআউট বা ডিভাইস পরিবর্তনের সময় কি আপনি কী হারাতে চান না? নিশ্চিত করুন যে আপনি চ্যাট ব্যাকআপ সক্ষম করেছেন সেটিংসে।",
     "newGroup": "নতুন গ্রুপ",
     "newSpace": "নতুন স্পেস",
-    "enterSpace": "স্পেসে প্রবেশ করুন",
     "allSpaces": "সব স্পেস",
     "hidePresences": "স্ট্যাটাস তালিকা লুকান?",
     "doNotShowAgain": "আবার দেখাবেন না",
     "wasDirectChatDisplayName": "খালি চ্যাট (পূর্বে {oldDisplayName})",
-    "newSpaceDescription": "স্পেস আপনাকে আপনার চ্যাটগুলো একত্রিত করতে এবং ব্যক্তিগত বা পাবলিক কমিউনিটি তৈরি করতে দেয়।",
-    "encryptThisChat": "এই চ্যাট এনক্রিপ্ট করুন",
-    "disableEncryptionWarning": "নিরাপত্তার জন্য আপনি পূর্বে সক্রিয় থাকলে এই চ্যাটে এনক্রিপশন বন্ধ করতে পারবেন না।",
-    "sorryThatsNotPossible": "দুঃখিত... এটি সম্ভব নয়",
     "deviceKeys": "ডিভাইস কীসমূহ:",
     "reopenChat": "চ্যাট পুনরায় খোলা",
     "noBackupWarning": "সতর্কতা! চ্যাট ব্যাকআপ ছাড়া, আপনি আপনার এনক্রিপ্টেড বার্তাগুলিতে অ্যাক্সেস হারাবেন। লগ আউট করার আগে চ্যাট ব্যাকআপ সক্ষম করা অত্যন্ত সুপারিশ করা হয়।",
@@ -2431,7 +2236,6 @@
     "openLinkInBrowser": "ব্রাউজারে লিঙ্ক খুলুন",
     "reportErrorDescription": "😞 ওহ না। কিছু ভুল হয়েছে। আপনি চাইলে এই বাগটি ডেভেলপারদের কাছে রিপোর্ট করতে পারেন।",
     "report": "রিপোর্ট করুন",
-    "setTheme": "থিম সেট করুন:",
     "setColorTheme": "রঙের থিম সেট করুন:",
     "invite": "আমন্ত্রণ জানান",
     "inviteGroupChat": "📨 গ্রুপ চ্যাট আমন্ত্রণ",
@@ -2450,12 +2254,8 @@
     "yourGlobalUserIdIs": "আপনার গ্লোবাল ইউজার-আইডি হলো: ",
     "noUsersFoundWithQuery": "দুঃখিত, \"{query}\" এর সাথে কোনও ব্যবহারকারী পাওয়া যায়নি। দয়া করে ভুল টাইপ হয়েছে কি না তা পরীক্ষা করুন।",
     "knocking": "নক করা হচ্ছে",
-    "chatCanBeDiscoveredViaSearchOnServer": "চ্যাটটি সার্ভারে অনুসন্ধানের মাধ্যমে খুঁজে পাওয়া যেতে পারে {server} এ",
-    "searchChatsRooms": "#চ্যাট, @ব্যবহারকারীদের জন্য অনুসন্ধান করুন...",
     "nothingFound": "কিছুই পাওয়া যায়নি...",
     "groupName": "গ্রুপের নাম",
-    "createGroupAndInviteUsers": "একটি গ্রুপ তৈরি করুন এবং ব্যবহারকারীদের আমন্ত্রণ জানান",
-    "groupCanBeFoundViaSearch": "অনুসন্ধানের মাধ্যমে গ্রুপটি খুঁজে পাওয়া যায়",
     "wrongRecoveryKey": "দুঃখিত... এটি সঠিক পুনরুদ্ধার কী মনে হচ্ছে না।",
     "startConversation": "আলাপ শুরু করুন",
     "commandHint_sendraw": "কাঁচা JSON পাঠান",
@@ -2469,11 +2269,8 @@
     "pleaseChooseAStrongPassword": "অনুগ্রহ করে একটি শক্তিশালী পাসওয়ার্ড নির্বাচন করুন",
     "passwordsDoNotMatch": "পাসওয়ার্ডগুলি মিলছে না",
     "passwordIsWrong": "আপনার প্রবেশ করা পাসওয়ার্ডটি ভুল",
-    "publicChatAddresses": "পাবলিক চ্যাট ঠিকানা",
-    "createNewAddress": "নতুন ঠিকানা তৈরি করুন",
     "joinSpace": "স্পেসে যোগ দিন",
     "publicSpaces": "পাবলিক স্পেস",
-    "addChatOrSubSpace": "চ্যাট বা সাব স্পেস যোগ করুন",
     "subspace": "সাবস্পেস",
     "decline": "প্রত্যাখ্যান করুন",
     "thisDevice": "এই ডিভাইস:",
@@ -2482,15 +2279,11 @@
     "searchMore": "আরও অনুসন্ধান করুন...",
     "gallery": "গ্যালারি",
     "files": "ফাইলসমূহ",
-    "sessionLostBody": "আপনার সেশন হারিয়ে গেছে। দয়া করে এই ত্রুটিটি ডেভেলপারদের {url} এ রিপোর্ট করুন। ত্রুটির বার্তা হলো: {error}",
-    "restoreSessionBody": "অ্যাপটি এখন আপনার ব্যাকআপ থেকে আপনার সেশন পুনরুদ্ধার করার চেষ্টা করছে। দয়া করে এই ত্রুটিটি ডেভেলপারদের {url} এ রিপোর্ট করুন। ত্রুটির বার্তা হলো: {error}",
     "sendReadReceipts": "পড়ার রসিদ পাঠান",
     "sendTypingNotificationsDescription": "অন্য অংশগ্রহণকারীরা দেখতে পাবে আপনি নতুন বার্তা টাইপ করছেন কখন।",
     "sendReadReceiptsDescription": "অন্য অংশগ্রহণকারীরা দেখতে পাবে আপনি কখন একটি বার্তা পড়েছেন।",
     "formattedMessages": "ফরম্যাটেড বার্তা",
     "formattedMessagesDescription": "মার্কডাউনের মাধ্যমে বল্ড টেক্সটের মতো সমৃদ্ধ বার্তা বিষয়বস্তু দেখান।",
-    "verifyOtherUser": "🔐 অন্য ব্যবহারকারীর সত্যতা যাচাই করুন",
-    "verifyOtherUserDescription": "যদি আপনি অন্য ব্যবহারকারীর সত্যতা যাচাই করেন, তবে আপনি নিশ্চিত হতে পারেন আপনি সত্যিই কার সাথে লিখছেন। 💪\n\nযখন আপনি যাচাই শুরু করবেন, তখন আপনি এবং অন্য ব্যবহারকারী অ্যাপে একটি পপআপ দেখবেন। সেখানে আপনি একে অপরের সাথে তুলনা করতে হবে একটি সিরিজ ইমোজি বা সংখ্যার।\n\nএটি করার সবচেয়ে ভালো উপায় হলো দেখা বা ভিডিও কল শুরু করা। 👩‍💻",
     "verifyOtherDevice": "🔐 অন্য ডিভাইসের সত্যতা যাচাই করুন",
     "verifyOtherDeviceDescription": "যখন আপনি অন্য ডিভাইসের সত্যতা যাচাই করেন, সেই ডিভাইসগুলো কী বিনিময় করতে পারে, যা আপনার সামগ্রিক নিরাপত্তা বাড়ায়। 💪 যখন আপনি যাচাই শুরু করবেন, তখন অ্যাপে একটি পপআপ উভয় ডিভাইসে দেখাবে। সেখানে আপনি একে অপরের সাথে তুলনা করতে হবে একটি সিরিজ ইমোজি বা সংখ্যার। যাচাই শুরু করার আগে উভয় ডিভাইস হাতের কাছে থাকা উত্তম। 🤳",
     "acceptedKeyVerification": "{sender} কী যাচাই গ্রহণ করেছেন",
@@ -2526,10 +2319,6 @@
     "updateInstalled": "🎉 আপডেট {version} ইনস্টল হয়েছে!",
     "changelog": "চেঞ্জলগ",
     "sendCanceled": "পাঠানো বাতিল হয়েছে",
-    "loginWithMatrixId": "ম্যাট্রিক্স-আইডি দিয়ে লগইন করুন",
-    "discoverHomeservers": "হোমসার্ভার আবিষ্কার করুন",
-    "whatIsAHomeserver": "হোমসার্ভার কী?",
-    "homeserverDescription": "আপনার সমস্ত ডেটা হোমসার্ভারে সংরক্ষিত হয়, ঠিক যেমন একটি ইমেল প্রদানকারী। আপনি কোন হোমসার্ভার ব্যবহার করতে চান তা নির্বাচন করতে পারেন, তবে আপনি এখনও সবাইকে যোগাযোগ করতে পারেন। আরও জানুন https://matrix.org এ।",
     "doesNotSeemToBeAValidHomeserver": "এটি একটি মানানসই হোমসার্ভার বলে মনে হচ্ছে না। ভুল URL?",
     "calculatingFileSize": "ফাইলের আকার গণনা করা হচ্ছে...",
     "prepareSendingAttachment": "সংযুক্তি পাঠানোর প্রস্তুতি নিচ্ছি...",
@@ -2541,11 +2330,9 @@
     "oneOfYourDevicesIsNotVerified": "আপনার ডিভাইসের একটি যাচাই হয়নি",
     "noticeChatBackupDeviceVerification": "নোট: যখন আপনি আপনার সমস্ত ডিভাইস চ্যাট ব্যাকআপের সাথে সংযুক্ত করবেন, তারা স্বয়ংক্রিয়ভাবে যাচাই হয়।",
     "continueText": "চালিয়ে যান",
-    "welcomeText": "হেই হেই 👋 এটি ফ্লাফি চ্যাট। আপনি যে কোনও হোমসার্ভারে সাইন ইন করতে পারেন, যা https://matrix.org এর সাথে সামঞ্জস্যপূর্ণ। এবং তারপর যে কোনও ব্যক্তির সাথে চ্যাট করুন। এটি একটি বিশাল বিকেন্দ্রীকৃত বার্তা প্রেরণ নেটওয়ার্ক!",
     "blur": "ধূসর:",
     "opacity": "অপেক্ষা:",
     "setWallpaper": "ওয়ালপেপার সেট করুন",
-    "manageAccount": "অ্যাকাউন্ট পরিচালনা করুন",
     "noContactInformationProvided": "সার্ভার কোনও বৈধ যোগাযোগের তথ্য প্রদান করে না",
     "contactServerAdmin": "সার্ভার অ্যাডমিনের সাথে যোগাযোগ করুন",
     "contactServerSecurity": "সার্ভার সুরক্ষা সংক্রান্ত যোগাযোগ করুন",
@@ -2564,11 +2351,8 @@
     "unableToJoinChat": "চ্যাটে যোগ দিতে পারছেন না। হয়তো অন্য পক্ষটি ইতিমধ্যে কথোপকথন বন্ধ করে দিয়েছে।",
     "previous": "আগে",
     "otherPartyNotLoggedIn": "অন্য পক্ষ বর্তমানে লগ ইন করেনি এবং তাই বার্তা গ্রহণ করতে পারবে না!",
-    "appWantsToUseForLogin": "'{server}' ব্যবহার করে লগ ইন করুন",
-    "appWantsToUseForLoginDescription": "আপনি এইভাবে অ্যাপ এবং ওয়েবসাইটকে আপনার সম্পর্কে তথ্য শেয়ার করতে অনুমতি দিচ্ছেন।",
     "open": "খুলুন",
     "waitingForServer": "সার্ভারের জন্য অপেক্ষা করছে...",
-    "appIntroduction": "ফ্লাফি চ্যাট আপনাকে বিভিন্ন মেসেঞ্জার ব্যবহার করে আপনার বন্ধুদের সাথে চ্যাট করার সুযোগ দেয়। আরও জানুন https://matrix.org বা কেবল *Continue* ট্যাপ করুন।",
     "newChatRequest": "📩 নতুন চ্যাট অনুরোধ",
     "contentNotificationSettings": "বিষয়বস্তুর বিজ্ঞপ্তি সেটিংস",
     "generalNotificationSettings": "সাধারণ বিজ্ঞপ্তি সেটিংস",
@@ -2645,11 +2429,9 @@
     "taTooltip": "অনুবাদ সহায়তার জন্য L2 ব্যবহার করুন",
     "interactiveTranslatorSliderHeader": "ইন্টারেক্টিভ অনুবাদক",
     "interactiveGrammarSliderHeader": "ইন্টারেক্টিভ ব্যাকরণ চেকার",
-    "interactiveTranslatorRequired": "প্রয়োজনীয়",
     "waTooltip": "সহায়তা ছাড়াই L2 ব্যবহার",
     "interactiveTranslator": "অনুবাদ সহায়তা",
     "noIdenticalLanguages": "অনুগ্রহ করে ভিন্ন ভিত্তি এবং লক্ষ্য ভাষা নির্বাচন করুন",
-    "searchBy": "দেশ এবং ভাষা দ্বারা অনুসন্ধান করুন",
     "joinWithClassCode": "কোর্সে যোগ দিন",
     "languageLevelPreA1": "নবীন নিম্ন (প্রি A1)",
     "languageLevelA1": "নবীন মধ্য (এ1)",
@@ -2670,19 +2452,14 @@
     "saveChanges": "পরিবর্তন সংরক্ষণ করুন",
     "publicProfileTitle": "আমার প্রোফাইল খুঁজে পাওয়ার অনুমতি দিন",
     "publicProfileDesc": "চালু করলে, অন্য ব্যবহারকারীরা গ্লোবাল সার্চ বারে আপনার প্রোফাইল খুঁজে পাবে এবং চ্যাটের জন্য অনুরোধ পাঠাতে পারবে। এই মুহূর্তে, আপনি গ্রহণ বা অস্বীকার করার সিদ্ধান্ত নিতে পারেন।",
-    "errorDisableIT": "অনুবাদ সহায়তা বন্ধ করা হয়েছে।",
-    "errorDisableIGC": "ব্যাকরণ সহায়তা বন্ধ করা হয়েছে।",
     "errorDisableITUserDesc": "অনুবাদ সহায়তা সেটিংস আপডেট করতে এখানে ক্লিক করুন",
     "errorDisableIGCUserDesc": "ব্যাকরণ সহায়তা সেটিংস আপডেট করতে এখানে ক্লিক করুন",
     "errorDisableITClassDesc": "এই কোর্সের জন্য অনুবাদ সহায়তা বন্ধ করা হয়েছে।",
     "errorDisableIGCClassDesc": "এই কোর্সের জন্য ব্যাকরণ সহায়তা বন্ধ করা হয়েছে।",
-    "error405Title": "ভাষা সেট করা হয়নি",
     "error405Desc": "অনুগ্রহ করে মূল মেনু > শিক্ষার সেটিংসে আপনার ভাষা সেট করুন।",
     "termsAndConditions": "শর্তাবলী ও শর্তসমূহ",
     "andCertifyIAmAtLeast13YearsOfAge": "এবং আমি নিশ্চিত করি যে আমি কমপক্ষে ১৬ বছর বয়সী।",
-    "error502504Title": "উফ, অনলাইনে অনেক ছাত্র রয়েছে!",
     "error502504Desc": "পাঙ্গিয়া বটগুলি আপডেট হওয়ার সময় অনুবাদ এবং ব্যাকরণ সরঞ্জামগুলি ধীর বা অপ্রাপ্য হতে পারে।",
-    "error404Title": "অনুবাদ ত্রুটি!",
     "error404Desc": "পাঙ্গিয়া বট নিশ্চিত নয় কিভাবে এটি অনুবাদ করবে...",
     "errorPleaseRefresh": "আমরা এটি দেখছি! দয়া করে রিফ্রেশ করুন এবং আবার চেষ্টা করুন।",
     "connectedToStaging": "স্টেজিং-এ সংযুক্ত",
@@ -2720,13 +2497,9 @@
     "definitionsToolName": "শব্দের সংজ্ঞা",
     "definitionsToolDescription": "সক্রিয় হলে, নীল রঙে আন্ডারলাইন করা শব্দগুলিতে ক্লিক করে সংজ্ঞা দেখা যায়। বার্তাগুলিতে ক্লিক করে সংজ্ঞা অ্যাক্সেস করুন।",
     "welcomeBack": "ফিরে আসায় স্বাগতম! আপনি যদি ২০২৩-২০২৪ পাইলটের অংশ হয়ে থাকেন, তবে আমাদের সাথে যোগাযোগ করুন আপনার বিশেষ পাইলট সাবস্ক্রিপশনের জন্য। আপনি যদি একজন শিক্ষক হন যিনি (অথবা আপনার প্রতিষ্ঠান) আপনার ক্লাসের জন্য লাইসেন্স কিনেছেন, তবে আমাদের সাথে যোগাযোগ করুন আপনার শিক্ষক সাবস্ক্রিপশনের জন্য।",
-    "downloadTxtFile": "টেক্সট ফাইল ডাউনলোড করুন",
-    "downloadCSVFile": "CSV ফাইল ডাউনলোড করুন",
     "promotionalSubscriptionDesc": "আপনার বর্তমানে একটি আজীবন প্রচারমূলক সাবস্ক্রিপশন রয়েছে। আপনার সাবস্ক্রিপশন পরিবর্তনের জন্য support@pangea.chat এ বার্তা পাঠান।",
     "originalSubscriptionPlatform": "{purchasePlatform} এর মাধ্যমে কেনা সাবস্ক্রিপশন",
     "oneWeekTrial": "এক সপ্তাহের ট্রায়াল",
-    "downloadXLSXFile": "এক্সেল ফাইল ডাউনলোড করুন",
-    "unkDisplayName": "অজানা",
     "wwCountryDisplayName": "বিশ্বব্যাপী",
     "afCountryDisplayName": "আফগানিস্তান",
     "axCountryDisplayName": "আল্যান্ড দ্বীপপুঞ্জ",
@@ -3021,7 +2794,6 @@
     "chatCapacityHasBeenChanged": "চ্যাট ক্ষমতা পরিবর্তিত হয়েছে",
     "chatCapacitySetTooLow": "চ্যাট ক্ষমতা কমপক্ষে {count} হতে হবে।",
     "chatCapacityExplanation": "চ্যাট ক্ষমতা চ্যাটে অনুমোদিত সদস্যের সংখ্যাকে সীমাবদ্ধ করে।",
-    "tooManyRequest": "অনেক বেশি অনুরোধ, দয়া করে পরে আবার চেষ্টা করুন।",
     "enterNumber": "একটি পূর্ণসংখ্যা মান লিখুন।",
     "practice": "অভ্যাস",
     "versionNotFound": "সংস্করণ পাওয়া যায়নি",
@@ -3031,7 +2803,6 @@
     "deleteSubscriptionWarningTitle": "আপনার একটি সক্রিয় সাবস্ক্রিপশন রয়েছে",
     "deleteSubscriptionWarningBody": "আপনার অ্যাকাউন্ট মুছে ফেলা স্বয়ংক্রিয়ভাবে আপনার সাবস্ক্রিপশন বাতিল করবে না।",
     "manageSubscription": "সাবস্ক্রিপশন পরিচালনা করুন",
-    "error520Title": "অনুগ্রহ করে আবার চেষ্টা করুন।",
     "error520Desc": "দুঃখিত, আমরা আপনার বার্তা বুঝতে পারিনি...",
     "wordsUsed": "ব্যবহৃত শব্দ",
     "level": "স্তর",
@@ -3049,7 +2820,6 @@
     "other": "অন্য",
     "levelShort": "স্তর {level}",
     "noCapacityLimit": "কোন ক্ষমতা সীমা নেই",
-    "downloadGroupText": "গ্রুপ টেক্সট ডাউনলোড করুন",
     "notificationsOn": "বিজ্ঞপ্তি চালু",
     "notificationsOff": "বিজ্ঞপ্তি বন্ধ",
     "joinWithCode": "কোড দিয়ে যোগ দিন",
@@ -3113,24 +2883,12 @@
     "whatIsTheMorphTag": "'{wordForm}' এর {morphologicalFeature} কী?",
     "dataAvailable": "ডেটা উপলব্ধতা",
     "available": "উপলব্ধ",
-    "pangeaBotIsFallible": "পাঙ্গিয়া বটও ভুল করে!",
-    "whatIsMeaning": "'{lemma}' এর অর্থ কী?",
     "chooseLemmaMeaningInstructionsBody": "বার্তার শব্দের সাথে অর্থ মিলান!",
-    "doubleClickToEdit": "সম্পাদনা করতে ডাবল ক্লিক করুন।",
-    "topicLabel": "বিষয়",
-    "topicPlaceholder": "একটি বিষয় নির্বাচন করুন...",
-    "modePlaceholder": "একটি মোড নির্বাচন করুন...",
-    "learningObjectiveLabel": "শিক্ষার লক্ষ্য",
-    "learningObjectivePlaceholder": "একটি শিক্ষার লক্ষ্য নির্বাচন করুন...",
-    "targetLanguageLabel": "লক্ষ্য ভাষা",
     "cefrLevelLabel": "CEFR স্তর",
     "image": "ছবি",
     "video": "ভিডিও",
     "nan": "প্রযোজ্য নয়",
-    "addVocabulary": "শব্দভাণ্ডার যোগ করুন",
     "instructions": "নির্দেশনা",
-    "numberOfLearners": "শিক্ষার্থীর সংখ্যা",
-    "mustBeInteger": "একটি পূর্ণসংখ্যা হতে হবে যেমন ১, ২, ৩, ...",
     "constructUsePvmDesc": "ভয়েস মেসেজে তৈরি",
     "leaveSpaceDescription": "কোর্স থেকে ছেড়ে গেলে, আপনি এর মধ্যে সমস্ত চ্যাট ছেড়ে যাবেন। অন্যান্য ব্যবহারকারীরা দেখবে যে আপনি কোর্স ছেড়ে গেছেন।",
     "constructUseCorMmDesc": "সঠিক বার্তা অর্থ",
@@ -3145,7 +2903,6 @@
     "ttsDisabledBody": "আপনি আপনার শেখার সেটিংসে টেক্সট-টু-স্পিচ চালু করতে পারেন",
     "noSpaceDescriptionYet": "এখনো কোনও কোর্সের বিবরণ তৈরি হয়নি।",
     "tooLargeToSend": "এই বার্তা পাঠানোর জন্য খুব বড়",
-    "exitWithoutSaving": "আপনি কি নিশ্চিত যে আপনি সংরক্ষণ না করে ছেড়ে যেতে চান?",
     "enableAutocorrectPopupTitle": "আপনার লক্ষ্য ভাষার কীবোর্ড যোগ করুন: সেটিংসে যান",
     "enableAutocorrectPopupSteps": "  • সেটিংস\n  • সাধারণ\n  • কীবোর্ড\n  • কীবোর্ডসমূহ\n  • নতুন কীবোর্ড যোগ করুন",
     "enableAutocorrectPopupDescription": "একবার ভাষা নির্বাচন করলে, আপনি আপনার কীবোর্ডের নিচে বাম পাশে ছোট গ্লোব আইকনে ক্লিক করে নতুন ইনস্টলকৃত কীবোর্ডটি সক্রিয় করতে পারেন।",
@@ -3156,11 +2913,8 @@
     "displayName": "প্রদর্শন নাম",
     "leaveRoomDescription": "আপনি এই চ্যাট থেকে ছেড়ে যাচ্ছেন। অন্যান্য ব্যবহারকারীরা দেখবে যে আপনি চ্যাট ছেড়ে গেছেন।",
     "confirmUserId": "আপনার পাঞ্জিয়া চ্যাটের ব্যবহারকার নাম নিশ্চিত করুন যাতে আপনি আপনার অ্যাকাউন্ট মুছে ফেলতে পারেন।",
-    "startingToday": "আজ থেকে শুরু",
-    "oneWeekFreeTrial": "এক সপ্তাহের ফ্রি ট্রায়াল",
     "paidSubscriptionStarts": "{startDate} থেকে শুরু",
     "cancelInSubscriptionSettings": " • সাবস্ক্রিপশন সেটিংসে যেকোনো সময় বাতিল করুন",
-    "cancelToAvoidCharges": " • চার্জ এড়াতে {trialEnds} এর আগে বাতিল করুন",
     "downloadGboard": "Gboard ডাউনলোড করুন",
     "autocorrectNotAvailable": "দুঃখিত, এই বৈশিষ্ট্যের জন্য আপনার প্ল্যাটফর্ম বর্তমানে সমর্থিত নয়। আরও উন্নতির জন্য অপেক্ষা করুন!",
     "pleaseUpdateApp": "অ্যাপটি আপডেট করুন চালিয়ে যেতে।",
@@ -3170,17 +2924,12 @@
     "knockSpaceSuccess": "আপনি এই কোর্সে যোগদানের জন্য অনুরোধ করেছেন! একজন অ্যাডমিন আপনার অনুরোধ পেলে উত্তর দেবেন 😄",
     "chooseWordAudioInstructionsBody": "সম্পূর্ণ বার্তাটি শুনুন। তারপর শব্দের সাথে অডিও মিলান করুন।",
     "chooseMorphsInstructionsBody": "ব্যাকরণ প্রশ্নের জন্য পাজল টুকরোগুলিতে ক্লিক করুন!",
-    "pleaseEnterInt": "একটি সংখ্যা লিখুন দয়া করে",
     "home": "হোম",
     "join": "যোগ দিন",
     "resetInstructionTooltipsTitle": "নির্দেশনা টিপস রিসেট করুন",
     "resetInstructionTooltipsDesc": "নতুন ব্যবহারকারীর জন্য নির্দেশনা টিপস দেখানোর জন্য ক্লিক করুন।",
-    "randomize": "র্যান্ডমাইজ করুন",
     "clear": "পরিষ্কার করুন",
-    "featuredActivities": "বিশেষ বৈশিষ্ট্যযুক্ত",
     "save": "সংরক্ষণ করুন",
-    "startChat": "চ্যাট শুরু করুন",
-    "translationProblem": "অনুবাদ সমস্যা",
     "askToJoin": "যোগ দেওয়ার জন্য জিজ্ঞাসা করুন",
     "emptyChatWarningTitle": "চ্যাট খালি",
     "emptyChatWarningDesc": "আপনি এখনও কারোকে আপনার চ্যাটে আমন্ত্রণ জানাননি। চ্যাট সেটিংসে গিয়ে আপনার যোগাযোগ বা বটকে আমন্ত্রণ জানান। আপনি পরে এটি করতে পারেন।",
@@ -3210,17 +2959,13 @@
     "timesUsedIndependently": "স্বতন্ত্রভাবে ব্যবহারের সময়",
     "timesUsedWithAssistance": "সহায়তার সাথে ব্যবহারের সময়",
     "shareInviteCode": "আমন্ত্রণ কোড শেয়ার করুন: {code}",
-    "leaderboard": "নেতৃস্থান তালিকা",
     "skipForNow": "এখন জন্য এড়িয়ে যান",
     "permissions": "অনুমতিসমূহ",
     "spaceChildPermission": "কোন ব্যক্তি এই কোর্সে নতুন চ্যাট যোগ করতে পারে",
-    "addEnvironmentOverride": "পরিবেশ অতিক্রম যোগ করুন",
     "defaultOption": "ডিফল্ট",
     "deleteChatDesc": "আপনি কি নিশ্চিত যে আপনি এই চ্যাটটি মুছে ফেলতে চান? এটি সকল অংশগ্রহণকারীর জন্য মুছে ফেলা হবে এবং চ্যাটের সমস্ত বার্তা আর অনুশীলন বা শেখার বিশ্লেষণের জন্য উপলব্ধ থাকবে না।",
     "deleteSpaceDesc": "কোর্স এবং যেকোনো নির্বাচিত চ্যাট সকল অংশগ্রহণকারীর জন্য মুছে ফেলা হবে এবং চ্যাটের সমস্ত বার্তা আর অনুশীলন বা শেখার বিশ্লেষণের জন্য উপলব্ধ থাকবে না। এই ক্রিয়া পূর্বাবস্থায় ফিরিয়ে আনা যাবে না।",
     "launch": "শুরু করুন",
-    "searchChats": "চ্যাট অনুসন্ধান করুন",
-    "maxFifty": "সর্বোচ্চ ৫০",
     "configureSpace": "কোর্স কনফিগার করুন",
     "pinMessages": "বার্তা পিন করুন",
     "setJoinRules": "যোগদানের নিয়ম সেট করুন",
@@ -3253,9 +2998,6 @@
     "failedToFetchTranscription": "ট্রান্সক্রিপশন আনতে ব্যর্থ হয়েছে",
     "deleteEmptySpaceDesc": "কোর্সটি সব অংশগ্রহণকারীর জন্য মুছে ফেলা হবে। এই কাজটি পূর্বাবস্থায় ফিরিয়ে আনা যাবে না।",
     "regenerate": "পুনরায় তৈরি করুন",
-    "mySavedActivities": "আমার সংরক্ষিত কার্যকলাপ",
-    "noSavedActivities": "কোন সংরক্ষিত কার্যকলাপ নেই",
-    "saveActivity": "এই কার্যকলাপ সংরক্ষণ করুন",
     "failedToPlayVideo": "ভিডিও প্লে করতে ব্যর্থ হয়েছে",
     "done": "সম্পন্ন",
     "inThisSpace": "এই কোর্সে",
@@ -3266,13 +3008,9 @@
     "numInvited": "{count} টা আমন্ত্রণ জানানো হয়েছে",
     "saved": "সংরক্ষিত",
     "reset": "রিসেট",
-    "errorFetchingActivitiesMessage": "অ্যাকটিভিটিগুলি আনতে ব্যর্থ হয়েছে",
     "errorFetchingDefinition": "সংজ্ঞা আনতে ব্যর্থ হয়েছে",
     "errorProcessAnalytics": "অ্যানালিটিক্স প্রক্রিয়া করতে ব্যর্থ হয়েছে",
     "errorDownloading": "ডাউনলোড ব্যর্থ হয়েছে",
-    "errorLoadingSpaceChildren": "এই কোর্সের চ্যাট লোড করতে ব্যর্থ হয়েছে",
-    "unexpectedError": "অপ্রত্যাশিত ত্রুটি।",
-    "pleaseReload": "অনুগ্রহ করে পুনরায় লোড করুন এবং আবার চেষ্টা করুন।",
     "translationError": "অনুবাদ ত্রুটি",
     "check": "পরীক্ষা করুন",
     "unableToFindRoom": "সেই কোডের সাথে কোনও চ্যাট বা কোর্স পাওয়া যায়নি। অনুগ্রহ করে আবার চেষ্টা করুন।",
@@ -3281,19 +3019,14 @@
     "request": "অনুরোধ",
     "requestAll": "সব অনুরোধ করুন",
     "confirmMessageUnpin": "আপনি কি নিশ্চিত যে আপনি এই বার্তা আনপিন করতে চান?",
-    "saveAndLaunch": "সংরক্ষণ করুন এবং চালু করুন",
-    "launchToSpace": "কোর্সে চালু করুন",
     "pending": "বিচারাধীন",
     "inactive": "অচল",
-    "confirmRole": "ভূমিকা নিশ্চিত করুন",
     "openRoleLabel": "খোলা",
     "finishedTheActivity": "🎯 {username} এই কার্যক্রম শেষ করেছেন",
     "activitySummaryError": "কার্যক্রমের সারাংশ উপলব্ধ নয়",
     "requestSummaries": "সারাংশের জন্য অনুরোধ করুন",
-    "generatingNewActivities": "আপনি এই ভাষা জোড়ার প্রথম ব্যবহারকারী! দয়া করে এক মিনিট দিন, আমরা আপনার জন্য কার্যক্রম প্রস্তুত করছি।",
     "requestAccessTitle": "বিশ্লেষণ অ্যাক্সেসের জন্য অনুরোধ করবেন?",
     "requestAccessDesc": "আপনি কি অংশগ্রহণকারীদের বিশ্লেষণ দেখার জন্য অ্যাক্সেসের জন্য অনুরোধ করতে চান?\n\nযদি অংশগ্রহণকারীরা সম্মত হন, এই কোর্সের অ্যাডমিনরা দেখতে পারবেন:\n    • মোট শব্দভাণ্ডার\n    • মোট ব্যাকরণ ধারণা\n    • সম্পন্ন কার্যক্রমের মোট সেশন\n    • ব্যবহৃত নির্দিষ্ট ব্যাকরণ ধারণাগুলি, সঠিক ও ভুল\n\nতারা দেখতে পারবেন না:\n    • কোর্সের বাইরে চ্যাটে বার্তা\n    • শব্দভাণ্ডার তালিকা",
-    "requestAccess": "অনুরোধ করুন ({count})",
     "analyticsInactiveTitle": "নিষ্ক্রিয় ব্যবহারকারীদের জন্য অনুরোধ পাঠানো যায়নি",
     "analyticsInactiveDesc": "নিষ্ক্রিয় ব্যবহারকারীরা যারা এই বৈশিষ্ট্য চালু হওয়ার পর থেকে লগইন করেননি, তারা আপনার অনুরোধ দেখবে না।\n\nতাদের ফিরে আসার পরে 'অনুরোধ' বোতাম দেখা যাবে। আপনি পরে তাদের নামের নিচে থাকা 'অনুরোধ' বোতামে ক্লিক করে আবার পাঠাতে পারেন।",
     "accessRequestedTitle": "বিশ্লেষণ অ্যাক্সেস অনুরোধ",
@@ -3316,8 +3049,6 @@
     "accessDesc": "আপনি আপনার কোর্সকে বিশ্বব্যাপী উন্মুক্ত করতে পারেন! অথবা, আপনার কোর্সকে ব্যক্তিগত এবং নিরাপদ করে তুলুন।",
     "createGroupChatDesc": "যেখানে কার্যকলাপ সেশন শুরু হয় এবং শেষ হয়, সেখানে গ্রুপ চ্যাটগুলি রুটিন যোগাযোগের জন্য খোলা থাকবে।",
     "deleteDesc": "শুধুমাত্র অ্যাডমিনরা কোর্স মুছে দিতে পারেন। এটি একটি ধ্বংসাত্মক ক্রিয়া যা সমস্ত ব্যবহারকারীকে সরিয়ে দেয় এবং কোর্সের মধ্যে নির্বাচিত সমস্ত চ্যাট মুছে দেয়। সাবধানতার সাথে এগিয়ে যান।",
-    "noCourseFound": "ওহ, এই কোর্সের জন্য একটি পরিকল্পনা দরকার!\n\nকোর্স পরিকল্পনা হলো বিষয়বস্তুর ক্রম এবং কথোপকথনের কার্যকলাপের একটি সিরিজ।",
-    "additionalParticipants": "+ {num} অন্যান্য",
     "whatNow": "এখন কি?",
     "chooseNextActivity": "আপনার পরবর্তী কার্যকলাপ নির্বাচন করুন!",
     "letsGo": "চলুন",
@@ -3330,13 +3061,11 @@
     "waitNotDone": "অপেক্ষা করুন, আমি শেষ করিনি!",
     "waitingForOthersToFinish": "অন্যদের শেষ করার জন্য অপেক্ষা করছি...",
     "generatingSummary": "চ্যাট বিশ্লেষণ এবং ফলাফল তৈরি করা হচ্ছে",
-    "findCourse": "একটি কোর্স খুঁজুন",
     "pingParticipantsNotification": "{user} ব্যবহারকারীদের খুঁজছেন যাতে {room} এ কার্যকলাপ সেশনে যোগ দিতে পারে",
     "course": "কোর্স",
     "courses": "কোর্সসমূহ",
     "goToCourse": "কোর্সে যান: {course}",
     "activityComplete": "এই কার্যকলাপটি সম্পন্ন হয়েছে। কার্যকলাপের সারাংশ নিচে পাওয়া যাবে।",
-    "startNewSession": "নতুন সেশন শুরু করুন",
     "joinOpenSession": "খোলা সেশনে যোগ দিন",
     "activityNotFound": "ক্রিয়াকলাপ পাওয়া যায়নি",
     "myActivities": "আমার কার্যক্রম",
@@ -3441,26 +3170,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -3537,14 +3246,6 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
@@ -3569,31 +3270,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3649,23 +3330,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3705,28 +3374,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -3744,14 +3391,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3944,22 +3583,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4015,10 +3638,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4028,10 +3647,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4107,27 +3722,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4445,10 +4044,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4458,10 +4053,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4549,14 +4140,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4573,10 +4156,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4589,15 +4168,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4749,14 +4320,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4770,14 +4333,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6000,10 +5555,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6044,10 +5595,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6120,10 +5667,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6393,47 +5936,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6453,19 +5956,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6529,10 +6020,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6573,14 +6060,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6592,14 +6071,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6637,10 +6108,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6657,27 +6124,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6801,10 +6252,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6814,10 +6261,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6834,14 +6277,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6981,18 +6416,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7041,10 +6464,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7054,18 +6473,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7108,23 +6515,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7148,10 +6543,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7159,14 +6550,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7271,18 +6654,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7335,10 +6706,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7365,10 +6732,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7549,7 +6912,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "কার্যকলাপের আপডেটের জন্য আগামীকাল আবার চেক করুন।",
-    "activityDropdownDesc": "আপনি যখন এই কার্যকলাপ শেষ করবেন, নিচের ক্লিক করুন",
     "languageMismatchTitle": "ভাষার মিল নেই",
     "languageMismatchDesc": "আপনার লক্ষ্য ভাষা এই কার্যকলাপের ভাষার সাথে মিলছে না। আপনার লক্ষ্য ভাষা আপডেট করবেন?",
     "reportWordIssueTooltip": "শব্দের তথ্য সমস্যা রিপোর্ট করুন",
@@ -7562,10 +6924,6 @@
     "selectAll": "সব নির্বাচন করুন",
     "deselectAll": "সব বাতিল করুন",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7614,17 +6972,11 @@
         "placeholders": {}
     },
     "startOwn": "নিজের শুরু করুন",
-    "joinCourseDesc": "প্রতিটি কোর্সে ৮-১০টি ক্রমবর্ধমান বিষয় রয়েছে যার সাথে বিভিন্ন কার্যক্রমভিত্তিক ভাষা শেখার কার্যক্রম রয়েছে।",
     "newMessageInPangeaChat": "💬 পেঙ্গিয়া চ্যাটে নতুন বার্তা",
     "shareCourse": "কোর্স শেয়ার করুন",
     "addCourse": "একটি কোর্স যোগ করুন",
-    "joinPublicCourse": "পাবলিক কোর্সে যোগ দিন",
     "vocabLevelsDesc": "এখানে আপনি শব্দের স্তর উন্নত করলে শব্দগুলি যাবে!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7637,10 +6989,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7659,7 +7007,6 @@
     "emojiView": "ইমোজি ভিউ",
     "feedbackDialogDesc": "আমি ও ভুল করি! আমাকে উন্নত করতে সাহায্য করার জন্য কিছু আছে?",
     "contactHasBeenInvitedToTheCourse": "যোগাযোগকে কোর্সে আমন্ত্রণ জানানো হয়েছে",
-    "activityStatsButtonTooltip": "কার্যকলাপের তথ্য",
     "allow": "অনুমতি দিন",
     "deny": "অস্বীকার করুন",
     "enabledRenewal": "সাবস্ক্রিপশন নবীকরণ সক্ষম করুন",
@@ -7927,10 +7274,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8986,16 +8329,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "পরবর্তী বিষয় উন্মুক্ত করার জন্য কার্যক্রম",
-    "activitiesToUnlockTopicDesc": "পরবর্তী কোর্স বিষয় উন্মুক্ত করার জন্য কার্যক্রমের সংখ্যা নির্ধারণ করুন",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "সঠিক শব্দভাণ্ডার সংজ্ঞা অনুশীলন",
     "constructUseIncLMDesc": "ভুল শব্দভাণ্ডার সংজ্ঞা অনুশীলন",
     "constructUseCorLADesc": "সঠিক শব্দভাণ্ডার অডিও অনুশীলন",
@@ -9003,7 +8336,6 @@
     "constructUseBonus": "শব্দভাণ্ডার অনুশীলনের সময় বোনাস",
     "practiceVocab": "শব্দভাণ্ডার অনুশীলন",
     "selectMeaning": "অর্থ নির্বাচন করুন",
-    "selectAudio": "মিলানো অডিও নির্বাচন করুন",
     "anotherRound": "আরেকটি রাউন্ড",
     "activitySettingsOverrideWarning": "কার্যকলাপ পরিকল্পনার দ্বারা নির্ধারিত ভাষা এবং ভাষার স্তর",
     "voice": "কণ্ঠ",
@@ -9035,10 +8367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9056,12 +8384,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "ডাউনলোড শুরু হয়েছে",
     "webDownloadPermissionMessage": "যদি আপনার ব্রাউজার ডাউনলোড ব্লক করে, অনুগ্রহ করে এই সাইটের জন্য ডাউনলোড সক্ষম করুন।",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9156,11 +8479,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "কিছু ভুল হয়েছে, এবং আমরা এটি ঠিক করতে কঠোর পরিশ্রম করছি। পরে আবার চেক করুন।",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "লেখার সহায়তা সক্রিয় করুন",
     "autoIGCToolDescription": "লক্ষ্য ভাষায় পাঠানো বার্তা সংশোধন করতে স্বয়ংক্রিয়ভাবে প্যাঙ্গিয়া চ্যাট টুলগুলি চালান।",
     "@autoIGCToolName": {
@@ -9216,24 +8534,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "ব্যাকরণ",
-    "spanTypeWordChoice": "শব্দ নির্বাচন",
     "spanTypeSpelling": "বানান",
     "spanTypePunctuation": "বিরাম চিহ্ন",
     "spanTypeStyle": "শৈলী",
     "spanTypeFluency": "প্রবাহ",
     "spanTypeAccents": "উচ্চারণ",
     "spanTypeCapitalization": "বড় হাতের অক্ষর",
-    "spanTypeCorrection": "সংশোধন",
     "spanFeedbackTitle": "সংশোধন সমস্যা রিপোর্ট করুন",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9258,10 +8565,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9274,13 +8577,7 @@
     "longPressToRecordVoiceMessage": "ভয়েস মেসেজ রেকর্ড করতে দীর্ঘ প্রেস করুন।",
     "pause": "বিরতি",
     "resume": "পুনরায় শুরু করুন",
-    "newSubSpace": "নতুন সাব স্পেস",
-    "moveToDifferentSpace": "ভিন্ন স্পেসে সরান",
-    "removeFromSpaceDescription": "চ্যাটটি স্থান থেকে মুছে ফেলা হবে কিন্তু আপনার চ্যাট তালিকায় এখনও প্রদর্শিত হবে।",
     "countChats": "{chats} চ্যাট",
-    "spaceMemberOf": "{spaces} এর সদস্য",
-    "spaceMemberOfCanKnock": "{spaces} এর সদস্যরা নক করতে পারে",
-    "donate": "দান করুন",
     "startedAPoll": "{username} একটি ভোট শুরু করেছে।",
     "poll": "ভোট",
     "startPoll": "ভোট শুরু করুন",
@@ -9304,23 +8601,15 @@
     "newStickerPack": "নতুন স্টিকার প্যাক",
     "stickerPackName": "স্টিকার প্যাকের নাম",
     "attribution": "অ্যাট্রিবিউশন",
-    "skipChatBackup": "চ্যাট ব্যাকআপ বাদ দিন",
-    "skipChatBackupWarning": "আপনি কি নিশ্চিত? চ্যাট ব্যাকআপ সক্ষম না করলে আপনি আপনার বার্তাগুলিতে প্রবেশাধিকার হারাতে পারেন যদি আপনি আপনার ডিভাইস পরিবর্তন করেন।",
-    "loadingMessages": "বার্তা লোড হচ্ছে",
-    "setupChatBackup": "চ্যাট ব্যাকআপ সেট আপ করুন",
     "noMoreResultsFound": "আরও কোন ফলাফল পাওয়া যায়নি",
     "chatSearchedUntil": "চ্যাট অনুসন্ধান করা হয়েছে {time} পর্যন্ত",
     "federationBaseUrl": "ফেডারেশন বেস URL",
     "clientWellKnownInformation": "ক্লায়েন্ট-ওয়েল-নোwn তথ্য:",
     "baseUrl": "বেস URL",
     "identityServer": "আইডেন্টিটি সার্ভার:",
-    "versionWithNumber": "সংস্করণ: {version}",
     "logs": "লগস",
-    "advancedConfigs": "উন্নত কনফিগারেশন",
     "advancedConfigurations": "উন্নত কনফিগারেশনসমূহ",
-    "signInWithLabel": "সাইন ইন করুন:",
     "selectAllWords": "শ্রবণে শোনা সমস্ত শব্দ নির্বাচন করুন",
-    "joinCourseForActivities": "কার্যকলাপের জন্য একটি কোর্সে যোগ দিন।",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9357,18 +8646,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9376,26 +8653,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9501,22 +8758,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9545,19 +8786,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9565,15 +8794,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9774,11 +8995,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "একটি ক্লাসে? আপনার যোগদান কোড এখানে দিন।",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "অটো-হাইলাইট অডিও বার্তা",
     "selectAudioMessagesOnPlayDescription": "অডিও বার্তা বাজানোর সময় স্বয়ংক্রিয়ভাবে হাইলাইট করুন",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9822,18 +9038,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "এই কোর্সে এমন বিষয় রয়েছে যার মধ্যে {input} এর চেয়ে কম কার্যক্রম রয়েছে। দয়া করে এমন একটি সংখ্যা প্রবেশ করুন যা {minValue} এর সমান বা তার কম।",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "এখানে ক্লিক করুন পুনরায় সাইন ইন করতে।",
     "@clickToLogin": {
@@ -10250,17 +9454,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "একটি কার্টুনের মতো হলুদ ভালুক যার হাত উত্তেজনায় উঁচু করা হয়েছে।",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "শিখতে আরও জানার জন্য শব্দ নির্বাচন করুন",
     "requireAnalyticsAccessTitle": "যোগ দিতে বিশ্লেষণ অ্যাক্সেস প্রয়োজন",
     "requireAnalyticsAccessDesc": "অংশগ্রহণকারীদের এই কোর্সে যোগ দিতে তাদের শেখার বিশ্লেষণে অ্যাক্সেস দিতে হবে",
     "analyticsAccessNoticeTitle": "বিশ্লেষণ অ্যাক্সেস প্রয়োজন",
     "analyticsAccessNoticeDesc": "এই কোর্সে যোগ দিয়ে, আপনি প্রশাসকদের আপনার শেখার বিশ্লেষণে অ্যাক্সেস দিতে সম্মত হন।",
-    "skipOnboardingClassCodeDesc": "স্বতন্ত্রভাবে শিখছেন? চিন্তা করবেন না, আপনি:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10278,10 +9476,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10310,7 +9504,6 @@
     "pickCefrLevelTeacherStepTitle": "আপনি কোন স্তর শেখান?",
     "pickCefrLevelStudentStepTitle": "আপনি কোন স্তরে?",
     "customCourseStepTitle": "একটি কাস্টম কোর্স পেতে এই ফর্মটি পূরণ করুন",
-    "aboutYourClass": "আপনার ক্লাস সম্পর্কে",
     "courseCodeStepErrorMessage": "দয়া করে আপনার কোডটি পরীক্ষা করুন এবং আবার চেষ্টা করুন",
     "institution": "প্রতিষ্ঠান",
     "courseGoals": "কোর্সের লক্ষ্য",
@@ -10353,10 +9546,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10473,12 +9662,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "প্যাঙ্গিয়া চ্যাট লোগো",
     "introChatDetails": "হ্যালো বলুন! আপনার সহপাঠীদের সাথে পরিচয় করিয়ে দিন, বন্ধু খুঁজুন, এবং কার্যক্রমের বাইরে চ্যাট করুন।",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10522,11 +9706,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "কার্যকলাপের কার্যক্রম",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "উচ্চারণের সরঞ্জাম",
     "audioTranscription": "এআই অডিও ট্রান্সক্রিপশন",
     "visualLearnerSupport": "ভিজ্যুয়াল লার্নার সাপোর্ট",
@@ -10567,7 +9746,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "এই কার্যকলাপটি খেলতে একটি কোর্সে যোগ দিন।",
     "resizeCoursePanel": "কোর্স প্যানেল আকার পরিবর্তন করুন",
     "undo": "পুনরুদ্ধার করুন",
     "unlock": "মুক্ত করুন",
@@ -10581,7 +9759,6 @@
     "addCourseBrowsePublic": "সার্বজনীন কোর্স ব্রাউজ করুন",
     "browsePublicCourses": "সার্বজনীন কোর্স ব্রাউজ করুন",
     "editProfile": "প্রোফাইল সম্পাদনা করুন",
-    "numObjectives": "{count} লক্ষ্য",
     "mapSearchHint": "কার্যকলাপ অনুসন্ধান করুন",
     "mapSearchNoResults": "দৃশ্যে কোন মিল নেই",
     "mapFilterAllLanguages": "সমস্ত ভাষা",
@@ -10590,7 +9767,6 @@
     "mapFilterCompleted": "সম্পন্ন",
     "mapFilterReset": "রিসেট",
     "activityTypeConversation": "আলাপ",
-    "lockedMissionRequirement": "মিশন আনলক করতে পূর্ববর্তী মিশন সম্পন্ন করুন",
     "playAgain": "পুনরায় খেলুন",
     "reviewActivity": "পর্যালোচনা",
     "mapEmptyInView": "আপনার স্তর বা ভাষায় এখানে কিছুই নেই। আপনার ফিল্টারগুলি প্রসারিত করুন বা জুম আউট করুন।",
@@ -10605,14 +9781,9 @@
     "scrollToBottom": "নিচে স্ক্রোল করুন",
     "courseImage": "কোর্সের ছবি",
     "avatarPreview": "অ্যাভাটার প্রিভিউ",
-    "activityPhoto": "অ্যাক্টিভিটি ফটো",
     "emotePreview": "ইমোট প্রিভিউ: {name}",
     "activityLabel": "কার্যকলাপ: {title}",
     "resetMapView": "মানচিত্রের দৃশ্য পুনরায় সেট করুন",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10665,14 +9836,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10702,10 +9865,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10762,10 +9921,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_bo.arb
+++ b/lib/l10n/intl_bo.arb
@@ -51,10 +51,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@admin": {
         "type": "String",
         "placeholders": {}
@@ -64,19 +60,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
-    "@addAccount": {},
     "@close": {
         "type": "String",
         "placeholders": {}
@@ -228,10 +211,6 @@
             }
         }
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youAcceptedTheInvitation": {},
     "@banFromChat": {
         "type": "String",
@@ -341,10 +320,6 @@
         "placeholders": {}
     },
     "@tryAgain": {},
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blocked": {
         "type": "String",
         "placeholders": {}
@@ -355,10 +330,6 @@
                 "type": "String"
             }
         }
-    },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "@unbanUserDescription": {},
     "@userAndUserAreTyping": {
@@ -409,9 +380,6 @@
     },
     "@link": {},
     "@widgetUrlError": {},
-    "@emailOrUsername": {},
-    "@newSpaceDescription": {},
-    "@chatDescription": {},
     "@next": {
         "type": "String",
         "placeholders": {}
@@ -432,8 +400,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@enterSpace": {},
-    "@encryptThisChat": {},
     "@fileName": {
         "type": "String",
         "placeholders": {}
@@ -459,7 +425,6 @@
         "placeholders": {}
     },
     "@reopenChat": {},
-    "@pleaseEnterRecoveryKey": {},
     "@create": {
         "type": "String",
         "placeholders": {}
@@ -486,10 +451,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@addWidget": {},
     "@all": {
         "type": "String",
@@ -511,10 +472,6 @@
         }
     },
     "@noKeyForThisMessage": {},
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@inviteText": {
         "type": "String",
         "placeholders": {
@@ -544,11 +501,6 @@
         }
     },
     "@pushNotificationsNotAvailable": {},
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {},
     "@replaceRoomWithNewerVersion": {
         "type": "String",
         "placeholders": {}
@@ -571,10 +523,6 @@
             }
         }
     },
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@cantOpenUri": {
         "type": "String",
         "placeholders": {
@@ -584,7 +532,6 @@
         }
     },
     "@sender": {},
-    "@storeInAndroidKeystore": {},
     "@hideRedactedEvents": {
         "type": "String",
         "placeholders": {}
@@ -645,10 +592,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@passwordHasBeenChanged": {
         "type": "String",
         "placeholders": {}
@@ -669,7 +612,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveKeyManuallyDescription": {},
     "@none": {
         "type": "String",
         "placeholders": {}
@@ -680,14 +622,6 @@
         "placeholders": {}
     },
     "@whyIsThisMessageEncrypted": {},
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "@rejectedTheInvitation": {
         "type": "String",
         "placeholders": {
@@ -705,10 +639,6 @@
             }
         }
     },
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@importFromZipFile": {},
     "@or": {
         "type": "String",
@@ -716,16 +646,10 @@
     },
     "@dehydrateWarning": {},
     "@noOtherDevicesFound": {},
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@emptyChat": {
         "type": "String",
         "placeholders": {}
     },
-    "@storeSecurlyOnThisDevice": {},
-    "@yourChatBackupHasBeenSetUp": {},
     "@chatBackup": {
         "type": "String",
         "placeholders": {}
@@ -742,7 +666,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {},
     "@unmuteChat": {
         "type": "String",
         "placeholders": {}
@@ -774,14 +697,6 @@
     "@participant": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@yes": {
         "type": "String",
@@ -867,7 +782,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@unlockOldMessages": {},
     "@identity": {
         "type": "String",
         "placeholders": {}
@@ -1045,7 +959,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterRecoveryKeyDescription": {},
     "@guestsAreForbidden": {
         "type": "String",
         "placeholders": {}
@@ -1210,7 +1123,6 @@
         "description": "State that {command} is not a valid /command."
     },
     "@redactMessageDescription": {},
-    "@recoveryKey": {},
     "@redactMessage": {
         "type": "String",
         "placeholders": {}
@@ -1285,10 +1197,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@verifyStart": {
         "type": "String",
         "placeholders": {}
@@ -1307,7 +1215,6 @@
         "placeholders": {}
     },
     "@serverRequiresEmail": {},
-    "@screenSharingTitle": {},
     "@widgetCustom": {},
     "@sentCallInformations": {
         "type": "String",
@@ -1407,7 +1314,6 @@
         "placeholders": {}
     },
     "@messageInfo": {},
-    "@disableEncryptionWarning": {},
     "@directChat": {},
     "@encryptionNotEnabled": {
         "type": "String",
@@ -1431,21 +1337,15 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {},
     "@enterAnEmailAddress": {
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {},
     "@commandHint_kick": {
         "type": "String",
         "description": "Usage hint for the command /kick"
     },
     "@copiedToClipboard": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1492,10 +1392,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@confirmMatrixId": {},
     "@learnMore": {},
     "@iHaveClickedOnLink": {
@@ -1516,7 +1412,6 @@
     },
     "@newGroup": {},
     "@bundleName": {},
-    "@removeFromSpace": {},
     "@dateAndTimeOfDay": {
         "type": "String",
         "placeholders": {
@@ -1562,10 +1457,6 @@
         "placeholders": {}
     },
     "@pleaseEnterANumber": {},
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youKicked": {
         "placeholders": {
             "user": {
@@ -1612,22 +1503,12 @@
             }
         }
     },
-    "@sorryThatsNotPossible": {},
     "@oopsSomethingWentWrong": {
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@shareInviteLink": {},
     "@commandHint_markasdm": {},
-    "@recoveryKeyLost": {},
     "@cuddleContent": {
         "type": "String",
         "placeholders": {
@@ -1654,14 +1535,6 @@
     },
     "@deviceKeys": {},
     "@waitingPartnerNumbers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -1693,15 +1566,10 @@
         "type": "String",
         "placeholders": {}
     },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@settings": {
         "type": "String",
         "placeholders": {}
     },
-    "@setTheme": {},
     "@changeTheHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -1722,10 +1590,6 @@
                 "type": "String"
             }
         }
-    },
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
     },
     "@changeDeviceName": {
         "type": "String",
@@ -1878,7 +1742,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@storeInSecureStorageDescription": {},
     "@openChat": {},
     "@kickUserDescription": {},
     "@sendAMessage": {
@@ -1895,13 +1758,11 @@
         "placeholders": {}
     },
     "@pinMessage": {},
-    "@screenSharingDetail": {},
     "@muteChat": {
         "type": "String",
         "placeholders": {}
     },
     "@invite": {},
-    "@enableMultiAccounts": {},
     "@anyoneCanJoin": {
         "type": "String",
         "placeholders": {}
@@ -1984,9 +1845,7 @@
     "changeYourAvatar": "ཁྱེད་རང་གི་རྟེན་སྣོན་ལ་བསྐྱར་བཅོས་",
     "channelCorruptedDecryptError": "གསང་བརྗོད་བརྗེས་སྤྱོད་བྱེད་ཡོད་པ།",
     "chat": "ཆད་སྒྲིག",
-    "yourChatBackupHasBeenSetUp": "ཁྱེད་རང་གི་ཆད་སྒྲིག་བརྗེས་སྤྱོད་ཡོད།",
     "chatBackup": "ཆད་སྒྲིག་བརྗེས་",
-    "chatBackupDescription": "ཁྱེད་རང་གི་རྩོམ་ལས་ཆེན་པོ་ཡོད་པའི་ཚེས་ལོ་ལས་བརྗེས་སྤྱོད་བྱེད་ཡོད་པའི་སྤྱོད་ལས་ལོག་ལས་བརྗེས་སྤྱོད་ཡོད། ཁྱེད་རང་གི་ལས་སྒྲིག་ལས་བརྗེས་སྤྱོད་ལ་བརྗེས་སྤྱོད་བྱེད་ཡོད་པ་ལས་སྤྱོད་ལ་མེད་མི་འདུག",
     "chatDetails": "ཆད་སྒྲིག་བརྗེས་ལག",
     "chats": "ཆད་སྒྲིག་ཚོད",
     "chooseAStrongPassword": "ཁྱེད་རང་གི་སྤྱོད་ལས་སྤྱོད་ལ་ལོག་ལས་བཟོ་བཅོས་",
@@ -1999,7 +1858,6 @@
     "configureChat": "ཆ་ཚང་ལ་རང་བཞིན་སྒྲིག་སྟེང་།",
     "confirm": "རྟོགས་རྟགས།",
     "connect": "འབྲེལ་མཐུད།",
-    "contactHasBeenInvitedToTheGroup": "དབྱེན་ཁང་ལ་འདི་ལ་འདུག འདི་ལ་འདུག",
     "contentHasBeenReported": "དེབ་ཚུ་ལག་ཁྱེར་མིང་ལ་བཀོད་ཡོད།",
     "copiedToClipboard": "བརྗེད་སྟོན་ལ་འགྱོ་བའི་སྒོ་ལ་བསྐྱར་བརྗོད།",
     "copy": "བརྗེད་སྟོན།",
@@ -2007,11 +1865,9 @@
     "couldNotDecryptMessage": "ཚིག་རྟགས་ལྟར་མེད་པའི་ཚིག་རྟགས།: {error}",
     "checkList": "རྟེན་སྒྲིག་རྟེན་སྒྲིག།",
     "countParticipants": "{count} སྡེབ་ཚན།",
-    "countInvited": "{count} འབུལ་བའི་སྡེབ་ཚན།",
     "create": "འགྱུར་བཅོས།",
     "createdTheChat": "💬 {username} ཆ་ཚང་ལ་འགྱུར་བཅོས།",
     "createGroup": "དབྱེན་ཁང་འདུག",
-    "createNewSpace": "གསལ་བཀྲམ་གསར་པ།",
     "currentlyActive": "ད་ལྟ་ལ་ལས་ཀ་འབད་ཡོད།",
     "darkTheme": "ནག",
     "dateAndTimeOfDay": "{date}, {timeOfDay}",
@@ -2037,9 +1893,6 @@
     "emoteKeyboardNoRecents": "འདི་ལས་སྤྱོད་མི་ཚུལ་ལས་མེད་ལས་འབུལ་བའི་རོལ་བརྗེ་འདི་ལས་སྟོན།...",
     "emotePacks": "གདམ་ཁང་ལུས་སྤྱོད་ལས་བཟོ་བའི་རོལ་བརྗེ།",
     "emoteSettings": "གདམ་ཁང་ཚུལ་ཁེལ།",
-    "globalChatId": "འབྲེལ་མཐར་གྱི་གླེང་བརྗོད་རེད།",
-    "accessAndVisibility": "དཀའ་སྤྱོད་དང་ལྟར་སྟོན་བརྗོད།",
-    "accessAndVisibilityDescription": "གདམ་ཁང་ལ་སྤྱོད་འབད་ནི་གི་རེད། དེ་ལ་གདམ་ཁང་ལ་སྤྱོད་འབད་ནི་གི་རེད།",
     "calls": "འཚོལ་བ།",
     "customEmojisAndStickers": "རོལ་བརྗེ་དང་སྒྲིབ་ཚུལ་ལས་བཟོ།",
     "customEmojisAndStickersBody": "རོལ་བརྗེ་དང་སྒྲིབ་ཚུལ་ལས་བཟོ་བའི་རོལ་བརྗེ་དང་སྒྲིབ་ཚུལ་ལས་བཟོ་བའི་རོལ་བརྗེ་ལུས་སྤྱོད་ནི་གི་རེད།",
@@ -2047,7 +1900,6 @@
     "emptyChat": "ལུས་སྤྱོད་མེད།",
     "enableEmotesGlobally": "རོལ་བརྗེ་ལས་བཟོ་བའི་རོལ་བརྗེ་ལས་བཟོ།",
     "enableEncryption": "རིམ་སྣོན་ལས་བཟོ།",
-    "enableEncryptionWarning": "ཁྱེད་ཀྱིས་རིམ་སྣོན་ལས་བཟོ་ནས་སྤྱོད་མི་ཚུལ་ལས་མེད་བརྗེ་བ་མིན་ནུག། ཁྱེད་ཀྱི་དགོས་མཁྱེན་གྱི་རེད།",
     "encrypted": "རིམ་སྣོན་བཟོ།",
     "encryption": "ཁྱད་རིམ",
     "encryptionNotEnabled": "ཁྱད་རིམ་མི་སྤྱོད་པའི་ཡོད།",
@@ -2055,7 +1907,6 @@
     "enterAnEmailAddress": "གྲངས་རིམ་གསལ་བཤད་འབད་ནི།",
     "homeserver": "ཁང་སེར་ཧོམ།",
     "errorObtainingLocation": "ལོ་གསལ་འདི་བསྐྱར་བཏོན་ནས་འགྱོ་བའི་ཤེས་རེའི་ཤེས་རེ།: {error}",
-    "everythingReady": "ཟེར་བཏོན་ཡོད།",
     "extremeOffensive": "མཐར་མཐར་སྤྱོད་མི་ཚུལ་མེད་པ།",
     "fileName": "ཡིག་སྣོད་མིང་",
     "fluffychat": "ཕླུབ་ཕླུབ་ཆེན་",
@@ -2064,9 +1915,7 @@
     "fromJoining": "ལུས་སྤྱོད་ནས།",
     "fromTheInvitation": "འདི་ནས་འབྲེལ་བ་བྱེད་པ།",
     "group": "དབྱེན་ཁང་",
-    "chatDescription": "ཚེས་རིམ་བཀོད་ཡོད།",
     "chatDescriptionHasBeenChanged": "ཚེས་རིམ་བཀོད་ཡོད།",
-    "groupIsPublic": "དབྱེན་ཁང་ནང་མི་ཁུངས་ཡོད།",
     "groups": "དགོངས་པའི་ཚོགས་",
     "groupWith": "{displayname} ལ་འབྲེལ་བ་བྱེད་",
     "guestsAreForbidden": "གནས་ཁང་འབྲེལ་བ་མི་རུང་",
@@ -2088,7 +1937,6 @@
     "incorrectPassphraseOrKey": "མི་བསྟན་པའི་སྐད་ཆ་ཐོག་མེད་པའི་སྐད་ཆ་ལ་འགྱོ་བ",
     "inoffensive": "མི་སྤྱོད་པ",
     "inviteContact": "དབང་འདེམས་འབད།",
-    "inviteContactToGroup": "དབང་འདེམས་འབད་ལུས་ {groupName}",
     "noChatDescriptionYet": "ཚིག་རྟགས་མེད་པའི་ལག་ཁྱེར་མེད་པ།",
     "tryAgain": "ལོག་ལོག་འགྱོ།",
     "invalidServerName": "མིན་ལེན་མེད་པའི་སརྣག་མཁན་མིང་",
@@ -2119,8 +1967,6 @@
     "no": "མི།",
     "noConnectionToTheServer": "ལག་ལེན་ལ་འབྲེལ་མེད།",
     "noEmotesFound": "རང་བཞིན་ལས་མེད། 😕",
-    "noEncryptionForPublicRooms": "ཁྱེད་རང་གིས་ལུས་སྤྱོད་ལ་ལོག་འདེབས་ལ་འགྱོ་མི་ཚུལ་ལས་སྤྱོད་འཐབ་དགོས།",
-    "noGoogleServicesWarning": "Firebase Cloud Messaging ཁྱེད་རང་ལ་འབྱོར་མི་ཚུལ་ལས་མེད། ལོག་འདེབས་ལ་བསྐུར་འབད་ནས་ཁྱེད་རང་གིས་ཚིག་རྒྱུན་ལ་ལོག་འདེབས་ལ་འགྱོ་མི་ཚུལ་ལས་སྤྱོད་འཐབ་དགོས། ntfy ལུས་སྤྱོད་འབད་ནས་ཁྱེད་རང་གིས་ཚིག་རྒྱུན་ལ་ལོག་འདེབས་ལ་འགྱོ་མི་ཚུལ་ལས་སྤྱོད་འཐབ་དགོས། ntfy དང་གཅིག་ལས་སྤྱོད་འཐབ་ནས་ཁྱེད་རང་གིས་ཚིག་རྒྱུན་ལ་ལོག་འདེབས་ལ་འགྱོ་མི་ཚུལ་ལས་སྤྱོད་འཐབ་དགོས།",
     "noMatrixServer": "{server1} ནང་མེད་པའི་མ་ལག་ལེན་ལས་འབྱོར་བ་ཡོད། {server2} ལ་བསྐུར་འབད་ན་ཡོད་པས།",
     "shareInviteLink": "འཕྲིན་ལམ་ཚིག་ལག་ལེན་འབད།",
     "scanQrCode": "QR ལམ་ལུས་སྤྱོད་འབད།",
@@ -2142,12 +1988,10 @@
     "openCamera": "ཁྱེར་སྒེར་ལྟ་བུ་སྟེང་བཀོད།",
     "openVideoCamera": "བརྙན་ལེན་ལྟ་བུ་སྟེང་བཀོད།",
     "oneClientLoggedOut": "ཁྱེར་ལས་གནང་བའི་ཁེངས་སྤྱོད་མི་གཙང་བརྗེ་བ་བྱེད་ཡོད།",
-    "addAccount": "ཁེངས་སྤྱོད་ལག་ལེན་སྐོར་ལོག་འབད།",
     "editBundlesForAccount": "ཁེངས་སྤྱོད་ལག་ལེན་ལས་བསྒྱུར་བྱེད།",
     "addToBundle": "ལག་ལེན་ལུ་སྤྱོད་ལེན་འབད།",
     "removeFromBundle": "དེའི་སྦེལ་ལོག",
     "bundleName": "སེར་མཚན",
-    "enableMultiAccounts": "(BETA) འདི་ལ་རང་སྤྱོད་གི་རང་སྤྱོད་ཁང་ཚོའི་ལས་ཀ་ལས་འབྱུང་བའི་ལས་སྤྱོད་ལས་འབྱུང་བ",
     "openInMaps": "ནང་ལས་སྒེར་ལོག",
     "link": "འབྲེལ་གཏོད",
     "serverRequiresEmail": "འདི་ལག་ལེན་སོར་བརྒྱབ་ནས་ཁྱེད་ཀྱི་རིགས་སྤྱོད་གི་གནད་སྡེབ་ལས་སྤྱོད་འབད་དགོས།",
@@ -2159,7 +2003,6 @@
     "passwordHasBeenChanged": "གསལ་བཀོད་རྟོགས་སོང་བཞག",
     "overview": "ལོག",
     "passwordRecoverySettings": "གསལ་བཀོད་སྤྱོད་ལས་འབད་བའི་ཁུངས་སྤྱོད",
-    "passwordRecovery": "གསལ་བཀོད་སྤྱོད་ལས",
     "people": "མི",
     "pickImage": "བརྗེད་སྒོར་གདམས་ནས་འདེགས",
     "pin": "Pin",
@@ -2168,7 +2011,6 @@
     "pleaseChooseAPasscode": "ကျေးဇူးပြု၍ စကားဝှက်ကိုရွေးချယ်ပါ",
     "pleaseClickOnLink": "အီးမေးလ်အတွင်းရှိလင့်ခ်ကိုနှိပ်ပြီးနောက်ဆက်လုပ်ပါ",
     "pleaseEnter4Digits": "ကျေးဇူးပြု၍ ၄ လုံးအထိနံပါတ်ထည့်ပါ သို့မဟုတ်အက်ပလီကေးရှင်းပိတ်ရန်အတွက်လက်လွတ်ထားပါ",
-    "pleaseEnterRecoveryKey": "ကျေးဇူးပြု၍ သင်၏ပြန်လည်ရယူသောသော့ကိုထည့်ပါ",
     "pleaseEnterYourPassword": "ကျေးဇူးပြု၍ သင်၏စကားဝှက်ကိုထည့်ပါ",
     "pleaseEnterYourPin": "ကျေးဇူးပြု၍ သင်၏ pin ကိုထည့်ပါ",
     "pleaseEnterYourUsername": "ကျေးဇူးပြု၍ သင်၏အသုံးပြုသူအမည်ကိုထည့်ပါ",
@@ -2188,7 +2030,6 @@
     "rejectedTheInvitation": "{username} འདི་ལ་འདེབས་བཏང་བཞག་ཡིན།",
     "removeAllOtherDevices": "གཞི་བཙུགས་ལས་གཞི་བཙུགས་ལ་བཏོན",
     "removedBy": "{username} འདི་ལ་བཏོན་ཡིན།",
-    "removeDevice": "གཞི་བཙུགས་ལ་བཏོན",
     "unbanFromChat": "ལག་ལེན་ལས་བཀལ་བ",
     "removeYourAvatar": "ཁྱེད་རང་གི་རོལ་བར་བཏོན",
     "replaceRoomWithNewerVersion": "གོང་ཁང་ལ་གསར་བར་བཟོ་བ",
@@ -2200,8 +2041,6 @@
     "saveFile": "ཡིག་སྲུང་བརྒྱབ",
     "search": "བཀོད་རོགས",
     "security": "གཙོ་ཁུངས",
-    "recoveryKey": "རང་བཙུགས་ཁྱབ་ལེན",
-    "recoveryKeyLost": "རང་དབང་ཁྱབ་ལེན་འདི་བཏོན་ནས་ཡོད་པས།",
     "send": "ཕྱེད་རོགས།",
     "sendAMessage": "ཚིག་གཅིག་ཕྱེད་རོགས།",
     "sendAsText": "ཚིག་ཡིག་ཚིག་གཅིག་ཕྱེད་རོགས།",
@@ -2220,7 +2059,6 @@
     "separateChatTypes": "གསལ་བཤད་ཚོད་ལེན་དང་དགོངས་སྒྲིག་ཚོད་ལེན་ལྟར་སྣོན།",
     "setAsCanonicalAlias": "དེའི་ལག་ཁྱེར་ལས་སྤྱོད་འབད།",
     "setChatDescription": "ཚོད་ཚན་བརྡ་སྦྱོར་ལག་ཁྱེར་འབད།",
-    "setPermissionsLevel": "དབྱེད་སྤྱོད་ཚད་ལག་ཁྱེར།",
     "setStatus": "རང་བཞིན་སྟོང་པོ་ལག་ཁྱེར།",
     "settings": "ཚད་ལྟར་ཚུལ།",
     "share": "ཚར་བ།",
@@ -2230,8 +2068,6 @@
     "presencesToggle": "ཕྱི་ལུས་ལས་སྤྱོད་མཁན་ཚོར་སྟོང་པོ་སྟེང་ལེན།",
     "skip": "རྒྱབ།",
     "sourceCode": "མིང་ཚིག་སྒྲིག་ཚིག",
-    "spaceIsPublic": "གནས་སྟངས་མིང་ཚིག་ཡོད།",
-    "spaceName": "གནས་སྟངས་མིང་།",
     "startedACall": "{senderName} ལས་སྐད་སྐུར་འབད།",
     "status": "རང་བཞིན་སྟེང་",
     "statusExampleMessage": "ཁྱེད་རང་དེ་སྐད་ཆ་གི་ཡོད་པས།",
@@ -2243,7 +2079,6 @@
     "theyMatch": "ཁོང་ཚོ་རེད།",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "ཁོངས་སྤྱོད་འདི་ལས་སྤྱོད་མི་ཚུལ་ལས་འགྱོ་བ་འདུག། ལོག་འགྱོ་ལོག་འགྱོ་གི་དུས་སྐབས་ལ་ལོག་འགྱོ་གི་འགྱོ་བ་འདུག།",
-    "transferFromAnotherDevice": "གཞི་རྟེན་གྱི་གོ་བརྗོད་ནས་འགྱོ་བ",
     "tryToSendAgain": "ལོག་འགྱོ་ལོག་འགྱོ་ལོག་འགྱོ་གི་དུས་སྐབས་ལ་ལོག་འགྱོ་གི་དུས་སྐབས་ལ་ལོག་འགྱོ་གི་འགྱོ་བ",
     "unavailable": "མེད་པ",
     "unbannedUser": "{username} མི་ལས་བཀལ་བཏོན་ནས {targetName} ལ་བཀལ་བཏོན།",
@@ -2253,7 +2088,6 @@
     "unknownEvent": "མིན་འདུག འདི་གི་སྒོར་བརྗེ '{type}'",
     "unmuteChat": "ཆ་ཚང་ལ་མི་འདུག་བསྐྱར་བཀོད",
     "unpin": "མི་སྤྱོད་བཀོད",
-    "unreadChats": "{unreadCount, plural, =1{1 མི་ལས་ཆ་ཚང་} other{{unreadCount} མི་ལས་ཆ་ཚང་}}",
     "userAndOthersAreTyping": "{username} དང་ {count} གཅིག་གི་མི་སྣང་བརྗེ་བྱེད་ནས་བརྗེ་བརྗེ་བྱེད་ནས་བརྗེ་བརྗེ་བྱེད་ནས་བརྗེ་བརྗེ་བྱེད་ནས།",
     "userAndUserAreTyping": "{username} དང་ {username2} གཅིག་གི་མི་སྣང་བརྗེ་བྱེད་ནས།",
     "userIsTyping": "{username} མི་སྣང་བརྗེ་བྱེད་ནས།",
@@ -2266,8 +2100,6 @@
     "verifyStart": "བཟོ་བཅོས་ལ་སྦྱོར་བཅོས་",
     "verifySuccess": "ཁྱེད་རང་གིས་བཟོ་བཅོས་བྱེད་མཁན་ཡིན།",
     "verifyTitle": "གཞི་བཙུགས་གནང་བའི་གནང་བ།",
-    "videoCall": "བརྙན་འདེབས་འཚོལ།",
-    "visibilityOfTheChatHistory": "ཆ་ཚང་ལོ་རྟགས་སྟོན་པའི་སྟེང་།",
     "visibleForAllParticipants": "ཚོགས་མང་པོ་ལ་སྟོན་པ།",
     "visibleForEveryone": "ཚོགས་མང་པོ་ལ་སྟོན་པ།",
     "voiceMessage": "སྐད་སྒྱུར་གྱི་ཚིག",
@@ -2277,10 +2109,7 @@
     "wallpaper": "རྟེན་འབྲེལ།",
     "warning": "འགྲོ་བརྗེ!",
     "weSentYouAnEmail": "ངེད་ཚོས་ཁྱེད་ལ་གློག་འཕྲིན་གཏང་ཡོད།",
-    "whoCanPerformWhichAction": "གལ་ཏེ་སྤྱོད་ལེན་གོ་བརྗོད་འབད་རུང་།",
-    "whoIsAllowedToJoinThisGroup": "གདན་ཚོགས་ལ་སྤྱོད་ལེན་འབད་ནི་ག་རེ་ཡོད།",
     "whyDoYouWantToReportThis": "ཁྱེད་རང་ག་རེ་སྤྱོད་འཚོལ་འདི་ལ་འདེམས་གནང་གི་ཡོད།",
-    "wipeChatBackup": "ཁྱེད་ཀྱི་ཚེས་རིམ་སྤྱོད་འཚོལ་ལས་བརྒྱབ་ནས་གསར་བརྗོད་བྱེད་དགོས་ཀྱི་སྤྱོད་ལེན་འབད་ནི་འདི་ལ་གནང་བ་ཡོད་པས།",
     "withTheseAddressesRecoveryDescription": "དེ་ལས་ཁྱེད་ཀྱི་ནང་ལས་སྤྱོད་འཚོལ་ལས་སྤྱོད་ལེན་གྱི་ལས་སྤྱོད་ལེན་འབད་ནི་འདི་ལ་གནང་བ་ཡོད།",
     "writeAMessage": "ཚིག་གཅིག་ཟེར་ནས་གསར་ཚིག་ཟེར།",
     "yes": "ཨིན།",
@@ -2293,9 +2122,7 @@
     "messageType": "پیغام قسم",
     "sender": "بەشەری",
     "openGallery": "کەتیبخانە بکەوە",
-    "removeFromSpace": "لە فضاەکە هەڵوەشێنە",
     "start": "دەستپێکردن",
-    "pleaseEnterRecoveryKeyDescription": "بۆ کردنەوەی پەیامەکانی کۆن، تکایە کلیلەکەی گەڕاندنەوەی خۆت داخڵ بکە کە لە کەسایەتی پێشووتر دروست کراوە. کلیلەکەی گەڕاندنەوەی خۆت پاسووردت نیە.",
     "publish": "بڵاو کردنەوە",
     "openChat": "کەتیب بکەوە",
     "markAsRead": "نیشان بدە وەک خوێندراو",
@@ -2306,12 +2133,9 @@
     "confirmEventUnpin": "ئایا دڵنیایە لە ئەوەی بەردەوام بە نیشانە نەکردنی ڕووداوەکە؟",
     "emojis": "ئیمۆجیز",
     "placeCall": "بەردەوام بە پەیوەندی کردن",
-    "voiceCall": "پەیوەندی دەنگی",
     "unsupportedAndroidVersion": "وەشانەکەی ئەندڕۆید پشتیوانی نەکراوە",
     "unsupportedAndroidVersionLong": "འདི་ལ་ལས་ཀ་འདི་གི་ལས་ཀ་འབྱུང་བ་ལ་ལོ་གསར་བར་ལོག་འདུག བརྟེན་འབད་གནང་བ་ལས་སྤྱོད་འབད་དགོས། ཁྱེད་ཀྱིས་རིམ་ལས་ལོག་འབད་དགོས་ཅིང་ལོག་འདུག ཡང་ན་ Lineage OS གི་གནད་སྡེབ་ལ་བསྐུར་བཏབ་གནང་བ་འདི་ལས་མེད།",
-    "videoCallsBetaWarning": "འདི་ལ་བརྟེན་འབད་གནང་བ་ལས་སྤྱོད་འབད་དགོས། ཁྱེད་ཀྱིས་འདི་ལ་ལས་འགྱོ་བ་མེད་ལས་འགྱོ་མི་ཚུལ་ལ་ལོག་འདུག དེ་ལས་འགྱོ་མི་ཚུལ་ལ་ལོག་འདུག",
     "experimentalVideoCalls": "ལས་འགྱོ་བའི་བརྟེན་འབད་ལས་འགྱོ་བ",
-    "emailOrUsername": "གྲངས་རིམ་གྱི་རེད་ན་མིང་གི་རེད",
     "addWidget": "Widget ལ་སྤྱོད་འབད།",
     "widgetVideo": "བརྙན་རིམ",
     "widgetEtherpad": "ཚིག་རྟགས་རྩོམ་ལེན",
@@ -2333,35 +2157,19 @@
     "youKickedAndBanned": "🙅 ཁྱེད་རང་གིས {user} ལ་འགན་ཁང་བསྐྱར་བཏང་དང་འགན་ཁང་བསྐྱར་བཏང་བྱུང་།",
     "youUnbannedUser": "ཁྱེད་རང་གིས {user} ལ་འགན་ཁང་བསྐྱར་བཏང་བྱུང་།",
     "hasKnocked": "🚪 {user} ནང་བརྗེ་བྱེད་ཡོད།",
-    "usersMustKnock": "བཀོད་སྤྱོད་མི་ཚོས་བརྗེ་བྱེད་བྱེད་མི་ཚོས།",
-    "noOneCanJoin": "མི་གཅིག་ལ་འབྲེལ་མཐུད་འབད་མི་ཚོས།",
     "knock": "བརྗེ་བྱེད།",
     "users": "བཀོད་སྤྱོད་པོ།",
-    "unlockOldMessages": "རྩོམ་ལས་བསྐྱར་སྤྱོད་བྱེད།",
-    "storeInSecureStorageDescription": "འདི་ལུ་བསྐྱར་བརྗེ་བྱེད་ཚུལ་ལས་སྤྱོད་བྱེད་ལག་ལེན་ལས་འགྱོ་བའི་སྤྱིར་ལས་འདི་ལས་སྤྱོད་བྱེད།",
-    "saveKeyManuallyDescription": "འདི་ལུ་ཁྱེད་རང་གིས་སྤྱོད་ཚུལ་ལས་སྤྱོད་བྱེད་ལག་ལེན་ལས་འགྱོ་བའི་སྤྱིར་ལས་འདི་ལས་སྤྱོད་བྱེད།",
-    "storeInAndroidKeystore": "ནང་བསྲེགས་ནི་ནང་བསྲེགས་ལག་ཁྱེར་སྟེང་",
-    "storeInAppleKeyChain": "ནང་བསྲེགས་ནི་ནང་བསྲེགས་ལག་ཁྱེར་སྟེང་",
-    "storeSecurlyOnThisDevice": "འདི་ལ་སྲུང་བར་བསྲེགས་ནས་བརྗེས་སྟེང་",
     "countFiles": "{count} ཡིག་ཚིག་",
     "user": "བཀྲམས་པོ་",
     "custom": "བདེན་སྤྱོད་",
-    "foregroundServiceRunning": "འདི་ལ་སྤྱོད་ལམ་སྟེང་པའི་སྒོ་སྤྱོད་འདི་སྟེང་",
-    "screenSharingTitle": "རྟེན་སྒོ་བརྗོད་",
-    "screenSharingDetail": "ཁྱེད་ཀྱིས་ཁྱེར་སྒོ་ནང་བརྗོད་འབད་ཡོད་པ་ནི་ནང་བསྲེགས་ལག་ཁྱེར་སྟེང་",
     "whyIsThisMessageEncrypted": "འདི་ལ་དེབ་འབྱོར་མི་འདུག་? ",
     "noKeyForThisMessage": "འདི་ལ་དེབ་འབྱོར་མི་འདུག་ སྟེང་ལ་ཁྱེད་ཀྱིས་འདི་ལ་ཁྱེར་སྒོ་ནང་བརྗོད་འབད་ཡོད་པ་ལས་འདི་ལ་བརྗོད་འབད་མི་ཚུལ་ ཁྱེད་ཀྱིས་འདི་ལ་ཁྱེར་སྒོ་ནང་བརྗོད་འབད་ཡོད་པ་ལས་འདི་ལ་བརྗོད་འབད་མི་ཚུལ་! ",
     "newGroup": "གཞི་རྟེན་གཞི་རྟེན་",
     "newSpace": "གཞི་རྟེན་ས་ཁང་",
-    "enterSpace": "གཞི་རྟེན་ས་ཁང་",
     "allSpaces": "ཆ་ཚང་གི་ས་ཁུལ།",
     "hidePresences": "རང་བཞིན་སྟེང་ལས་རོགས་སྤོས་བཏང་གི་རེད་?",
     "doNotShowAgain": "ལོག་འབུལ་མི་ལེན་",
     "wasDirectChatDisplayName": "ལོག་འབུལ་མེད་ (ལོག་འབུལ་མི་ལེན་ {oldDisplayName})",
-    "newSpaceDescription": "སེར་ཁུལ་ཚུ་ཁྱེད་ཀྱི་བརྗོད་ཚིགས་ལ་བརྒྱབ་པ་དང་ཁང་དུ་གནས་སྟངས་དང་མིང་ཚིག་སྤྱོད་ལེན་པ་ཡོད།",
-    "encryptThisChat": "འདི་ལ་བརྗོད་ཚིགས་ལྟར་བརྒྱབ་",
-    "disableEncryptionWarning": "ལས་སྤྱོད་ལས་སྤྱོད་འབད་མི་ཚུལ་ལས་སྤྱོད་ལས་བརྒྱབ་མི་ཚུལ་ལས་བརྒྱབ་པ་ལས་སྤྱོད་མི་ཚུལ་ལས་བརྒྱབ་",
-    "sorryThatsNotPossible": "དགོངས་པ...འདི་མི་ཚུལ་ཡོད་པ་མེད་",
     "deviceKeys": "རང་བཞིན་ཁུལ་ལས་སྤྱོད་ལེན་:",
     "reopenChat": "བརྗོད་ཚིགས་ལ་ལོག་འབུལ་",
     "noBackupWarning": "འདི་ལ་བརྗོད་ཚིགས་ལ་བརྒྱབ་མི་ཚུལ་ལས་སྤྱོད་མི་ཚུལ་ལས་བརྒྱབ་! ཁྱེད་ཀྱིས་བརྗོད་ཚིགས་ལ་བརྒྱབ་མི་ཚུལ་ལས་སྤྱོད་མི་ཚུལ་ལས་བརྒྱབ་པ་སྟེང་སྤྱོད་ལེན་པ་སྟེང་སྤྱོད་ལེན་",
@@ -2378,12 +2186,8 @@
     "yourGlobalUserIdIs": "ཁྱེད་ཀྱི་གླེང་བརྗོད་ཁུངས་གྱི་རྒྱལ་ཁབ་ཁུངས་ནང་ཡོད།: ",
     "noUsersFoundWithQuery": "གཙོ་བོ་ལ་བརྗོད་བྱེད་ \"{query}\" ལ་ལེགས་སྤྱོད་མི་ཚེས་ཁང་ལ་ལོག་འགྱོ་བ་མེད། ཁྱེད་ཀྱིས་བརྗོད་བྱེད་པའི་སྐབས་ལ་བརྗོད་བྱེད་མི་ཚེས་ཁང་ལ་ལོག་འགྱོ་བ་ཡིན་ནམ།",
     "knocking": "བཀོད་ཡོད་པ།",
-    "chatCanBeDiscoveredViaSearchOnServer": "ཚོད་ལམ་ལས་བརྗོད་བྱེད་ {server} ལ་ལེགས་སྤྱོད་མི་ཚེས་ཁང་ལ་ལོག་འགྱོ་བ་ཡིན།",
-    "searchChatsRooms": "#ཚོད་ལམ།, @བརྗོད་ཚེས།...",
     "nothingFound": "མི་ཚེས་ལ་ལེགས་སྤྱོད་མི་ཚེས་ཁང་ལ་ལོག་འགྱོ་བ་མེད།",
     "groupName": "དབྱེན་ཁང་",
-    "createGroupAndInviteUsers": "དབྱེན་ཁང་འདི་ལ་བཟོ་བཅོས་ནས་བརྗོད་ཚེས་ལ་བརྗོད་བྱེད།",
-    "groupCanBeFoundViaSearch": "དབྱེན་ཁང་ལ་ལེགས་སྤྱོད་མི་ཚེས་ཁང་ལ་ལོག་འགྱོ་བ་ཡིན།",
     "wrongRecoveryKey": "དགོས་མི་ཡིན... འདི་ནི་བརྗོད་བྱེད་པའི་བསྐུར་བརྗོད་ཁུངས་མི་འདི་འདི་ལས་མི་འདུག།",
     "startConversation": "ཆོས་ཚོད་ལ་ལོག་འགྱོ།",
     "commandHint_sendraw": "json ལོག་འགྱོ་བརྗོད་བྱེད།",
@@ -2397,11 +2201,8 @@
     "pleaseChooseAStrongPassword": "བརྟེན་འབྱུང་མེད་པའི་ནང་བསྐྱར་བཀོད་གཟིགས།",
     "passwordsDoNotMatch": "ནང་བསྐྱར་བཀོད་ཚུ་མཐུན་མེད།",
     "passwordIsWrong": "ཁྱེད་ཀྱི་ནང་བསྐྱར་བཀོད་འབད་ཡོད་པའི་ནང་བསྐྱར་བཀོད་འབད་མི་འདུག",
-    "publicChatAddresses": "མིང་ཚིག་མཁན་ལས་འབྲེལ་བ",
-    "createNewAddress": "གསར་བའི་ཁུལ་ལས་འབྲེལ་བ",
     "joinSpace": "ཁུལ་ལ་འབྲེལ་བ",
     "publicSpaces": "མིང་ཚིག་མཁན་ལས་འབྲེལ་བ",
-    "addChatOrSubSpace": "ཆབ་དང་སེལ་ལོག་ལ་འབྲེལ་བ",
     "subspace": "སྱོན་སྤྱོད་ས་ཁུལ",
     "decline": "འགྱོ་བ",
     "thisDevice": "འདི་ལག་ལེན་སྤྱོད་འབད་ཡོད་པ།",
@@ -2410,15 +2211,11 @@
     "searchMore": "འཚོལ་འབད་ཡོད་པ་འདི་ལ།",
     "gallery": "རིམ་སྒྲིག",
     "files": "ཡིག་སྣོད",
-    "sessionLostBody": "ཁྱེད་ཀྱི་སྒྲིག་ཚེས་བཏོན་ཡོད། འདི་ལུས་བརྗེ་བའི་ཤེས་རབ་ལ {url} ལ་འགྱོ་བཅོས་གནང་བ། འབྲེལ་བའི་ཚིགས་ནི་ {error}",
-    "restoreSessionBody": "རང་བཞིན་གྱི་སྒྲིག་ཚེས་ལ་སྤྱིར་བཏོན་བྱེད་ནས་སྤྱོད་ལམ་ལེན་འབད་ཡོད། འདི་ལུས་བརྗེ་བའི་ཤེས་རབ་ལ {url} ལ་འགྱོ་བཅོས་གནང་བ། འབྲེལ་བའི་ཚིགས་ནི་ {error}",
     "sendReadReceipts": "རྒྱབ་སྤྱོད་བརྗོད་བྱེད་རོགས",
     "sendTypingNotificationsDescription": "གླེང་སྒྲིག་ལ་སྤྱོད་མཁན་ཚོ་གིས་ཁྱེད་ཀྱང་ག་རེ་སྣང་བ་ལག་ལེན་འབད་ཡོད་རེད།",
     "sendReadReceiptsDescription": "གླེང་སྒྲིག་ལ་སྤྱོད་མཁན་ཚོ་གིས་ཁྱེད་ཀྱང་ག་རེ་སྣང་བ་ལག་ལེན་འབད་ཡོད་རེད།",
     "formattedMessages": "རིམ་སྒྲིག་བྱེད་ཡོད་པའི་ཚིགས",
     "formattedMessagesDescription": "མཁན་ཚོ་གིས་སྤྱོད་ཡོད་པའི་ཚིགས་ལ་བརྗེ་བར་བཟོ་བའི་རིམ་སྒྲིག་ཚིགས་ལུས་སྤྱོད་བྱེད་ནི་ markdown ལུས་བཟོ་བའི་རིམ་སྒྲིག་ཚིགས།",
-    "verifyOtherUser": "🔐 གྲུབ་ཚིག་གི་གཅིག་གིས་བཟོ་བའི་རིམ་སྒྲིག",
-    "verifyOtherUserDescription": "ཁྱེད་ཀྱང་གཅིག་གིས་གྲུབ་ཚིག་ལ་བཟོ་བའི་རིམ་སྒྲིག་བྱེད་ནས་ཁྱེད་ཀྱང་གང་རེ་སྣང་བ་ལག་ལེན་འབད་ཡོད། 💪\n\nཁྱེད་ཀྱང་གཅིག་གིས་བཟོ་བའི་རིམ་ལ་སྤྱོད་ནས་ཁྱེད་ཀྱང་གི་སྤྱི་ཚོགས་ལ་སྤྱོད་ནས་སྤྱི་ཚོགས་ལ་སྤྱོད་ནས་སྤྱོད་ལམ་ལེན་འབད་ནི་ཡོད། འདི་ལུས་བརྗེ་བའི་ཤེས་རབ་ལ {url} ལ་འགྱོ་བཅོས་གནང་བ།",
     "verifyOtherDevice": "🔐 གྲུབ་ཚིག་གཅིག་གིས་བཟོ་བའི་རིམ་སྒྲིག",
     "verifyOtherDeviceDescription": "ཁྱེད་ཀྱང་གཅིག་གིས་གྲུབ་ཚིག་ལ་བཟོ་བའི་རིམ་སྒྲིག་བྱེད་ནས་ཁྱེད་ཀྱང་གི་ལས་སྤྱོད་ལ་སྤྱོད་ནས་སྤྱོད་ལམ་ལེན་འབད་ནི་ཡོད། 💪 ཁྱེད་ཀྱང་གཅིག་གིས་བཟོ་བའི་རིམ་ལ་སྤྱོད་ནས་ཁྱེད་ཀྱང་གི་ལས་སྤྱོད་ལ་སྤྱོད་ནས་སྤྱོད་ལམ་ལེན་འབད་ནི་ཡོད། འདི་ལུས་བརྗེ་བའི་ཤེས་རབ་ལ {url} ལ་འགྱོ་བཅོས་གནང་བ།",
     "acceptedKeyVerification": "{sender} ལ་སྤྱོད་ནས་ཁྱེད་ཀྱང་གི་ཁྱབ་ལམ་ལེན་འབད་བའི་རིམ་སྒྲིག",
@@ -2434,10 +2231,6 @@
     "updateInstalled": "🎉 {version} ལུས་སྟོན་བསྟན་!",
     "changelog": "བསྒྲགས་ཚིག",
     "sendCanceled": "བརྗེ་བརྗོད་བསྟན་ནི་ལུས་སྟོན་བསྟན་",
-    "loginWithMatrixId": "Matrix-ID ལུས་སྟོན་བསྟན་",
-    "discoverHomeservers": "ཁྱེད་རང་གི་ཁོངས་སྐད་ལུས་སྟོན་བསྟན་",
-    "whatIsAHomeserver": "ཁོངས་སྐད་ལུས་སྟོན་ག་རེད་?",
-    "homeserverDescription": "ཁྱེད་རང་གི་དོན་ལས་བརྗེ་སྤྱོད་ལུས་སྟོན་བསྟན་, ལྟར་འབྲེལ་བ་ལས་སྤྱི་ཚོགས་ལུས་སྟོན་བསྟན་ ལུས་སྟོན་བསྟན་, ཁྱེད་རང་གི་ཁོངས་སྐད་ལུས་སྟོན་བསྟན་, ལུས་སྟོན་བསྟན་ https://matrix.org ལ་ལེན་པ་ཡོད་པ་ལས་སྤྱི་ཚོགས་ལུས་སྟོན་བསྟན་",
     "doesNotSeemToBeAValidHomeserver": "ཁོངས་སྐད་ལུས་སྟོན་ལ་འབྲེལ་བ་མེད་པའི་རེད། ཁོངས་སྐད་ལུས་སྟོན་ལ་སྤྱི་ཚོགས་མེད་པ་རེད?",
     "calculatingFileSize": "ཡིག་སྣོན་ལུས་སྟོན་བསྟན་...",
     "prepareSendingAttachment": "རྩོལ་བའི་རྟགས་སྤྱོད་ལུས་སྟོན་བསྟན་...",
@@ -2449,11 +2242,9 @@
     "oneOfYourDevicesIsNotVerified": "ཁྱེད་རང་གི་གཞུང་ལས་ཁག་གི་རང་བཞིན་མི་བརྟེན་པ།",
     "noticeChatBackupDeviceVerification": "གཙོ་བོ།: ཁྱེད་རང་གི་གཞུང་ལས་ཁག་ཚོད་ལས་སྤྱོད་འབད་ནས་སྤྱོད་ལམ་ལ་བརྟེན་པ་ཡོད།",
     "continueText": "རྒྱབ་",
-    "welcomeText": "བཀྲ་ཤིས་བདེ་ལེགས 👋 འདི་ནི་ཕལུཕི་ཆེད་ཡིག་གི་མིང་། ཁྱེད་རང་གི་གནས་ཚུལ་ལ་འབྲེལ་བ་ཡོད་པའི་སེར་ཧེལ་ལས་སྤྱོད་འབད་ནས་འབྲེལ་བ་འབད་ནི་ཡོད། དེ་ནས་སྐད་རག་ལ་འབྲེལ་བ་འབད། འདི་ནི་རང་བཞིན་གྱི་མངའ་རོལ་འབྲེལ་མཐར་འཁོད་མི་འདུག!",
     "blur": "བརྒྱབ་:",
     "opacity": "མེད་སྟོང་:",
     "setWallpaper": "གདུང་སྒོར་ཁེབས་སྟེང་",
-    "manageAccount": "ཁེབས་སྟེང་ལས་འཛིན་",
     "noContactInformationProvided": "འབྲེལ་མཐུད་འབད་མི་ཚུལ་ལས་ཁག་གི་གནས་སྟངས་མེད་པ།",
     "contactServerAdmin": "འབྲེལ་བ་ལས་འཛིན་མཁན་ལ་འབོད་",
     "contactServerSecurity": "འབྲེལ་བ་ལས་འཛིན་ལས་སྤྱོད་ལ་འབོད་",
@@ -2472,11 +2263,8 @@
     "unableToJoinChat": "གནད་སྡེབ་ལ་འཇུག་འབད་མི་ཚུལ། དེ་ལས་གནད་སྡེབ་གཅིག་ལས་ཁོང་ཚོ་འདི་ལས་འགྱོ་མི་ཚུལ།",
     "previous": "རྒྱབ་ལོག",
     "otherPartyNotLoggedIn": "གནད་སྡེབ་གཅིག་ལས་མི་ལོག་པ་ཡོད་མི་རེད། དེ་ལས་ཁོང་ཚོ་གནད་སྡེབ་འདི་ལས་འགྱོ་མི་ཚུལ།",
-    "appWantsToUseForLogin": "'{server}' ལ་གནང་བའི་སྤྱོད་ལམ་གཏོད།",
-    "appWantsToUseForLoginDescription": "ཁྱེད་རང་གི་རང་བཞིན་གྱི་ཚོད་ལས་འབྲེལ་གཏང་དང་དེ་ལས་འབྲེལ་གཏང་སྤྱོད་ལམ་ལས་ཁོངས་སྤྱོད་འབད་དགོས།",
     "open": "གནང་",
     "waitingForServer": "ལས་འགན་འདི་ལུ་དུས་འདི་འགྱོ་བའི་དུས།",
-    "appIntroduction": "FluffyChat ཁྱེད་རང་གི་གྲོགས་འབྲེལ་ལས་འབྲེལ་བརྒྱབ་དེ་ལས་འབྲེལ་ལམ་ལས་ཁོངས་སྤྱོད་འབད་དགོས། ཁོང་ཚོ་ལ་བསྟན་པའི་ལེགས་སྤྱོད་ལས་ཁོངས་སྤྱོད་འབད་དགོས། https://matrix.org ལ་འཚོལ་བ་གཅིག་ལས་སྤྱོད་འབད་ན་བཟོ་བཅོས་འདི་ལས་ཁོངས་སྤྱོད་འབད་དགོས།",
     "newChatRequest": "📩 གནད་སྡེབ་གསར་པ།",
     "contentNotificationSettings": "རང་སྤྱོད་འདི་ལས་ཁོངས་སྤྱོད་འབད་དགོས།",
     "generalNotificationSettings": "ལུས་སྤྱོད་འདི་ལས་ཁོངས་སྤྱོད་འབད་དགོས།",
@@ -2533,11 +2321,9 @@
     "taTooltip": "L2 ལུས་སྤྱོད་ནས་སྒྲོམ་བཅོས་རྟགས་སྤྱོད",
     "interactiveTranslatorSliderHeader": "རང་སྤྱོད་སྒྲོམ་བཅོས་",
     "interactiveGrammarSliderHeader": "རང་སྤྱོད་སྒྲོམ་བཅོས་བརྗེ་སྤྱོད",
-    "interactiveTranslatorRequired": "དགོས་པའི་",
     "waTooltip": "L2 ལུས་སྤྱོད་མི་སྤྱོད་སྤྱོད",
     "interactiveTranslator": "རང་སྤྱོད་སྒྲོམ་བཅོས་",
     "noIdenticalLanguages": "བརྗེད་ཡོད་པའི་སྐད་ཡིག་དང་སྤྱོད་ལུགས་ལ་འབྱོར་བ་མི་འདུག",
-    "searchBy": "རྒྱལ་ཁབ་དང་སྐད་ཡིག་ལྟར་བཤད་ནས་བཤད་འདེད།",
     "joinWithClassCode": "ཚོང་ཚད་ལ་སྡེབ་སྤྱོད་ན།",
     "languageLevelPreA1": "Novice Low (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -2558,19 +2344,14 @@
     "saveChanges": "བརྗེ་བཅོས་ལོག་འབད།",
     "publicProfileTitle": "ངའི་ཕོརམ་ལུས་ལ་བཟོ་བཅོས་བྱེད་ནས་བརྟེན་པ།",
     "publicProfileDesc": "འདི་ལས་སྤྱོད་ནས་ཁྱེད་ཀྱི་ཕོརམ་ལུས་ལ་བཟོ་བཅོས་བྱེད་ནས་གླེང་བ་འདེམས་ནས་སྤྱོད་ཚུལ་ལས་འགོད་ནས་འགྱོ་བའི་སྤྱོད་ལས་འདི་ལས་སྤྱོད་ནས་ཁྱེད་ཀྱི་ཕོརམ་ལུས་ལ་བཟོ་བཅོས་བྱེད་ནས་གནང་བ།",
-    "errorDisableIT": "ཁྱེད་ཀྱི་སྐད་ཚིག་རྒྱུན་ལས་འབད་མེད།",
-    "errorDisableIGC": "རྒྱུན་ལས་འབད་མེད།",
     "errorDisableITUserDesc": "འདི་ལས་སྤྱོད་ནས་སྐད་ཚིག་རྒྱུན་ལས་འབད་ནི་ལ་བརྟེན་པ།",
     "errorDisableIGCUserDesc": "འདི་ལས་སྤྱོད་ནས་རྒྱུན་ལས་འབད་ནི་ལ་བརྟེན་པ།",
     "errorDisableITClassDesc": "འདི་ལས་སྤྱོད་ནས་འདི་ལུས་ལ་བཟོ་བཅོས་ལས་འབད་མེད།",
     "errorDisableIGCClassDesc": "འདི་ལས་སྤྱོད་ནས་རྒྱུན་ལས་འབད་མེད།",
-    "error405Title": "སྱོན་ཚན་མེད།",
     "error405Desc": "Խնդրում ենք սահմանել ձեր լեզուները Մենյու գլխավոր > Ուսուցման կարգավորումներ բաժնում։",
     "termsAndConditions": "Պայմաններն ու դրույթները",
     "andCertifyIAmAtLeast13YearsOfAge": "և վկայում եմ, որ ինձ առնվազն 16 տարեկան եմ։",
-    "error502504Title": "Վայ, շատ ուսանողներ են առցանց!",
     "error502504Desc": "Թարգմանության և գրականության գործիքները կարող են դանդաղել կամ անհասանելի լինել, մինչ Պանգեա բոտերը լրացնում են տվյալները։",
-    "error404Title": "Թարգմանության սխալ!",
     "error404Desc": "Պանգեա Բոտը չգիտի, թե ինչպես թարգմանել դա...",
     "errorPleaseRefresh": "Մենք աշխատում ենք դրա վրա։ Խնդրում ենք թարմացնել և փորձել նորից։",
     "connectedToStaging": "Միացված է ստաժինգին",
@@ -2602,8 +2383,6 @@
     "igcToggleDescription": "འདི་ལུས་སྤྱོད་ལམ་ལ་སྤྱོད་ལོག་བརྗེ་བ་ཡོད། འདི་ནི་སྤྱོད་ལམ་ལ་སྤྱོད་ལོག་བརྗེ་བ་ལས་སྤྱོད་ལོག་བརྗེ་བ་ལས་སྤྱོད་ལོག་བརྗེ་བ་ཡོད།",
     "originalMessage": "མིང་འབྲེལ་བའི་ཚིག་གཅིག",
     "oneWeekTrial": "གཅིག་ཕྱིར་སྤྱིར་བཏང་ཚོད་གཅིག",
-    "downloadXLSXFile": "Excel ཡིག་སྐོར་རྐྱབས",
-    "unkDisplayName": "མི་དགོས་པ།",
     "wwCountryDisplayName": "འཛམ་གླིང་ཆེན་པོ།",
     "afCountryDisplayName": "ཨཕ་གན་སི་ཐཱན།",
     "axCountryDisplayName": "ཨ་ལན་མཚོ་མཚོ།",
@@ -2884,7 +2663,6 @@
     "deleteSubscriptionWarningTitle": "ཁྱེད་ཀྱི་དུས་ཚོད་འགྱོ་བའི་དོན་ལས་འགྱོ་མི་ཚུལ།",
     "deleteSubscriptionWarningBody": "ཁྱེད་ཀྱི་ཁུལ་ལས་བཏང་ནས་ཁྱེད་ཀྱི་དུས་ཚོད་འགྱོ་བ་འབད་མི་ཚུལ།",
     "manageSubscription": "དུས་ཚོད་ལུས་སྤྱོད་ལམ་བསྐྱར་བཟོ།",
-    "error520Title": "རྒྱབ་སྐད་འགྱོ་མི་ཚུལ།",
     "error520Desc": "དགོས་མཁོ་གནང་བ་མེད་པ, ངེས་བཀལ་མི་ཚུལ།...",
     "wordsUsed": "ཚིགས་ལུས་སྤྱོད།",
     "level": "ལོངས།",
@@ -2902,7 +2680,6 @@
     "other": "གཞིའི་ཚིག",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "ལག་ལེན་མེད",
-    "downloadGroupText": "དབྱེད་ཁང་གི་ཚིག་རྟགས་རོལ་འདེགས།",
     "notificationsOn": "ཚེད་རིམ་སྒྲིག་བཀལ།",
     "notificationsOff": "ཚེད་རིམ་མེད།",
     "joinWithCode": "རོལ་འདེགས་ལ་ལོག་འབད།",
@@ -2966,25 +2743,12 @@
     "whatIsTheMorphTag": "‘{wordForm}’གི {morphologicalFeature}་ག་རེ་ཡོད།",
     "dataAvailable": "དོན་ཚན་ལས་བརྗེ་འབད་ཡོད།",
     "available": "ཡོད།",
-    "pangeaBotIsFallible": "Pangea Bot རང་སྤྱོད་འགྱོ་བ་ཡོད།",
-    "whatIsMeaning": "‘{lemma}’གི་ནང་གསལ་ག་རེ་ཡོད།",
     "chooseLemmaMeaningInstructionsBody": "གསལ་བཀྱོད་ཚུ་ལག་ཁྱེར་གྱིས་ཚིག་ཚིག་ལ་རོལ་བ་བྱེད།",
-    "doubleClickToEdit": "ཉེར་ཉེར་གཉིས་མཁོ་ལ་ལོག་གཏོད་ནས་ཁྱེད་རང་གིས་ཁ་སྐད་བསྒྱུར།",
-    "topicLabel": "ལག་ལེན།",
-    "topicPlaceholder": "ལག་ལེན་གཟིགས་ནས་ལེགས་སོ།...",
-    "modePlaceholder": "ལས་ཀ་གཅིག་གི་གནང་བ...",
-    "learningObjectiveLabel": "སློངས་སྦྱོང་གནང་བའི་སྒོ་སྐབས",
-    "learningObjectivePlaceholder": "སློངས་སྦྱོང་གནང་བའི་སྒོ་སྐབས་གཅིག་གི་གནང་བ...",
-    "targetLanguageLabel": "ལུས་སྐད",
     "cefrLevelLabel": "CEFR ལོག་ཚད",
     "image": "རང་བཞིན",
     "video": "བརྙན་རིམ",
     "nan": "མི་འདུག",
-    "addVocabulary": "སློངས་སྦྱོང་བཅོས",
     "instructions": "གནང་བ",
-    "numberOfLearners": "སློངས་སྦྱོང་བའི་རྟགས",
-    "mustBeInteger": "ལག་ལེན་གཅིག་གི་རྟགས་ལས་བྱུང་བ་ལ་ལོག་ཚད་གཅིག་གི་བརྗེ་བ",
-    "exitWithoutSaving": "ཁྱེད་ཀྱང་མེད་རེད་པས་བསྐྱར་བརྗེ་མི་འབྱུང་།",
     "enableAutocorrectPopupTitle": "ཁྱེད་ཀྱང་སྒྲོམ་བཅོས་བཀོད་ལག་ཁྱེར་བཀོད་པའི་སྒྲོམ་བཅོས་སྤྱོད་ལམ་ལ་འགྱོ།",
     "enableAutocorrectPopupSteps": "  • དེའི་སྒྲོམ\n  • དེའི་རང་བཞིན\n  • ཁྱེད་རང་གི་ཁྱེར་སྒྲོམ\n  • ཁྱེད་རང་གི་ཁྱེར་སྒྲོམ་ཚུ\n  • གསར་བའི་ཁྱེར་སྒྲོམ་ལ་འབོད།",
     "enableAutocorrectPopupDescription": "ལུས་སྐད་གཏོད་ནས་སྒྲོམ་བཅོས་བཀོད་ལག་ཁྱེར་བཀོད་པའི་སྒྲོམ་བཅོས་སྤྱོད་ལམ་ལ་འགྱོ།",
@@ -2995,23 +2759,16 @@
     "displayName": "མིང་ཚིག",
     "leaveRoomDescription": "ཁྱེད་ཀྱང་འདི་ནས་ཁྱེད་རང་གི་ཆོས་ཚོད་ལ་འགྱོ། གཞན་ཚོ་ཁྱེད་ཀྱང་འདི་ལ་འགྱོ་བའི་སྟེང་ཁྱེད་རང་གི་འགྱོ་བ་ལ་ལེན་སྤྱོད་བྱེད་ཡོད།",
     "confirmUserId": "ཁྱེད་ཀྱང་ཁྱེར་བཀོད་ལག་ཁྱེར་བཀོད་ལག་ལ་འགྱོ་སྟེང་ཁྱེད་ཀྱང་ཁྱེར་བཀོད་ལག་ལ་འགྱོ་བའི་སྟེང་ཁྱེད་རང་གི་ཁྱེར་སྒྲོམ་ལ་འགྱོ།",
-    "startingToday": "དེ་ལས་འགྱོ།",
-    "oneWeekFreeTrial": "གཅིག་ཕྱིར་སྐབས་སྤྱོད་ལག་ལ་བརྗེ་བཅོས།",
     "paidSubscriptionStarts": "ལོ་འགྱོ {startDate}",
     "cancelInSubscriptionSettings": "• ལོ་འགྱོ་ལས་འགྱོ་སྟེང་ཁྱེད་ཀྱང་འགྱོ།",
-    "cancelToAvoidCharges": "• {trialEnds} སྟེང་འགྱོ་སྟེང་ཁྱེད་ཀྱང་འགྱོ།",
     "downloadGboard": "Gboard ལག་ཁྱེར་བཀོད།",
     "autocorrectNotAvailable": "གལ་ཏེ་ཁྱེད་ཀྱང་འདི་ལ་ལོག་ལས་བསྐྱར་བརྗེ་མི་འབྱུང་། ལོག་ལས་བསྐྱར་བརྗེ་ལ་ལོག་ལས་བསྐྱར་བརྗེ་ལ་འགྱོ།",
     "pleaseUpdateApp": "ཁྱེད་རང་ལ་ལོག་ལས་བསྐྱར་བརྗེ་ལ་འགྱོ།",
     "chooseEmojiInstructionsBody": "གྲུབ་ཚིག་ལ་གཅིག་ལ་བསྐྱར་བརྗེ་བྱེད་ནས་ཁྱེད་ཀྱང་གི་ཚིག་གི་སྤྱོད་ལམ་ལ་འགྱོ། བརྗེ་བཅོས་མེད་ནི་ལས་འགྱོ་མི་འདུག! མེད་ཚད་མེད་ལས་འགྱོ་མི་འདུག! 😅",
     "resetInstructionTooltipsTitle": "指示工具提示をリセット",
     "resetInstructionTooltipsDesc": "新しいユーザー向けの指示ツールチップを表示するにはクリックしてください。",
-    "randomize": "ランダム化",
     "clear": "クリア",
-    "featuredActivities": "注目の活動",
     "save": "保存",
-    "startChat": "チャットを開始",
-    "translationProblem": "翻訳の問題",
     "askToJoin": "འབྲེལ་བ་དགོས།",
     "emptyChatWarningTitle": "ཚོད་མེད་སྐད་ཆ།",
     "emptyChatWarningDesc": "ཁྱེད་ཀྱིས་ཁྱེད་རང་ལ་སྐད་ཆ་ལ་འདེགས་མི་འབྱུང་། ཁྱེད་ཀྱིས་ཚོད་ལས་ཁྱེད་རང་ལ་འབྲེལ་བ་འབད་དེ་ལས་སྤྱོད་འབད་ནི་འགྱོ་ཡོད།",
@@ -3041,17 +2798,13 @@
     "timesUsedIndependently": "རང་ཉེར་བརྗོད་ཡོད་པའི་རྩིས།",
     "timesUsedWithAssistance": "རང་ཉེར་བརྗོད་ཡོད་པའི་རྩིས།",
     "shareInviteCode": "རྩལ་བརྗོད་ལེན་འཁོར་ལོག {code} ལ་བརྗེད།",
-    "leaderboard": "རྒྱབ་སྤྱོད་ཁང་།",
     "skipForNow": "ད་ལྟ་ལས་འགྱོ་བའི་ལུང་།",
     "permissions": "གདམ་ཁག།",
     "spaceChildPermission": "གང་འདི་ལ་གསར་ཚེས་གཏོད་བཅོས་འབད་ནི་གཅིག་གི་རེད་པ།",
-    "addEnvironmentOverride": "ཁྱེད་རང་གི་ཁོངས་སྐབས་ལ་བརྡ་སྤྱོད་བཀོད་ནས།",
     "defaultOption": "གདམ་ཁག",
     "deleteChatDesc": "ཁྱེད་རང་གིས་འདི་ལ་གནང་བའི་ཆོག་ལས་བཏོན་ནི་སྤྱོད་འཇུག་ཡོད་མི་ཡིན་པས། འདི་ནི་ཚོད་ལས་སྤྱོད་མི་ཚོད་ལས་བཏོན་ན་འགྱོ་མི་ཚུལ་ལ་འགྱོ་མི་འདུག།",
     "deleteSpaceDesc": "ཁོངས་སྐབས་དང་གནང་བའི་ཆོག་ལས་ཚོད་ལས་བཏོན་ན་འདི་ནི་ཚོད་ལས་སྤྱོད་མི་ཚོད་ལས་བཏོན་ན་འགྱོ་མི་ཚུལ་ལ་འགྱོ་མི་འདུག། འདི་ལ་འགྱོ་མི་ཚུལ་ལ་འགྱོ་མི་འདུག།",
     "launch": "འགྱོ་རོགས།",
-    "searchChats": "ཆོག་ལས་བཟོ་བཅོས།",
-    "maxFifty": "མཐའ་མར 50",
     "configureSpace": "ཁོངས་སྐབས་ཚོད་ལས་བཟོ་བཅོས།",
     "pinMessages": "ཚིག་རྟགས་སྤྱོད་ལེན།",
     "setJoinRules": "ལག་ལེན་སྒོམ་སྐབས་ཚུལ་ཁྱད་རོགས།",
@@ -3085,9 +2838,6 @@
     "failedToFetchTranscription": "རང་སྣང་ཚིག་གི་སྐད་རེད་མེད།",
     "deleteEmptySpaceDesc": "འདི་ལས་སྤྱོད་ལས་སྤྱོད་མི་ཚུལ་ལས་སྤྱོད་གནང་བའི་སློབ་ཚན་ཚུ་གཏོད་ནས་སྤྱོད་མི་ཚུལ་ལས་སྤྱོད་གནང་བའི་ལས་རོལ།",
     "regenerate": "རིགས་སྤྱོད་ལ་ལོག་འཇུག།",
-    "mySavedActivities": "ངའི་དོན་ཚན་སྲུང་བའི་ལས་ཀ",
-    "noSavedActivities": "དོན་ཚན་སྲུང་བའི་ལས་ཀ་མེད",
-    "saveActivity": "འདི་ལས་ཀ་སྲུང་བའི་རེད",
     "failedToPlayVideo": "བརྙན་རིམ་ལུས་འགྱོ་མི་བྱེད",
     "done": "མཉམ་པའི",
     "inThisSpace": "འདིའི་སློབ་ཚན",
@@ -3098,13 +2848,9 @@
     "numInvited": "{count} རྟགས་སྤོངས",
     "saved": "སྲུང་བ",
     "reset": "ལེན་སྤྱོད",
-    "errorFetchingActivitiesMessage": "ལས་ཀ་ཕེབས་འབོར་མི་བྱེད",
     "errorFetchingDefinition": "བརྗེད་སྟོན་མི་བྱེད",
     "errorProcessAnalytics": "ལས་ཀ་ལས་སྒྲིག་བཅོས་མི་བྱེད",
     "errorDownloading": "རེད་སྐབས་འགྱོ་མི་བྱེད།",
-    "errorLoadingSpaceChildren": "འདི་ལུས་སྤྱིར་ལོག་འབད་མི་བྱེད།",
-    "unexpectedError": "མི་འབྲེལ་བར་སྐབས།",
-    "pleaseReload": "ཁྱེད་རང་ལ་ལོག་འཇུག་གི་འདི་ལ་ལོག་འཇུག་འབད་དེ་ལས་འགྱོ་གི་ཡོད།",
     "translationError": "ཁྱད་ཆོས་སྐད་ཅིག་འབད་མི་བྱེད།",
     "check": "བརྟེན་འབད།",
     "unableToFindRoom": "དེ་ལ་ལོག་འཇུག་གི་ཁོངས་སུ་མེད། ཁྱེད་རང་ལ་ལོག་འཇུག་འབད་དེ་ལས་འགྱོ་གི་ཡོད།",
@@ -3113,19 +2859,14 @@
     "request": "རྒྱུན་རིམ།",
     "requestAll": "ཚོད་རྒྱུན་རིམ།",
     "confirmMessageUnpin": "ཁྱེད་རང་ཚེས་བརྗེ་བརྗོད་འབད་དེ་ལ་མི་འདུག་གི་ཡོད་པས།",
-    "saveAndLaunch": "ཁྱེད་རང་ལ་སྲུང་བརྗེ་བཅོས་དང་ལོག་འཇུག།",
-    "launchToSpace": "ལས་ཀ་ལ་ལོག་འཇུག།",
     "pending": "དབྱར་བ",
     "inactive": "མིན་ལུས་",
-    "confirmRole": "ལས་ཀ་རྟག་པ་འབད།",
     "openRoleLabel": "གཙོ་བོ",
     "finishedTheActivity": "🎯 {username} འདི་ལ་སྤྱོད་འདུག",
     "activitySummaryError": "ལས་ཀ་རྒྱབ་སྤྱོད་འབད་མི་ཚུལ།",
     "requestSummaries": "ལོག་ལ་དབྱར་བ་འདི་ལ་བཀོད་རོགས།",
-    "generatingNewActivities": "ཁྱེད་ཀྱིས་འདི་ལ་སྤྱོད་ལམ་གཟིགས་སྤྱོད་འདུག! སྤྱོད་ལམ་གཟིགས་སྤྱོད་འདི་ལ་ཁྱེད་ཀྱིས་ལོག་འགྱོ་བར་བརྗེ་བ་ཡིན།",
     "requestAccessTitle": "Bisa minta akses analitik?",
     "requestAccessDesc": "ཁྱེད་ཀྱིས་སྤྱོད་ལམ་གཟིགས་སྤྱོད་འདུག་ལ་ལོག་འགྱོ་བའི་ལས་ཀ་ལ་བཀོད་རོགས་འདི་ལ་དབྱར་བ་འདི་ལ་བཀོད་རོགས།\n\nལོག་ལ་སྤྱོད་ལམ་གཟིགས་སྤྱོད་འདུག་ན་ལོག་འགྱོ་བར་བརྗེ་བ་ཡིན། ཁྱེད་ཀྱིས་ལོག་འགྱོ་བར་བརྗེ་བ་འབད་ན་ལོག་འགྱོ་བར་བརྗེ་བ་ལ་ལོག་འགྱོ།",
-    "requestAccess": "ལོག་འགྱོ་འདི་ལ ({count})",
     "analyticsInactiveTitle": "ལོག་འགྱོ་བའི་ལས་ཀ་མེད་པའི་ལོག་ལ་འབད་མི་ཚུལ།",
     "analyticsInactiveDesc": "ལོག་འགྱོ་བའི་ལས་ཀ་མེད་པའི་ལོག་ལ་ལོག་འགྱོ་བར་བརྗེ་བ་མེད་པས།\n\nལོག་འགྱོ་འབད་འདི་ལ་ལོག་འགྱོ་བར་བརྗེ་བ་ལ་ལོག་འགྱོ། ཁྱེད་ཀྱིས་ལོག་འགྱོ་བར་བརྗེ་བ་འབད་ན་ལོག་འགྱོ་བར་བརྗེ་བ་ལ་ལོག་འགྱོ།",
     "accessRequestedTitle": "ᠪᠠᠢᠯᠠᠭᠤᠯᠤ ᠪᠠᠢᠯᠠᠭᠤᠯᠤ ᠪᠠᠢᠯᠠᠭᠤᠯᠤ ᠪᠠᠢᠯᠠᠭᠤᠯᠤ",
@@ -3148,8 +2889,6 @@
     "accessDesc": "ཁྱེད་རང་གི་སློབ་ཚན་ལ་འགྱོ་བ་ལུས་པ་ལས་འབད་ནས་འབད་རོགས། ຫོད་ན་ཁྱེད་རང་གི་སློབ་ཚན་གང་འདི་ལས་འགན་ལས་འབད་ན་གནང་བ།",
     "createGroupChatDesc": "འདི་ནས་ལས་འགན་སྐར་མ་ལོག་བརྗེ་བ་ལས་འགན་ལས་འབད་ནས་ལོག་བརྗེ་བ་ལས་འགན་ལས་འབད།",
     "deleteDesc": "གནད་སྡེ་ལས་འགན་ལས་འབད་ན་དགོས། འདི་ནས་ལས་འགན་ལས་འབད་ན་སྤྱོད་ལེན་འབད་མི་ཚོའི་ལས་འགན་ལས་འབད་ན་ལས་འགན་ལས་འབད།",
-    "noCourseFound": "ཨེ, འདི་ནས་སློབ་ཚན་ལ་ལོག་བརྗེ་བ་ལེགས་སོ།\n\nསློབ་ཚན་ལས་ལོག་བརྗེ་བ་ནི་སློབ་ཚན་ལས་སྤྱོད་ལེན་འབད་ནས་སྐབས་སྟོན་ལས་སྤྱོད་ལེན་འབད།",
-    "additionalParticipants": "+ {num} ཚོད་ལོག་པ།",
     "whatNow": "ད་ལྟ་ག་རེ་ཡོད།",
     "chooseNextActivity": "ཁྱེད་རང་གི་ཤེས་ཡོད་ལུས་པ་ཚུ་གནང་བ།",
     "letsGo": "ངེད་ཚོ་ངེད་ལ་འགྱོ།",
@@ -3162,13 +2901,11 @@
     "waitNotDone": "Aguarda, não terminei!",
     "waitingForOthersToFinish": "མི་ཚེས་བརྒྱབ་ནས་ལོག་བྱེད་འདུག...",
     "generatingSummary": "ཚོད་ལམ་གྱིས་གནད་སྣང་བྱེད་ནས་ལོག་བྱེད།",
-    "findCourse": "ཚོང་ཁང་བཟོ་བཅོས།",
     "pingParticipantsNotification": "{user} ཚོང་ཁང་ལ་ལོག་བྱེད་ལས་སྤྱོད་ལེན་ལ་འདུག",
     "course": "ཚོང་ཁང།",
     "courses": "ཚོང་ཁང་ཚོད།",
     "goToCourse": "ཚོང་ཁང་ལ་འགྱོ: {course}",
     "activityComplete": "འདི་ལས་བཟོ་བཅོས་ཡོད། ལས་བཟོ་བཅོས་སྤྱོད་ལེན་འདི་ནང་ལ་འབད་ཡོད་མི་སྤྱོད་ལེན་འབད་ནས་འདི་ལས་སྤྱོད་འབད།",
-    "startNewSession": "གསར་འཛུལ་སྤྱོད་ལས་སྤྱོད་འགྱོ",
     "joinOpenSession": "གསར་འཛུལ་སྤྱོད་ལས་སྤྱོད་འགྱོ",
     "activityNotFound": "ལས་ཀ་མེད",
     "myActivities": "ངའི་ལས་ཀ",
@@ -3230,26 +2967,6 @@
         "placeholders": {}
     },
     "@checkList": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3329,14 +3046,6 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
@@ -3361,31 +3070,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3441,23 +3130,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3497,28 +3174,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -3538,16 +3193,6 @@
     "@formattedMessagesDescription": {
         "type": "String",
         "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
-        "type": "String",
-        "placeholders": {
-            "url": {}
-        }
     },
     "@verifyOtherDevice": {
         "type": "String",
@@ -3635,22 +3280,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -3706,10 +3335,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -3719,10 +3344,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -3798,27 +3419,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4056,10 +3661,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4069,10 +3670,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4156,14 +3753,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4180,10 +3769,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4196,15 +3781,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4329,14 +3906,6 @@
         "placeholders": {}
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5506,10 +5075,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error520Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error520Desc": {
         "type": "String",
         "placeholders": {}
@@ -5579,10 +5144,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5852,47 +5413,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5912,23 +5433,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@exitWithoutSaving": {
         "type": "String",
         "placeholders": {}
     },
@@ -5972,14 +5477,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -5991,14 +5488,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6024,27 +5513,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6168,10 +5641,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6181,10 +5650,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6201,14 +5666,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6348,18 +5805,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6408,10 +5853,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6421,18 +5862,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6475,23 +5904,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6515,10 +5932,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6526,14 +5939,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6638,18 +6043,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6702,10 +6095,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6729,10 +6118,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -6855,7 +6240,6 @@
     "leave": "འཁོར་བ",
     "leftTheChat": "ཚོད་ལོག",
     "lightTheme": "ཉིན་ལྡན",
-    "loadCountMoreParticipants": "{count} མཉམ་ཚོགས་མང་བའི་སྡེབ་ཚན་ལག་ལེན།",
     "dehydrate": "ཚེས་གཉིས་སྤྱོད་ལེན་དང་གནས་སྡེབ་བརྒྱབ་",
     "dehydrateWarning": "འདི་ལས་འགོག་མི་ཚུལ་མེད། སྤྱོད་ལེན་འབད་ནི་ལས་སྤྱོད་འགོག་བྱེད་མི་ཚུལ་ལས་སྤྱོད་འབད་བཏང་བ་བྱེད།",
     "hydrate": "Backup ཡིག་སྣོད་ནས་སྤྱོད་ལེན།",
@@ -6864,12 +6248,10 @@
     "locationDisabledNotice": "ཁྱེད་ཀྱི་སྤྱོད་ལེན་ལས་འགོག་མི་ཚུལ། ཁྱེད་ཀྱིས་ཁྱེད་རང་གི་སྡེབ་ཚན་ལ་ལེགས་སྤྱོད་འབད་ནས་སྤྱོད་ལེན་འབད་ནི་ལས་སྤྱོད་འབད་བར་འགྱོ་བ།",
     "locationPermissionDeniedNotice": "ཁྱེད་ཀྱིས་སྡེབ་ཚན་ལ་ལེགས་སྤྱོད་འབད་མི་ཚུལ། ཁྱེད་ཀྱིས་ཁྱེད་རང་གི་སྡེབ་ཚན་ལ་ལེགས་སྤྱོད་འབད་ནས་སྤྱོད་ལེན་འབད་ནི་ལས་སྤྱོད་འབད་བར་འགྱོ་བ།",
     "login": "ལོག་འཇོག",
-    "logInTo": "{homeserver} ལ་ལོག་འཇོག",
     "logout": "ཁྱེད་རང་ལོག",
     "openLinkInBrowser": "འདིར་འགྱོ་འཇུག་འབད་ནི་ལག་ལེན་འབད་ནི།",
     "reportErrorDescription": "😭 ཨོང་མེད། གནད་སྟོན་འདི་ལས་འགོད་བྱེད་མི་ཚུལ་ལས་འགོད་འབད་ནི།",
     "report": "རེད་འདོད།",
-    "setTheme": "དབྱེ་བའི་དབྱེ་བ།",
     "setColorTheme": "རིགས་ལུས་དབྱེ་བ།",
     "invite": "འདེམས་བཅུད།",
     "inviteGroupChat": "📨 ཚོགས་གནས་གཅིག་འདེམས་བཅུད།",
@@ -7240,7 +6622,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "གདམས་མཁན་ཚོ་ལ་ལོག་འགྱོ་རུང་གི་ཡོད་པས།",
     "areYouSure": "ཁྱེད་རང་དགོས་རེད་པས།",
     "areYouSureYouWantToLogout": "ཁྱེད་རང་དགོས་རེད་པས། ཁྱེད་ཀྱིས་ཕྱིར་བཀོད་འགྱོ་དགོས་ཀྱི་ཡོད་པས།",
     "askSSSSSign": "ཕྱིར་བཀོད་འགྱོ་བའི་ལས་སྒྲིག་ལས་སྤྱོད་འབད་ནས། ཁྱེད་ཀྱི་གསར་བརྗེ་སྤྱོད་ལུས་གསལ་བརྗེ་འབད་དགོས།",
@@ -7285,8 +6666,6 @@
     "definitionsToolName": "ཡིག་ཚགས་བཟོ་བཅོས",
     "definitionsToolDescription": "འདི་ལས་འགོད་ནས་སྤྱི་ཚེས་སྟོན་པའི་སྒྲོམ་སྒྲིག་ལུས་སྟེང་ལ་ལོག་འབད་ནི་ཡིན། ཚེས་གྲངས་ལ་ལོག་འབད་ནས་སྒྲོམ་སྒྲིག་ལ་འགྱོ་ནི་ཡིན།",
     "welcomeBack": "བཀྲ་ཤིས་བཀྲ་ཤིས། ཁྱེད་ཀྱིས 2023-2024 ལོའི སྤོབས་ལམ་ལས་སྤྱོད་བྱེད་ཡོད་མི་རེད་པའི་སྤྱི་ཚེས་ལས་འབྲེལ་བ་བྱེད་རོགས་གནང་གི་ཡོད་མི་སྤྱི་ཚེས་ལ་འབྲེལ་བ་བྱེད་རོགས་གནང་གི་ཡོད། ཁྱེད་ཀྱིས་རྒྱལ་ཁབ་སློབ་ཚོགས་ལ་ལོག་འབད་ཡོད་པའི་སྤྱི་ཚེས་ལ་འབྲེལ་བ་བྱེད་རོགས་གནང་གི་ཡོད།",
-    "downloadTxtFile": "ཚེས་རིང་ཡིག་ཚགས་འགྱོ་བཅོས་",
-    "downloadCSVFile": "CSV ཡིག་ཚགས་འགྱོ་བཅོས་",
     "promotionalSubscriptionDesc": "ཁྱེད་ཀྱིས་ད་ལྟ་ལ་ལོ་རྒྱལ་ཁབ་ལ་ལོག་འབད་ཡོད་པའི་སྤྱི་ཚེས་ལ་ལོག་འབད་ཡོད། ཁྱེད་ཀྱིས་འབྲེལ་བ་བྱེད་ལས་སྤྱོད་ལེན་ལ་བསྐུར་གནང་བའི་ལས་ཁེར་ལ་འདེམས་སོ།",
     "originalSubscriptionPlatform": "ལོག་འབད་ཚུལ་ཁང་ {purchasePlatform} ལས་འབྲེལ་བ་བྱེད་ཡོད།",
     "endActivity": "ສິ້ນສຸດກິດຈະກຳ",
@@ -7300,7 +6679,6 @@
     "inviteYourFriends": "ເຊີນໝູ່ຂອງທ່ານ",
     "playWithAI": "ເລີ່ມຫຼິ້ນກັບ AI ໃນຕອນນີ້",
     "courseStartDesc": "Pangea Bot ພ້ອມໃຫ້ໃຊ້ງານເວລາໃດກໍໄດ້!\n\n...ແຕ່ການຮຽນຮູ້ດີກວ່າກັບໝູ່!",
-    "activityDropdownDesc": "ເມື່ອທ່ານເຮັດກິດຈະກຳນີ້ສຳເລັດແລ້ວ, ໃຫ້ກົດລຸ່ມຂ້າງລຸ່ມ",
     "languageMismatchTitle": "ການບໍລິການພາສາບໍ່ຕົງກັນ",
     "languageMismatchDesc": "ພາສາໝາຍເປັນຫຍັງບໍ? ກະລຸນາອັບເດດພາສາໝາຍຂອງທ່ານບໍ?",
     "reportWordIssueTooltip": "ລາຍງານບັນຫາຂໍ້ມູນຄວາມຫມາຍຂອງຄວາມ",
@@ -7440,14 +6818,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -7501,10 +6871,6 @@
         "placeholders": {}
     },
     "@courseStartDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7668,16 +7034,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktiviteti për të Çliruar Temën Tjetër",
-    "activitiesToUnlockTopicDesc": "Caktoni numrin e aktiviteteve për të çliruar temën tjetër të kursit",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Korekt vokab definicij praksi",
     "constructUseIncLMDesc": "Nekorekt vokab definicij praksi",
     "constructUseCorLADesc": "Korekt vokab audio praksi",
@@ -7685,7 +7041,6 @@
     "constructUseBonus": "Bonus tokom vokab prakse",
     "practiceVocab": "Vežbaj vokabular",
     "selectMeaning": "Izaberi značenje",
-    "selectAudio": "Izaberi odgovarajući audio",
     "anotherRound": "Još jedan krug",
     "activitySettingsOverrideWarning": "Idioma y nivel de idioma determinados por el plan de actividad",
     "voice": "Voz",
@@ -7717,10 +7072,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -7738,12 +7089,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Download initiated",
     "webDownloadPermissionMessage": "If your browser blocks downloads, please enable downloads for this site.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -7838,11 +7184,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Nǐng bǐng wǒng, yǐng wǒng bǐng wǒng. Cǐng bǐng yǐng bǐng.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Buka bantuan nulis",
     "autoIGCToolDescription": "Secara otomatis menjalankan alat Pangea Chat untuk memperbaiki pesan yang dikirim ke bahasa target.",
     "@autoIGCToolName": {
@@ -7898,24 +7239,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatika",
-    "spanTypeWordChoice": "Izbor reči",
     "spanTypeSpelling": "Pravopis",
     "spanTypePunctuation": "Interpunkcija",
     "spanTypeStyle": "Stil",
     "spanTypeFluency": "Tečnost",
     "spanTypeAccents": "Akcenti",
     "spanTypeCapitalization": "Velika slova",
-    "spanTypeCorrection": "Ispravka",
     "spanFeedbackTitle": "Prijavi problem sa ispravkom",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -7940,10 +7270,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -7956,13 +7282,7 @@
     "longPressToRecordVoiceMessage": "Nhấn và giữ để ghi âm tin nhắn thoại.",
     "pause": "Tạm dừng",
     "resume": "Tiếp tục",
-    "newSubSpace": "Không gian phụ mới",
-    "moveToDifferentSpace": "Chuyển đến không gian khác",
-    "removeFromSpaceDescription": "Obrolan akan dihapus dari ruang tetapi masih muncul di daftar obrolan Anda.",
     "countChats": "{chats} obrolan",
-    "spaceMemberOf": "Anggota ruang {spaces}",
-    "spaceMemberOfCanKnock": "Anggota ruang {spaces} dapat mengetuk",
-    "donate": "Donasi",
     "startedAPoll": "{username} memulai jajak pendapat.",
     "poll": "Jajak pendapat",
     "startPoll": "Mulai jajak pendapat",
@@ -7986,23 +7306,15 @@
     "newStickerPack": "Paket stiker baru",
     "stickerPackName": "Nama paket stiker",
     "attribution": "Attribution",
-    "skipChatBackup": "Skip chat backup",
-    "skipChatBackupWarning": "Are you sure? Without enabling the chat backup you may lose access to your messages if you switch your device.",
-    "loadingMessages": "Loading messages",
-    "setupChatBackup": "Set up chat backup",
     "noMoreResultsFound": "No more results found",
     "chatSearchedUntil": "Chat searched until {time}",
     "federationBaseUrl": "Federation Base URL",
     "clientWellKnownInformation": "Client-Well-Known Information:",
     "baseUrl": "Base URL",
     "identityServer": "Identiteti Server:",
-    "versionWithNumber": "Versioni: {version}",
     "logs": "Dëgjo",
-    "advancedConfigs": "Konfigurime të Avancuara",
     "advancedConfigurations": "Konfigurimet e Avancuara",
-    "signInWithLabel": "Identifikohu me:",
     "selectAllWords": "Zgjidhni të gjitha fjalët që dëgjoni në audio",
-    "joinCourseForActivities": "Bashkohuni në një kurs për të provuar aktivitete.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -8039,18 +7351,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -8058,26 +7358,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -8183,22 +7463,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8227,19 +7491,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8247,15 +7499,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -8456,11 +7700,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "I na klasi? Stavi svoj join kod ovde.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Auto-highlight audio messages",
     "selectAudioMessagesOnPlayDescription": "Automatically highlight audio messages when played",
     "@selectAudioMessagesOnPlayToolName": {
@@ -8484,7 +7723,6 @@
         }
     },
     "chatCapacityExplanation": "གླེང་མོལ་ཚད་བཀག་གིས་གླེང་མོལ་ནང་གི་ཚོགས་མི་གྲངས་འབོར་ལ་ཚད་བཀག་བཀོད་ཆོག",
-    "tooManyRequest": "རེ་ཞུ་མང་དྲགས། ཏོག་ཙམ་ནས་ཡང་བསྐུར་བཟོས།",
     "enterNumber": "ཧྲིལ་གྲངས་ཀྱི་ཐང་གཅིག་ནང་འཇུག་བྱོས།",
     "practice": "སྦྱོང་བརྡར",
     "versionNotFound": "པར་གཞི་མ་རྙེད།",
@@ -8494,11 +7732,9 @@
     "knockSpaceSuccess": "ཁྱེད་ཀྱིས་སློབ་ཚན་འདིར་ཞུགས་རྒྱུའི་རེ་ཞུ་བཏང་ཟིན། དོ་དམ་པས་ཁྱེད་ཀྱི་རེ་ཞུར་ལན་འདེབས་བྱེད་སྲིད། 😀",
     "chooseWordAudioInstructionsBody": "བརྗོད་ཚང་མར་ཉོན། དེ་ནས་སྒྲ་དང་ཚིག་ཟུང་སྦྱར་བྱོས།",
     "chooseMorphsInstructionsBody": "བརྡ་སྤྲོད་ཀྱི་དྲི་བ་ཚོའི་ཆེད་དུ་སྦྱོར་ཚན་གྱི་ཆ་ཤས་ལ་ཐོག་གནོན་བྱོས!",
-    "pleaseEnterInt": "ཧྲིལ་གྲངས་ཤིག་ནང་འཇུག་བྱོས།",
     "home": "གཙོ་ངོས",
     "join": "ཞུགས",
     "startOwn": "རང་གི་གསར་རྩོམ",
-    "joinCourseDesc": "སློབ་ཚན་རེར་བརྗོད་གཞི་ 8-10 ཡོད་ལ། ལས་འགན་ལ་གཞི་བཅོལ་བའི་སྐད་ཡིག་སྦྱོང་བརྡར་བྱ་འགུལ་མང་པོ་ཡོད།",
     "emptyChatSearch": "གཅིག་སྒྲིལ་འཕྲིན་དང་གླེང་མོལ་མ་རྙེད། ཚིག་སྦྱོར་ཡང་དག་ཡིན་མིན་ཞིབ་བཤེར་བྱོས།",
     "newMessageInPangeaChat": "💬 པན་གེ་ཡ་གླེང་མོལ་ནང་འཕྲིན་གསར་པ།",
     "shareCourse": "སློབ་ཚན་མཉམ་སྤྱོད",
@@ -8507,7 +7743,6 @@
         "placeholders": {}
     },
     "addCourse": "སློབ་ཚན་སྣོན",
-    "joinPublicCourse": "སྤྱི་ཡོངས་སློབ་ཚན་ལ་ཞུགས",
     "vocabLevelsDesc": "ཚིག་མཛོད་ཀྱི་ཚིག་ཚོ་ཐོབ་གྲངས་ཡར་རྒྱས་བྱས་རྗེས་འདིར་འོང་བ་ཡིན།",
     "activityAnalyticsTooltipBody": "འདི་ཚོ་ཁྱེད་ཀྱིས་བསྐྱར་ཞིབ་དང་སྦྱོང་བརྡར་གྱི་ཆེད་དུ་ཉར་ཚགས་བྱས་པའི་བྱ་འགུལ་རེད།",
     "numSavedActivities": "ཉར་ཚགས་བྱས་པའི་བྱ་འགུལ་གྲངས་འབོར",
@@ -8519,7 +7754,6 @@
     "emojiView": "ཡི་གེ་རིས་མཐོང་ཚུལ",
     "feedbackDialogDesc": "ངས་ཀྱང་ནོར་འཁྲུལ་བྱེད་སྲིད! ང་ཡར་རྒྱས་གཏོང་རྒྱུར་སྐུལ་མ་ཅི་ཞིག་ཡོད?",
     "contactHasBeenInvitedToTheCourse": "འབྲེལ་བ་ཟིན་པར་སློབ་ཚན་ལ་གདན་ཞུ་བཏང་ཟིན།",
-    "activityStatsButtonTooltip": "བྱ་འགུལ་གྱི་ཆ་འཕྲིན",
     "allow": "ཆོག",
     "deny": "མི་ཆོག",
     "enabledRenewal": "ཉོ་ཡུན་གསར་བསྐྲུན་སྤྱོད་གཏོང",
@@ -8779,18 +8013,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Dai kursi na tema zhi fuwi {input} fuwi. Plis enka numar zhi fuwi zhi fuwi {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Klicka här för att logga in igen.",
     "@clickToLogin": {
@@ -9207,17 +8429,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "A cartoonish yellow bear with its arms raised in excitement.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Pilih kata-kata untuk belajar lebih lanjut tentang mereka",
     "requireAnalyticsAccessTitle": "Memerlukan akses analitik untuk bergabung",
     "requireAnalyticsAccessDesc": "Peserta harus memberikan akses ke analitik pembelajaran mereka untuk bergabung dengan kursus ini",
     "analyticsAccessNoticeTitle": "Akses Analitik Diperlukan",
     "analyticsAccessNoticeDesc": "Dengan bergabung dengan kursus ini, Anda setuju untuk memberikan akses kepada admin ke analitik pembelajaran Anda.",
-    "skipOnboardingClassCodeDesc": "Belajar secara mandiri? Jangan khawatir, Anda bisa:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9235,10 +8451,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9267,7 +8479,6 @@
     "pickCefrLevelTeacherStepTitle": "Kiun nivelon vi instruas?",
     "pickCefrLevelStudentStepTitle": "Kiun nivelon vi estas?",
     "customCourseStepTitle": "Plenigu ĉi tiun formularon por ricevi personigitan kurson",
-    "aboutYourClass": "O vašem razredu",
     "courseCodeStepErrorMessage": "Proszę sprawdzić swój kod i spróbować ponownie",
     "institution": "Instytucja",
     "courseGoals": "Ciljevi kursa",
@@ -9310,10 +8521,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9430,12 +8637,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logo",
     "introChatDetails": "Sema hello! Jitambulishe kwa washiriki wenzako wa kurs, pata marafiki, na zungumza nje ya shughuli.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9479,11 +8681,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Aktioner för aktivitet",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Tukang sebutan",
     "audioTranscription": "Transkripsi audio AI",
     "visualLearnerSupport": "Dukungan pembelajar visual",
@@ -9524,7 +8721,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Join a course that includes this activity to play it.",
     "resizeCoursePanel": "Resize course panel",
     "undo": "Undo",
     "unlock": "Unlock",
@@ -9538,7 +8734,6 @@
     "addCourseBrowsePublic": "Shfletoni kurset publike",
     "browsePublicCourses": "Shfletoni kurset publike",
     "editProfile": "Redaktoni profilin",
-    "numObjectives": "{count} objektiva",
     "mapSearchHint": "Kërkoni aktivitete",
     "mapSearchNoResults": "Nuk ka përputhje në pamje",
     "mapFilterAllLanguages": "Të gjitha gjuhët",
@@ -9547,7 +8742,6 @@
     "mapFilterCompleted": "Komplet",
     "mapFilterReset": "Reset",
     "activityTypeConversation": "Konversasi",
-    "lockedMissionRequirement": "Selesaikan misi sebelumnya untuk membuka kunci",
     "playAgain": "Main lagi",
     "reviewActivity": "Tinjau",
     "mapEmptyInView": "Tidak ada di sini pada level atau bahasa Anda. Perluas filter Anda atau perbesar.",
@@ -9562,14 +8756,9 @@
     "scrollToBottom": "Rrokullisni poshtë",
     "courseImage": "Imazhi i kursit",
     "avatarPreview": "Paraprak i avatarit",
-    "activityPhoto": "Foto e aktivitetit",
     "emotePreview": "Paraprak i emote: {name}",
     "activityLabel": "Aktivitet: {title}",
     "resetMapView": "Nulstil kortvisning",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9622,14 +8811,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9659,10 +8840,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -9719,10 +8896,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_ca.arb
+++ b/lib/l10n/intl_ca.arb
@@ -72,11 +72,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Es pot entrar al xat com a convidadi",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "N’esteu seguri?",
     "@areYouSure": {
         "type": "String",
@@ -369,11 +364,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "El contacte ha estat convidat al grup",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "copiedToClipboard": "S’ha copiat al porta-retalls",
     "@copiedToClipboard": {
         "type": "String",
@@ -533,11 +523,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "No podreu desactivar el xifratge mai més. N’esteu segur?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Xifrat",
     "@encrypted": {
         "type": "String",
@@ -594,11 +579,6 @@
     },
     "group": "Grup",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "El grup és públic",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -672,15 +652,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Convida contacte a {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Convidat",
     "@invited": {
@@ -793,15 +764,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Carrega {count} participants més",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "S’està carregant… Espereu.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -826,15 +788,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Inicia sessió a {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Finalitza la sessió",
     "@logout": {
@@ -883,11 +836,6 @@
     },
     "noEmotesFound": "No s’ha trobat cap emoticona. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Sembla que no teniu els Serveis de Google al telèfon. Això és una bona decisió respecte a la vostra privadesa! Per a rebre notificacions automàtiques del FluffyChat, us recomanem instaŀlar ntfy. Amb ntfy o qualsevol altre proveïdor de Unified Push, pots rebre notificacions de forma segura i lliure. Pots instaŀlar ntfy des de la PlayStore o des de F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -982,11 +930,6 @@
     },
     "passwordHasBeenChanged": "La contrasenya ha canviat",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Recuperació de contrassenya",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1095,11 +1038,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Elimina dispositiu",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Aixeca el veto",
     "@unbanFromChat": {
@@ -1213,11 +1151,6 @@
                 "type": "String"
             }
         }
-    },
-    "setPermissionsLevel": "Defineix el nivell de permisos",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
     },
     "setStatus": "Defineix l’estat",
     "@setStatus": {
@@ -1354,15 +1287,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unreadChats": "{unreadCount, plural, =1{1 xat no llegit} other{{unreadCount} xats no llegits}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "userAndOthersAreTyping": "{username} i {count} més estan escrivint…",
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -1442,16 +1366,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Videotrucada",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Visibilitat de l’historial del xat",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Visible per a tots els participants",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1489,11 +1403,6 @@
     },
     "weSentYouAnEmail": "Us hem enviat un missatge de correu electrònic",
     "@weSentYouAnEmail": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Qui pot unir-se a aquest grup",
-    "@whoIsAllowedToJoinThisGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1579,11 +1488,6 @@
     "@sendOnEnter": {},
     "clearArchive": "Neteja l’arxiu",
     "@clearArchive": {},
-    "chatBackupDescription": "Els teus xats antics estan protegits amb una clau de recuperació. Assegureu-vos de no perdre-la.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoplayImages": "Reprodueix automàticament enganxines i emoticones animades",
     "@autoplayImages": {
         "type": "String",
@@ -1596,16 +1500,6 @@
     },
     "blocked": "Blocat",
     "@blocked": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "Tot és a punt!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Nom de l’espai",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1649,8 +1543,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "S’ha configurat la còpia de seguretat del xat.",
-    "@yourChatBackupHasBeenSetUp": {},
     "contentHasBeenReported": "El contingut s’ha denunciat als administradors del servidor",
     "@contentHasBeenReported": {
         "type": "String",
@@ -1658,13 +1550,6 @@
     },
     "enableEncryption": "Activa el xifratge",
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "addAccount": "Afegeix un compte",
-    "@addAccount": {},
-    "noEncryptionForPublicRooms": "Només podreu activar el xifratge quan la sala ja no sigui accessible públicament.",
-    "@noEncryptionForPublicRooms": {
         "type": "String",
         "placeholders": {}
     },
@@ -1703,23 +1588,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Transfereix des d’un altre dispositiu",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoCanPerformWhichAction": "Qui pot efectuar quina acció",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Per què voleu denunciar això?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Voleu suprimir la còpia de seguretat dels xats per a crear una clau de recuperació nova?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1755,11 +1625,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "createNewSpace": "Espai nou",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "errorObtainingLocation": "S’ha produït un error en obtenir la ubicació: {error}",
     "@errorObtainingLocation": {
         "type": "String",
@@ -1781,11 +1646,6 @@
     },
     "showPassword": "Mostra la contrasenya",
     "@showPassword": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "L’espai és públic",
-    "@spaceIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -1995,25 +1855,13 @@
     "@messagesStyle": {},
     "widgetUrlError": "La URL no és vàlida.",
     "@widgetUrlError": {},
-    "emailOrUsername": "Email o nom d'usuàrïi",
-    "@emailOrUsername": {},
-    "newSpaceDescription": "Els espais et permeten consolidar els teus xats i construir comunitats públiques o privades.",
-    "@newSpaceDescription": {},
-    "chatDescription": "Descripció del xat",
-    "@chatDescription": {},
     "editRoomAliases": "Canvia els àlies de la sala",
     "@editRoomAliases": {
         "type": "String",
         "placeholders": {}
     },
-    "enterSpace": "Obre l'espai",
-    "@enterSpace": {},
-    "encryptThisChat": "Xifra aquest xat",
-    "@encryptThisChat": {},
     "reopenChat": "Reobre el xat",
     "@reopenChat": {},
-    "pleaseEnterRecoveryKey": "Introdueix la teva clau de recuperació:",
-    "@pleaseEnterRecoveryKey": {},
     "widgetNameError": "Posa el nom públic.",
     "@widgetNameError": {},
     "inoffensive": "Inofensiu",
@@ -2039,8 +1887,6 @@
     "@commandHint_markasgroup": {},
     "pushNotificationsNotAvailable": "Les notificacions push no estan disponibles",
     "@pushNotificationsNotAvailable": {},
-    "storeInAppleKeyChain": "Desa en la Apple KeyChain",
-    "@storeInAppleKeyChain": {},
     "replaceRoomWithNewerVersion": "Substitueix la sala amb la versió més recent",
     "@replaceRoomWithNewerVersion": {
         "type": "String",
@@ -2054,8 +1900,6 @@
     "@chatPermissions": {},
     "sender": "Remitent",
     "@sender": {},
-    "storeInAndroidKeystore": "Desa en la Android KeyStore",
-    "@storeInAndroidKeystore": {},
     "offensive": "Ofensiu",
     "@offensive": {
         "type": "String",
@@ -2063,8 +1907,6 @@
     },
     "makeAdminDescription": "Un cop hagis fet admin aquesta persona ja no podràs desfer-ho, ja que llavors tindrà els mateixos permisos que tu.",
     "@makeAdminDescription": {},
-    "saveKeyManuallyDescription": "Per desar aquesta clau manualment, pica l'eina de compartir o copia-la al porta-retalls.",
-    "@saveKeyManuallyDescription": {},
     "editBundlesForAccount": "Edita paquets per aquest compte",
     "@editBundlesForAccount": {},
     "whyIsThisMessageEncrypted": "Per què no es pot llegir aquest missatge?",
@@ -2086,8 +1928,6 @@
             }
         }
     },
-    "videoCallsBetaWarning": "Tingues en compte que les trucades de vídeo estan encara en beta. Pot ser que no funcioni bé o que falli en alguna plataforma.",
-    "@videoCallsBetaWarning": {},
     "participant": "Participant",
     "@participant": {
         "type": "String",
@@ -2106,8 +1946,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unlockOldMessages": "Desbloqueja els missatges antics",
-    "@unlockOldMessages": {},
     "optionalRedactReason": "(Opcional) El motiu per estripar el missatge...",
     "@optionalRedactReason": {},
     "dehydrate": "Exporta la sessió i neteja el dispositiu",
@@ -2118,8 +1956,6 @@
     "@exportEmotePack": {},
     "experimentalVideoCalls": "Trucades de vídeo experimentals",
     "@experimentalVideoCalls": {},
-    "pleaseEnterRecoveryKeyDescription": "Per desbloquejar els missatges antics, introdueix la clau de recuperació que vas generar en una sessió anterior. La clau de recuperació NO és la teva contrasenya.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "openInMaps": "Obre als mapes",
     "@openInMaps": {
         "type": "String",
@@ -2168,8 +2004,6 @@
     },
     "redactMessageDescription": "S'estriparà el missatge per a totser d'aquesta conversa. Aquesta acció és irreversible.",
     "@redactMessageDescription": {},
-    "recoveryKey": "Clau de recuperació",
-    "@recoveryKey": {},
     "invalidInput": "L'entrada no és vàlida!",
     "@invalidInput": {},
     "doNotShowAgain": "No ho tornis a mostrar",
@@ -2178,8 +2012,6 @@
     "@report": {},
     "serverRequiresEmail": "Aquest servidor necessita validar la teva adreça per registrar-t'hi.",
     "@serverRequiresEmail": {},
-    "screenSharingTitle": "compartició de pantalla",
-    "@screenSharingTitle": {},
     "widgetCustom": "Personalització",
     "@widgetCustom": {},
     "googlyEyesContent": "{senderName} t'ha enviat un parell d'ulls",
@@ -2218,8 +2050,6 @@
     "@openLinkInBrowser": {},
     "messageInfo": "Informació del missatge",
     "@messageInfo": {},
-    "disableEncryptionWarning": "Per motius de seguretat, un cop activat, no es pot desactivar el xifratge.",
-    "@disableEncryptionWarning": {},
     "directChat": "Xat directe",
     "@directChat": {},
     "wrongPinEntered": "Pin incorrecte! Torna-ho a provar en {seconds} segons...",
@@ -2235,10 +2065,6 @@
     "@sendTypingNotifications": {},
     "inviteGroupChat": "📨 Convida al grup",
     "@inviteGroupChat": {},
-    "foregroundServiceRunning": "Aquesta notificació apareix quan el servei de primer pla està corrent.",
-    "@foregroundServiceRunning": {},
-    "voiceCall": "Videotrucada",
-    "@voiceCall": {},
     "commandHint_unban": "Aixeca el veto a aquesti usuàriï per aquesta sala",
     "@commandHint_unban": {
         "type": "String",
@@ -2275,8 +2101,6 @@
     "@newGroup": {},
     "bundleName": "Nom del paquet",
     "@bundleName": {},
-    "removeFromSpace": "Esborra de l'espai",
-    "@removeFromSpace": {},
     "roomUpgradeDescription": "El xat serà recreat amb una versió de sala nova. Totis lis participants seran notificadis que han de canviar al nou xat. Pots llegir més sobre les versions de sala a https://spec.matrix.org/latest/rooms/",
     "@roomUpgradeDescription": {},
     "pleaseEnterANumber": "Introdueix un número major que 0",
@@ -2303,14 +2127,10 @@
             }
         }
     },
-    "sorryThatsNotPossible": "Aquesta acció no és possible",
-    "@sorryThatsNotPossible": {},
     "shareInviteLink": "Comparteix un enllaç d'invitació",
     "@shareInviteLink": {},
     "commandHint_markasdm": "Marca com a conversa directa la sala amb aquesta ID de Matrix",
     "@commandHint_markasdm": {},
-    "recoveryKeyLost": "Que has perdut la clau de recuperació?",
-    "@recoveryKeyLost": {},
     "cuddleContent": "{senderName} et fa una carícia",
     "@cuddleContent": {
         "type": "String",
@@ -2327,8 +2147,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "Tria el tema:",
-    "@setTheme": {},
     "youJoinedTheChat": "T'has afegit al xat",
     "@youJoinedTheChat": {},
     "openVideoCamera": "Obre la càmera per a fer un vídeo",
@@ -2383,8 +2201,6 @@
     "@custom": {},
     "noBackupWarning": "Compte! Si no actives la còpia de seguretat dels xats, perdràs accés als teus missatges xifrats. És molt recomanable activar-ho abans de tancar la sessió.",
     "@noBackupWarning": {},
-    "storeInSecureStorageDescription": "Desa la clau de recuperació en l'emmagatzematge segur d'aquest dispositiu.",
-    "@storeInSecureStorageDescription": {},
     "openChat": "Obre el xat",
     "@openChat": {},
     "kickUserDescription": "Li usuàrïi ha estat expulsadi però no vetadi. Als xats públics, pot tornar-hi a entrar en qualsevol moment.",
@@ -2395,14 +2211,8 @@
     "@pinMessage": {},
     "invite": "Convida",
     "@invite": {},
-    "enableMultiAccounts": "(Beta) Activa multi-compte en aquest dispositiu",
-    "@enableMultiAccounts": {},
     "unsupportedAndroidVersionLong": "Aquesta funcionalitat només funciona amb versions d'Android més noves.",
     "@unsupportedAndroidVersionLong": {},
-    "storeSecurlyOnThisDevice": "Desa de forma segura en aquest dispositiu",
-    "@storeSecurlyOnThisDevice": {},
-    "screenSharingDetail": "Estàs compartint la teva pantalla a FluffyChat",
-    "@screenSharingDetail": {},
     "placeCall": "Truca",
     "@placeCall": {},
     "block": "Bloca",
@@ -2417,8 +2227,6 @@
     "@pleaseChooseAStrongPassword": {},
     "groupName": "Nom del grup",
     "@groupName": {},
-    "createGroupAndInviteUsers": "Crea un grup i convida-hi usuàrïis",
-    "@createGroupAndInviteUsers": {},
     "wrongRecoveryKey": "Malauradament, aquesta clau de recuperació no és la correcta.",
     "@wrongRecoveryKey": {},
     "transparent": "Transparent",
@@ -2437,24 +2245,10 @@
     "@pleaseEnterYourCurrentPassword": {},
     "newPassword": "Contrasenya nova",
     "@newPassword": {},
-    "restoreSessionBody": "L'aplicació provarà de restaurar la teva sessió des de la còpia de seguretat. Si us plau, comunica aquest error a l'equi pde desenvolupament a {url}. El missatge d'error és {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "formattedMessages": "Missatges amb format",
     "@formattedMessages": {},
     "formattedMessagesDescription": "Mostra contingut amb format enriquit com text en cursiva, fent servir markdown.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Verifica uni altri usuàrïi",
-    "@verifyOtherUser": {},
     "verifyOtherDevice": "🔐 Verifica un altre dispositiu",
     "@verifyOtherDevice": {},
     "initAppError": "S'ha produït un error mentre s'inicialitzava l'aplicació",
@@ -2478,8 +2272,6 @@
     "@searchForUsers": {},
     "subspace": "Subespai",
     "@subspace": {},
-    "addChatOrSubSpace": "Afegeix un xat o un subespai",
-    "@addChatOrSubSpace": {},
     "decline": "Denega",
     "@decline": {},
     "sendReadReceipts": "Envia informes de tecleig",
@@ -2526,10 +2318,6 @@
     },
     "nothingFound": "No s'ha trobat res...",
     "@nothingFound": {},
-    "searchChatsRooms": "Cerca #sales, @usuariïs...",
-    "@searchChatsRooms": {},
-    "groupCanBeFoundViaSearch": "El grup es pot trobar per la cerca general",
-    "@groupCanBeFoundViaSearch": {},
     "databaseMigrationBody": "Espereu un moment, si us plau.",
     "@databaseMigrationBody": {},
     "passwordsDoNotMatch": "Les contrasenyes no coincideixen",
@@ -2542,20 +2330,6 @@
     "@publicSpaces": {},
     "thisDevice": "Aquest dispositiu:",
     "@thisDevice": {},
-    "sessionLostBody": "S'ha perdut la teva sessió. Si us plau, comunica aquest error a l'equip de desenvolupament a {url}. El missatge d'error és: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "verifyOtherUserDescription": "Si verifiques aquesti usuàrïi, podràs estar seguri de a qui estàs escrivint. . 💪\n\nQuan inicies una verificació, l'altra persona i tu veureu un missatge emergent a l'app. Us sortiran un seguit d'emojis o números a cada pantalla, que haureu de comparar.\n\nLa millor manera de fer-ho és quedar en persona o fer una vídeo-trucada. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDeviceDescription": "Quan verifiques un altre dispositiu, aquests poden intercanviar claus, així que es millora la seguretat total. 💪 Quan comences una verificació, apareixerà un missatge emergent a tots dos dispositius. A cadascun hi apareixerà un seguit d'emojis o de números que hauràs de comparar. El millor és tenir tots dos dispositius a mà abans d'iniciar la verificació. 🤳",
     "@verifyOtherDeviceDescription": {},
     "requestedKeyVerification": "{sender} ha soŀlicitat verificar claus",
@@ -2657,12 +2431,8 @@
     "@changeTheVisibilityOfChatHistory": {},
     "changeTheCanonicalRoomAlias": "Canvia l'adreça principal del xat",
     "@changeTheCanonicalRoomAlias": {},
-    "accessAndVisibilityDescription": "Qui pot entrar a aquesta conversa i com pot ser descoberta.",
-    "@accessAndVisibilityDescription": {},
     "customEmojisAndStickers": "Emojis i stickers propis",
     "@customEmojisAndStickers": {},
-    "accessAndVisibility": "Accés i visibilitat",
-    "@accessAndVisibility": {},
     "calls": "Trucades",
     "@calls": {},
     "hideRedactedMessages": "Amaga els missatges estripats",
@@ -2677,10 +2447,6 @@
     "@gallery": {},
     "noDatabaseEncryption": "No es pot xifrar la base de dades en aquesta plataforma",
     "@noDatabaseEncryption": {},
-    "usersMustKnock": "Lis membres han de picar a la porta",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Ningú s'hi pot ficar",
-    "@noOneCanJoin": {},
     "customEmojisAndStickersBody": "Afegeix o comparteix emojis o stickers. Els podràs fer servir en qualsevol conversa.",
     "@customEmojisAndStickersBody": {},
     "hideRedactedMessagesBody": "Si algú estripa un missatge, ja no apareixerà a l'historial de la conversa.",
@@ -2715,16 +2481,10 @@
     "@appLockDescription": {},
     "swipeRightToLeftToReply": "Llisca de dreta esquerra per respondre",
     "@swipeRightToLeftToReply": {},
-    "globalChatId": "Identificador global de xat",
-    "@globalChatId": {},
-    "createNewAddress": "Crea una adreça nova",
-    "@createNewAddress": {},
     "searchMore": "Cerca més...",
     "@searchMore": {},
     "files": "Arxius",
     "@files": {},
-    "publicChatAddresses": "Adreces públiques del xat",
-    "@publicChatAddresses": {},
     "unreadChatsInApp": "{appname}: {unread} converses pendents",
     "@unreadChatsInApp": {
         "type": "String",
@@ -2742,14 +2502,6 @@
         "type": "String",
         "count": {}
     },
-    "loginWithMatrixId": "Entra amb l'id de Matrix",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Descobreix servidors",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Què és un servidor de Matrix?",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "Totes les teves dades s'emmagatzemen al servidor, com passa amb el e-mail. Pots triar quin servidor vols fer servir sense témer a no poder comunicar gent d'altres servidors. Llegeix-ne més a https://matrix.org.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "No sembla un servidor compatible. Pot ser que la URL estigui malament?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "noMoreChatsFound": "No hi ha més xats...",
@@ -2762,15 +2514,6 @@
     "@unread": {},
     "spaces": "Espais",
     "@spaces": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "El xat es pot descobrir amb la cerca de {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "calculatingFileSize": "S'està calculant la mida de l'arxiu...",
     "@calculatingFileSize": {},
     "prepareSendingAttachment": "S'està preparant per enviar l'adjunt...",
@@ -2825,14 +2568,10 @@
     },
     "oneOfYourDevicesIsNotVerified": "Un dels teus dispositius no està verificat",
     "@oneOfYourDevicesIsNotVerified": {},
-    "welcomeText": "Hola hola! 👋 Això és FluffyChat. Pots iniciar sessió en qualsevol servidor compatible amb https://matrix.org. I llavors xatejar amb qualsevol. És una xarxa enorme de missatgeria descentralitzada !",
-    "@welcomeText": {},
     "blur": "Difumina:",
     "@blur": {},
     "opacity": "Opacitat:",
     "@opacity": {},
-    "manageAccount": "Gestiona el compte",
-    "@manageAccount": {},
     "contactServerAdmin": "Contacta l'admin del servidor",
     "@contactServerAdmin": {},
     "contactServerSecurity": "Contacta l'equip de seguretat del servidor",
@@ -2994,21 +2733,8 @@
             }
         }
     },
-    "appWantsToUseForLogin": "Fes servir '{server}' per iniciar sessió",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Consenteixes que l'app i la web comparteixen informació sobre tu.",
-    "@appWantsToUseForLoginDescription": {},
     "open": "Obre",
     "@open": {},
-    "appIntroduction": "El FluffyChat et permet xatejar amb amiguis entre diverses aplicacions. Llegeix-ne més a https://matrix.org o pica \"Continua\".",
-    "@appIntroduction": {},
     "waitingForServer": "S'està esperant el servidor...",
     "@waitingForServer": {},
     "shareKeysWith": "Comparteix les claus amb...",
@@ -3032,7 +2758,6 @@
     "ignoreUser": "Ignora l'usuari",
     "normalUser": "Usuari normal",
     "checkList": "Llista de verificació",
-    "countInvited": "{count} convidats",
     "sentVoiceMessage": "🎙️ {duration} - Missatge de veu de {sender}",
     "approve": "Aprovar",
     "youHaveKnocked": "Has tocat a la porta",
@@ -3047,11 +2772,9 @@
     "taTooltip": "L2 utilitza amb assistència de traducció",
     "interactiveTranslatorSliderHeader": "Traductor interactiu",
     "interactiveGrammarSliderHeader": "Comprovador de gramàtica interactiu",
-    "interactiveTranslatorRequired": "Requerit",
     "waTooltip": "Ús de L2 sense assistència",
     "interactiveTranslator": "Assistència de traducció",
     "noIdenticalLanguages": "Si us plau, tria idiomes base i de destinació diferents",
-    "searchBy": "Cerca per país i idiomes",
     "joinWithClassCode": "Uneix-te al curs",
     "languageLevelPreA1": "Novell Baix (Pre A1)",
     "languageLevelA1": "Novell Mitjà (A1)",
@@ -3072,19 +2795,14 @@
     "saveChanges": "Desa els canvis",
     "publicProfileTitle": "Permet que el meu perfil sigui trobat en la cerca",
     "publicProfileDesc": "En activarlo, permeteu que altres usuaris trobin el vostre perfil a la barra de cerca global i enviïn sol·licituds de xat. En aquest moment, podeu triar acceptar o rebutjar la sol·licitud.",
-    "errorDisableIT": "L'assistència de traducció està desactivada.",
-    "errorDisableIGC": "L'assistència de gramàtica està desactivada.",
     "errorDisableITUserDesc": "Fes clic aquí per actualitzar la configuració d'assistència de traducció",
     "errorDisableIGCUserDesc": "Fes clic aquí per actualitzar la configuració d'assistència de gramàtica",
     "errorDisableITClassDesc": "L'assistència de traducció està desactivada per al curs en què es troba aquest xat.",
     "errorDisableIGCClassDesc": "L'assistència de gramàtica està desactivada per al curs en què es troba aquest xat.",
-    "error405Title": "Idiomes no configurats",
     "error405Desc": "Si us plau, configureu els vostres idiomes al Menú Principal > Configuració d'Aprenentatge.",
     "termsAndConditions": "Termes i Condicions",
     "andCertifyIAmAtLeast13YearsOfAge": " i certifico que tinc almenys 16 anys.",
-    "error502504Title": "Uau, hi ha molts estudiants en línia!",
     "error502504Desc": "Les eines de traducció i gramàtica poden ser lentes o no estar disponibles mentre els bots de Pangea s'actualitzen.",
-    "error404Title": "Error de traducció!",
     "error404Desc": "El Pangea Bot no està segur de com traduir això...",
     "errorPleaseRefresh": "Ho estem investigant! Si us plau, actualitza i torna a provar.",
     "connectedToStaging": "Connectat a l'Entorn de Proves",
@@ -3122,13 +2840,9 @@
     "definitionsToolName": "Definicions de paraules",
     "definitionsToolDescription": "Quan està activat, les paraules subratllades en blau es poden clicar per veure definicions. Fes clic als missatges per accedir a les definicions.",
     "welcomeBack": "Benvingut de nou! Si vau formar part del pilot 2023-2024, poseu-vos en contacte amb nosaltres per a la vostra subscripció especial de pilot. Si sou un professor que ha comprat (o la vostra institució ha comprat) llicències per a la vostra classe, poseu-vos en contacte amb nosaltres per a la vostra subscripció d'professor.",
-    "downloadTxtFile": "Descarregar Fitxer de Text",
-    "downloadCSVFile": "Descarregar Fitxer CSV",
     "promotionalSubscriptionDesc": "Actualment teniu una subscripció promocional de per vida. Envia un missatge a support@pangea.chat per ajudar-vos a canviar la vostra subscripció.",
     "originalSubscriptionPlatform": "Subscripció comprada a través de {purchasePlatform}",
     "oneWeekTrial": "Prova d'una Setmana",
-    "downloadXLSXFile": "Descarregar Fitxer Excel",
-    "unkDisplayName": "Desconegut",
     "wwCountryDisplayName": "Mundial",
     "afCountryDisplayName": "Afganistan",
     "axCountryDisplayName": "Illes Aland",
@@ -3423,7 +3137,6 @@
     "chatCapacityHasBeenChanged": "Capacitat de xat canviada",
     "chatCapacitySetTooLow": "La capacitat de xat ha de ser almenys {count}.",
     "chatCapacityExplanation": "La capacitat de xat limita el nombre de membres que poden participar en un xat.",
-    "tooManyRequest": "Massa sol·licituds, si us plau, torna-ho a provar més tard.",
     "enterNumber": "Si us plau, introdueix un valor numèric sencer.",
     "practice": "Practica",
     "versionNotFound": "Versió no trobada",
@@ -3433,7 +3146,6 @@
     "deleteSubscriptionWarningTitle": "Tens una subscripció activa",
     "deleteSubscriptionWarningBody": "Eliminant el teu compte no cancel·larà automàticament la teva subscripció.",
     "manageSubscription": "Gestiona la subscripció",
-    "error520Title": "Si us plau, intenta-ho de nou.",
     "error520Desc": "Ho sentim, no hem pogut entendre el teu missatge...",
     "wordsUsed": "Paraules utilitzades",
     "level": "Nivell",
@@ -3451,7 +3163,6 @@
     "other": "Altres",
     "levelShort": "NIVL {level}",
     "noCapacityLimit": "Sense límit de capacitat",
-    "downloadGroupText": "Descarrega el text del grup",
     "notificationsOn": "Notificacions activades",
     "notificationsOff": "Notificacions desactivades",
     "joinWithCode": "Uneix-te amb codi",
@@ -3515,24 +3226,12 @@
     "whatIsTheMorphTag": "Què és el {morphologicalFeature} de '{wordForm}'?",
     "dataAvailable": "Disponibilitat de dades",
     "available": "Disponible",
-    "pangeaBotIsFallible": "El Pangea Bot també comete errors!",
-    "whatIsMeaning": "Què vol dir '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Combina els significats amb les paraules del missatge!",
-    "doubleClickToEdit": "Fes doble clic per editar.",
-    "topicLabel": "Tema",
-    "topicPlaceholder": "Tria un tema...",
-    "modePlaceholder": "Tria un mode...",
-    "learningObjectiveLabel": "Objectiu d'aprenentatge",
-    "learningObjectivePlaceholder": "Tria un objectiu d'aprenentatge...",
-    "targetLanguageLabel": "Idioma objectiu",
     "cefrLevelLabel": "Nivell CEFR",
     "image": "Imatge",
     "video": "Vídeo",
     "nan": "No aplicable",
-    "addVocabulary": "Afegeix vocabulari",
     "instructions": "Instruccions",
-    "numberOfLearners": "Nombre d'aprenents",
-    "mustBeInteger": "Ha de ser un nombre enter, p. ex. 1, 2, 3, ...",
     "constructUsePvmDesc": "Producit en missatge de veu",
     "leaveSpaceDescription": "En sortir del curs, sortiràs de tots els xats dins d'ell. Altres usuaris veuran que has sortit del curs.",
     "constructUseCorMmDesc": "Missatge correcte amb significat",
@@ -3547,7 +3246,6 @@
     "ttsDisabledBody": "Pots habilitar el text a veu a la configuració d'aprenentatge",
     "noSpaceDescriptionYet": "Encara no s'ha creat cap descripció del curs.",
     "tooLargeToSend": "Aquest missatge és massa gran per enviar",
-    "exitWithoutSaving": "Estàs segur que vols sortir sense desar?",
     "enableAutocorrectPopupTitle": "Afegeix el teclat del teu idioma objectiu anant a:",
     "enableAutocorrectPopupSteps": "  • Configuració\n  • General\n  • Teclat\n  • Teclats\n  • Afegeix un teclat nou",
     "enableAutocorrectPopupDescription": "Un cop seleccionat l'idioma, pots fer clic a la petita icona del globus a la part inferior esquerra del teclat per activar el teclat recentment instal·lat.",
@@ -3558,11 +3256,8 @@
     "displayName": "Nom de visualització",
     "leaveRoomDescription": "Estàs a punt de sortir d'aquest xat. Els altres usuaris veuran que has sortit del xat.",
     "confirmUserId": "Confirma el teu nom d'usuari de Pangea Chat per eliminar el teu compte.",
-    "startingToday": "A partir d'avui",
-    "oneWeekFreeTrial": "Prova gratuïta d'una setmana",
     "paidSubscriptionStarts": "Comença {startDate}",
     "cancelInSubscriptionSettings": "• Cancel·la en qualsevol moment a la configuració de la subscripció",
-    "cancelToAvoidCharges": "• Cancel·la abans de {trialEnds} per evitar càrrecs",
     "downloadGboard": "Baixa Gboard",
     "autocorrectNotAvailable": "Lamentablement, la teva plataforma actualment no és compatible amb aquesta funció. Estigues atent a futurs desenvolupaments!",
     "pleaseUpdateApp": "Actualitza l'aplicació per continuar.",
@@ -3572,17 +3267,12 @@
     "knockSpaceSuccess": "Has sol·licitat unir-te a aquest curs! Un administrador respondre la teva sol·licitud quan la rebi 😀",
     "chooseWordAudioInstructionsBody": "Escolta el missatge complet. Després, combina els àudios amb les paraules.",
     "chooseMorphsInstructionsBody": "Fes clic a les peces del trencaclosques per a preguntes de gramàtica!",
-    "pleaseEnterInt": "Si us plau, introdueix un número",
     "home": "Inici",
     "join": "Uneix-te",
     "resetInstructionTooltipsTitle": "Restableix les pistes d'instruccions",
     "resetInstructionTooltipsDesc": "Fes clic per mostrar pistes d'instruccions com per a un usuari completament nou.",
-    "randomize": "Barreja",
     "clear": "Esborra",
-    "featuredActivities": "Destacades",
     "save": "Desa",
-    "startChat": "Inicia un xat",
-    "translationProblem": "Problema de traducció",
     "askToJoin": "Prega per unir-te",
     "emptyChatWarningTitle": "El xat està buit",
     "emptyChatWarningDesc": "No has convidat ningú al teu xat. Ves a la configuració del xat per convidar els teus contactes o el Bot. També pots fer-ho més tard.",
@@ -3612,17 +3302,13 @@
     "timesUsedIndependently": "Vegades utilitzat de manera independent",
     "timesUsedWithAssistance": "Vegades utilitzat amb assistència",
     "shareInviteCode": "Comparteix el codi d'invitació: {code}",
-    "leaderboard": "Classificació",
     "skipForNow": "Ometre per ara",
     "permissions": "Permisos",
     "spaceChildPermission": "Qui pot afegir nous xats a aquest curs",
-    "addEnvironmentOverride": "Afegeix una substitució de l'entorn",
     "defaultOption": "Per defecte",
     "deleteChatDesc": "Estàs segur que vols eliminar aquest xat? S'eliminarà per a tots els participants i tots els missatges dins del xat ja no estaran disponibles per a pràctica o anàlisi d'aprenentatge.",
     "deleteSpaceDesc": "El curs i qualsevol xat seleccionat s'eliminaran per a tots els participants i tots els missatges dins del xat ja no estaran disponibles per a pràctica o anàlisi d'aprenentatge. Aquesta acció no es pot desfer.",
     "launch": "Llançar",
-    "searchChats": "Cerca converses",
-    "maxFifty": "Màxim 50",
     "configureSpace": "Configura el curs",
     "pinMessages": "Fixa missatges",
     "setJoinRules": "Estableix les regles d'entrada",
@@ -3656,9 +3342,6 @@
     "failedToFetchTranscription": "Error en obtenir la transcripció",
     "deleteEmptySpaceDesc": "El curs s'eliminarà per a tots els participants. Aquesta acció no es pot desfer.",
     "regenerate": "Regenerar",
-    "mySavedActivities": "Les meves activitats desades",
-    "noSavedActivities": "No hi ha activitats desades",
-    "saveActivity": "Desa aquesta activitat",
     "failedToPlayVideo": "Error en reproduir el vídeo",
     "done": "Fet",
     "inThisSpace": "En aquest curs",
@@ -3669,13 +3352,9 @@
     "numInvited": "{count} convidat",
     "saved": "Desat",
     "reset": "Restablir",
-    "errorFetchingActivitiesMessage": "No s'han pogut obtenir les activitats",
     "errorFetchingDefinition": "No s'ha pogut obtenir la definició",
     "errorProcessAnalytics": "No s'han pogut processar les anàlisis",
     "errorDownloading": "La baixada ha fallat",
-    "errorLoadingSpaceChildren": "No s'han pogut carregar els xats d'aquest curs",
-    "unexpectedError": "Error inesperat.",
-    "pleaseReload": "Si us plau, recarregui i intenti-ho de nou.",
     "translationError": "Error de traducció",
     "check": "Comprovar",
     "unableToFindRoom": "No s'ha trobat cap xat o curs amb aquest codi. Torna-ho a provar.",
@@ -3684,19 +3363,14 @@
     "request": "Sol·licitar",
     "requestAll": "Sol·licitar Tot",
     "confirmMessageUnpin": "Estàs segur que vols desfixar aquest missatge?",
-    "saveAndLaunch": "Desa i Llança",
-    "launchToSpace": "Llançar al curs",
     "pending": "Pendent",
     "inactive": "Inactiu",
-    "confirmRole": "Confirma el rol",
     "openRoleLabel": "OBERT",
     "finishedTheActivity": "🎯 {username} ha finalitzat aquesta activitat",
     "activitySummaryError": "Resum d'activitats no disponible",
     "requestSummaries": "Sol·licitar resums",
-    "generatingNewActivities": "Ets el primer usuari d'aquesta parella de llengües! Si us plau, dona'ns un minut, estem preparant activitats exclusives per a tu.",
     "requestAccessTitle": "Sol·licitar accés a l'analítica?",
     "requestAccessDesc": "Vols sol·licitar accés per veure les analítiques dels participants?\n\nSi els participants hi estan d'acord, els administradors d'aquest curs podran veure:\n    • vocabulari total\n    • conceptes gramaticals totals\n    • sessions d'activitat completes\n    • els conceptes gramaticals específics utilitzats, correctament i incorrectament\n\nNo podran veure:\n    • missatges en converses fora del curs\n    • llistat de vocabulari",
-    "requestAccess": "Sol·licitar accés ({count})",
     "analyticsInactiveTitle": "Les sol·licituds a usuaris inactius no es van poder enviar",
     "analyticsInactiveDesc": "Els usuaris inactius que no han iniciat sessió des de la introducció d'aquesta funció no veuran la teva sol·licitud.\n\nEl botó de Sol·licitar apareixerà quan tornin. Pots reenviar la sol·licitud més tard fent clic al botó de Sol·licitar sota el seu nom quan estigui disponible.",
     "accessRequestedTitle": "Sol·licitud d'accés a analítiques",
@@ -3719,8 +3393,6 @@
     "accessDesc": "Pots fer que el teu curs sigui obert al món! O bé, fer que el teu curs sigui privat i segur.",
     "createGroupChatDesc": "Mentre que les sessions d'activitat comencen i acaben, els xats de grup romandran oberts per a la comunicació rutinària.",
     "deleteDesc": "Només els administradors poden eliminar un curs. Aquesta és una acció destructiva que elimina tots els usuaris i elimina tots els xats seleccionats dins del curs. Procedeix amb precaució.",
-    "noCourseFound": "Oh, aquest curs necessita un pla!\n\nEls plans de curs són una seqüència de temes i activitats de conversa.",
-    "additionalParticipants": "+ {num} altres",
     "whatNow": "I ara què?",
     "chooseNextActivity": "Tria la teva propera activitat!",
     "letsGo": "Anem-hi",
@@ -3733,13 +3405,11 @@
     "waitNotDone": "Espera, encara no he acabat!",
     "waitingForOthersToFinish": "Esperant que la resta acabi...",
     "generatingSummary": "Analitzant el xat i generant resultats",
-    "findCourse": "Troba un curs",
     "pingParticipantsNotification": "{user} busca usuaris per unir-se a la sessió d'activitat a {room}",
     "course": "Curs",
     "courses": "Cursos",
     "goToCourse": "Ves al curs: {course}",
     "activityComplete": "Aquesta activitat s'ha completat. El resum de l'activitat hauria d'estar disponible a sota.",
-    "startNewSession": "Inicia una nova sessió",
     "joinOpenSession": "Uneix-te a una sessió oberta",
     "activityNotFound": "Activitat no trobada",
     "myActivities": "Les meves activitats",
@@ -3802,14 +3472,6 @@
     "@checkList": {
         "type": "String",
         "placeholders": {}
-    },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@sentVoiceMessage": {
         "type": "String",
@@ -3881,10 +3543,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3894,10 +3552,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -3985,14 +3639,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4009,10 +3655,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4025,15 +3667,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4185,14 +3819,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4206,14 +3832,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5436,10 +5054,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5480,10 +5094,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5556,10 +5166,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5829,47 +5435,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5889,19 +5455,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -5965,10 +5519,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6009,14 +5559,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6028,14 +5570,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6073,10 +5607,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6093,27 +5623,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6237,10 +5751,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6250,10 +5760,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6270,14 +5776,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6417,18 +5915,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6477,10 +5963,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6490,18 +5972,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6544,23 +6014,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6584,10 +6042,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6595,14 +6049,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6707,18 +6153,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6771,10 +6205,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6801,10 +6231,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -6985,7 +6411,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Revisa demà per actualitzacions de l'activitat.",
-    "activityDropdownDesc": "Quan hagis acabat amb aquesta activitat, fes clic a sota",
     "languageMismatchTitle": "Desajust de llengua",
     "languageMismatchDesc": "La teva llengua objectiu no coincideix amb la llengua d'aquesta activitat. Actualitzar la teva llengua objectiu?",
     "reportWordIssueTooltip": "Informar d'un problema amb la informació de la paraula",
@@ -6998,10 +6423,6 @@
     "selectAll": "Selecciona tot",
     "deselectAll": "Desselecciona tot",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7050,17 +6471,11 @@
         "placeholders": {}
     },
     "startOwn": "Comença el teu propi",
-    "joinCourseDesc": "Cada curs té entre 8 i 10 temes seqüenciats amb una gamma d'activitats d'aprenentatge de llengües basades en tasques.",
     "newMessageInPangeaChat": "📝 Nou missatge a Pangea Chat",
     "shareCourse": "Comparteix el curs",
     "addCourse": "Afegeix un curs",
-    "joinPublicCourse": "Uneix-te al curs públic",
     "vocabLevelsDesc": "Aquí és on aniran les paraules de vocabulari un cop les hagis pujat de nivell!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7073,10 +6488,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7095,7 +6506,6 @@
     "emojiView": "Vista d'emoji",
     "feedbackDialogDesc": "Jo també cometo errors! Hi ha alguna cosa que pugui fer per millorar?",
     "contactHasBeenInvitedToTheCourse": "El contacte ha estat convidat al curs",
-    "activityStatsButtonTooltip": "Informació de l'activitat",
     "allow": "Permetre",
     "deny": "Denegar",
     "enabledRenewal": "Habilitar la renovació de la subscripció",
@@ -7363,10 +6773,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8422,16 +7828,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Activitats per Desbloquejar el Proper Tema",
-    "activitiesToUnlockTopicDesc": "Estableix el nombre d'activitats per desbloquejar el proper tema del curs",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Pràctica correcta de definicions de vocabulari",
     "constructUseIncLMDesc": "Pràctica incorrecta de definicions de vocabulari",
     "constructUseCorLADesc": "Pràctica correcta d'àudio de vocabulari",
@@ -8439,7 +7835,6 @@
     "constructUseBonus": "Boni durant la pràctica de vocabulari",
     "practiceVocab": "Practica vocabulari",
     "selectMeaning": "Selecciona el significat",
-    "selectAudio": "Selecciona l'àudio corresponent",
     "anotherRound": "Una altra ronda",
     "activitySettingsOverrideWarning": "Idioma i nivell d'idioma determinats pel pla d'activitat",
     "voice": "Veu",
@@ -8471,10 +7866,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8492,12 +7883,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Descàrrega iniciada",
     "webDownloadPermissionMessage": "Si el teu navegador bloqueja les descàrregues, si us plau, activa les descàrregues per a aquest lloc.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8592,11 +7978,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Alguna cosa ha anat malament, i estem treballant dur per solucionar-ho. Comprova-ho més tard.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Activar l'assistència d'escriptura",
     "autoIGCToolDescription": "Executar automàticament les eines de Pangea Chat per corregir els missatges enviats a l'idioma de destinació.",
     "@autoIGCToolName": {
@@ -8652,24 +8033,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramàtica",
-    "spanTypeWordChoice": "Elecció de paraules",
     "spanTypeSpelling": "Ortografia",
     "spanTypePunctuation": "Puntuació",
     "spanTypeStyle": "Estil",
     "spanTypeFluency": "Fluïdesa",
     "spanTypeAccents": "Accents",
     "spanTypeCapitalization": "Majúscules",
-    "spanTypeCorrection": "Correcció",
     "spanFeedbackTitle": "Informar d'un problema de correcció",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8694,10 +8064,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8710,13 +8076,7 @@
     "longPressToRecordVoiceMessage": "Mantingueu premut per gravar un missatge de veu.",
     "pause": "Pausa",
     "resume": "Reprendre",
-    "newSubSpace": "Nou subespai",
-    "moveToDifferentSpace": "Moure's a un espai diferent",
-    "removeFromSpaceDescription": "El xat serà eliminat de l'espai però continuarà apareixent a la teva llista de xats.",
     "countChats": "{chats} xats",
-    "spaceMemberOf": "Membre de l'espai de {spaces}",
-    "spaceMemberOfCanKnock": "Membre de l'espai de {spaces} pot trucar",
-    "donate": "Dona",
     "startedAPoll": "{username} ha iniciat una enquesta.",
     "poll": "Enquesta",
     "startPoll": "Inicia l'enquesta",
@@ -8740,23 +8100,15 @@
     "newStickerPack": "Nou paquet d'adhesius",
     "stickerPackName": "Nom del paquet d'adhesius",
     "attribution": "Atribució",
-    "skipChatBackup": "Saltar la còpia de seguretat del xat",
-    "skipChatBackupWarning": "Estàs segur? Sense habilitar la còpia de seguretat del xat, podries perdre l'accés als teus missatges si canvies de dispositiu.",
-    "loadingMessages": "Carregant missatges",
-    "setupChatBackup": "Configura la còpia de seguretat del xat",
     "noMoreResultsFound": "No s'han trobat més resultats",
     "chatSearchedUntil": "Xat cercat fins a {time}",
     "federationBaseUrl": "URL base de la federació",
     "clientWellKnownInformation": "Informació coneguda del client:",
     "baseUrl": "URL base",
     "identityServer": "Servidor d'identitat:",
-    "versionWithNumber": "Versió: {version}",
     "logs": "Registres",
-    "advancedConfigs": "Configuracions avançades",
     "advancedConfigurations": "Configuracions avançades",
-    "signInWithLabel": "Inicia sessió amb:",
     "selectAllWords": "Selecciona totes les paraules que escoltes a l'àudio",
-    "joinCourseForActivities": "Uneix-te a un curs per provar activitats.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -8793,18 +8145,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -8812,26 +8152,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -8937,22 +8257,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8981,19 +8285,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9001,15 +8293,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9210,11 +8494,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "En una classe? Posar el vostre codi d'unió aquí.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Destacar automàticament els missatges d'àudio",
     "selectAudioMessagesOnPlayDescription": "Destacar automàticament els missatges d'àudio quan es reprodueixin",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9258,18 +8537,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Aquest curs té temes amb menys de {input} activitats. Si us plau, introdueix un número menor o igual a {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Feu clic aquí per tornar a iniciar sessió.",
     "@clickToLogin": {
@@ -9686,17 +8953,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Un ós groc de dibuix animat amb els braços alçats d'emoció.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Selecciona paraules per aprendre'n més",
     "requireAnalyticsAccessTitle": "Requereix accés a l'analítica per unir-se",
     "requireAnalyticsAccessDesc": "Els participants han de concedir accés a les seves analítiques d'aprenentatge per unir-se a aquest curs",
     "analyticsAccessNoticeTitle": "Accés a l'analítica requerit",
     "analyticsAccessNoticeDesc": "En unir-te a aquest curs, acceptes concedir als administradors accés a les teves analítiques d'aprenentatge.",
-    "skipOnboardingClassCodeDesc": "Aprenent de manera independent? No et preocupis, pots:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9714,10 +8975,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9746,7 +9003,6 @@
     "pickCefrLevelTeacherStepTitle": "Quin nivell ensenyes?",
     "pickCefrLevelStudentStepTitle": "Quin nivell ets?",
     "customCourseStepTitle": "Omple aquest formulari per obtenir un curs personalitzat",
-    "aboutYourClass": "Sobre la teva classe",
     "courseCodeStepErrorMessage": "Si us plau, comprova el teu codi i torna-ho a intentar",
     "institution": "Institut",
     "courseGoals": "Objectius del curs",
@@ -9789,10 +9045,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9909,12 +9161,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logotip de Pangea Chat",
     "introChatDetails": "Digues hola! Presenta't als teus companys participants del curs, troba amics i xateja fora de les activitats.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9958,11 +9205,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Accions d'activitat",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Eines de pronunciació",
     "audioTranscription": "Transcripció d'àudio AI",
     "visualLearnerSupport": "Suport per a aprenents visuals",
@@ -10003,7 +9245,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Uneix-te a un curs que inclogui aquesta activitat per jugar-la.",
     "resizeCoursePanel": "Redimensionar el panell del curs",
     "undo": "Desfer",
     "unlock": "Desbloquejar",
@@ -10017,7 +9258,6 @@
     "addCourseBrowsePublic": "Explora cursos públics",
     "browsePublicCourses": "Explora cursos públics",
     "editProfile": "Edita el perfil",
-    "numObjectives": "{count} objectius",
     "mapSearchHint": "Cerca activitats",
     "mapSearchNoResults": "Sense coincidències a la vista",
     "mapFilterAllLanguages": "Totes les llengües",
@@ -10026,7 +9266,6 @@
     "mapFilterCompleted": "Complet",
     "mapFilterReset": "Restableix",
     "activityTypeConversation": "Conversació",
-    "lockedMissionRequirement": "Acaba la missió anterior per desbloquejar",
     "playAgain": "Juga de nou",
     "reviewActivity": "Revisar",
     "mapEmptyInView": "No hi ha res aquí al teu nivell o idioma. Ampliu els vostres filtres o allunyeu-vos.",
@@ -10041,14 +9280,9 @@
     "scrollToBottom": "Desplaçar-se fins a la part inferior",
     "courseImage": "Imatge del curs",
     "avatarPreview": "Previsualització de l'avatar",
-    "activityPhoto": "Foto de l'activitat",
     "emotePreview": "Previsualització d'emocions: {name}",
     "activityLabel": "Activitat: {title}",
     "resetMapView": "Restableix la vista del mapa",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10101,14 +9335,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10138,10 +9364,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10198,10 +9420,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_cs.arb
+++ b/lib/l10n/intl_cs.arb
@@ -83,11 +83,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Mohou se připojit hosté",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Jste si jistý?",
     "@areYouSure": {
         "type": "String",
@@ -364,11 +359,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Vaše zprávy jsou zabezpečeny bezpečnostním klíčem. Ujistěte se, prosím, že klíč neztratíte.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Bližší údaje o chatu",
     "@chatDetails": {
         "type": "String",
@@ -500,11 +490,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Kontakt byl pozván do skupiny",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Obsah byl nahlášen správcům serveru",
     "@contentHasBeenReported": {
         "type": "String",
@@ -556,11 +541,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Nový prostor",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Aktuálně aktivní",
     "@currentlyActive": {
@@ -704,11 +684,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Šifrování již nebude možné vypnout. Jste si tím jisti?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Šifrováno",
     "@encrypted": {
         "type": "String",
@@ -747,11 +722,6 @@
             }
         }
     },
-    "everythingReady": "Vše připraveno!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Extrémně urážlivé",
     "@extremeOffensive": {
         "type": "String",
@@ -789,11 +759,6 @@
     },
     "group": "Skupina",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Skupina je veřejná",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -887,15 +852,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Pozvat kontakt do {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Pozvaný",
     "@invited": {
@@ -1008,15 +964,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Načíst dalších {count} účastníků",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Načítání… Prosíme vyčkejte.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -1041,15 +988,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Přihlášení k {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Odhlásit",
     "@logout": {
@@ -1113,16 +1051,6 @@
     },
     "noEmotesFound": "Nebyly nalezeny žádné emotikony. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Můžete aktivovat šifrování jakmile místnost přestane být veřejně dostupná.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Zdá se, že služba Firebase Cloud Messaging není ve vašem zařízení k dispozici. Chcete-li i nadále přijímat push oznámení, doporučujeme nainstalovat ntfy. Pomocí ntfy nebo jiného poskytovatele Unified Push můžete přijímat oznámení push zabezpečeným způsobem přenosu dat. Aplikaci ntfy si můžete stáhnout z obchodu PlayStore nebo z webu F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1254,11 +1182,6 @@
     },
     "passwordHasBeenChanged": "Heslo bylo změněno",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Obnova hesla",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1402,11 +1325,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Odstraňit zařízení",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Zrušit zákaz chatu",
     "@unbanFromChat": {
@@ -1561,11 +1479,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Nastavit úroveň oprávnění",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Nastavit stav",
     "@setStatus": {
         "type": "String",
@@ -1607,16 +1520,6 @@
     },
     "sourceCode": "Zdrojové kódy",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Prostor je veřejný",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Název prostoru",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1675,11 +1578,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Přenos z jiného zařízení",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Zkuste odeslat znovu",
     "@tryToSendAgain": {
         "type": "String",
@@ -1735,15 +1633,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 nepřečtený chat} other{{unreadCount} nepřečtené chaty}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} a {count} dalších píší…",
     "@userAndOthersAreTyping": {
@@ -1829,16 +1718,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Video hovor",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Viditelnost historie chatu",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Viditelné pro všechny účastnící se",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1884,23 +1763,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Kdo může provést jakou akci",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Kdo se může připojit do této skupiny",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Proč to chcete nahlásit?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Chcete vymazat zálohu chatu a vytvořit nový bezpečnostní klíč?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1951,18 +1815,12 @@
     "@serverRequiresEmail": {},
     "addToBundle": "Přidat do balíčku",
     "@addToBundle": {},
-    "addAccount": "Přidat účet",
-    "@addAccount": {},
     "bundleName": "Název balíčku",
     "@bundleName": {},
     "link": "Odkaz",
     "@link": {},
-    "yourChatBackupHasBeenSetUp": "Vaše záloha chatu byla nastavena.",
-    "@yourChatBackupHasBeenSetUp": {},
     "editBundlesForAccount": "Upravit balíčky pro tento účet",
     "@editBundlesForAccount": {},
-    "enableMultiAccounts": "(BETA) Na tomto zařízení povolte více účtů",
-    "@enableMultiAccounts": {},
     "oneClientLoggedOut": "Jeden z vašich klientů byl odhlášen",
     "@oneClientLoggedOut": {},
     "removeFromBundle": "Odstranit z tohoto balíčku",
@@ -1983,8 +1841,6 @@
     "@openGallery": {},
     "start": "Start",
     "@start": {},
-    "removeFromSpace": "Odstranit z tohoto místa",
-    "@removeFromSpace": {},
     "commandHint_clearcache": "Vymazat mezipamět",
     "@commandHint_clearcache": {
         "type": "String",
@@ -2034,16 +1890,10 @@
     },
     "emojis": "Emojis",
     "@emojis": {},
-    "voiceCall": "Hlasový hovor",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "Nepodporovaná verze Androidu",
     "@unsupportedAndroidVersion": {},
-    "videoCallsBetaWarning": "Upozorňujeme, že videohovory jsou aktuálně ve verzi beta. Nemusí fungovat podle očekávání nebo fungovat vůbec na všech platformách.",
-    "@videoCallsBetaWarning": {},
     "placeCall": "Zavolejte",
     "@placeCall": {},
-    "emailOrUsername": "E-mail nebo uživatelské jméno",
-    "@emailOrUsername": {},
     "experimentalVideoCalls": "Experimentální videohovory",
     "@experimentalVideoCalls": {},
     "unsupportedAndroidVersionLong": "Tato funkce vyžaduje novější verzi Android. Zkontrolujte prosím aktualizace nebo podporu Lineage OS.",
@@ -2137,8 +1987,6 @@
     "@widgetNameError": {},
     "errorAddingWidget": "Chyba při přidávání widgetu.",
     "@errorAddingWidget": {},
-    "disableEncryptionWarning": "Z bezpečnostních důvodů nemůžete vypnout šifrování v chatu, kde již bylo dříve zapnuto.",
-    "@disableEncryptionWarning": {},
     "confirmMatrixId": "Prosím, potvrďte vaše Matrix ID, abyste mohli smazat váš účet.",
     "@confirmMatrixId": {},
     "commandHint_googly": "Poslat kroutící se očička",
@@ -2190,8 +2038,6 @@
             }
         }
     },
-    "storeInAndroidKeystore": "Uložit v Android KeyStore",
-    "@storeInAndroidKeystore": {},
     "dehydrate": "Exportovat sezení a promazat zařízení",
     "@dehydrate": {},
     "newGroup": "Nová skupina",
@@ -2200,18 +2046,12 @@
     "@doNotShowAgain": {},
     "commandHint_markasdm": "Označit jako místnost přímé konverzace s daným Matrix ID",
     "@commandHint_markasdm": {},
-    "recoveryKey": "Klíč k obnovení",
-    "@recoveryKey": {},
     "hydrate": "Obnovit ze záložního souboru",
     "@hydrate": {},
-    "pleaseEnterRecoveryKey": "Prosím vložte váš klíč pro obnovení:",
-    "@pleaseEnterRecoveryKey": {},
     "createGroup": "Vytvořit skupinu",
     "@createGroup": {},
     "shareInviteLink": "Sdílet pozvánku",
     "@shareInviteLink": {},
-    "pleaseEnterRecoveryKeyDescription": "K odemknutí vašich starých zpráv prosím vložte váš klíč k obnovení vygenerovaný v předchozím sezení. Váš klíč k obnovení NENÍ vaše heslo.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "setColorTheme": "Nastavit barvy:",
     "@setColorTheme": {},
     "importEmojis": "Importovat Emoji",
@@ -2224,8 +2064,6 @@
     "@replace": {},
     "users": "Uživatelé",
     "@users": {},
-    "storeInAppleKeyChain": "Uložit v Apple KeyChain",
-    "@storeInAppleKeyChain": {},
     "jumpToLastReadMessage": "Skočit na naposledy přečtenou zprávu",
     "@jumpToLastReadMessage": {},
     "redactedBy": "Smazáno uživatelem {username}",
@@ -2249,8 +2087,6 @@
     "@allSpaces": {},
     "noOtherDevicesFound": "Žádná ostatní zařízení nebyla nalezena",
     "@noOtherDevicesFound": {},
-    "chatDescription": "Popis konverzace",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "Popis konverzace byl změněn",
     "@chatDescriptionHasBeenChanged": {},
     "noChatDescriptionYet": "Zatím nebyl vytvořen žádný popis konverzace.",
@@ -2274,26 +2110,10 @@
             }
         }
     },
-    "newSpaceDescription": "Prostory umožňují organizovat Vaše konverzace a vytvářet soukromé nebo veřejné komunity.",
-    "@newSpaceDescription": {},
-    "setTheme": "Nastavit vzhled:",
-    "@setTheme": {},
     "sendTypingNotifications": "Posílat oznámení o psaní",
     "@sendTypingNotifications": {},
     "commandHint_markasgroup": "Označit jako skupinu",
     "@commandHint_markasgroup": {},
-    "recoveryKeyLost": "Ztracený klíč k obnovení?",
-    "@recoveryKeyLost": {},
-    "unlockOldMessages": "Odemknout staré zprávy",
-    "@unlockOldMessages": {},
-    "foregroundServiceRunning": "Toto oznámení se zobrazuje když běží služba na pozadí.",
-    "@foregroundServiceRunning": {},
-    "screenSharingDetail": "Sdílíte svou obrazovku přes FluffyChat",
-    "@screenSharingDetail": {},
-    "encryptThisChat": "Zašifrovat tuto konverzaci",
-    "@encryptThisChat": {},
-    "sorryThatsNotPossible": "Omlouváme se… to není možné",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "Klíče zařízení:",
     "@deviceKeys": {},
     "reopenChat": "Znovu otevřít konverzaci",
@@ -2315,8 +2135,6 @@
     },
     "newSpace": "Nový prostor",
     "@newSpace": {},
-    "screenSharingTitle": "sdílení obrazovky",
-    "@screenSharingTitle": {},
     "user": "Uživatel",
     "@user": {},
     "fileHasBeenSavedAt": "Soubor uložen do {path}",
@@ -2332,12 +2150,6 @@
     "@custom": {},
     "dehydrateWarning": "Tuto akci nelze vzít zpět. Ujistěte se že záložní soubor máte bezpečně uložen.",
     "@dehydrateWarning": {},
-    "storeInSecureStorageDescription": "Klíč k obnovení uložte v zabezpečeném úložišti tohoto zařízení.",
-    "@storeInSecureStorageDescription": {},
-    "saveKeyManuallyDescription": "Uložte tento klíč manuálně pomocí systémového dialogu sdílení nebo zkopírováním do schránky.",
-    "@saveKeyManuallyDescription": {},
-    "storeSecurlyOnThisDevice": "Uložit bezpečně na tomto zařízení",
-    "@storeSecurlyOnThisDevice": {},
     "countFiles": "{count} souborů",
     "@countFiles": {
         "placeholders": {
@@ -2353,16 +2165,10 @@
     },
     "appLockDescription": "Zamknout aplikaci pomocí PIN kódu když není používána",
     "@appLockDescription": {},
-    "globalChatId": "Globální ID chatu",
-    "@globalChatId": {},
-    "accessAndVisibility": "Přístup a viditelnost",
-    "@accessAndVisibility": {},
     "calls": "Volání",
     "@calls": {},
     "customEmojisAndStickers": "Vlastní emoji a nálepky",
     "@customEmojisAndStickers": {},
-    "accessAndVisibilityDescription": "Kdo se může připojit a najít tuto konverzaci.",
-    "@accessAndVisibilityDescription": {},
     "customEmojisAndStickersBody": "Přidat nebo sdílet vlastní emoji nebo nálepky, které mohou být použité v konverzaci.",
     "@customEmojisAndStickersBody": {},
     "swipeRightToLeftToReply": "Potáhněte z prava do leva pro odpověď",
@@ -2419,15 +2225,6 @@
     "@ignoreUser": {},
     "normalUser": "Normalní uživatel",
     "@normalUser": {},
-    "countInvited": "{count} pozváno",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "invitedBy": "📩 Pozván {user}",
     "@invitedBy": {
         "placeholders": {
@@ -2444,8 +2241,6 @@
             }
         }
     },
-    "usersMustKnock": "Uživatelé musí zaklepat",
-    "@usersMustKnock": {},
     "setCustomPermissionLevel": "Nastavit vlastní úroveň oprávnění",
     "@setCustomPermissionLevel": {},
     "changedTheChatDescription": "{username} změnil/a popis konverzace",
@@ -2456,8 +2251,6 @@
     "@checkList": {},
     "knock": "Zaklepat",
     "@knock": {},
-    "enterSpace": "Vstoupit do prostoru",
-    "@enterSpace": {},
     "hidePresences": "Skrýt seznam událostí?",
     "@hidePresences": {},
     "noBackupWarning": "Pozor! Bez povolení zálohování konverzací ztratíte přístup k zašifrovaným zprávám. Důrazně doporučujeme zálohování konverzací před odhlášením povolit.",
@@ -2507,25 +2300,10 @@
     "@yourGlobalUserIdIs": {},
     "knocking": "Klepání",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Konverzaci naleznete vyhledáváním na {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "searchChatsRooms": "Vyhledat #konverzace, @uživatele...",
-    "@searchChatsRooms": {},
     "nothingFound": "Nic nenalezeno...",
     "@nothingFound": {},
     "groupName": "Název skupiny",
     "@groupName": {},
-    "createGroupAndInviteUsers": "Vytvořit skupinu a pozvat uživatele",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "Skupinu naleznete vyhledávním",
-    "@groupCanBeFoundViaSearch": {},
     "startConversation": "Začít konverzaci",
     "@startConversation": {},
     "commandHint_sendraw": "Odeslat soubor json",
@@ -2550,23 +2328,17 @@
     "@passwordsDoNotMatch": {},
     "passwordIsWrong": "Zadané heslo je nesprávné",
     "@passwordIsWrong": {},
-    "publicChatAddresses": "Adresy veřejných konverzací",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Vytvořit novou adresu",
-    "@createNewAddress": {},
     "thisDevice": "Toto zařzení:",
     "@thisDevice": {},
     "setPermissionsLevelDescription": "Vyberte níže předdefinovanou roli nebo zadejte vlastní úroveň oprávnění mezi 0 a 100.",
     "commandHint_roomupgrade": "Upgradujte tento pokoj na danou verzi pokoje",
     "sendImages": "Odeslat {count} obrázek",
     "synchronizingPleaseWaitCounter": "Synchronizuji… ({percentage}%)",
-    "noOneCanJoin": "Nikdo se nemůže připojit",
     "kickUserDescription": "Uživatel je vyhozen z chatu, ale není zablokován. Ve veřejných chatech se může kdykoli znovu připojit.",
     "noUsersFoundWithQuery": "Bohužel nebyl nalezen žádný uživatel s \"{query}\". Zkontrolujte, zda jste neudělali překlep.",
     "wrongRecoveryKey": "Omlouváme se... zdá se, že toto není správný klíč pro obnovení.",
     "joinSpace": "Připojit se ke prostoru",
     "publicSpaces": "Veřejné prostory",
-    "addChatOrSubSpace": "Přidat chat nebo podprostor",
     "subspace": "Podprostor",
     "decline": "Odmítnout",
     "initAppError": "Při inicializaci aplikace došlo k chybě",
@@ -2574,15 +2346,11 @@
     "searchMore": "Hledat více...",
     "gallery": "Galerie",
     "files": "Soubory",
-    "sessionLostBody": "Vaše relace byla ztracena. Prosím, nahlaste tuto chybu vývojářům na {url}. Chybová zpráva je: {error}",
-    "restoreSessionBody": "Aplikace se nyní snaží obnovit vaši relaci ze zálohy. Prosím, nahlaste tuto chybu vývojářům na {url}. Chybová zpráva je: {error}",
     "sendReadReceipts": "Odesílat potvrzení přečtení",
     "sendTypingNotificationsDescription": "Ostatní účastníci chatu vidí, když píšete novou zprávu.",
     "sendReadReceiptsDescription": "Ostatní účastníci chatu vidí, kdy jste přečetli zprávu.",
     "formattedMessages": "Formátované zprávy",
     "formattedMessagesDescription": "Zobrazit bohatý obsah zpráv, například tučný text, pomocí markdownu.",
-    "verifyOtherUser": "🔐 Ověřit jiného uživatele",
-    "verifyOtherUserDescription": "Pokud ověříte jiného uživatele, můžete si být jisti, že opravdu píšete tomu správnému. 💪\n\nKdyž zahájíte ověření, uvidíte v aplikaci vyskakovací okno. Tam uvidíte sérii emoji nebo čísel, které si musíte navzájem porovnat.\n\nNejlepší je se setkat nebo začít videohovor. 👩‍💻",
     "verifyOtherDevice": "🔐 Ověřit jiné zařízení",
     "verifyOtherDeviceDescription": "Když ověříte jiné zařízení, mohou si tato zařízení vyměňovat klíče, čímž se zvýší vaše celková bezpečnost. 💪 Když zahájíte ověření, objeví se v aplikaci vyskakovací okno na obou zařízeních. Tam uvidíte sérii emoji nebo čísel, které si musíte navzájem porovnat. Nejlepší je mít obě zařízení po ruce před začátkem ověření. 🤓",
     "acceptedKeyVerification": "{sender} přijal ověření klíče",
@@ -2618,10 +2386,6 @@
     "updateInstalled": "🎉 Nainstalována aktualizace {version}!",
     "changelog": "Seznam změn",
     "sendCanceled": "Odeslání zrušeno",
-    "loginWithMatrixId": "Přihlásit se pomocí Matrix-ID",
-    "discoverHomeservers": "Objevte domácí servery",
-    "whatIsAHomeserver": "Co je domácí server?",
-    "homeserverDescription": "Všechna vaše data jsou uložena na domácím serveru, stejně jako u poskytovatele e-mailu. Můžete si vybrat, který domácí server chcete používat, a přesto komunikovat se všemi. Více na https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Zdá se, že nejde o kompatibilní domácí server. Špatná URL?",
     "calculatingFileSize": "Vypočítávám velikost souboru...",
     "prepareSendingAttachment": "Připravit odeslání přílohy...",
@@ -2633,11 +2397,9 @@
     "oneOfYourDevicesIsNotVerified": "Jedno z vašich zařízení není ověřeno",
     "noticeChatBackupDeviceVerification": "Poznámka: Když připojíte všechna svá zařízení k záloze chatu, jsou automaticky ověřena.",
     "continueText": "Pokračovat",
-    "welcomeText": "Ahoj ahoj 👋 Toto je FluffyChat. Můžete se přihlásit na jakýkoli domácí server, který je kompatibilní s https://matrix.org. A pak si můžete psát s kýmkoli. Je to obrovská decentralizovaná síť pro zasílání zpráv!",
     "blur": "Rozostření:",
     "opacity": "Průhlednost:",
     "setWallpaper": "Nastavit pozadí",
-    "manageAccount": "Spravovat účet",
     "noContactInformationProvided": "Server neposkytuje žádné platné kontaktní informace",
     "contactServerAdmin": "Kontaktovat správce serveru",
     "contactServerSecurity": "Kontaktovat bezpečnost serveru",
@@ -2656,11 +2418,8 @@
     "unableToJoinChat": "Nelze se připojit ke chatu. Možná druhá strana již ukončila konverzaci.",
     "previous": "Předchozí",
     "otherPartyNotLoggedIn": "Druhá strana momentálně není přihlášena a nemůže tak přijímat zprávy!",
-    "appWantsToUseForLogin": "Použít '{server}' pro přihlášení",
-    "appWantsToUseForLoginDescription": "Tímto umožňujete aplikaci a webové stránce sdílet informace o vás.",
     "open": "Otevřít",
     "waitingForServer": "Čekání na server...",
-    "appIntroduction": "FluffyChat vám umožňuje chatovat s přáteli přes různé messengery. Více se dozvíte na https://matrix.org nebo jednoduše klepněte na *Pokračovat*.",
     "newChatRequest": "📩 Nová žádost o chat",
     "contentNotificationSettings": "Nastavení oznámení obsahu",
     "generalNotificationSettings": "Obecná nastavení oznámení",
@@ -2735,11 +2494,9 @@
     "taTooltip": "L2 použití s překladatelskou asistencí",
     "interactiveTranslatorSliderHeader": "Interaktivní překladač",
     "interactiveGrammarSliderHeader": "Interaktivní kontrola gramatiky",
-    "interactiveTranslatorRequired": "Požadováno",
     "waTooltip": "Použití L2 bez pomoci",
     "interactiveTranslator": "Pomoc s překladem",
     "noIdenticalLanguages": "Prosím, vyberte různé základní a cílové jazyky",
-    "searchBy": "Hledat podle země a jazyků",
     "joinWithClassCode": "Připojit se ke kurzu",
     "languageLevelPreA1": "Nováček Nízká (Pre A1)",
     "languageLevelA1": "Nováček Mid (A1)",
@@ -2760,19 +2517,14 @@
     "saveChanges": "Uložit změny",
     "publicProfileTitle": "Povolit, aby mě profil byl nalezen ve vyhledávání",
     "publicProfileDesc": "Zapnutím umožníte ostatním uživatelům najít váš profil v globálním vyhledávacím panelu a posílat žádosti o chat. V tuto chvíli můžete požadavek přijmout nebo odmítnout.",
-    "errorDisableIT": "Pomoc s překladem je vypnuta.",
-    "errorDisableIGC": "Pomoc s gramatikou je vypnuta.",
     "errorDisableITUserDesc": "Klikněte zde pro aktualizaci nastavení pomoci s překladem",
     "errorDisableIGCUserDesc": "Klikněte zde pro aktualizaci nastavení pomoci s gramatikou",
     "errorDisableITClassDesc": "Pomoc s překladem je vypnuta pro kurz, ve kterém je tento chat.",
     "errorDisableIGCClassDesc": "Pomoc s gramatikou je vypnuta pro kurz, ve kterém je tento chat.",
-    "error405Title": "Jazyky nejsou nastaveny",
     "error405Desc": "Prosím, nastavte své jazyky v Hlavním menu > Nastavení učení.",
     "termsAndConditions": "Obchodními podmínkami",
     "andCertifyIAmAtLeast13YearsOfAge": "a potvrzuji, že mám alespoň 16 let.",
-    "error502504Title": "Wow, je online hodně studentů!",
     "error502504Desc": "Nástroje pro překlad a gramatiku mohou být pomalé nebo nedostupné, zatímco se boty Pangea dožene.",
-    "error404Title": "Chyba překladu!",
     "error404Desc": "Bot Pangea si není jistý, jak to přeložit...",
     "errorPleaseRefresh": "Řešíme to! Prosím, načtěte stránku znovu a zkuste to znovu.",
     "connectedToStaging": "Připojeno k testovací verzi",
@@ -2810,13 +2562,9 @@
     "definitionsToolName": "Definice slov",
     "definitionsToolDescription": "Když je povoleno, slova podtržená modře lze kliknutím zobrazit jejich definice. Klikněte na zprávy pro přístup k definicím.",
     "welcomeBack": "Vítejte zpět! Pokud jste byli součástí pilotního projektu 2023-2024, kontaktujte nás ohledně vaší speciální pilotní předplatného. Pokud jste učitel, který (nebo vaše instituce) zakoupil licence pro vaši třídu, kontaktujte nás ohledně vašeho učitelského předplatného.",
-    "downloadTxtFile": "Stáhnout textový soubor",
-    "downloadCSVFile": "Stáhnout CSV soubor",
     "promotionalSubscriptionDesc": "Aktuálně máte doživotní promo předplatné. Kontaktujte support@pangea.chat pro pomoc s změnou předplatného.",
     "originalSubscriptionPlatform": "Předplatné zakoupeno přes {purchasePlatform}",
     "oneWeekTrial": "Jedno-týdenní zkušební verze",
-    "downloadXLSXFile": "Stáhnout Excel soubor",
-    "unkDisplayName": "Neznámý",
     "wwCountryDisplayName": "Celosvětově",
     "afCountryDisplayName": "Afghánistán",
     "axCountryDisplayName": "Alandy",
@@ -3111,7 +2859,6 @@
     "chatCapacityHasBeenChanged": "Kapacita chatu byla změněna",
     "chatCapacitySetTooLow": "Kapacita chatu musí být alespoň {count}.",
     "chatCapacityExplanation": "Kapacita chatu omezuje počet členů povolených v chatu.",
-    "tooManyRequest": "Příliš mnoho požadavků, zkuste to prosím později.",
     "enterNumber": "Zadejte celé číslo.",
     "practice": "Procvičování",
     "versionNotFound": "Verze nenalezena",
@@ -3121,7 +2868,6 @@
     "deleteSubscriptionWarningTitle": "Máte aktivní předplatné",
     "deleteSubscriptionWarningBody": "Smazání vašeho účtu automaticky nezruší vaše předplatné.",
     "manageSubscription": "Spravovat předplatné",
-    "error520Title": "Prosím zkuste to znovu.",
     "error520Desc": "Omlouváme se, nerozuměli jsme vaší zprávě...",
     "wordsUsed": "Použité slova",
     "level": "Úroveň",
@@ -3139,7 +2885,6 @@
     "other": "Jiné",
     "levelShort": "ÚROVEŇ {level}",
     "noCapacityLimit": "Žádný limit kapacity",
-    "downloadGroupText": "Stáhnout text skupiny",
     "notificationsOn": "Oznámení zapnuta",
     "notificationsOff": "Oznámení vypnuta",
     "joinWithCode": "Připojit se s kódem",
@@ -3203,24 +2948,12 @@
     "whatIsTheMorphTag": "Co je {morphologicalFeature} u '{wordForm}'?",
     "dataAvailable": "Dostupnost dat",
     "available": "Dostupné",
-    "pangeaBotIsFallible": "Pangea Bot dělá také chyby!",
-    "whatIsMeaning": "Co znamená '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Spojte významy se slovy ve zprávě!",
-    "doubleClickToEdit": "Dvakrát klikněte pro úpravu.",
-    "topicLabel": "Téma",
-    "topicPlaceholder": "Vyberte téma...",
-    "modePlaceholder": "Vyberte režim...",
-    "learningObjectiveLabel": "Cíl učení",
-    "learningObjectivePlaceholder": "Vyberte cíl učení...",
-    "targetLanguageLabel": "Cílový jazyk",
     "cefrLevelLabel": "Úroveň CEFR",
     "image": "Obrázek",
     "video": "Video",
     "nan": "Nepoužitelné",
-    "addVocabulary": "Přidat slovní zásobu",
     "instructions": "Pokyny",
-    "numberOfLearners": "Počet studentů",
-    "mustBeInteger": "Musí být celé číslo např. 1, 2, 3, ...",
     "constructUsePvmDesc": "Vytvořeno ve formě hlasové zprávy",
     "leaveSpaceDescription": "Opuštěním kurzu opustíte všechny chaty v něm. Ostatní uživatelé uvidí, že jste kurz opustili.",
     "constructUseCorMmDesc": "Správný význam zprávy",
@@ -3235,7 +2968,6 @@
     "ttsDisabledBody": "Můžete povolit převod textu na řeč v nastavení vašeho učení",
     "noSpaceDescriptionYet": "Ještě nebyl vytvořen popis kurzu.",
     "tooLargeToSend": "Tato zpráva je příliš velká na odeslání",
-    "exitWithoutSaving": "Opravdu chcete odejít bez uložení?",
     "enableAutocorrectPopupTitle": "Přidejte klávesnici cílového jazyka přechodem na:",
     "enableAutocorrectPopupSteps": "  • Nastavení\n  • Obecné\n  • Klávesnice\n  • Klávesnice\n  • Přidat novou klávesnici",
     "enableAutocorrectPopupDescription": "Po výběru jazyka můžete kliknout na malou ikonu glóbu v levém dolním rohu klávesnice, abyste aktivovali nově nainstalovanou klávesnici.",
@@ -3246,11 +2978,8 @@
     "displayName": "Zobrazované jméno",
     "leaveRoomDescription": "Chystáte se opustit tento chat. Ostatní uživatelé uvidí, že jste chat opustili.",
     "confirmUserId": "Prosím potvrďte své uživatelské jméno v Pangea Chatu, abyste mohli smazat svůj účet.",
-    "startingToday": "Od dnešního dne",
-    "oneWeekFreeTrial": "Týdenní bezplatná zkušební doba",
     "paidSubscriptionStarts": "Začíná {startDate}",
     "cancelInSubscriptionSettings": " • Zrušit kdykoli v nastavení předplatného",
-    "cancelToAvoidCharges": " • Zrušit před {trialEnds} a vyhnout se poplatkům",
     "downloadGboard": "Stáhnout Gboard",
     "autocorrectNotAvailable": "Bohužel vaše platforma momentálně nepodporuje tuto funkci. Sledujte další vývoj!",
     "pleaseUpdateApp": "Prosím aktualizujte aplikaci, abyste mohli pokračovat.",
@@ -3260,17 +2989,12 @@
     "knockSpaceSuccess": "Požádali jste o připojení k tomuto kurzu! Administrátor odpoví na vaši žádost, jakmile ji obdrží 😄",
     "chooseWordAudioInstructionsBody": "Poslouchejte úplnou zprávu. Poté přiřaďte audia ke slovům.",
     "chooseMorphsInstructionsBody": "Klikněte na puzzle kousky pro gramatické otázky!",
-    "pleaseEnterInt": "Zadejte číslo",
     "home": "Domů",
     "join": "Připojit se",
     "resetInstructionTooltipsTitle": "Obnovit instrukční nápovědy",
     "resetInstructionTooltipsDesc": "Klikněte pro zobrazení instrukčních nápověd, jako pro úplného nováčka.",
-    "randomize": "Náhodně",
     "clear": "Vymazat",
-    "featuredActivities": "Zvýrazněné",
     "save": "Uložit",
-    "startChat": "Začít chat",
-    "translationProblem": "Problém s překladem",
     "askToJoin": "Požádat o připojení",
     "emptyChatWarningTitle": "Chat je prázdný",
     "emptyChatWarningDesc": "Ještě jste nikoho nezval do svého chatu. Přejděte do nastavení chatu, abyste pozvali své kontakty nebo bota. Můžete to udělat i později.",
@@ -3300,17 +3024,13 @@
     "timesUsedIndependently": "Počet použití samostatně",
     "timesUsedWithAssistance": "Počet použití s pomocí",
     "shareInviteCode": "Sdílet kód pozvánky: {code}",
-    "leaderboard": "Žebříček",
     "skipForNow": "Přeskočit zatím",
     "permissions": "Oprávnění",
     "spaceChildPermission": "Kdo může přidat nové chaty do tohoto kurzu",
-    "addEnvironmentOverride": "Přidat přepsání prostředí",
     "defaultOption": "Výchozí",
     "deleteChatDesc": "Jste si jistí, že chcete smazat tento chat? Bude smazán pro všechny účastníky a všechny zprávy v chatu již nebudou dostupné pro praxi nebo analytiku učení.",
     "deleteSpaceDesc": "Kurz a jakékoli vybrané chaty budou smazány pro všechny účastníky a všechny zprávy v chatu již nebudou dostupné pro praxi nebo analytiku učení. Tato akce nelze vrátit zpět.",
     "launch": "Spustit",
-    "searchChats": "Hledat chaty",
-    "maxFifty": "Max 50",
     "configureSpace": "Nastavit kurz",
     "pinMessages": " Připnout zprávy",
     "setJoinRules": "Nastavit pravidla připojení",
@@ -3344,9 +3064,6 @@
     "failedToFetchTranscription": "Nepodařilo se načíst přepis",
     "deleteEmptySpaceDesc": "Kurz bude smazán pro všechny účastníky. Tato akce nelze vrátit zpět.",
     "regenerate": "Vygenerovat znovu",
-    "mySavedActivities": "Mé uložené aktivity",
-    "noSavedActivities": "Žádné uložené aktivity",
-    "saveActivity": "Uložit tuto aktivitu",
     "failedToPlayVideo": "Nepodařilo se přehrát video",
     "done": "Hotovo",
     "inThisSpace": "V tomto kurzu",
@@ -3357,13 +3074,9 @@
     "numInvited": "{count} pozváno",
     "saved": "Uloženo",
     "reset": "Obnovit",
-    "errorFetchingActivitiesMessage": "Nepodařilo se načíst aktivity",
     "errorFetchingDefinition": "Nepodařilo se načíst definici",
     "errorProcessAnalytics": "Nepodařilo se zpracovat analytiku",
     "errorDownloading": "Stahování selhalo",
-    "errorLoadingSpaceChildren": "Nepodařilo se načíst chaty v tomto kurzu",
-    "unexpectedError": "Neočekávaná chyba.",
-    "pleaseReload": "Prosím, načtěte stránku znovu a zkuste to znovu.",
     "translationError": "Chyba překladu",
     "check": "Zkontrolovat",
     "unableToFindRoom": "Nebyly nalezeny žádné chaty nebo kurzy s tímto kódem. Zkuste to prosím znovu.",
@@ -3372,19 +3085,14 @@
     "request": "Žádost",
     "requestAll": "Žádat vše",
     "confirmMessageUnpin": "Jste si jistí, že chcete odpojit tuto zprávu?",
-    "saveAndLaunch": "Uložit a spustit",
-    "launchToSpace": "Spustit do kurzu",
     "pending": "Čeká se",
     "inactive": "Neaktivní",
-    "confirmRole": "Potvrdit roli",
     "openRoleLabel": "Otevřeno",
     "finishedTheActivity": "🎯 {username} ukončil tuto aktivitu",
     "activitySummaryError": "Souhrny aktivit nejsou k dispozici",
     "requestSummaries": "Požádat o souhrny",
-    "generatingNewActivities": "Jste první uživatel tohoto jazykového páru! Počkejte chvíli, připravujeme aktivity právě pro vás.",
     "requestAccessTitle": "Požádat o přístup k analýzám?",
     "requestAccessDesc": "Chcete požádat o přístup k zobrazení analytiky účastníků?\n\nPokud se účastníci shodnou, správci tohoto kurzu budou moci vidět:\n    • celkovou slovní zásobu\n    • celkové gramatické koncepty\n    • počet dokončených aktivit\n    • konkrétní gramatické koncepty použité správně a nesprávně\n\nNebudou moci vidět:\n    • zprávy v chatech mimo kurz\n    • seznam slovní zásoby",
-    "requestAccess": "Požádat o přístup ({count})",
     "analyticsInactiveTitle": "Žádosti o přístup od neaktivních uživatelů nemohly být odeslány",
     "analyticsInactiveDesc": "Neaktivní uživatelé, kteří se od té doby, co byla tato funkce představena, nepřihlásili, neuvidí vaši žádost.\n\nTlačítko Žádost se zobrazí, jakmile se vrátí. Můžete požadavek znovu odeslat později kliknutím na tlačítko Žádost pod jejich jménem, když bude dostupné.",
     "accessRequestedTitle": "Žádost o přístup k analytice",
@@ -3407,8 +3115,6 @@
     "accessDesc": "Můžete udělat svůj kurz otevřený pro celý svět! Nebo ho udělat soukromým a zabezpečeným.",
     "createGroupChatDesc": "Zatímco se začínají a končí aktivity, skupinové chaty zůstanou otevřené pro rutinní komunikaci.",
     "deleteDesc": "Pouze správci mohou smazat kurz. Jedná se o destruktivní akci, která odstraní všechny uživatele a smaže všechny vybrané chaty v kurzu. Postupujte opatrně.",
-    "noCourseFound": "Ó, tento kurz potřebuje plán!\n\nPlány kurzů jsou posloupností témat a aktivit konverzace.",
-    "additionalParticipants": "+ {num} dalších",
     "whatNow": "Co teď?",
     "chooseNextActivity": "Vyberte si další aktivitu!",
     "letsGo": "Jdeme na to",
@@ -3421,13 +3127,11 @@
     "waitNotDone": "Počkej, ještě nejsem hotový!",
     "waitingForOthersToFinish": "Čekám na ostatní, až dokončí...",
     "generatingSummary": "Analyzuji chat a generuji výsledky",
-    "findCourse": "Najít kurz",
     "pingParticipantsNotification": "{user} hledá uživatele, kteří se připojí ke schůzce v {room}",
     "course": "Kurz",
     "courses": "Kurzy",
     "goToCourse": "Přejít na kurz: {course}",
     "activityComplete": "Tato aktivita byla dokončena. Shrnutí aktivity by mělo být k dispozici níže.",
-    "startNewSession": "Začít novou relaci",
     "joinOpenSession": "Připojit se k otevřené relaci",
     "activityNotFound": "Aktivita nenalezena",
     "myActivities": "Mé aktivity",
@@ -3494,10 +3198,6 @@
             }
         }
     },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@kickUserDescription": {
         "type": "String",
         "placeholders": {}
@@ -3519,10 +3219,6 @@
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3558,28 +3254,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -3597,14 +3271,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3797,22 +3463,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -3868,10 +3518,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -3881,10 +3527,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -3960,27 +3602,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4298,10 +3924,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4311,10 +3933,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4402,14 +4020,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4426,10 +4036,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4442,15 +4048,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4602,14 +4200,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4623,14 +4213,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5853,10 +5435,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5897,10 +5475,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5973,10 +5547,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6246,47 +5816,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6306,19 +5836,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6382,10 +5900,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6426,14 +5940,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6445,14 +5951,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6490,10 +5988,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6510,27 +6004,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6654,10 +6132,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6667,10 +6141,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6687,14 +6157,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6834,18 +6296,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6894,10 +6344,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6907,18 +6353,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6961,23 +6395,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7001,10 +6423,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7012,14 +6430,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7124,18 +6534,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7188,10 +6586,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7218,10 +6612,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7402,7 +6792,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Zítra se vraťte pro aktualizace aktivit.",
-    "activityDropdownDesc": "Když dokončíte tuto aktivitu, klikněte níže",
     "languageMismatchTitle": "Neshoda jazyka",
     "languageMismatchDesc": "Váš cílový jazyk se neshoduje s jazykem této aktivity. Chcete aktualizovat svůj cílový jazyk?",
     "reportWordIssueTooltip": "Nahlásit problém s informacemi o slově",
@@ -7415,10 +6804,6 @@
     "selectAll": "Vybrat vše",
     "deselectAll": "Zrušit výběr všeho",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7467,17 +6852,11 @@
         "placeholders": {}
     },
     "startOwn": "Začít svůj vlastní",
-    "joinCourseDesc": "Každý kurz má 8-10 sekvenčních témat s řadou aktivit založených na úkolech pro učení jazyků.",
     "newMessageInPangeaChat": "📝 Nová zpráva v chatu Pangea",
     "shareCourse": "Sdílet kurz",
     "addCourse": "Přidat kurz",
-    "joinPublicCourse": "Připojit se k veřejnému kurzu",
     "vocabLevelsDesc": "Zde se objeví slovíčka, jakmile je vylepšíte na vyšší úroveň!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7490,10 +6869,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7512,7 +6887,6 @@
     "emojiView": "Zobrazení emoji",
     "feedbackDialogDesc": "Dělám chyby také! Můžete mi pomoci se zlepšit?",
     "contactHasBeenInvitedToTheCourse": "Kontaktní osoba byla pozvána do kurzu",
-    "activityStatsButtonTooltip": "Informace o aktivitě",
     "allow": "Povolit",
     "deny": "Odmítnout",
     "enabledRenewal": "Povolit obnovení předplatného",
@@ -7780,10 +7154,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8839,16 +8209,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktivity k odemčení dalšího tématu",
-    "activitiesToUnlockTopicDesc": "Nastavte počet aktivit k odemčení dalšího tématu kurzu",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Správná praxe definice slovní zásoby",
     "constructUseIncLMDesc": "Nesprávná praxe definice slovní zásoby",
     "constructUseCorLADesc": "Správná praxe audio slovní zásoby",
@@ -8856,7 +8216,6 @@
     "constructUseBonus": "Bonus během praxe slovní zásoby",
     "practiceVocab": "Procvičování slovní zásoby",
     "selectMeaning": "Vyberte význam",
-    "selectAudio": "Vyberte odpovídající audio",
     "anotherRound": "Další kolo",
     "activitySettingsOverrideWarning": "Jazyk a jazyková úroveň určené plánem aktivity",
     "voice": "Hlas",
@@ -8888,10 +8247,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8909,12 +8264,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Stahování zahájeno",
     "webDownloadPermissionMessage": "Pokud váš prohlížeč blokuje stahování, povolte prosím stahování pro tuto stránku.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9009,11 +8359,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Něco se pokazilo a my na tom tvrdě pracujeme. Zkontrolujte to prosím později.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Povolit asistenci při psaní",
     "autoIGCToolDescription": "Automaticky spouštět nástroje Pangea Chat pro opravu odeslaných zpráv do cílového jazyka.",
     "@autoIGCToolName": {
@@ -9069,24 +8414,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatika",
-    "spanTypeWordChoice": "Výběr slov",
     "spanTypeSpelling": "Pravopis",
     "spanTypePunctuation": "Interpunkce",
     "spanTypeStyle": "Styl",
     "spanTypeFluency": "Plynulost",
     "spanTypeAccents": "Přízvuky",
     "spanTypeCapitalization": "Velká písmena",
-    "spanTypeCorrection": "Oprava",
     "spanFeedbackTitle": "Nahlásit problém s opravou",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9111,10 +8445,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9125,13 +8455,7 @@
     "longPressToRecordVoiceMessage": "Dlouze stiskněte pro nahrání hlasové zprávy.",
     "pause": "Pauza",
     "resume": "Pokračovat",
-    "newSubSpace": "Nový podprostor",
-    "moveToDifferentSpace": "Přesunout do jiného prostoru",
-    "removeFromSpaceDescription": "Chat bude odstraněn z prostoru, ale stále se zobrazí ve vašem seznamu chatů.",
     "countChats": "{chats} chaty",
-    "spaceMemberOf": "Člen prostoru {spaces}",
-    "spaceMemberOfCanKnock": "Člen prostoru {spaces} může zaklepat",
-    "donate": "Darovat",
     "startedAPoll": "{username} zahájil anketu.",
     "poll": "Anketa",
     "startPoll": "Zahájit anketu",
@@ -9155,23 +8479,15 @@
     "newStickerPack": "Nový balíček nálepek",
     "stickerPackName": "Název balíčku nálepek",
     "attribution": "Připsání",
-    "skipChatBackup": "Přeskočit zálohu chatu",
-    "skipChatBackupWarning": "Jste si jisti? Bez povolení zálohy chatu můžete ztratit přístup k vašim zprávám, pokud přepnete zařízení.",
-    "loadingMessages": "Načítání zpráv",
-    "setupChatBackup": "Nastavit zálohu chatu",
     "noMoreResultsFound": "Nebyly nalezeny žádné další výsledky",
     "chatSearchedUntil": "Chat prohledán do {time}",
     "federationBaseUrl": "Základní URL federace",
     "clientWellKnownInformation": "Informace o klientovi:",
     "baseUrl": "Základní URL",
     "identityServer": "Identitní server:",
-    "versionWithNumber": "Verze: {version}",
     "logs": "Protokoly",
-    "advancedConfigs": "Pokročilé konfigurace",
     "advancedConfigurations": "Pokročilé konfigurace",
-    "signInWithLabel": "Přihlásit se pomocí:",
     "selectAllWords": "Vyberte všechna slova, která slyšíte v audionahrávce",
-    "joinCourseForActivities": "Připojte se k kurzu, abyste vyzkoušeli aktivity.",
     "@moreEvents": {
         "type": "String",
         "placeholders": {}
@@ -9196,18 +8512,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9215,26 +8519,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9340,22 +8624,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9384,19 +8652,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9404,15 +8660,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9613,11 +8861,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Ve třídě? Vložte sem svůj kód pro připojení.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automaticky zvýraznit audio zprávy",
     "selectAudioMessagesOnPlayDescription": "Automaticky zvýraznit audio zprávy při přehrávání",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9661,18 +8904,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Tento kurz má témata s méně než {input} aktivitami. Prosím, zadejte číslo menší nebo rovné {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Klikněte sem pro opětovné přihlášení.",
     "@clickToLogin": {
@@ -10089,17 +9320,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Kreslená žlutá medvěd s rukama vztyčenýma v nadšení.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Vyberte slova, abyste se o nich dozvěděli více",
     "requireAnalyticsAccessTitle": "Vyžadovat přístup k analytice pro připojení",
     "requireAnalyticsAccessDesc": "Účastníci musí udělit přístup k jejich analytice učení, aby se mohli připojit k tomuto kurzu",
     "analyticsAccessNoticeTitle": "Vyžaduje se přístup k analytice",
     "analyticsAccessNoticeDesc": "Připojením k tomuto kurzu souhlasíte s tím, že udělíte administrátorům přístup k vaší analytice učení.",
-    "skipOnboardingClassCodeDesc": "Učíte se nezávisle? Nebojte se, můžete:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10117,10 +9342,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10149,7 +9370,6 @@
     "pickCefrLevelTeacherStepTitle": "Jakou úroveň učíte?",
     "pickCefrLevelStudentStepTitle": "Jakou úroveň máte?",
     "customCourseStepTitle": "Vyplňte tento formulář pro získání vlastního kurzu",
-    "aboutYourClass": "O vaší třídě",
     "courseCodeStepErrorMessage": "Zkontrolujte svůj kód a zkuste to znovu",
     "institution": "Instituce",
     "courseGoals": "Cíle kurzu",
@@ -10192,10 +9412,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10312,12 +9528,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logo Pangea Chat",
     "introChatDetails": "Pozdravte se! Představte se svým spoluúčastníkům kurzu, najděte přátele a povídejte si mimo aktivity.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10361,11 +9572,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Akce aktivity",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Nástroje pro výslovnost",
     "audioTranscription": "AI přepis zvuku",
     "visualLearnerSupport": "Podpora vizuálních učitelů",
@@ -10406,7 +9612,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Připojte se k kurzu, který zahrnuje tuto aktivitu, abyste ji mohli hrát.",
     "resizeCoursePanel": "Změnit velikost panelu kurzu",
     "undo": "Zpět",
     "unlock": "Odemknout",
@@ -10420,7 +9625,6 @@
     "addCourseBrowsePublic": "Procházet veřejné kurzy",
     "browsePublicCourses": "Procházet veřejné kurzy",
     "editProfile": "Upravit profil",
-    "numObjectives": "{count} cíle",
     "mapSearchHint": "Hledat aktivity",
     "mapSearchNoResults": "Žádné shody v zobrazení",
     "mapFilterAllLanguages": "Všechny jazyky",
@@ -10429,7 +9633,6 @@
     "mapFilterCompleted": "Dokončeno",
     "mapFilterReset": "Resetovat",
     "activityTypeConversation": "Konverzace",
-    "lockedMissionRequirement": "Dokončete předchozí misi, abyste odemkli",
     "playAgain": "Hrát znovu",
     "reviewActivity": "Přehled",
     "mapEmptyInView": "Na vaší úrovni nebo jazyce není nic. Rozšiřte své filtry nebo se přiblížte.",
@@ -10444,14 +9647,9 @@
     "scrollToBottom": "Přejít na konec",
     "courseImage": "Obrázek kurzu",
     "avatarPreview": "Náhled avatara",
-    "activityPhoto": "Fotografie aktivity",
     "emotePreview": "Náhled emoce: {name}",
     "activityLabel": "Aktivita: {title}",
     "resetMapView": "Obnovit zobrazení mapy",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10504,14 +9702,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10541,10 +9731,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10601,10 +9787,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_da.arb
+++ b/lib/l10n/intl_da.arb
@@ -57,7 +57,6 @@
     "appLock": "App-lås",
     "appLockDescription": "Lås appen, når den ikke er i brug, med en pinkode",
     "archive": "Arkiv",
-    "areGuestsAllowedToJoin": "Er gæstebrugere tilladt at deltage",
     "areYouSure": "Er du sikker?",
     "areYouSureYouWantToLogout": "Er du sikker på, at du vil logge ud?",
     "askSSSSSign": "For at kunne underskrive den anden person, skal du indtaste din sikre butikspasssætning eller gendannelsesnøgle.",
@@ -102,9 +101,7 @@
     "changeYourAvatar": "Skift din avatar",
     "channelCorruptedDecryptError": "Krypteringen er blevet beskadiget",
     "chat": "Chat",
-    "yourChatBackupHasBeenSetUp": "Din chat-backup er blevet oprettet.",
     "chatBackup": "Chat-backup",
-    "chatBackupDescription": "Dine gamle beskeder er sikret med en gendannelsesnøgle. Sørg for, at du ikke mister den.",
     "chatDetails": "Chatdetaljer",
     "chats": "Chats",
     "chooseAStrongPassword": "Vælg et stærkt password",
@@ -137,7 +134,6 @@
     "configureChat": "Konfigurer chat",
     "confirm": "Bekræft",
     "connect": "Forbind",
-    "contactHasBeenInvitedToTheGroup": "Kontakt er blevet inviteret til gruppen",
     "contentHasBeenReported": "Indholdet er blevet rapporteret til serveradministratorerne",
     "copiedToClipboard": "Kopieret til udklipsholder",
     "copy": "Kopier",
@@ -145,11 +141,9 @@
     "couldNotDecryptMessage": "Kunne ikke dekryptere besked: {error}",
     "checkList": "Tjekliste",
     "countParticipants": "{count} deltagere",
-    "countInvited": "{count} inviteret",
     "create": "Opret",
     "createdTheChat": "💬 {username} oprettede chatten",
     "createGroup": "Opret gruppe",
-    "createNewSpace": "Nyt rum",
     "currentlyActive": "Aktivt i øjeblikket",
     "darkTheme": "Mørk",
     "dateAndTimeOfDay": "{date}, {timeOfDay}",
@@ -175,9 +169,6 @@
     "emoteKeyboardNoRecents": "Nyligt brugte emotes vises her...",
     "emotePacks": "Emote-pakker til rum",
     "emoteSettings": "Emote-indstillinger",
-    "globalChatId": "Global chat-ID",
-    "accessAndVisibility": "Adgang og synlighed",
-    "accessAndVisibilityDescription": "Hvem der har adgang til at deltage i denne chat, og hvordan chatten kan opdages.",
     "calls": "Opkald",
     "customEmojisAndStickers": "Brugerdefinerede emojis og klistermærker",
     "customEmojisAndStickersBody": "Tilføj eller del brugerdefinerede emojis eller klistermærker, som kan bruges i enhver chat.",
@@ -185,7 +176,6 @@
     "emptyChat": "Tom chat",
     "enableEmotesGlobally": "Aktivér emote-pakke globalt",
     "enableEncryption": "Aktivér kryptering",
-    "enableEncryptionWarning": "Du vil ikke kunne deaktivere krypteringen igen. Er du sikker?",
     "encrypted": "Krypteret",
     "encryption": "Kryptering",
     "encryptionNotEnabled": "Kryptering er ikke aktiveret",
@@ -193,7 +183,6 @@
     "enterAnEmailAddress": "Indtast en e-mailadresse",
     "homeserver": "Hjemmeserver",
     "errorObtainingLocation": "Fejl ved hentning af placering: {error}",
-    "everythingReady": "Alt klar!",
     "extremeOffensive": "Ekstremt krænkende",
     "fileName": "Filnavn",
     "fluffychat": "FluffyChat",
@@ -202,9 +191,7 @@
     "fromJoining": "Fra tilslutning",
     "fromTheInvitation": "Fra invitationen",
     "group": "Gruppe",
-    "chatDescription": "Chatbeskrivelse",
     "chatDescriptionHasBeenChanged": "Chatbeskrivelsen er blevet ændret",
-    "groupIsPublic": "Gruppen er offentlig",
     "groups": "Grupper",
     "groupWith": "Gruppe med {displayname}",
     "guestsAreForbidden": "Gæster er forbudt",
@@ -226,7 +213,6 @@
     "incorrectPassphraseOrKey": "Forkert adgangsord eller gendannelsesnøgle",
     "inoffensive": "Harmløs",
     "inviteContact": "Inviter kontakt",
-    "inviteContactToGroup": "Inviter kontakt til {groupName}",
     "noChatDescriptionYet": "Ingen chatbeskrivelse oprettet endnu.",
     "tryAgain": "Prøv igen",
     "invalidServerName": "Ugyldigt servernavn",
@@ -247,7 +233,6 @@
     "leave": "Forlad",
     "leftTheChat": "Forlod chatten",
     "lightTheme": "Lyst",
-    "loadCountMoreParticipants": "Indlæs {count} flere deltagere",
     "dehydrate": "Eksporter session og slet enhed",
     "dehydrateWarning": "Denne handling kan ikke fortrydes. Sørg for at gemme backup-filen sikkert.",
     "hydrate": "Gendan fra backup-fil",
@@ -256,7 +241,6 @@
     "locationDisabledNotice": "Lokalitetstjenester er deaktiveret. Aktiver dem for at kunne dele din placering.",
     "locationPermissionDeniedNotice": "Tilladelse til lokalitet nægtet. Giv tilladelse for at kunne dele din placering.",
     "login": "Log ind",
-    "logInTo": "Log ind på {homeserver}",
     "logout": "Log ud",
     "mention": "Nævn",
     "messages": "Beskeder",
@@ -271,8 +255,6 @@
     "no": "Nej",
     "noConnectionToTheServer": "Ingen forbindelse til serveren",
     "noEmotesFound": "Ingen emojis fundet. 😕",
-    "noEncryptionForPublicRooms": "Du kan kun aktivere kryptering, når rummet ikke længere er offentligt tilgængeligt.",
-    "noGoogleServicesWarning": "Firebase Cloud Messaging ser ud til ikke at være tilgængelig på din enhed. For stadig at modtage push-notifikationer anbefaler vi at installere ntfy. Med ntfy eller en anden Unified Push-udbyder kan du modtage push-notifikationer på en sikker måde. Du kan downloade ntfy fra PlayStore eller F-Droid.",
     "noMatrixServer": "{server1} er ikke en matrixserver, brug {server2} i stedet?",
     "shareInviteLink": "Del invitationslink",
     "scanQrCode": "Scan QR-kode",
@@ -294,12 +276,10 @@
     "openCamera": "Åbn kamera",
     "openVideoCamera": "Åbn kamera til en video",
     "oneClientLoggedOut": "En af dine klienter er blevet logget ud",
-    "addAccount": "Tilføj konto",
     "editBundlesForAccount": "Rediger pakker for denne konto",
     "addToBundle": "Tilføj til pakke",
     "removeFromBundle": "Fjern fra denne pakke",
     "bundleName": "Pakke navn",
-    "enableMultiAccounts": "(BETA) Aktiver flere konti på denne enhed",
     "openInMaps": "Åbn i kort",
     "link": "Link",
     "serverRequiresEmail": "Denne server skal validere din e-mailadresse for registrering.",
@@ -311,7 +291,6 @@
     "passwordHasBeenChanged": "Kodeord er blevet ændret",
     "overview": "Oversigt",
     "passwordRecoverySettings": "Indstillinger for nulstilling af adgangskode",
-    "passwordRecovery": "Nulstilling af adgangskode",
     "people": "Folk",
     "pickImage": "Vælg et billede",
     "pin": "Pin",
@@ -320,7 +299,6 @@
     "pleaseChooseAPasscode": "Vælg venligst en adgangskode",
     "pleaseClickOnLink": "Klik venligst på linket i e-mailen og fortsæt.",
     "pleaseEnter4Digits": "Indtast venligst 4 cifre eller lad være med at indtaste for at deaktivere app-lås.",
-    "pleaseEnterRecoveryKey": "Indtast venligst din gendannelsesnøgle:",
     "pleaseEnterYourPassword": "Indtast venligst din adgangskode",
     "pleaseEnterYourPin": "Indtast venligst din pinkode",
     "pleaseEnterYourUsername": "Indtast venligst dit brugernavn",
@@ -340,7 +318,6 @@
     "rejectedTheInvitation": "{username} afviste invitationen",
     "removeAllOtherDevices": "Fjern alle andre enheder",
     "removedBy": "Fjernet af {username}",
-    "removeDevice": "Fjern enhed",
     "unbanFromChat": "Fjern ban fra chat",
     "removeYourAvatar": "Fjern dit avatar",
     "replaceRoomWithNewerVersion": "Erstat rum med nyere version",
@@ -352,8 +329,6 @@
     "saveFile": "Gem fil",
     "search": "Søg",
     "security": "Sikkerhed",
-    "recoveryKey": "Gendannelsesnøgle",
-    "recoveryKeyLost": "Gendannelsesnøgle mistet?",
     "send": "Send",
     "sendAMessage": "Send en besked",
     "sendAsText": "Send som tekst",
@@ -372,7 +347,6 @@
     "separateChatTypes": "Separate direkte chats og grupper",
     "setAsCanonicalAlias": "Indstil som hovedalias",
     "setChatDescription": "Indstil chatbeskrivelse",
-    "setPermissionsLevel": "Indstil tilladelsesniveau",
     "setStatus": "Indstil status",
     "settings": "Indstillinger",
     "share": "Del",
@@ -382,8 +356,6 @@
     "presencesToggle": "Vis statusbeskeder fra andre brugere",
     "skip": "Spring over",
     "sourceCode": "Kildekode",
-    "spaceIsPublic": "Rummet er offentligt",
-    "spaceName": "Rummets navn",
     "startedACall": "{senderName} startede et opkald",
     "status": "Status",
     "statusExampleMessage": "Hvordan har du det i dag?",
@@ -395,7 +367,6 @@
     "theyMatch": "De Stemmer Overens",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "For mange forespørgsler. Prøv igen senere!",
-    "transferFromAnotherDevice": "Overfør fra en anden enhed",
     "tryToSendAgain": "Prøv at sende igen",
     "unavailable": "Utilgængelig",
     "unbannedUser": "{username} ophævede forbuddet for {targetName}",
@@ -405,7 +376,6 @@
     "unknownEvent": "Ukendt begivenhed '{type}'",
     "unmuteChat": "Fjern lyd på chat",
     "unpin": "Fjern fastgørelse",
-    "unreadChats": "{unreadCount, plural, =1{1 ulæst chat} other{{unreadCount} ulæste chats}}",
     "userAndOthersAreTyping": "{username} og {count} andre skriver…",
     "userAndUserAreTyping": "{username} og {username2} skriver…",
     "userIsTyping": "{username} skriver…",
@@ -418,8 +388,6 @@
     "verifyStart": "Start verifikation",
     "verifySuccess": "Du har bekræftet med succes!",
     "verifyTitle": "Bekræfter anden konto",
-    "videoCall": "Videoopkald",
-    "visibilityOfTheChatHistory": "Synlighed af chat-historikken",
     "visibleForAllParticipants": "Synlig for alle deltagere",
     "visibleForEveryone": "Synlig for alle",
     "voiceMessage": "Stemmebesked",
@@ -429,10 +397,7 @@
     "wallpaper": "Tapet:",
     "warning": "Advarsel!",
     "weSentYouAnEmail": "Vi har sendt dig en e-mail",
-    "whoCanPerformWhichAction": "Hvem kan udføre hvilken handling",
-    "whoIsAllowedToJoinThisGroup": "Hvem har tilladelse til at deltage i denne gruppe",
     "whyDoYouWantToReportThis": "Hvorfor vil du rapportere dette?",
-    "wipeChatBackup": "Slet din chat-sikkerhedskopi for at oprette en ny gendannelsesnøgle?",
     "withTheseAddressesRecoveryDescription": "Med disse adresser kan du gendanne din adgangskode.",
     "writeAMessage": "Skriv en besked…",
     "yes": "Ja",
@@ -445,9 +410,7 @@
     "messageType": "Beskedtype",
     "sender": "Afsender",
     "openGallery": "Åbn galleri",
-    "removeFromSpace": "Fjern fra rum",
     "start": "Start",
-    "pleaseEnterRecoveryKeyDescription": "For at låse dine gamle beskeder op, skal du indtaste din gendannelsesnøgle, som er genereret i en tidligere session. Din gendannelsesnøgle er IKKE din adgangskode.",
     "publish": "Udgiv",
     "openChat": "Åbn chat",
     "markAsRead": "Marker som læst",
@@ -458,12 +421,9 @@
     "confirmEventUnpin": "Er du sikker på, at du vil fjerne fastgørelsen af begivenheden permanent?",
     "emojis": "Emojis",
     "placeCall": "Foretag opkald",
-    "voiceCall": "Stemmeopkald",
     "unsupportedAndroidVersion": "Ikke-understøttet Android-version",
     "unsupportedAndroidVersionLong": "Denne funktion kræver en nyere Android-version. Tjek venligst for opdateringer eller Lineage OS-understøttelse.",
-    "videoCallsBetaWarning": "Bemærk venligst, at videoopkald i øjeblikket er i beta. De fungerer måske ikke som forventet eller overhovedet på alle platforme.",
     "experimentalVideoCalls": "Eksperimentelle videoopkald",
-    "emailOrUsername": "E-mail eller brugernavn",
     "addWidget": "Tilføj widget",
     "widgetVideo": "Video",
     "widgetEtherpad": "Tekstnotat",
@@ -485,35 +445,19 @@
     "youKickedAndBanned": "🙅‍♀️ Du sparkede og bandlyste {user}",
     "youUnbannedUser": "Du ophævede bandlysningen af {user}",
     "hasKnocked": "🚪 {user} har banket på",
-    "usersMustKnock": "Brugere skal banke på",
-    "noOneCanJoin": "Ingen kan deltage",
     "knock": "Bank på",
     "users": "Brugere",
-    "unlockOldMessages": "Lås op for gamle beskeder",
-    "storeInSecureStorageDescription": "Opbevar gendannelsesnøglen i den sikre lagring på denne enhed.",
-    "saveKeyManuallyDescription": "Gem denne nøgle manuelt ved at aktivere systemets delingsdialog eller clipboard.",
-    "storeInAndroidKeystore": "Opbevar i Android Keystore",
-    "storeInAppleKeyChain": "Opbevar i Apple KeyChain",
-    "storeSecurlyOnThisDevice": "Opbevar sikkert på denne enhed",
     "countFiles": "{count} filer",
     "user": "Bruger",
     "custom": "Brugerdefineret",
-    "foregroundServiceRunning": "Denne meddelelse vises, når foreground-tjenesten kører.",
-    "screenSharingTitle": "skærmdeling",
-    "screenSharingDetail": "Du deler din skærm i FuffyChat",
     "whyIsThisMessageEncrypted": "Hvorfor er denne besked ulæselig?",
     "noKeyForThisMessage": "Dette kan ske, hvis beskeden blev sendt, før du har logget ind på din konto på denne enhed.\n\nDet er også muligt, at afsenderen har blokeret din enhed, eller at der er opstået problemer med internetforbindelsen.\n\nEr du i stand til at læse beskeden på en anden session? Så kan du overføre beskeden derfra! Gå til Indstillinger > Enheder og sørg for, at dine enheder har verificeret hinanden. Når du åbner rummet næste gang, og begge sessioner er i forgrunden, vil nøglerne blive overført automatisk.\n\nVil du ikke miste nøglerne, når du logger ud eller skifter enhed? Sørg for, at du har aktiveret chat-sikkerhedskopien i indstillingerne.",
     "newGroup": "Ny gruppe",
     "newSpace": "Nyt rum",
-    "enterSpace": "Indtast rum",
     "allSpaces": "Alle rum",
     "hidePresences": "Skjul statusliste?",
     "doNotShowAgain": "Vis ikke igen",
     "wasDirectChatDisplayName": "Tom chat (var {oldDisplayName})",
-    "newSpaceDescription": "Rum giver dig mulighed for at samle dine chats og opbygge private eller offentlige fællesskaber.",
-    "encryptThisChat": "Krypter denne chat",
-    "disableEncryptionWarning": "Af sikkerhedsmæssige grunde kan du ikke deaktivere kryptering i en chat, hvor det tidligere er blevet aktiveret.",
-    "sorryThatsNotPossible": "Beklager... det er ikke muligt",
     "deviceKeys": "Enheds nøgler:",
     "reopenChat": "Genåbne chat",
     "noBackupWarning": "Advarsel! Uden at aktivere chat-sikkerhedskopien mister du adgang til dine krypterede beskeder. Det anbefales kraftigt at aktivere chat-sikkerhedskopien, før du logger ud.",
@@ -526,7 +470,6 @@
     "openLinkInBrowser": "Åbn link i browser",
     "reportErrorDescription": "😞 Åh nej. Noget gik galt. Hvis du vil, kan du rapportere denne fejl til udviklerne.",
     "report": "rapporter",
-    "setTheme": "Vælg tema:",
     "setColorTheme": "Vælg farvetema:",
     "invite": "Inviter",
     "inviteGroupChat": "📨 Inviter gruppechat",
@@ -545,12 +488,8 @@
     "yourGlobalUserIdIs": "Dit globale bruger-ID er: ",
     "noUsersFoundWithQuery": "Desværre kunne der ikke findes nogen bruger med \"{query}\". Tjek venligst, om du har lavet en stavefejl.",
     "knocking": "Banker på",
-    "chatCanBeDiscoveredViaSearchOnServer": "Chat kan findes via søgning på {server}",
-    "searchChatsRooms": "Søg efter #chats, @brugere...",
     "nothingFound": "Intet fundet...",
     "groupName": "Gruppenavn",
-    "createGroupAndInviteUsers": "Opret en gruppe og inviter brugere",
-    "groupCanBeFoundViaSearch": "Gruppen kan findes via søgning",
     "wrongRecoveryKey": "Beklager... dette ser ikke ud til at være den korrekte gendannelsesnøgle.",
     "startConversation": "Start samtale",
     "commandHint_sendraw": "Send rå json",
@@ -564,11 +503,8 @@
     "pleaseChooseAStrongPassword": "Vælg venligst en stærk adgangskode",
     "passwordsDoNotMatch": "Adgangskoder stemmer ikke overens",
     "passwordIsWrong": "Din indtastede adgangskode er forkert",
-    "publicChatAddresses": "Offentlige chatadresser",
-    "createNewAddress": "Opret ny adresse",
     "joinSpace": "Deltag i rum",
     "publicSpaces": "Offentlige rum",
-    "addChatOrSubSpace": "Tilføj chat eller underrum",
     "subspace": "Underrum",
     "decline": "Afvis",
     "thisDevice": "Denne enhed:",
@@ -577,15 +513,11 @@
     "searchMore": "Søg mere...",
     "gallery": "Galleri",
     "files": "Filer",
-    "sessionLostBody": "Din session er mistet. Venligst rapporter denne fejl til udviklerne på {url}. Fejlmeddelelsen er: {error}",
-    "restoreSessionBody": "Appen forsøger nu at gendanne din session fra backupen. Venligst rapporter denne fejl til udviklerne på {url}. Fejlmeddelelsen er: {error}",
     "sendReadReceipts": "Send læsekvitteringer",
     "sendTypingNotificationsDescription": "Andre deltagere i en chat kan se, når du skriver en ny besked.",
     "sendReadReceiptsDescription": "Andre deltagere i en chat kan se, hvornår du har læst en besked.",
     "formattedMessages": "Formaterede beskeder",
     "formattedMessagesDescription": "Vis rigt indhold som fed tekst ved hjælp af markdown.",
-    "verifyOtherUser": "🔐 Verificer anden bruger",
-    "verifyOtherUserDescription": "Hvis du verificerer en anden bruger, kan du være sikker på, at du virkelig skriver til den rigtige person. 💪\n\nNår du starter en verifikation, vil du og den anden bruger se en popup i appen. Der vil derefter vises en række emojis eller tal, som I skal sammenligne.\n\nDen bedste måde at gøre dette på er at mødes eller starte en videoopkald. 👭",
     "verifyOtherDevice": "🔐 Verificer anden enhed",
     "verifyOtherDeviceDescription": "Når du bekræfter en anden enhed, kan disse enheder udveksle nøgler, hvilket øger din samlede sikkerhed. 💪 Når du starter en verifikation, vises der en popup i appen på begge enheder. Der vil derefter være en række emojis eller tal, som du skal sammenligne med hinanden. Det er bedst at have begge enheder klar, før du starter verifikationen. 🤳",
     "acceptedKeyVerification": "{sender} accepterede nøgleverifikation",
@@ -621,10 +553,6 @@
     "updateInstalled": "🎉 Opdatering {version} installeret!",
     "changelog": "Ændringslog",
     "sendCanceled": "Afsendelse annulleret",
-    "loginWithMatrixId": "Log ind med Matrix-ID",
-    "discoverHomeservers": "Opdag hjemservere",
-    "whatIsAHomeserver": "Hvad er en hjemserver?",
-    "homeserverDescription": "Alle dine data er gemt på hjemserveren, ligesom en e-mailudbyder. Du kan vælge, hvilken hjemserver du vil bruge, mens du stadig kan kommunikere med alle. Lær mere på https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Det ser ikke ud til at være en kompatibel hjemserver. Forkert URL?",
     "calculatingFileSize": "Beregner filstørrelse...",
     "prepareSendingAttachment": "Forbereder afsendelse af vedhæftning...",
@@ -636,11 +564,9 @@
     "oneOfYourDevicesIsNotVerified": "En af dine enheder er ikke verificeret",
     "noticeChatBackupDeviceVerification": "Bemærk: Når du tilslutter alle dine enheder til chat-sikkerhedskopien, bliver de automatisk verificeret.",
     "continueText": "Fortsæt",
-    "welcomeText": "Hej Hej 👋 Dette er FluffyChat. Du kan logge ind på enhver hjemserver, der er kompatibel med https://matrix.org. Og så chatte med hvem som helst. Det er et stort decentraliseret beskednetværk!",
     "blur": "Udsæt:",
     "opacity": "Gennemsigtighed:",
     "setWallpaper": "Indstil baggrund",
-    "manageAccount": "Administrer konto",
     "noContactInformationProvided": "Serveren giver ingen gyldige kontaktoplysninger",
     "contactServerAdmin": "Kontakt serveradministrator",
     "contactServerSecurity": "Kontakt serverens sikkerhed",
@@ -659,11 +585,8 @@
     "unableToJoinChat": "Kan ikke deltage i chat. Måske har den anden part allerede lukket samtalen.",
     "previous": "Forrige",
     "otherPartyNotLoggedIn": "Den anden part er i øjeblikket ikke logget ind og kan derfor ikke modtage beskeder!",
-    "appWantsToUseForLogin": "Brug '{server}' til at logge ind",
-    "appWantsToUseForLoginDescription": "Du giver hermed appen og hjemmesiden tilladelse til at dele oplysninger om dig.",
     "open": "Åben",
     "waitingForServer": "Venter på server...",
-    "appIntroduction": "FluffyChat lader dig chatte med dine venner på tværs af forskellige beskedtjenester. Lær mere på https://matrix.org eller tryk bare på *Fortsæt*.",
     "newChatRequest": "📩 Ny chatanmodning",
     "contentNotificationSettings": "Indstillinger for indholdsnotifikationer",
     "generalNotificationSettings": "Generelle notifikationsindstillinger",
@@ -740,11 +663,9 @@
     "taTooltip": "L2 brug med oversættelsesassistance",
     "interactiveTranslatorSliderHeader": "Interaktiv Oversætter",
     "interactiveGrammarSliderHeader": "Interaktiv Grammatik Tjekker",
-    "interactiveTranslatorRequired": "Påkrævet",
     "waTooltip": "L2 brug uden assistance",
     "interactiveTranslator": "Oversættelsesassistance",
     "noIdenticalLanguages": "Vælg venligst forskellige base- og målsprog",
-    "searchBy": "Søg efter land og sprog",
     "joinWithClassCode": "Deltag i kursus",
     "languageLevelPreA1": "Novice Low (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -765,19 +686,14 @@
     "saveChanges": "Gem ændringer",
     "publicProfileTitle": "Tillad mit profil at blive fundet i søgning",
     "publicProfileDesc": "Ved at tænde for dette, kan andre brugere finde dit profil i den globale søgelinje og sende anmodninger om chat. På dette tidspunkt kan du vælge at acceptere eller afvise anmodningen.",
-    "errorDisableIT": "Oversættelsesassistance er slået fra.",
-    "errorDisableIGC": "Grammatikkens assistance er slået fra.",
     "errorDisableITUserDesc": "Klik her for at opdatere oversættelsesassistanceindstillinger",
     "errorDisableIGCUserDesc": "Klik her for at opdatere grammatikkens assistanceindstillinger",
     "errorDisableITClassDesc": "Oversættelsesassistance er deaktiveret for kurset, som denne chat er i.",
     "errorDisableIGCClassDesc": "Grammatikassistance er deaktiveret for kurset, som denne chat er i.",
-    "error405Title": "Sprog er ikke indstillet",
     "error405Desc": "Indstil dine sprog i Hovedmenu > Læringsindstillinger.",
     "termsAndConditions": "Vilkår og betingelser",
     "andCertifyIAmAtLeast13YearsOfAge": " og bekræfter, at jeg er mindst 16 år gammel.",
-    "error502504Title": "Wow, der er mange elever online!",
     "error502504Desc": "Oversættelses- og grammatikværktøjer kan være langsomme eller utilgængelige, mens Pangea-botterne indhenter.",
-    "error404Title": "Oversættelsesfejl!",
     "error404Desc": "Pangea-botten er ikke sikker på, hvordan det skal oversætte det...",
     "errorPleaseRefresh": "Vi undersøger det! Opdater venligst siden og prøv igen.",
     "connectedToStaging": "Forbundet til staging",
@@ -815,13 +731,9 @@
     "definitionsToolName": "Orddefinitioner",
     "definitionsToolDescription": "Når den er aktiveret, kan ord understreget med blåt klikkes for definitioner. Klik på beskeder for at få adgang til definitioner.",
     "welcomeBack": "Velkommen tilbage! Hvis du var en del af pilotprojektet 2023-2024, bedes du kontakte os for dit særlige pilotabonnement. Hvis du er lærer, der har (eller din institution har) købt licenser til din klasse, kontakt os for dit lærerabonnement.",
-    "downloadTxtFile": "Download tekstfil",
-    "downloadCSVFile": "Download CSV-fil",
     "promotionalSubscriptionDesc": "Du har i øjeblikket et livstids kampagnetilbud. Send en besked til support@pangea.chat for hjælp til at ændre dit abonnement.",
     "originalSubscriptionPlatform": "Abonnement købt via {purchasePlatform}",
     "oneWeekTrial": "Én uges prøveperiode",
-    "downloadXLSXFile": "Download Excel-fil",
-    "unkDisplayName": "Ukendt",
     "wwCountryDisplayName": "Verdensomspændende",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Åland Islands",
@@ -1116,7 +1028,6 @@
     "chatCapacityHasBeenChanged": "Chatkapacitet ændret",
     "chatCapacitySetTooLow": "Chatkapaciteten skal være mindst {count}.",
     "chatCapacityExplanation": "Chatkapacitet begrænser antallet af medlemmer i en chat.",
-    "tooManyRequest": "For mange forespørgsler, prøv igen senere.",
     "enterNumber": "Indtast venligst et helt tal.",
     "practice": "Øv",
     "versionNotFound": "Version ikke fundet",
@@ -1126,7 +1037,6 @@
     "deleteSubscriptionWarningTitle": "Du har et aktivt abonnement",
     "deleteSubscriptionWarningBody": "Sletning af din konto vil ikke automatisk afbryde dit abonnement.",
     "manageSubscription": "Administrer abonnement",
-    "error520Title": "Prøv igen.",
     "error520Desc": "Beklager, vi kunne ikke forstå din besked...",
     "wordsUsed": "Ord brugt",
     "level": "Niveau",
@@ -1144,7 +1054,6 @@
     "other": "Andet",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "Ingen kapacitetsgrænse",
-    "downloadGroupText": "Download gruppe tekst",
     "notificationsOn": "Notifikationer til",
     "notificationsOff": "Notifikationer fra",
     "joinWithCode": "Deltag med kode",
@@ -1208,24 +1117,12 @@
     "whatIsTheMorphTag": "Hvad er {morphologicalFeature} af '{wordForm}'?",
     "dataAvailable": "Data tilgængelighed",
     "available": "Tilgængelig",
-    "pangeaBotIsFallible": "Pangea Bot laver også fejl!",
-    "whatIsMeaning": "Hvad betyder '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Match betydninger med ordene i beskeden!",
-    "doubleClickToEdit": "Dobbeltklik for at redigere.",
-    "topicLabel": "Emne",
-    "topicPlaceholder": "Vælg et emne...",
-    "modePlaceholder": "Vælg en tilstand...",
-    "learningObjectiveLabel": "Læringsmål",
-    "learningObjectivePlaceholder": "Vælg et læringsmål...",
-    "targetLanguageLabel": "Mål sprog",
     "cefrLevelLabel": "CEFR-niveau",
     "image": "Billede",
     "video": "Video",
     "nan": "Ikke relevant",
-    "addVocabulary": "Tilføj ordforråd",
     "instructions": "Instruktioner",
-    "numberOfLearners": "Antal elever",
-    "mustBeInteger": "Skal være et heltal f.eks. 1, 2, 3, ...",
     "constructUsePvmDesc": "Produceret i stemmemeddelelse",
     "leaveSpaceDescription": "Ved at forlade kurset vil du forlade alle chats inden for det. Andre brugere vil se, at du har forladt kurset.",
     "constructUseCorMmDesc": "Korrekt beskedbetydning",
@@ -1240,7 +1137,6 @@
     "ttsDisabledBody": "Du kan aktivere tale-til-tekst i dine læringsindstillinger",
     "noSpaceDescriptionYet": "Der er endnu ikke oprettet en kursusbeskrivelse.",
     "tooLargeToSend": "Denne besked er for stor til at sende",
-    "exitWithoutSaving": "Er du sikker på, at du vil forlade uden at gemme?",
     "enableAutocorrectPopupTitle": "Tilføj dit målsprog-tastatur ved at gå til:",
     "enableAutocorrectPopupSteps": "  • Indstillinger\n  • Generelt\n  • Tastatur\n  • Tastaturer\n  • Tilføj nyt tastatur",
     "enableAutocorrectPopupDescription": "Når sproget er valgt, kan du klikke på det lille globus-ikon nederst til venstre på dit tastatur for at aktivere det nyinstallerede tastatur.",
@@ -1251,11 +1147,8 @@
     "displayName": "Visningsnavn",
     "leaveRoomDescription": "Du er ved at forlade denne chat. Andre brugere vil se, at du har forladt chatten.",
     "confirmUserId": "Bekræft venligst dit Pangea Chat-brugernavn for at slette din konto.",
-    "startingToday": "Fra i dag",
-    "oneWeekFreeTrial": "En uges gratis prøveperiode",
     "paidSubscriptionStarts": "Starter {startDate}",
     "cancelInSubscriptionSettings": "Afmeld når som helst i abonnementindstillinger",
-    "cancelToAvoidCharges": "Afmeld før {trialEnds} for at undgå gebyrer",
     "downloadGboard": "Download Gboard",
     "autocorrectNotAvailable": "Desværre understøttes din platform ikke i øjeblikket til denne funktion. Følg med for yderligere udvikling!",
     "pleaseUpdateApp": "Opdater venligst appen for at fortsætte.",
@@ -1265,17 +1158,12 @@
     "knockSpaceSuccess": "Du har anmodet om at deltage i dette kursus! En administrator vil svare på din anmodning, når de modtager den 😄",
     "chooseWordAudioInstructionsBody": "Lyt til den komplette besked. Match derefter lydene med ordene.",
     "chooseMorphsInstructionsBody": "Klik på puslespilsbrikkerne for grammatiske spørgsmål!",
-    "pleaseEnterInt": "Indtast venligst et tal",
     "home": "Hjem",
     "join": "Deltag",
     "resetInstructionTooltipsTitle": "Nulstil vejledningstips",
     "resetInstructionTooltipsDesc": "Klik for at vise vejledningstips som for en helt ny bruger.",
-    "randomize": "Tilfældig",
     "clear": "Ryd",
-    "featuredActivities": "Udvalgt",
     "save": "Gem",
-    "startChat": "Start en chat",
-    "translationProblem": "Oversættelsesproblem",
     "askToJoin": "Anmod om at deltage",
     "emptyChatWarningTitle": "Chat er tom",
     "emptyChatWarningDesc": "Du har ikke inviteret nogen til din chat. Gå til Chat-indstillinger for at invitere dine kontakter eller Bot. Du kan også gøre dette senere.",
@@ -1305,17 +1193,13 @@
     "timesUsedIndependently": "Brugt uafhængigt antal gange",
     "timesUsedWithAssistance": "Brugt med assistance antal gange",
     "shareInviteCode": "Del invitationskode: {code}",
-    "leaderboard": "Topscorer",
     "skipForNow": "Spring over for nu",
     "permissions": "Tilladelser",
     "spaceChildPermission": "Hvem kan tilføje nye chats til dette kursus",
-    "addEnvironmentOverride": "Tilføj miljøoverstyring",
     "defaultOption": "Standard",
     "deleteChatDesc": "Er du sikker på, at du vil slette denne chat? Den vil blive slettet for alle deltagere, og alle beskeder i chatten vil ikke længere være tilgængelige til øvelse eller læringsanalyser.",
     "deleteSpaceDesc": "Kurset og eventuelle valgte chats vil blive slettet for alle deltagere, og alle beskeder i chatten vil ikke længere være tilgængelige til øvelse eller læringsanalyser. Denne handling kan ikke fortrydes.",
     "launch": "Start",
-    "searchChats": "Søg chats",
-    "maxFifty": "Maks 50",
     "configureSpace": "Konfigurer kursus",
     "pinMessages": "Fastgør beskeder",
     "setJoinRules": "Indstil tilmeldingsregler",
@@ -1349,9 +1233,6 @@
     "failedToFetchTranscription": "Mislykkedes med at hente transskriptionen",
     "deleteEmptySpaceDesc": "Kurset vil blive slettet for alle deltagere. Denne handling kan ikke fortrydes.",
     "regenerate": "Genopret",
-    "mySavedActivities": "Mine gemte aktiviteter",
-    "noSavedActivities": "Ingen gemte aktiviteter",
-    "saveActivity": "Gem denne aktivitet",
     "failedToPlayVideo": "Mislykkedes med at afspille video",
     "done": "Færdig",
     "inThisSpace": "I dette kursus",
@@ -1362,13 +1243,9 @@
     "numInvited": "{count} inviteret",
     "saved": "Gemt",
     "reset": "Nulstil",
-    "errorFetchingActivitiesMessage": "Kunne ikke hente aktiviteter",
     "errorFetchingDefinition": "Kunne ikke hente definition",
     "errorProcessAnalytics": "Kunne ikke behandle analytics",
     "errorDownloading": "Download mislykkedes",
-    "errorLoadingSpaceChildren": "Kunne ikke indlæse chats inden for dette kursus",
-    "unexpectedError": "Uventet fejl.",
-    "pleaseReload": "Genindlæs venligst og prøv igen.",
     "translationError": "Oversættelsesfejl",
     "check": "Tjek",
     "unableToFindRoom": "Ingen chat eller kursus fundet med den kode. Prøv igen.",
@@ -1377,19 +1254,14 @@
     "request": "Anmodning",
     "requestAll": "Anmod om alt",
     "confirmMessageUnpin": "Er du sikker på, at du vil fjerne fastgørelsen af denne besked?",
-    "saveAndLaunch": "Gem og start",
-    "launchToSpace": "Start til kursus",
     "pending": "Afventer",
     "inactive": "Inaktiv",
-    "confirmRole": "Bekræft rolle",
     "openRoleLabel": "ÅBEN",
     "finishedTheActivity": "🎯 {username} afsluttede denne aktivitet",
     "activitySummaryError": "Aktivitetsoversigter er ikke tilgængelige",
     "requestSummaries": "Anmod om oversigter",
-    "generatingNewActivities": "Du er den første bruger af denne sprogpar! Giv os et øjeblik, vi forbereder aktiviteter kun til dig.",
     "requestAccessTitle": "Anmod om adgang til analyser?",
     "requestAccessDesc": "Vil du anmode om adgang til at se deltageranalyser?\n\nHvis deltagerne er enige, vil administratorerne for dette kursus kunne se deres:\n    • samlet ordforråd\n    • samlede grammatiske begreber\n    • samlede gennemførte aktivitetsessioner\n    • de specifikke grammatiske begreber, der er brugt, korrekt og forkert\n\nDe vil ikke kunne se deres:\n    • beskeder i chats uden for kurset\n    • ordforrådslisten",
-    "requestAccess": "Anmod om adgang ({count})",
     "analyticsInactiveTitle": "Anmodninger til inaktive brugere kunne ikke sendes",
     "analyticsInactiveDesc": "Inaktive brugere, der ikke har logget ind, siden denne funktion blev introduceret, vil ikke se din anmodning.\n\nAnmodningsknappen vil vises, når de vender tilbage. Du kan gensende anmodningen senere ved at klikke på Anmodningsknappen under deres navn, når den er tilgængelig.",
     "accessRequestedTitle": "Anmodning om adgang til analytics",
@@ -1412,8 +1284,6 @@
     "accessDesc": "Du kan gøre dit kursus åbent for alle! Eller gøre det privat og sikkert.",
     "createGroupChatDesc": "Mens aktivitetsessioner starter og slutter, forbliver gruppechats åbne for rutinemæssig kommunikation.",
     "deleteDesc": "Kun administratorer kan slette et kursus. Dette er en destruktiv handling, der fjerner alle brugere og sletter alle valgte chats inden for kurset. Vær forsigtig.",
-    "noCourseFound": "Åh, dette kursus har brug for en plan!\n\nKursusplaner er en sekvens af emner og samtaleaktiviteter.",
-    "additionalParticipants": "+ {num} andre",
     "whatNow": "Hvad nu?",
     "chooseNextActivity": "Vælg din næste aktivitet!",
     "letsGo": "Lad os gå",
@@ -1426,13 +1296,11 @@
     "waitNotDone": "Vent, jeg er ikke færdig!",
     "waitingForOthersToFinish": "Venter på, at de andre bliver færdige...",
     "generatingSummary": "Analyserer chat og genererer resultater",
-    "findCourse": "Find et kursus",
     "pingParticipantsNotification": "{user} leder efter brugere til at deltage i aktivitetssessionen i {room}",
     "course": "Kursus",
     "courses": "Kurser",
     "goToCourse": "Gå til kursus: {course}",
     "activityComplete": "Denne aktivitet er fuldført. Resuméet af aktiviteten bør være tilgængeligt nedenfor.",
-    "startNewSession": "Start ny session",
     "joinOpenSession": "Deltag i åben session",
     "activityNotFound": "Aktivitet ikke fundet",
     "myActivities": "Mine aktiviteter",
@@ -1606,10 +1474,6 @@
         "placeholders": {}
     },
     "@archive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@areGuestsAllowedToJoin": {
         "type": "String",
         "placeholders": {}
     },
@@ -1885,15 +1749,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@yourChatBackupHasBeenSetUp": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@chatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -2029,10 +1885,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@contentHasBeenReported": {
         "type": "String",
         "placeholders": {}
@@ -2069,14 +1921,6 @@
             }
         }
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@create": {
         "type": "String",
         "placeholders": {}
@@ -2090,10 +1934,6 @@
         }
     },
     "@createGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -2204,18 +2044,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -2241,10 +2069,6 @@
         "placeholders": {}
     },
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2284,10 +2108,6 @@
             }
         }
     },
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@extremeOffensive": {
         "type": "String",
         "placeholders": {}
@@ -2320,15 +2140,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@chatDescriptionHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -2426,14 +2238,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "@noChatDescriptionYet": {
         "type": "String",
@@ -2551,14 +2355,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@dehydrate": {
         "type": "String",
         "placeholders": {}
@@ -2590,14 +2386,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@logout": {
         "type": "String",
@@ -2652,14 +2440,6 @@
         "placeholders": {}
     },
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2758,10 +2538,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addAccount": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@editBundlesForAccount": {
         "type": "String",
         "placeholders": {}
@@ -2775,10 +2551,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableMultiAccounts": {
         "type": "String",
         "placeholders": {}
     },
@@ -2826,10 +2598,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@people": {
         "type": "String",
         "placeholders": {}
@@ -2863,10 +2631,6 @@
         "placeholders": {}
     },
     "@pleaseEnter4Digits": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKey": {
         "type": "String",
         "placeholders": {}
     },
@@ -2969,10 +2733,6 @@
             }
         }
     },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unbanFromChat": {
         "type": "String",
         "placeholders": {}
@@ -3014,14 +2774,6 @@
         "placeholders": {}
     },
     "@security": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
         "type": "String",
         "placeholders": {}
     },
@@ -3125,10 +2877,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@setStatus": {
         "type": "String",
         "placeholders": {}
@@ -3166,14 +2914,6 @@
         "placeholders": {}
     },
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -3229,10 +2969,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@tryToSendAgain": {
         "type": "String",
         "placeholders": {}
@@ -3279,14 +3015,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -3365,14 +3093,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@visibleForAllParticipants": {
         "type": "String",
         "placeholders": {}
@@ -3409,19 +3129,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -3473,15 +3181,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3532,10 +3232,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3544,15 +3240,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3676,43 +3364,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3732,18 +3388,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
@@ -3757,10 +3401,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3783,22 +3423,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3853,10 +3477,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3940,31 +3560,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -4020,23 +3620,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4076,28 +3664,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4115,14 +3681,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4315,22 +3873,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4386,10 +3928,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4399,10 +3937,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4478,27 +4012,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4824,10 +4342,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4837,10 +4351,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4928,14 +4438,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4952,10 +4454,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4968,15 +4466,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5128,14 +4618,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5149,14 +4631,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6379,10 +5853,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6423,10 +5893,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6499,10 +5965,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6772,47 +6234,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6832,19 +6254,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6908,10 +6318,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6952,14 +6358,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6971,14 +6369,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -7016,10 +6406,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7036,27 +6422,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7180,10 +6550,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7193,10 +6559,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7213,14 +6575,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7360,18 +6714,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7420,10 +6762,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7433,18 +6771,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7487,23 +6813,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7527,10 +6841,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7538,14 +6848,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7650,18 +6952,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7714,10 +7004,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7744,10 +7030,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7928,7 +7210,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Tjek igen i morgen for opdateringer om aktiviteten.",
-    "activityDropdownDesc": "Når du er færdig med denne aktivitet, klik nedenfor",
     "languageMismatchTitle": "Sprogfejl",
     "languageMismatchDesc": "Dit målsprog stemmer ikke overens med sproget for denne aktivitet. Vil du opdatere dit målsprog?",
     "reportWordIssueTooltip": "Rapporter problem med ordinformation",
@@ -7941,10 +7222,6 @@
     "selectAll": "Vælg alle",
     "deselectAll": "Fravælg alle",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7993,17 +7270,11 @@
         "placeholders": {}
     },
     "startOwn": "Start min egen",
-    "joinCourseDesc": "Hvert kursus har 8-10 sequencerede emner med en række opgavebaserede sprogindlæringsaktiviteter.",
     "newMessageInPangeaChat": "💬 Ny besked i Pangea Chat",
     "shareCourse": "Del kursus",
     "addCourse": "Tilføj et kursus",
-    "joinPublicCourse": "Deltag i offentligt kursus",
     "vocabLevelsDesc": "Her vil ordforrådsord blive placeret, når du har opgraderet dem!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8016,10 +7287,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8038,7 +7305,6 @@
     "emojiView": "Emoji visning",
     "feedbackDialogDesc": "Jeg laver også fejl! Er der noget, der kan hjælpe mig med at forbedre mig?",
     "contactHasBeenInvitedToTheCourse": "Kontakt er blevet inviteret til kurset",
-    "activityStatsButtonTooltip": "Aktivitetsinfo",
     "allow": "Tillad",
     "deny": "Afvis",
     "enabledRenewal": "Aktiver abonnement fornyelse",
@@ -8306,10 +7572,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9365,16 +8627,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktiviteter til at låse op for næste emne",
-    "activitiesToUnlockTopicDesc": "Indstil antallet af aktiviteter for at låse op for det næste kursusemne",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Korrekt orddefinition praksis",
     "constructUseIncLMDesc": "Forkert orddefinition praksis",
     "constructUseCorLADesc": "Korrekt ordlyd praksis",
@@ -9382,7 +8634,6 @@
     "constructUseBonus": "Bonus under ordpraksis",
     "practiceVocab": "Øv ordforråd",
     "selectMeaning": "Vælg betydningen",
-    "selectAudio": "Vælg den matchende lyd",
     "anotherRound": "En runde mere",
     "activitySettingsOverrideWarning": "Sprog og sprogniveau bestemt af aktivitetsplan",
     "voice": "Stemme",
@@ -9414,10 +8665,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9435,12 +8682,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Download påbegyndt",
     "webDownloadPermissionMessage": "Hvis din browser blokerer downloads, bedes du aktivere downloads for dette site.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9535,11 +8777,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Noget gik galt, og vi arbejder hårdt på at løse det. Tjek igen senere.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Aktivér skriveassistance",
     "autoIGCToolDescription": "Kør automatisk Pangea Chat-værktøjer for at rette sendte beskeder til målsproget.",
     "@autoIGCToolName": {
@@ -9595,24 +8832,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Grammatik",
-    "spanTypeWordChoice": "Ordvalg",
     "spanTypeSpelling": "Stavning",
     "spanTypePunctuation": "Interpunktion",
     "spanTypeStyle": "Stil",
     "spanTypeFluency": "Flydende",
     "spanTypeAccents": "Accenter",
     "spanTypeCapitalization": "Versalisering",
-    "spanTypeCorrection": "Korrektur",
     "spanFeedbackTitle": "Rapporter korrektion problem",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9637,10 +8863,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9653,13 +8875,7 @@
     "longPressToRecordVoiceMessage": "Tryk længe for at optage en stemmemeddelelse.",
     "pause": "Pause",
     "resume": "Fortsæt",
-    "newSubSpace": "Nyt underområde",
-    "moveToDifferentSpace": "Flyt til et andet område",
-    "removeFromSpaceDescription": "Chatten vil blive fjernet fra rummet, men vil stadig vises i din chatliste.",
     "countChats": "{chats} chats",
-    "spaceMemberOf": "Rumsmedlem af {spaces}",
-    "spaceMemberOfCanKnock": "Rumsmedlem af {spaces} kan banke",
-    "donate": "Doner",
     "startedAPoll": "{username} startede en afstemning.",
     "poll": "Afstemning",
     "startPoll": "Start afstemning",
@@ -9683,23 +8899,15 @@
     "newStickerPack": "Ny klistermærkepakke",
     "stickerPackName": "Klistermærkepakkens navn",
     "attribution": "Attribution",
-    "skipChatBackup": "Spring chatbackup over",
-    "skipChatBackupWarning": "Er du sikker? Uden at aktivere chatbackup kan du miste adgangen til dine beskeder, hvis du skifter enhed.",
-    "loadingMessages": "Indlæser beskeder",
-    "setupChatBackup": "Opsæt chatbackup",
     "noMoreResultsFound": "Ingen flere resultater fundet",
     "chatSearchedUntil": "Chat søgt indtil {time}",
     "federationBaseUrl": "Føderationens basis-URL",
     "clientWellKnownInformation": "Klient-velkendte oplysninger:",
     "baseUrl": "Basis-URL",
     "identityServer": "Identitetsserver:",
-    "versionWithNumber": "Version: {version}",
     "logs": "Logfiler",
-    "advancedConfigs": "Avancerede konfigurationer",
     "advancedConfigurations": "Avancerede konfigurationer",
-    "signInWithLabel": "Log ind med:",
     "selectAllWords": "Vælg alle de ord, du hører i lyden",
-    "joinCourseForActivities": "Deltag i et kursus for at prøve aktiviteter.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9736,18 +8944,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9755,26 +8951,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9880,22 +9056,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9924,19 +9084,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9944,15 +9092,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10153,11 +9293,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "I en klasse? Sæt din join-kode her.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automatisk fremhævning af lydbeskeder",
     "selectAudioMessagesOnPlayDescription": "Fremhæv automatisk lydbeskeder, når de afspilles",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10201,18 +9336,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Dette kursus har emner med færre end {input} aktiviteter. Indtast venligst et tal, der er mindre end eller lig med {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Klik her for at logge ind igen.",
     "@clickToLogin": {
@@ -10629,17 +9752,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "En tegneserieagtig gul bjørn med armene hævet i begejstring.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Vælg ord for at lære mere om dem",
     "requireAnalyticsAccessTitle": "Krav om adgang til analyser for at deltage",
     "requireAnalyticsAccessDesc": "Deltagere skal give adgang til deres læringsanalyser for at deltage i dette kursus",
     "analyticsAccessNoticeTitle": "Adgang til analyser kræves",
     "analyticsAccessNoticeDesc": "Ved at deltage i dette kursus accepterer du at give administratorer adgang til dine læringsanalyser.",
-    "skipOnboardingClassCodeDesc": "Lærer du selvstændigt? Bare rolig, du kan:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10657,10 +9774,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10689,7 +9802,6 @@
     "pickCefrLevelTeacherStepTitle": "Hvilket niveau underviser du på?",
     "pickCefrLevelStudentStepTitle": "Hvilket niveau er du på?",
     "customCourseStepTitle": "Udfyld denne formular for at få et tilpasset kursus",
-    "aboutYourClass": "Om din klasse",
     "courseCodeStepErrorMessage": "Kontroller venligst din kode og prøv igen",
     "institution": "Institution",
     "courseGoals": "Kursusmål",
@@ -10732,10 +9844,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10852,12 +9960,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat-logo",
     "introChatDetails": "Sig hej! Præsenter dig selv for dine medkursusdeltagere, find venner, og chat uden for aktiviteter.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10901,11 +10004,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Aktivitets handlinger",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Udtale værktøjer",
     "audioTranscription": "AI lydtranskription",
     "visualLearnerSupport": "Visuel læringsstøtte",
@@ -10946,7 +10044,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Deltag i et kursus, der inkluderer denne aktivitet for at spille den.",
     "resizeCoursePanel": "Ændr størrelse på kursuspanelet",
     "undo": "Fortryd",
     "unlock": "Lås op",
@@ -10960,7 +10057,6 @@
     "addCourseBrowsePublic": "Gennemse offentlige kurser",
     "browsePublicCourses": "Gennemse offentlige kurser",
     "editProfile": "Rediger profil",
-    "numObjectives": "{count} mål",
     "mapSearchHint": "Søg aktiviteter",
     "mapSearchNoResults": "Ingen matches i visningen",
     "mapFilterAllLanguages": "Alle sprog",
@@ -10969,7 +10065,6 @@
     "mapFilterCompleted": "Fuldført",
     "mapFilterReset": "Nulstil",
     "activityTypeConversation": "Samtale",
-    "lockedMissionRequirement": "Afslut den forrige mission for at låse op",
     "playAgain": "Spil igen",
     "reviewActivity": "Gennemgå",
     "mapEmptyInView": "Der er intet her på dit niveau eller sprog. Udvid dine filtre eller zoom ud.",
@@ -10984,14 +10079,9 @@
     "scrollToBottom": "Rul til bunden",
     "courseImage": "Kursusbillede",
     "avatarPreview": "Avatar forhåndsvisning",
-    "activityPhoto": "Aktivitetsbillede",
     "emotePreview": "Emote forhåndsvisning: {name}",
     "activityLabel": "Aktivitet: {title}",
     "resetMapView": "Nulstil kortvisning",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11044,14 +10134,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11081,10 +10163,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11141,10 +10219,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -87,11 +87,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Dürfen Gäste beitreten",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Bist du sicher?",
     "@areYouSure": {
         "type": "String",
@@ -363,11 +358,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Deine Nachrichten sind mit einem Wiederherstellungsschlüssel gesichert. Bitte stelle sicher, dass du ihn nicht verlierst.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Chatdetails",
     "@chatDetails": {
         "type": "String",
@@ -498,11 +488,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Kontakt wurde in die Gruppe eingeladen",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Der Inhalt wurde den Serveradministratoren gemeldet",
     "@contentHasBeenReported": {
         "type": "String",
@@ -554,11 +539,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Neuer Space",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Jetzt gerade online",
     "@currentlyActive": {
@@ -702,11 +682,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Du wirst die Verschlüsselung nicht mehr ausstellen können. Bist Du sicher?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Verschlüsselt",
     "@encrypted": {
         "type": "String",
@@ -745,11 +720,6 @@
             }
         }
     },
-    "everythingReady": "Alles fertig!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Extrem beleidigend",
     "@extremeOffensive": {
         "type": "String",
@@ -787,11 +757,6 @@
     },
     "group": "Gruppe",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Öffentliche Gruppe",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -885,15 +850,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Kontakt in die Gruppe {groupName} einladen",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Eingeladen",
     "@invited": {
@@ -1006,15 +962,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "{count} weitere Mitglieder laden",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Lade … Bitte warten.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -1039,15 +986,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Bei {homeserver} anmelden",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Abmelden",
     "@logout": {
@@ -1111,16 +1049,6 @@
     },
     "noEmotesFound": "Keine Emoticons gefunden. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Du kannst die Verschlüsselung erst aktivieren, sobald dieser Raum nicht mehr öffentlich zugänglich ist.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Firebase Cloud Messaging scheint auf deinem Gerät nicht verfügbar zu sein. Um trotzdem Push-Benachrichtigungen zu erhalten, empfehlen wir die Installation von ntfy. Mit ntfy oder einem anderen Unified-Push-Anbieter kannst du Push-Benachrichtigungen datensicher empfangen. Du kannst ntfy im PlayStore oder bei F-Droid herunterladen.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1240,11 +1168,6 @@
     },
     "passwordHasBeenChanged": "Passwort wurde geändert",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Passwort wiederherstellen",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1388,11 +1311,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Gerät entfernen",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Verbannung aufheben",
     "@unbanFromChat": {
@@ -1547,11 +1465,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Berechtigungsstufe einstellen",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Status ändern",
     "@setStatus": {
         "type": "String",
@@ -1593,16 +1506,6 @@
     },
     "sourceCode": "Quellcode",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Space ist öffentlich",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Space-Name",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1661,11 +1564,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Von anderem Gerät übertragen",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Noch mal versuchen zu senden",
     "@tryToSendAgain": {
         "type": "String",
@@ -1721,15 +1619,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 ungelesene Unterhaltung} other{{unreadCount} ungelesene Unterhaltungen}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} und {count} andere schreiben …",
     "@userAndOthersAreTyping": {
@@ -1815,16 +1704,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Videoanruf",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Sichtbarkeit des Chat-Verlaufs",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Sichtbar für alle Mitglieder",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1870,23 +1749,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Wer kann welche Aktion ausführen",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Wer darf der Gruppe beitreten",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Warum willst du dies melden?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Den Chat-Backup löschen, um einen neuen Wiederherstellungsschlüssel zu erstellen?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1945,24 +1809,20 @@
     },
     "addToSpace": "Zum Space hinzufügen",
     "serverRequiresEmail": "Dieser Server muss deine E-Mail-Adresse für die Registrierung überprüfen.",
-    "enableMultiAccounts": "(BETA) Aktiviere Multi-Accounts für dieses Gerät",
     "bundleName": "Name des Bundles",
     "removeFromBundle": "Von diesem Bundle entfernen",
     "addToBundle": "Zu einem Bundle hinzufügen",
     "editBundlesForAccount": "Bundles für dieses Konto bearbeiten",
-    "addAccount": "Konto hinzufügen",
     "oneClientLoggedOut": "Einer deiner Clients wurde abgemeldet",
     "homeserver": "Homeserver",
     "sendOnEnter": "Senden mit Enter",
     "link": "Link",
-    "yourChatBackupHasBeenSetUp": "Dein Chat-Backup wurde eingerichtet.",
     "unverified": "Unverifiziert",
     "messageInfo": "Nachrichten-Info",
     "time": "Zeit",
     "messageType": "Nachrichtentyp",
     "sender": "Absender:in",
     "openGallery": "Galerie öffnen",
-    "removeFromSpace": "Aus dem Space entfernen",
     "start": "Start",
     "repeatPassword": "Passwort wiederholen",
     "commandHint_dm": "Starte einen direkten Chat\nBenutze --no-encryption, um die Verschlüsselung auszuschalten",
@@ -1994,10 +1854,7 @@
     "pinMessage": "An Raum anheften",
     "emojis": "Emojis",
     "placeCall": "Anruf tätigen",
-    "voiceCall": "Sprachanruf",
     "unsupportedAndroidVersion": "Nicht unterstützte Android-Version",
-    "videoCallsBetaWarning": "Bitte beachte, dass sich Videoanrufe derzeit in der Beta-Phase befinden. Sie funktionieren möglicherweise nicht wie erwartet oder überhaupt nicht auf allen Plattformen.",
-    "emailOrUsername": "E-Mail oder Benutzername",
     "unsupportedAndroidVersionLong": "Diese Funktion erfordert eine neuere Android-Version. Bitte suche nach Updates oder prüfe die Lineage-OS-Unterstützung.",
     "experimentalVideoCalls": "Experimentelle Videoanrufe",
     "reactedWith": "{sender} reagierte mit {reaction}",
@@ -2090,19 +1947,11 @@
             }
         }
     },
-    "recoveryKey": "Wiederherstellungs-Schlüssel",
-    "recoveryKeyLost": "Wiederherstellungsschlüssel verloren?",
     "user": "Benutzer",
     "custom": "Benutzerdefiniert",
-    "storeInAndroidKeystore": "Im Android KeyStore speichern",
-    "storeSecurlyOnThisDevice": "Auf diesem Gerät sicher speichern",
     "dehydrate": "Sitzung exportieren und Gerät löschen",
     "dehydrateWarning": "Diese Aktion kann nicht rückgängig gemacht werden. Stelle sicher, dass du die Sicherungsdatei sicher aufbewahrst.",
     "hydrate": "Aus Sicherungsdatei wiederherstellen",
-    "unlockOldMessages": "Entsperre alte Nachrichten",
-    "pleaseEnterRecoveryKeyDescription": "Um deine alten Nachrichten zu entsperren, gib bitte den Wiederherstellungsschlüssel ein, der in einer früheren Sitzung generiert wurde. Dein Wiederherstellungsschlüssel ist NICHT dein Passwort.",
-    "saveKeyManuallyDescription": "Speicher diesen Schlüssel manuell, indem du den Systemfreigabedialog oder die Zwischenablage auslöst.",
-    "pleaseEnterRecoveryKey": "Bitte gib deinen Wiederherstellungsschlüssel ein:",
     "countFiles": "{count} Dateien",
     "@countFiles": {
         "placeholders": {
@@ -2112,8 +1961,6 @@
         }
     },
     "users": "Benutzer",
-    "storeInSecureStorageDescription": "Speicher den Wiederherstellungsschlüssel im sicheren Speicher dieses Geräts.",
-    "storeInAppleKeyChain": "Im Apple KeyChain speichern",
     "confirmMatrixId": "Bitte bestätigen deine Matrix-ID, um dein Konto zu löschen.",
     "supposedMxid": "das sollte sein {mxid}",
     "@supposedMxid": {
@@ -2128,15 +1975,10 @@
     "commandHint_markasgroup": "Als Gruppe markieren",
     "doNotShowAgain": "Nicht mehr anzeigen",
     "noKeyForThisMessage": "Dies kann passieren, wenn die Nachricht gesendet wurde, bevor du dich auf diesem Gerät bei deinem Konto angemeldet hast.\n\nEs ist auch möglich, dass der Absender dein Gerät blockiert hat oder etwas mit der Internetverbindung schief gelaufen ist.\n\nKannst du die Nachricht in einer anderen Sitzung lesen? Dann kannst du die Nachricht davon übertragen! Gehe zu den Einstellungen > Geräte und vergewissere dich, dass sich deine Geräte gegenseitig verifiziert haben. Wenn du den Raum das nächste Mal öffnest und beide Sitzungen im Vordergrund sind, werden die Schlüssel automatisch übertragen.\n\nDu möchtest die Schlüssel beim Abmelden oder Gerätewechsel nicht verlieren? Stelle sicher, dass du das Chat-Backup in den Einstellungen aktiviert hast.",
-    "foregroundServiceRunning": "Diese Benachrichtigung wird angezeigt, wenn der Vordergrunddienst ausgeführt wird.",
-    "screenSharingTitle": "Bildschirm teilen",
     "whyIsThisMessageEncrypted": "Warum ist diese Nachricht nicht lesbar?",
     "newGroup": "Neue Gruppe",
     "newSpace": "Neuer Space",
-    "enterSpace": "Raum betreten",
     "allSpaces": "Alle Spaces",
-    "screenSharingDetail": "Du teilst deinen Bildschirm in FuffyChat",
-    "newSpaceDescription": "Mit Spaces kannst du deine Chats zusammenfassen und private oder öffentliche Communities aufbauen.",
     "wasDirectChatDisplayName": "Leerer Chat (war {oldDisplayName})",
     "@wasDirectChatDisplayName": {
         "type": "String",
@@ -2146,7 +1988,6 @@
             }
         }
     },
-    "encryptThisChat": "Diesen Chat verschlüsseln",
     "googlyEyesContent": "{senderName} hat dir Googly Eyes gesendet",
     "@googlyEyesContent": {
         "type": "String",
@@ -2168,7 +2009,6 @@
             }
         }
     },
-    "sorryThatsNotPossible": "Sorry ... das ist nicht möglich",
     "hugContent": "{senderName} umarmt dich",
     "@hugContent": {
         "type": "String",
@@ -2179,7 +2019,6 @@
         }
     },
     "commandHint_googly": "Glupschaugen senden",
-    "disableEncryptionWarning": "Aus Sicherheitsgründen kannst du die Verschlüsselung in einem Chat nicht deaktivieren, wo sie zuvor aktiviert wurde.",
     "reopenChat": "Chat wieder eröffnen",
     "noBackupWarning": "Achtung! Ohne Aktivierung des Chat-Backups verlierst du den Zugriff auf deine verschlüsselten Nachrichten. Vor dem Ausloggen wird dringend empfohlen, das Chat-Backup zu aktivieren.",
     "noOtherDevicesFound": "Keine anderen Geräte anwesend",
@@ -2198,7 +2037,6 @@
     "openLinkInBrowser": "Link im Browser öffnen",
     "reportErrorDescription": "😭 Oh nein. Etwas ist schief gelaufen. Wenn du möchtest, kannst du den Bug bei den Entwicklern melden.",
     "report": "Melden",
-    "signInWithLabel": "Anmelden mit:",
     "importNow": "Jetzt importieren",
     "importEmojis": "Emojis importieren",
     "importFromZipFile": "Aus ZIP-Datei importieren",
@@ -2231,13 +2069,11 @@
             }
         }
     },
-    "setTheme": "Design festlegen:",
     "setColorTheme": "Farbdesign einstellen:",
     "invite": "Einladen",
     "optionalRedactReason": "(Optional) Grund für die Löschung dieser Nachricht...",
     "messagesStyle": "Nachrichten:",
     "chatPermissions": "Chatberechtigungen",
-    "chatDescription": "Chatbeschreibung",
     "chatDescriptionHasBeenChanged": "Chatbeschreibung geändert",
     "noChatDescriptionYet": "Noch keine Chatbeschreibung vorhanden.",
     "invalidServerName": "Ungültiger Servername",
@@ -2278,10 +2114,8 @@
     "roomUpgradeDescription": "Der Chat wird dann mit der neuen Raumversion neu erstellt. Alle Teilnehmer werden benachrichtigt, dass sie zum neuen Chat wechseln müssen. Mehr über Raumversionen erfährst du unter https://spec.matrix.org/latest/rooms/",
     "kickUserDescription": "Der Benutzer wird aus dem Chat geworfen, aber nicht gebannt. In öffentlichen Chats kann der Benutzer jederzeit wieder beitreten.",
     "blockListDescription": "Du kannst Benutzer blockieren, die dich stören. Von Benutzern auf deiner persönlichen Blocklierliste kannst du keine Nachrichten oder Raumeinladungen mehr erhalten.",
-    "createGroupAndInviteUsers": "Gruppe erstellen und Nutzer einladen",
     "startConversation": "Unterhaltung starten",
     "blockedUsers": "Blockierte Benutzer",
-    "groupCanBeFoundViaSearch": "Gruppe kann über die Suche gefunden werden",
     "noUsersFoundWithQuery": "Leider konnte mit \"{query}\" kein Benutzer gefunden werden. Bitte schau nach, ob dir ein Tippfehler unterlaufen ist.",
     "@noUsersFoundWithQuery": {
         "type": "String",
@@ -2297,7 +2131,6 @@
     "wrongRecoveryKey": "Entschuldigung ... das scheint nicht der richtige Wiederherstellungsschlüssel zu sein.",
     "blockUsername": "Blockiere Benutzername",
     "groupName": "Gruppenname",
-    "searchChatsRooms": "Suche nach #Chats, @Nutzer ...",
     "databaseMigrationTitle": "Datenbank wird optimiert",
     "databaseMigrationBody": "Bitte warten. Dies kann einen Moment dauern.",
     "thisDevice": "Dieses Gerät:",
@@ -2311,44 +2144,17 @@
     "subspace": "Sub-Space",
     "select": "Auswählen",
     "pleaseChooseAStrongPassword": "Bitte wähle ein starkes Passwort",
-    "addChatOrSubSpace": "Chat oder Sub-Space hinzufügen",
     "leaveEmptyToClearStatus": "Leer lassen, um den Status zu löschen.",
     "joinSpace": "Space beitreten",
     "searchForUsers": "Suche nach @benutzer ...",
     "initAppError": "Beim Starten der App ist ein Fehler aufgetreten",
-    "sessionLostBody": "Die App versucht nun, deine Sitzung aus der Sicherung wiederherzustellen. Bitte melde diesen Fehler an die Entwickler unter {url}. Die Fehlermeldung lautet: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Die App versucht nun, deine Sitzung aus der Sicherung wiederherzustellen. Bitte melde diesen Fehler an die Entwickler unter {url}. Die Fehlermeldung lautet: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendReadReceipts": "Lesebestätigungen senden",
     "formattedMessages": "Formatierte Nachrichten",
     "sendTypingNotificationsDescription": "Andere Teilnehmer in einem Chat können sehen, wenn du eine neue Nachricht tippst.",
     "formattedMessagesDescription": "Formatierte Nachrichteninhalte wie fettgedruckten Text mit Markdown anzeigen.",
-    "verifyOtherUser": "🔐 Anderen Benutzer verifizieren",
     "sendReadReceiptsDescription": "Andere Teilnehmer in einem Chat können sehen, ob du eine Nachricht gelesen hast.",
     "transparent": "Transparent",
     "verifyOtherDevice": "🔐 Anderes Gerät verifizieren",
-    "verifyOtherUserDescription": "Wenn du einen anderen Benutzer verifizierst, kannst du sicher sein, dass du weißt, an wen du wirklich schreibst. 💪\n\nWenn du eine Verifizierung startest, wird dir und dem anderen Nutzer ein Popup in der App angezeigt. Dort siehst du dann eine Reihe von Emojis oder Zahlen, die ihr miteinander vergleichen müsst.\n\nDas geht am besten, wenn man sich trifft oder einen Videoanruf startet. 👭",
     "acceptedKeyVerification": "{sender} hat die Schlüsselverifikation akzeptiert",
     "@acceptedKeyVerification": {
         "type": "String",
@@ -2429,18 +2235,6 @@
         }
     },
     "customEmojisAndStickersBody": "Eigene Emojis oder Sticker zur Nutzung im Chat hinzufügen oder teilen.",
-    "globalChatId": "Globale Chat-ID",
-    "accessAndVisibility": "Zugang und Sichtbarkeit",
-    "accessAndVisibilityDescription": "Wer darf dem Chat beitreten und wie kann der Chat gefunden werden.",
-    "chatCanBeDiscoveredViaSearchOnServer": "Chat kann über die Suche auf {server} gefunden werden",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "appLockDescription": "App mit einer PIN sperren, wenn sie nicht verwendet wird",
     "calls": "Anrufe",
     "customEmojisAndStickers": "Eigene Emojis und Sticker",
@@ -2456,10 +2250,6 @@
         "type": "String",
         "count": {}
     },
-    "usersMustKnock": "Benutzer müssen anklopfen",
-    "noOneCanJoin": "Niemand kann beitreten",
-    "createNewAddress": "Neue Adresse erstellen",
-    "publicChatAddresses": "Öffentliche Chat-Adressen",
     "gallery": "Galerie",
     "files": "Dateien",
     "restricted": "Beschränkt",
@@ -2541,11 +2331,7 @@
     "changelog": "Änderungsprotokoll",
     "sendCanceled": "Senden abgebrochen",
     "noChatsFoundHere": "Hier wurden noch keine Chats gefunden. Starte einen neuen Chat mit jemandem, indem du die Schaltfläche unten verwenden. ⤵️",
-    "whatIsAHomeserver": "Was ist ein Homeserver?",
     "doesNotSeemToBeAValidHomeserver": "Scheint kein kompatibler Homeserver zu sein. Falsche URL?",
-    "loginWithMatrixId": "Mit Matrix-ID anmelden",
-    "discoverHomeservers": "Server suchen",
-    "homeserverDescription": "Alle deine Daten werden auf einem Homeserver gespeichert, so wie bei einem E-Mail Anbieter. Du kannst aussuchen, welchen Homeserver du benutzen willst und kannst trotzdem mit allen kommunizieren. Erfahre mehr auf https://matrix.org.",
     "sendingAttachment": "Anhang wird gesendet ...",
     "generatingVideoThumbnail": "Generiere Video-Vorschaubild ...",
     "serverLimitReached": "Server-Limit erreicht! Warte {seconds} Sekunden ...",
@@ -2585,9 +2371,7 @@
     "noticeChatBackupDeviceVerification": "Hinweis: Wenn du alle deine Geräte mit dem Chat-Backup verbindest, sind sie automatisch verifiziert.",
     "setWallpaper": "Hintergrund ändern",
     "opacity": "Deckkraft:",
-    "welcomeText": "Hey Hey 👋 Das ist FluffyChat. Du kannst sich bei jedem Homeserver anmelden, der mit https://matrix.org kompatibel ist. Und dann mit jedem chatten. Das hier ist ein riesiges dezentrales Nachrichtennetzwerk!",
     "blur": "Verwischen:",
-    "manageAccount": "Konto verwalten",
     "continueText": "Fortfahren",
     "noContactInformationProvided": "Der Server stellt keine gültigen Kontaktinformationen bereit",
     "contactServerAdmin": "Serveradministrator kontaktieren",
@@ -2623,7 +2407,6 @@
     "compress": "Komprimieren",
     "supportPage": "Support-Seite",
     "serverInformation": "Server-Informationen:",
-    "appIntroduction": "Mit FluffyChat kannst du über verschiedene Messenger hinweg mit deinen Freunden chatten. Erfahre mehr dazu auf https://matrix.org oder tippe einfach auf *Fortfahren*.",
     "newChatRequest": "📩 Neue Chat-Anfrage",
     "synchronizingPleaseWaitCounter": " Synchronisierung… ({percentage}%)",
     "@synchronizingPleaseWaitCounter": {
@@ -2637,16 +2420,6 @@
     "waitingForServer": "Auf Server warten...",
     "previous": "Vorige",
     "otherPartyNotLoggedIn": "Der User ist aktuell nicht eingeloggt und kann daher keine Nachrichten empfangen!",
-    "appWantsToUseForLogin": "Nutze '{server}' um dich einzuloggen",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Hiermit erlaubst du der App und der Website, Informationen über dich weiterzugeben.",
     "open": "Offen",
     "notificationRuleContainsUserName": "Enthält Benutzernamen",
     "notificationRuleContainsUserNameDescription": "Benachrichtigt den Benutzer, wenn eine Nachricht seinen Benutzernamen enthält.",
@@ -2692,15 +2465,6 @@
     "notificationRuleEncryptedDescription": "Benachrichtigt den Benutzer über Nachrichten in verschlüsselten Räumen.",
     "notificationRuleJitsiDescription": "Benachrichtigt den Benutzer über Jitsi-Widget-Ereignisse.",
     "checkList": "Checkliste",
-    "countInvited": "{count} invited",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "notificationRuleIsUserMention": "Benutzererwähnung",
     "notificationRuleContainsDisplayName": "Enthält den Anzeigenamen",
     "notificationRuleContainsDisplayNameDescription": "Benachrichtigt den Benutzer, wenn eine Nachricht seinen Anzeigenamen enthält.",
@@ -2754,9 +2518,6 @@
     "noMessagesYet": "Noch keine Nachrichten",
     "longPressToRecordVoiceMessage": "Lange drücken, um eine Sprachnachricht aufzunehmen.",
     "pause": "Pause",
-    "newSubSpace": "Neuer Sub-Space",
-    "moveToDifferentSpace": "In einen anderen space wechseln",
-    "removeFromSpaceDescription": "Der Chat wird aus dem Space entfernt, erscheint aber weiterhin in Ihrer Chatliste.",
     "countChats": "{chats} Chats",
     "@countChats": {
         "type": "String",
@@ -2766,25 +2527,6 @@
             }
         }
     },
-    "spaceMemberOf": "Space-Mitglieder von {spaces}",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "Space-Mitglieder von {spaces} kann klopfen",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "Spenden",
     "resume": "Fortsetzen",
     "startedAPoll": "{username} hat eine Umfrage gestartet.",
     "@startedAPoll": {
@@ -2829,10 +2571,6 @@
     "changedTheChatDescription": "{username} hat die Chatbeschreibung geändert",
     "changedTheChatName": "{username} den Chatnamen geändert",
     "saveChanges": "Änderungen speichern",
-    "skipChatBackup": "Chatsicherung überspringen",
-    "skipChatBackupWarning": "Bist du sicher? Ohne die Chatsicherung zu aktivieren, kannst du den Zugriff auf deine Nachrichten verlieren, wenn du dein Gerät wechselst.",
-    "loadingMessages": "Nachrichten werden geladen",
-    "setupChatBackup": "Chatsicherung einrichten",
     "createSticker": "Sticker oder Emoji erstellen",
     "useAsSticker": "Als Sticker verwenden",
     "useAsEmoji": "Als Emoji verwenden",
@@ -2851,51 +2589,34 @@
     },
     "attribution": "Attribuierung",
     "identityServer": "Identitätsserver:",
-    "versionWithNumber": "Version: {version}",
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "logs": "Protokolle",
     "baseUrl": "Basis-URL",
-    "advancedConfigs": "Erweiterte Konfigurationen",
     "advancedConfigurations": "Erweiterte Konfigurationen",
     "@clearArchive": {},
     "@scanQrCode": {},
     "@addToSpace": {},
     "@serverRequiresEmail": {},
-    "@enableMultiAccounts": {},
     "@bundleName": {},
     "@removeFromBundle": {},
     "@addToBundle": {},
     "@editBundlesForAccount": {},
-    "@addAccount": {},
     "@oneClientLoggedOut": {},
     "@homeserver": {},
     "@sendOnEnter": {},
     "@link": {},
-    "@yourChatBackupHasBeenSetUp": {},
     "@unverified": {},
     "@messageInfo": {},
     "@time": {},
     "@messageType": {},
     "@sender": {},
     "@openGallery": {},
-    "@removeFromSpace": {},
     "@start": {},
     "@repeatPassword": {},
     "@publish": {},
     "@pinMessage": {},
     "@emojis": {},
     "@placeCall": {},
-    "@voiceCall": {},
     "@unsupportedAndroidVersion": {},
-    "@videoCallsBetaWarning": {},
-    "@emailOrUsername": {},
     "@unsupportedAndroidVersionLong": {},
     "@experimentalVideoCalls": {},
     "@markAsRead": {},
@@ -2915,43 +2636,25 @@
     "@youRejectedTheInvitation": {},
     "@youJoinedTheChat": {},
     "@youAcceptedTheInvitation": {},
-    "@recoveryKey": {},
-    "@recoveryKeyLost": {},
     "@user": {},
     "@custom": {},
-    "@storeInAndroidKeystore": {},
-    "@storeSecurlyOnThisDevice": {},
     "@dehydrate": {},
     "@dehydrateWarning": {},
     "@hydrate": {},
-    "@unlockOldMessages": {},
-    "@pleaseEnterRecoveryKeyDescription": {},
-    "@saveKeyManuallyDescription": {},
-    "@pleaseEnterRecoveryKey": {},
     "@users": {},
-    "@storeInSecureStorageDescription": {},
-    "@storeInAppleKeyChain": {},
     "@confirmMatrixId": {},
     "@commandHint_markasdm": {},
     "@commandHint_markasgroup": {},
     "@doNotShowAgain": {},
     "@noKeyForThisMessage": {},
-    "@foregroundServiceRunning": {},
-    "@screenSharingTitle": {},
     "@whyIsThisMessageEncrypted": {},
     "@newGroup": {},
     "@newSpace": {},
-    "@enterSpace": {},
     "@allSpaces": {},
-    "@screenSharingDetail": {},
-    "@newSpaceDescription": {},
-    "@encryptThisChat": {},
     "@deviceKeys": {},
     "@commandHint_cuddle": {},
     "@commandHint_hug": {},
-    "@sorryThatsNotPossible": {},
     "@commandHint_googly": {},
-    "@disableEncryptionWarning": {},
     "@reopenChat": {},
     "@noBackupWarning": {},
     "@noOtherDevicesFound": {},
@@ -2972,13 +2675,11 @@
     "@shareInviteLink": {},
     "@tryAgain": {},
     "@redactMessageDescription": {},
-    "@setTheme": {},
     "@setColorTheme": {},
     "@invite": {},
     "@optionalRedactReason": {},
     "@messagesStyle": {},
     "@chatPermissions": {},
-    "@chatDescription": {},
     "@chatDescriptionHasBeenChanged": {},
     "@noChatDescriptionYet": {},
     "@invalidServerName": {},
@@ -2997,17 +2698,14 @@
     "@roomUpgradeDescription": {},
     "@kickUserDescription": {},
     "@blockListDescription": {},
-    "@createGroupAndInviteUsers": {},
     "@startConversation": {},
     "@blockedUsers": {},
-    "@groupCanBeFoundViaSearch": {},
     "@block": {},
     "@yourGlobalUserIdIs": {},
     "@commandHint_sendraw": {},
     "@wrongRecoveryKey": {},
     "@blockUsername": {},
     "@groupName": {},
-    "@searchChatsRooms": {},
     "@databaseMigrationTitle": {},
     "@databaseMigrationBody": {},
     "@thisDevice": {},
@@ -3021,7 +2719,6 @@
     "@subspace": {},
     "@select": {},
     "@pleaseChooseAStrongPassword": {},
-    "@addChatOrSubSpace": {},
     "@leaveEmptyToClearStatus": {},
     "@joinSpace": {},
     "@searchForUsers": {},
@@ -3030,11 +2727,9 @@
     "@formattedMessages": {},
     "@sendTypingNotificationsDescription": {},
     "@formattedMessagesDescription": {},
-    "@verifyOtherUser": {},
     "@sendReadReceiptsDescription": {},
     "@transparent": {},
     "@verifyOtherDevice": {},
-    "@verifyOtherUserDescription": {},
     "@verifyOtherDeviceDescription": {},
     "@incomingMessages": {},
     "@commandHint_unignore": {},
@@ -3044,9 +2739,6 @@
     "@stickers": {},
     "@discover": {},
     "@customEmojisAndStickersBody": {},
-    "@globalChatId": {},
-    "@accessAndVisibility": {},
-    "@accessAndVisibilityDescription": {},
     "@appLockDescription": {},
     "@calls": {},
     "@customEmojisAndStickers": {},
@@ -3057,10 +2749,6 @@
     "@passwordRecoverySettings": {},
     "@knock": {},
     "@knocking": {},
-    "@usersMustKnock": {},
-    "@noOneCanJoin": {},
-    "@createNewAddress": {},
-    "@publicChatAddresses": {},
     "@gallery": {},
     "@files": {},
     "@restricted": {},
@@ -3084,11 +2772,7 @@
     "@changelog": {},
     "@sendCanceled": {},
     "@noChatsFoundHere": {},
-    "@whatIsAHomeserver": {},
     "@doesNotSeemToBeAValidHomeserver": {},
-    "@loginWithMatrixId": {},
-    "@discoverHomeservers": {},
-    "@homeserverDescription": {},
     "@sendingAttachment": {},
     "@generatingVideoThumbnail": {},
     "@calculatingFileSize": {},
@@ -3098,9 +2782,7 @@
     "@noticeChatBackupDeviceVerification": {},
     "@setWallpaper": {},
     "@opacity": {},
-    "@welcomeText": {},
     "@blur": {},
-    "@manageAccount": {},
     "@continueText": {},
     "@noContactInformationProvided": {},
     "@contactServerAdmin": {},
@@ -3118,12 +2800,10 @@
     "@compress": {},
     "@supportPage": {},
     "@serverInformation": {},
-    "@appIntroduction": {},
     "@newChatRequest": {},
     "@waitingForServer": {},
     "@previous": {},
     "@otherPartyNotLoggedIn": {},
-    "@appWantsToUseForLoginDescription": {},
     "@open": {},
     "@notificationRuleContainsUserName": {},
     "@notificationRuleContainsUserNameDescription": {},
@@ -3201,10 +2881,6 @@
     "@noMessagesYet": {},
     "@longPressToRecordVoiceMessage": {},
     "@pause": {},
-    "@newSubSpace": {},
-    "@moveToDifferentSpace": {},
-    "@removeFromSpaceDescription": {},
-    "@donate": {},
     "@resume": {},
     "@poll": {},
     "@startPoll": {},
@@ -3222,10 +2898,6 @@
     "@changedTheChatDescription": {},
     "@changedTheChatName": {},
     "@saveChanges": {},
-    "@skipChatBackup": {},
-    "@skipChatBackupWarning": {},
-    "@loadingMessages": {},
-    "@setupChatBackup": {},
     "@createSticker": {},
     "@useAsSticker": {},
     "@useAsEmoji": {},
@@ -3239,11 +2911,9 @@
     "taTooltip": "L2 Verwendung mit Übersetzungshilfe",
     "interactiveTranslatorSliderHeader": "Interaktiver Übersetzer",
     "interactiveGrammarSliderHeader": "Interaktiver Grammatikprüfer",
-    "interactiveTranslatorRequired": "Erforderlich",
     "waTooltip": "L2 Verwendung ohne Hilfe",
     "interactiveTranslator": "Übersetzungshilfe",
     "noIdenticalLanguages": "Bitte wählen Sie unterschiedliche Ausgangs- und Zielsprache",
-    "searchBy": "Suche nach Land und Sprachen",
     "joinWithClassCode": "Kurs beitreten",
     "languageLevelPreA1": "Anfänger Niedrig (Pre A1)",
     "languageLevelA1": "Novize Mitte (A1)",
@@ -3263,19 +2933,14 @@
     "whatIsYourBaseLanguage": "Was ist deine Ausgangssprache?",
     "publicProfileTitle": "Erlauben Sie, dass mein Profil in der Suche gefunden wird",
     "publicProfileDesc": "Wenn Sie es einschalten, können andere Benutzer Ihr Profil in der globalen Suchleiste finden und Chat-Anfragen senden. An diesem Punkt können Sie die Anfrage akzeptieren oder ablehnen.",
-    "errorDisableIT": "Übersetzungshilfe ist deaktiviert.",
-    "errorDisableIGC": "Grammatikhilfe ist deaktiviert.",
     "errorDisableITUserDesc": "Klicken Sie hier, um die Einstellungen für Übersetzungshilfe zu aktualisieren",
     "errorDisableIGCUserDesc": "Klicken Sie hier, um die Einstellungen für Grammatikhilfe zu aktualisieren",
     "errorDisableITClassDesc": "Die Übersetzungshilfe ist für den Kurs, in dem sich dieser Chat befindet, deaktiviert.",
     "errorDisableIGCClassDesc": "Die Grammatikhilfe ist für den Kurs, in dem sich dieser Chat befindet, deaktiviert.",
-    "error405Title": "Sprachen nicht eingestellt",
     "error405Desc": "Bitte stellen Sie Ihre Sprachen im Hauptmenü > Lerneinstellungen ein.",
     "termsAndConditions": "Allgemeinen Geschäftsbedingungen",
     "andCertifyIAmAtLeast13YearsOfAge": " zu und bestätigen, dass ich mindestens 16 Jahre alt bin.",
-    "error502504Title": "Wow, es sind viele Schüler online!",
     "error502504Desc": "Übersetzungs- und Grammatiktools könnten langsam sein oder nicht verfügbar sein, während die Pangea-Bots aufholen.",
-    "error404Title": "Übersetzungsfehler!",
     "error404Desc": "Der Pangea-Bot ist sich nicht sicher, wie das zu übersetzen ist...",
     "errorPleaseRefresh": "Wir kümmern uns darum! Bitte laden Sie die Seite neu und versuchen Sie es erneut.",
     "connectedToStaging": "Mit Staging verbunden",
@@ -3313,13 +2978,9 @@
     "definitionsToolName": "Wortdefinitionen",
     "definitionsToolDescription": "Wenn aktiviert, können Wörter, die blau unterstrichen sind, angeklickt werden, um Definitionen anzuzeigen. Klicken Sie auf Nachrichten, um Definitionen zu erhalten.",
     "welcomeBack": "Willkommen zurück! Wenn Sie Teil des Pilotprojekts 2023-2024 waren, kontaktieren Sie uns bitte für Ihr spezielles Pilotabonnement. Wenn Sie Lehrer sind, der (oder dessen Institution) Lizenzen für Ihre Klasse gekauft hat, kontaktieren Sie uns für Ihr Lehrerausweis.",
-    "downloadTxtFile": "Textdatei herunterladen",
-    "downloadCSVFile": "CSV-Datei herunterladen",
     "promotionalSubscriptionDesc": "Sie haben derzeit ein lebenslanges Aktionsabonnement. Kontaktieren Sie support@pangea.chat, um Hilfe bei der Änderung Ihres Abonnements zu erhalten.",
     "originalSubscriptionPlatform": "Abonnement gekauft über {purchasePlatform}",
     "oneWeekTrial": "Einwöchige Testversion",
-    "downloadXLSXFile": "Excel-Datei herunterladen",
-    "unkDisplayName": "Unbekannt",
     "wwCountryDisplayName": "Weltweit",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Alandinseln",
@@ -3614,7 +3275,6 @@
     "chatCapacityHasBeenChanged": "Chat-Kapazität wurde geändert",
     "chatCapacitySetTooLow": "Die Chat-Kapazität muss mindestens {count} sein.",
     "chatCapacityExplanation": "Die Chat-Kapazität begrenzt die Anzahl der Mitglieder, die in einem Chat erlaubt sind.",
-    "tooManyRequest": "Zu viele Anfragen, bitte versuchen Sie es später erneut.",
     "enterNumber": "Bitte geben Sie eine ganze Zahl ein.",
     "practice": "Üben",
     "versionNotFound": "Version nicht gefunden",
@@ -3624,7 +3284,6 @@
     "deleteSubscriptionWarningTitle": "Sie haben ein aktives Abonnement",
     "deleteSubscriptionWarningBody": "Das Löschen Ihres Kontos wird Ihr Abonnement nicht automatisch kündigen.",
     "manageSubscription": "Abonnement verwalten",
-    "error520Title": "Bitte versuchen Sie es erneut.",
     "error520Desc": "Entschuldigung, wir konnten Ihre Nachricht nicht verstehen...",
     "wordsUsed": "Verwendete Wörter",
     "level": "Stufe",
@@ -3642,7 +3301,6 @@
     "other": "Andere",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "Keine Kapazitätsbegrenzung",
-    "downloadGroupText": "Gruppentext herunterladen",
     "notificationsOn": "Benachrichtigungen aktiviert",
     "notificationsOff": "Benachrichtigungen deaktiviert",
     "joinWithCode": "Mit Code beitreten",
@@ -3706,24 +3364,12 @@
     "whatIsTheMorphTag": "Was ist das {morphologicalFeature} von '{wordForm}'?",
     "dataAvailable": "Datenverfügbarkeit",
     "available": "Verfügbar",
-    "pangeaBotIsFallible": "Pangea Bot macht auch Fehler!",
-    "whatIsMeaning": "Was bedeutet '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Ordne Bedeutungen den Wörtern in der Nachricht zu!",
-    "doubleClickToEdit": "Doppelklicken zum Bearbeiten.",
-    "topicLabel": "Thema",
-    "topicPlaceholder": "Wählen Sie ein Thema...",
-    "modePlaceholder": "Wählen Sie einen Modus...",
-    "learningObjectiveLabel": "Lernziel",
-    "learningObjectivePlaceholder": "Wählen Sie ein Lernziel...",
-    "targetLanguageLabel": "Zielsprache",
     "cefrLevelLabel": "CEFR-Niveau",
     "image": "Bild",
     "video": "Video",
     "nan": "Nicht zutreffend",
-    "addVocabulary": "Vokabular hinzufügen",
     "instructions": "Anweisungen",
-    "numberOfLearners": "Anzahl der Lernenden",
-    "mustBeInteger": "Muss eine ganze Zahl sein, z.B. 1, 2, 3, ...",
     "constructUsePvmDesc": "In Sprachmitteilung produziert",
     "leaveSpaceDescription": "Wenn Sie den Kurs verlassen, verlassen Sie alle Chats darin. Andere Nutzer sehen, dass Sie den Kurs verlassen haben.",
     "constructUseCorMmDesc": "Korrekte Nachrichtenbedeutung",
@@ -3738,7 +3384,6 @@
     "ttsDisabledBody": "Sie können die Text-zu-Sprache-Funktion in Ihren Lerneinstellungen aktivieren",
     "noSpaceDescriptionYet": "Noch keine Kursbeschreibung erstellt.",
     "tooLargeToSend": "Diese Nachricht ist zu groß zum Senden",
-    "exitWithoutSaving": "Möchten Sie wirklich ohne Speichern verlassen?",
     "enableAutocorrectPopupTitle": "Fügen Sie Ihre Zielsprachentastatur hinzu, indem Sie zu gehen:",
     "enableAutocorrectPopupSteps": "  • Einstellungen\n  • Allgemein\n  • Tastatur\n  • Tastaturen\n  • Neue Tastatur hinzufügen",
     "enableAutocorrectPopupDescription": "Sobald die Sprache ausgewählt ist, können Sie auf das kleine Globus-Symbol unten links auf Ihrer Tastatur klicken, um die neu installierte Tastatur zu aktivieren.",
@@ -3749,11 +3394,8 @@
     "displayName": "Anzeigename",
     "leaveRoomDescription": "Sie sind dabei, diesen Chat zu verlassen. Andere Benutzer werden sehen, dass Sie den Chat verlassen haben.",
     "confirmUserId": "Bitte bestätigen Sie Ihren Pangea-Chat-Benutzernamen, um Ihr Konto zu löschen.",
-    "startingToday": "Ab heute",
-    "oneWeekFreeTrial": "Eine Woche kostenlos testen",
     "paidSubscriptionStarts": "Beginnt am {startDate}",
     "cancelInSubscriptionSettings": "• Jederzeit in den Abonnement-Einstellungen kündigen",
-    "cancelToAvoidCharges": "• Vor {trialEnds} kündigen, um Gebühren zu vermeiden",
     "downloadGboard": "Gboard herunterladen",
     "autocorrectNotAvailable": "Leider wird diese Plattform derzeit nicht für diese Funktion unterstützt. Bleiben Sie dran für weitere Entwicklungen!",
     "pleaseUpdateApp": "Bitte aktualisieren Sie die App, um fortzufahren.",
@@ -3763,17 +3405,12 @@
     "knockSpaceSuccess": "Sie haben die Anfrage gestellt, an diesem Kurs teilzunehmen! Ein Administrator wird auf Ihre Anfrage antworten, sobald er sie erhält 😄",
     "chooseWordAudioInstructionsBody": "Hören Sie sich die vollständige Nachricht an. Ordnen Sie dann die Audios den Wörtern zu.",
     "chooseMorphsInstructionsBody": "Klicken Sie auf die Puzzleteile für Grammatikfragen!",
-    "pleaseEnterInt": "Bitte geben Sie eine Zahl ein",
     "home": "Startseite",
     "join": "Beitreten",
     "resetInstructionTooltipsTitle": "Anleitungstooltips zurücksetzen",
     "resetInstructionTooltipsDesc": "Klicke, um Anleitungstooltips wie für einen völlig neuen Benutzer anzuzeigen.",
-    "randomize": "Zufällig",
     "clear": "Löschen",
-    "featuredActivities": "Vorgestellt",
     "save": "Speichern",
-    "startChat": "Chat starten",
-    "translationProblem": "Übersetzungsproblem",
     "askToJoin": "Frage zum Beitritt",
     "emptyChatWarningTitle": "Chat ist leer",
     "emptyChatWarningDesc": "Du hast niemanden zu deinem Chat eingeladen. Gehe zu den Chat-Einstellungen, um deine Kontakte oder den Bot einzuladen. Du kannst das auch später tun.",
@@ -3803,17 +3440,13 @@
     "timesUsedIndependently": "Anzahl der unabhängigen Verwendungen",
     "timesUsedWithAssistance": "Anzahl der Verwendungen mit Unterstützung",
     "shareInviteCode": "Einladungs-Code teilen: {code}",
-    "leaderboard": "Bestenliste",
     "skipForNow": "Jetzt überspringen",
     "permissions": "Berechtigungen",
     "spaceChildPermission": "Wer kann neue Chats zu diesem Kurs hinzufügen",
-    "addEnvironmentOverride": "Umgebungsüberschreibung hinzufügen",
     "defaultOption": "Standard",
     "deleteChatDesc": "Möchten Sie diesen Chat wirklich löschen? Er wird für alle Teilnehmer gelöscht und alle Nachrichten im Chat sind nicht mehr für Übungen oder Lernanalysen verfügbar.",
     "deleteSpaceDesc": "Der Kurs und alle ausgewählten Chats werden für alle Teilnehmer gelöscht und alle Nachrichten im Chat sind nicht mehr für Übungen oder Lernanalysen verfügbar. Diese Aktion kann nicht rückgängig gemacht werden.",
     "launch": "Starten",
-    "searchChats": "Chats suchen",
-    "maxFifty": "Maximal 50",
     "configureSpace": "Kurs konfigurieren",
     "pinMessages": "Nachrichten anheften",
     "setJoinRules": "Beitrittsregeln festlegen",
@@ -3847,9 +3480,6 @@
     "failedToFetchTranscription": "Transkription konnte nicht abgerufen werden",
     "deleteEmptySpaceDesc": "Der Kurs wird für alle Teilnehmer gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.",
     "regenerate": "Neu generieren",
-    "mySavedActivities": "Meine gespeicherten Aktivitäten",
-    "noSavedActivities": "Keine gespeicherten Aktivitäten",
-    "saveActivity": "Aktivität speichern",
     "failedToPlayVideo": "Video konnte nicht abgespielt werden",
     "done": "Fertig",
     "inThisSpace": "In diesem Kurs",
@@ -3860,13 +3490,9 @@
     "numInvited": "{count} eingeladen",
     "saved": "Gespeichert",
     "reset": "Zurücksetzen",
-    "errorFetchingActivitiesMessage": "Fehler beim Abrufen der Aktivitäten",
     "errorFetchingDefinition": "Fehler beim Abrufen der Definition",
     "errorProcessAnalytics": "Fehler bei der Verarbeitung der Analysen",
     "errorDownloading": "Download fehlgeschlagen",
-    "errorLoadingSpaceChildren": "Fehler beim Laden der Chats innerhalb dieses Kurses",
-    "unexpectedError": "Unerwarteter Fehler.",
-    "pleaseReload": "Bitte neu laden und erneut versuchen.",
     "translationError": "Übersetzungsfehler",
     "check": "Prüfen",
     "unableToFindRoom": "Kein Chat oder Kurs mit diesem Code gefunden. Bitte versuchen Sie es erneut.",
@@ -3875,19 +3501,14 @@
     "request": "Anfrage",
     "requestAll": "Alle anfordern",
     "confirmMessageUnpin": "Möchten Sie diese Nachricht wirklich lösen?",
-    "saveAndLaunch": "Speichern und starten",
-    "launchToSpace": "Starten Sie den Kurs",
     "pending": "Ausstehend",
     "inactive": "Inaktiv",
-    "confirmRole": "Rolle bestätigen",
     "openRoleLabel": "OFFEN",
     "finishedTheActivity": "🎯 {username} hat diese Aktivität beendet",
     "activitySummaryError": "Aktivitätszusammenfassungen nicht verfügbar",
     "requestSummaries": "Zusammenfassungen anfordern",
-    "generatingNewActivities": "Sie sind der erste Benutzer dieses Sprachpaares! Bitte geben Sie uns eine Minute, wir bereiten Aktivitäten nur für Sie vor.",
     "requestAccessTitle": "Zugriff auf Analysen anfordern?",
     "requestAccessDesc": "Möchten Sie Zugriff auf die Teilnehmeranalyse beantragen?\n\nWenn die Teilnehmer zustimmen, können Administratoren dieses Kurses ihre:\n    • Gesamtvokabular\n    • Gesammtgrammatik-Konzepte\n    • Anzahl der abgeschlossenen Aktivitätssitzungen\n    • die verwendeten Grammatik-Konzepte, richtig und falsch\n\nSie werden nicht in der Lage sein, ihre:\n    • Nachrichten in Chats außerhalb des Kurses\n    • Vokabelliste",
-    "requestAccess": "Zugriff anfordern ({count})",
     "analyticsInactiveTitle": "Anfragen an inaktive Benutzer konnten nicht gesendet werden",
     "analyticsInactiveDesc": "Inaktive Benutzer, die sich seit der Einführung dieses Features nicht angemeldet haben, sehen Ihre Anfrage nicht.\n\nDer Button „Anfrage“ erscheint, sobald sie zurückkehren. Sie können die Anfrage später erneut senden, indem Sie auf den Button „Anfrage“ unter ihrem Namen klicken, wenn dieser verfügbar ist.",
     "accessRequestedTitle": "Anfrage für Analytics-Zugriff",
@@ -3910,8 +3531,6 @@
     "accessDesc": "Sie können Ihren Kurs für die Welt öffnen! Oder machen Sie Ihren Kurs privat und sicher.",
     "createGroupChatDesc": "Während Aktivitätssitzungen starten und enden, bleiben Gruppenchats für die routinemäßige Kommunikation offen.",
     "deleteDesc": "Nur Administratoren können einen Kurs löschen. Dies ist eine zerstörerische Aktion, die alle Benutzer entfernt und alle ausgewählten Chats im Kurs löscht. Bitte vorsichtig vorgehen.",
-    "noCourseFound": "Oh, dieser Kurs braucht einen Plan!\n\nKurspläne sind eine Abfolge von Themen und Gesprächsaktivitäten.",
-    "additionalParticipants": "+ {num} weitere",
     "whatNow": "Was jetzt?",
     "chooseNextActivity": "Wählen Sie Ihre nächste Aktivität!",
     "letsGo": "Los geht's",
@@ -3924,13 +3543,11 @@
     "waitNotDone": "Warte, ich bin noch nicht fertig!",
     "waitingForOthersToFinish": "Warte, bis die anderen fertig sind...",
     "generatingSummary": "Chat wird analysiert und Ergebnisse werden generiert",
-    "findCourse": "Kurs finden",
     "pingParticipantsNotification": "{user} sucht nach Nutzern, die an der Sitzung in {room} teilnehmen möchten",
     "course": "Kurs",
     "courses": "Kurse",
     "goToCourse": "Zum Kurs: {course}",
     "activityComplete": "Diese Aktivität wurde abgeschlossen. Die Zusammenfassung der Aktivität sollte unten verfügbar sein.",
-    "startNewSession": "Neue Sitzung starten",
     "joinOpenSession": "Offene Sitzung beitreten",
     "activityNotFound": "Aktivität nicht gefunden",
     "myActivities": "Meine Aktivitäten",
@@ -4004,10 +3621,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4017,10 +3630,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4104,14 +3713,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4128,10 +3729,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4144,15 +3741,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4304,14 +3893,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4325,14 +3906,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5555,10 +5128,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5599,10 +5168,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5675,10 +5240,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5948,47 +5509,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6008,19 +5529,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6084,10 +5593,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6128,14 +5633,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6147,14 +5644,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6192,10 +5681,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6212,27 +5697,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6356,10 +5825,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6369,10 +5834,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6389,14 +5850,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6536,18 +5989,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6596,10 +6037,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6609,18 +6046,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6663,23 +6088,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6703,10 +6116,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6714,14 +6123,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6826,18 +6227,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6890,10 +6279,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6920,10 +6305,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7104,7 +6485,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Kehren Sie morgen zurück, um Updates zur Aktivität zu erhalten.",
-    "activityDropdownDesc": "Wenn Sie mit dieser Aktivität fertig sind, klicken Sie unten",
     "languageMismatchTitle": "Sprachinkonsistenz",
     "languageMismatchDesc": "Ihre Zielsprache stimmt nicht mit der Sprache dieser Aktivität überein. Möchten Sie Ihre Zielsprache aktualisieren?",
     "reportWordIssueTooltip": "Meldung eines Wortinformationsproblems",
@@ -7117,10 +6497,6 @@
     "selectAll": "Alle auswählen",
     "deselectAll": "Alle abwählen",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7169,17 +6545,11 @@
         "placeholders": {}
     },
     "startOwn": "Eigene starten",
-    "joinCourseDesc": "Jeder Kurs besteht aus 8-10 sequenziellen Themen mit einer Vielzahl von aufgabenbasierten Sprachlernaktivitäten.",
     "newMessageInPangeaChat": "🗨️ Neue Nachricht im Pangea-Chat",
     "shareCourse": "Kurs teilen",
     "addCourse": "Einen Kurs hinzufügen",
-    "joinPublicCourse": "Öffentlichen Kurs beitreten",
     "vocabLevelsDesc": "Hier kommen die Vokabeln hin, sobald du sie aufgestuft hast!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7192,10 +6562,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7214,7 +6580,6 @@
     "emojiView": "Emoji-Ansicht",
     "feedbackDialogDesc": "Ich mache auch Fehler! Gibt es etwas, das mir helfen kann, mich zu verbessern?",
     "contactHasBeenInvitedToTheCourse": "Kontakt wurde zum Kurs eingeladen",
-    "activityStatsButtonTooltip": "Aktivitätsinformationen",
     "allow": "Erlauben",
     "deny": "Ablehnen",
     "enabledRenewal": "Abonnementverlängerung aktivieren",
@@ -7482,10 +6847,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8541,16 +7902,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktivitäten zum Freischalten des nächsten Themas",
-    "activitiesToUnlockTopicDesc": "Legen Sie die Anzahl der Aktivitäten fest, um das nächste Kursthema freizuschalten",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Korrekte Vokabeldefinitionsübung",
     "constructUseIncLMDesc": "Falsche Vokabeldefinitionsübung",
     "constructUseCorLADesc": "Korrekte Vokabelaudioübung",
@@ -8558,7 +7909,6 @@
     "constructUseBonus": "Bonus während der Vokabelübung",
     "practiceVocab": "Vokabeln üben",
     "selectMeaning": "Wähle die Bedeutung",
-    "selectAudio": "Wähle das passende Audio",
     "anotherRound": "Eine weitere Runde",
     "activitySettingsOverrideWarning": "Sprache und Sprachniveau werden durch den Aktivitätsplan bestimmt",
     "voice": "Stimme",
@@ -8590,10 +7940,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8611,12 +7957,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Download gestartet",
     "webDownloadPermissionMessage": "Wenn Ihr Browser Downloads blockiert, aktivieren Sie bitte Downloads für diese Seite.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8711,11 +8052,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Etwas ist schiefgelaufen, und wir arbeiten hart daran, es zu beheben. Überprüfen Sie es später erneut.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Schreibassistenz aktivieren",
     "autoIGCToolDescription": "Automatisch Pangea Chat-Tools ausführen, um gesendete Nachrichten in die Zielsprache zu korrigieren.",
     "@autoIGCToolName": {
@@ -8733,15 +8069,12 @@
     },
     "federationBaseUrl": "Föderation Basis-URL",
     "clientWellKnownInformation": "Client-Well-Known-Information:",
-    "spanTypeGrammar": "Grammatik",
-    "spanTypeWordChoice": "Wortwahl",
     "spanTypeSpelling": "Rechtschreibung",
     "spanTypePunctuation": "Zeichensetzung",
     "spanTypeStyle": "Stil",
     "spanTypeFluency": "Flüssigkeit",
     "spanTypeAccents": "Akzente",
     "spanTypeCapitalization": "Großschreibung",
-    "spanTypeCorrection": "Korrektur",
     "spanFeedbackTitle": "Korrekturproblem melden",
     "selectAllWords": "Wählen Sie alle Wörter aus, die Sie im Audio hören",
     "aboutMeHint": "Über mich",
@@ -8752,20 +8085,11 @@
     "greatPractice": "Großartige Übung!",
     "usedNoHints": "Gute Arbeit, keine Hinweise verwendet zu haben!",
     "youveCompletedPractice": "Sie haben die Übung abgeschlossen, machen Sie weiter, um besser zu werden!",
-    "joinCourseForActivities": "Treten Sie einem Kurs bei, um Aktivitäten auszuprobieren.",
     "@federationBaseUrl": {
         "type": "String",
         "placeholders": {}
     },
     "@clientWellKnownInformation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
         "type": "String",
         "placeholders": {}
     },
@@ -8790,10 +8114,6 @@
         "placeholders": {}
     },
     "@spanTypeCapitalization": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeCorrection": {
         "type": "String",
         "placeholders": {}
     },
@@ -8834,10 +8154,6 @@
         "placeholders": {}
     },
     "@youveCompletedPractice": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9038,11 +8354,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "In einer Klasse? Gib hier deinen Beitrittscode ein.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Audio-Nachrichten automatisch hervorheben",
     "selectAudioMessagesOnPlayDescription": "Audio-Nachrichten automatisch hervorheben, wenn sie abgespielt werden",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9086,18 +8397,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Dieser Kurs hat Themen mit weniger als {input} Aktivitäten. Bitte geben Sie eine Zahl ein, die kleiner oder gleich {minValue} ist.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Klicken Sie hier, um sich wieder anzumelden.",
     "@clickToLogin": {
@@ -9514,17 +8813,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Ein cartoonartiger gelber Bär mit erhobenen Armen vor Aufregung.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Wählen Sie Wörter aus, um mehr über sie zu erfahren",
     "requireAnalyticsAccessTitle": "Analytikzugang erforderlich, um beizutreten",
     "requireAnalyticsAccessDesc": "Teilnehmer müssen den Zugriff auf ihre Lernanalysen gewähren, um an diesem Kurs teilzunehmen",
     "analyticsAccessNoticeTitle": "Analytikzugang erforderlich",
     "analyticsAccessNoticeDesc": "Durch die Teilnahme an diesem Kurs stimmen Sie zu, den Administratoren Zugriff auf Ihre Lernanalysen zu gewähren.",
-    "skipOnboardingClassCodeDesc": "Unabhängig lernen? Keine Sorge, Sie können:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9542,10 +8835,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9574,7 +8863,6 @@
     "pickCefrLevelTeacherStepTitle": "Welches Niveau unterrichtest du?",
     "pickCefrLevelStudentStepTitle": "Welches Niveau bist du?",
     "customCourseStepTitle": "Fülle dieses Formular aus, um einen individuellen Kurs zu erhalten",
-    "aboutYourClass": "Über deinen Kurs",
     "courseCodeStepErrorMessage": "Bitte überprüfe deinen Code und versuche es erneut",
     "institution": "Institution",
     "courseGoals": "Kursziele",
@@ -9617,10 +8905,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9737,12 +9021,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat-Logo",
     "introChatDetails": "Sag Hallo! Stelle dich deinen Mitkursteilnehmern vor, finde Freunde und chatte außerhalb der Aktivitäten.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9786,11 +9065,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Aktivitätsaktionen",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Aussprachewerkzeuge",
     "audioTranscription": "KI-Audio-Transkription",
     "visualLearnerSupport": "Unterstützung für visuelle Lernende",
@@ -9831,7 +9105,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Tritt einem Kurs bei, der diese Aktivität enthält, um sie zu spielen.",
     "resizeCoursePanel": "Kursfenstergröße ändern",
     "undo": "Rückgängig machen",
     "unlock": "Freischalten",
@@ -9845,7 +9118,6 @@
     "addCourseBrowsePublic": "Öffentliche Kurse durchsuchen",
     "browsePublicCourses": "Öffentliche Kurse durchsuchen",
     "editProfile": "Profil bearbeiten",
-    "numObjectives": "{count} Ziele",
     "mapSearchHint": "Aktivitäten suchen",
     "mapSearchNoResults": "Keine Übereinstimmungen in der Ansicht",
     "mapFilterAllLanguages": "Alle Sprachen",
@@ -9854,7 +9126,6 @@
     "mapFilterCompleted": "Abgeschlossen",
     "mapFilterReset": "Zurücksetzen",
     "activityTypeConversation": "Gespräch",
-    "lockedMissionRequirement": "Beende die vorherige Mission, um freizuschalten",
     "playAgain": "Nochmals spielen",
     "reviewActivity": "Überprüfen",
     "mapEmptyInView": "Nichts hier auf deinem Niveau oder in deiner Sprache. Erweitere deine Filter oder zoome heraus.",
@@ -9869,14 +9140,9 @@
     "scrollToBottom": "Zum Ende scrollen",
     "courseImage": "Kursbild",
     "avatarPreview": "Avatar-Vorschau",
-    "activityPhoto": "Aktivitätsfoto",
     "emotePreview": "Emote-Vorschau: {name}",
     "activityLabel": "Aktivität: {title}",
     "resetMapView": "Kartenansicht zurücksetzen",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9929,14 +9195,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9966,10 +9224,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10026,10 +9280,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_el.arb
+++ b/lib/l10n/intl_el.arb
@@ -44,11 +44,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Επιτρέπεται στους επισκέπτες χρήστες να συμμετάσχουν",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "blocked": "Αποκλείστηκε",
     "@blocked": {
         "type": "String",
@@ -515,31 +510,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@reportErrorDescription": {
         "type": "String",
         "placeholders": {}
     },
     "@directChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
-    "@addAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -683,10 +658,6 @@
             }
         }
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youAcceptedTheInvitation": {
         "type": "String",
         "placeholders": {}
@@ -793,10 +764,6 @@
         },
         "type": "String"
     },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unbanUserDescription": {
         "type": "String",
         "placeholders": {}
@@ -852,18 +819,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@emailOrUsername": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@next": {
         "type": "String",
         "placeholders": {}
@@ -873,14 +828,6 @@
         "placeholders": {}
     },
     "@editRoomAliases": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
         "type": "String",
         "placeholders": {}
     },
@@ -912,10 +859,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterRecoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@create": {
         "type": "String",
         "placeholders": {}
@@ -944,10 +887,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@addWidget": {
         "type": "String",
         "placeholders": {}
@@ -969,10 +908,6 @@
         "type": "String"
     },
     "@noKeyForThisMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1011,14 +946,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@replaceRoomWithNewerVersion": {
         "type": "String",
         "placeholders": {}
@@ -1039,15 +966,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@sender": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
         "type": "String",
         "placeholders": {}
     },
@@ -1103,10 +1022,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@passwordHasBeenChanged": {
         "type": "String",
         "placeholders": {}
@@ -1120,10 +1035,6 @@
         "placeholders": {}
     },
     "@copy": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -1142,14 +1053,6 @@
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "@rejectedTheInvitation": {
         "type": "String",
@@ -1171,10 +1074,6 @@
             }
         }
     },
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@or": {
         "type": "String",
         "placeholders": {}
@@ -1187,19 +1086,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@emptyChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@yourChatBackupHasBeenSetUp": {
         "type": "String",
         "placeholders": {}
     },
@@ -1212,10 +1099,6 @@
         }
     },
     "@submit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@videoCallsBetaWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1246,14 +1129,6 @@
     "@participant": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@yes": {
         "type": "String",
@@ -1336,10 +1211,6 @@
         "placeholders": {}
     },
     "@register": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
         "type": "String",
         "placeholders": {}
     },
@@ -1485,10 +1356,6 @@
         "placeholders": {}
     },
     "@openCamera": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -1650,10 +1517,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@redactMessage": {
         "type": "String",
         "placeholders": {}
@@ -1721,10 +1584,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@verifyStart": {
         "type": "String",
         "placeholders": {}
@@ -1746,10 +1605,6 @@
         "placeholders": {}
     },
     "@serverRequiresEmail": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
         "type": "String",
         "placeholders": {}
     },
@@ -1845,10 +1700,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@directChat": {
         "type": "String",
         "placeholders": {}
@@ -1877,15 +1728,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterAnEmailAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@voiceCall": {
         "type": "String",
         "placeholders": {}
     },
@@ -1894,10 +1737,6 @@
         "description": "Usage hint for the command /kick"
     },
     "@copiedToClipboard": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1945,10 +1784,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@learnMore": {
         "type": "String",
         "placeholders": {}
@@ -1982,10 +1817,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -2039,10 +1870,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youKicked": {
         "placeholders": {
             "user": {
@@ -2070,31 +1897,15 @@
             }
         }
     },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@oopsSomethingWentWrong": {
         "type": "String",
         "placeholders": {}
-    },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@shareInviteLink": {
         "type": "String",
         "placeholders": {}
     },
     "@commandHint_markasdm": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
         "type": "String",
         "placeholders": {}
     },
@@ -2111,14 +1922,6 @@
         "placeholders": {}
     },
     "@waitingPartnerNumbers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -2146,15 +1949,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@settings": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -2181,10 +1976,6 @@
                 "type": "String"
             }
         }
-    },
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
     },
     "@passwordForgotten": {
         "type": "String",
@@ -2342,10 +2133,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@openChat": {
         "type": "String",
         "placeholders": {}
@@ -2370,19 +2157,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@muteChat": {
         "type": "String",
         "placeholders": {}
     },
     "@invite": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableMultiAccounts": {
         "type": "String",
         "placeholders": {}
     },
@@ -2404,8 +2183,6 @@
     "changeTheNameOfTheGroup": "Αλλαγή ονόματος ομάδας",
     "channelCorruptedDecryptError": "Ο κρυπτογραφημένος κώδικας έχει καταστραφεί",
     "chat": "Συνομιλία",
-    "yourChatBackupHasBeenSetUp": "Η δημιουργία αντιγράφων ασφαλείας της συνομιλίας σας έχει ρυθμιστεί.",
-    "chatBackupDescription": "Τα παλιά σας μηνύματα είναι ασφαλή με ένα κλειδί ανάκτησης. Παρακαλώ βεβαιωθείτε ότι δεν το χάνετε.",
     "clearArchive": "Διαγραφή αρχείου",
     "commandHint_markasdm": "Σημειώστε ως άμεσο μήνυμα για το δοσμένο ID του Matrix",
     "commandHint_markasgroup": "Σημειώστε ως ομάδα",
@@ -2431,7 +2208,6 @@
     "configureChat": "Ρύθμιση συνομιλίας",
     "confirm": "Επιβεβαίωση",
     "connect": "Σύνδεση",
-    "contactHasBeenInvitedToTheGroup": "Ο επαφή έχει προσκληθεί στην ομάδα",
     "contentHasBeenReported": "Το περιεχόμενο έχει αναφερθεί στους διαχειριστές του διακομιστή",
     "copiedToClipboard": "Αντιγράφηκε στο πρόχειρο",
     "copy": "Αντιγραφή",
@@ -2439,11 +2215,9 @@
     "couldNotDecryptMessage": "Αδύνατη η αποκρυπτογράφηση μηνύματος: {error}",
     "checkList": "Λίστα ελέγχου",
     "countParticipants": "{count} συμμετέχοντες",
-    "countInvited": "{count} προσκεκλημένοι",
     "create": "Δημιουργία",
     "createdTheChat": "💬 {username} δημιούργησε τη συνομιλία",
     "createGroup": "Δημιουργία ομάδας",
-    "createNewSpace": "Νέος χώρος",
     "currentlyActive": "Ενεργό αυτήν τη στιγμή",
     "darkTheme": "Σκοτεινό",
     "dateAndTimeOfDay": "{date}, {timeOfDay}",
@@ -2469,9 +2243,6 @@
     "emoteKeyboardNoRecents": "Πρόσφατα χρησιμοποιημένα emoji θα εμφανίζονται εδώ...",
     "emotePacks": "Πακέτα emoji για το δωμάτιο",
     "emoteSettings": "Ρυθμίσεις emoji",
-    "globalChatId": "Παγκόσμιο ID συνομιλίας",
-    "accessAndVisibility": "Πρόσβαση και ορατότητα",
-    "accessAndVisibilityDescription": "Ποιος επιτρέπεται να συμμετάσχει σε αυτήν τη συνομιλία και πώς μπορεί να βρεθεί η συνομιλία.",
     "calls": "Κλήσεις",
     "customEmojisAndStickers": "Προσαρμοσμένα emojis και αυτοκόλλητα",
     "customEmojisAndStickersBody": "Προσθέστε ή μοιραστείτε προσαρμοσμένα emojis ή αυτοκόλλητα που μπορούν να χρησιμοποιηθούν σε οποιαδήποτε συνομιλία.",
@@ -2479,7 +2250,6 @@
     "emptyChat": "Άδειο chat",
     "enableEmotesGlobally": "Ενεργοποίηση πακέτου emoji σε όλο το σύστημα",
     "enableEncryption": "Ενεργοποίηση κρυπτογράφησης",
-    "enableEncryptionWarning": "Δεν θα μπορείτε πλέον να απενεργοποιήσετε την κρυπτογράφηση. Είστε σίγουροι;",
     "encrypted": "Κρυπτογραφημένο",
     "encryption": "Κρυπτογράφηση",
     "encryptionNotEnabled": "Η κρυπτογράφηση δεν είναι ενεργοποιημένη",
@@ -2487,7 +2257,6 @@
     "enterAnEmailAddress": "Εισάγετε μια διεύθυνση email",
     "homeserver": "Homeserver",
     "errorObtainingLocation": "Σφάλμα κατά την απόκτηση τοποθεσίας: {error}",
-    "everythingReady": "Όλα έτοιμα!",
     "extremeOffensive": "Απολύτως προσβλητικό",
     "fileName": "Όνομα αρχείου",
     "fluffychat": "FluffyChat",
@@ -2496,9 +2265,7 @@
     "fromJoining": "Από την ένταξη",
     "fromTheInvitation": "Από την πρόσκληση",
     "group": "Ομάδα",
-    "chatDescription": "Περιγραφή συνομιλίας",
     "chatDescriptionHasBeenChanged": "Η περιγραφή της συνομιλίας άλλαξε",
-    "groupIsPublic": "Η ομάδα είναι δημόσια",
     "groups": "Ομάδες",
     "groupWith": "Ομάδα με {displayname}",
     "guestsAreForbidden": "Οι επισκέπτες απαγορεύονται",
@@ -2520,7 +2287,6 @@
     "incorrectPassphraseOrKey": "Λάθος φράση πρόσβασης ή κλειδί ανάκτησης",
     "inoffensive": "Ακίνδυνο",
     "inviteContact": "Πρόσκληση επαφής",
-    "inviteContactToGroup": "Πρόσκληση επαφής στο {groupName}",
     "noChatDescriptionYet": "Δεν έχει δημιουργηθεί ακόμη περιγραφή συνομιλίας.",
     "tryAgain": "Δοκιμάστε ξανά",
     "invalidServerName": "Μη έγκυρο όνομα διακομιστή",
@@ -2541,7 +2307,6 @@
     "leave": "Αποχώρηση",
     "leftTheChat": "Έφυγε από τη συζήτηση",
     "lightTheme": "Φωτεινό",
-    "loadCountMoreParticipants": "Φόρτωση {count} επιπλέον συμμετεχόντων",
     "dehydrate": "Εξαγωγή συνεδρίας και διαγραφή συσκευής",
     "dehydrateWarning": "Αυτή η ενέργεια δεν μπορεί να αναιρεθεί. Βεβαιωθείτε ότι αποθηκεύετε με ασφάλεια το αρχείο αντιγράφου ασφαλείας.",
     "hydrate": "Ανάκτηση από αρχείο δημιουργίας αντιγράφων ασφαλείας",
@@ -2550,7 +2315,6 @@
     "locationDisabledNotice": "Οι υπηρεσίες τοποθεσίας είναι απενεργοποιημένες. Παρακαλώ ενεργοποιήστε τες για να μπορείτε να μοιραστείτε την τοποθεσία σας.",
     "locationPermissionDeniedNotice": "Η άδεια τοποθεσίας απορρίφθηκε. Παρακαλώ δώστε την για να μπορείτε να μοιραστείτε την τοποθεσία σας.",
     "login": "Σύνδεση",
-    "logInTo": "Συνδεθείτε στο {homeserver}",
     "logout": "Αποσύνδεση",
     "mention": "Αναφορά",
     "messages": "Μηνύματα",
@@ -2565,8 +2329,6 @@
     "no": "Όχι",
     "noConnectionToTheServer": "Δεν υπάρχει σύνδεση με τον διακομιστή",
     "noEmotesFound": "Δεν βρέθηκαν εμοτέ. 😝",
-    "noEncryptionForPublicRooms": "Μπορείτε να ενεργοποιήσετε την κρυπτογράφηση μόνο όταν το δωμάτιο δεν είναι πλέον δημόσια προσβάσιμο.",
-    "noGoogleServicesWarning": "Το Firebase Cloud Messaging δεν φαίνεται να είναι διαθέσιμο στη συσκευή σας. Για να λαμβάνετε ακόμα ειδοποιήσεις push, προτείνουμε την εγκατάσταση του ntfy. Με το ntfy ή έναν άλλο πάροχο Unified Push μπορείτε να λαμβάνετε ειδοποιήσεις push με ασφαλή τρόπο. Μπορείτε να κατεβάσετε το ntfy από το PlayStore ή από το F-Droid.",
     "noMatrixServer": "{server1} δεν είναι διακομιστής matrix, να χρησιμοποιήσω το {server2} αντί αυτού;",
     "shareInviteLink": "Μοιραστείτε τον σύνδεσμο πρόσκλησης",
     "scanQrCode": "Σάρωση κωδικού QR",
@@ -2588,12 +2350,10 @@
     "openCamera": "Άνοιγμα κάμερας",
     "openVideoCamera": "Άνοιγμα κάμερας για βίντεο",
     "oneClientLoggedOut": "Ένας από τους πελάτες σας έχει αποσυνδεθεί",
-    "addAccount": "Προσθήκη λογαριασμού",
     "editBundlesForAccount": "Επεξεργασία πακέτων για αυτόν τον λογαριασμό",
     "addToBundle": "Προσθήκη στο πακέτο",
     "removeFromBundle": "Αφαίρεση από αυτό το πακέτο",
     "bundleName": "Όνομα πακέτου",
-    "enableMultiAccounts": "(BETA) Ενεργοποίηση πολλαπλών λογαριασμών σε αυτήν τη συσκευή",
     "openInMaps": "Άνοιγμα στους χάρτες",
     "link": "Σύνδεσμος",
     "serverRequiresEmail": "Αυτός ο διακομιστής χρειάζεται να επικυρώσει τη διεύθυνση email σας για εγγραφή.",
@@ -2605,7 +2365,6 @@
     "passwordHasBeenChanged": "Ο κωδικός πρόσβασης έχει αλλάξει",
     "overview": "Επισκόπηση",
     "passwordRecoverySettings": "Ρυθμίσεις ανάκτησης κωδικού πρόσβασης",
-    "passwordRecovery": "Ανάκτηση κωδικού πρόσβασης",
     "people": "Άνθρωποι",
     "pickImage": "Επιλέξτε μια εικόνα",
     "pin": "Καρφίτσωμα",
@@ -2614,7 +2373,6 @@
     "pleaseChooseAPasscode": "Παρακαλώ επιλέξτε έναν κωδικό πρόσβασης",
     "pleaseClickOnLink": "Παρακαλώ κάντε κλικ στον σύνδεσμο στο email και συνεχίστε.",
     "pleaseEnter4Digits": "Παρακαλώ εισάγετε 4 ψηφία ή αφήστε κενό για να απενεργοποιήσετε το κλείδωμα εφαρμογής.",
-    "pleaseEnterRecoveryKey": "Παρακαλώ εισάγετε το κλειδί ανάκτησης σας:",
     "pleaseEnterYourPassword": "Παρακαλώ εισάγετε τον κωδικό πρόσβασής σας",
     "pleaseEnterYourPin": "Παρακαλώ εισάγετε το PIN σας",
     "pleaseEnterYourUsername": "Παρακαλώ εισάγετε το όνομα χρήστη σας",
@@ -2634,7 +2392,6 @@
     "rejectedTheInvitation": "{username} απέρριψε την πρόσκληση",
     "removeAllOtherDevices": "Αφαίρεση όλων των άλλων συσκευών",
     "removedBy": "Αφαιρέθηκε από {username}",
-    "removeDevice": "Αφαίρεση συσκευής",
     "unbanFromChat": "Άρση αποκλεισμού από τη συνομιλία",
     "removeYourAvatar": "Αφαίρεση του προφίλ σας",
     "replaceRoomWithNewerVersion": "Αντικαταστήστε το δωμάτιο με νεότερη έκδοση",
@@ -2646,8 +2403,6 @@
     "saveFile": "Αποθήκευση αρχείου",
     "search": "Αναζήτηση",
     "security": "Ασφάλεια",
-    "recoveryKey": "Κλειδί ανάκτησης",
-    "recoveryKeyLost": "Έχετε χάσει το κλειδί ανάκτησης;",
     "send": "Αποστολή",
     "sendAMessage": "Αποστολή μηνύματος",
     "sendAsText": "Αποστολή ως κείμενο",
@@ -2666,7 +2421,6 @@
     "separateChatTypes": "Διαχωρισμός άμεσων μηνυμάτων και ομάδων",
     "setAsCanonicalAlias": "Ορισμός ως κύριο ψευδώνυμο",
     "setChatDescription": "Ορισμός περιγραφής συνομιλίας",
-    "setPermissionsLevel": "Ορισμός επιπέδου δικαιωμάτων",
     "setStatus": "Ορισμός κατάστασης",
     "settings": "Ρυθμίσεις",
     "share": "Κοινοποίηση",
@@ -2676,8 +2430,6 @@
     "presencesToggle": "Εμφάνιση μηνυμάτων κατάστασης από άλλους χρήστες",
     "skip": "Παραλείπω",
     "sourceCode": "Κώδικας πηγής",
-    "spaceIsPublic": "Ο χώρος είναι δημόσιος",
-    "spaceName": "Όνομα χώρου",
     "startedACall": "{senderName} ξεκίνησε μια κλήση",
     "status": "Κατάσταση",
     "statusExampleMessage": "Πώς είστε σήμερα;",
@@ -2689,7 +2441,6 @@
     "theyMatch": "Ταιριάζουν",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "Πάρα πολλά αιτήματα. Παρακαλώ δοκιμάστε ξανά αργότερα!",
-    "transferFromAnotherDevice": "Μεταφορά από άλλη συσκευή",
     "tryToSendAgain": "Προσπαθήστε ξανά να στείλετε",
     "unavailable": "Μη διαθέσιμο",
     "unbannedUser": "{username} άρπαξε τον αποκλεισμό του {targetName}",
@@ -2699,7 +2450,6 @@
     "unknownEvent": "Άγνωστο γεγονός '{type}'",
     "unmuteChat": "Αναίρεση σίγασης συνομιλίας",
     "unpin": "Αφαίρεση από την κορυφή",
-    "unreadChats": "{unreadCount, plural, =1{1 μη αναγνωσμένο μήνυμα} other{{unreadCount} μη αναγνωσμένα μηνύματα}}",
     "userAndOthersAreTyping": "{username} και {count} άλλοι πληκτρολογούν…",
     "userAndUserAreTyping": "{username} και {username2} πληκτρολογούν…",
     "userIsTyping": "{username} πληκτρολογεί…",
@@ -2712,8 +2462,6 @@
     "verifyStart": "Ξεκινήστε την επαλήθευση",
     "verifySuccess": "Επιτυχής επαλήθευση!",
     "verifyTitle": "Επαλήθευση άλλου λογαριασμού",
-    "videoCall": "Βιντεοκλήση",
-    "visibilityOfTheChatHistory": "Ορατότητα του ιστορικού συνομιλίας",
     "visibleForAllParticipants": "Ορατό για όλους τους συμμετέχοντες",
     "visibleForEveryone": "Ορατό για όλους",
     "voiceMessage": "Φωνητικό μήνυμα",
@@ -2723,10 +2471,7 @@
     "wallpaper": "Φόντο:",
     "warning": "Προειδοποίηση!",
     "weSentYouAnEmail": "Σας στείλαμε ένα email",
-    "whoCanPerformWhichAction": "Ποιος μπορεί να εκτελέσει ποια ενέργεια",
-    "whoIsAllowedToJoinThisGroup": "Ποιος επιτρέπεται να συμμετάσχει σε αυτήν την ομάδα",
     "whyDoYouWantToReportThis": "Γιατί θέλετε να αναφέρετε αυτό;",
-    "wipeChatBackup": "Διαγράψτε το αντίγραφο ασφαλείας της συνομιλίας σας για να δημιουργήσετε ένα νέο κλειδί ανάκτησης;",
     "withTheseAddressesRecoveryDescription": "Με αυτές τις διευθύνσεις μπορείτε να ανακτήσετε τον κωδικό πρόσβασής σας.",
     "writeAMessage": "Γράψτε ένα μήνυμα…",
     "yes": "Ναι",
@@ -2739,9 +2484,7 @@
     "messageType": "Τύπος μηνύματος",
     "sender": "Αποστολέας",
     "openGallery": "Άνοιγμα γκαλερί",
-    "removeFromSpace": "Αφαίρεση από τον χώρο",
     "start": "Έναρξη",
-    "pleaseEnterRecoveryKeyDescription": "Για να ξεκλειδώσετε τα παλιά μηνύματά σας, εισάγετε το κλειδί ανάκτησης που δημιουργήθηκε σε προηγούμενη συνεδρία. Το κλειδί ανάκτησης ΔΕΝ είναι ο κωδικός πρόσβασής σας.",
     "publish": "Δημοσίευση",
     "openChat": "Άνοιγμα συνομιλίας",
     "markAsRead": "Σημείωσε ως διαβασμένο",
@@ -2752,12 +2495,9 @@
     "confirmEventUnpin": "Είστε βέβαιοι ότι θέλετε να αποσυνδέσετε οριστικά το γεγονός;",
     "emojis": "Εμοji",
     "placeCall": "Κάντε κλήση",
-    "voiceCall": "Φωνητική κλήση",
     "unsupportedAndroidVersion": "Μη υποστηριζόμενη έκδοση Android",
     "unsupportedAndroidVersionLong": "Αυτή η λειτουργία απαιτεί νεότερη έκδοση Android. Παρακαλούμε ελέγξτε για ενημερώσεις ή υποστήριξη Lineage OS.",
-    "videoCallsBetaWarning": "Παρακαλούμε σημειώστε ότι οι βιντεοκλήσεις βρίσκονται επί του παρόντος σε beta. Μπορεί να μην λειτουργούν όπως αναμένεται ή καθόλου σε όλες τις πλατφόρμες.",
     "experimentalVideoCalls": "Πειραματικές βιντεοκλήσεις",
-    "emailOrUsername": "Email ή όνομα χρήστη",
     "addWidget": "Προσθήκη widget",
     "widgetVideo": "Βίντεο",
     "widgetEtherpad": "Κείμενο σημείωσης",
@@ -2779,35 +2519,19 @@
     "youKickedAndBanned": "🙅‍♀️ Απομακρύνατε και αποκλείσατε τον {user}",
     "youUnbannedUser": "Απελευθερώσατε τον {user}",
     "hasKnocked": "🚪 {user} χτύπησε",
-    "usersMustKnock": "Οι χρήστες πρέπει να χτυπήσουν",
-    "noOneCanJoin": "Κανείς δεν μπορεί να συμμετάσχει",
     "knock": "Χτύπημα",
     "users": "Χρήστες",
-    "unlockOldMessages": "Ξεκλείδωμα παλαιών μηνυμάτων",
-    "storeInSecureStorageDescription": "Αποθηκεύστε το κλειδί ανάκαμψης στην ασφαλή αποθήκευση αυτής της συσκευής.",
-    "saveKeyManuallyDescription": "Αποθηκεύστε αυτό το κλειδί χειροκίνητα ενεργοποιώντας το διάλογο κοινής χρήσης συστήματος ή το πρόχειρο.",
-    "storeInAndroidKeystore": "Αποθήκευση στο Android KeyStore",
-    "storeInAppleKeyChain": "Αποθήκευση στο Apple KeyChain",
-    "storeSecurlyOnThisDevice": "Αποθήκευση με ασφάλεια σε αυτήν τη συσκευή",
     "countFiles": "{count} αρχεία",
     "user": "Χρήστης",
     "custom": "Προσαρμοσμένο",
-    "foregroundServiceRunning": "Αυτή η ειδοποίηση εμφανίζεται όταν τρέχει η υπηρεσία μπροστά.",
-    "screenSharingTitle": "κοινή χρήση οθόνης",
-    "screenSharingDetail": "Μοιράζεστε την οθόνη σας στο FuffyChat",
     "whyIsThisMessageEncrypted": "Γιατί αυτό το μήνυμα είναι μη αναγνώσιμο;",
     "noKeyForThisMessage": "Αυτό μπορεί να συμβεί αν το μήνυμα στάλθηκε πριν συνδεθείτε στον λογαριασμό σας σε αυτήν τη συσκευή.\n\nΕίναι επίσης πιθανό ο αποστολέας να έχει μπλοκάρει τη συσκευή σας ή να υπήρξε κάποιο πρόβλημα με τη σύνδεση στο διαδίκτυο.\n\nΜπορείτε να διαβάσετε το μήνυμα σε μια άλλη συνεδρία; Τότε μπορείτε να μεταφέρετε το μήνυμα από αυτήν! Μεταβείτε στις Ρυθμίσεις > Συσκευές και βεβαιωθείτε ότι οι συσκευές σας έχουν επαληθευτεί η μία την άλλη. Όταν ανοίξετε ξανά το δωμάτιο και και οι δύο συνεδρίες είναι στην μπροστινή γραμμή, τα κλειδιά θα μεταδοθούν αυτόματα.\n\nΔεν θέλετε να χάσετε τα κλειδιά κατά το αποσύνδεση ή την αλλαγή συσκευής; Βεβαιωθείτε ότι έχετε ενεργοποιήσει την εφεδρεία συνομιλίας στις ρυθμίσεις.",
     "newGroup": "Νέα ομάδα",
     "newSpace": "Νέος χώρος",
-    "enterSpace": "Εισέλθετε στον χώρο",
     "allSpaces": "Όλοι οι χώροι",
     "hidePresences": "Απόκρυψη λίστας κατάστασης;",
     "doNotShowAgain": "Μην το εμφανίζετε ξανά",
     "wasDirectChatDisplayName": "Άδειο chat (ήταν {oldDisplayName})",
-    "newSpaceDescription": "Οι χώροι σας επιτρέπουν να ενοποιήσετε τις συνομιλίες σας και να δημιουργήσετε ιδιωτικές ή δημόσιες κοινότητες.",
-    "encryptThisChat": "Κρυπτογραφήστε αυτήν τη συνομιλία",
-    "disableEncryptionWarning": "Για λόγους ασφαλείας, δεν μπορείτε να απενεργοποιήσετε την κρυπτογράφηση σε μια συνομιλία όπου είχε ενεργοποιηθεί προηγουμένως.",
-    "sorryThatsNotPossible": "Λυπούμαστε... αυτό δεν είναι δυνατό",
     "deviceKeys": "Κλειδιά συσκευής:",
     "reopenChat": "Άνοιγμα ξανά συνομιλίας",
     "noBackupWarning": "Προειδοποίηση! Χωρίς ενεργοποίηση αντιγράφου ασφαλείας συνομιλίας, θα χάσετε την πρόσβαση στα κρυπτογραφημένα μηνύματά σας. Συνιστάται ιδιαίτερα να ενεργοποιήσετε το αντίγραφο ασφαλείας πριν αποσυνδεθείτε.",
@@ -2820,7 +2544,6 @@
     "openLinkInBrowser": "Άνοιγμα συνδέσμου στον περιηγητή",
     "reportErrorDescription": "😞 Ωχ. Κάτι πήγε στραβά. Αν θέλετε, μπορείτε να αναφέρετε αυτό το σφάλμα στους προγραμματιστές.",
     "report": "αναφορά",
-    "setTheme": "Ορίστε θέμα:",
     "setColorTheme": "Ορίστε χρωματικό θέμα:",
     "invite": "Πρόσκληση",
     "inviteGroupChat": "📨 Πρόσκληση σε ομαδική συνομιλία",
@@ -2839,12 +2562,8 @@
     "yourGlobalUserIdIs": "Το παγκόσμιο αναγνωριστικό χρήστη σας είναι: ",
     "noUsersFoundWithQuery": "Δυστυχώς, δεν βρέθηκε χρήστης με την ερώτηση \"{query}\". Παρακαλώ ελέγξτε αν κάνατε τυπογραφικό λάθος.",
     "knocking": "Χτυπάει",
-    "chatCanBeDiscoveredViaSearchOnServer": "Η συνομιλία μπορεί να βρεθεί μέσω της αναζήτησης στο {server}",
-    "searchChatsRooms": "Αναζήτηση για #συνομιλίες, @χρήστες...",
     "nothingFound": "Δεν βρέθηκε τίποτα...",
     "groupName": "Όνομα ομάδας",
-    "createGroupAndInviteUsers": "Δημιουργήστε μια ομάδα και προσκαλέστε χρήστες",
-    "groupCanBeFoundViaSearch": "Η ομάδα μπορεί να βρεθεί μέσω αναζήτησης",
     "wrongRecoveryKey": "Λυπάμαι... αυτό δεν φαίνεται να είναι το σωστό κλειδί ανάκτησης.",
     "startConversation": "Ξεκινήστε συνομιλία",
     "commandHint_sendraw": "Αποστολή ακατέργαστου json",
@@ -2858,11 +2577,8 @@
     "pleaseChooseAStrongPassword": "Παρακαλώ επιλέξτε έναν ισχυρό κωδικό πρόσβασης",
     "passwordsDoNotMatch": "Οι κωδικοί πρόσβασης δεν ταιριάζουν",
     "passwordIsWrong": "Ο εισαγόμενος κωδικός πρόσβασης είναι λανθασμένος",
-    "publicChatAddresses": "Διευθύνσεις δημόσιων συνομιλιών",
-    "createNewAddress": "Δημιουργία νέας διεύθυνσης",
     "joinSpace": "Συμμετοχή στον χώρο",
     "publicSpaces": "Δημόσιοι χώροι",
-    "addChatOrSubSpace": "Προσθήκη συνομιλίας ή υποχώρου",
     "subspace": "Υποχώρος",
     "decline": "Απόρριψη",
     "thisDevice": "Αυτή η συσκευή:",
@@ -2871,15 +2587,11 @@
     "searchMore": "Αναζήτηση περισσότερο...",
     "gallery": "Πινακοθήκη",
     "files": "Αρχεία",
-    "sessionLostBody": "Η συνεδρία σας χάθηκε. Παρακαλούμε αναφέρετε αυτό το σφάλμα στους προγραμματιστές στο {url}. Το μήνυμα σφάλματος είναι: {error}",
-    "restoreSessionBody": "Η εφαρμογή προσπαθεί τώρα να επαναφέρει τη συνεδρία σας από το αντίγραφο ασφαλείας. Παρακαλούμε αναφέρετε αυτό το σφάλμα στους προγραμματιστές στο {url}. Το μήνυμα σφάλματος είναι: {error}",
     "sendReadReceipts": "Αποστολή αποδείξεων ανάγνωσης",
     "sendTypingNotificationsDescription": "Οι άλλοι συμμετέχοντες σε μια συνομιλία μπορούν να δουν πότε πληκτρολογείτε ένα νέο μήνυμα.",
     "sendReadReceiptsDescription": "Οι άλλοι συμμετέχοντες σε μια συνομιλία μπορούν να δουν πότε έχετε διαβάσει ένα μήνυμα.",
     "formattedMessages": "Μορφοποιημένα μηνύματα",
     "formattedMessagesDescription": "Εμφάνιση πλούσιου περιεχομένου μηνυμάτων όπως έντονο κείμενο χρησιμοποιώντας markdown.",
-    "verifyOtherUser": "🔐 Επιβεβαίωση άλλου χρήστη",
-    "verifyOtherUserDescription": "Αν επιβεβαιώσετε έναν άλλο χρήστη, μπορείτε να είστε σίγουροι ότι γνωρίζετε πραγματικά σε ποιον γράφετε. 💪\n\nΌταν ξεκινάτε μια επιβεβαίωση, εσείς και ο άλλος χρήστης θα δείτε ένα αναδυόμενο παράθυρο στην εφαρμογή. Εκεί θα δείτε μια σειρά από emoji ή αριθμούς που πρέπει να συγκρίνετε μεταξύ σας.\n\nΟ καλύτερος τρόπος να το κάνετε αυτό είναι να συναντηθείτε ή να ξεκινήσετε μια βιντεκλήση. 👭",
     "verifyOtherDevice": "🔐 Επιβεβαίωση άλλης συσκευής",
     "verifyOtherDeviceDescription": "Όταν επιβεβαιώνετε μια άλλη συσκευή, αυτές οι συσκευές μπορούν να ανταλλάξουν κλειδιά, αυξάνοντας τη συνολική ασφάλειά σας. 💪 Όταν ξεκινάτε μια επιβεβαίωση, θα εμφανιστεί ένα αναδυόμενο παράθυρο στην εφαρμογή και στις δύο συσκευές. Εκεί θα δείτε μια σειρά από emoji ή αριθμούς που πρέπει να συγκρίνετε. Είναι καλύτερο να έχετε και τις δύο συσκευές έτοιμες πριν ξεκινήσετε την επιβεβαίωση. 🤳",
     "acceptedKeyVerification": "{sender} αποδέχτηκε την επιβεβαίωση κλειδιού",
@@ -2915,10 +2627,6 @@
     "updateInstalled": "🎉 Εγκαταστάθηκε η ενημέρωση {version}!",
     "changelog": "Αλλαγές",
     "sendCanceled": "Η αποστολή ακυρώθηκε",
-    "loginWithMatrixId": "Σύνδεση με Matrix-ID",
-    "discoverHomeservers": "Ανακαλύψτε τους διακομιστές",
-    "whatIsAHomeserver": "Τι είναι ένας διακομιστής σπιτιού;",
-    "homeserverDescription": "Όλα τα δεδομένα σας αποθηκεύονται στον διακομιστή σπιτιού, όπως και ένας πάροχος email. Μπορείτε να επιλέξετε ποιον διακομιστή σπιτιού θέλετε να χρησιμοποιήσετε, ενώ μπορείτε ακόμα να επικοινωνείτε με όλους. Μάθετε περισσότερα στο https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Δεν φαίνεται να είναι συμβατός διακομιστής σπιτιού. Λάθος URL;",
     "calculatingFileSize": "Υπολογισμός μεγέθους αρχείου...",
     "prepareSendingAttachment": "Ετοιμασία αποστολής συνημμένου...",
@@ -2930,11 +2638,9 @@
     "oneOfYourDevicesIsNotVerified": "Ένα από τα συσκευές σας δεν είναι επαληθευμένο",
     "noticeChatBackupDeviceVerification": "Σημείωση: Όταν συνδέσετε όλες τις συσκευές σας στο αντίγραφο ασφαλείας συνομιλίας, αυτομάτως επαληθεύονται.",
     "continueText": "Συνέχεια",
-    "welcomeText": "Γεια Γεια 👋 Αυτό είναι το FluffyChat. Μπορείτε να συνδεθείτε σε οποιονδήποτε διακομιστή σπιτιού, ο οποίος είναι συμβατός με το https://matrix.org. Και στη συνέχεια να συνομιλήσετε με οποιονδήποτε. Είναι ένα τεράστιο αποκεντρωμένο δίκτυο μηνυμάτων!",
     "blur": "Θάμπωμα:",
     "opacity": "Αδιαφάνεια:",
     "setWallpaper": "Ορισμός φόντου",
-    "manageAccount": "Διαχείριση λογαριασμού",
     "noContactInformationProvided": "Ο διακομιστής δεν παρέχει έγκυρες πληροφορίες επικοινωνίας",
     "contactServerAdmin": "Επικοινωνήστε με τον διαχειριστή του διακομιστή",
     "contactServerSecurity": "Επικοινωνία με την ασφάλεια διακομιστή",
@@ -2953,11 +2659,8 @@
     "unableToJoinChat": "Αδύνατη η συμμετοχή στη συνομιλία. Ίσως το άλλο μέρος έχει ήδη κλείσει τη συνομιλία.",
     "previous": "Προηγούμενο",
     "otherPartyNotLoggedIn": "Το άλλο μέρος δεν είναι αυτήν τη στιγμή συνδεδεμένο και επομένως δεν μπορεί να λάβει μηνύματα!",
-    "appWantsToUseForLogin": "Χρησιμοποιήστε '{server}' για σύνδεση",
-    "appWantsToUseForLoginDescription": "Επιτρέπετε στην εφαρμογή και στον ιστότοπο να μοιράζονται πληροφορίες σχετικά με εσάς.",
     "open": "Άνοιγμα",
     "waitingForServer": "Αναμονή για διακομιστή...",
-    "appIntroduction": "Το FluffyChat σας επιτρέπει να συνομιλείτε με τους φίλους σας σε διαφορετικά μηνύματα. Μάθετε περισσότερα στο https://matrix.org ή απλώς πατήστε *Συνέχεια*.",
     "newChatRequest": "📩 Νέα αίτηση συνομιλίας",
     "contentNotificationSettings": "Ρυθμίσεις ειδοποιήσεων περιεχομένου",
     "generalNotificationSettings": "Γενικές ρυθμίσεις ειδοποιήσεων",
@@ -3034,11 +2737,9 @@
     "taTooltip": "L2 χρήση με βοήθεια μετάφρασης",
     "interactiveTranslatorSliderHeader": "Διαδραστικός Μεταφραστής",
     "interactiveGrammarSliderHeader": "Διαδραστικός Έλεγχος Γραμματικής",
-    "interactiveTranslatorRequired": "Απαιτείται",
     "waTooltip": "Χρήση L2 χωρίς βοήθεια",
     "interactiveTranslator": "Βοήθεια μετάφρασης",
     "noIdenticalLanguages": "Παρακαλώ επιλέξτε διαφορετικές βασικές και στόχους γλώσσες",
-    "searchBy": "Αναζήτηση με βάση χώρα και γλώσσες",
     "joinWithClassCode": "Εγγραφή στο μάθημα",
     "languageLevelPreA1": "Νέος Χαμηλός (Προ Α1)",
     "languageLevelA1": "Νέος Μέσος (A1)",
@@ -3059,19 +2760,14 @@
     "saveChanges": "Αποθήκευση αλλαγών",
     "publicProfileTitle": "Να επιτρέπεται η εύρεση του προφίλ μου στην αναζήτηση",
     "publicProfileDesc": "Με την ενεργοποίηση, επιτρέπετε σε άλλους χρήστες να βρουν το προφίλ σας στη διεθνή γραμμή αναζήτησης και να στείλουν αιτήματα συνομιλίας. Σε αυτό το σημείο, μπορείτε να επιλέξετε να αποδεχτείτε ή να αρνηθείτε το αίτημα.",
-    "errorDisableIT": "Η βοήθεια μετάφρασης είναι απενεργοποιημένη.",
-    "errorDisableIGC": "Η βοήθεια γραμματικής είναι απενεργοποιημένη.",
     "errorDisableITUserDesc": "Κάντε κλικ εδώ για να ενημερώσετε τις ρυθμίσεις βοήθειας μετάφρασης",
     "errorDisableIGCUserDesc": "Κάντε κλικ εδώ για να ενημερώσετε τις ρυθμίσεις βοήθειας γραμματικής",
     "errorDisableITClassDesc": "Η βοήθεια μετάφρασης είναι απενεργοποιημένη για το μάθημα στο οποίο βρίσκεται αυτή η συνομιλία.",
     "errorDisableIGCClassDesc": "Η βοήθεια γραμματικής είναι απενεργοποιημένη για το μάθημα στο οποίο βρίσκεται αυτή η συνομιλία.",
-    "error405Title": "Οι γλώσσες δεν έχουν οριστεί",
     "error405Desc": "Ορίστε τις γλώσσες σας στο Μενού > Ρυθμίσεις Μάθησης.",
     "termsAndConditions": "Όρους και Προϋποθέσεις",
     "andCertifyIAmAtLeast13YearsOfAge": " και πιστοποιώ ότι είμαι τουλάχιστον 16 ετών.",
-    "error502504Title": "Ω, υπάρχουν πολλοί μαθητές online!",
     "error502504Desc": "Τα εργαλεία μετάφρασης και γραμματικής ενδέχεται να είναι αργά ή μη διαθέσιμα ενώ οι bots της Pangea ενημερώνονται.",
-    "error404Title": "Σφάλμα μετάφρασης!",
     "error404Desc": "Ο Pangea Bot δεν είναι σίγουρος πώς να μεταφράσει αυτό...",
     "errorPleaseRefresh": "Το ερευνούμε! Παρακαλούμε ανανεώστε και δοκιμάστε ξανά.",
     "connectedToStaging": "Συνδεδεμένο με το Staging",
@@ -3109,13 +2805,9 @@
     "definitionsToolName": "Ορισμοί Λέξεων",
     "definitionsToolDescription": "Όταν ενεργοποιείται, οι λέξεις με υπογράμμιση μπλε μπορούν να πατηθούν για ορισμούς. Πατήστε μηνύματα για πρόσβαση στους ορισμούς.",
     "welcomeBack": "Καλώς ήρθατε ξανά! Αν ήσασταν μέρος του πιλοτικού προγράμματος 2023-2024, παρακαλούμε επικοινωνήστε μαζί μας για τη ειδική σας συνδρομή πιλοτικού προγράμματος. Αν είστε εκπαιδευτικός που έχει αγοράσει (ή η εκπαιδευτική σας ιδιότητα έχει αγοράσει) άδειες για την τάξη σας, επικοινωνήστε μαζί μας για τη συνδρομή εκπαιδευτικού.",
-    "downloadTxtFile": "Λήψη αρχείου κειμένου",
-    "downloadCSVFile": "Λήψη αρχείου CSV",
     "promotionalSubscriptionDesc": "Έχετε επί του παρόντος μια συνδρομή προώθησης διάρκειας ζωής. Στείλτε μήνυμα στο support@pangea.chat για βοήθεια στην αλλαγή της συνδρομής σας.",
     "originalSubscriptionPlatform": "Συνδρομή αγοράστηκε μέσω {purchasePlatform}",
     "oneWeekTrial": "Δοκιμαστική περίοδος μιας εβδομάδας",
-    "downloadXLSXFile": "Λήψη αρχείου Excel",
-    "unkDisplayName": "Άγνωστο",
     "wwCountryDisplayName": "Παγκόσμιος",
     "afCountryDisplayName": "Αφγανιστάν",
     "axCountryDisplayName": "Νήσοι Αλάντες",
@@ -3410,7 +3102,6 @@
     "chatCapacityHasBeenChanged": "Η χωρητικότητα της συνομιλίας άλλαξε",
     "chatCapacitySetTooLow": "Η χωρητικότητα της συνομιλίας πρέπει να είναι τουλάχιστον {count}.",
     "chatCapacityExplanation": "Η χωρητικότητα της συνομιλίας περιορίζει τον αριθμό των μελών που επιτρέπονται σε μια συνομιλία.",
-    "tooManyRequest": "Πάρα πολλά αιτήματα, παρακαλώ δοκιμάστε ξανά αργότερα.",
     "enterNumber": "Παρακαλώ εισάγετε μια ακέραια τιμή.",
     "practice": "Εξάσκηση",
     "versionNotFound": "Δεν βρέθηκε έκδοση",
@@ -3420,7 +3111,6 @@
     "deleteSubscriptionWarningTitle": "Έχετε ενεργή συνδρομή",
     "deleteSubscriptionWarningBody": "Η διαγραφή του λογαριασμού σας δεν θα ακυρώσει αυτόματα τη συνδρομή σας.",
     "manageSubscription": "Διαχείριση συνδρομής",
-    "error520Title": "Παρακαλώ δοκιμάστε ξανά.",
     "error520Desc": "Λυπούμαστε, δεν καταλάβαμε το μήνυμά σας...",
     "wordsUsed": "Χρησιμοποιημένες λέξεις",
     "level": "Επίπεδο",
@@ -3438,7 +3128,6 @@
     "other": "Άλλο",
     "levelShort": "ΕΠΙΠΕΔΟ {level}",
     "noCapacityLimit": "Χωρίς όριο χωρητικότητας",
-    "downloadGroupText": "Λήψη κειμένου ομάδας",
     "notificationsOn": "Ειδοποιήσεις ενεργές",
     "notificationsOff": "Ειδοποιήσεις απενεργοποιημένες",
     "joinWithCode": "Συμμετοχή με κωδικό",
@@ -3502,24 +3191,12 @@
     "whatIsTheMorphTag": "Τι είναι το {morphologicalFeature} του '{wordForm}'?",
     "dataAvailable": "Διαθεσιμότητα δεδομένων",
     "available": "Διαθέσιμο",
-    "pangeaBotIsFallible": "Ο Pangea Bot κάνει και λάθη!",
-    "whatIsMeaning": "Τι σημαίνει το '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Ταιριάξτε τις σημασίες με τις λέξεις στο μήνυμα!",
-    "doubleClickToEdit": "Διπλό κλικ για επεξεργασία.",
-    "topicLabel": "Θέμα",
-    "topicPlaceholder": "Επιλέξτε ένα θέμα...",
-    "modePlaceholder": "Επιλέξτε μια λειτουργία...",
-    "learningObjectiveLabel": "Στόχος μάθησης",
-    "learningObjectivePlaceholder": "Επιλέξτε στόχο μάθησης...",
-    "targetLanguageLabel": "Στόχος γλώσσα",
     "cefrLevelLabel": "Επίπεδο CEFR",
     "image": "Εικόνα",
     "video": "Βίντεο",
     "nan": "Μη εφαρμόσιμο",
-    "addVocabulary": "Προσθήκη λεξιλογίου",
     "instructions": "Οδηγίες",
-    "numberOfLearners": "Αριθμός μαθητών",
-    "mustBeInteger": "Πρέπει να είναι ακέραιος π.χ. 1, 2, 3, ...",
     "constructUsePvmDesc": "Παράγεται σε φωνητικό μήνυμα",
     "leaveSpaceDescription": "Αφήνοντας το μάθημα, θα αφήσετε όλες τις συνομιλίες μέσα σε αυτό. Οι άλλοι χρήστες θα δουν ότι έχετε φύγει από το μάθημα.",
     "constructUseCorMmDesc": "Ορθό μήνυμα σημασίας",
@@ -3534,7 +3211,6 @@
     "ttsDisabledBody": "Μπορείτε να ενεργοποιήσετε τη φωνητική ανάγνωση στις ρυθμίσεις εκμάθησης",
     "noSpaceDescriptionYet": "Δεν έχει δημιουργηθεί ακόμη περιγραφή μαθήματος.",
     "tooLargeToSend": "Αυτό το μήνυμα είναι πολύ μεγάλο για αποστολή",
-    "exitWithoutSaving": "Είστε βέβαιοι ότι θέλετε να φύγετε χωρίς να αποθηκεύσετε;",
     "enableAutocorrectPopupTitle": "Προσθέστε το πληκτρολόγιο της γλώσσας στόχου πηγαίνοντας στα:",
     "enableAutocorrectPopupSteps": "  • Ρυθμίσεις\n  • Γενικά\n  • Πληκτρολόγιο\n  • Πληκτρολόγια\n  • Προσθήκη νέου πληκτρολογίου",
     "enableAutocorrectPopupDescription": "Μόλις επιλεγεί η γλώσσα, μπορείτε να κάνετε κλικ στο μικρό εικονίδιο του κόσμου στο κάτω αριστερό μέρος του πληκτρολογίου σας για να ενεργοποιήσετε το νέο εγκατεστημένο πληκτρολόγιο.",
@@ -3545,11 +3221,8 @@
     "displayName": "Εμφανιζόμενο όνομα",
     "leaveRoomDescription": "Πρόκειται να φύγετε από αυτήν τη συνομιλία. Οι άλλοι χρήστες θα δουν ότι έχετε φύγει.",
     "confirmUserId": "Παρακαλούμε επιβεβαιώστε το όνομα χρήστη Pangea Chat για να διαγράψετε τον λογαριασμό σας.",
-    "startingToday": "Από σήμερα",
-    "oneWeekFreeTrial": "Μια εβδομάδα δωρεάν δοκιμής",
     "paidSubscriptionStarts": "Ξεκινάει {startDate}",
     "cancelInSubscriptionSettings": "• Ακύρωση οποιαδήποτε στιγμή στις ρυθμίσεις συνδρομής",
-    "cancelToAvoidCharges": "• Ακύρωση πριν από {trialEnds} για να αποφύγετε χρεώσεις",
     "downloadGboard": "Κατεβάστε το Gboard",
     "autocorrectNotAvailable": "Δυστυχώς, η πλατφόρμα σας δεν υποστηρίζεται αυτήν τη στιγμή για αυτήν τη λειτουργία. Μείνετε συντονισμένοι για περαιτέρω ανάπτυξη!",
     "pleaseUpdateApp": "Παρακαλούμε ενημερώστε την εφαρμογή για να συνεχίσετε.",
@@ -3559,17 +3232,12 @@
     "knockSpaceSuccess": "Έχετε ζητήσει να συμμετάσχετε σε αυτό το μάθημα! Ένας διαχειριστής θα απαντήσει στο αίτημά σας μόλις το λάβει 😀",
     "chooseWordAudioInstructionsBody": "Ακούστε το πλήρες μήνυμα. Στη συνέχεια, ταιριάξτε τα ηχητικά με τις λέξεις.",
     "chooseMorphsInstructionsBody": "Κάντε κλικ στα κομμάτια παζλ για γραμματικές ερωτήσεις!",
-    "pleaseEnterInt": "Παρακαλούμε εισάγετε έναν αριθμό",
     "home": "Αρχική",
     "join": "Συμμετοχή",
     "resetInstructionTooltipsTitle": "Επαναφορά οδηγιών βοήθειας",
     "resetInstructionTooltipsDesc": "Κάντε κλικ για να εμφανίσετε ξανά τις οδηγίες βοήθειας, όπως για έναν ολοκαίνουργιο χρήστη.",
-    "randomize": "Τυχαία επιλογή",
     "clear": "Καθαρισμός",
-    "featuredActivities": "Προτεινόμενες",
     "save": "Αποθήκευση",
-    "startChat": "Ξεκίνα μια συνομιλία",
-    "translationProblem": "Πρόβλημα μετάφρασης",
     "askToJoin": "Ζήτησε να συμμετάσχεις",
     "emptyChatWarningTitle": "Η συνομιλία είναι κενή",
     "emptyChatWarningDesc": "Δεν έχεις προσκαλέσει κανέναν στη συνομιλία σου. Πήγαινε στις ρυθμίσεις συνομιλίας για να προσκαλέσεις τις επαφές σου ή το Bot. Μπορείς επίσης να το κάνεις αργότερα.",
@@ -3599,17 +3267,13 @@
     "timesUsedIndependently": "Χρησιμοποιήθηκε αυτόνομα",
     "timesUsedWithAssistance": "Χρησιμοποιήθηκε με βοήθεια",
     "shareInviteCode": "Μοιραστείτε τον κωδικό πρόσκλησης: {code}",
-    "leaderboard": "Κατάταξη",
     "skipForNow": "Παραλείψτε προς το παρόν",
     "permissions": "Άδειες",
     "spaceChildPermission": "Ποιος μπορεί να προσθέσει νέες συνομιλίες σε αυτό το μάθημα",
-    "addEnvironmentOverride": "Προσθήκη παραμέτρου περιβάλλοντος",
     "defaultOption": "Προεπιλογή",
     "deleteChatDesc": "Είστε σίγουροι ότι θέλετε να διαγράψετε αυτήν τη συνομιλία; Θα διαγραφεί για όλους τους συμμετέχοντες και όλα τα μηνύματα μέσα στη συνομιλία δεν θα είναι πλέον διαθέσιμα για πρακτική ή αναλυτικά δεδομένα μάθησης.",
     "deleteSpaceDesc": "Το μάθημα και οποιεσδήποτε επιλεγμένες συνομιλίες θα διαγραφούν για όλους τους συμμετέχοντες και όλα τα μηνύματα μέσα στη συνομιλία δεν θα είναι πλέον διαθέσιμα για πρακτική ή αναλυτικά δεδομένα μάθησης. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
     "launch": "Έναρξη",
-    "searchChats": "Αναζήτηση συνομιλιών",
-    "maxFifty": "Μέγιστο 50",
     "configureSpace": "Διαμόρφωση μαθήματος",
     "pinMessages": "Καρφιτσώστε μηνύματα",
     "setJoinRules": "Ορίστε κανόνες συμμετοχής",
@@ -3643,9 +3307,6 @@
     "failedToFetchTranscription": "Αποτυχία λήψης μεταγραφής",
     "deleteEmptySpaceDesc": "Το μάθημα θα διαγραφεί για όλους τους συμμετέχοντες. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
     "regenerate": "Αναδημιουργία",
-    "mySavedActivities": "Αποθηκευμένες Δραστηριότητες μου",
-    "noSavedActivities": "Δεν υπάρχουν αποθηκευμένες δραστηριότητες",
-    "saveActivity": "Αποθήκευση αυτής της δραστηριότητας",
     "failedToPlayVideo": "Αποτυχία αναπαραγωγής βίντεο",
     "done": "Ολοκληρώθηκε",
     "inThisSpace": "Σε αυτό το μάθημα",
@@ -3656,13 +3317,9 @@
     "numInvited": "{count} προσκεκλημένοι",
     "saved": "Αποθηκευμένο",
     "reset": "Επαναφορά",
-    "errorFetchingActivitiesMessage": "Αποτυχία λήψης δραστηριοτήτων",
     "errorFetchingDefinition": "Αποτυχία λήψης ορισμού",
     "errorProcessAnalytics": "Αποτυχία επεξεργασίας αναλυτικών στοιχείων",
     "errorDownloading": "Η λήψη απέτυχε",
-    "errorLoadingSpaceChildren": "Αποτυχία φόρτωσης συνομιλιών εντός αυτού του μαθήματος",
-    "unexpectedError": "Απρόβλεπτο σφάλμα.",
-    "pleaseReload": "Παρακαλώ επαναφορτώστε και δοκιμάστε ξανά.",
     "translationError": "Σφάλμα μετάφρασης",
     "check": "Έλεγχος",
     "unableToFindRoom": "Δεν βρέθηκε συνομιλία ή μάθημα με αυτόν τον κωδικό. Παρακαλώ δοκιμάστε ξανά.",
@@ -3671,19 +3328,14 @@
     "request": "Αίτημα",
     "requestAll": "Ζήτηση Όλα",
     "confirmMessageUnpin": "Είστε σίγουροι ότι θέλετε να αποσυνδέσετε αυτό το μήνυμα;",
-    "saveAndLaunch": "Αποθήκευση και Εκκίνηση",
-    "launchToSpace": "Εκκίνηση στην πορεία",
     "pending": "Εκκρεμεί",
     "inactive": "Ανενεργό",
-    "confirmRole": "Επιβεβαίωση ρόλου",
     "openRoleLabel": "ΑΝΟΙΧΤΟ",
     "finishedTheActivity": "🎯 {username} ολοκλήρωσε αυτήν τη δραστηριότητα",
     "activitySummaryError": "Οι περιλήψεις δραστηριοτήτων δεν είναι διαθέσιμες",
     "requestSummaries": "Αιτήματα περιλήψεων",
-    "generatingNewActivities": "Είστε ο πρώτος χρήστης αυτής της ζεύξης γλωσσών! Παρακαλούμε δώστε μας ένα λεπτό, ετοιμάζουμε δραστηριότητες αποκλειστικά για εσάς.",
     "requestAccessTitle": "Ζητήστε πρόσβαση σε αναλύσεις;",
     "requestAccessDesc": "Θα θέλατε να ζητήσετε πρόσβαση για να δείτε τα αναλυτικά στοιχεία των συμμετεχόντων;\n\nΑν οι συμμετέχοντες συμφωνήσουν, οι διαχειριστές αυτού του μαθήματος θα μπορούν να δουν:\n    • συνολικό λεξιλόγιο\n    • συνολικές γραμματικές έννοιες\n    • συνολικές συνεδρίες δραστηριότητας που ολοκληρώθηκαν\n    • τις συγκεκριμένες γραμματικές έννοιες που χρησιμοποιήθηκαν, σωστά και λανθασμένα\n\nΔεν θα μπορούν να δουν:\n    • μηνύματα σε συνομιλίες εκτός του μαθήματος\n    • λίστα λεξιλογίου",
-    "requestAccess": "Αίτηση πρόσβασης ({count})",
     "analyticsInactiveTitle": "Οι αιτήσεις σε ανενεργούς χρήστες δεν μπορούν να σταλούν",
     "analyticsInactiveDesc": "Οι ανενεργοί χρήστες που δεν έχουν συνδεθεί από τότε που εισήχθη αυτή η λειτουργία δεν θα δουν το αίτημά σας.\n\nΤο κουμπί Αίτημα θα εμφανιστεί μόλις επιστρέψουν. Μπορείτε να ξαναστείλετε το αίτημα αργότερα κάνοντας κλικ στο κουμπί Αίτημα κάτω από το όνομά τους όταν είναι διαθέσιμο.",
     "accessRequestedTitle": "Αίτημα πρόσβασης στα αναλυτικά στοιχεία",
@@ -3706,8 +3358,6 @@
     "accessDesc": "Μπορείτε να κάνετε το μάθημά σας ανοιχτό στον κόσμο! Ή, να το κρατήσετε ιδιωτικό και ασφαλές.",
     "createGroupChatDesc": "Ενώ οι συνεδρίες δραστηριοτήτων ξεκινούν και τελειώνουν, οι ομαδικές συνομιλίες θα παραμένουν ανοιχτές για τακτική επικοινωνία.",
     "deleteDesc": "Μόνο διαχειριστές μπορούν να διαγράψουν ένα μάθημα. Αυτή είναι μια καταστροφική ενέργεια που αφαιρεί όλους τους χρήστες και διαγράφει όλες τις επιλεγμένες συνομιλίες εντός του μαθήματος. Προχωρήστε με προσοχή.",
-    "noCourseFound": "Ωχ, αυτό το μάθημα χρειάζεται ένα πλάνο!\n\nΤα πλάνα μαθημάτων είναι μια σειρά θεμάτων και δραστηριοτήτων συζήτησης.",
-    "additionalParticipants": "+ {num} άλλοι",
     "whatNow": "Τι τώρα;",
     "chooseNextActivity": "Επιλέξτε την επόμενη δραστηριότητά σας!",
     "letsGo": "Πάμε",
@@ -3720,13 +3370,11 @@
     "waitNotDone": "Περίμενε, δεν έχω τελειώσει!",
     "waitingForOthersToFinish": "Αναμονή για τους υπόλοιπους να τελειώσουν...",
     "generatingSummary": "Ανάλυση συνομιλίας και δημιουργία αποτελεσμάτων",
-    "findCourse": "Βρείτε ένα μάθημα",
     "pingParticipantsNotification": "{user} ψάχνει χρήστες να συμμετάσχουν στη συνεδρία δραστηριότητας στο {room}",
     "course": "Μάθημα",
     "courses": "Μαθήματα",
     "goToCourse": "Πήγαινε στο μάθημα: {course}",
     "activityComplete": "Αυτή η δραστηριότητα έχει ολοκληρωθεί. Η περίληψη της δραστηριότητας θα πρέπει να είναι διαθέσιμη παρακάτω.",
-    "startNewSession": "Ξεκινήστε νέα συνεδρία",
     "joinOpenSession": "Συμμετοχή σε ανοιχτή συνεδρία",
     "activityNotFound": "Δεν βρέθηκε δραστηριότητα",
     "myActivities": "Οι δραστηριότητές μου",
@@ -3772,26 +3420,6 @@
     "@@locale": "el",
     "@@last_modified": "2026-07-13 10:08:00.885569",
     "@checkList": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3871,14 +3499,6 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
@@ -3903,31 +3523,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3983,23 +3583,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4039,28 +3627,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4078,14 +3644,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4278,22 +3836,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4349,10 +3891,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4362,10 +3900,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4441,27 +3975,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4779,10 +4297,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4792,10 +4306,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4883,14 +4393,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4907,10 +4409,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4923,15 +4421,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5083,14 +4573,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5104,14 +4586,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6334,10 +5808,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6378,10 +5848,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6454,10 +5920,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6727,47 +6189,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6787,19 +6209,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6863,10 +6273,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6907,14 +6313,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6926,14 +6324,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6971,10 +6361,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6991,27 +6377,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7135,10 +6505,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7148,10 +6514,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7168,14 +6530,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7315,18 +6669,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7375,10 +6717,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7388,18 +6726,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7442,23 +6768,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7482,10 +6796,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7493,14 +6803,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7605,18 +6907,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7669,10 +6959,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7699,10 +6985,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7883,7 +7165,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Ελέγξτε ξανά αύριο για ενημερώσεις δραστηριότητας.",
-    "activityDropdownDesc": "Όταν τελειώσετε με αυτή τη δραστηριότητα, κάντε κλικ παρακάτω",
     "languageMismatchTitle": "Αντιφάσεις γλώσσας",
     "languageMismatchDesc": "Η γλώσσα στόχος σας δεν ταιριάζει με τη γλώσσα αυτής της δραστηριότητας. Θέλετε να ενημερώσετε τη γλώσσα στόχο;",
     "reportWordIssueTooltip": "Αναφορά προβλήματος με τις πληροφορίες της λέξης",
@@ -7896,10 +7177,6 @@
     "selectAll": "Επιλογή όλων",
     "deselectAll": "Αποεπιλογή όλων",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7948,17 +7225,11 @@
         "placeholders": {}
     },
     "startOwn": "Ξεκίνα το δικό σου",
-    "joinCourseDesc": "Κάθε μάθημα έχει 8-10 διαδοχικά θέματα με μια σειρά δραστηριοτήτων μάθησης γλώσσας βασισμένων σε εργασίες.",
     "newMessageInPangeaChat": "🔊 Νέο μήνυμα στο Pangea Chat",
     "shareCourse": "Μοιράσου το μάθημα",
     "addCourse": "Πρόσθεσε ένα μάθημα",
-    "joinPublicCourse": "Συνδεθείτε σε δημόσιο μάθημα",
     "vocabLevelsDesc": "Εδώ θα προστεθούν οι λέξεις λεξιλογίου μόλις τις αναβαθμίσετε!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7971,10 +7242,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7993,7 +7260,6 @@
     "emojiView": "Προβολή emoji",
     "feedbackDialogDesc": "Κάνω λάθη κι εγώ! Οτιδήποτε μπορεί να με βοηθήσει να βελτιωθώ;",
     "contactHasBeenInvitedToTheCourse": "Η επαφή έχει προσκληθεί στο μάθημα",
-    "activityStatsButtonTooltip": "Πληροφορίες δραστηριότητας",
     "allow": "Επιτρέπω",
     "deny": "Αρνούμαι",
     "enabledRenewal": "Ενεργοποίηση Ανανέωσης Συνδρομής",
@@ -8261,10 +7527,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9320,16 +8582,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Δραστηριότητες για Ξεκλείδωμα Επόμενου Θέματος",
-    "activitiesToUnlockTopicDesc": "Ορίστε τον αριθμό των δραστηριοτήτων για να ξεκλειδώσετε το επόμενο θέμα του μαθήματος",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Διόρθωση πρακτικής ορισμού λεξιλογίου",
     "constructUseIncLMDesc": "Λάθος πρακτική ορισμού λεξιλογίου",
     "constructUseCorLADesc": "Διόρθωση πρακτικής ήχου λεξιλογίου",
@@ -9337,7 +8589,6 @@
     "constructUseBonus": "Μπόνους κατά τη διάρκεια της πρακτικής λεξιλογίου",
     "practiceVocab": "Πρακτική λεξιλογίου",
     "selectMeaning": "Επιλέξτε την έννοια",
-    "selectAudio": "Επιλέξτε τον αντίστοιχο ήχο",
     "anotherRound": "Μια ακόμη γύρος",
     "activitySettingsOverrideWarning": "Η γλώσσα και το επίπεδο γλώσσας καθορίζονται από το σχέδιο δραστηριότητας",
     "voice": "Φωνή",
@@ -9369,10 +8620,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9390,12 +8637,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Η λήψη ξεκίνησε",
     "webDownloadPermissionMessage": "Εάν ο περιηγητής σας μπλοκάρει τις λήψεις, παρακαλώ ενεργοποιήστε τις λήψεις για αυτόν τον ιστότοπο.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9490,11 +8732,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Κάτι πήγε στραβά και εργαζόμαστε σκληρά για να το διορθώσουμε. Έλεγξε ξανά αργότερα.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Ενεργοποίηση βοήθειας γραφής",
     "autoIGCToolDescription": "Αυτόματα εκτελέστε τα εργαλεία Pangea Chat για να διορθώσετε τα αποσταλμένα μηνύματα στη γλώσσα στόχο.",
     "@autoIGCToolName": {
@@ -9518,13 +8755,7 @@
     "longPressToRecordVoiceMessage": "Πατήστε παρατεταμένα για να ηχογραφήσετε φωνητικό μήνυμα.",
     "pause": "Παύση",
     "resume": "Συνέχεια",
-    "newSubSpace": "Νέος υποχώρος",
-    "moveToDifferentSpace": "Μετακίνηση σε διαφορετικό χώρο",
-    "removeFromSpaceDescription": "Η συνομιλία θα αφαιρεθεί από το χώρο αλλά θα εμφανίζεται ακόμα στη λίστα συνομιλιών σας.",
     "countChats": "{chats} συνομιλίες",
-    "spaceMemberOf": "Μέλος χώρου {spaces}",
-    "spaceMemberOfCanKnock": "Μέλος χώρου {spaces} μπορεί να χτυπήσει",
-    "donate": "Δωρεά",
     "startedAPoll": "{username} ξεκίνησε μια δημοσκόπηση.",
     "poll": "Δημοσκόπηση",
     "startPoll": "Ξεκινήστε τη δημοσκόπηση",
@@ -9548,23 +8779,15 @@
     "newStickerPack": "Νέο πακέτο αυτοκόλλητων",
     "stickerPackName": "Όνομα πακέτου αυτοκόλλητων",
     "attribution": "Αναγνώριση",
-    "skipChatBackup": "Παράλειψη αντιγράφου ασφαλείας συνομιλίας",
-    "skipChatBackupWarning": "Είστε σίγουροι; Χωρίς την ενεργοποίηση του αντιγράφου ασφαλείας συνομιλίας, μπορεί να χάσετε την πρόσβαση στα μηνύματά σας αν αλλάξετε συσκευή.",
-    "loadingMessages": "Φόρτωση μηνυμάτων",
-    "setupChatBackup": "Ρύθμιση αντιγράφου ασφαλείας συνομιλίας",
     "noMoreResultsFound": "Δεν βρέθηκαν περισσότερα αποτελέσματα",
     "chatSearchedUntil": "Η συνομιλία αναζητήθηκε μέχρι {time}",
     "federationBaseUrl": "Βασικό URL Ομοσπονδίας",
     "clientWellKnownInformation": "Πληροφορίες Πελάτη-Γνωστές:",
     "baseUrl": "Βασικό URL",
     "identityServer": "Διακομιστής Ταυτότητας:",
-    "versionWithNumber": "Έκδοση: {version}",
     "logs": "Καταγραφές",
-    "advancedConfigs": "Προχωρημένες Ρυθμίσεις",
     "advancedConfigurations": "Προχωρημένες ρυθμίσεις",
-    "signInWithLabel": "Συνδεθείτε με:",
     "selectAllWords": "Επιλέξτε όλες τις λέξεις που ακούτε στον ήχο",
-    "joinCourseForActivities": "Εγγραφείτε σε ένα μάθημα για να δοκιμάσετε δραστηριότητες.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9601,18 +8824,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9620,26 +8831,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9745,22 +8936,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9789,19 +8964,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9809,27 +8972,16 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
         "type": "String",
         "placeholders": {}
     },
-    "@joinCourseForActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spanTypeGrammar": "Γραμματική",
-    "spanTypeWordChoice": "Επιλογή Λέξης",
     "spanTypeSpelling": "Ορθογραφία",
     "spanTypePunctuation": "Στίξη",
     "spanTypeStyle": "Στυλ",
     "spanTypeFluency": "Άνεση",
     "spanTypeAccents": "Τονισμοί",
     "spanTypeCapitalization": "Κεφαλαιοποίηση",
-    "spanTypeCorrection": "Διόρθωση",
     "spanFeedbackTitle": "Αναφορά προβλήματος διόρθωσης",
     "aboutMeHint": "Σχετικά με εμένα",
     "changeEmail": "Αλλαγή email",
@@ -9839,14 +8991,6 @@
     "greatPractice": "Υπέροχη πρακτική!",
     "usedNoHints": "Καλή δουλειά που δεν χρησιμοποίησες καμία υπόδειξη!",
     "youveCompletedPractice": "Ολοκλήρωσες την πρακτική, συνέχισε έτσι για να βελτιωθείς!",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9868,10 +9012,6 @@
         "placeholders": {}
     },
     "@spanTypeCapitalization": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeCorrection": {
         "type": "String",
         "placeholders": {}
     },
@@ -10108,11 +9248,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Σε μάθημα; Βάλε τον κωδικό συμμετοχής σου εδώ.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Αυτόματη επισήμανση ηχητικών μηνυμάτων",
     "selectAudioMessagesOnPlayDescription": "Αυτόματα επισήμανση ηχητικών μηνυμάτων κατά την αναπαραγωγή",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10156,18 +9291,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Αυτό το μάθημα έχει θέματα με λιγότερες από {input} δραστηριότητες. Παρακαλώ εισάγετε έναν αριθμό μικρότερο ή ίσο με {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Κάντε κλικ εδώ για να συνδεθείτε ξανά.",
     "@clickToLogin": {
@@ -10584,17 +9707,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Ένας καρτουνίστικος κίτρινος αρκούδος με τα χέρια του υψωμένα από ενθουσιασμό.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Επιλέξτε λέξεις για να μάθετε περισσότερα γι' αυτές",
     "requireAnalyticsAccessTitle": "Απαιτείται πρόσβαση σε αναλύσεις για να συμμετάσχετε",
     "requireAnalyticsAccessDesc": "Οι συμμετέχοντες πρέπει να παραχωρήσουν πρόσβαση στις αναλύσεις μάθησής τους για να συμμετάσχουν σε αυτό το μάθημα",
     "analyticsAccessNoticeTitle": "Απαιτείται πρόσβαση σε αναλύσεις",
     "analyticsAccessNoticeDesc": "Με την συμμετοχή σας σε αυτό το μάθημα, συμφωνείτε να παραχωρήσετε στους διαχειριστές πρόσβαση στις αναλύσεις μάθησής σας.",
-    "skipOnboardingClassCodeDesc": "Μαθαίνετε ανεξάρτητα; Μην ανησυχείτε, μπορείτε να:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10612,10 +9729,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10644,7 +9757,6 @@
     "pickCefrLevelTeacherStepTitle": "Ποιο επίπεδο διδάσκετε;",
     "pickCefrLevelStudentStepTitle": "Ποιο επίπεδο είστε;",
     "customCourseStepTitle": "Συμπληρώστε αυτή τη φόρμα για να αποκτήσετε ένα προσαρμοσμένο μάθημα",
-    "aboutYourClass": "Σχετικά με την τάξη σας",
     "courseCodeStepErrorMessage": "Παρακαλώ ελέγξτε τον κωδικό σας και δοκιμάστε ξανά",
     "institution": "Ίδρυμα",
     "courseGoals": "Στόχοι Μαθήματος",
@@ -10687,10 +9799,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10807,12 +9915,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Λογότυπο Pangea Chat",
     "introChatDetails": "Πες γειά! Παρουσίασε τον εαυτό σου στους υπόλοιπους συμμετέχοντες του μαθήματος, βρες φίλους και συνομιλήστε εκτός δραστηριοτήτων.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10856,11 +9959,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Ενέργειες δραστηριότητας",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Εργαλεία προφοράς",
     "audioTranscription": "Αυτόματη μεταγραφή ήχου",
     "visualLearnerSupport": "Υποστήριξη οπτικών μαθητών",
@@ -10901,7 +9999,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Εγγραφείτε σε ένα μάθημα που περιλαμβάνει αυτή τη δραστηριότητα για να το παίξετε.",
     "resizeCoursePanel": "Αλλαγή μεγέθους πίνακα μαθήματος",
     "undo": "Αναίρεση",
     "unlock": "Ξεκλείδωμα",
@@ -10915,7 +10012,6 @@
     "addCourseBrowsePublic": "Περιήγηση σε δημόσια μαθήματα",
     "browsePublicCourses": "Περιήγηση σε δημόσια μαθήματα",
     "editProfile": "Επεξεργασία προφίλ",
-    "numObjectives": "{count} στόχοι",
     "mapSearchHint": "Αναζητήστε δραστηριότητες",
     "mapSearchNoResults": "Δεν υπάρχουν αποτελέσματα στην προβολή",
     "mapFilterAllLanguages": "Όλες οι γλώσσες",
@@ -10924,7 +10020,6 @@
     "mapFilterCompleted": "Ολοκληρώθηκε",
     "mapFilterReset": "Επαναφορά",
     "activityTypeConversation": "Συζήτηση",
-    "lockedMissionRequirement": "Ολοκληρώστε την προηγούμενη αποστολή για να ξεκλειδώσετε",
     "playAgain": "Παίξτε ξανά",
     "reviewActivity": "Αξιολόγηση",
     "mapEmptyInView": "Δεν υπάρχει τίποτα εδώ στο επίπεδό σας ή στη γλώσσα σας. Διευρύνετε τα φίλτρα σας ή απομακρυνθείτε.",
@@ -10939,14 +10034,9 @@
     "scrollToBottom": "Κύλιση προς τα κάτω",
     "courseImage": "Εικόνα μαθήματος",
     "avatarPreview": "Προεπισκόπηση avatar",
-    "activityPhoto": "Φωτογραφία δραστηριότητας",
     "emotePreview": "Προεπισκόπηση emote: {name}",
     "activityLabel": "Δραστηριότητα: {title}",
     "resetMapView": "Επαναφορά προβολής χάρτη",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10999,14 +10089,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11036,10 +10118,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11096,10 +10174,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -170,11 +170,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Are guest users allowed to join",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Are you sure?",
     "@areYouSure": {
         "type": "String",
@@ -466,15 +461,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "Your chat backup has been set up.",
-    "@yourChatBackupHasBeenSetUp": {},
     "chatBackup": "Chat backup",
     "@chatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "Your messages are secured with a recovery key. Please make sure you don't lose it.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -495,7 +483,6 @@
     },
     "clearArchive": "Clear archive",
     "@clearArchive": {},
-    "joinTheCourseToPlay": "Join a course that includes this activity to play it.",
     "resizeCoursePanel": "Resize course panel",
     "close": "Close",
     "@close": {
@@ -669,11 +656,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Contact has been invited to the group",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "The content has been reported to the server admins",
     "@contentHasBeenReported": {
         "type": "String",
@@ -714,15 +696,6 @@
             }
         }
     },
-    "countInvited": "{count} invited",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "create": "Create",
     "@create": {
         "type": "String",
@@ -739,11 +712,6 @@
     },
     "createGroup": "Create group",
     "@createGroup": {},
-    "createNewSpace": "New space",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "currentlyActive": "Currently active",
     "@currentlyActive": {
         "type": "String",
@@ -875,12 +843,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "globalChatId": "Global chat ID",
-    "@globalChatId": {},
-    "accessAndVisibility": "Access and visibility",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Who is allowed to join this chat and how the chat can be discovered.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Calls",
     "@calls": {},
     "customEmojisAndStickers": "Custom emojis and stickers",
@@ -904,11 +866,6 @@
     },
     "enableEncryption": "Enable encryption",
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "enableEncryptionWarning": "You won't be able to disable the encryption anymore. Are you sure?",
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -952,11 +909,6 @@
             }
         }
     },
-    "everythingReady": "Everything ready!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Extremely offensive",
     "@extremeOffensive": {
         "type": "String",
@@ -997,15 +949,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatDescription": "Chat description",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "Chat description changed",
     "@chatDescriptionHasBeenChanged": {},
-    "groupIsPublic": "Group is public",
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "groups": "Groups",
     "@groups": {
         "type": "String",
@@ -1100,15 +1045,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Invite contact to {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "noChatDescriptionYet": "No chat description created yet.",
     "@noChatDescriptionYet": {},
@@ -1231,15 +1167,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Load {count} more participants",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "dehydrate": "Export session and wipe device",
     "@dehydrate": {},
     "dehydrateWarning": "This action cannot be undone. Ensure you safely store the backup file.",
@@ -1270,15 +1197,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Log in to {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Logout",
     "@logout": {
@@ -1353,16 +1271,6 @@
     },
     "noEmotesFound": "No emotes found. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "You can only activate encryption as soon as the room is no longer publicly accessible.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Firebase Cloud Messaging doesn't appear to be available on your device. To still receive push notifications, we recommend installing ntfy. With ntfy or another Unified Push provider you can receive push notifications in a data secure way. You can download ntfy from the PlayStore or from F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1473,8 +1381,6 @@
     },
     "oneClientLoggedOut": "One of your clients has been logged out",
     "@oneClientLoggedOut": {},
-    "addAccount": "Add account",
-    "@addAccount": {},
     "editBundlesForAccount": "Edit bundles for this account",
     "@editBundlesForAccount": {},
     "addToBundle": "Add to bundle",
@@ -1483,8 +1389,6 @@
     "@removeFromBundle": {},
     "bundleName": "Bundle name",
     "@bundleName": {},
-    "enableMultiAccounts": "(BETA) Enable multi accounts on this device",
-    "@enableMultiAccounts": {},
     "openInMaps": "Open in maps",
     "@openInMaps": {
         "type": "String",
@@ -1528,11 +1432,6 @@
     "@overview": {},
     "passwordRecoverySettings": "Password recovery settings",
     "@passwordRecoverySettings": {},
-    "passwordRecovery": "Password recovery",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "people": "People",
     "@people": {
         "type": "String",
@@ -1577,8 +1476,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "pleaseEnterRecoveryKey": "Please enter your recovery key:",
-    "@pleaseEnterRecoveryKey": {},
     "pleaseEnterYourPassword": "Please enter your password",
     "@pleaseEnterYourPassword": {
         "type": "String",
@@ -1694,11 +1591,6 @@
             }
         }
     },
-    "removeDevice": "Remove device",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "unbanFromChat": "Unban from chat",
     "@unbanFromChat": {
         "type": "String",
@@ -1774,10 +1666,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKey": "Recovery key",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Recovery key lost?",
-    "@recoveryKeyLost": {},
     "send": "Send",
     "@send": {
         "type": "String",
@@ -1892,11 +1780,6 @@
     },
     "setChatDescription": "Set chat description",
     "@setChatDescription": {},
-    "setPermissionsLevel": "Set permissions level",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Set status",
     "@setStatus": {
         "type": "String",
@@ -1943,16 +1826,6 @@
     },
     "sourceCode": "Source code",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Space is public",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Space name",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -2020,11 +1893,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Transfer from another device",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Try to send again",
     "@tryToSendAgain": {
         "type": "String",
@@ -2080,15 +1948,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 unread chat} other{{unreadCount} unread chats}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} and {count} others are typing…",
     "@userAndOthersAreTyping": {
@@ -2176,16 +2035,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Video call",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Visibility of the chat history",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Visible for all participants",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -2231,23 +2080,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Who can perform which action",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Who is allowed to join this group",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Why do you want to report this?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Wipe your chat backup to create a new recovery key?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -2296,12 +2130,8 @@
     "@sender": {},
     "openGallery": "Open gallery",
     "@openGallery": {},
-    "removeFromSpace": "Remove from space",
-    "@removeFromSpace": {},
     "start": "Start",
     "@start": {},
-    "pleaseEnterRecoveryKeyDescription": "To unlock your old messages, please enter your recovery key that has been generated in a previous session. Your recovery key is NOT your password.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "publish": "Publish",
     "@publish": {},
     "openChat": "Open Chat",
@@ -2332,18 +2162,12 @@
     "@emojis": {},
     "placeCall": "Place call",
     "@placeCall": {},
-    "voiceCall": "Voice call",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "Unsupported Android version",
     "@unsupportedAndroidVersion": {},
     "unsupportedAndroidVersionLong": "This feature requires a newer Android version. Please check for updates or Lineage OS support.",
     "@unsupportedAndroidVersionLong": {},
-    "videoCallsBetaWarning": "Please note that video calls are currently in beta. They might not work as expected or work at all on all platforms.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "Experimental video calls",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "Email or username",
-    "@emailOrUsername": {},
     "addWidget": "Add widget",
     "@addWidget": {},
     "widgetVideo": "Video",
@@ -2440,26 +2264,10 @@
             }
         }
     },
-    "usersMustKnock": "Users must knock",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "No one can join",
-    "@noOneCanJoin": {},
     "knock": "Knock",
     "@knock": {},
     "users": "Users",
     "@users": {},
-    "unlockOldMessages": "Unlock old messages",
-    "@unlockOldMessages": {},
-    "storeInSecureStorageDescription": "Store the recovery key in the secure storage of this device.",
-    "@storeInSecureStorageDescription": {},
-    "saveKeyManuallyDescription": "Save this key manually by triggering the system share dialog or clipboard.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "Store in Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Store in Apple KeyChain",
-    "@storeInAppleKeyChain": {},
-    "storeSecurlyOnThisDevice": "Store securely on this device",
-    "@storeSecurlyOnThisDevice": {},
     "countFiles": "{count} files",
     "@countFiles": {
         "placeholders": {
@@ -2472,12 +2280,6 @@
     "@user": {},
     "custom": "Custom",
     "@custom": {},
-    "foregroundServiceRunning": "This notification appears when the foreground service is running.",
-    "@foregroundServiceRunning": {},
-    "screenSharingTitle": "screen sharing",
-    "@screenSharingTitle": {},
-    "screenSharingDetail": "You are sharing your screen in FuffyChat",
-    "@screenSharingDetail": {},
     "whyIsThisMessageEncrypted": "Why is this message unreadable?",
     "@whyIsThisMessageEncrypted": {},
     "noKeyForThisMessage": "This can happen if the message was sent before you have signed in to your account at this device.\n\nIt is also possible that the sender has blocked your device or something went wrong with the internet connection.\n\nAre you able to read the message on another session? Then you can transfer the message from it! Go to Settings > Devices and make sure that your devices have verified each other. When you open the room the next time and both sessions are in the foreground, the keys will be transmitted automatically.\n\nDo you not want to lose the keys when logging out or switching devices? Make sure that you have enabled the chat backup in the settings.",
@@ -2486,8 +2288,6 @@
     "@newGroup": {},
     "newSpace": "New space",
     "@newSpace": {},
-    "enterSpace": "Enter space",
-    "@enterSpace": {},
     "allSpaces": "All spaces",
     "@allSpaces": {},
     "hidePresences": "Hide Status List?",
@@ -2503,14 +2303,6 @@
             }
         }
     },
-    "newSpaceDescription": "Spaces allows you to consolidate your chats and build private or public communities.",
-    "@newSpaceDescription": {},
-    "encryptThisChat": "Encrypt this chat",
-    "@encryptThisChat": {},
-    "disableEncryptionWarning": "For security reasons you can not disable encryption in a chat, where it has been enabled before.",
-    "@disableEncryptionWarning": {},
-    "sorryThatsNotPossible": "Sorry... that is not possible",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "Device keys:",
     "@deviceKeys": {},
     "reopenChat": "Reopen chat",
@@ -2549,8 +2341,6 @@
     "@reportErrorDescription": {},
     "report": "report",
     "@report": {},
-    "setTheme": "Set theme:",
-    "@setTheme": {},
     "setColorTheme": "Set color theme:",
     "@setColorTheme": {},
     "invite": "Invite",
@@ -2601,25 +2391,10 @@
     },
     "knocking": "Knocking",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Chat can be discovered via the search on {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "searchChatsRooms": "Search for #chats, @users...",
-    "@searchChatsRooms": {},
     "nothingFound": "Nothing found...",
     "@nothingFound": {},
     "groupName": "Group name",
     "@groupName": {},
-    "createGroupAndInviteUsers": "Create a group and invite users",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "Group can be found via search",
-    "@groupCanBeFoundViaSearch": {},
     "wrongRecoveryKey": "Sorry... this does not seem to be the correct recovery key.",
     "@wrongRecoveryKey": {},
     "startConversation": "Start conversation",
@@ -2646,16 +2421,10 @@
     "@passwordsDoNotMatch": {},
     "passwordIsWrong": "Your entered password is wrong",
     "@passwordIsWrong": {},
-    "publicChatAddresses": "Public chat addresses",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Create new address",
-    "@createNewAddress": {},
     "joinSpace": "Join space",
     "@joinSpace": {},
     "publicSpaces": "Public spaces",
     "@publicSpaces": {},
-    "addChatOrSubSpace": "Add chat or sub space",
-    "@addChatOrSubSpace": {},
     "subspace": "Subspace",
     "@subspace": {},
     "decline": "Decline",
@@ -2679,30 +2448,6 @@
     "@gallery": {},
     "files": "Files",
     "@files": {},
-    "sessionLostBody": "Your session is lost. Please report this error to the developers at {url}. The error message is: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "The app now tries to restore your session from the backup. Please report this error to the developers at {url}. The error message is: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendReadReceipts": "Send read receipts",
     "@sendReadReceipts": {},
     "sendTypingNotificationsDescription": "Other participants in a chat can see when you are typing a new message.",
@@ -2713,10 +2458,6 @@
     "@formattedMessages": {},
     "formattedMessagesDescription": "Display rich message content like bold text using markdown.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Verify other user",
-    "@verifyOtherUser": {},
-    "verifyOtherUserDescription": "If you verify another user, you can be sure that you know who you are really writing to. 💪\n\nWhen you start a verification, you and the other user will see a popup in the app. There you will then see a series of emojis or numbers that you have to compare with each other.\n\nThe best way to do this is to meet up or start a video call. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDevice": "🔐 Verify other device",
     "@verifyOtherDevice": {},
     "verifyOtherDeviceDescription": "When you verify another device, those devices can exchange keys, increasing your overall security. 💪 When you start a verification, a popup will appear in the app on both devices. There you will then see a series of emojis or numbers that you have to compare with each other. It's best to have both devices handy before you start the verification. 🤳",
@@ -2873,14 +2614,6 @@
     "@changelog": {},
     "sendCanceled": "Sending canceled",
     "@sendCanceled": {},
-    "loginWithMatrixId": "Login with Matrix-ID",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Discover homeservers",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "What is a homeserver?",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "All your data is stored on the homeserver, just like an email provider. You can choose which homeserver you want to use, while you can still communicate with everyone. Learn more at at https://matrix.org.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "Doesn't seem to be a compatible homeserver. Wrong URL?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "calculatingFileSize": "Calculating file size...",
@@ -2920,16 +2653,12 @@
     "@noticeChatBackupDeviceVerification": {},
     "continueText": "Continue",
     "@continueText": {},
-    "welcomeText": "Hey Hey 👋 This is FluffyChat. You can sign in to any homeserver, which is compatible with https://matrix.org. And then chat with anyone. It's a huge decentralized messaging network!",
-    "@welcomeText": {},
     "blur": "Blur:",
     "@blur": {},
     "opacity": "Opacity:",
     "@opacity": {},
     "setWallpaper": "Set wallpaper",
     "@setWallpaper": {},
-    "manageAccount": "Manage account",
-    "@manageAccount": {},
     "noContactInformationProvided": "Server does not provide any valid contact information",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "Contact server admin",
@@ -2966,23 +2695,10 @@
     "@previous": {},
     "otherPartyNotLoggedIn": "The other party is currently not logged in and therefore cannot receive messages!",
     "@otherPartyNotLoggedIn": {},
-    "appWantsToUseForLogin": "Use '{server}' to log in",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "You hereby allow the app and website to share information about you.",
-    "@appWantsToUseForLoginDescription": {},
     "open": "Open",
     "@open": {},
     "waitingForServer": "Waiting for server...",
     "@waitingForServer": {},
-    "appIntroduction": "FluffyChat lets you chat with your friends across different messengers. Learn more at https://matrix.org or just tap *Continue*.",
-    "@appIntroduction": {},
     "newChatRequest": "📩 New chat request",
     "@newChatRequest": {},
     "contentNotificationSettings": "Content notification settings",
@@ -3144,9 +2860,6 @@
     "longPressToRecordVoiceMessage": "Long press to record voice message.",
     "pause": "Pause",
     "resume": "Resume",
-    "newSubSpace": "New sub space",
-    "moveToDifferentSpace": "Move to different space",
-    "removeFromSpaceDescription": "The chat will be removed from the space but still appear in your chat list.",
     "countChats": "{chats} chats",
     "@countChats": {
         "type": "String",
@@ -3156,25 +2869,6 @@
             }
         }
     },
-    "spaceMemberOf": "Space member of {spaces}",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "Space member of {spaces} can knock",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "Donate",
     "startedAPoll": "{username} started a poll.",
     "@startedAPoll": {
         "type": "String",
@@ -3223,10 +2917,6 @@
     "newStickerPack": "New sticker pack",
     "stickerPackName": "Sticker pack name",
     "attribution": "Attribution",
-    "skipChatBackup": "Skip chat backup",
-    "skipChatBackupWarning": "Are you sure? Without enabling the chat backup you may lose access to your messages if you switch your device.",
-    "loadingMessages": "Loading messages",
-    "setupChatBackup": "Set up chat backup",
     "noMoreResultsFound": "No more results found",
     "chatSearchedUntil": "Chat searched until {time}",
     "@chatSearchedUntil": {
@@ -3245,22 +2935,10 @@
     "@baseUrl": {},
     "identityServer": "Identity Server:",
     "@identityServer": {},
-    "versionWithNumber": "Version: {version}",
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "logs": "Logs",
     "@logs": {},
-    "advancedConfigs": "Advanced Configs",
-    "@advancedConfigs": {},
     "advancedConfigurations": "Advanced configurations",
     "@advancedConfigurations": {},
-    "signInWithLabel": "Sign in with:",
     "ignore": "Block",
     "ignoredUsers": "Blocked users",
     "writeAMessageLangCodes": "Type in {l1} or {l2}...",
@@ -3280,11 +2958,9 @@
     "taTooltip": "L2 use with translation assistance",
     "interactiveTranslatorSliderHeader": "Interactive Translator",
     "interactiveGrammarSliderHeader": "Interactive Grammar Checker",
-    "interactiveTranslatorRequired": "Required",
     "waTooltip": "L2 use without assistance",
     "interactiveTranslator": "Translation assistance",
     "noIdenticalLanguages": "Please choose different base and target languages",
-    "searchBy": "Search by country and languages",
     "joinWithClassCode": "Join course",
     "languageLevelPreA1": "Novice Low (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -3312,19 +2988,14 @@
     "whatIsYourBaseLanguage": "What is your base language?",
     "publicProfileTitle": "Allow my profile to be found in search",
     "publicProfileDesc": "By turning on, you enable other users to find your profile in the global search bar and send requests to chat. At this point, you can choose to accept or deny the request.",
-    "errorDisableIT": "Translation assistance is turned off.",
-    "errorDisableIGC": "Grammar assistance is turned off.",
     "errorDisableITUserDesc": "Click here to update translation assistance settings",
     "errorDisableIGCUserDesc": "Click here to update grammar assistance settings",
     "errorDisableITClassDesc": "Translation assistance is turned off for the course that this chat is in.",
     "errorDisableIGCClassDesc": "Grammar assistance is turned off for the course that this chat is in.",
-    "error405Title": "Languages not set",
     "error405Desc": "Please set your languages in Main Menu > Learning Settings.",
     "termsAndConditions": "Terms and Conditions",
     "andCertifyIAmAtLeast13YearsOfAge": " and certify I am at least 16 years of age.",
-    "error502504Title": "Wow, there are a lot of students online!",
     "error502504Desc": "Translation and grammar tools may be slow or unavailable while the Pangea bots catch up.",
-    "error404Title": "Translation error!",
     "error404Desc": "Pangea Bot isn't sure how to translate that...",
     "errorPleaseRefresh": "We're looking into it! Please reload and try again.",
     "connectedToStaging": "Connected to Staging",
@@ -3362,8 +3033,6 @@
     "definitionsToolName": "Word Definitions",
     "definitionsToolDescription": "When enabled, words underlined in blue can be clicked for definitions. Click messages to access definitions.",
     "welcomeBack": "Welcome back! If you were part of the 2023-2024 pilot, please contact us for your special pilot subscription. If you are a teacher who has (or whose institution has) purchased licenses for your class, contact us for your teacher subscription.",
-    "downloadTxtFile": "Download Text File",
-    "downloadCSVFile": "Download CSV File",
     "promotionalSubscriptionDesc": "You currently have a lifetime promotional subscription. Message support@pangea.chat for help changing your subscription.",
     "originalSubscriptionPlatform": "Subscription purchased through {purchasePlatform}",
     "@originalSubscriptionPlatform": {
@@ -3374,8 +3043,6 @@
         }
     },
     "oneWeekTrial": "One Week Trial",
-    "downloadXLSXFile": "Download Excel File",
-    "unkDisplayName": "Unknown",
     "wwCountryDisplayName": "World Wide",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Aland Islands",
@@ -3736,7 +3403,6 @@
         }
     },
     "chatCapacityExplanation": "Chat capacity limits the number of members allowed in a chat.",
-    "tooManyRequest": "Too many request, please try again later.",
     "enterNumber": "Please enter a whole number value.",
     "practice": "Practice",
     "versionNotFound": "Version Not Found",
@@ -3760,7 +3426,6 @@
     "deleteSubscriptionWarningTitle": "You have an active subscription",
     "deleteSubscriptionWarningBody": "Deleting your account will not automatically cancel your subscription.",
     "manageSubscription": "Manage Subscription",
-    "error520Title": "Please try again.",
     "error520Desc": "Sorry, we could not understand your message...",
     "wordsUsed": "Words Used",
     "level": "Level",
@@ -3786,7 +3451,6 @@
         }
     },
     "noCapacityLimit": "No capacity limit",
-    "downloadGroupText": "Download group text",
     "notificationsOn": "Notifications on",
     "notificationsOff": "Notifications off",
     "joinWithCode": "Join with code",
@@ -3872,35 +3536,12 @@
     },
     "dataAvailable": "Data availability",
     "available": "Available",
-    "pangeaBotIsFallible": "Pangea Bot makes mistakes too!",
-    "whatIsMeaning": "What does '{lemma}' mean?",
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            },
-            "partOfSpeech": {
-                "type": "String"
-            }
-        }
-    },
     "chooseLemmaMeaningInstructionsBody": "Match meanings with the words in the message!",
-    "doubleClickToEdit": "Double-click to edit.",
-    "topicLabel": "Topic",
-    "topicPlaceholder": "Choose a topic...",
-    "modePlaceholder": "Choose a mode...",
-    "learningObjectiveLabel": "Learning Objective",
-    "learningObjectivePlaceholder": "Choose a learning objective...",
-    "targetLanguageLabel": "Target language",
     "cefrLevelLabel": "CEFR level",
     "image": "Image",
     "video": "Video",
     "nan": "Not applicable",
-    "addVocabulary": "Add vocabulary",
     "instructions": "Instructions",
-    "numberOfLearners": "Number of learners",
-    "mustBeInteger": "Must be an integer e.g. 1, 2, 3, ...",
     "constructUsePvmDesc": "Produced in voice message",
     "leaveSpaceDescription": "By leaving the course, you will leave all of the chats within it. Other users will see that you have left the course.",
     "constructUseCorMmDesc": "Correct message meaning",
@@ -3923,7 +3564,6 @@
     "ttsDisabledBody": "You can enable text-to-speech in your learning settings",
     "noSpaceDescriptionYet": "No course description created yet.",
     "tooLargeToSend": "This message is too large to send",
-    "exitWithoutSaving": "Are you sure you want to leave without saving?",
     "enableAutocorrectPopupTitle": "Add your target language keyboard by going to:",
     "enableAutocorrectPopupSteps": "  • Settings\n  • General\n  • Keyboard\n  • Keyboards\n  • Add New Keyboard",
     "enableAutocorrectPopupDescription": "Once the language is selected, you can click the small globe icon on the bottom left of your keyboard to activate the newly installed keyboard.",
@@ -3934,8 +3574,6 @@
     "displayName": "Display name",
     "leaveRoomDescription": "You're about to leave this chat. Other users will see that you have left the chat.",
     "confirmUserId": "Please confirm your Pangea Chat username in order to delete your account.",
-    "startingToday": "Starting today",
-    "oneWeekFreeTrial": "One week free trial",
     "paidSubscriptionStarts": "Starting {startDate}",
     "@paidSubscriptionStarts": {
         "type": "String",
@@ -3946,15 +3584,6 @@
         }
     },
     "cancelInSubscriptionSettings": "• Cancel at any time in subscription settings",
-    "cancelToAvoidCharges": "• Cancel before {trialEnds} to avoid charges",
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
-    },
     "downloadGboard": "Download Gboard",
     "autocorrectNotAvailable": "Unfortunately your platform is not currently supported for this feature. Stay tuned for further development!",
     "pleaseUpdateApp": "Please update the app to continue.",
@@ -3964,17 +3593,12 @@
     "knockSpaceSuccess": "You have requested to join this course! An admin will respond to your request when they receive it 😀",
     "chooseWordAudioInstructionsBody": "Listen to the complete message. Then match the audios with the words.",
     "chooseMorphsInstructionsBody": "Click the puzzle pieces for grammar questions!",
-    "pleaseEnterInt": "Please enter a number",
     "home": "Home",
     "join": "Join",
     "resetInstructionTooltipsTitle": "Reset instruction tooltips",
     "resetInstructionTooltipsDesc": "Click to show instruction tooltips like for a brand new user.",
-    "randomize": "Randomize",
     "clear": "Clear",
-    "featuredActivities": "Featured",
     "save": "Save",
-    "startChat": "Start a chat",
-    "translationProblem": "Translation problem",
     "askToJoin": "Ask to join",
     "emptyChatWarningTitle": "Chat is empty",
     "emptyChatWarningDesc": "You haven't invited anyone to your chat. Go to Chat settings to invite your contacts or the Bot. You can also do this later.",
@@ -4011,17 +3635,13 @@
             }
         }
     },
-    "leaderboard": "Leaderboard",
     "skipForNow": "Skip for now",
     "permissions": "Permissions",
     "spaceChildPermission": "Who can add new chats to this course",
-    "addEnvironmentOverride": "Add environment override",
     "defaultOption": "Default",
     "deleteChatDesc": "Are you sure you want to delete this chat? It will be deleted for all participants and all messages within the chat will no longer be available for practice or learning analytics.",
     "deleteSpaceDesc": "The course and any selected chats will be deleted for all participants and all messages within the chat will no longer be available for practice or learning analytics. This action cannot be undone.",
     "launch": "Launch",
-    "searchChats": "Search chats",
-    "maxFifty": "Max 50",
     "configureSpace": "Configure course",
     "pinMessages": "Pin messages",
     "setJoinRules": "Set join rules",
@@ -4064,9 +3684,6 @@
     "failedToFetchTranscription": "Failed to fetch transcription",
     "deleteEmptySpaceDesc": "The course will be deleted for all participants. This action cannot be undone.",
     "regenerate": "Regenerate",
-    "mySavedActivities": "My Saved Activities",
-    "noSavedActivities": "No saved activities",
-    "saveActivity": "Save this activity",
     "failedToPlayVideo": "Failed to play video",
     "done": "Done",
     "inThisSpace": "In this course",
@@ -4093,13 +3710,9 @@
     },
     "saved": "Saved",
     "reset": "Reset",
-    "errorFetchingActivitiesMessage": "Failed to fetch activities",
     "errorFetchingDefinition": "Failed to fetch definition",
     "errorProcessAnalytics": "Failed to process analytics",
     "errorDownloading": "Download failed",
-    "errorLoadingSpaceChildren": "Failed to load chats within this course",
-    "unexpectedError": "Unexpected error.",
-    "pleaseReload": "Please reload and try again.",
     "translationError": "Translation error",
     "check": "Check",
     "unableToFindRoom": "No chat or course found with that code. Please try again.",
@@ -4119,11 +3732,8 @@
     "request": "Request",
     "requestAll": "Request All",
     "confirmMessageUnpin": "Are you sure you want to unpin this message?",
-    "saveAndLaunch": "Save and Launch",
-    "launchToSpace": "Launch to course",
     "pending": "Pending",
     "inactive": "Inactive",
-    "confirmRole": "Confirm role",
     "openRoleLabel": "OPEN",
     "finishedTheActivity": "🎯 {username} wrapped up this activity",
     "@finishedTheActivity": {
@@ -4136,18 +3746,8 @@
     },
     "activitySummaryError": "Activity summaries unavailable",
     "requestSummaries": "Request summaries",
-    "generatingNewActivities": "You're the first user of this language pair! Please give us a minute, we're preparing activities just for you.",
     "requestAccessTitle": "Request analytics access?",
     "requestAccessDesc": "Would you like to request access to view participant analytics?\n\nIf participants agree, you will be able to view their:\n    • total vocabulary\n    • total grammar concepts\n    • total activity sessions completed\n    • the specific grammar concepts used, correctly and incorrectly\n\nYou will not be able to view their:\n    • messages in chats outside the course\n    • vocabulary list",
-    "requestAccess": "Request access ({count})",
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "analyticsInactiveTitle": "Requests to inactive users couldn’t be sent",
     "analyticsInactiveDesc": "Inactive users who haven't logged in since this feature was introduced won't see your request.\n\nThe Request button will appear once they return. You can resend the request later by clicking the Request button under their name when it's available.",
     "accessRequestedTitle": "Analytics Access Request",
@@ -4197,16 +3797,6 @@
     "accessDesc": "You can make your course open to the world! Or, make your course private and secure.",
     "createGroupChatDesc": "Whereas activity sessions start and end, group chats will stay open for routine communication.",
     "deleteDesc": "Only admins can delete a course. This is a destructive action which removes all users and deletes all selected chats within the course. Proceed with caution.",
-    "noCourseFound": "Oh, this course needs a plan!\n\nCourse plans are a sequence of topics and conversation activities.",
-    "additionalParticipants": "+ {num} others",
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "whatNow": "What now?",
     "chooseNextActivity": "Choose your next activity!",
     "letsGo": "Let's go",
@@ -4246,7 +3836,6 @@
         "course": {}
     },
     "activityComplete": "This activity has been completed. The activity summary should be available below.",
-    "startNewSession": "Start new session",
     "joinOpenSession": "Join open session",
     "activityNotFound": "Activity not found",
     "starsEarnedOfTotal": "{earned} of {total} stars earned",
@@ -4294,7 +3883,6 @@
     "loginToAccount": "Login to my account",
     "languages": "Languages",
     "startOwn": "Start my own",
-    "joinCourseDesc": "Each course has 8-10 sequenced topics with a range of task-based language learning activities.",
     "courseCodeHint": "Course code",
     "signupOption": "How do you want to sign up?",
     "withApple": "With Apple",
@@ -4316,7 +3904,6 @@
     "inviteYourFriends": "Invite your friends",
     "playWithAI": "Play with AI for now",
     "courseStartDesc": "Pangea Bot is ready to go anytime!\n\n...but learning is better with friends!",
-    "activityDropdownDesc": "When you’re done with this activity, click below",
     "languageMismatchTitle": "Language mismatch",
     "emptyChatSearch": "No DMs or chats found. Make sure your search is spelled correctly.",
     "languageMismatchDesc": "Your target language doesn't match the language of this activity. Update your target language?",
@@ -4349,7 +3936,6 @@
     "addCourseStartMyOwn": "Start my own",
     "addCourseEnterCode": "Enter code for private course",
     "addCourseBrowsePublic": "Browse public courses",
-    "joinPublicCourse": "Join public course",
     "vocabLevelsDesc": "This is where vocab words will go once you’ve leveled them up!",
     "activityAnalyticsTooltipBody": "These are your saved activities for review and practice.",
     "numSavedActivities": "Number of saved activities",
@@ -4362,7 +3948,6 @@
     "feedbackDialogDesc": "I make mistakes too! Anything to help me improve?",
     "contactHasBeenInvitedToTheCourse": "Contact has been invited to the course",
     "inviteFriends": "Invite friends",
-    "activityStatsButtonTooltip": "Activity info",
     "allow": "Allow",
     "deny": "Deny",
     "enabledRenewal": "Enable Subscription Renewal",
@@ -4635,7 +4220,6 @@
     "constructUseBonus": "Bonus during vocab practice",
     "practiceVocab": "Practice vocabulary",
     "selectMeaning": "Select the meaning",
-    "selectAudio": "Select the matching audio",
     "anotherRound": "Another round",
     "ssoDialogTitle": "Waiting for sign in to complete",
     "ssoDialogDesc": "We opened a new tab so you can sign in securely.",
@@ -4643,8 +4227,6 @@
     "disableLanguageToolsTitle": "Disable language tools",
     "disableLanguageToolsDesc": "Would you like to disable automatic language assistance?",
     "screenSizeWarning": "For the best experience using this application, please expand your screen size.",
-    "activitiesToUnlockTopicTitle": "Activities to Unlock Next Topic",
-    "activitiesToUnlockTopicDesc": "Set the number of activities to unlock the next course topic",
     "starsToUnlockObjectiveTitle": "Stars per Mission",
     "starsToUnlockObjectiveDesc": "Set the number of stars needed to complete each mission",
     "maxStarsPerMissionWarning": "This course has missions where only {maxValue} stars can be earned. Please enter a number less than or equal to {maxValue}.",
@@ -4659,7 +4241,6 @@
     "activitySettingsOverrideWarning": "Language and language level determined by activity plan",
     "voice": "Voice",
     "youLeftTheChat": "🚪 You left the chat",
-    "downloadInitiated": "Download initiated",
     "webDownloadPermissionMessage": "If your browser blocks downloads, please enable downloads for this site.",
     "exitPractice": "Your practice session progress won't be saved.",
     "practiceGrammar": "Practice grammar",
@@ -4674,28 +4255,23 @@
     "knockDesc": "Your request has been sent to course admin! You'll be let in if they approve.",
     "knockAccepted": "Your join request was accepted! You can now enter the course.",
     "@knockAccepted": {},
-    "findCourse": "Find a course",
     "browsePublicCourses": "Browse public courses",
     "publicInviteDescChat": "Search for users to invite them to this chat.",
     "publicInviteDescSpace": "Search for users to invite them to this space.",
     "useActivityImageAsChatBackground": "Use activity image as chat background",
     "chatWithSupport": "Chat with Support",
     "newCourseAccess": "By default, courses are publicly searchable and require admin approval to join. You can edit these settings at any time.",
-    "courseLoadingError": "Something went wrong, and we're hard at work fixing it. Check again later.",
     "onboardingLanguagesTitle": "What language are you learning?",
     "supportSubtitle": "Questions? We're here to help!",
     "autoIGCToolName": "Enable writing assistance",
     "autoIGCToolDescription": "Automatically run Pangea Chat tools to correct sent messages to target language.",
     "emptyAudioError": "Recording failed. Please check your audio permissions and try again.",
-    "spanTypeGrammar": "Grammar",
-    "spanTypeWordChoice": "Word Choice",
     "spanTypeSpelling": "Spelling",
     "spanTypePunctuation": "Punctuation",
     "spanTypeStyle": "Style",
     "spanTypeFluency": "Fluency",
     "spanTypeAccents": "Accents",
     "spanTypeCapitalization": "Capitalization",
-    "spanTypeCorrection": "Correction",
     "spanFeedbackTitle": "Report correction issue",
     "selectAllWords": "Select all the words you hear in the audio",
     "aboutMeHint": "About me",
@@ -4706,7 +4282,6 @@
     "greatPractice": "Great practice!",
     "usedNoHints": "Nice job not using any hints!",
     "youveCompletedPractice": "You've completed practice, keep it up to get better!",
-    "joinCourseForActivities": "Join a course to try activities.",
     "courseDescription": "Courses consist of 3-8 modules each with activities to encourage practicing words in different contexts",
     "emailVerificationFailed": "Email verification failed. Please try again.",
     "unlockLearningTools": "Unlock learning tools",
@@ -4769,7 +4344,6 @@
     "notificationRuleDM": "Direct Message",
     "notificationRuleDMDescription": "Notifies the user about messages in direct message rooms.",
     "enableEmailNotifications": "Enable email notifications",
-    "joinSpaceOnboardingDesc": "In a class? Put your join code here.",
     "selectAudioMessagesOnPlayToolName": "Auto-highlight audio messages",
     "selectAudioMessagesOnPlayDescription": "Automatically highlight audio messages when played",
     "learningAnalytics": "Learning analytics",
@@ -4786,18 +4360,6 @@
     },
     "emailLoginMethod": "email",
     "clickToAddEmail": "Click here to add an email address.",
-    "minActivitiesPerTopicWarning": "This course has topics with fewer than {input} activities. Please enter a number less than or equal to {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
-    },
     "clickToLogin": "Click here to sign back in.",
     "spanTypeDefinition": "Definition",
     "spanTypeVerbConjugation": "Verb Conjugation",
@@ -4866,15 +4428,6 @@
     "enableNotificationsTitle": "Never miss a chat!",
     "enableNotificationsDesc": "Allow notifications for Pangea Chat and stay connected with your language buddies!",
     "enableNotifications": "Allow notifications",
-    "numObjectives": "{count} objectives",
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "cannotIgnoreYourself": "You cannot block yourself",
     "blockUsernameHint": "Block username",
     "errorTryAgainSoon": "Writing assistance is taking a bit longer than expected. Try again in a second!",
@@ -4893,10 +4446,8 @@
     "requireAnalyticsAccessTitle": "Require analytics access to join",
     "requireAnalyticsAccessDesc": "Participants must grant access to their learning analytics to join this course",
     "moreOptions": "More options",
-    "bearImageDescription": "A cartoonish yellow bear with its arms raised in excitement.",
     "analyticsAccessNoticeTitle": "Analytics Access Required",
     "analyticsAccessNoticeDesc": "By joining this course, you agree to grant admins access to your learning analytics.",
-    "skipOnboardingClassCodeDesc": "Learning independently? Don't worry, you can:",
     "setPermissionsLevelDesc": "Please choose a predefined role below or enter a custom permission level. Pick a whole number between 0 and 100.",
     "reportContentIssue": "Report content issue",
     "userTypeTitle": "I use Pangea Chat to",
@@ -4909,13 +4460,11 @@
     "pickCefrLevelTeacherStepTitle": "What level do you teach?",
     "pickCefrLevelStudentStepTitle": "What level are you?",
     "customCourseStepTitle": "Fill this form to get a custom course",
-    "aboutYourClass": "About your class",
     "courseCodeStepErrorMessage": "Please check your code and try again",
     "institution": "Institution",
     "courseGoals": "Course Goals",
     "missingLanguageException": "Please choose valid base and target languages",
     "selectChats": "Select Chats",
-    "pangeaChatLogo": "Pangea Chat logo",
     "plainTextFile": "Text",
     "completedActivitiesTitle": "Finished ({num})",
     "@completedActivitiesTitle": {
@@ -4965,11 +4514,9 @@
     "mapFilterCompleted": "Completed",
     "mapFilterReset": "Reset",
     "activityTypeConversation": "Conversation",
-    "lockedMissionRequirement": "Finish the previous mission to unlock",
     "playAgain": "Play again",
     "reviewActivity": "Review",
     "mapEmptyInView": "Nothing here at your level or language. Widen your filters or zoom out.",
-    "activityActions": "Activity actions",
     "back": "Back",
     "viewCurrentOrFinished": "View current or finished",
     "pronunciationTools": "Pronunciation tools",
@@ -4992,8 +4539,6 @@
     "@courseImage": {},
     "avatarPreview": "Avatar preview",
     "@avatarPreview": {},
-    "activityPhoto": "Activity photo",
-    "@activityPhoto": {},
     "emotePreview": "Emote preview: {name}",
     "@emotePreview": {
         "placeholders": {
@@ -5056,22 +4601,17 @@
     "joinedCourseListLabel": "Joined course list",
     "analyticsAndSettingsLabel": "Analytics and Settings options",
     "searchActivitiesLabel": "Search for activities on map",
-    "filteredActivitiesLabel": "Filtered activity list", 
-    "activityFilterButtonsLabel": "Language, difficulty, and progress filter buttons", 
-    "mapZoomLabel": "Map zoom controls", 
-    "activityMapLabel": "Activity map", 
-    "writingAssistanceTutorialInputBar": "You can write in any language! We'll help you correct mistakes.",
-    "abDisplayName": "Abkhazian", 
-    "elDisplayName": "Greek",
-    "etDisplayName": "Estonian",
+    "filteredActivitiesLabel": "Filtered activity list",
     "activityFilterButtonsLabel": "Language, difficulty, and progress filter buttons",
     "mapZoomLabel": "Map zoom controls",
     "activityMapLabel": "Activity map",
     "writingAssistanceTutorialInputBar": "You can write in any language! We'll help you correct mistakes.",
+    "abDisplayName": "Abkhazian",
+    "elDisplayName": "Greek",
     "missingCourseOutline": "This course is no longer available",
     "missingCourseOutlineCta": "This course is no longer available. Pick a new course plan.",
     "welcome": "Welcome",
-    "courseRequest": "Course request", 
+    "courseRequest": "Course request",
     "onboarding": "Onboarding",
     "selectImageFromDevice": "Select image from device",
     "dinoAvatarLabel": "A dinosaur with sunglasses",

--- a/lib/l10n/intl_eo.arb
+++ b/lib/l10n/intl_eo.arb
@@ -82,11 +82,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Ĉu gastoj rajtas aliĝi",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Ĉu vi certas?",
     "@areYouSure": {
         "type": "String",
@@ -358,11 +353,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Via savkopio de babilo estas sekurigita per sekureca ŝlosilo. Bonvolu certigi, ke vi ne perdos ĝin.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Detaloj pri babilo",
     "@chatDetails": {
         "type": "String",
@@ -489,11 +479,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Kontakto invitiĝis al la grupo",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "La enhavo raportiĝis al la administrantoj de la servilo",
     "@contentHasBeenReported": {
         "type": "String",
@@ -545,11 +530,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Nova aro",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Nun aktiva",
     "@currentlyActive": {
@@ -693,11 +673,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Vi ne povos malŝalti la ĉifradon. Ĉu vi certas?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Ĉifrite",
     "@encrypted": {
         "type": "String",
@@ -736,11 +711,6 @@
             }
         }
     },
-    "everythingReady": "Ĉio pretas!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Tre ofenda",
     "@extremeOffensive": {
         "type": "String",
@@ -778,11 +748,6 @@
     },
     "group": "Grupo",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Grupo estas publika",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -876,15 +841,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Inviti kontakton al {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Invitita",
     "@invited": {
@@ -997,15 +953,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Enlegi {count} pliajn partoprenantojn",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Enlegante… bonvolu atendi.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -1020,15 +967,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Saluti servilon {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Adiaŭi",
     "@logout": {
@@ -1092,16 +1030,6 @@
     },
     "noEmotesFound": "Neniuj mienetoj troviĝis. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Vi nur povas aktivigi ĉifradon kiam la ĉambro ne plu estas publike alirebla.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Ŝajnas, ke via telefono ne havas servojn de Google. Tio estas bona decido por via privateco! Por ricevadi pasivajn sciigojn en FluffyChat, ni rekomendas, ke vi uzu la https://microg.org/ aŭ https://unifiedpush.org/.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1216,11 +1144,6 @@
     },
     "passwordHasBeenChanged": "Pasvorto ŝanĝiĝis",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Rehavo de pasvorto",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1364,11 +1287,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Forigi aparaton",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Malforbari",
     "@unbanFromChat": {
@@ -1519,11 +1437,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Agordi nivelon de permesoj",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Agordi staton",
     "@setStatus": {
         "type": "String",
@@ -1565,16 +1478,6 @@
     },
     "sourceCode": "Fontkodo",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Aro estas publika",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Nomo de aro",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1633,11 +1536,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Transporti de alia aparato",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Reprovi sendi",
     "@tryToSendAgain": {
         "type": "String",
@@ -1693,15 +1591,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 nelegita babilo} other{{unreadCount} nelegitaj babiloj}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} kaj {count} aliaj tajpas…",
     "@userAndOthersAreTyping": {
@@ -1787,16 +1676,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Vidvoko",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Videbleco de historio de la babilo",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Videbla al ĉiuj partoprenantoj",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1842,23 +1721,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Kiu povas kion",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Kiu rajtas aliĝi al ĉi tiu grupo",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Kial vi volas tion ĉi raporti?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Ĉu forviŝi la savkopion de via babilo por krei novan sekurecan ŝlosilon?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1960,7 +1824,6 @@
     "unread": "Nelegitaj",
     "space": "Spaco",
     "spaces": "Spacoj",
-    "yourChatBackupHasBeenSetUp": "Via babilo-daŭdpreno estis agordita.",
     "commandHint_markasdm": "Marku kiel rektan mesaĝan ĉambron por la donita Matrix-ID",
     "commandHint_markasgroup": "Marku kiel grupon",
     "commandHint_clearcache": "Forviŝu kaŝmemoron",
@@ -1968,17 +1831,12 @@
     "commandHint_discardsession": "Forĵetu sesion",
     "commandHint_dm": "Komencu rektan babilon\nUzu --no-encryption por malaktivigi ĉifron",
     "checkList": "Kontrolu Listo",
-    "countInvited": "{count} invitita",
     "createGroup": "Krei grupon",
     "chatPermissions": "Permesoj por babilejo",
     "emoteKeyboardNoRecents": "Lastatempe uzitaj emojoj aperos ĉi tie...",
-    "globalChatId": "Tutmonda babileja ID",
-    "accessAndVisibility": "Aksesado kaj videbleco",
-    "accessAndVisibilityDescription": "Kiu rajtas aliĝi al ĉi tiu babilejo kaj kiel la babilejo povas esti malkovrita.",
     "calls": "Vokoj",
     "customEmojisAndStickers": "Propraj emojoj kaj etikedoj",
     "customEmojisAndStickersBody": "Aldoni aŭ kundividi proprajn emojojn aŭ etikedojn kiuj povas esti uzataj en ajna babilejo.",
-    "chatDescription": "Babileja priskribo",
     "chatDescriptionHasBeenChanged": "Babileja priskribo ŝanĝita",
     "hideRedactedMessages": "Kaŝi redaktitajn mesaĝojn",
     "hideRedactedMessagesBody": "Se iu redaktas mesaĝon, ĉi tiu mesaĝo ne plu estos videbla en la babilejo.",
@@ -2002,23 +1860,18 @@
     "scanQrCode": "Skani QR-kodon",
     "openVideoCamera": "Malfermi fotilon por filmeto",
     "oneClientLoggedOut": "Unu el viaj klientoj estis elsaligita",
-    "addAccount": "Aldoni konton",
     "editBundlesForAccount": "Redakti pakaĵojn por ĉi tiu konto",
     "addToBundle": "Aldoni al pakaĵo",
     "removeFromBundle": "Forigi de ĉi tiu pakaĵo",
     "bundleName": "Pakaĵa nomo",
-    "enableMultiAccounts": "(BETA) Ebligi multajn kontoĵojn sur ĉi tiu aparato",
     "openInMaps": "Malfermi en mapoj",
     "link": "Ligilo",
     "serverRequiresEmail": "Ĉi tiu servilo bezonas validigi vian retadreso por registriĝo.",
     "overview": "Superrigardo",
     "passwordRecoverySettings": "Agordoj por pasvorta restarigo",
-    "pleaseEnterRecoveryKey": "Bonvolu enmeti vian restarigan ŝlosilon:",
     "redactedBy": "Redaktita de {username}",
     "directChat": "Rekta babilejo",
     "redactedByBecause": "Redaktita de {username} ĉar: \"{reason}\"",
-    "recoveryKey": "Restariga ŝlosilo",
-    "recoveryKeyLost": "Ĉu vi perdis la restarigan ŝlosilon?",
     "sendImages": "Sendu {count} bildon",
     "separateChatTypes": "Apartigu Rektajn Babilejojn kaj Grupojn",
     "setChatDescription": "Agordu priskribon de la babilejo",
@@ -2030,9 +1883,7 @@
     "messageType": "Tipo de mesaĝo",
     "sender": "Sendanto",
     "openGallery": "Malfermu galerion",
-    "removeFromSpace": "Forigu de la spaco",
     "start": "Komenci",
-    "pleaseEnterRecoveryKeyDescription": "Por malŝlosi viajn malnovajn mesaĝojn, bonvolu enmeti vian restarigan ŝlosilon, kiu estis generita en antaŭa sesio. Via restariga ŝlosilo NE estas via pasvorto.",
     "publish": "Publikigi",
     "openChat": "Malfermu babilonon",
     "markAsRead": "Marki kiel legita",
@@ -2043,12 +1894,9 @@
     "confirmEventUnpin": "Ĉu vi certas, ke vi volas permanente forigi la strekiĝon de la evento?",
     "emojis": "Emojioj",
     "placeCall": "Fari telefonvokon",
-    "voiceCall": "Voĉa vokado",
     "unsupportedAndroidVersion": "Ne subtenata Android-versio",
     "unsupportedAndroidVersionLong": "Ĉi tiu funkcio postulas pli novan Android-version. Bonvolu kontroli por ĝisdatigoj aŭ subteno de Lineage OS.",
-    "videoCallsBetaWarning": "Bonvolu noti, ke video-vokoj estas nuntempe en beta. Ili eble ne funkcias laŭ atendo aŭ eĉ ne funkcias ĉe ĉiuj platformoj.",
     "experimentalVideoCalls": "Eksperimentaj video-vokoj",
-    "emailOrUsername": "Retpoŝto aŭ uzantnomo",
     "addWidget": "Aldoni fenestron",
     "widgetVideo": "Video",
     "widgetEtherpad": "Teksta notico",
@@ -2070,35 +1918,19 @@
     "youKickedAndBanned": "🙅‍♀️ Vi forpelis kaj malpermesis {user}",
     "youUnbannedUser": "Vi malpermesis {user}",
     "hasKnocked": "🚪 {user} batořis",
-    "usersMustKnock": "Uzantoj devas batoři",
-    "noOneCanJoin": "Neniu povas aliŭi",
     "knock": "Batoři",
     "users": "Uzantoj",
-    "unlockOldMessages": "Malfermi malnovajn mesaŹojn",
-    "storeInSecureStorageDescription": "Konservu la restarigan klavon en la sekura stokado de tiu aparato.",
-    "saveKeyManuallyDescription": "Konservu tiun klavon mane per aktivigo de la sistemo dividi dialogon aŭ tondejon.",
-    "storeInAndroidKeystore": "Konservi en Android KeyStore",
-    "storeInAppleKeyChain": "Konservi en Apple KeyChain",
-    "storeSecurlyOnThisDevice": "Sekure konservi sur tiu aparato",
     "countFiles": "{count} dosieroj",
     "user": "Uzanto",
     "custom": "Kustoma",
-    "foregroundServiceRunning": "Ĉi tiu sciigo aperas kiam la antaŭa servo funkcias.",
-    "screenSharingTitle": "ekrano divido",
-    "screenSharingDetail": "Vi dividas vian ekranon en FuffyChat",
     "whyIsThisMessageEncrypted": "Kial ĉi tiu mesaĝo estas nelegebla?",
     "noKeyForThisMessage": "Tio povas okazi se la mesaĝo estis sendita antaŭ ol vi ensignis en vian konton ĉe ĉi tiu aparato.\n\nEstas ankaŭ eble ke la sendinto blokis vian aparaton aŭ io malsukcesis kun la interreta konekto.\n\nĈu vi povas legi la mesaĝon en alia sesio? Tiam vi povas transdoni ĝin de tie! Iru al Agordoj > Aparatoj kaj certiĝu ke viaj aparatoj reciproke konfirmis unu la alian. Kiam vi malfermas la ĉambron denove kaj ambaŭ sesioj estas en la antaŭaĵo, la ŝlosiloj estos transdonitaj aŭtomate.\n\nĈu vi ne volas perdi la ŝlosilojn kiam vi elsalutas aŭ ŝanĝas aparatojn? Certiĝu ke vi ebligis la babiladon-daŭdbackupon en la agordoj.",
     "newGroup": "Nova grupo",
     "newSpace": "Nova spaco",
-    "enterSpace": "Eniri spacon",
     "allSpaces": "Ĉiuj spacoj",
     "hidePresences": "Kaŝi Statuso-Liston?",
     "doNotShowAgain": "Ne montri denove",
     "wasDirectChatDisplayName": "Malplena babilejo (antaŭe {oldDisplayName})",
-    "newSpaceDescription": "Spacoj ebligas vin kunigi viajn babilejojn kaj konstrui private aŭ publike komunumo.",
-    "encryptThisChat": "Ĉifri ĉi tiun babilejon",
-    "disableEncryptionWarning": "Pro sekurecaj kialoj vi ne povas malaktivigi ĉifradon en babilejo, kie ĝi estis antaŭe ebligita.",
-    "sorryThatsNotPossible": "Pardonu... tio ne estas ebla",
     "deviceKeys": "Aparatarojĥavtoj:",
     "reopenChat": "Re-omalferu babilejon",
     "noBackupWarning": "Averto! Sen ebligado de babileja sekurkopio, vi perdas aliron al viaj ĉifritaj mesaĝoj. Estas tre rekomendinde unue ebligi la babilejan sekurkopion antaŭ ensaluti.",
@@ -2111,7 +1943,6 @@
     "openLinkInBrowser": "Malfermu ligilon en retumilo",
     "reportErrorDescription": "😞 Ho ve. Io eraris. Se vi volas, vi povas raporti ĉi tiun eraron al la programistoj.",
     "report": "raporti",
-    "setTheme": "Agordi temon:",
     "setColorTheme": "Agordi kolortemon:",
     "invite": "Inviti",
     "inviteGroupChat": "📨 Inviti grupan babilonon",
@@ -2130,12 +1961,8 @@
     "yourGlobalUserIdIs": "Via tutmonda uzant-ID estas: ",
     "noUsersFoundWithQuery": "Bedaŭrinde, neniu uzanto povis esti trovita kun \"{query}\". Bonvolu kontroli ĉu vi eraris en tajpado.",
     "knocking": "Knokado",
-    "chatCanBeDiscoveredViaSearchOnServer": "La babilono povas esti trovita per serĉo en {server}",
-    "searchChatsRooms": "Serĉu #babilonojn, @uzantojn...",
     "nothingFound": "Neniam trovita...",
     "groupName": "Grupo nomo",
-    "createGroupAndInviteUsers": "Krei grupon kaj inviti uzantojn",
-    "groupCanBeFoundViaSearch": "Grupo povas esti trovita per serĉo",
     "wrongRecoveryKey": "Pardonu... ĉi tio ŝajnas ne esti la ĝusta restariga ŝlosilo.",
     "startConversation": "Komenci konversacion",
     "commandHint_sendraw": "Sendu krudan json",
@@ -2149,11 +1976,8 @@
     "pleaseChooseAStrongPassword": "Bonvolu elekti fortan pasvorton",
     "passwordsDoNotMatch": "Pasvortoj ne kongruas",
     "passwordIsWrong": "Via enmetita pasvorto estas malĝusta",
-    "publicChatAddresses": "Publikaj babilej-adresoj",
-    "createNewAddress": "Krei novan adreson",
     "joinSpace": "Aliĝi al spaco",
     "publicSpaces": "Publikaj spacoj",
-    "addChatOrSubSpace": "Aldoni babiladon aŭ subspacon",
     "subspace": "Subspaco",
     "decline": "Malakcepti",
     "thisDevice": "Ĉi tiu aparato:",
@@ -2162,15 +1986,11 @@
     "searchMore": "Serĉi pli...",
     "gallery": "Galerio",
     "files": "Dosieroj",
-    "sessionLostBody": "Via sesio estas perdita. Bonvolu raporti ĉi tiun eraron al la programistoj ĉe {url}. La erarmesaĝo estas: {error}",
-    "restoreSessionBody": "La aplikaĵo nun provas restarigi vian sesion el la sekurkopio. Bonvolu raporti ĉi tiun eraron al la programistoj ĉe {url}. La erarmesaĝo estas: {error}",
     "sendReadReceipts": "Sendi legitajn ricevetojn",
     "sendTypingNotificationsDescription": "Aliaj partoprenantoj en babilado povas vidi kiam vi tajpas novan mesaĝon.",
     "sendReadReceiptsDescription": "Aliaj partoprenantoj en babilado povas vidi kiam vi legis mesaĝon.",
     "formattedMessages": "Formatitaj mesaĝoj",
     "formattedMessagesDescription": "Montru riĉan mesaĝenhavon kiel grasa teksto uzante markdown.",
-    "verifyOtherUser": "🔐 Konfirmu alian uzanton",
-    "verifyOtherUserDescription": "Se vi konfirmas alian uzanton, vi povas esti certa ke vi scias al kiu vi verŝajne skribas. 💪\n\nKiam vi komencas konfirmadon, vi kaj la alia uzanto vidos fenestron en la aplikaĵo. Tie vi vidos serion de emojioj aŭ nombroj, kiujn vi devas kompari inter si.\n\nLa plej bona maniero fari tion estas renkontiĝi aŭ komenci videovokon. 👩‍💻",
     "verifyOtherDevice": "🔐 Konfirmu alian aparaton",
     "verifyOtherDeviceDescription": "Kiam vi konfirmas alian aparaton, tiuj aparatoj povas interŝanĝi ŝlosilojn, pligrandante vian tutan sekurecon. 💪 Kiam vi komencas konfirmadon, aperos fenestro en la aplikaĵo ĉe ambaŭ aparatoj. Tie vi vidos serion de emojioj aŭ nombroj, kiujn vi devas kompari inter si. Estas plej bone havi ambaŭ aparatojn ĉe vi antaŭ ol komenci la konfirmadon. 🤳",
     "acceptedKeyVerification": "{sender} akceptis ŝlosilan konfirmadon",
@@ -2206,10 +2026,6 @@
     "updateInstalled": "🎉 Ĝisdatigo {version} instalita!",
     "changelog": "Ĝisdato",
     "sendCanceled": "Sendado nuligita",
-    "loginWithMatrixId": "Ensaluti kun Matrix-ID",
-    "discoverHomeservers": "Malkovru hejmservilojn",
-    "whatIsAHomeserver": "Kio estas hejmservo?",
-    "homeserverDescription": "Ĉiuj viaj datumoj estas stokitaj en la hejmservo, same kiel ĉe retpoŝta provizanto. Vi povas elekti kiun hejmservon vi volas uzi, dum vi daŭre povas komuniki kun ĉiuj. Lernu pli ĉe https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Ne ŝajnas esti kongrua hejmservo. Malĝusta URL?",
     "calculatingFileSize": "Kalkulanta dosiera grandecon...",
     "prepareSendingAttachment": "Preparante sendi aldonaĵon...",
@@ -2221,11 +2037,9 @@
     "oneOfYourDevicesIsNotVerified": "Unu el viaj aparatoj ne estas konfirmita",
     "noticeChatBackupDeviceVerification": "Noto: Kiam vi konektas ĉiujn viajn aparatojn al la bazo de babilado, ili estas aŭtomate konfirmitaj.",
     "continueText": "Daŭrigi",
-    "welcomeText": "Saluton 👋 Ĉi tio estas FluffyChat. Vi povas ensaluti al ajna hejmservo, kiu estas kongrua kun https://matrix.org. Kaj poste babilu kun iu ajn. Ĝi estas granda disigita mesaĝa reto!",
     "blur": "Malfokusigi:",
     "opacity": "Opaco:",
     "setWallpaper": "Agordi fonbildon",
-    "manageAccount": "Administri konton",
     "noContactInformationProvided": "La servilo ne provizas validan kontaktinformon",
     "contactServerAdmin": "Kontaktu la administranton de la servilo",
     "contactServerSecurity": "Kontaktu la sekurecon de la servilo",
@@ -2244,11 +2058,8 @@
     "unableToJoinChat": "Neeblas aliĝi al la babilejo. Eble la alia partio jam fermis la konversacion.",
     "previous": "Antaŭa",
     "otherPartyNotLoggedIn": "La alia partio nun ne estas ensalutita kaj tial ne povas ricevi mesaĝojn!",
-    "appWantsToUseForLogin": "Uzu '{server}' por ensaluti",
-    "appWantsToUseForLoginDescription": "Vi permesas al la aplikaĵo kaj retejo dividi informojn pri vi.",
     "open": "Malfermi",
     "waitingForServer": "Atendas la servilon...",
-    "appIntroduction": "FluffyChat permesas al vi babili kun viaj amikoj tra malsamaj mesaĝistoj. Lernu pli ĉe https://matrix.org aŭ simple tapu *Daŭrigu*.",
     "newChatRequest": "📩 Nova babilepeto",
     "contentNotificationSettings": "Agordoj por sciigo pri enhavo",
     "generalNotificationSettings": "Ĝeneralaj sciigaj agordoj",
@@ -2323,11 +2134,9 @@
     "taTooltip": "L2 uzi kun tradukada helpo",
     "interactiveTranslatorSliderHeader": "Interaga Tradukilo",
     "interactiveGrammarSliderHeader": "Interaga Gramatika Kontrolilo",
-    "interactiveTranslatorRequired": "Postulata",
     "waTooltip": "Uzo sen helpo",
     "interactiveTranslator": "Tradukada subteno",
     "noIdenticalLanguages": "Bonvolu elekti malsamajn bazajn kaj celajn lingvojn",
-    "searchBy": "Serĉi laŭ lando kaj lingvoj",
     "joinWithClassCode": "Aliĝi al kurso",
     "languageLevelPreA1": "Novice Malalta (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -2348,19 +2157,14 @@
     "saveChanges": "Konservi ŝanĝojn",
     "publicProfileTitle": "Permesi ke mia profilo estu trovita en serĉo",
     "publicProfileDesc": "Per ŝalti, vi ebligas al aliaj uzantoj trovi vian profilon en la tutmonda serĉa stango kaj sendi petojn por babili. Je ĉi tiu punkto, vi povas elekti akcepti aŭ malakcepti la peton.",
-    "errorDisableIT": "Tradukado-helpo estas malŝaltita.",
-    "errorDisableIGC": "Gramatika helpo estas malŝaltita.",
     "errorDisableITUserDesc": "Klaku ĉi tie por ĝisdatigi agordojn pri tradukhelpado",
     "errorDisableIGCUserDesc": "Klaku ĉi tie por ĝisdatigi gramatikajn helpagordojn",
     "errorDisableITClassDesc": "Tradukhelpado estas malŝaltita por la kurso en kiu ĉi tiu babilejo estas.",
     "errorDisableIGCClassDesc": "Gramatika helpo estas malŝaltita por la kurso en kiu ĉi tiu babilejo estas.",
-    "error405Title": "Lingvoj ne agorditaj",
     "error405Desc": "Bonvolu agordi viajn lingvojn en Ĉefa menuo > Lernagordoj.",
     "termsAndConditions": "Kondicxoj kaj Kondicxoj",
     "andCertifyIAmAtLeast13YearsOfAge": " kaj atestigas ke mi estas almenaŭ 16 jarojn aĝa.",
-    "error502504Title": "Vau, estas multaj studentoj enrete!",
     "error502504Desc": "Tradukiloj kaj gramatikaj iloj eble estos malrapidaj aŭ nehaveblaj dum la Pangea-botoj okupiĝas.",
-    "error404Title": "Traduk-eraro!",
     "error404Desc": "Pangea-boto ne certas kiel traduki tion...",
     "errorPleaseRefresh": "Ni esploras ĝin! Bonvolu reŝarĝi kaj provi denove.",
     "connectedToStaging": "Konektita al Testa Medio",
@@ -2398,13 +2202,9 @@
     "definitionsToolName": "Vortaj Difinoj",
     "definitionsToolDescription": "Kiam ebligita, vortoj substrekitaj en bluo povas esti klaketaj por difinoj. Klaku mesaĝojn por akiri difinojn.",
     "welcomeBack": "Bonvenon reen! Se vi partoprenis la pilotprogramon 2023-2024, bonvolu kontakti nin por via speciala piloto-abono. Se vi estas instruisto kiu aĉetis (aŭ via institucio aĉetis) permesilojn por via klaso, kontakti nin por via instruista abono.",
-    "downloadTxtFile": "Elŝuti Tekstan Dosieron",
-    "downloadCSVFile": "Elŝuti CSV-Dosieron",
     "promotionalSubscriptionDesc": "Vi nuntempe havas vivdaŭran promocian abonadon. Sendu mesaĝon al support@pangea.chat por helpo pri ŝanĝo de via abonado.",
     "originalSubscriptionPlatform": "Abono aĉetita tra {purchasePlatform}",
     "oneWeekTrial": "Unu-semajna Provo",
-    "downloadXLSXFile": "Elŝuti Excel-Dosieron",
-    "unkDisplayName": "Nekonata",
     "wwCountryDisplayName": "Tra Laŭ Tutmondi",
     "afCountryDisplayName": "Afganujo",
     "axCountryDisplayName": "Alandaj Insuloj",
@@ -2699,7 +2499,6 @@
     "chatCapacityHasBeenChanged": "Kapacito de babilejo ŝanĝita",
     "chatCapacitySetTooLow": "Kapacito de babilejo devas esti almenaŭ {count}.",
     "chatCapacityExplanation": "Kapacito de babilejo limigas la nombron de membroj en babilejo.",
-    "tooManyRequest": "Tro da petoj, bonvolu provi denove pli poste.",
     "enterNumber": "Bonvolu enmeti tutan nombrvaloron.",
     "practice": "Praktiko",
     "versionNotFound": "Versio Ne Trovebla",
@@ -2709,7 +2508,6 @@
     "deleteSubscriptionWarningTitle": "Vi havas aktivan abonon",
     "deleteSubscriptionWarningBody": "Forigi vian konton ne nuligos vian abonon aŭtomate.",
     "manageSubscription": "Administri Abonon",
-    "error520Title": "Bonvolu provi denove.",
     "error520Desc": "Pardonu, ni ne povis kompreni vian mesaĝon...",
     "wordsUsed": "Vortoj Uziĝis",
     "level": "Nivelo",
@@ -2727,7 +2525,6 @@
     "other": "Alia",
     "levelShort": "NIV {level}",
     "noCapacityLimit": "Sen kapacita limigo",
-    "downloadGroupText": "Elŝuti grupan tekston",
     "notificationsOn": "Sciigoj aktivigitaj",
     "notificationsOff": "Sciigoj malaktivigitaj",
     "joinWithCode": "Aliĝi kun kodo",
@@ -2791,24 +2588,12 @@
     "whatIsTheMorphTag": "Kio estas la {morphologicalFeature} de '{wordForm}'?",
     "dataAvailable": "Datumoj disponeblaj",
     "available": "Disponebla",
-    "pangeaBotIsFallible": "Pangea Bot ankaŭ eraras!",
-    "whatIsMeaning": "Kion signifas '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Harmonii signifojn kun la vortoj en la mesaĝo!",
-    "doubleClickToEdit": "Duoble-klaku por redakti.",
-    "topicLabel": "Temo",
-    "topicPlaceholder": "Elektu temon...",
-    "modePlaceholder": "Elektu modon...",
-    "learningObjectiveLabel": "Lernocelo",
-    "learningObjectivePlaceholder": "Elektu lernocelon...",
-    "targetLanguageLabel": "Cel-lingvo",
     "cefrLevelLabel": "CEFR-nivelo",
     "image": "Bildo",
     "video": "Video",
     "nan": "Ne aplikebla",
-    "addVocabulary": "Aldoni vortprovizon",
     "instructions": "Instrukcioj",
-    "numberOfLearners": "Nombro de lernantoj",
-    "mustBeInteger": "Devas esti entjero, ekzemple 1, 2, 3, ...",
     "constructUsePvmDesc": "Produktita en voĉmesaĝo",
     "leaveSpaceDescription": "Per forlaso de la kurso, vi forlasos ĉiujn babilejojn ene de ĝi. Aliaj uzantoj vidos ke vi forlasis la kurson.",
     "constructUseCorMmDesc": "Korekta mesaĝa signifo",
@@ -2823,7 +2608,6 @@
     "ttsDisabledBody": "Vi povas ŝalti tekston-al-paroladon en viaj lernaj agordoj",
     "noSpaceDescriptionYet": "Ankoraŭ ne kreita priskribo de kurso.",
     "tooLargeToSend": "Ĉi tiu mesaĝo estas tro granda por sendi",
-    "exitWithoutSaving": "Ĉu vi certas ke vi volas forlasi sen konservi?",
     "enableAutocorrectPopupTitle": "Aldoni vian celan lingvon-klavaron per irado al:",
     "enableAutocorrectPopupSteps": "  • Agordoj\n  • Ĝenerala\n  • Klavaro\n  • Klavaroj\n  • Aldoni novan klavaron",
     "enableAutocorrectPopupDescription": "Post kiam la lingvo estas elektita, vi povas klaki la malgrandan globan ikonon ĉe la maldekstra angulo de via klavaro por aktivigi la novan instalitan klavaron.",
@@ -2834,11 +2618,8 @@
     "displayName": "Montra nomo",
     "leaveRoomDescription": "Vi estas proksima forlasi ĉi tiun babilejon. Aliaj uzantoj vidos ke vi forlasis la babilejon.",
     "confirmUserId": "Bonvolu konfirmi vian Pangea Babilejo uzantnomon por forigi vian konton.",
-    "startingToday": "Komencante hodiaŭ",
-    "oneWeekFreeTrial": "Unu semajno senpaga provtempo",
     "paidSubscriptionStarts": "Komencas {startDate}",
     "cancelInSubscriptionSettings": "• Nuligi iam ajn en abonaj agordoj",
-    "cancelToAvoidCharges": "• Nuligi antaŭ {trialEnds} por eviti ŝarĝojn",
     "downloadGboard": "Elŝuti Gboard",
     "autocorrectNotAvailable": "Bedaŭrinde via platformo ne estas nun subtenata por ĉi tiu trajto. Restu kunlaboranta por plua evoluo!",
     "pleaseUpdateApp": "Bonvolu ĝisdatigi la aplikaĵon por daŭrigi.",
@@ -2848,17 +2629,12 @@
     "knockSpaceSuccess": "Vi petis aliĝi al ĉi tiu kurso! Administranto respondos al via peto kiam ili ricevos ĝin 😄",
     "chooseWordAudioInstructionsBody": "Aŭskultu la plenan mesaĝon. Poste egaligu la aŭdiojn kun la vortoj.",
     "chooseMorphsInstructionsBody": "Klaku la pecetojn de puzlo por gramatikaj demandoj!",
-    "pleaseEnterInt": "Bonvolu enmeti nombron",
     "home": "Hejm",
     "join": "Aliĝi",
     "resetInstructionTooltipsTitle": "Restarigi instrukciajn ilustraĵojn",
     "resetInstructionTooltipsDesc": "Klaku por montri instrukciajn ilustraĵojn kiel por tute nova uzanto.",
-    "randomize": "Hazardigi",
     "clear": "Forigi",
-    "featuredActivities": "Elstaraj",
     "save": "Konservi",
-    "startChat": "Komenci konversacion",
-    "translationProblem": "Tradukproblemo",
     "askToJoin": "Petu aliĝi",
     "emptyChatWarningTitle": "La konversacio estas malplena",
     "emptyChatWarningDesc": "Vi ne invitis iun al via konversacio. Iru al Agordoj de Konversacio por inviti viajn kontaktojn aŭ la Boton. Vi ankaŭ povas fari tion poste.",
@@ -2888,17 +2664,13 @@
     "timesUsedIndependently": "Fojo uzata sendepende",
     "timesUsedWithAssistance": "Fojo uzata kun helpo",
     "shareInviteCode": "Dividu invitkodon: {code}",
-    "leaderboard": "Gvidtabla",
     "skipForNow": "Preterpasi por nun",
     "permissions": "Permesoj",
     "spaceChildPermission": "Kiu povas aldoni novajn babilejojn al ĉi tiu kurso",
-    "addEnvironmentOverride": "Aldoni medio-ŝanĝon",
     "defaultOption": "Defaŭlta",
     "deleteChatDesc": "Ĉu vi certas ke vi volas forigi ĉi tiun babilejon? Ĝi estos forigita por ĉiuj partoprenantoj kaj ĉiuj mesaĝoj ene de la babilejo ne plu estos haveblaj por praktiko aŭ lernado-analizoj.",
     "deleteSpaceDesc": "La kurso kaj ĉiuj elektitaj babilejoj estos forigitaj por ĉiuj partoprenantoj kaj ĉiuj mesaĝoj ene de la babilejo ne plu estos haveblaj por praktiko aŭ lernado-analizoj. Ĉi tiu ago ne povas esti malkonata.",
     "launch": "Lanĉi",
-    "searchChats": "Serĉi babilejojn",
-    "maxFifty": "Maks. 50",
     "configureSpace": "Agordi kurson",
     "pinMessages": "Streki mesaĝojn",
     "setJoinRules": "Agordi enirregulojn",
@@ -2932,9 +2704,6 @@
     "failedToFetchTranscription": "Malsukcesis akiri la transskribon",
     "deleteEmptySpaceDesc": "La kurso estos forigita por ĉiuj partoprenantoj. Ĉi tiu ago ne povas esti malfarita.",
     "regenerate": "Regeneri",
-    "mySavedActivities": "Miaj konservitaj agadoj",
-    "noSavedActivities": "Neniuj konservitaj agadoj",
-    "saveActivity": "Konservi ĉi tiun agadon",
     "failedToPlayVideo": "Malsukcesis ludi la videon",
     "done": "Fino",
     "inThisSpace": "En ĉi tiu kurso",
@@ -2945,13 +2714,9 @@
     "numInvited": "{count} invitita",
     "saved": "Konservita",
     "reset": "Restarigi",
-    "errorFetchingActivitiesMessage": "Malsukcesis akiri agadojn",
     "errorFetchingDefinition": "Malsukcesis akiri difinon",
     "errorProcessAnalytics": "Malsukcesis prilabori analizojn",
     "errorDownloading": "Malsukcesis elŝuti",
-    "errorLoadingSpaceChildren": "Malsukcesis ŝarĝi babiladojn ene de ĉi tiu kurso",
-    "unexpectedError": "Nekontata eraro.",
-    "pleaseReload": "Bonvolu reŝargi kaj provu denove.",
     "translationError": "Eraro en traduko",
     "check": "Kontrolu",
     "unableToFindRoom": "Neniu babilado aŭ kurso trovita kun tiu kodo. Bonvolu provi denove.",
@@ -2960,19 +2725,14 @@
     "request": "Petado",
     "requestAll": "Petu Ĉiujn",
     "confirmMessageUnpin": "Ĉu vi certas, ke vi volas malfiksi ĉi tiun mesaĝon?",
-    "saveAndLaunch": "Konservi kaj Lanĉi",
-    "launchToSpace": "Lanĉi al kurso",
     "pending": "Atendanta",
     "inactive": "Nekonata",
-    "confirmRole": "Konfirmu rolon",
     "openRoleLabel": "Malfermita",
     "finishedTheActivity": "🎯 {username} finis ĉi tiun agadon",
     "activitySummaryError": "Aktivitatresumoj ne disponeblas",
     "requestSummaries": "Petaj resumoj",
-    "generatingNewActivities": "Vi estas la unua uzanto de ĉi tiu lingvoparo! Bonvolu atendi momenton, ni pretigas aktivadojn ĝuste por vi.",
     "requestAccessTitle": "Petu aliron al analitiko?",
     "requestAccessDesc": "Ĉu vi ŝatus peti aliron por vidi partoprenantajn analitikojn?\n\nSe partoprenantoj konsentas, administrantoj de ĉi tiu kurso povos vidi iliajn:\n    • totalan vortprovizon\n    • totalajn gramatikajn konceptojn\n    • totalajn kompletigitajn aktivadsesiojn\n    • specifajn gramatikajn konceptojn uzitajn, ĝuste kaj erare\n\nIli ne povos vidi iliajn:\n    • mesaĝojn en babiladoj ekster la kurso\n    • vortprovizoliston",
-    "requestAccess": "Petu aliron ({count})",
     "analyticsInactiveTitle": "Petoj al neaktivaj uzantoj ne povis esti senditaj",
     "analyticsInactiveDesc": "Neaktivaj uzantoj kiuj ne ensalutis ekde kiam ĉi tiu funkcio estis enkondukita, ne vidos vian peton.\n\nLa butono Peti aperos kiam ili revenos. Vi povas resendigi la peton poste klakante la butonon Peti sub ilia nomo kiam ĝi estos disponebla.",
     "accessRequestedTitle": "Petado pri Analitika Alirpermeso",
@@ -2995,8 +2755,6 @@
     "accessDesc": "Vi povas fari vian kurson malfermita al la mondo! Aŭ, fari vian kurson private kaj sekura.",
     "createGroupChatDesc": "Dum agado-sesioj komenciĝas kaj finiĝas, grupaj babilejoj restos malfermita por regula komunikado.",
     "deleteDesc": "Nur administrantoj povas forigi kurson. Ĉi tio estas detrua ago kiu forigas ĉiujn uzantojn kaj forigas ĉiujn elektitajn babilejojn ene de la kurso. Estu singarda.",
-    "noCourseFound": "Ho, ĉi tiu kurso bezonas planon!\n\nKursoj estas sekvenco de temoj kaj konversaciaj agadoj.",
-    "additionalParticipants": "+ {num} aliaj",
     "whatNow": "Kio nun?",
     "chooseNextActivity": "Elektu vian sekvan agadon!",
     "letsGo": "Ni ekiru",
@@ -3009,13 +2767,11 @@
     "waitNotDone": "Atendu, mi ne finisis!",
     "waitingForOthersToFinish": "Atendas la aliajn finiĝi...",
     "generatingSummary": "Analizante babiladon kaj generante rezultojn",
-    "findCourse": "Trovu kurson",
     "pingParticipantsNotification": "{user} serĉas uzantojn por aliĝi al la aktivec-sesio en {room}",
     "course": "Kurso",
     "courses": "Kursoj",
     "goToCourse": "Iri al kurso: {course}",
     "activityComplete": "Ĉi tiu aktiveco estas finita. La resumo de la aktiveco devus esti havebla sube.",
-    "startNewSession": "Komenci novan sesion",
     "joinOpenSession": "Aliĝi al malfermita sesio",
     "activityNotFound": "Aktiveco ne trovita",
     "myActivities": "Miaj aktivecoj",
@@ -3203,10 +2959,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@yourChatBackupHasBeenSetUp": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@commandHint_markasdm": {
         "type": "String",
         "placeholders": {}
@@ -3235,14 +2987,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@createGroup": {
         "type": "String",
         "placeholders": {}
@@ -3255,18 +2999,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -3276,10 +3008,6 @@
         "placeholders": {}
     },
     "@customEmojisAndStickersBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3375,10 +3103,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addAccount": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@editBundlesForAccount": {
         "type": "String",
         "placeholders": {}
@@ -3392,10 +3116,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableMultiAccounts": {
         "type": "String",
         "placeholders": {}
     },
@@ -3416,10 +3136,6 @@
         "placeholders": {}
     },
     "@passwordRecoverySettings": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKey": {
         "type": "String",
         "placeholders": {}
     },
@@ -3445,14 +3161,6 @@
                 "type": "String"
             }
         }
-    },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
-        "type": "String",
-        "placeholders": {}
     },
     "@sendImages": {
         "type": "String",
@@ -3506,15 +3214,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3565,10 +3265,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3577,15 +3273,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3709,43 +3397,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3765,18 +3421,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
@@ -3790,10 +3434,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3816,22 +3456,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3886,10 +3510,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3973,31 +3593,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -4053,23 +3653,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4109,28 +3697,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4148,14 +3714,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4348,22 +3906,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4419,10 +3961,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4432,10 +3970,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4511,27 +4045,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4849,10 +4367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4862,10 +4376,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4953,14 +4463,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4977,10 +4479,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4993,15 +4491,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5153,14 +4643,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5174,14 +4656,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6404,10 +5878,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6448,10 +5918,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6524,10 +5990,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6797,47 +6259,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6857,19 +6279,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6933,10 +6343,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6977,14 +6383,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6996,14 +6394,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -7041,10 +6431,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7061,27 +6447,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7205,10 +6575,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7218,10 +6584,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7238,14 +6600,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7385,18 +6739,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7445,10 +6787,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7458,18 +6796,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7512,23 +6838,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7552,10 +6866,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7563,14 +6873,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7675,18 +6977,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7739,10 +7029,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7769,10 +7055,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7953,7 +7235,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Kontrolu denove morgaŭ por agadaj ĝisdatigoj.",
-    "activityDropdownDesc": "Kiam vi finis ĉi tiun agadon, klaku sube",
     "languageMismatchTitle": "Lingva manko",
     "languageMismatchDesc": "Via celolingvo ne kongruas kun la lingvo de ĉi tiu agado. Ĉu vi volas ĝisdatigi vian celolingvon?",
     "reportWordIssueTooltip": "Raporti pri problemo kun vorto",
@@ -7966,10 +7247,6 @@
     "selectAll": "Elekti ĉiujn",
     "deselectAll": "Malselekti ĉiujn",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8018,17 +7295,11 @@
         "placeholders": {}
     },
     "startOwn": "Komencu mian propran",
-    "joinCourseDesc": "Ĉiu kurso havas 8-10 sinsekvajn temojn kun gamo de task-bazitaj lingvolernaj agadoj.",
     "newMessageInPangeaChat": "🗨️ Nova mesaĝo en Pangea Babilejo",
     "shareCourse": "Dividi kurson",
     "addCourse": "Aldoni kurson",
-    "joinPublicCourse": "Aliĝi al publika kurso",
     "vocabLevelsDesc": "Jen kie vortoj de vortprovizo iros post kiam vi ilin plibonigos!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8041,10 +7312,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8063,7 +7330,6 @@
     "emojiView": "Emoji vido",
     "feedbackDialogDesc": "Mi ankaŭ faras erarojn! Ĉu io por helpi min plibonigi?",
     "contactHasBeenInvitedToTheCourse": "Kontakto estis invitita al la kurso",
-    "activityStatsButtonTooltip": "Aktiveco informo",
     "allow": "Permesi",
     "deny": "Malpermesi",
     "enabledRenewal": "Ebligi Abonrenovigon",
@@ -8331,10 +7597,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9390,16 +8652,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktivecoj por Malŝlosi Sekvan Temon",
-    "activitiesToUnlockTopicDesc": "Agordu la nombron de aktivecoj por malŝlosi la sekvan kurson",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Ĝusta vortaro difino praktiko",
     "constructUseIncLMDesc": "Malĝusta vortaro difino praktiko",
     "constructUseCorLADesc": "Ĝusta vortaro aŭdio praktiko",
@@ -9407,7 +8659,6 @@
     "constructUseBonus": "Bonus dum vortaro praktiko",
     "practiceVocab": "Praktiku vortaron",
     "selectMeaning": "Elektu la signifon",
-    "selectAudio": "Elektu la kongruan aŭdion",
     "anotherRound": "Alia rundo",
     "activitySettingsOverrideWarning": "Lingvo kaj lingvonivelo determinita de la aktiviteca plano",
     "voice": "Voĉo",
@@ -9439,10 +8690,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9460,12 +8707,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Elŝuto iniciatita",
     "webDownloadPermissionMessage": "Se via retumilo blokas elŝutojn, bonvolu ebligi elŝutojn por ĉi tiu retejo.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9560,11 +8802,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Io malĝuste okazis, kaj ni diligente laboras por ripari ĝin. Kontrolu denove poste.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Ebligi skriban asistadon",
     "autoIGCToolDescription": "Aŭtomate funkciigi Pangea Chat-ilojn por korekti senditajn mesaĝojn al la cellingvo.",
     "@autoIGCToolName": {
@@ -9620,24 +8857,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatiko",
-    "spanTypeWordChoice": "Vortelekto",
     "spanTypeSpelling": "Ortografio",
     "spanTypePunctuation": "Punkto",
     "spanTypeStyle": "Stilo",
     "spanTypeFluency": "Flueco",
     "spanTypeAccents": "Akcentoj",
     "spanTypeCapitalization": "Kapitaligo",
-    "spanTypeCorrection": "Korektado",
     "spanFeedbackTitle": "Raporti korektadon",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9662,10 +8888,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9678,13 +8900,7 @@
     "longPressToRecordVoiceMessage": "Longa premado por registri voĉan mesaĝon.",
     "pause": "Pauzi",
     "resume": "Daŭrigi",
-    "newSubSpace": "Nova subspaco",
-    "moveToDifferentSpace": "Movi al alia spaco",
-    "removeFromSpaceDescription": "La konversacio estos forigita el la spaco sed ankoraŭ aperos en via konversacia listo.",
     "countChats": "{chats} konversacioj",
-    "spaceMemberOf": "Spaca membro de {spaces}",
-    "spaceMemberOfCanKnock": "Spaca membro de {spaces} povas frapi",
-    "donate": "Donaci",
     "startedAPoll": "{username} komencis enketon.",
     "poll": "Enketo",
     "startPoll": "Komenci enketon",
@@ -9708,23 +8924,15 @@
     "newStickerPack": "Nova etikedpako",
     "stickerPackName": "Nomo de etikedpako",
     "attribution": "Atribuo",
-    "skipChatBackup": "Salti ĉat-backupon",
-    "skipChatBackupWarning": "Ĉu vi certas? Sen aktivigi la ĉat-backupon vi eble perdos aliron al viaj mesaĝoj se vi ŝanĝas vian aparaton.",
-    "loadingMessages": "Ŝarĝante mesaĝojn",
-    "setupChatBackup": "Agordi ĉat-backupon",
     "noMoreResultsFound": "Neniuj pliaj rezultoj trovita",
     "chatSearchedUntil": "Ĉato serĉita ĝis {time}",
     "federationBaseUrl": "Federacia Baz URL",
     "clientWellKnownInformation": "Klienta-Bone-Konata Informo:",
     "baseUrl": "Baz URL",
     "identityServer": "Identeca Servilo:",
-    "versionWithNumber": "Versio: {version}",
     "logs": "Registroj",
-    "advancedConfigs": "Avancitaj Agordoj",
     "advancedConfigurations": "Avancitaj agordoj",
-    "signInWithLabel": "Ensalutu per:",
     "selectAllWords": "Elektu ĉiujn vortojn, kiujn vi aŭdas en la sono",
-    "joinCourseForActivities": "Aliĝu al kurso por provi aktivadojn.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9761,18 +8969,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9780,26 +8976,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9905,22 +9081,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9949,19 +9109,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9969,15 +9117,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10178,11 +9318,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "En klaso? Metu vian aliĝkodon ĉi tie.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Aŭtomate emfazi aŭdmesaĝojn",
     "selectAudioMessagesOnPlayDescription": "Aŭtomate emfazi aŭdmesaĝojn kiam ili estas ludataj",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10226,18 +9361,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Ĉi tiu kurso havas temojn kun malpli ol {input} aktivadoj. Bonvolu enigi numeron malpli ol aŭ egala al {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Klaku ĉi tie por reensaluti.",
     "@clickToLogin": {
@@ -10654,17 +9777,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Karikatura flava urso kun siaj brakoj levitaj en ekscito.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Elektu vortojn por lerni pli pri ili",
     "requireAnalyticsAccessTitle": "Postuli aliron al analitiko por aliĝi",
     "requireAnalyticsAccessDesc": "Partoprenantoj devas doni aliron al siaj lernaj analitiko por aliĝi al ĉi tiu kurso",
     "analyticsAccessNoticeTitle": "Aldona aliro al analitiko postulata",
     "analyticsAccessNoticeDesc": "Per aliĝo al ĉi tiu kurso, vi konsentas doni al administrantoj aliron al viaj lernaj analitiko.",
-    "skipOnboardingClassCodeDesc": "Lerni sendepende? Ne zorgu, vi povas:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10682,10 +9799,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10714,7 +9827,6 @@
     "pickCefrLevelTeacherStepTitle": "Kiun nivelon vi instruas?",
     "pickCefrLevelStudentStepTitle": "Kiun nivelon vi estas?",
     "customCourseStepTitle": "Plenigu ĉi tiun formularon por ricevi personigitan kurson",
-    "aboutYourClass": "Pri via klaso",
     "courseCodeStepErrorMessage": "Bonvolu kontroli vian kodon kaj provi denove",
     "institution": "Institucio",
     "courseGoals": "Kursaj Celoj",
@@ -10757,10 +9869,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10877,12 +9985,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Ĉatlogo",
     "introChatDetails": "Diru saluton! Enkonduku vin al viaj samkursanoj, trovu amikojn, kaj babbadu ekster aktivadoj.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10926,11 +10029,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Aktivaj agoj",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Prononcaj iloj",
     "audioTranscription": "AI aŭdtranskribo",
     "visualLearnerSupport": "Subteno por vizualaj lernantoj",
@@ -10971,7 +10069,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Aliĝu al kurso, kiu inkluzivas ĉi tiun aktivon por ludi ĝin.",
     "resizeCoursePanel": "Redimensioni kurspanelon",
     "undo": "Malfari",
     "unlock": "Malŝlosi",
@@ -10985,7 +10082,6 @@
     "addCourseBrowsePublic": "Serĉu publikajn kursojn",
     "browsePublicCourses": "Serĉu publikajn kursojn",
     "editProfile": "Redaktu profilon",
-    "numObjectives": "{count} celoj",
     "mapSearchHint": "Serĉu aktivecojn",
     "mapSearchNoResults": "Neniuj kongruoj en vido",
     "mapFilterAllLanguages": "Ĉiuj lingvoj",
@@ -10994,7 +10090,6 @@
     "mapFilterCompleted": "Finita",
     "mapFilterReset": "Reagordi",
     "activityTypeConversation": "Konversacio",
-    "lockedMissionRequirement": "Fini la antaŭan misio por malŝlosi",
     "playAgain": "Ludi denove",
     "reviewActivity": "Revizii",
     "mapEmptyInView": "Nenio ĉi tie ĉe via nivelo aŭ lingvo. Larĝigu viajn filtrilojn aŭ malproksimiĝu.",
@@ -11009,14 +10104,9 @@
     "scrollToBottom": "Rulumu al fundo",
     "courseImage": "Kursa bildo",
     "avatarPreview": "Antaŭprezento de avataro",
-    "activityPhoto": "Aktiveca foto",
     "emotePreview": "Emota antaŭprezento: {name}",
     "activityLabel": "Aktiveco: {title}",
     "resetMapView": "Reagordi mapan vidon",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11069,14 +10159,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11106,10 +10188,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11166,10 +10244,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -68,11 +68,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "¿Pueden unirse usuarios de visita?",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "¿Estás seguro?",
     "@areYouSure": {
         "type": "String",
@@ -330,11 +325,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Tus mensajes están protegidos por una llave de seguridad. Procura no perderla.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Detalles del chat",
     "@chatDetails": {
         "type": "String",
@@ -374,11 +364,6 @@
     },
     "connect": "Conectar",
     "@connect": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "El contacto ha sido invitado al grupo",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -536,11 +521,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Ya no podrá deshabilitar el cifrado. ¿Estás seguro?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encryption": "Cifrado",
     "@encryption": {
         "type": "String",
@@ -562,11 +542,6 @@
     },
     "enterAnEmailAddress": "Introducir una dirección de correo electrónico",
     "@enterAnEmailAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "¡Todo listo!",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -597,11 +572,6 @@
     },
     "group": "Grupo",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "El grupo es público",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -670,15 +640,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Invitar contacto a {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Invitado",
     "@invited": {
@@ -786,15 +747,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Mostrar {count} participantes más",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Cargando… Por favor espere.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -809,15 +761,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Iniciar sesión en {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Cerrar sesión",
     "@logout": {
@@ -866,16 +809,6 @@
     },
     "noEmotesFound": "Ningún emote encontrado. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Sólo se puede activar el cifrado en cuanto la sala deja de ser de acceso público.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Parece que no tienes servicios de Firebase Cloud Messaging en tu dispositivo. Para recibir de todas formas notificaciones, recomendamos instalar ntfy. Con ntfy o cualquier proveedor Unified Push, puedes recibir notificaciones manteniendo seguridad de datos. Puedes descargar ntfy de la PlayStore o de F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1044,11 +977,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Eliminar dispositivo",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Eliminar la expulsión",
     "@unbanFromChat": {
@@ -1243,11 +1171,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Transferir desde otro dispositivo",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Intentar enviar nuevamente",
     "@tryToSendAgain": {
         "type": "String",
@@ -1303,15 +1226,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 chat no leído} other{{unreadCount} chats no leídos}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} y {count} más están escribiendo…",
     "@userAndOthersAreTyping": {
@@ -1397,16 +1311,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Video llamada",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Visibilidad del historial del chat",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Visible para todos los participantes",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1449,11 +1353,6 @@
     },
     "weSentYouAnEmail": "Te enviamos un correo electrónico",
     "@weSentYouAnEmail": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Quién tiene permitido unirse al grupo",
-    "@whoIsAllowedToJoinThisGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1515,8 +1414,6 @@
     },
     "oneClientLoggedOut": "Se ha cerrado en la sesión de uno de sus clientes",
     "@oneClientLoggedOut": {},
-    "addAccount": "Añadir cuenta",
-    "@addAccount": {},
     "editBundlesForAccount": "Editar paquetes para esta cuenta",
     "@editBundlesForAccount": {},
     "addToBundle": "Agregar al paquete",
@@ -1525,11 +1422,6 @@
     "@bundleName": {},
     "saveFile": "Guardar el archivo",
     "@saveFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "setPermissionsLevel": "Establecer nivel de permisos",
-    "@setPermissionsLevel": {
         "type": "String",
         "placeholders": {}
     },
@@ -1596,19 +1488,9 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceIsPublic": "El espacio es público",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "commandInvalid": "Comando inválido",
     "@commandInvalid": {
         "type": "String"
-    },
-    "passwordRecovery": "Recuperación de contraseña",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
     },
     "security": "Seguridad",
     "@security": {
@@ -1652,11 +1534,6 @@
     },
     "reason": "Razón",
     "@reason": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "createNewSpace": "Nuevo espacio",
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1918,8 +1795,6 @@
     "@removeFromBundle": {},
     "link": "Link",
     "@link": {},
-    "enableMultiAccounts": "(BETA) habilite varias cuenta en este dispositivo",
-    "@enableMultiAccounts": {},
     "pleaseEnter4Digits": "Ingrese 4 dígitos o déjelo en blanco para deshabilitar el bloqueo de la aplicación.",
     "@pleaseEnter4Digits": {
         "type": "String",
@@ -1945,28 +1820,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceName": "Nombre del espacio",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoCanPerformWhichAction": "Quién puede realizar qué acción",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "¿Por qué quieres denunciar esto?",
     "@whyDoYouWantToReportThis": {
         "type": "String",
         "placeholders": {}
     },
-    "wipeChatBackup": "¿Limpiar la copia de seguridad de tu chat para crear una nueva clave de recuperación?",
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "yourChatBackupHasBeenSetUp": "Se ha configurado la copia de respaldo del chat.",
-    "@yourChatBackupHasBeenSetUp": {},
     "unverified": "No verificado",
     "@unverified": {},
     "commandHint_clearcache": "Limpiar cache",
@@ -1985,8 +1843,6 @@
     },
     "repeatPassword": "Repite la contraseña",
     "@repeatPassword": {},
-    "removeFromSpace": "Eliminar del espacio",
-    "@removeFromSpace": {},
     "openGallery": "Abrir galería",
     "@openGallery": {},
     "start": "Iniciar",
@@ -2064,8 +1920,6 @@
             }
         }
     },
-    "emailOrUsername": "Correo electrónico o nombre de usuario",
-    "@emailOrUsername": {},
     "countFiles": "{count} archivos",
     "@countFiles": {
         "placeholders": {
@@ -2076,8 +1930,6 @@
     },
     "reportUser": "Reportar usuario",
     "@reportUser": {},
-    "voiceCall": "Llamada de voz",
-    "@voiceCall": {},
     "reactedWith": "{sender} reaccionó con {reaction}",
     "@reactedWith": {
         "type": "String",
@@ -2098,12 +1950,8 @@
     "@replace": {},
     "unsupportedAndroidVersionLong": "Esta característica requiere una versión más reciente de Android. Por favor, compruebe las actualizaciones o la compatibilidad de LineageOS.",
     "@unsupportedAndroidVersionLong": {},
-    "storeSecurlyOnThisDevice": "Almacenar de forma segura en este dispositivo",
-    "@storeSecurlyOnThisDevice": {},
     "openChat": "Abrir chat",
     "@openChat": {},
-    "screenSharingDetail": "Usted está compartiendo su pantalla en FluffyChat",
-    "@screenSharingDetail": {},
     "widgetVideo": "Vídeo",
     "@widgetVideo": {},
     "dismiss": "Descartar",
@@ -2134,18 +1982,10 @@
     },
     "messagesStyle": "Mensajes:",
     "@messagesStyle": {},
-    "chatDescription": "Descripción del chat",
-    "@chatDescription": {},
-    "enterSpace": "Unirse al espacio",
-    "@enterSpace": {},
-    "pleaseEnterRecoveryKey": "Por favor, introduzca su clave de recuperación:",
-    "@pleaseEnterRecoveryKey": {},
     "widgetNameError": "Por favor, proporciona un nombre para mostrar.",
     "@widgetNameError": {},
     "addWidget": "Añadir widget",
     "@addWidget": {},
-    "storeInAppleKeyChain": "Almacenar en la KeyChain de Apple",
-    "@storeInAppleKeyChain": {},
     "hydrate": "Restaurar desde fichero de copia de seguridad",
     "@hydrate": {},
     "invalidServerName": "Nombre del servidor no válido",
@@ -2154,10 +1994,6 @@
     "@chatPermissions": {},
     "sender": "Remitente",
     "@sender": {},
-    "storeInAndroidKeystore": "Almacenar en la KeyStore de Android",
-    "@storeInAndroidKeystore": {},
-    "saveKeyManuallyDescription": "Compartir esta clave manualmente usando el diálogo de compartir del sistema o el portapapeles.",
-    "@saveKeyManuallyDescription": {},
     "whyIsThisMessageEncrypted": "¿Por qué no se puede leer este mensaje?",
     "@whyIsThisMessageEncrypted": {},
     "setChatDescription": "Establecer descripción del chat",
@@ -2173,18 +2009,12 @@
             }
         }
     },
-    "videoCallsBetaWarning": "Tenga en cuenta que las videollamadas están actualmente en fase beta. Es posible que no funcionen como se espera o que no funcionen de ninguna manera en algunas plataformas.",
-    "@videoCallsBetaWarning": {},
-    "unlockOldMessages": "Desbloquear mensajes viejos",
-    "@unlockOldMessages": {},
     "optionalRedactReason": "(Opcional) Motivo para censurar este mensaje...",
     "@optionalRedactReason": {},
     "dehydrate": "Exportar sesión y limpiar dispositivo",
     "@dehydrate": {},
     "experimentalVideoCalls": "Videollamadas experimentales",
     "@experimentalVideoCalls": {},
-    "pleaseEnterRecoveryKeyDescription": "Para desbloquear sus viejos mensajes, introduzca su clave de recuperación que se generó en una sesión anterior. Su clave de recuperación NO es su contraseña.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "redactedByBecause": "Censurado por {username} porque: \"{reason}\"",
     "@redactedByBecause": {
         "type": "String",
@@ -2217,12 +2047,8 @@
     },
     "redactMessageDescription": "El mensaje será censurado para todas las personas participantes en la conversación. Esto no se puede deshacer.",
     "@redactMessageDescription": {},
-    "recoveryKey": "Clave de recuperación",
-    "@recoveryKey": {},
     "doNotShowAgain": "No mostrar de nuevo",
     "@doNotShowAgain": {},
-    "screenSharingTitle": "Compartir la pantalla",
-    "@screenSharingTitle": {},
     "widgetCustom": "Personalizado",
     "@widgetCustom": {},
     "youBannedUser": "Usted prohibió el acceso a {user}",
@@ -2235,8 +2061,6 @@
     },
     "directChat": "Chat directo",
     "@directChat": {},
-    "foregroundServiceRunning": "Esta notificación aparece cuando el servicio en segundo plano se está ejecutando.",
-    "@foregroundServiceRunning": {},
     "wasDirectChatDisplayName": "Chat vacío (era {oldDisplayName})",
     "@wasDirectChatDisplayName": {
         "type": "String",
@@ -2262,8 +2086,6 @@
     "@shareInviteLink": {},
     "commandHint_markasdm": "Marcar como sala de mensajes directos para el ID de Matrix",
     "@commandHint_markasdm": {},
-    "recoveryKeyLost": "¿Perdió su clave de recuperación?",
-    "@recoveryKeyLost": {},
     "emoteKeyboardNoRecents": "Los emotes usados recientemente aparecerán aquí...",
     "@emoteKeyboardNoRecents": {
         "type": "String",
@@ -2292,8 +2114,6 @@
     "@createGroup": {},
     "custom": "Personalizado",
     "@custom": {},
-    "storeInSecureStorageDescription": "Almacenar la clave de recuperación en el almacenamiento seguro de este dispositivo.",
-    "@storeInSecureStorageDescription": {},
     "pinMessage": "Anclar a la sala",
     "@pinMessage": {},
     "googlyEyesContent": "{senderName} te manda ojos saltones",
@@ -2353,12 +2173,6 @@
     "@alwaysUse24HourFormat": {
         "description": "Set to true to always display time of day in 24 hour format."
     },
-    "accessAndVisibility": "Acceso y visibilidad",
-    "@accessAndVisibility": {},
-    "globalChatId": "ID de chat Global",
-    "@globalChatId": {},
-    "accessAndVisibilityDescription": "A quién se le permite unirse a este chat y cómo se puede descubrir el chat.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Llamadas",
     "@calls": {},
     "customEmojisAndStickers": "Emojis y stickers personalizados",
@@ -2378,8 +2192,6 @@
     },
     "placeCall": "Llamar",
     "@placeCall": {},
-    "disableEncryptionWarning": "Por motivos de seguridad no es posible deshabilitar el cifrado en un chat si ha sido habilitado previamente.",
-    "@disableEncryptionWarning": {},
     "setColorTheme": "Poner tema de color:",
     "@setColorTheme": {},
     "inviteGroupChat": "📨 Invitar a grupo",
@@ -2427,19 +2239,6 @@
             }
         }
     },
-    "appWantsToUseForLogin": "Usar '{server}' para entrar",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Por la presente permites a la app y web compartir información sobre ti.",
-    "@appWantsToUseForLoginDescription": {},
-    "encryptThisChat": "Cifrar este chat",
-    "@encryptThisChat": {},
     "transparent": "Transparente",
     "@transparent": {},
     "select": "Elegir",
@@ -2452,8 +2251,6 @@
     "@subspace": {},
     "openLinkInBrowser": "Abrir enlace en navegador",
     "@openLinkInBrowser": {},
-    "setTheme": "Poner tema:",
-    "@setTheme": {},
     "learnMore": "Aprender más",
     "@learnMore": {},
     "incomingMessages": "Mensajes entrantes",
@@ -2572,10 +2369,6 @@
             }
         }
     },
-    "groupCanBeFoundViaSearch": "Los grupos se pueden encontrar buscando",
-    "@groupCanBeFoundViaSearch": {},
-    "addChatOrSubSpace": "Añadir chat o sub espacio",
-    "@addChatOrSubSpace": {},
     "sendRoomNotifications": "Mandar notificación @sala",
     "@sendRoomNotifications": {},
     "changeTheChatPermissions": "Cambiar los permisos de chat",
@@ -2599,10 +2392,6 @@
             }
         }
     },
-    "usersMustKnock": "Los usuarios han de avisar",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Nadie puede unirse",
-    "@noOneCanJoin": {},
     "reopenChat": "Reabrir chat",
     "@reopenChat": {},
     "hidePresences": "¿Esconder la lista de estado?",
@@ -2662,21 +2451,8 @@
     "@makeAdminDescription": {},
     "knocking": "Avisando",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "El chat se puede descubrir buscando en {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "searchChatsRooms": "Buscar #chats, @usuarios...",
-    "@searchChatsRooms": {},
     "groupName": "Nombre de grupo",
     "@groupName": {},
-    "createGroupAndInviteUsers": "Crear un grupo e invitar usuarios",
-    "@createGroupAndInviteUsers": {},
     "databaseMigrationTitle": "La base de datos está optimizada",
     "@databaseMigrationTitle": {},
     "searchForUsers": "Buscar @usuarios...",
@@ -2689,18 +2465,6 @@
     "@files": {},
     "initAppError": "Hubo un error al arrancar la app",
     "@initAppError": {},
-    "sessionLostBody": "Se perdió tu sesión. Por favor, informa de este error a los desarrolladores en {url}. El mensaje de error es: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "unreadChatsInApp": "{appname}: {unread} chats no leídos",
     "@unreadChatsInApp": {
         "type": "String",
@@ -2761,8 +2525,6 @@
     "@blur": {},
     "continueText": "Continuar",
     "@continueText": {},
-    "welcomeText": "Eh, eh, 👋 Esto es FluffyChat. Puedes acceder a cualquier homeserver, que sea compatible con https://matrix.org. Y luego chatear con cualquiera. ¡Es una red de mensajería descentralizada enorme!",
-    "@welcomeText": {},
     "opacity": "Opacidad:",
     "@opacity": {},
     "version": "Versión",
@@ -2818,26 +2580,12 @@
     "@wrongRecoveryKey": {},
     "leaveEmptyToClearStatus": "Deja vacío para limpiar tu estado.",
     "@leaveEmptyToClearStatus": {},
-    "restoreSessionBody": "La app ahora trata de recuperar tu sesión de la copia de seguridad. Por favor, informa de este error a los desarrolladores en {url}. El mensaje de error es: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendReadReceipts": "Mandar recibos de lectura",
     "@sendReadReceipts": {},
     "sendTypingNotificationsDescription": "Otros participantes en un chat pueden ver cuándo estás escribiendo un mensaje.",
     "@sendTypingNotificationsDescription": {},
     "sendReadReceiptsDescription": "Otros participantes en un chat pueden ver cuándo has leído un mensaje.",
     "@sendReadReceiptsDescription": {},
-    "verifyOtherUserDescription": "Si verificas a otro usuario, puedes estar seguro de a quién estás escribiendo realmente. 💪\n\nCuando empiezas una verificación, tú y el otro usuario veréis una ventana emergente en la app. En ella veréis una serie de emojiso números que tenéis que comparar.\n\nLa mejor forma de hacer esto es quedar o una videollamada. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDeviceDescription": "Cuando verificas otro dispositivo, esos dispositivos pueden intercambiar claves, incrementando tu seguridad global. 💪 Cuando inicias una verificación, aparece una ventana en la app en ambos dispositivos. En ella, verás una serie de emojis o números que tienes que comparar. Es mejor tener ambos dispositivos a mano antes de empezar la verificación. 🤳",
     "@verifyOtherDeviceDescription": {},
     "canceledKeyVerification": "{sender} canceló la verificación de clave",
@@ -2890,12 +2638,6 @@
     "@markAsUnread": {},
     "changeTheDescriptionOfTheGroup": "Cambiar la descripción del chat",
     "@changeTheDescriptionOfTheGroup": {},
-    "sorryThatsNotPossible": "Lo siento... eso no es posible",
-    "@sorryThatsNotPossible": {},
-    "publicChatAddresses": "Dirección de chat pública",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Crear nueva dirección",
-    "@createNewAddress": {},
     "boldText": "Texto en negrita",
     "@boldText": {},
     "italicText": "Texto en cursiva",
@@ -2906,8 +2648,6 @@
     "@searchMore": {},
     "knock": "Aviso",
     "@knock": {},
-    "newSpaceDescription": "Los espacios permiten consolidar los chats y montar comunidades privadas o públicas.",
-    "@newSpaceDescription": {},
     "pleaseEnterANumber": "Por favor pon un número mayor que 0",
     "@pleaseEnterANumber": {},
     "archiveRoomDescription": "El chat se moverá al archivo. Otros usuarios podrán ver que has abandonado el chat.",
@@ -2918,8 +2658,6 @@
     "@passwordsDoNotMatch": {},
     "passwordIsWrong": "La clave que has puesto es incorrecta",
     "@passwordIsWrong": {},
-    "verifyOtherUser": "🔐 Verificar a otro usuario",
-    "@verifyOtherUser": {},
     "isReadyForKeyVerification": "{sender} está preparado para verificación de clave",
     "@isReadyForKeyVerification": {
         "type": "String",
@@ -2938,8 +2676,6 @@
     "@oneOfYourDevicesIsNotVerified": {},
     "noticeChatBackupDeviceVerification": "Nota: Cuando conectas todos tus dispositivos a la copia de seguridad del chat, son verificados automáticamente.",
     "@noticeChatBackupDeviceVerification": {},
-    "manageAccount": "Gestionar cuenta",
-    "@manageAccount": {},
     "contactServerAdmin": "Contactar con el administrador del servidor",
     "@contactServerAdmin": {},
     "contactServerSecurity": "Contactar con seguridad del servidor",
@@ -2954,8 +2690,6 @@
     "@unableToJoinChat": {},
     "waitingForServer": "Esperando al servidor...",
     "@waitingForServer": {},
-    "discoverHomeservers": "Descubrir homeservers",
-    "@discoverHomeservers": {},
     "synchronizingPleaseWaitCounter": " Sincronizando… ({percentage}%)",
     "@synchronizingPleaseWaitCounter": {
         "type": "String",
@@ -2983,8 +2717,6 @@
     "@noKeyForThisMessage": {},
     "banUserDescription": "Se expulsará al usuario del chat y no podrá volver a entrar hasta que se le permita.",
     "@banUserDescription": {},
-    "loginWithMatrixId": "Entrar con un ID de Matrix",
-    "@loginWithMatrixId": {},
     "changeTheCanonicalRoomAlias": "Cambiar la dirección pública principal de chat",
     "@changeTheCanonicalRoomAlias": {},
     "noContactInformationProvided": "El servidor no suministra ninguna información de contacto válida",
@@ -3011,14 +2743,8 @@
             }
         }
     },
-    "homeserverDescription": "Todos tus datos se guardan en el homeserver, como en un proveedor de correo electrónico. Puedes elegir el homeserver que quieres usar, a la par que te puedes comunicar con todos. Más en https://matrix.org.",
-    "@homeserverDescription": {},
-    "whatIsAHomeserver": "¿Qué es un homeserver?",
-    "@whatIsAHomeserver": {},
     "open": "Abrir",
     "@open": {},
-    "appIntroduction": "FluffyChat te permite chatear con tus amigos con diferentes mensajerías. Aprende más en https://matrix.org o simplemente pincha *Continuar*.",
-    "@appIntroduction": {},
     "previous": "Anterior",
     "@previous": {},
     "otherPartyNotLoggedIn": "La otra parte ahora mismo no está conectada y por tanto ¡no puede recibir mensajes!",
@@ -3039,15 +2765,6 @@
     "@commandHint_roomupgrade": {},
     "checkList": "Lista de tareas",
     "@checkList": {},
-    "countInvited": "{count} invitado",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "sentVoiceMessage": "🎙️ {duration} - Mensaje de voz de {sender}",
     "@sentVoiceMessage": {
         "type": "String",
@@ -3096,12 +2813,6 @@
     "@pause": {},
     "resume": "Continuar",
     "@resume": {},
-    "newSubSpace": "Nuevo sub espacio",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Mover a otro espacio",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "El chat sera removido del espacio pero continuara apareciendo en tu lista de chats.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} chats",
     "@countChats": {
         "type": "String",
@@ -3129,10 +2840,8 @@
     "answersVisible": "Respuestas visibles",
     "@answersVisible": {},
     "deny": "Denegar",
-    "donate": "Donar",
     "pleaseChooseAUsername": "Por favor, elija un nombre de usuario",
     "signUp": "Registrarse",
-    "setupChatBackup": "Configurar copia de respaldo de chat",
     "pleaseEnterValidEmail": "Por favor ingrese un correo electrónico válido.",
     "pleaseChooseAtLeastChars": "Por favor elegir al menos {min} carácteres",
     "@pleaseChooseAtLeastChars": {
@@ -3159,12 +2868,10 @@
     "saveChanges": "Guardar",
     "changeTheNameOfTheClass": "Cambiar el nombre",
     "changeTheNameOfTheChat": "Cambiar el nombre del chat",
-    "interactiveTranslatorRequired": "Requerido",
     "interactiveTranslatorSliderHeader": "Asistencia de traducción",
     "interactiveTranslator": "Asistencia de traducción",
     "errorPleaseRefresh": "¡Algo salió mal! El error ha sido registrado y lo estamos investigando. Mientras tanto, actualice la página y vuelva a intentarlo. Si el error persiste, háganoslo saber en support@pangea.chat.",
     "noIdenticalLanguages": "Por favor, elija diferentes idiomas base e idiomas de aprender.",
-    "searchBy": "Buscar por país e idiomas",
     "needsItMessage": "Espera, ¡ese no es {targetLanguage}! ¿Necesitas ayuda para traducir?",
     "@needsItMessage": {
         "type": "String",
@@ -3176,7 +2883,6 @@
     },
     "publicProfileTitle": "Perfil público",
     "publicProfileDesc": "Al activarlo, permite que otros usuarios encuentren su perfil en la barra de búsqueda global y envíen solicitudes para chatear. En este punto, puede optar por aceptar o rechazar la solicitud.",
-    "error405Title": "Idiomas no seleccionados.",
     "error405Desc": "Por favor, seleccione sus idiomas en Ajustes de cuenta > Ajustes de aprendizaje.",
     "holdForInfo": "Use clic largo para ver información de la palabra.",
     "allDone": "¡Listo!",
@@ -3202,17 +2908,13 @@
     "taTooltip": "Uso de L2 con asistencia de traducción",
     "waTooltip": "Uso de L2 sin asistencia",
     "interactiveGrammarSliderHeader": "Asistencia gramatical",
-    "errorDisableIT": "La asistencia de traducción está deshabilitada.",
-    "errorDisableIGC": "La asistencia gramatical está deshabilitada.",
     "errorDisableITUserDesc": "Haga clic aquí para actualizar la configuración de asistencia de traducción.",
     "errorDisableIGCUserDesc": "Haga clic aquí para actualizar la configuración de asistencia gramatical.",
     "learningSettings": "Ajustes de aprendizaje",
     "updateNow": "Comenzar actualización en segundo plano.",
     "termsAndConditions": "Términos y condiciones",
     "andCertifyIAmAtLeast13YearsOfAge": " y certifico que tengo al menos 16 años.",
-    "error502504Title": "¡Vaya! Hay muchos estudiantes conectados.",
     "error502504Desc": "Las herramientas de assistencia gramatical y de traducción pueden ser lentas o no estar disponibles mientras los bots de Pangea se ponen al día.",
-    "error404Title": "¡Error de traducción!",
     "error404Desc": "Pangea Bot no está seguro de cómo traducir eso.",
     "itToggleDescription": "Esta herramienta de aprendizaje identificará palabras en su idioma base y lo ayudará a traducirlas a su idioma a aprender. Aunque es raro, la AI puede cometer errores de traducción de vez en cuando.",
     "igcToggleDescription": "Esta herramienta de aprendizaje identificará errores comunes de ortografía, gramática y puntuación en su mensaje y sugerirá correcciones. Aunque es raro, la AI puede cometer errores de corrección de vez en cuando.",
@@ -3224,12 +2926,9 @@
     "notAvailable": "No disponible",
     "taAndGaTooltip": "Uso de la L2 con ayuda de traducción y asistencia gramatical.",
     "subscriptionManagementUnavailable": "Gestión de suscripciones no disponible",
-    "downloadTxtFile": "Descargar archivo de texto",
-    "downloadCSVFile": "Descargar archivo CSV",
     "promotionalSubscriptionDesc": "Su suscripción actual es promocional. Envíe un mensaje a support@pangea.chat para cambiar su suscripción.",
     "originalSubscriptionPlatform": "Suscripción adquirida a través de",
     "oneWeekTrial": "Una semana de prueba",
-    "unkDisplayName": "unknown",
     "wwCountryDisplayName": "Mundial",
     "afCountryDisplayName": "Afganistán",
     "axCountryDisplayName": "Islas Åland",
@@ -3477,7 +3176,6 @@
     "yeCountryDisplayName": "Yemen",
     "zmCountryDisplayName": "Zambia",
     "zwCountryDisplayName": "Zimbabue",
-    "downloadXLSXFile": "Descargar archivo Excel",
     "welcomeBack": "¡Bienvenido de nuevo! Si formó parte del piloto 2023-2024, póngase en contacto con nosotros para obtener su suscripción especial de piloto. Si es usted un profesor que ha adquirido (o cuya institución ha adquirido) licencias para su clase, póngase en contacto con nosotros para obtener su suscripción de profesor.",
     "pay": "Finalizar compra",
     "youreInvited": "📩 ¡Estás invitado!",
@@ -3573,7 +3271,6 @@
     "deleteSubscriptionWarningTitle": "YTienes una suscripción activa",
     "deleteSubscriptionWarningBody": "Eliminar tu cuenta no cancelará automáticamente tu suscripción.",
     "manageSubscription": "Gestionar Suscripción",
-    "error520Title": "Por favor, intenta de nuevo.",
     "error520Desc": "Lo sentimos, no pudimos entender tu mensaje...",
     "wordsUsed": "Palabras Usadas",
     "level": "Nivel",
@@ -3589,12 +3286,10 @@
     "chatCapacity": "Capacidad de chat",
     "chatCapacityHasBeenChanged": "Capacidad de chat modificada",
     "chatCapacityExplanation": "La capacidad del chat limita el número de usuarios no administradores permitidos en un chat.",
-    "tooManyRequest": "Demasiadas solicitudes, por favor inténtelo más tarde.",
     "playAudio": "Reproducir",
     "stop": "Stop",
     "other": "Otros",
     "noCapacityLimit": "Sin límite de capacidad",
-    "downloadGroupText": "Descargar texto del grupo",
     "enableAutocorrectWarning": "¡Atención! Es necesario añadir el teclado del idioma de destino",
     "writeAMessageLangCodes": "Escribe en {l1} o {l2}...",
     "@writeAMessageLangCodes": {
@@ -3698,31 +3393,11 @@
     },
     "dataAvailable": "Disponibilidad de datos",
     "available": "Disponible",
-    "pangeaBotIsFallible": "¡El Pangea Bot también comete errores!",
-    "whatIsMeaning": "¿Qué significa '{lemma}'?",
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
-    "doubleClickToEdit": "Haz doble clic para editar.",
-    "topicLabel": "Tema",
-    "topicPlaceholder": "Elige un tema...",
-    "modePlaceholder": "Elige un modo...",
-    "learningObjectiveLabel": "Objetivo de Aprendizaje",
-    "learningObjectivePlaceholder": "Elige un objetivo de aprendizaje...",
-    "targetLanguageLabel": "Idioma objetivo",
     "cefrLevelLabel": "Nivel CEFR",
     "image": "Imagen",
     "video": "Video",
     "nan": "No aplicable",
-    "addVocabulary": "Agregar vocabulario",
     "instructions": "Instrucciones",
-    "numberOfLearners": "Número de aprendices",
-    "mustBeInteger": "Debe ser un número entero, por ejemplo, 1, 2, 3, ...",
     "constructUsePvmDesc": "Producido en mensaje de voz",
     "constructUseCorMmDesc": "Significado correcto del mensaje",
     "constructUseIncMmDesc": "Significado incorrecto del mensaje",
@@ -3743,7 +3418,6 @@
     "ttsDisbledTitle": "Texto a voz deshabilitado",
     "ttsDisabledBody": "Puedes habilitar texto a voz en la configuración de aprendizaje",
     "tooLargeToSend": "Este mensaje es demasiado grande para enviar",
-    "exitWithoutSaving": "¿Estás seguro de que quieres salir sin guardar?",
     "enableAutocorrectPopupTitle": "Agrega el teclado de tu idioma objetivo yendo a:",
     "enableAutocorrectPopupSteps": "  • Configuración\n  • General\n  • Teclado\n  • Teclados\n  • Agregar nuevo teclado",
     "enableAutocorrectPopupDescription": "Una vez que se seleccione el idioma, puedes hacer clic en el pequeño ícono de globo en la esquina inferior izquierda de tu teclado para activar el teclado recién instalado.",
@@ -3753,8 +3427,6 @@
     "displayName": "Nombre para mostrar",
     "leaveRoomDescription": "Estás a punto de salir de este chat. Otros usuarios verán que has salido del chat.",
     "confirmUserId": "Por favor, confirma tu nombre de usuario de Pangea Chat para poder eliminar tu cuenta.",
-    "startingToday": "A partir de hoy",
-    "oneWeekFreeTrial": "Una semana de prueba gratuita",
     "paidSubscriptionStarts": "Comenzando {startDate}",
     "@paidSubscriptionStarts": {
         "type": "String",
@@ -3765,15 +3437,6 @@
         }
     },
     "cancelInSubscriptionSettings": "• Cancela en cualquier momento en la configuración de suscripción",
-    "cancelToAvoidCharges": "• Cancela antes de {trialEnds} para evitar cargos",
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
-    },
     "downloadGboard": "Descargar Gboard",
     "autocorrectNotAvailable": "Desafortunadamente, tu plataforma no es compatible actualmente con esta función. ¡Mantente atento a futuros desarrollos!",
     "constructUseGaDesc": "Asistencia gramatical",
@@ -3785,17 +3448,12 @@
     "morphAnalyticsListBody": "¡Estos son todos los conceptos gramaticales en el idioma que estás aprendiendo! Los desbloquearás a medida que los encuentres mientras chateas. Haz clic para más detalles.",
     "chooseWordAudioInstructionsBody": "Escucha el mensaje completo. Luego empareja los audios con las palabras.",
     "chooseMorphsInstructionsBody": "¡Haz clic en las piezas del rompecabezas para preguntas gramaticales!",
-    "pleaseEnterInt": "Por favor, introduce un número",
     "home": "Inicio",
     "join": "Unirse",
     "resetInstructionTooltipsTitle": "Restablecer las descripciones emergentes de instrucciones",
     "resetInstructionTooltipsDesc": "Haz clic para mostrar las descripciones emergentes de instrucciones como si fueras un usuario nuevo.",
-    "randomize": "Aleatorizar",
     "clear": "Limpiar",
-    "featuredActivities": "Destacadas",
     "save": "Guardar",
-    "startChat": "Iniciar un chat",
-    "translationProblem": "Problema de traducción",
     "askToJoin": "Pedir unirse",
     "emptyChatWarningTitle": "El chat está vacío",
     "emptyChatWarningDesc": "No has invitado a nadie a tu chat. Ve a la configuración del chat para invitar a tus contactos o al Bot. También puedes hacer esto más tarde.",
@@ -3824,13 +3482,10 @@
     "timesUsedIndependently": "Veces utilizado de forma independiente",
     "timesUsedWithAssistance": "Veces utilizado con asistencia",
     "shareInviteCode": "Compartir código de invitación: {code}",
-    "leaderboard": "Tabla de clasificación",
     "skipForNow": "Saltar por ahora",
     "permissions": "Permisos",
-    "addEnvironmentOverride": "Agregar anulación de entorno",
     "defaultOption": "Predeterminado",
     "launch": "Lanzar",
-    "searchChats": "Buscar chats",
     "pinMessages": "Fijar mensajes",
     "setJoinRules": "Establecer reglas de unión",
     "changeGeneralSettings": "Cambiar configuraciones generales",
@@ -3875,10 +3530,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -3895,27 +3546,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -4035,10 +3670,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -4047,19 +3678,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addEnvironmentOverride": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@defaultOption": {
         "type": "String",
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
         "type": "String",
         "placeholders": {}
     },
@@ -4099,7 +3722,6 @@
     "constructUseCollected": "Recopilado en chat",
     "deleteChatDesc": "¿Estás seguro de que deseas eliminar este chat? Se eliminará para todos los participantes y todos los mensajes dentro del chat ya no estarán disponibles para práctica o análisis de aprendizaje.",
     "deleteSpaceDesc": "El espacio y cualquier chat y/o subespacio seleccionado se eliminarán para todos los participantes y todos los mensajes dentro del chat ya no estarán disponibles para práctica o análisis de aprendizaje. Esta acción no se puede deshacer.",
-    "maxFifty": "Máximo 50",
     "activities": "Actividades",
     "access": "Acceso",
     "howSpaceCanBeFound": "Cómo se puede encontrar este espacio",
@@ -4123,9 +3745,6 @@
     "failedToFetchTranscription": "Error al obtener la transcripción",
     "deleteEmptySpaceDesc": "El espacio será eliminado para todos los participantes. Esta acción no se puede deshacer.",
     "regenerate": "Regenerar",
-    "mySavedActivities": "Mis actividades guardadas",
-    "noSavedActivities": "No hay actividades guardadas",
-    "saveActivity": "Guardar esta actividad",
     "failedToPlayVideo": "Error al reproducir el video",
     "done": "Hecho",
     "inThisSpace": "En este espacio",
@@ -4136,13 +3755,9 @@
     "numInvited": "{count} invitado",
     "saved": "Guardado",
     "reset": "Restablecer",
-    "errorFetchingActivitiesMessage": "Error al obtener actividades",
     "errorFetchingDefinition": "Error al obtener la definición",
     "errorProcessAnalytics": "Error al procesar análisis",
     "errorDownloading": "Error en la descarga",
-    "errorLoadingSpaceChildren": "Error al cargar chats dentro de este espacio",
-    "unexpectedError": "Error inesperado.",
-    "pleaseReload": "Por favor, recarga e intenta de nuevo.",
     "translationError": "Error de traducción",
     "check": "Verificar",
     "unableToFindRoom": "No se encontró chat o espacio con ese código. Por favor, intenta de nuevo.",
@@ -4163,10 +3778,6 @@
         "placeholders": {}
     },
     "@deleteSpaceDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -4266,18 +3877,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -4326,10 +3925,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -4339,18 +3934,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -4383,19 +3966,14 @@
     "request": "Solicitar",
     "requestAll": "Solicitar todo",
     "confirmMessageUnpin": "¿Estás seguro de que quieres desanclar este mensaje?",
-    "saveAndLaunch": "Guardar y lanzar",
-    "launchToSpace": "Lanzar al curso",
     "pending": "Pendiente",
     "inactive": "Inactivo",
-    "confirmRole": "Confirmar rol",
     "openRoleLabel": "ABIERTO",
     "finishedTheActivity": "🎯 {username} finalizó esta actividad",
     "activitySummaryError": "Resúmenes de actividades no disponibles",
     "requestSummaries": "Solicitar resúmenes",
-    "generatingNewActivities": "¡Eres el primer usuario de este par de idiomas! Por favor, danos un minuto, estamos preparando actividades solo para ti.",
     "requestAccessTitle": "¿Solicitar acceso a la analítica?",
     "requestAccessDesc": "¿Te gustaría solicitar acceso para ver análisis de participantes?\n\nSi los participantes están de acuerdo, los administradores de este curso podrán ver:\n    • vocabulario total\n    • conceptos gramaticales totales\n    • sesiones de actividad completadas\n    • los conceptos gramaticales específicos utilizados, correctamente e incorrectamente\n\nNo podrán ver:\n    • mensajes en chats fuera del curso\n    • lista de vocabulario",
-    "requestAccess": "Solicitar acceso ({count})",
     "analyticsInactiveTitle": "Las solicitudes a usuarios inactivos no pudieron ser enviadas",
     "analyticsInactiveDesc": "Los usuarios inactivos que no han iniciado sesión desde que se introdujo esta función no verán tu solicitud.\n\nEl botón de Solicitar aparecerá una vez que regresen. Puedes reenviar la solicitud más tarde haciendo clic en el botón Solicitar bajo su nombre cuando esté disponible.",
     "accessRequestedTitle": "Solicitud de acceso a análisis",
@@ -4418,8 +3996,6 @@
     "accessDesc": "¡Puedes hacer que tu curso sea abierto al mundo! O, hacer que tu curso sea privado y seguro.",
     "createGroupChatDesc": "Mientras que las sesiones de actividad comienzan y terminan, los chats grupales permanecerán abiertos para la comunicación rutinaria.",
     "deleteDesc": "Solo los administradores pueden eliminar un curso. Esta es una acción destructiva que elimina a todos los usuarios y elimina todos los chats seleccionados dentro del curso. Procede con precaución.",
-    "noCourseFound": "¡Oh, este curso necesita un plan!\n\nLos planes de curso son una secuencia de temas y actividades de conversación.",
-    "additionalParticipants": "+ {num} otros",
     "whatNow": "¿Y ahora?",
     "chooseNextActivity": "¡Elige tu próxima actividad!",
     "letsGo": "¡Vamos!",
@@ -4432,13 +4008,11 @@
     "waitNotDone": "¡Espera, no he terminado!",
     "waitingForOthersToFinish": "Esperando a que los demás terminen...",
     "generatingSummary": "Analizando el chat y generando resultados",
-    "findCourse": "Buscar un curso",
     "pingParticipantsNotification": "{user} busca usuarios para unirse a la sesión de actividad en {room}",
     "course": "Curso",
     "courses": "Cursos",
     "goToCourse": "Ir al curso: {course}",
     "activityComplete": "Esta actividad ha sido completada. El resumen de la actividad debería estar disponible abajo.",
-    "startNewSession": "Iniciar nueva sesión",
     "joinOpenSession": "Unirse a sesión abierta",
     "activityNotFound": "Actividad no encontrada",
     "myActivities": "Mis actividades",
@@ -4563,23 +4137,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -4603,10 +4165,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -4614,14 +4172,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -4726,18 +4276,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -4790,10 +4328,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -4820,10 +4354,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -5004,7 +4534,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Vuelve mañana para ver las actualizaciones de la actividad.",
-    "activityDropdownDesc": "Cuando termines con esta actividad, haz clic abajo",
     "languageMismatchTitle": "Incompatibilidad de idioma",
     "languageMismatchDesc": "El idioma de destino no coincide con el idioma de esta actividad. ¿Quieres actualizar tu idioma de destino?",
     "reportWordIssueTooltip": "Reportar problema con la información de la palabra",
@@ -5017,10 +4546,6 @@
     "selectAll": "Seleccionar todo",
     "deselectAll": "Deseleccionar todo",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -5069,17 +4594,11 @@
         "placeholders": {}
     },
     "startOwn": "Comenzar el propio",
-    "joinCourseDesc": "Cada curso tiene de 8 a 10 temas secuenciados con una variedad de actividades de aprendizaje de idiomas basadas en tareas.",
     "newMessageInPangeaChat": "🗨️ Nuevo mensaje en Pangea Chat",
     "shareCourse": "Compartir curso",
     "addCourse": "Agregar un curso",
-    "joinPublicCourse": "Unirse a curso público",
     "vocabLevelsDesc": "¡Aquí es donde irán las palabras de vocabulario una vez que las hayas subido de nivel!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -5092,10 +4611,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -5142,7 +4657,6 @@
     "emojiView": "Vista de emoji",
     "feedbackDialogDesc": "¡Yo también cometo errores! ¿Algo que me ayude a mejorar?",
     "contactHasBeenInvitedToTheCourse": "El contacto ha sido invitado al curso",
-    "activityStatsButtonTooltip": "Información de actividad",
     "allow": "Permitir",
     "enabledRenewal": "Habilitar renovación de suscripción",
     "subscriptionEndsOn": "La suscripción termina el",
@@ -5409,10 +4923,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -6468,16 +5978,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Actividades para Desbloquear el Siguiente Tema",
-    "activitiesToUnlockTopicDesc": "Establecer el número de actividades para desbloquear el siguiente tema del curso",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Práctica de definición de vocabulario correcta",
     "constructUseIncLMDesc": "Práctica de definición de vocabulario incorrecta",
     "constructUseCorLADesc": "Práctica de audio de vocabulario correcta",
@@ -6485,7 +5985,6 @@
     "constructUseBonus": "Bonificación durante la práctica de vocabulario",
     "practiceVocab": "Practicar vocabulario",
     "selectMeaning": "Seleccionar el significado",
-    "selectAudio": "Seleccionar el audio correspondiente",
     "anotherRound": "Otra ronda",
     "activitySettingsOverrideWarning": "Idioma y nivel de idioma determinados por el plan de actividad",
     "voice": "Voz",
@@ -6517,10 +6016,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -6538,12 +6033,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Descarga iniciada",
     "webDownloadPermissionMessage": "Si tu navegador bloquea las descargas, por favor habilita las descargas para este sitio.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -6638,11 +6128,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Algo salió mal y estamos trabajando arduamente para solucionarlo. Revisa de nuevo más tarde.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Habilitar asistencia de escritura",
     "autoIGCToolDescription": "Ejecutar automáticamente las herramientas de Pangea Chat para corregir los mensajes enviados al idioma de destino.",
     "@autoIGCToolName": {
@@ -6698,24 +6183,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramática",
-    "spanTypeWordChoice": "Elección de palabras",
     "spanTypeSpelling": "Ortografía",
     "spanTypePunctuation": "Puntuación",
     "spanTypeStyle": "Estilo",
     "spanTypeFluency": "Fluidez",
     "spanTypeAccents": "Acentos",
     "spanTypeCapitalization": "Capitalización",
-    "spanTypeCorrection": "Corrección",
     "spanFeedbackTitle": "Informar problema de corrección",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -6740,16 +6214,10 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
     },
-    "spaceMemberOf": "Miembro del espacio de {spaces}",
-    "spaceMemberOfCanKnock": "Miembro del espacio de {spaces} puede tocar",
     "pollQuestion": "Pregunta de la encuesta",
     "answerOption": "Opción de respuesta",
     "addAnswerOption": "Agregar opción de respuesta",
@@ -6767,26 +6235,6 @@
     "stickerPackNameAlreadyExists": "El nombre del paquete de stickers ya existe",
     "newStickerPack": "Nuevo paquete de stickers",
     "stickerPackName": "Nombre del paquete de stickers",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pollQuestion": {
         "type": "String",
         "placeholders": {}
@@ -6864,35 +6312,16 @@
         "placeholders": {}
     },
     "attribution": "Atribución",
-    "skipChatBackup": "Omitir copia de seguridad del chat",
-    "skipChatBackupWarning": "¿Estás seguro? Sin habilitar la copia de seguridad del chat, puedes perder el acceso a tus mensajes si cambias de dispositivo.",
-    "loadingMessages": "Cargando mensajes",
     "noMoreResultsFound": "No se encontraron más resultados",
     "chatSearchedUntil": "Chat buscado hasta {time}",
     "federationBaseUrl": "URL base de la federación",
     "clientWellKnownInformation": "Información conocida del cliente:",
     "baseUrl": "URL base",
     "identityServer": "Servidor de identidad:",
-    "versionWithNumber": "Versión: {version}",
     "logs": "Registros",
-    "advancedConfigs": "Configuraciones avanzadas",
     "advancedConfigurations": "Configuraciones avanzadas",
-    "signInWithLabel": "Iniciar sesión con:",
     "selectAllWords": "Selecciona todas las palabras que escuches en el audio",
-    "joinCourseForActivities": "Únete a un curso para probar actividades.",
     "@attribution": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
         "type": "String",
         "placeholders": {}
     },
@@ -6924,19 +6353,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -6944,15 +6361,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -7153,11 +6562,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "¿En una clase? Pon tu código de unión aquí.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Resaltar automáticamente los mensajes de audio",
     "selectAudioMessagesOnPlayDescription": "Resaltar automáticamente los mensajes de audio cuando se reproducen",
     "@selectAudioMessagesOnPlayToolName": {
@@ -7201,18 +6605,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Este curso tiene temas con menos de {input} actividades. Por favor, ingresa un número menor o igual a {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Haga clic aquí para volver a iniciar sesión.",
     "@clickToLogin": {
@@ -7629,17 +7021,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Un oso amarillo caricaturesco con los brazos levantados en emoción.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Selecciona palabras para aprender más sobre ellas",
     "requireAnalyticsAccessTitle": "Requiere acceso a análisis para unirse",
     "requireAnalyticsAccessDesc": "Los participantes deben otorgar acceso a sus análisis de aprendizaje para unirse a este curso",
     "analyticsAccessNoticeTitle": "Acceso a Análisis Requerido",
     "analyticsAccessNoticeDesc": "Al unirte a este curso, aceptas otorgar a los administradores acceso a tus análisis de aprendizaje.",
-    "skipOnboardingClassCodeDesc": "¿Aprendiendo de forma independiente? No te preocupes, puedes:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -7657,10 +7043,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7689,7 +7071,6 @@
     "pickCefrLevelTeacherStepTitle": "¿Qué nivel enseñas?",
     "pickCefrLevelStudentStepTitle": "¿Qué nivel eres?",
     "customCourseStepTitle": "Completa este formulario para obtener un curso personalizado",
-    "aboutYourClass": "Acerca de tu clase",
     "courseCodeStepErrorMessage": "Por favor, verifica tu código y vuelve a intentarlo",
     "institution": "Institución",
     "courseGoals": "Objetivos del curso",
@@ -7732,10 +7113,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -7852,12 +7229,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logo de Pangea Chat",
     "introChatDetails": "¡Di hola! Preséntate a tus compañeros participantes del curso, encuentra amigos y chatea fuera de las actividades.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -7901,11 +7273,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Acciones de actividad",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Herramientas de pronunciación",
     "audioTranscription": "Transcripción de audio con IA",
     "visualLearnerSupport": "Soporte para aprendices visuales",
@@ -7946,7 +7313,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Únete a un curso que incluya esta actividad para jugarla.",
     "resizeCoursePanel": "Redimensionar panel del curso",
     "undo": "Deshacer",
     "unlock": "Desbloquear",
@@ -7960,7 +7326,6 @@
     "addCourseBrowsePublic": "Explorar cursos públicos",
     "browsePublicCourses": "Explorar cursos públicos",
     "editProfile": "Editar perfil",
-    "numObjectives": "{count} objetivos",
     "mapSearchHint": "Buscar actividades",
     "mapSearchNoResults": "No hay coincidencias en la vista",
     "mapFilterAllLanguages": "Todos los idiomas",
@@ -7969,7 +7334,6 @@
     "mapFilterCompleted": "Completado",
     "mapFilterReset": "Restablecer",
     "activityTypeConversation": "Conversación",
-    "lockedMissionRequirement": "Termina la misión anterior para desbloquear",
     "playAgain": "Jugar de nuevo",
     "reviewActivity": "Revisar",
     "mapEmptyInView": "No hay nada aquí en tu nivel o idioma. Amplía tus filtros o aleja.",
@@ -7984,14 +7348,9 @@
     "scrollToBottom": "Desplazarse hasta el final",
     "courseImage": "Imagen del curso",
     "avatarPreview": "Vista previa del avatar",
-    "activityPhoto": "Foto de actividad",
     "emotePreview": "Vista previa de emote: {name}",
     "activityLabel": "Actividad: {title}",
     "resetMapView": "Restablecer vista del mapa",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -8044,14 +7403,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -8081,10 +7432,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -8141,10 +7488,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_et.arb
+++ b/lib/l10n/intl_et.arb
@@ -83,11 +83,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Kas külalised võivad liituda",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Kas sa oled kindel?",
     "@areYouSure": {
         "type": "String",
@@ -364,11 +359,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Sinu vestluste varukoopia on krüptitud taastamiseks mõeldud turvavõtmega. Palun vaata, et sa seda ei kaota.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Vestluse teave",
     "@chatDetails": {
         "type": "String",
@@ -500,11 +490,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Sinu kontakt on kutsutud liituma vestlusrühma",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Saatsime selle sisu kohta teate koduserveri haldajate",
     "@contentHasBeenReported": {
         "type": "String",
@@ -556,11 +541,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Uus kogukond",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Hetkel aktiivne",
     "@currentlyActive": {
@@ -704,11 +684,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Sa ei saa hiljem enam krüptimist välja lülitada. Kas oled kindel?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Krüptitud",
     "@encrypted": {
         "type": "String",
@@ -747,11 +722,6 @@
             }
         }
     },
-    "everythingReady": "Kõik on valmis!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Äärmiselt solvav",
     "@extremeOffensive": {
         "type": "String",
@@ -789,11 +759,6 @@
     },
     "group": "Vestlusrühm",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Vestlusrühm on avalik",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -887,15 +852,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Kutsu sõpru ja tuttavaid {groupName} liikmeks",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Kutsutud",
     "@invited": {
@@ -1008,15 +964,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Lisa veel {count} osalejat",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Laadin andmeid… Palun oota.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -1041,15 +988,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Logi sisse {homeserver} serverisse",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Logi välja",
     "@logout": {
@@ -1113,16 +1051,6 @@
     },
     "noEmotesFound": "Ühtegi emotsioonitegevust ei leidunud. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Sa võid krüptimise kasutusele võtta niipea, kui jututuba pole enam avalik.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Tundub, et sinu nutiseadmes pole Firebase Cloud Messaging teenuseid. Sinu privaatsuse mõttes on see kindlasti hea otsus! Kui sa soovid FluffyChatis näha tõuketeavitusi, siis soovitame, et selle jaoks kasutad ntfy liidestust. Kasutades ntfyd või mõnda muud Unified Push standardil põhinevat liidestust saad tõuketeavitusi turvalisel moel. Ntfy rakendus on saadaval nii PlayStore kui F-Droidi rakendusepoodides.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1254,11 +1182,6 @@
     },
     "passwordHasBeenChanged": "Salasõna on muudetud",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Salasõna taastamine",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1402,11 +1325,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Eemalda seade",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Eemalda suhtluskeeld",
     "@unbanFromChat": {
@@ -1561,11 +1479,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Seadista õigusi",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Määra olek",
     "@setStatus": {
         "type": "String",
@@ -1607,16 +1520,6 @@
     },
     "sourceCode": "Lähtekood",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Kogukond on avalik",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Kogukonna nimi",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1675,11 +1578,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Tõsta teisest seadmest",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Proovi uuesti saata",
     "@tryToSendAgain": {
         "type": "String",
@@ -1735,15 +1633,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 lugemata vestlus} other{{unreadCount} lugemata vestlust}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} ja {count} muud kirjutavad…",
     "@userAndOthersAreTyping": {
@@ -1829,16 +1718,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Videokõne",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Vestluse ajaloo nähtavus",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Nähtav kõikidele osalejatele",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1884,23 +1763,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Erinevatele kasutajatele lubatud toimingud",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Kes võivad selle vestlusrühmaga liituda",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Miks sa soovid sellest teatada?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Kas kustutame sinu vestluste varukoopia ja loome uue taastamiseks mõeldud krüptovõtme?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1949,8 +1813,6 @@
     "@homeserver": {},
     "serverRequiresEmail": "See koduserver eeldab registreerimisel kasutatava e-postiaadressi kinnitamist.",
     "@serverRequiresEmail": {},
-    "enableMultiAccounts": "(KATSELINE) Pruugi selles seadmes mitut Matrix'i kasutajakontot",
-    "@enableMultiAccounts": {},
     "bundleName": "Köite nimi",
     "@bundleName": {},
     "removeFromBundle": "Eemalda sellest köitest",
@@ -1959,14 +1821,10 @@
     "@addToBundle": {},
     "editBundlesForAccount": "Muuda selle kasutajakonto köiteid",
     "@editBundlesForAccount": {},
-    "addAccount": "Lisa kasutajakonto",
-    "@addAccount": {},
     "oneClientLoggedOut": "Üks sinu klientrakendustest on Matrix'i võrgust välja loginud",
     "@oneClientLoggedOut": {},
     "link": "Link",
     "@link": {},
-    "yourChatBackupHasBeenSetUp": "Sinu vestluste varundus on seadistatud.",
-    "@yourChatBackupHasBeenSetUp": {},
     "unverified": "Verifitseerimata",
     "@unverified": {},
     "repeatPassword": "Korda salasõna",
@@ -1981,8 +1839,6 @@
     "@sender": {},
     "openGallery": "Ava galerii",
     "@openGallery": {},
-    "removeFromSpace": "Eemalda kogukonnast",
-    "@removeFromSpace": {},
     "start": "Alusta",
     "@start": {},
     "commandHint_discardsession": "Loobu sessioonist",
@@ -2036,16 +1892,10 @@
     "@placeCall": {},
     "unsupportedAndroidVersion": "See Androidi versioon ei ole toetatud",
     "@unsupportedAndroidVersion": {},
-    "voiceCall": "Häälkõne",
-    "@voiceCall": {},
     "confirmEventUnpin": "Kas sa oled kindel, et tahad esiletõstetud sündmuse jäädavalt eemaldada?",
     "@confirmEventUnpin": {},
     "pinMessage": "Tõsta sõnum jututoas esile",
     "@pinMessage": {},
-    "videoCallsBetaWarning": "Palun arvesta, et videokõned on veel beetajärgus. Nad ei pruugi veel toimida kõikidel platvormidel korrektselt.",
-    "@videoCallsBetaWarning": {},
-    "emailOrUsername": "E-posti aadress või kasutajanimi",
-    "@emailOrUsername": {},
     "experimentalVideoCalls": "Katselised videokõned",
     "@experimentalVideoCalls": {},
     "unsupportedAndroidVersionLong": "See funktsionaalsus eeldab uuemat Androidi versiooni. Palun kontrolli, kas sinu nutiseadmele leidub süsteemiuuendusi või saaks seal Lineage OSi kasutada.",
@@ -2137,28 +1987,8 @@
     },
     "publish": "Avalda",
     "@publish": {},
-    "pleaseEnterRecoveryKey": "Palun sisesta oma taastevõti:",
-    "@pleaseEnterRecoveryKey": {},
-    "recoveryKey": "Taastevõti",
-    "@recoveryKey": {},
     "users": "Kasutajad",
     "@users": {},
-    "storeInSecureStorageDescription": "Salvesta taastevõti selle seadme turvahoidlas.",
-    "@storeInSecureStorageDescription": {},
-    "saveKeyManuallyDescription": "Salvesta see krüptovõti kasutades selle süsteemi jagamisvalikuid või lõikelauda.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "Vali salvestuskohaks Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Vali salvestuskohaks Apple KeyChain",
-    "@storeInAppleKeyChain": {},
-    "recoveryKeyLost": "Kas taasetvõti on kadunud?",
-    "@recoveryKeyLost": {},
-    "pleaseEnterRecoveryKeyDescription": "Vanade sõnumite lugemiseks palun siseta oma varasemas sessioonis loodud taastevõti. Taastamiseks mõeldud krüptovõti EI OLE sinu salasõna.",
-    "@pleaseEnterRecoveryKeyDescription": {},
-    "storeSecurlyOnThisDevice": "Salvesta turvaliselt selles seadmes",
-    "@storeSecurlyOnThisDevice": {},
-    "unlockOldMessages": "Muuda vanad sõnumid loetavaks",
-    "@unlockOldMessages": {},
     "countFiles": "{count} faili",
     "@countFiles": {
         "placeholders": {
@@ -2200,16 +2030,8 @@
     "@newGroup": {},
     "newSpace": "Uus kogukond",
     "@newSpace": {},
-    "enterSpace": "Sisene kogukonda",
-    "@enterSpace": {},
-    "screenSharingTitle": "ekraani jagamine",
-    "@screenSharingTitle": {},
-    "foregroundServiceRunning": "See teavitus toimib siis, kui esiplaaniteenus töötab.",
-    "@foregroundServiceRunning": {},
     "allSpaces": "Kõik kogukonnad",
     "@allSpaces": {},
-    "screenSharingDetail": "Sa jagad oma ekraani FuffyChati vahendusel",
-    "@screenSharingDetail": {},
     "doNotShowAgain": "Ära näita uuesti",
     "@doNotShowAgain": {},
     "commandHint_cuddle": "Saada üks kaisutus",
@@ -2254,16 +2076,8 @@
             }
         }
     },
-    "encryptThisChat": "Krüpti see vestlus",
-    "@encryptThisChat": {},
-    "disableEncryptionWarning": "Kui vestluses on krüptimine kasutusele võetud, siis turvalisuse huvides ei saa seda hiljem välja lülitada.",
-    "@disableEncryptionWarning": {},
-    "sorryThatsNotPossible": "Vabandust... see ei ole võimalik",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "Seadme võtmed:",
     "@deviceKeys": {},
-    "newSpaceDescription": "Kogukonnad võimaldavad sul koondada erinevaid vestlusi ning korraldada avalikku või privaatset ühistegevust.",
-    "@newSpaceDescription": {},
     "reopenChat": "Alusta vestlust uuesti",
     "@reopenChat": {},
     "noOtherDevicesFound": "Muid seadmeid ei leidu",
@@ -2309,14 +2123,10 @@
     "@sendTypingNotifications": {},
     "createGroup": "Loo vestlusrühm",
     "@createGroup": {},
-    "setTheme": "Vali teema:",
-    "@setTheme": {},
     "tryAgain": "Proovi uuesti",
     "@tryAgain": {},
     "chatPermissions": "Vestluse õigused",
     "@chatPermissions": {},
-    "chatDescription": "Vestluse kirjeldus",
-    "@chatDescription": {},
     "noChatDescriptionYet": "Vestluse kirjeldus on puudu.",
     "@noChatDescriptionYet": {},
     "optionalRedactReason": "(Kui soovid lisada) Sõnumi muutmise põhjus...",
@@ -2408,14 +2218,10 @@
     "@kickUserDescription": {},
     "blockListDescription": "Sul on võimalik blokeerida neid kasutajaid, kes sind segavad. Oma isiklikku blokerimisloendisse lisatud kasutajad ei saa sulle saata sõnumeid ega kutseid.",
     "@blockListDescription": {},
-    "createGroupAndInviteUsers": "Lisavestlusrühm ja kutsu sinna kasutajaid",
-    "@createGroupAndInviteUsers": {},
     "startConversation": "Alusta vestlust",
     "@startConversation": {},
     "blockedUsers": "Blokeeritud kasutajad",
     "@blockedUsers": {},
-    "groupCanBeFoundViaSearch": "Vestlusrühm on leitav otsinguga",
-    "@groupCanBeFoundViaSearch": {},
     "noUsersFoundWithQuery": "Päringuga „{query}“ ei leidunud kahkus ühtegi kasutajat. Palun kontrolli, et päringus poleks vigu.",
     "@noUsersFoundWithQuery": {
         "type": "String",
@@ -2439,8 +2245,6 @@
     "@groupName": {},
     "databaseMigrationTitle": "Andmebaas on optimeeritud",
     "@databaseMigrationTitle": {},
-    "searchChatsRooms": "Otsi #vestlusi, @kasutajaid...",
-    "@searchChatsRooms": {},
     "databaseMigrationBody": "Palun oota üks hetk. Natuke võib kuluda aega.",
     "@databaseMigrationBody": {},
     "thisDevice": "See seade:",
@@ -2465,8 +2269,6 @@
     "@select": {},
     "pleaseChooseAStrongPassword": "Palun sisesta korralik salasõna",
     "@pleaseChooseAStrongPassword": {},
-    "addChatOrSubSpace": "Lisa vestlus või jututuba",
-    "@addChatOrSubSpace": {},
     "leaveEmptyToClearStatus": "Senise oleku eemaldamiseks jäta väärtus tühjaks.",
     "@leaveEmptyToClearStatus": {},
     "joinSpace": "Liitu kogukonnaga",
@@ -2475,44 +2277,16 @@
     "@searchForUsers": {},
     "initAppError": "Rakenduse käivitamisel tekkis viga",
     "@initAppError": {},
-    "sessionLostBody": "Sinu sessioon on kadunud. Palun teata sellest veast arendajatele siin: {url} märkides veateate: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Nüüd üritab rakendus taastada sinu sessiooni varukoopiast. Palun teata sellest veast arendajatele siin: {url} märkides veateate: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "transparent": "Läbipaistev",
     "@transparent": {},
     "sendReadReceipts": "Saada lugemisteatisi",
     "@sendReadReceipts": {},
-    "verifyOtherUserDescription": "Kui sa oled vestluse teise osapoole verifitseerinud, siis saad kindel olla, et tead, kellega suhtled. 💪\n\nKui alustad verifitseerimist, siis sinul ja teisel osapoolel tekib rakenduses hüpikaken. Seal kuvatakse emotikonide või numbrite jada, mida peate omavahel võrdlema.\n\nKõige lihtsam on seda teha kas omavahelise kohtumise ajal või videokõne kestel. 👭",
-    "@verifyOtherUserDescription": {},
     "sendTypingNotificationsDescription": "Muud vestluses osalejad saavad näha, kui sa oled uut sõnumit kirjutamas.",
     "@sendTypingNotificationsDescription": {},
     "sendReadReceiptsDescription": "Muud vestluses osalejad näevad, kas oled sõnumit lugenud.",
     "@sendReadReceiptsDescription": {},
     "formattedMessages": "Vormindatud sõnumid",
     "@formattedMessages": {},
-    "verifyOtherUser": "🔐 Verifitseeri teine kasutaja",
-    "@verifyOtherUser": {},
     "verifyOtherDevice": "🔐 Verifitseeri oma muu seade",
     "@verifyOtherDevice": {},
     "canceledKeyVerification": "{sender} katkestas krüptovõtmete verifitseerimise",
@@ -2602,37 +2376,16 @@
             }
         }
     },
-    "globalChatId": "Üldine vestluse tunnus",
-    "@globalChatId": {},
-    "accessAndVisibilityDescription": "Kes võib selle vestlusega liituda ja kuidas on võimalik seda vestlust leida.",
-    "@accessAndVisibilityDescription": {},
     "hideRedactedMessagesBody": "Kui keegi muudab sõnumit, siis teda enam ei kuvataks vestluses.",
     "@hideRedactedMessagesBody": {},
-    "usersMustKnock": "Kasutajad peavad uksele koputama",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Mitte keegi ei saa liituda",
-    "@noOneCanJoin": {},
     "knocking": "Koputus uksele",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Vestluse või jututoa saad leida otsingust serveris {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "publicChatAddresses": "Vestluse avalik aadress",
-    "@publicChatAddresses": {},
     "noDatabaseEncryption": "Andmebaasi krüptimine pole sellel platvormil toetatud",
     "@noDatabaseEncryption": {},
     "knock": "Koputa uksele",
     "@knock": {},
     "appLockDescription": "Kui sa rakendust parasjagu ei kasuta, siis lukusta ta PIN-koodiga",
     "@appLockDescription": {},
-    "accessAndVisibility": "Ligipääsetavus ja nähtavus",
-    "@accessAndVisibility": {},
     "calls": "Kõned",
     "@calls": {},
     "customEmojisAndStickers": "Kohandatud emotikonid ja kleepsud",
@@ -2647,8 +2400,6 @@
     "@overview": {},
     "passwordRecoverySettings": "Salasõna taastamise seadistused",
     "@passwordRecoverySettings": {},
-    "createNewAddress": "Loo uus aadress",
-    "@createNewAddress": {},
     "thereAreCountUsersBlocked": "Hetkel on {count} blokeeritud kasutajat.",
     "@thereAreCountUsersBlocked": {
         "type": "String",
@@ -2762,14 +2513,6 @@
     "@sendCanceled": {},
     "noChatsFoundHere": "Siin ei leidu veel ühtegi vestlust. Alusta uut vestlust klõpsides allpool asuvat nuppu. ⤵️",
     "@noChatsFoundHere": {},
-    "loginWithMatrixId": "Logi sisse Matrix-ID alusel",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Leia koduservereid",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Mis on koduserver?",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "Sarnaselt e-postiteenuse pakkujale on kõik sinu sõnumid salvestatud koduserveris. Sa võid valida sellise koduserveri, nagu sulle meeldib ja nad kõik suudavad teiste koduserveritega suhelda. Lisateavet leiad veebisaidist https://matrix.org.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "Ei tundu olema ühilduv koduserver. Kas võrguaadress on ikka õige?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "prepareSendingAttachment": "Valmistume manuse saatmiseks...",
@@ -2809,12 +2552,8 @@
     "@noticeChatBackupDeviceVerification": {},
     "continueText": "Jätka",
     "@continueText": {},
-    "welcomeText": "Tere, tere 👋 See on FluffyChat. Sa võid sisse logida igasse koduserverisse, mis ühildub https://matrix.org serveriga. Ja seejärel saad suhelda kõigiga. Tegemist on ikka väga suure detsentraliseeritud sõnumivõrguga!",
-    "@welcomeText": {},
     "setWallpaper": "Määra taustapildiks",
     "@setWallpaper": {},
-    "manageAccount": "Halda kasutajakontot",
-    "@manageAccount": {},
     "blur": "Hägusus:",
     "@blur": {},
     "opacity": "Läbipaistmatus:",
@@ -2875,21 +2614,8 @@
     "@otherPartyNotLoggedIn": {},
     "open": "Ava",
     "@open": {},
-    "appWantsToUseForLoginDescription": "Järgnevaga lubad sa, et rakendus ja veebisait jagavad teavet sinu kohta.",
-    "@appWantsToUseForLoginDescription": {},
-    "appWantsToUseForLogin": "Sisselogimiseks kasuta serverit '{server}'",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "waitingForServer": "Ootame serveri vastust...",
     "@waitingForServer": {},
-    "appIntroduction": "FluffyChat võimaldab sul suhelda sõprade ja tuttavatega, kes kasutavad erinevaid sõnumikliente. Lisateavet leiad https://matrix.org saidist või lihtsalt klõpsi „Jätka“.",
-    "@appIntroduction": {},
     "synchronizingPleaseWaitCounter": " Sünkroniseerime… ({percentage}%)",
     "@synchronizingPleaseWaitCounter": {
         "type": "String",
@@ -3042,15 +2768,6 @@
     "@pleaseWaitUntilInvited": {},
     "youHaveKnocked": "Sa oled koputanud",
     "@youHaveKnocked": {},
-    "countInvited": "{count} kutsutut",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "sentVoiceMessage": "🎙️ {duration} - Häälsõnum kasutajalt {sender}",
     "@sentVoiceMessage": {
         "type": "String",
@@ -3085,12 +2802,6 @@
     "@pause": {},
     "resume": "Jätka",
     "@resume": {},
-    "newSubSpace": "Uus alamkogukond",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Tõsta teise kogukonda",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "See vestlus eemaldatakse nüüd kogukonnast, kuid on jätkuvalt nähtav sinu vestluste loendis.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} vestlust",
     "@countChats": {
         "type": "String",
@@ -3100,26 +2811,6 @@
             }
         }
     },
-    "spaceMemberOf": "Kogukonna liige: {spaces}",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "{spaces} kogukonna liige võib uksele koputada",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "Toeta meid rahaliselt",
-    "@donate": {},
     "startedAPoll": "{username} koostas küsitluse.",
     "@startedAPoll": {
         "type": "String",
@@ -3189,14 +2880,6 @@
     "@stickerPackName": {},
     "attribution": "Autoriõigused",
     "@attribution": {},
-    "skipChatBackup": "Jäta vestluse varundamine vahele",
-    "@skipChatBackup": {},
-    "skipChatBackupWarning": "Kas oled kindel? Kui sa pole lülitanud sisse vestluste krüptovõtmete varundust, siis võid oma seadme vahetamisel kaotada ligipääsu oma senistele sõnumitele.",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "Laadin sõnumeid",
-    "@loadingMessages": {},
-    "setupChatBackup": "Võta kasutusele vestluste varundus",
-    "@setupChatBackup": {},
     "changedTheChatDescription": "{username} muutis vestluse kirjeldust",
     "@changedTheChatDescription": {},
     "changedTheChatName": "{username} muutis vestluse nime",
@@ -3218,11 +2901,9 @@
     "taTooltip": "L2 kasutamine tõlke abiga",
     "interactiveTranslatorSliderHeader": "Interaktiivne tõlkija",
     "interactiveGrammarSliderHeader": "Interaktiivne grammatika kontroll",
-    "interactiveTranslatorRequired": "Nõutud",
     "waTooltip": "L2 kasutamine ilma abita",
     "interactiveTranslator": "Tõlkeabi",
     "noIdenticalLanguages": "Palun vali erinevad baas- ja sihtkeeled",
-    "searchBy": "Otsi riigi ja keelte järgi",
     "joinWithClassCode": "Liitu ruumiga",
     "languageLevelPreA1": "Algaja Madal (Eel A1)",
     "languageLevelA1": "Algaja Kesktase (A1)",
@@ -3242,19 +2923,14 @@
     "whatIsYourBaseLanguage": "Mis on teie põhikeel?",
     "publicProfileTitle": "Luba minu profiili otsingus leida",
     "publicProfileDesc": "Lülitades sisse võimaldate teistel kasutajatel leida teie profiili globaalset otsinguriba kaudu ja saata vestlussoove. Sel hetkel saate otsustada, kas nõustute või keeldute soovist.",
-    "errorDisableIT": "Tõlkeabi on välja lülitatud.",
-    "errorDisableIGC": "Grammatikaabi on välja lülitatud.",
     "errorDisableITUserDesc": "Klõpsake siin, et uuendada tõlkeabi seadeid",
     "errorDisableIGCUserDesc": "Klõpsake siin, et uuendada grammatikaabi seadeid",
     "errorDisableITClassDesc": "Tõlkeabi on välja lülitatud selle vestluse ruumi jaoks.",
     "errorDisableIGCClassDesc": "Grammatikaabi on välja lülitatud selle vestluse ruumi jaoks.",
-    "error405Title": "Keeled pole määratud",
     "error405Desc": "Palun seadistage oma keeled peamenüüs > Õpeseadistused.",
     "termsAndConditions": "Tingimuste ja nõuetega",
     "andCertifyIAmAtLeast13YearsOfAge": " ning kinnitan, et olen vähemalt 16 aastat vana.",
-    "error502504Title": "Vau, veebis on palju õpilasi!",
     "error502504Desc": "Tõlke- ja grammatikatööriistad võivad olla aeglased või kättesaamatud, kuni Pangea botid jõuavad järele.",
-    "error404Title": "Tõlkeviga!",
     "error404Desc": "Pangea bot ei ole kindel, kuidas seda tõlkida...",
     "errorPleaseRefresh": "Uurime seda välja! Palun laadin uuesti ja proovi uuesti.",
     "connectedToStaging": "Ühendatud etappserveriga",
@@ -3291,13 +2967,9 @@
     "definitionsToolName": "Sõnade definitsioonid",
     "definitionsToolDescription": "Kui see on lubatud, saab sinise allajoonitud sõnu klõpsata definitsioonide saamiseks. Klõpsake sõnumeid, et pääseda definitsioonidele.",
     "welcomeBack": "Tere tulemast tagasi! Kui osalesite 2023-2024 pilootprogrammis, võtke meiega ühendust oma erilise pilootkuulutuse saamiseks. Kui olete õpetaja, kellel on (või kelle asutus on) ostnud litsentse oma klassile, võtke meiega ühendust oma õpetajapaketiks.",
-    "downloadTxtFile": "Laadi alla tekstifail",
-    "downloadCSVFile": "Laadi alla CSV-fail",
     "promotionalSubscriptionDesc": "Teil on praegu eluaegne kampaania tellimus. Abi saamiseks saatke sõnum aadressile support@pangea.chat.",
     "originalSubscriptionPlatform": "Tellimus osteti {purchasePlatform} kaudu",
     "oneWeekTrial": "Ühe nädala prooviperiood",
-    "downloadXLSXFile": "Laadi alla Exceli fail",
-    "unkDisplayName": "Tundmatu",
     "wwCountryDisplayName": "Maailm",
     "afCountryDisplayName": "Afganistan",
     "axCountryDisplayName": "Alandsaared",
@@ -3592,7 +3264,6 @@
     "chatCapacityHasBeenChanged": "Vestluse maht on muudetud",
     "chatCapacitySetTooLow": "Vestluse maht peab olema vähemalt {count}.",
     "chatCapacityExplanation": "Vestluse maht piirab vestluses lubatud liikmete arvu.",
-    "tooManyRequest": "Liiga palju päringuid, proovige hiljem uuesti.",
     "enterNumber": "Palun sisestage täisarvuline väärtus.",
     "practice": "Praktika",
     "versionNotFound": "Versiooni ei leitud",
@@ -3602,7 +3273,6 @@
     "deleteSubscriptionWarningTitle": "Teil on aktiivne tellimus",
     "deleteSubscriptionWarningBody": "Konto kustutamine ei tühista automaatselt teie tellimust.",
     "manageSubscription": "Halda tellimust",
-    "error520Title": "Palun proovige uuesti.",
     "error520Desc": "Vabandame, me ei saanud teie sõnumit aru...",
     "wordsUsed": "Kasutatud sõnad",
     "level": "Tase",
@@ -3620,7 +3290,6 @@
     "other": "Muu",
     "levelShort": "TASE {level}",
     "noCapacityLimit": "Piirangut võimsusele ei ole",
-    "downloadGroupText": "Laadige alla grupitekst",
     "notificationsOn": "Teavitused sisse",
     "notificationsOff": "Teavitused välja",
     "joinWithCode": "Liitu koodiga",
@@ -3684,24 +3353,12 @@
     "whatIsTheMorphTag": "Mis on '{wordForm}' {morphologicalFeature}?",
     "dataAvailable": "Andmete saadavus",
     "available": "Saadaval",
-    "pangeaBotIsFallible": "Pangea bot teevib ka vigu!",
-    "whatIsMeaning": "Mida tähendab '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Sobita tähendused sõnadega sõnumis!",
-    "doubleClickToEdit": "Kaksklõpsake redigeerimiseks.",
-    "topicLabel": "Teema",
-    "topicPlaceholder": "Valige teema...",
-    "modePlaceholder": "Valige režiim...",
-    "learningObjectiveLabel": "Õppeeesmärk",
-    "learningObjectivePlaceholder": "Valige õppeeesmärk...",
-    "targetLanguageLabel": "Eesmärk keel",
     "cefrLevelLabel": "CEFR tase",
     "image": "Pilt",
     "video": "Video",
     "nan": "Ei kohaldata",
-    "addVocabulary": "Lisa sõnavara",
     "instructions": "Juhised",
-    "numberOfLearners": "Õppijate arv",
-    "mustBeInteger": "Peab olema täisarv, nt 1, 2, 3, ...",
     "constructUsePvmDesc": "Toodetud häälsõnumina",
     "leaveSpaceDescription": "Lahkudes ruumist, lahkute kõigist selles olevatest vestlustest. Teised kasutajad näevad, et olete ruumist lahkunud.",
     "constructUseCorMmDesc": "Õige sõnumi tähendus",
@@ -3716,7 +3373,6 @@
     "ttsDisabledBody": "Saate keelata teksti kõneks muutmise oma õpeseadete kaudu",
     "noSpaceDescriptionYet": "Hetkel pole ruumi kirjelduse loomist.",
     "tooLargeToSend": "See sõnum on liiga suur saatmiseks",
-    "exitWithoutSaving": "Olete kindel, et soovite lahkuda ilma salvestamata?",
     "enableAutocorrectPopupTitle": "Lisa oma sihtkeele klaviatuur, minnes aadressile:",
     "enableAutocorrectPopupSteps": "  • Seaded\n  • Üldine\n  • Klaviatuur\n  • Klaviatuurid\n  • Lisa uus klaviatuur",
     "enableAutocorrectPopupDescription": "Kui keel on valitud, saate klaviatuuri vasakus alumises nurgas oleva väikese globaalse ikooni klõpsates aktiveerida hiljuti installitud klaviatuuri.",
@@ -3727,11 +3383,8 @@
     "displayName": "Nimi kuvatud",
     "leaveRoomDescription": "Oled sellest vestlusest lahkumas. Teised kasutajad näevad, et oled lahkunud vestlusest.",
     "confirmUserId": "Palun kinnita oma Pangea Vestluse kasutajanimi, et oma konto kustutada.",
-    "startingToday": "Alates täna",
-    "oneWeekFreeTrial": "Ühe nädala tasuta prooviperiood",
     "paidSubscriptionStarts": "Algab {startDate}",
     "cancelInSubscriptionSettings": "• Tühista igal ajal tellimuse seadetes",
-    "cancelToAvoidCharges": "• Tühista enne {trialEnds}, et vältida tasusid",
     "downloadGboard": "Laadi alla Gboard",
     "autocorrectNotAvailable": "Kahjuks ei ole teie platvorm praegu selle funktsiooni jaoks toetatud. Jälgige edasisi arenguid!",
     "pleaseUpdateApp": "Palun uuendage rakendus, et jätkata.",
@@ -3741,17 +3394,12 @@
     "knockSpaceSuccess": "Oled esitanud taotluse selle ruumi liitumiseks! Admin vastab sinu taotlusele, kui ta selle saab 😀",
     "chooseWordAudioInstructionsBody": "Kuula kogu sõnumit. Seejärel sobita helid sõnadega, mida nad kõige paremini esindavad.",
     "chooseMorphsInstructionsBody": "Klikk puzzleosad grammatika küsimuste jaoks!",
-    "pleaseEnterInt": "Palun sisesta number",
     "home": "Kodu",
     "join": "Liitu",
     "resetInstructionTooltipsTitle": "Lähtesta juhiste tööriistaribad",
     "resetInstructionTooltipsDesc": "Klikkige, et näidata juhiste tööriistaribasid nagu uuel kasutajal.",
-    "randomize": "Juhuslikuks muutmine",
     "clear": "Puhasta",
-    "featuredActivities": "Esiletõstetud",
     "save": "Salvesta",
-    "startChat": "Alusta vestlust",
-    "translationProblem": "Tõlke probleem",
     "askToJoin": "Küsi liitumist",
     "emptyChatWarningTitle": "Vestlus on tühi",
     "emptyChatWarningDesc": "Sa ei ole kedagi vestlusesse kutsunud. Mine vestluse seadistustesse, et kutsuda oma kontakte või bot. Seda saab teha ka hiljem.",
@@ -3781,17 +3429,13 @@
     "timesUsedIndependently": "Kasutuskorrad iseseisvalt",
     "timesUsedWithAssistance": "Kasutuskorrad abiga",
     "shareInviteCode": "Jaga kutsekood: {code}",
-    "leaderboard": "Tabel",
     "skipForNow": "Jäta praegu vahele",
     "permissions": "Luba",
     "spaceChildPermission": "Kes saab lisada uusi vestlusi ja alamruume sellele ruumile",
-    "addEnvironmentOverride": "Lisa keskkonnamuutus",
     "defaultOption": "Vaikimisi",
     "deleteChatDesc": "Kas olete kindel, et soovite selle vestluse kustutada? See kustutatakse kõigilt osalejatelt ning kõik vestluse sõnumid ei ole enam saadaval harjutamiseks ega õppeanalüütikaks.",
     "deleteSpaceDesc": "Tüüp ja kõik valitud vestlused ja/või alamruumid kustutatakse kõigilt osalejatelt ning kõik vestluse sõnumid ei ole enam saadaval harjutamiseks ega õppeanalüütikaks. Seda toimingut ei saa tagasi võtta.",
     "launch": "Käivita",
-    "searchChats": "Otsi vestlusi",
-    "maxFifty": "Maksimum 50",
     "configureSpace": "Seadista ruum",
     "pinMessages": "Kinnita sõnumid",
     "setJoinRules": "Määra liitumisreeglid",
@@ -3825,9 +3469,6 @@
     "failedToFetchTranscription": "Transkriptsiooni toomine ebaõnnestus",
     "deleteEmptySpaceDesc": "Ruum kustutatakse kõigilt osalejatelt. Seda toimingut ei saa tagasi võtta.",
     "regenerate": "Uuesti genereeri",
-    "mySavedActivities": "Minu salvestatud tegevused",
-    "noSavedActivities": "Ei ole salvestatud tegevusi",
-    "saveActivity": "Salvesta see tegevus",
     "failedToPlayVideo": "Video mängimine ebaõnnestus",
     "done": "Valmis",
     "inThisSpace": "Selles ruumis",
@@ -3838,13 +3479,9 @@
     "numInvited": "{count} kutsutud",
     "saved": "Salvestatud",
     "reset": "Lähtesta",
-    "errorFetchingActivitiesMessage": "Tegevuste toomine ebaõnnestus",
     "errorFetchingDefinition": "Definitsiooni toomine ebaõnnestus",
     "errorProcessAnalytics": "Analüütika töötlemine ebaõnnestus",
     "errorDownloading": "Laadimine ebaõnnestus",
-    "errorLoadingSpaceChildren": "Vestluste laadimine selles ruumis ebaõnnestus",
-    "unexpectedError": "Ootamatu viga.",
-    "pleaseReload": "Palun laadi leht uuesti ja proovi uuesti.",
     "translationError": "Tõlkeviga",
     "check": "Kontrolli",
     "unableToFindRoom": "Selle koodiga vestlust või ruumi ei leitud. Palun proovi uuesti.",
@@ -3879,10 +3516,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3892,10 +3525,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -3979,14 +3608,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4003,10 +3624,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4019,15 +3636,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4175,14 +3784,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4196,14 +3797,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5426,10 +5019,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5470,10 +5059,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5546,10 +5131,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5819,47 +5400,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5879,19 +5420,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -5955,10 +5484,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -5999,14 +5524,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6018,14 +5535,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6063,10 +5572,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6083,27 +5588,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6227,10 +5716,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6240,10 +5725,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6260,14 +5741,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6407,18 +5880,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6467,10 +5928,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6480,18 +5937,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6513,19 +5958,14 @@
     "request": "Päring",
     "requestAll": "Pärida kõiki",
     "confirmMessageUnpin": "Oled sa kindel, et soovid selle sõnumi lahti ühendada?",
-    "saveAndLaunch": "Salvesta ja käivita",
-    "launchToSpace": "Käivita kursusele",
     "pending": "Ootel",
     "inactive": "Mitteaktiivne",
-    "confirmRole": "Kinnita roll",
     "openRoleLabel": "AVATUD",
     "finishedTheActivity": "🎯 {username} lõpetas selle tegevuse",
     "activitySummaryError": "Tegevuste kokkuvõtteid pole saadaval",
     "requestSummaries": "Paluda kokkuvõtteid",
-    "generatingNewActivities": "Olete selle keelepaari esimene kasutaja! Palun andke meile hetk, valmistame teile tegevusi.",
     "requestAccessTitle": "Küsi analüütika ligipääsu?",
     "requestAccessDesc": "Kas soovite taotleda juurdepääsu osalejate analüütikate vaatamiseks?\n\nKui osalejad nõustuvad, saavad selle kursuse administraatorid näha nende:\n    • kogu sõnavara\n    • kogu grammatikakontseptsioone\n    • kogu tehtud tegevussessioone\n    • kasutatud, õigesti ja valesti grammatikakontseptsioone\n\nNad ei näe:\n    • sõnumeid väljaspool kursust vestlustes\n    • sõnavara nimekirja",
-    "requestAccess": "Taotle juurdepääsu ({count})",
     "analyticsInactiveTitle": "Päringuid mitteaktiivsete kasutajate jaoks ei saadetud",
     "analyticsInactiveDesc": "Mitteaktiivsed kasutajad, kes pole sellest funktsioonist alates sisse loginud, ei näe teie taotlust.\n\nPäringu nupp ilmub, kui nad naasevad. Saate taotluse uuesti saata, klõpsates nupul 'Päring' nende nime all, kui see on saadaval.",
     "accessRequestedTitle": "Juurdepääsu analüütikatele taotlus",
@@ -6548,8 +5988,6 @@
     "accessDesc": "Saate teha oma kursuse avatud maailmale! Või muuda oma kursus privaatseks ja turvaliseks.",
     "createGroupChatDesc": "Kuna tegevussessioonid algavad ja lõpevad, jäävad grupivestlused avatuks regulaarseks suhtlemiseks.",
     "deleteDesc": "Ainult administraatorid saavad kursust kustutada. See on hävitav tegevus, mis eemaldab kõik kasutajad ja kustutab kõik valitud vestlused kursuse sees. Olge ettevaatlik.",
-    "noCourseFound": "Oh, sellele kursusele on vaja plaani!\n\nKursuse plaanid on teemade ja vestlusaktiviteetide jada.",
-    "additionalParticipants": "+ {num} teist",
     "whatNow": "Mis nüüd?",
     "chooseNextActivity": "Valige oma järgmine tegevus!",
     "letsGo": "Lähme",
@@ -6562,13 +6000,11 @@
     "waitNotDone": "Oota, ma ei ole veel valmis!",
     "waitingForOthersToFinish": "Ootan, kuni teised lõpetavad...",
     "generatingSummary": "Vestluse analüüs ja tulemuste genereerimine",
-    "findCourse": "Leia kursus",
     "pingParticipantsNotification": "{user} otsib kasutajaid tegevusnõupidamisse {room}",
     "course": "Kursus",
     "courses": "Kursused",
     "goToCourse": "Mine kursusele: {course}",
     "activityComplete": "See tegevus on lõpetatud. Tegevuse kokkuvõte peaks olema allpool saadaval.",
-    "startNewSession": "Alusta uut sessiooni",
     "joinOpenSession": "Liitu avatud sessiooniga",
     "activityNotFound": "Tegevust ei leitud",
     "myActivities": "Minu tegevused",
@@ -6642,23 +6078,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6682,10 +6106,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6693,14 +6113,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6805,18 +6217,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6869,10 +6269,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6899,10 +6295,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7083,7 +6475,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Kontrollige hommikul uuesti tegevuse uuenduste jaoks.",
-    "activityDropdownDesc": "Kui olete selle tegevusega valmis, klõpsake allpool",
     "languageMismatchTitle": "Keele sobimatus",
     "languageMismatchDesc": "Teie sihtkeel ei vasta selle tegevuse keelele. Kas soovite oma sihtkeelt uuendada?",
     "reportWordIssueTooltip": "Teata sõna teabega seotud probleemist",
@@ -7096,10 +6487,6 @@
     "selectAll": "Vali kõik",
     "deselectAll": "Tühista valik",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7148,17 +6535,11 @@
         "placeholders": {}
     },
     "startOwn": "Alusta oma",
-    "joinCourseDesc": "Igal kursusel on 8-10 järjestikust teemat koos erinevate ülesandepõhiste keeleõppetegevustega.",
     "newMessageInPangeaChat": "🗨️ Uus sõnum Pangea vestluses",
     "shareCourse": "Jaga kursust",
     "addCourse": "Lisa kursus",
-    "joinPublicCourse": "Liitu avaliku kursusega",
     "vocabLevelsDesc": "Siia lähevad sõnad, kui oled need tasemele tõstnud!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7171,10 +6552,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7193,7 +6570,6 @@
     "emojiView": "Emotikonide vaade",
     "feedbackDialogDesc": "Mina teen ka vigu! Kas on midagi, mis aitaks mul paremaks saada?",
     "contactHasBeenInvitedToTheCourse": "Kontakt on kutsutud kursusele",
-    "activityStatsButtonTooltip": "Tegevuse info",
     "allow": "Luba",
     "deny": "Keela",
     "enabledRenewal": "Luba tellimuse uuendamine",
@@ -7461,10 +6837,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8520,16 +7892,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Tegevused järgmise teema avamiseks",
-    "activitiesToUnlockTopicDesc": "Määrake tegevuste arv järgmise kursuse teema avamiseks",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Õige sõnavara määratlemise harjutus",
     "constructUseIncLMDesc": "Vale sõnavara määratlemise harjutus",
     "constructUseCorLADesc": "Õige sõnavara heliharjutus",
@@ -8537,7 +7899,6 @@
     "constructUseBonus": "Boonus sõnavara harjutamise ajal",
     "practiceVocab": "Harjuta sõnavara",
     "selectMeaning": "Vali tähendus",
-    "selectAudio": "Vali sobiv heli",
     "anotherRound": "Veel üks voor",
     "activitySettingsOverrideWarning": "Keele ja keele taseme määrab tegevusplaan",
     "voice": "Hääl",
@@ -8569,10 +7930,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8590,12 +7947,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Allalaadimine algatatud",
     "webDownloadPermissionMessage": "Kui teie brauser blokeerib allalaadimisi, lubage palun selle saidi jaoks allalaadimised.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8690,11 +8042,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Midagi läks valesti ja me teeme kõvasti tööd, et see parandada. Kontrolli hiljem uuesti.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Luba kirjutamise abi",
     "autoIGCToolDescription": "Käivita automaatselt Pangea Chat tööriistad, et parandada saadetud sõnumid sihtkeelde.",
     "@autoIGCToolName": {
@@ -8750,24 +8097,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Grammatika",
-    "spanTypeWordChoice": "Sõnavalik",
     "spanTypeSpelling": "Õigekiri",
     "spanTypePunctuation": "Interpunktsioon",
     "spanTypeStyle": "Stiil",
     "spanTypeFluency": "Sujuvus",
     "spanTypeAccents": "Aksendid",
     "spanTypeCapitalization": "Suurtähed",
-    "spanTypeCorrection": "Parandus",
     "spanFeedbackTitle": "Teata paranduse probleemist",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8792,10 +8128,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8804,13 +8136,9 @@
     "clientWellKnownInformation": "Kliendi hästi teada olev teave:",
     "baseUrl": "Põhi-URL",
     "identityServer": "Identiteediserver:",
-    "versionWithNumber": "Versioon: {version}",
     "logs": "Logid",
-    "advancedConfigs": "Täiustatud seaded",
     "advancedConfigurations": "Täiustatud konfiguratsioonid",
-    "signInWithLabel": "Logi sisse koos:",
     "selectAllWords": "Vali kõik sõnad, mida kuulad helifailist",
-    "joinCourseForActivities": "Liitu kursusega, et proovida tegevusi.",
     "@federationBaseUrl": {
         "type": "String",
         "placeholders": {}
@@ -8827,19 +8155,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8847,15 +8163,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9056,11 +8364,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Klassis? Pane oma liitumiskood siia.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automaatne helisõnumite esiletõstmine",
     "selectAudioMessagesOnPlayDescription": "Helisõnumid esitatuna automaatselt esile tõsta",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9104,18 +8407,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Selles kursuses on teemasid, kus on vähem kui {input} tegevust. Palun sisestage number, mis on väiksem või võrdne {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Klõpsa siin, et uuesti sisse logida.",
     "@clickToLogin": {
@@ -9532,17 +8823,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Koomiline kollane karu, kelle käed on elevusest üles tõstetud.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Vali sõnad, et neist rohkem teada saada",
     "requireAnalyticsAccessTitle": "Nõua analüütika juurdepääsu liitumiseks",
     "requireAnalyticsAccessDesc": "Osalejad peavad andma juurdepääsu oma õpikogemuse analüütikale, et liituda selle kursusega",
     "analyticsAccessNoticeTitle": "Nõutav analüütika juurdepääs",
     "analyticsAccessNoticeDesc": "Liitudes selle kursusega, nõustute andma administraatoritele juurdepääsu oma õpikogemuse analüütikale.",
-    "skipOnboardingClassCodeDesc": "Õpid iseseisvalt? Ära muretse, sa saad:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9560,10 +8845,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9592,7 +8873,6 @@
     "pickCefrLevelTeacherStepTitle": "Millisel tasemel sa õpetad?",
     "pickCefrLevelStudentStepTitle": "Millisel tasemel sa oled?",
     "customCourseStepTitle": "Täida see vorm, et saada kohandatud kursus",
-    "aboutYourClass": "Teie klassist",
     "courseCodeStepErrorMessage": "Palun kontrollige oma koodi ja proovige uuesti",
     "institution": "Asutus",
     "courseGoals": "Kursuse eesmärgid",
@@ -9635,10 +8915,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9755,12 +9031,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logo",
     "introChatDetails": "Tere! Tutvustage end oma kursuse kaasosalejatele, leidke sõpru ja vestelge tegevustest väljaspool.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9804,11 +9075,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Tegevuse toimingud",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Hääldustööriistad",
     "audioTranscription": "AI helisalvestus",
     "visualLearnerSupport": "Visuaalse õppija tugi",
@@ -9849,7 +9115,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Liitu kursusega, mis sisaldab seda tegevust, et seda mängida.",
     "resizeCoursePanel": "Kursuse paneeli suuruse muutmine",
     "undo": "Tühista",
     "unlock": "Avage",
@@ -9863,7 +9128,6 @@
     "addCourseBrowsePublic": "Sirvi avalikke kursusi",
     "browsePublicCourses": "Sirvi avalikke kursusi",
     "editProfile": "Muuda profiili",
-    "numObjectives": "{count} eesmärki",
     "mapSearchHint": "Otsi tegevusi",
     "mapSearchNoResults": "Vaates ei ole vasteid",
     "mapFilterAllLanguages": "Kõik keeled",
@@ -9872,7 +9136,6 @@
     "mapFilterCompleted": "Lõpetatud",
     "mapFilterReset": "Lähtesta",
     "activityTypeConversation": "Vestlus",
-    "lockedMissionRequirement": "Eelmise missiooni lõpetamiseks, et avada",
     "playAgain": "Mängi uuesti",
     "reviewActivity": "Ülevaade",
     "mapEmptyInView": "Sinu tasemel või keeles ei ole siin midagi. Laienda oma filtreid või suumi välja.",
@@ -9887,14 +9150,9 @@
     "scrollToBottom": "Kerige alla",
     "courseImage": "Kursuse pilt",
     "avatarPreview": "Avatar eelvaade",
-    "activityPhoto": "Tegevuse foto",
     "emotePreview": "Emote eelvaade: {name}",
     "activityLabel": "Tegevus: {title}",
     "resetMapView": "Lähtesta kaardi vaade",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9947,14 +9205,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9984,10 +9234,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10044,10 +9290,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_eu.arb
+++ b/lib/l10n/intl_eu.arb
@@ -63,11 +63,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Batu daitezke bisitan dauden erabiltzaileak?",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Ziur zaude?",
     "@areYouSure": {
         "type": "String",
@@ -323,11 +318,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Kontaktua taldera gonbidatu da",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "copiedToClipboard": "Arbelera kopiatu da",
     "@copiedToClipboard": {
         "type": "String",
@@ -452,11 +442,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Ezingo duzu zifratzea ezgaitu. Ziur zaude?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encryption": "Zifratzea",
     "@encryption": {
         "type": "String",
@@ -503,11 +488,6 @@
     },
     "group": "Taldea",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Taldea publikoa da",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -566,15 +546,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Gonbidatu kontaktua {groupName}(e)ra",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Gonbidatuta",
     "@invited": {
@@ -682,15 +653,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Kargatu {count} partaide gehiago",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Kargatzen… itxaron.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -705,15 +667,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Hasi saioa {homeserver}(e)n",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Amaitu saioa",
     "@logout": {
@@ -752,11 +705,6 @@
     },
     "noEmotesFound": "Ez da emoterik aurkitu. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Ez dirudi Firebase Cloud Messaging zure mugikorrean erabilgarri dagoenik. Jakinarazpenak jasotzeko ntfy instalatzea gomendatzen dugu. ntfy edo beste Unified Push hornitzaileren batekin, push jakinarazpenak jaso ditzazkezu datuentzako segurua den modu batean. ntfy PlayStore edo F-Droid dendetatik deskarga dezakezu.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -890,11 +838,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Kendu gailua",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Kendu txatean duen debekua",
     "@unbanFromChat": {
@@ -1204,16 +1147,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Bideo-deia",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Txat-historiaren ikusgaitasuna",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Partaide guztientzat ikusgai",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1246,11 +1179,6 @@
     },
     "wallpaper": "Horma-irudia:",
     "@wallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Nor batu daiteke talde honetara?",
-    "@whoIsAllowedToJoinThisGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1293,8 +1221,6 @@
     "@emojis": {},
     "placeCall": "Egin deia",
     "@placeCall": {},
-    "voiceCall": "Ahozko deia",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "Android bertsioa ez da bateragarria",
     "@unsupportedAndroidVersion": {},
     "unsupportedAndroidVersionLong": "Funtzio honek Android bertsio berriago bat behar du. Egiaztatu eguneraketak ote dauden edo begiratu Lineage OS-ek zure gailuarentzat aukerarik eskaintzen duen.",
@@ -1334,11 +1260,6 @@
         "type": "String",
         "description": "Usage hint for the command /send"
     },
-    "createNewSpace": "Gune berria",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "editBlockedServers": "Editatu blokeatutako zerbitzariak",
     "@editBlockedServers": {
         "type": "String",
@@ -1369,11 +1290,6 @@
                 "type": "String"
             }
         }
-    },
-    "everythingReady": "Dena prest!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
     },
     "extremeOffensive": "Izugarri iraingarria",
     "@extremeOffensive": {
@@ -1411,8 +1327,6 @@
     },
     "oneClientLoggedOut": "Zure gailuetako batek saioa amaitu du",
     "@oneClientLoggedOut": {},
-    "addAccount": "Gehitu kontua",
-    "@addAccount": {},
     "editBundlesForAccount": "Editatu kontu honetarako sortak",
     "@editBundlesForAccount": {},
     "oopsPushError": "Hara! Zoritxarrez, errore bat gertatu da push jakinarazpenak ezartzerakoan.",
@@ -1430,17 +1344,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unreadChats": "{unreadCount, plural, =1{irakurri gabeko txat 1} other {irakurri gabeko {unreadCount} txat}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
-    "videoCallsBetaWarning": "Kontuan izan bideo-deiak beta fasean daudela. Litekeena da behar bezala erabili ezin izatea —erabili ahal badira—.",
-    "@videoCallsBetaWarning": {},
     "all": "Guztia",
     "@all": {
         "type": "String",
@@ -1453,10 +1356,6 @@
     },
     "experimentalVideoCalls": "Bideo-dei esperimentalak",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "ePosta edo erabiltzaile-izena",
-    "@emailOrUsername": {},
-    "enableMultiAccounts": "(BETA) Gaitu kontu bat baino gehiago gailu honetan",
-    "@enableMultiAccounts": {},
     "openVideoCamera": "Ireki kamera bideorako",
     "@openVideoCamera": {
         "type": "String",
@@ -1589,11 +1488,6 @@
     },
     "chatBackup": "Txataren babeskopia",
     "@chatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "Txat zaharrak berreskuratze-gako batekin daude babestuta. Ez galdu gako hori.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -1745,8 +1639,6 @@
     "@confirmEventUnpin": {},
     "markAsRead": "Markatu irakurritzat",
     "@markAsRead": {},
-    "yourChatBackupHasBeenSetUp": "Txaten babeskopiak ezarri dira.",
-    "@yourChatBackupHasBeenSetUp": {},
     "clearArchive": "Ezabatu artxiboa",
     "@clearArchive": {},
     "commandHint_html": "Bidali testua HTML formatuan",
@@ -1864,11 +1756,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "noEncryptionForPublicRooms": "Zifratzea aktiba dezakezu soilik gelak publikoa izateari utzi badio.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "noMatrixServer": "{server1} ez da matrix zerbitzari bat, {server2} erabili nahi duzu haren ordez?",
     "@noMatrixServer": {
         "type": "String",
@@ -1922,11 +1809,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "passwordRecovery": "Pasahitzaren berreskurapena",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "people": "Jendea",
     "@people": {
         "type": "String",
@@ -1966,11 +1848,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Ezarri baimen-maila",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "shareLocation": "Partekatu kokapena",
     "@shareLocation": {
         "type": "String",
@@ -1981,16 +1858,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceIsPublic": "Gunea publikoa da",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Gunearen izena",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "synchronizingPleaseWait": "Sinkronizatzen… itxaron.",
     "@synchronizingPleaseWait": {
         "type": "String",
@@ -1998,11 +1865,6 @@
     },
     "tooManyRequestsWarning": "Eskaera gehiegi. Saiatu berriro geroago!",
     "@tooManyRequestsWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "transferFromAnotherDevice": "Beste gailu batetik transferitu",
-    "@transferFromAnotherDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -2028,22 +1890,10 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Nork zer egin dezakeen",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Ezabatu txataren babeskopia berreskuratze-gako berria sortzeko?",
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "messageInfo": "Mezuaren xehetasunak",
     "@messageInfo": {},
     "sender": "Igorlea",
     "@sender": {},
-    "removeFromSpace": "Kendu gunetik",
-    "@removeFromSpace": {},
     "start": "Hasi",
     "@start": {},
     "publish": "Argitaratu",
@@ -2137,26 +1987,14 @@
     "@widgetNameError": {},
     "errorAddingWidget": "Errorea widgeta gehitzerakoan.",
     "@errorAddingWidget": {},
-    "pleaseEnterRecoveryKey": "Sartu berreskuratze-gakoa:",
-    "@pleaseEnterRecoveryKey": {},
-    "recoveryKey": "Berreskuratze-gakoa",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Berreskuratze-gakoa galdu duzu?",
-    "@recoveryKeyLost": {},
     "users": "Erabiltzaileak",
     "@users": {},
-    "storeInAndroidKeystore": "Gorde Android KeyStore-n",
-    "@storeInAndroidKeystore": {},
     "dehydrate": "Esportatu saioa eta ezabatu gailua",
     "@dehydrate": {},
     "dehydrateWarning": "Ekintza hau ezin da desegin. Egiaztatu babeskopia toki seguruan gorde duzula.",
     "@dehydrateWarning": {},
     "hydrate": "Lehengoratu babeskopia bat erabiliz",
     "@hydrate": {},
-    "pleaseEnterRecoveryKeyDescription": "Mezu zaharrak ikusi ahal izateko, sartu aurreko saioan sortu zen berreskuratze-gakoa. Berreskuratze-gakoa EZ da zure pasahitza.",
-    "@pleaseEnterRecoveryKeyDescription": {},
-    "storeSecurlyOnThisDevice": "Gorde gailu honetan modu seguruan",
-    "@storeSecurlyOnThisDevice": {},
     "countFiles": "{count} fitxategi",
     "@countFiles": {
         "placeholders": {
@@ -2169,14 +2007,6 @@
     "@user": {},
     "custom": "Neurrira egindakoa",
     "@custom": {},
-    "storeInSecureStorageDescription": "Gorde berreskuratze-gakoa gailu honetako biltegiratze seguruan.",
-    "@storeInSecureStorageDescription": {},
-    "storeInAppleKeyChain": "Gorde Apple KeyChain-en",
-    "@storeInAppleKeyChain": {},
-    "unlockOldMessages": "Desblokeatu mezu zaharrak",
-    "@unlockOldMessages": {},
-    "saveKeyManuallyDescription": "Gorde eskuz gako hau gailuko partekatze-menua edo arbela erabiliz.",
-    "@saveKeyManuallyDescription": {},
     "confirmMatrixId": "Baieztatu zure Matrix IDa kontua ezabatu ahal izateko.",
     "@confirmMatrixId": {},
     "newSpace": "Gune berria",
@@ -2187,12 +2017,6 @@
     "@allSpaces": {},
     "newGroup": "Talde berria",
     "@newGroup": {},
-    "enterSpace": "Sartu gunera",
-    "@enterSpace": {},
-    "screenSharingTitle": "pantaila-partekatzea",
-    "@screenSharingTitle": {},
-    "screenSharingDetail": "Pantaila FluffyChaten partekatzen ari zara",
-    "@screenSharingDetail": {},
     "noKeyForThisMessage": "Mezua gailu honetan saioa hasi baino lehen bidali bazen gertatu daiteke.\n\nBeste aukera bat igorleak zure gailua blokeatu izana da, edo zerbaitek huts egin izana interneteko konexioan.\n\nMezua beste saio batean irakur dezakezu? Hala bada, mezua transferitu dezakezu! Zoaz Ezrpenetara > Gailuak eta baieztatu zure gailuek bata bestea egiaztatu dutela. Gela irekiko duzun hurrengo aldian eta bi saioak aurreko planoan irekita daudenean, gakoak automatikoki partekatuko dira.\n\nEz duzu gakorik galdu nahi saioa amaitu edo gailuak aldatzen dituzunean? Baieztatu ezarpenetan txaten babeskopiak gaituta dituzula.",
     "@noKeyForThisMessage": {},
     "supposedMxid": "Hau {mxid} izan behar da",
@@ -2206,8 +2030,6 @@
     },
     "commandHint_markasgroup": "Markatu talde bezala",
     "@commandHint_markasgroup": {},
-    "foregroundServiceRunning": "Jakinarazpen hau zerbitzua martxan dagoenean agertzen da.",
-    "@foregroundServiceRunning": {},
     "commandHint_markasdm": "Markatu mezu-zuzen gela bezala Matrix ID jakin honentzat",
     "@commandHint_markasdm": {},
     "wasDirectChatDisplayName": "Txata hutsik dago ({oldDisplayName} zen lehen)",
@@ -2229,12 +2051,6 @@
     "@fileIsTooBigForServer": {},
     "noOtherDevicesFound": "Ez da beste gailurik aurkitu",
     "@noOtherDevicesFound": {},
-    "newSpaceDescription": "Guneek txatak taldekatzea ahalbidetzen dute eta komunitate pribatu edo publikoak osatzea.",
-    "@newSpaceDescription": {},
-    "disableEncryptionWarning": "Segurtasun arrazoiak direla-eta, ezin duzu lehendik zifratuta zegoen txat bateko zifratzea ezgaitu.",
-    "@disableEncryptionWarning": {},
-    "encryptThisChat": "Zifratu txata",
-    "@encryptThisChat": {},
     "commandHint_hug": "Bidali besarkada",
     "@commandHint_hug": {},
     "hugContent": "{senderName}(e)k besarkatu zaitu",
@@ -2246,8 +2062,6 @@
             }
         }
     },
-    "sorryThatsNotPossible": "Barka… hori ez da posible",
-    "@sorryThatsNotPossible": {},
     "reopenChat": "Ireki txata berriro",
     "@reopenChat": {},
     "commandHint_googly": "Bidali begi dibertigarri batzuk",
@@ -2313,8 +2127,6 @@
     "@tryAgain": {},
     "messagesStyle": "Mezuak:",
     "@messagesStyle": {},
-    "chatDescription": "Txataren deskribapena",
-    "@chatDescription": {},
     "invalidServerName": "Zerbitzari-izenak ez du balio",
     "@invalidServerName": {},
     "chatPermissions": "Txataren baimenak",
@@ -2368,8 +2180,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "Ezarri gaia:",
-    "@setTheme": {},
     "createGroup": "Sortu taldea",
     "@createGroup": {},
     "invite": "Gonbidatu",
@@ -2406,12 +2216,8 @@
     "@pleaseEnterANumber": {},
     "kickUserDescription": "Erabiltzailea txatetik kanporatu da baina ez zaio debekua ezarri. Txat publikoen kasuan, edozein momentutan batu daiteke berriro.",
     "@kickUserDescription": {},
-    "createGroupAndInviteUsers": "Sortu talde bat eta gonbidatu partaideak",
-    "@createGroupAndInviteUsers": {},
     "startConversation": "Hasi elkarrizketa",
     "@startConversation": {},
-    "groupCanBeFoundViaSearch": "Bilaketa erabiliz aurkitu daiteke taldea",
-    "@groupCanBeFoundViaSearch": {},
     "noUsersFoundWithQuery": "Zoritxarrez ez da \"{query}\" duen erabiltzailerik aurkitu. Egiaztatu zuzen idatzi duzula.",
     "@noUsersFoundWithQuery": {
         "type": "String",
@@ -2429,8 +2235,6 @@
     "@wrongRecoveryKey": {},
     "groupName": "Taldearen izena",
     "@groupName": {},
-    "searchChatsRooms": "Bilatu #txatak, @erabiltzaileak…",
-    "@searchChatsRooms": {},
     "blockListDescription": "Gogaitzen zaituzten erabiltzaileak blokeatu ditzakezu. Ez duzu blokeatutakoen zerrendan dituzun erabiltzaileen mezurik edo gelara batzeko gonbidapenik jasoko.",
     "@blockListDescription": {},
     "blockedUsers": "Blokeatutako erabiltzaileak",
@@ -2461,8 +2265,6 @@
     "@select": {},
     "pleaseChooseAStrongPassword": "Aukeratu pasahitz sendo bat",
     "@pleaseChooseAStrongPassword": {},
-    "addChatOrSubSpace": "Gehitu txata edo azpi-gunea",
-    "@addChatOrSubSpace": {},
     "leaveEmptyToClearStatus": "Utzi hutsik zure egoera garbitzeko.",
     "@leaveEmptyToClearStatus": {},
     "joinSpace": "Batu gunera",
@@ -2475,30 +2277,6 @@
     "@decline": {},
     "initAppError": "Errorea aplikazioa abiaraztean",
     "@initAppError": {},
-    "sessionLostBody": "Zure saioa galdu da. Jakinarazi errorea garatzaileei {url} helbidean. Errorearen mezua ondorengoa da: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Aplikazioa babeskopia erabiliz saioa leheneratzen saiatuko da. Jakinarazi errorea garatzaileei {url} helbidean. Errorearen mezua ondorengoa da: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "transparent": "Gardena",
     "@transparent": {},
     "sendReadReceipts": "Bidali irakurri izanaren agiria",
@@ -2556,14 +2334,10 @@
     },
     "verifyOtherDeviceDescription": "Beste gailu bat egiaztatzean, gailu horiek gakoak truka ditzakete, eta segurtasun orokorra handitu. 💪 Egiaztapena hasten duzunean, laster-leiho bat agertuko da bi gailuetan. Bertan, elkarrekin alderatu behar diren emoji edo zenbaki batzuk ikusiko dituzu. Hobe da bi gailuak eskura izatea egiaztapena hasi aurretik. 🤳",
     "@verifyOtherDeviceDescription": {},
-    "verifyOtherUserDescription": "Beste erabiltzaile bat egiaztatzen baduzu, ziur egon zaitezke nori idazten ari zaren. 💪\n\nEgiaztapena hasten duzunean, zuk eta beste erabiltzaileak laster-leiho bat ikusiko duzue aplikazioan. Bertan, elkarrekin alderatu behar diren emoji edo zenbaki batzuk erakutsiko dira.\n\nBideo-dei bat hastea edo aurrez-aurre batzea da horretarako modurik onena. 👭",
-    "@verifyOtherUserDescription": {},
     "formattedMessagesDescription": "Erakutsi mezu aberatsen edukia markdown erabiliz, testu lodia esaterako.",
     "@formattedMessagesDescription": {},
     "sendTypingNotificationsDescription": "Txateko beste partaideek mezu berri bat idazten ari zarela ikus dezakete.",
     "@sendTypingNotificationsDescription": {},
-    "verifyOtherUser": "🔐 Egiaztatu beste erabiltzaile bat",
-    "@verifyOtherUser": {},
     "startedKeyVerification": "{sender}(e)k gakoen egiaztapena hasi du",
     "@startedKeyVerification": {
         "type": "String",
@@ -2604,21 +2378,10 @@
     },
     "noDatabaseEncryption": "Plataforma honetan ezin da datu-basea zifratu",
     "@noDatabaseEncryption": {},
-    "usersMustKnock": "Erabiltzaileek baimena eskatu behar dute",
-    "@usersMustKnock": {},
     "knock": "Eskatu baimena",
     "@knock": {},
     "knocking": "Baimena eskatzen",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Txata {server}(e)n bilaketa eginez aurkitu daiteke",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "thereAreCountUsersBlocked": "Une honetan {count} erabiltzaile daude blokeatuta.",
     "@thereAreCountUsersBlocked": {
         "type": "String",
@@ -2626,10 +2389,6 @@
     },
     "appLockDescription": "Blokeatu aplikazioa pin kode batekin erabiltzen ari ez zarenean",
     "@appLockDescription": {},
-    "accessAndVisibility": "Sarbidea eta ikusgaitasuna",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Nork du txat honetara batzeko baimena eta nola aurkitu daiteke txata.",
-    "@accessAndVisibilityDescription": {},
     "customEmojisAndStickers": "Emoji eta pegatina propioak",
     "@customEmojisAndStickers": {},
     "customEmojisAndStickersBody": "Gehitu edo partekatu edozein txatetan erabil daitezkeen emoji edo pegatina propioak.",
@@ -2644,16 +2403,8 @@
     "@overview": {},
     "passwordRecoverySettings": "Pasahitza berreskuratzeko ezarpenak",
     "@passwordRecoverySettings": {},
-    "globalChatId": "Txat ID orokorra",
-    "@globalChatId": {},
     "calls": "Deiak",
     "@calls": {},
-    "noOneCanJoin": "Ezin da inor batu",
-    "@noOneCanJoin": {},
-    "publicChatAddresses": "Txataren helbide publikoak",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Sortu helbide berria",
-    "@createNewAddress": {},
     "files": "Fitxategiak",
     "@files": {},
     "gallery": "Galeria",
@@ -2762,14 +2513,6 @@
     "@sendCanceled": {},
     "noChatsFoundHere": "Ez da txatik aurkitu. Hasi norbaitekin txateatzen beheko botoia erabiliz. ⤵️",
     "@noChatsFoundHere": {},
-    "homeserverDescription": "Zerbitzariak datuak gordetzen ditu, ePosta hornitzaileek mezuak gordetzen dituzten bezala. Nahi duzun zerbitzaria aukeratu dezakezu eta, hala ere, besteetako edonorekin hitz egin. Ikasi gehiago https://matrix.org webgunean.",
-    "@homeserverDescription": {},
-    "loginWithMatrixId": "Hasi saioa Matrix IDarekin",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Arakatu zerbitzariak",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Zer da zerbitzari bat?",
-    "@whatIsAHomeserver": {},
     "doesNotSeemToBeAValidHomeserver": "Ez dirudi zerbitzaria bateragarria denik. Zuzena da URLa?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "calculatingFileSize": "Fitxategiaren tamaina kalkulatzen…",
@@ -2809,16 +2552,12 @@
     "@noticeChatBackupDeviceVerification": {},
     "opacity": "Opakutasuna:",
     "@opacity": {},
-    "manageAccount": "Kudeatu kontua",
-    "@manageAccount": {},
     "setWallpaper": "Ezarri horma-irudia",
     "@setWallpaper": {},
     "blur": "Lausotu:",
     "@blur": {},
     "continueText": "Jarraitu",
     "@continueText": {},
-    "welcomeText": "Ieup 👋 Ongi etorri FluffyChat-era. https://matrix.org-rekin bateragarria den edozein zerbitzaritan hasi dezakezu saioa eta edonorekin txateatu. Mezularitza-sare deszentralizatu eraraldoia da!",
-    "@welcomeText": {},
     "contactServerAdmin": "Jarri harremanetan zerbitzariaren administratzailearekin",
     "@contactServerAdmin": {},
     "aboutHomeserver": "{homeserver}(e)ri buruz",
@@ -2873,17 +2612,6 @@
     "@previous": {},
     "otherPartyNotLoggedIn": "Besteak ez du saiorik hasita eta, beraz, ezin du mezurik jaso!",
     "@otherPartyNotLoggedIn": {},
-    "appWantsToUseForLogin": "Erabili '{server}' saioa hasteko",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Honenbestez, aplikazioak eta webguneak zuri buruzko informazioa partekatzea baimentzen duzu.",
-    "@appWantsToUseForLoginDescription": {},
     "open": "Ireki",
     "@open": {},
     "generalNotificationSettings": "Jakinarazpen orokorren ezarpenak",
@@ -2910,8 +2638,6 @@
     "@otherNotificationSettings": {},
     "waitingForServer": "Zerbitzariaren zain…",
     "@waitingForServer": {},
-    "appIntroduction": "FluffyChatek mezularitza-programa desberdinak erabiltzen dituzten lagunekin txateatzea ahalbidetzen dizu. Ikasi gehiago https://matrix.org estekan edo sakatu *Jarraitu*.",
-    "@appIntroduction": {},
     "synchronizingPleaseWaitCounter": " Sinkronizatzen… (%{percentage})",
     "@synchronizingPleaseWaitCounter": {
         "type": "String",
@@ -3044,15 +2770,6 @@
     "@pleaseWaitUntilInvited": {},
     "checkList": "Kontrol-zerrenda",
     "@checkList": {},
-    "countInvited": "{count} gonbidatu",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "sentVoiceMessage": "🎙️ {duration} - {sender}(r)en ahots-mezua",
     "@sentVoiceMessage": {
         "type": "String",
@@ -3085,38 +2802,12 @@
     "@pause": {},
     "resume": "Jarraitu",
     "@resume": {},
-    "moveToDifferentSpace": "Beste gune batera mugitu",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "Txata gunetik kenduko da, baina txaten zerrendan mantenduko da.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} txat",
     "@countChats": {
         "type": "String",
         "placeholders": {
             "chats": {
                 "type": "int"
-            }
-        }
-    },
-    "donate": "Egin dohaintza",
-    "@donate": {},
-    "newSubSpace": "Azpi-gune berria",
-    "@newSubSpace": {},
-    "spaceMemberOf": "{spaces} guneko kidea",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "{spaces} guneko kideak sartzeko baimena eska dezake",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
             }
         }
     },
@@ -3183,14 +2874,6 @@
     "@createSticker": {},
     "attribution": "Sortzailea",
     "@attribution": {},
-    "skipChatBackup": "Ez egin txataren babeskopia",
-    "@skipChatBackup": {},
-    "skipChatBackupWarning": "Ziur? Txataren babeskopia gaitzen ez baduzu, gailuz aldatuz gero mezuen sarbidea gal zenezake.",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "Mezuak kargatzen",
-    "@loadingMessages": {},
-    "setupChatBackup": "Ezarri txataren babeskopia",
-    "@setupChatBackup": {},
     "useAsSticker": "Erabili pegatina gisa",
     "@useAsSticker": {},
     "stickerPackNameAlreadyExists": "Pegatina-sortaren izena badago lehendik ere",
@@ -3207,11 +2890,9 @@
     "taTooltip": "L2 itzulpen laguntzarekin erabiltzeko",
     "interactiveTranslatorSliderHeader": "Interaktiboa Itzultzailea",
     "interactiveGrammarSliderHeader": "Interaktiboa Gramatika Egiaztatzailea",
-    "interactiveTranslatorRequired": "Beharrezkoa",
     "waTooltip": "Laguntzarik gabe erabiltzeko",
     "interactiveTranslator": "Itzulpen laguntza",
     "noIdenticalLanguages": "Mesedez, aukeratu hizkuntza oinarria eta helburua desberdinak izan daitezen",
-    "searchBy": "Bilatu herrialde eta hizkuntzen arabera",
     "joinWithClassCode": "Batu ikastaroan",
     "languageLevelPreA1": "Hasiberri Baxua (Pre A1)",
     "languageLevelA1": "Hasiberri Erdi (A1)",
@@ -3231,19 +2912,14 @@
     "whatIsYourBaseLanguage": "Zein da zure oinarrizko hizkuntza?",
     "publicProfileTitle": "Onartu nire profila bilaketetan agertzeko",
     "publicProfileDesc": "Gaituta, beste erabiltzaileek zure profila bilaketa globalean aurkitu eta chat eskaerak bidali ahal izango dituzte. Orain, eskaera onartu edo ukatu dezakezu.",
-    "errorDisableIT": "Itzulpen laguntza desgaituta dago.",
-    "errorDisableIGC": "Gramatika laguntza desgaituta dago.",
     "errorDisableITUserDesc": "Klikatu hemen itzulpen laguntza ezarpenak eguneratzeko",
     "errorDisableIGCUserDesc": "Klikatu hemen gramatika laguntza ezarpenak eguneratzeko",
     "errorDisableITClassDesc": "Itzulpen laguntza desgaituta dago ikastaro honetan dagoen chat-entzat.",
     "errorDisableIGCClassDesc": "Gramatika laguntza desgaituta dago ikastaro honetan dagoen chat-entzat.",
-    "error405Title": "Hizkuntzak ez daude ezarrita",
     "error405Desc": "Mesedez, ezarri zure hizkuntzak Nagusien Menuko > Ikaskuntza Ezarpenetan.",
     "termsAndConditions": " Baldintzak eta Baldintzak",
     "andCertifyIAmAtLeast13YearsOfAge": " eta ziurtatzen dut gutxienez 16 urte ditudala.",
-    "error502504Title": "Wow, ikasle asko daude linean!",
     "error502504Desc": "Itzulpen eta gramatika tresnak motel edo erabilgarri ez egon daitezke Pangea botak eguneratzen direnean.",
-    "error404Title": "Itzulpen errorea!",
     "error404Desc": "Pangea Botak ez du ziur nola itzuli hori...",
     "errorPleaseRefresh": "Begiratzen ari gara! Mesedez, kargatu berriro eta saiatu berriro.",
     "connectedToStaging": "Konektatuta Staging-era",
@@ -3281,13 +2957,9 @@
     "definitionsToolName": "Hitzaren Definizioak",
     "definitionsToolDescription": "Gaituta dagoenean, urdinez azpimarratutako hitzak klik egin daitezke definizioak ikusteko. Klik egin mezuei definizioak ikusteko.",
     "welcomeBack": "Ongi etorri berriro! 2023-2024ko pilotuaren parte bazina, jarri gurekin harremanetan zure pilotu espezifikoaren harpidetza lortzeko. Zure klasearentzat lizentziak erosi dituen irakaslea bazara (edo zure erakundeak erosi baditu), jarri gurekin harremanetan irakaslearen harpidetza lortzeko.",
-    "downloadTxtFile": "Deskargatu Testu Fitxategia",
-    "downloadCSVFile": "Deskargatu CSV Fitxategia",
     "promotionalSubscriptionDesc": "Une honetan promozio-eskubide bizia duzu. Laguntza lortzeko, mezua bidali support@pangea.chat helbidera zure harpidetza aldatzeko.",
     "originalSubscriptionPlatform": "Harpidetza {purchasePlatform} bidez erosi da",
     "oneWeekTrial": "Astebete Probako",
-    "downloadXLSXFile": "Deskargatu Excel Fitxategia",
-    "unkDisplayName": "Ezezaguna",
     "wwCountryDisplayName": "Munduan zehar",
     "afCountryDisplayName": "Afganistan",
     "axCountryDisplayName": "Aland uharteak",
@@ -3582,7 +3254,6 @@
     "chatCapacityHasBeenChanged": "Txat-ahalmena aldatu da",
     "chatCapacitySetTooLow": "Txat-ahalmena gutxienez {count} izan behar da.",
     "chatCapacityExplanation": "Txat-ahalmena chat batean onartzen diren kide kopurua mugatzen du.",
-    "tooManyRequest": "Eskari gehiegi, mesedez saiatu berriro beranduago.",
     "enterNumber": "Mesedez, sartu zenbaki osoa balio bat.",
     "practice": "Praktika",
     "versionNotFound": "Bertsiorik ez",
@@ -3592,7 +3263,6 @@
     "deleteSubscriptionWarningTitle": "Harpidetza aktibo duzu",
     "deleteSubscriptionWarningBody": "Zure kontua ezabatzeak ez du automatikoki zure harpidetza bertan behera utziko.",
     "manageSubscription": "Kudeatu Harpidetza",
-    "error520Title": "Saiatu berriro.",
     "error520Desc": "Barkatu, zure mezua ezin izan dugu ulertu...",
     "wordsUsed": "Erabilitako Hitzak",
     "level": "Maila",
@@ -3610,7 +3280,6 @@
     "other": "Beste",
     "levelShort": "LGA {level}",
     "noCapacityLimit": "Ez dago gaitasun mugarik",
-    "downloadGroupText": "Deskargatu talde testua",
     "notificationsOn": "Jakinarazpenak aktibo",
     "notificationsOff": "Jakinarazpenak desaktibatu",
     "joinWithCode": "Batu kodearekin",
@@ -3674,24 +3343,12 @@
     "whatIsTheMorphTag": "Zer da '{wordForm}'-ren {morphologicalFeature}?",
     "dataAvailable": "Datuen eskuragarritasuna",
     "available": "Eskuragarri",
-    "pangeaBotIsFallible": "Pangea Bot-ak ere akatsak egiten ditu!",
-    "whatIsMeaning": "Zer esan nahi du '{lemma}'-k?",
     "chooseLemmaMeaningInstructionsBody": "Baliokideen esanahiak hitzekin parekatu mezua irakurtzen!",
-    "doubleClickToEdit": "Egin klik bikoitza editatzeko.",
-    "topicLabel": "Gaia",
-    "topicPlaceholder": "Aukeratu gaia...",
-    "modePlaceholder": "Aukeratu modua...",
-    "learningObjectiveLabel": "Ikaskuntza Helburua",
-    "learningObjectivePlaceholder": "Aukeratu ikaskuntza helburua...",
-    "targetLanguageLabel": "Helburu hizkuntza",
     "cefrLevelLabel": "CEFR maila",
     "image": "Irudia",
     "video": "Bideoa",
     "nan": "Ez aplikagarria",
-    "addVocabulary": "Gehitu hiztegia",
     "instructions": "Argibideak",
-    "numberOfLearners": "Ikasleen kopurua",
-    "mustBeInteger": "Zenbaki osoa izan behar da, adibidez 1, 2, 3, ...",
     "constructUsePvmDesc": "Ahots mezu batean sortua",
     "leaveSpaceDescription": "Ikastaroa utziz, chat guztiak utziko dituzu bertan. Beste erabiltzaileek ikusi ahal izango dute ikastaroa utzi duzula.",
     "constructUseCorMmDesc": "Mezuaren esanahia zuzena",
@@ -3706,7 +3363,6 @@
     "ttsDisabledBody": "Gaitzeko testu-hizkuntzara itzultzeko aukera gaitzeko zure ikasketa ezarpenetan",
     "noSpaceDescriptionYet": "Oraindik ez da ikastaroaren deskribapenik sortu",
     "tooLargeToSend": "Mezu hau bidaltzeko oso handia da",
-    "exitWithoutSaving": "Ziur zaude gordailurik gabe irtengo zarela?",
     "enableAutocorrectPopupTitle": "Gehitu zure hizkuntza helburuaren teklatua honetara joanez:",
     "enableAutocorrectPopupSteps": "  • Ezarpenak\n  • Orokorra\n  • Teklatu\n  • Teklatuak\n  • Gehitu teklatu berria",
     "enableAutocorrectPopupDescription": "Hizkuntza aukeratu ondoren, teklatuaren behealdean ezkerreko globe ikono txikia klik egin dezakezu teklatu berria aktibatzeko.",
@@ -3717,11 +3373,8 @@
     "displayName": "Erakutsi izena",
     "leaveRoomDescription": "Chat hau utzi nahi duzu. Beste erabiltzaileek ikusi ahal izango dute chatetik alde egin duzula.",
     "confirmUserId": "Mesedez, berretsi zure Pangea Chat erabiltzaile-izena zure kontua ezabatzeko",
-    "startingToday": "Gaurtik aurrera",
-    "oneWeekFreeTrial": "Astebete doako proba",
     "paidSubscriptionStarts": "{startDate}tik aurrera",
     "cancelInSubscriptionSettings": "• Ezin duzu edozein momentutan bertan behera utzi harpidetza ezarpenetan",
-    "cancelToAvoidCharges": "• Utzi {trialEnds} baino lehen, kargak saihesteko",
     "downloadGboard": "Deskargatu Gboard",
     "autocorrectNotAvailable": "Zoritxarrez, zure plataforma ez da oraindik ezagutzen ez duen ezaugarria. Egon adi aurrerago garapenean!",
     "pleaseUpdateApp": "Mesedez, eguneratu aplikazioa jarraitzeko.",
@@ -3731,17 +3384,12 @@
     "knockSpaceSuccess": "Eskatu duzu ikastaro honetan parte hartzeko! Administratzaile batek erantzungo dizu eskaera jaso duenean 😃",
     "chooseWordAudioInstructionsBody": "Entzun mezua osorik. Ondoren, parekatu audioak hitzekin.",
     "chooseMorphsInstructionsBody": "Klikatu puzzle piezak gramatika galderak egiteko!",
-    "pleaseEnterInt": "Mesedez, sartu zenbaki bat",
     "home": "Hasiera",
     "join": "Parte hartu",
     "resetInstructionTooltipsTitle": "Berrezarri argibide-txertaketak",
     "resetInstructionTooltipsDesc": "Klik egin argibide-txertaketak erakusteko, erabiltzaile berri baten moduan.",
-    "randomize": "Ausazkoa",
     "clear": "Garbitu",
-    "featuredActivities": "Nabarmendutakoak",
     "save": "Gorde",
-    "startChat": "Hasi elkarrizketa",
-    "translationProblem": "Itzulpen arazoa",
     "askToJoin": "Galdetu bat egiteko",
     "emptyChatWarningTitle": "Chat hutsa da",
     "emptyChatWarningDesc": "Inor ez du gonbidatu zure chat-era. Joan chat ezarpenetara kontaktuak edo Bot gonbidatzeko. Hau geroago ere egin dezakezu.",
@@ -3771,17 +3419,13 @@
     "timesUsedIndependently": "Erabiltzeko aldizkakotasuna modu independentean",
     "timesUsedWithAssistance": "Laguntzarekin erabiltzeko aldizkakotasuna",
     "shareInviteCode": "Partekatu gonbidapen kodea: {code}",
-    "leaderboard": "Liderra taula",
     "skipForNow": "Utzi une honetan",
     "permissions": "Baimenak",
     "spaceChildPermission": "Nork gehitu dezake ikastaro honetan txate berriak",
-    "addEnvironmentOverride": "Gehitu ingurune gainkarga",
     "defaultOption": "Lehentasuna",
     "deleteChatDesc": "Ziur zaude txat hau ezabatu nahi duzula? Parte-hartzaile guztientzat ezabatuko da eta txataren mezu guztiak ez dira gehiago erabiliko praktikan edo ikasketa analitiketan.",
     "deleteSpaceDesc": "Ikastaroa eta aukeratutako txat guztiak ezabatuko dira parte-hartzaile guztientzat eta txataren mezu guztiak ez dira gehiago erabiliko praktikan edo ikasketa analitiketan. Ekintza hau ezin da desegin.",
     "launch": "Abiarazi",
-    "searchChats": "Bilatu txateak",
-    "maxFifty": "Gehienez 50",
     "configureSpace": "Konfiguratu ikastaroa",
     "pinMessages": "Pin mezuak",
     "setJoinRules": "Ezarri parte-hartzeko arauak",
@@ -3815,9 +3459,6 @@
     "failedToFetchTranscription": "Ezin izan da transkripzioa lortu",
     "deleteEmptySpaceDesc": "Ikastaroa parte-hartzaile guztientzat ezabatuko da. Ekintza hau ezin da desegin.",
     "regenerate": "Berriro sortu",
-    "mySavedActivities": "Nire gordeak diren jarduerak",
-    "noSavedActivities": "Ez dago gordetako jarduerarik",
-    "saveActivity": "Gorde jarduera hau",
     "failedToPlayVideo": "Ezin izan da bideoa jokatu",
     "done": "Eginda",
     "inThisSpace": "Ikastaro honetan",
@@ -3828,13 +3469,9 @@
     "numInvited": "{count} gonbidatu",
     "saved": "Gordeta",
     "reset": "Berrezarri",
-    "errorFetchingActivitiesMessage": "Ezin izan da jarduerak lortu",
     "errorFetchingDefinition": "Ezin izan da definizioa lortu",
     "errorProcessAnalytics": "Ezin izan da analitikak prozesatu",
     "errorDownloading": "Deskarga huts egin du",
-    "errorLoadingSpaceChildren": "Ezin izan da ikastaro honetan barruko txat batzuk kargatu",
-    "unexpectedError": "Errore ezezaguna.",
-    "pleaseReload": "Mesedez, kargatu berriro eta saiatu berriro.",
     "translationError": "Itzulpen errorea",
     "check": "Egiaztatu",
     "unableToFindRoom": "Ez da txata edo ikastaroa aurkitu kode horrekin. Saiatu berriro.",
@@ -3843,19 +3480,14 @@
     "request": "Eskatu",
     "requestAll": "Eskatu Guztiak",
     "confirmMessageUnpin": "Ziur zaude mezu hau pinik ez jartzeko?",
-    "saveAndLaunch": "Gorde eta abiarazi",
-    "launchToSpace": "Abi kursura",
     "pending": "Zain",
     "inactive": "Erlaxia",
-    "confirmRole": "Berretsi rola",
     "openRoleLabel": "IREKIA",
     "finishedTheActivity": "🎯 {username} jarduera hau amaitu du",
     "activitySummaryError": "Jarduera laburpenak ez daude eskuragarri",
     "requestSummaries": "Eskatu laburpenak",
-    "generatingNewActivities": "Lehen erabiltzailea zara hizkuntza bikote honetan! Mesedez, minutu bat eman, jarduerak prestatzen ari gara zuretzat.",
     "requestAccessTitle": "Eskaera analitika sarbidea?",
     "requestAccessDesc": "Zerbait nahi al duzu parte-hartzailearen analytics ikusteko sarbidea eskatu?\n\nParte-hartzaileek ados badaude, ikastaroaren administratzaileek haien:\n    • hizkuntza-berritasun osoa\n    • gramatika kontzeptu guztiak\n    • jarduera saio guztiak amaituak\n    • erabiltzen diren gramatika kontzeptu zehatzak, zuzen eta oker\n\nIkusi ahal izango dute haien:\n    • mezua ikastaroaren kanpoan dauden txatetan\n    • hiztegi zerrenda",
-    "requestAccess": "Eskatu sarbidea ({count})",
     "analyticsInactiveTitle": "Ezingo da eskaerarik bidali erabiltzaile inactiveentzat",
     "analyticsInactiveDesc": "Ez aktibo diren erabiltzaileek, ez baitute sartu funtzio hau sartu denetik, ez dute zure eskaeraren berri izango.\n\nEskatzeko botoia agertuko da berriro itzultzen direnean. Geroago berriro bidali dezakezu eskaera botoia sakatuz haien izenaren azpian, eskuragarri dagoenean.",
     "accessRequestedTitle": "Analytics Sarbide Eskaera",
@@ -3878,8 +3510,6 @@
     "accessDesc": "Zure ikastaroa mundu osoari irekita egin dezakezu! Edo, ikastaroa pribatua eta segurua egin",
     "createGroupChatDesc": "Ekintza saioak hasten eta bukatzen diren bitartean, talde txat hauek komunikazio erregularrerako irekita egongo dira",
     "deleteDesc": "Administratzaileek bakarrik ezabatu dezakete ikastaroa. Hau ekintza suntsitzailea da, erabiltzaile guztiak ezabatzen ditu eta ikastaroaren barruan aukeratutako txat guztiak ezabatzen ditu. Kontuz ibili",
-    "noCourseFound": "Aizu, ikastaro honek plan bat behar du!\n\nIkastaroaren planak gaiak eta elkarrizketa jarduerak dira",
-    "additionalParticipants": "+ {num} beste",
     "whatNow": "Zer orain?",
     "chooseNextActivity": "Hurrengo jarduera aukeratu!",
     "letsGo": "Goazen",
@@ -3892,13 +3522,11 @@
     "waitNotDone": "Itxaron, ez naiz amaitu!",
     "waitingForOthersToFinish": "Itxaron besteek amaitu arte...",
     "generatingSummary": "Txataren analisia eta emaitzak sortzen",
-    "findCourse": "Bilatu ikastaroa",
     "pingParticipantsNotification": "{user} erabiltzaileak bilatzen ari da {room} gelan jarduera saioan parte hartzeko erabiltzaileak",
     "course": "Ikastaroa",
     "courses": "Ikastaroak",
     "goToCourse": "Joan ikastaro batera: {course}",
     "activityComplete": "Ekintza hau burutu da. Ekintza laburpena behean egon beharko litzateke.",
-    "startNewSession": "Hasi saio berria",
     "joinOpenSession": "Batu irekita dagoen saiora",
     "activityNotFound": "Ez da ekintzarik aurkitu",
     "myActivities": "Nire ekintzak",
@@ -3972,10 +3600,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3985,10 +3609,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4072,14 +3692,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4096,10 +3708,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4112,15 +3720,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4272,14 +3872,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4293,14 +3885,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5523,10 +5107,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5567,10 +5147,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5643,10 +5219,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5916,47 +5488,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5976,19 +5508,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6052,10 +5572,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6096,14 +5612,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6115,14 +5623,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6160,10 +5660,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6180,27 +5676,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6324,10 +5804,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6337,10 +5813,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6357,14 +5829,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6504,18 +5968,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6564,10 +6016,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6577,18 +6025,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6631,23 +6067,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6671,10 +6095,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6682,14 +6102,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6794,18 +6206,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6858,10 +6258,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6888,10 +6284,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7072,7 +6464,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Egon etxeko egunean, eguneraketak ikusteko.",
-    "activityDropdownDesc": "Jarduera honekin amaitu duzunean, klikatu behean",
     "languageMismatchTitle": "Hizkuntza desberdintasuna",
     "languageMismatchDesc": "Zure helburu hizkuntza ez dator bat jarduera honen hizkuntzarekin. Eguneratu zure helburu hizkuntza nahi duzun moduan?",
     "reportWordIssueTooltip": "Txosten hitzaren informazio arazoa",
@@ -7085,10 +6476,6 @@
     "selectAll": "Hautatu guztiak",
     "deselectAll": "Desmarkatu guztiak",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7137,17 +6524,11 @@
         "placeholders": {}
     },
     "startOwn": "Hasi nirea",
-    "joinCourseDesc": "Ikastaro bakoitzak 8-10 gaika ditu, eta hizkuntzaren ikaskuntza jarduera oinarritutako zeregin sorta batekin.",
     "newMessageInPangeaChat": "💬 Pangea Txat-ean mezu berria",
     "shareCourse": "Partekatu ikastaroa",
     "addCourse": "Gehitu ikastaroa",
-    "joinPublicCourse": "Hasi ikastaro publikoa",
     "vocabLevelsDesc": "Hemen daude hitz-berriak mailakatzen dituzunean!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7160,10 +6541,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7182,7 +6559,6 @@
     "emojiView": "Emoji ikuskera",
     "feedbackDialogDesc": "Akatsak egiten ditut ere! Nola hobetzen laguntzeko ezer?",
     "contactHasBeenInvitedToTheCourse": "Kontaktua ikastaroan gonbidatu da",
-    "activityStatsButtonTooltip": "Jarduera informazioa",
     "allow": "Baimendu",
     "deny": "Ukatu",
     "enabledRenewal": "Harpidetzaren Berritzea Aktibatu",
@@ -7450,10 +6826,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8509,16 +7881,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Hurrengo gaia irekitzeko jarduerak",
-    "activitiesToUnlockTopicDesc": "Hurrengo ikastaro gaia irekitzeko jardueren kopurua ezarri",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Hitz-baliabideen definizio zuzena praktika",
     "constructUseIncLMDesc": "Hitz-baliabideen definizio okerra praktika",
     "constructUseCorLADesc": "Hitz-baliabideen audio zuzena praktika",
@@ -8526,7 +7888,6 @@
     "constructUseBonus": "Bonus hitz-baliabideen praktikaren bitartean",
     "practiceVocab": "Praktikatu hiztegia",
     "selectMeaning": "Aukeratu esanahia",
-    "selectAudio": "Aukeratu audio egokia",
     "anotherRound": "Beste txanda bat",
     "activitySettingsOverrideWarning": "Jarduera planak zehaztutako hizkuntza eta hizkuntza maila",
     "voice": "Ahots",
@@ -8558,10 +7919,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8579,12 +7936,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Deskarga hasi da",
     "webDownloadPermissionMessage": "Zure nabigatzaileak deskargak blokeatzen baditu, mesedez, gaitza itxaroteko deskargak webgune honentzat.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8679,11 +8031,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Zerbait oker joan da, eta horren konponketan lan gogorra egiten ari gara. Begiratu berriro geroago.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Idazteko laguntza aktibatu",
     "autoIGCToolDescription": "Automatikoki exekutatu Pangea Chat tresnak helburu hizkuntzara bidalitako mezuak zuzentzeko.",
     "@autoIGCToolName": {
@@ -8739,24 +8086,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatika",
-    "spanTypeWordChoice": "Hitz Aukera",
     "spanTypeSpelling": "Ortografia",
     "spanTypePunctuation": "Puntuazioa",
     "spanTypeStyle": "Estiloa",
     "spanTypeFluency": "Fluentzia",
     "spanTypeAccents": "Azentuak",
     "spanTypeCapitalization": "Kapitalizazioa",
-    "spanTypeCorrection": "Zuzenketa",
     "spanFeedbackTitle": "Zuzenketa arazoa txostenatu",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8781,10 +8117,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8795,13 +8127,9 @@
     "clientWellKnownInformation": "Bezeroaren ezagutza ona:",
     "baseUrl": "Oinarri URL-a",
     "identityServer": "Identitate zerbitzaria:",
-    "versionWithNumber": "Bertsioa: {version}",
     "logs": "Erregistroak",
-    "advancedConfigs": "Konfigurazio aurreratuak",
     "advancedConfigurations": "Konfigurazio aurreratuak",
-    "signInWithLabel": "Hasi saioa:",
     "selectAllWords": "Hitz guztiak hautatu audioan entzuten duzun guztia",
-    "joinCourseForActivities": "Batu ikastaro batera jarduerak probatzeko.",
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8830,19 +8158,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8850,15 +8166,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9059,11 +8367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Klase batean? Jarri zure sartu kodea hemen.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Audio mezuak automatikoki nabarmentzea",
     "selectAudioMessagesOnPlayDescription": "Audio mezuak automatikoki nabarmentzea erreproduzitzen direnean",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9107,18 +8410,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Ikastaro honek {input} jarduera baino gutxiago dituen gaiei buruzko ohartarazpen bat du. Mesedez, sartu {minValue} edo gutxiago den zenbaki bat.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Hemen klikatu berriro saioa hasteko.",
     "@clickToLogin": {
@@ -9535,17 +8826,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Ederki bat den kolore horiko hartz bat, besoak altxatuta pozik.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Hitzak hautatu ikasteko gehiago jakiteko",
     "requireAnalyticsAccessTitle": "Analitika sarbidea beharrezkoa da bat egiteko",
     "requireAnalyticsAccessDesc": "Parte-hartzaileek ikaskuntza analitikaren sarbidea eman behar dute ikastaro honetan parte hartzeko",
     "analyticsAccessNoticeTitle": "Analitika Sarbidea Beharrezkoa",
     "analyticsAccessNoticeDesc": "Ikastaro honetan parte hartuz, administratzaileei zure ikaskuntza analitikaren sarbidea emateko ados zaude.",
-    "skipOnboardingClassCodeDesc": "Independently ikasten? Ez kezkatu, egin dezakezu:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9563,10 +8848,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9595,7 +8876,6 @@
     "pickCefrLevelTeacherStepTitle": "Zer maila irakasten duzu?",
     "pickCefrLevelStudentStepTitle": "Zer maila zara?",
     "customCourseStepTitle": "Betetze formulario hau ikastaro pertsonalizatu bat lortzeko",
-    "aboutYourClass": "Zure klaseari buruz",
     "courseCodeStepErrorMessage": "Mesedez, egiaztatu zure kodea eta saiatu berriro",
     "institution": "Erakundea",
     "courseGoals": "Ikastaro Helburuak",
@@ -9638,10 +8918,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9758,12 +9034,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat irudia",
     "introChatDetails": "Agur esan! Aurkeztu zeure burua ikastaro parte-hartzaileei, aurkitu lagunak, eta jardueren kanpoan hitz egin.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9807,11 +9078,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Jarduera ekintzak",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Ahotsaren tresnak",
     "audioTranscription": "AI audio transkripzioa",
     "visualLearnerSupport": "Ikusizko ikaslearen laguntza",
@@ -9852,7 +9118,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Jarduera hau jokatzeko ikastaro batera batu.",
     "resizeCoursePanel": "Ikastaro panelaren tamaina aldatu",
     "undo": "Ezeztatu",
     "unlock": "Desblokeatu",
@@ -9866,7 +9131,6 @@
     "addCourseBrowsePublic": "Arakatu publiko ikastaroak",
     "browsePublicCourses": "Arakatu publiko ikastaroak",
     "editProfile": "Editatu profila",
-    "numObjectives": "{count} helburu",
     "mapSearchHint": "Bilatu jarduerak",
     "mapSearchNoResults": "Ez dago bat etorritakoen ikuspegian",
     "mapFilterAllLanguages": "Hizkuntza guztiak",
@@ -9875,7 +9139,6 @@
     "mapFilterCompleted": "Osatua",
     "mapFilterReset": "Berrezarri",
     "activityTypeConversation": "Elkarrizketa",
-    "lockedMissionRequirement": "Desblokeatzeko aurreko misioa amaitu",
     "playAgain": "Jolastu berriro",
     "reviewActivity": "Berrikusi",
     "mapEmptyInView": "Ez dago ezer zure mailan edo hizkuntzan. Zabaldu zure iragazkiak edo hurbildu.",
@@ -9890,14 +9153,9 @@
     "scrollToBottom": "Behera irristatu",
     "courseImage": "Ikastaroaren irudia",
     "avatarPreview": "Avatar aurrebista",
-    "activityPhoto": "Jardueraren argazkia",
     "emotePreview": "Emote aurrebista: {name}",
     "activityLabel": "Jarduera: {title}",
     "resetMapView": "Berrezarri mapa ikuskera",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9950,14 +9208,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9987,10 +9237,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10047,10 +9293,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_fa.arb
+++ b/lib/l10n/intl_fa.arb
@@ -138,11 +138,6 @@
             }
         }
     },
-    "areGuestsAllowedToJoin": "آیا مهمانان اجازه پیوستن دارند",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoplayImages": "پخش خودکار شکلک‌ها و برچسب‌های متحرک",
     "@autoplayImages": {
         "type": "String",
@@ -366,8 +361,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "پشتیبان گپ شما تنظیم شد.",
-    "@yourChatBackupHasBeenSetUp": {},
     "changeTheme": "تغییر پوسته",
     "@changeTheme": {
         "type": "String",
@@ -556,11 +549,6 @@
         },
         "description": "State that {command} is not a valid /command."
     },
-    "contactHasBeenInvitedToTheGroup": "مخاطب به گروه دعوت شد",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "sentAFile": "📁 {username} یک پرونده فرستاد",
     "@sentAFile": {
         "type": "String",
@@ -595,15 +583,6 @@
     "@weSentYouAnEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "loadCountMoreParticipants": "بارگیری {count} شرکت‌کننده دیگر",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "sentASticker": "😊 {username} یک برچسب فرستاد",
     "@sentASticker": {
@@ -735,11 +714,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "createNewSpace": "فضای جدید",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "deviceId": "شناسه دستگاه",
     "@deviceId": {
         "type": "String",
@@ -853,11 +827,6 @@
             }
         }
     },
-    "chatBackupDescription": "پیام‌های قدیمی شما با یک کلید بازیابی امن می‌شوند. لطفاً مطمئن شوید آن را گم نمی‌کنید.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "deactivateAccountWarning": "این کار حساب شما را غیرفعال می‌کند. این کنش برگشت‌ناپذیر است! آیا مطمئن هستید؟",
     "@deactivateAccountWarning": {
         "type": "String",
@@ -947,11 +916,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "groupIsPublic": "گروه عمومی است",
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "groupWith": "گروه با {displayname}",
     "@groupWith": {
         "type": "String",
@@ -973,11 +937,6 @@
     },
     "enableEncryption": "فعال کردن رمزنگاری",
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "enableEncryptionWarning": "نمی‌توانید رمزنگاری را غیرفعال کنید. آیا مطمئن هستید؟",
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1020,11 +979,6 @@
                 "type": "String"
             }
         }
-    },
-    "everythingReady": "همه‌چیز آماده است!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
     },
     "extremeOffensive": "بسیار توهین‌آمیز",
     "@extremeOffensive": {
@@ -1176,11 +1130,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "passwordRecovery": "بازیابی گذرواژه",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pin": "سنجاق کردن",
     "@pin": {
         "type": "String",
@@ -1237,8 +1186,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "pleaseEnterRecoveryKey": "لطفاً کلید بازیابی خود را وارد کنید:",
-    "@pleaseEnterRecoveryKey": {},
     "link": "پیوند",
     "@link": {},
     "iHaveClickedOnLink": "روی پیوند کلیک کردم",
@@ -1255,15 +1202,6 @@
     "@inoffensive": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "دعوت مخاطب به {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invitedUsersOnly": "فقط کاربران دعوت‌شده",
     "@invitedUsersOnly": {
@@ -1324,15 +1262,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "logInTo": "ورود به {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
-    },
     "moderator": "ناظر",
     "@moderator": {
         "type": "String",
@@ -1373,8 +1302,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "addAccount": "افزودن حساب",
-    "@addAccount": {},
     "people": "افراد",
     "@people": {
         "type": "String",
@@ -1474,23 +1401,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "noGoogleServicesWarning": "به نظر می‌رسد دستگاه شما سرویس‌های گوگل ندارد. این انتخاب خوبی برای حریم خصوصی است! برای دریافت آگاه‌سازها در فلافی‌چت، پیشنهاد می‌کنیم از https://ntfy.sh استفاده کنید. با ntfy یا یک فراهم‌کننده UnifiedPush می‌توانید آگاه‌سازهای امن دریافت کنید. می‌توانید ntfy را از Play Store یا F-Droid بارگیری کنید.",
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "رمزنگاری را تنها زمانی می‌توانید فعال کنید که اتاق عمومی نباشد.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "onlineKeyBackupEnabled": "پشتیبان‌گیری آنلاین کلید فعال است",
     "@onlineKeyBackupEnabled": {
         "type": "String",
         "placeholders": {}
     },
-    "enableMultiAccounts": "(آزمایشی) فعال کردن چند حساب در این دستگاه",
-    "@enableMultiAccounts": {},
     "pleaseClickOnLink": "لطفاً روی پیوند در رایانامه کلیک کنید و ادامه دهید.",
     "@pleaseClickOnLink": {
         "type": "String",
@@ -1688,11 +1603,6 @@
             }
         }
     },
-    "removeDevice": "پاک کردن دستگاه",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "reportMessage": "گزارش پیام",
     "@reportMessage": {
         "type": "String",
@@ -1703,8 +1613,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKey": "کلید بازیابی",
-    "@recoveryKey": {},
     "pushRules": "قوانین آگاه‌ساز",
     "@pushRules": {
         "type": "String",
@@ -1725,8 +1633,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKeyLost": "کلید بازیابی گم شد؟",
-    "@recoveryKeyLost": {},
     "fileHasBeenSavedAt": "پرونده در {path} ذخیره شد",
     "@fileHasBeenSavedAt": {
         "type": "String",
@@ -1736,8 +1642,6 @@
             }
         }
     },
-    "enterSpace": "ورود به فضا",
-    "@enterSpace": {},
     "wasDirectChatDisplayName": "گپ خالی (پیش‌تر {oldDisplayName} بود)",
     "@wasDirectChatDisplayName": {
         "type": "String",
@@ -1747,12 +1651,6 @@
             }
         }
     },
-    "newSpaceDescription": "فضاها امکان یکپارچه‌سازی گپ‌ها و ساخت جوامع خصوصی یا عمومی را فراهم می‌کنند.",
-    "@newSpaceDescription": {},
-    "encryptThisChat": "رمزنگاری این گپ",
-    "@encryptThisChat": {},
-    "sorryThatsNotPossible": "متأسفیم... این ممکن نیست",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "کلیدهای دستگاه:",
     "@deviceKeys": {},
     "fileIsTooBigForServer": "نمیتوان فرستاد! سرور تنها از پیوست های تا {max} پشتیبانی میکند.",
@@ -1777,30 +1675,14 @@
     },
     "noKeyForThisMessage": "اگر پیام پیش از ورود به حساب در این دستگاه فرستاده شده باشد، این مشکل ممکن است رخ دهد.\n\nهمچنین ممکن است فرستنده دستگاه شما را مسدود کرده باشد یا مشکلی در اتصال اینترنت وجود داشته باشد.\n\nآیا می‌توانید پیام را در نشست دیگری بخوانید؟ در این صورت، می‌توانید آن را منتقل کنید! به تنظیمات > دستگاه‌ها بروید و مطمئن شوید دستگاه‌هایتان یکدیگر را بازبینی کرده‌اند. هنگام باز کردن دوباره اتاق و فعال بودن هر دو نشست، کلیدها به‌صورت خودکار منتقل می‌شوند.\n\nآیا نمی‌خواهید هنگام خروج یا تغییر دستگاه کلیدها را گم کنید؟ مطمئن شوید پشتیبان گپ را در تنظیمات فعال کرده‌اید.",
     "@noKeyForThisMessage": {},
-    "disableEncryptionWarning": "به دلایل امنیتی نمی‌توانید رمزنگاری را در گپی که فعال شده غیرفعال کنید.",
-    "@disableEncryptionWarning": {},
     "newGroup": "گروه جدید",
     "@newGroup": {},
-    "foregroundServiceRunning": "این آگاه‌ساز زمانی ظاهر می‌شود که خدمت پیش‌زمینه فعال است.",
-    "@foregroundServiceRunning": {},
-    "storeSecurlyOnThisDevice": "ذخیره امن در این دستگاه",
-    "@storeSecurlyOnThisDevice": {},
-    "screenSharingDetail": "شما در حال هم‌رسانی صفحه‌نمایش خود در فلافی‌چت هستید",
-    "@screenSharingDetail": {},
     "newSpace": "فضای جدید",
     "@newSpace": {},
-    "saveKeyManuallyDescription": "این کلید را با استفاده از هم‌رسانی یا بریده‌دان به‌طور دستی ذخیره کنید.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "ذخیره در Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "ذخیره در Apple KeyChain",
-    "@storeInAppleKeyChain": {},
     "user": "کاربر",
     "@user": {},
     "custom": "سفارشی",
     "@custom": {},
-    "screenSharingTitle": "هم‌رسانی صفحه‌نمایش",
-    "@screenSharingTitle": {},
     "whyIsThisMessageEncrypted": "چرا این پیام خوانا نیست؟",
     "@whyIsThisMessageEncrypted": {},
     "reopenChat": "باز کردن دوباره گپ",
@@ -1810,8 +1692,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unlockOldMessages": "گشودن پیام‌های قدیمی",
-    "@unlockOldMessages": {},
     "share": "هم‌رسانی",
     "@share": {
         "type": "String",
@@ -1862,11 +1742,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "چه کسی می‌تواند چه کاری انجام دهد",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "writeAMessage": "نوشتن پیام…",
     "@writeAMessage": {
         "type": "String",
@@ -1876,11 +1751,6 @@
     "@widgetVideo": {},
     "youHaveBeenBannedFromThisChat": "شما از این گپ محروم شده‌اید",
     "@youHaveBeenBannedFromThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "setPermissionsLevel": "تنظیم سطح دسترسی",
-    "@setPermissionsLevel": {
         "type": "String",
         "placeholders": {}
     },
@@ -1896,11 +1766,6 @@
     },
     "showPassword": "نمایش گذرواژه",
     "@showPassword": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "نام فضا",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1953,11 +1818,6 @@
                 "type": "String"
             }
         }
-    },
-    "videoCall": "تماس تصویری",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
     },
     "visibleForAllParticipants": "قابل‌دید برای همه شرکت‌کنندگان",
     "@visibleForAllParticipants": {
@@ -2079,11 +1939,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceIsPublic": "فضا عمومی است",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "synchronizingPleaseWait": "در حال همگام‌سازی... لطفا صبر کنید.",
     "@synchronizingPleaseWait": {
         "type": "String",
@@ -2124,23 +1979,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "visibilityOfTheChatHistory": "قابلیت دیدن تاریخچه گپ",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "چه کسی اجازه پیوستن به این گروه را دارد",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "waitingPartnerNumbers": "در انتظار پذیرش اعداد توسط دیگری…",
     "@waitingPartnerNumbers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "برای ایجاد کلید بازیابی جدید، پشتیبان گپ خود را پاک می‌کنید؟",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -2151,10 +1991,6 @@
     },
     "openGallery": "بازکردن گالری",
     "@openGallery": {},
-    "removeFromSpace": "حذف از فضا",
-    "@removeFromSpace": {},
-    "pleaseEnterRecoveryKeyDescription": "برای گشودن قفل پیام‌های قدیمیتان، لطفا کلید بازیابی‌ای که در یک نشست پیشین تولید شده را وارد کنید. کلید بازیابی شما، رمز عبور شما نیست.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "confirmEventUnpin": "آیا از برداشتن سنجاق رویداد به صورت دائمی مطمئن هستید؟",
     "@confirmEventUnpin": {},
     "widgetEtherpad": "یادداشت متنی",
@@ -2181,15 +2017,6 @@
     "@youRejectedTheInvitation": {},
     "youAcceptedTheInvitation": "👍 شما دعوت را پذیرفتید",
     "@youAcceptedTheInvitation": {},
-    "emailOrUsername": "رایانامه(ایمیل) یا نام کاربری",
-    "@emailOrUsername": {},
-    "transferFromAnotherDevice": "انتقال از دستگاهی دیگر",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "videoCallsBetaWarning": "لطفا توجه داشته باشید که تماس‌های تصویری در حال حاضر آزمایشی هستند. ممکن است طبق انتظار کار نکنند یا روی همه پلتفرم‌ها اصلا کار نکنند.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "تماس‌های تصویری آزمایشی",
     "@experimentalVideoCalls": {},
     "placeCall": "برقراری تماس",
@@ -2202,15 +2029,6 @@
         "placeholders": {
             "username": {
                 "type": "String"
-            }
-        }
-    },
-    "unreadChats": "{unreadCount, plural, other{{unreadCount} گپ خوانده نشده}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
             }
         }
     },
@@ -2232,8 +2050,6 @@
     "@pinMessage": {},
     "emojis": "شکلک‌ها",
     "@emojis": {},
-    "voiceCall": "تماس صوتی",
-    "@voiceCall": {},
     "addWidget": "افزودن ویجت",
     "@addWidget": {},
     "widgetCustom": "سفارشی",
@@ -2282,8 +2098,6 @@
     },
     "users": "کاربرها",
     "@users": {},
-    "storeInSecureStorageDescription": "کلید بازیابی را در محل ذخیره‌سازی امن این دستگاه ذخیره کنید.",
-    "@storeInSecureStorageDescription": {},
     "jump": "پرش",
     "@jump": {},
     "report": "گزارش",
@@ -2347,15 +2161,6 @@
     "@spaces": {},
     "checkList": "فهرست بررسی",
     "@checkList": {},
-    "countInvited": "{count} دعوت‌شده",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "createGroup": "ساختن گروه",
     "@createGroup": {},
     "chatPermissions": "دسترسی‌های گپ",
@@ -2365,20 +2170,12 @@
         "type": "String",
         "placeholders": {}
     },
-    "globalChatId": "شناسه گپ سراسری",
-    "@globalChatId": {},
-    "accessAndVisibility": "دسترسی و قابلیت دید",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "چه کسی اجازه پیوستن به این گپ را دارد و گپ چگونه قابل کشف است.",
-    "@accessAndVisibilityDescription": {},
     "calls": "تماس‌ها",
     "@calls": {},
     "customEmojisAndStickers": "شکلک‌ها و برچسب‌های سفارشی",
     "@customEmojisAndStickers": {},
     "customEmojisAndStickersBody": "افزودن یا هم‌رسانی شکلک‌ها یا برچسب‌های سفارشی که در هر گپ قابل استفاده‌اند.",
     "@customEmojisAndStickersBody": {},
-    "chatDescription": "توضیح گپ",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "توضیح گپ تغییر کرد",
     "@chatDescriptionHasBeenChanged": {},
     "hideRedactedMessages": "پنهان کردن پیام‌های ویرایش‌شده",
@@ -2477,16 +2274,10 @@
             }
         }
     },
-    "usersMustKnock": "کاربران باید در بزنند",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "هیچ‌کس نمیتواند بپیوندد",
-    "@noOneCanJoin": {},
     "knock": "در زدن",
     "@knock": {},
     "hidePresences": "پنهان کردن فهرست وضعیت؟",
     "@hidePresences": {},
-    "setTheme": "تنظیم پوسته:",
-    "@setTheme": {},
     "setColorTheme": "تنظیم پوسته رنگی:",
     "@setColorTheme": {},
     "invite": "دعوت",
@@ -2537,25 +2328,10 @@
     },
     "knocking": "در زدن",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "گپ با جستجو در {server} قابل کشف است",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "searchChatsRooms": "جستجو برای #گپ‌ها، @کاربران...",
-    "@searchChatsRooms": {},
     "nothingFound": "چیزی پیدا نشد...",
     "@nothingFound": {},
     "groupName": "نام گروه",
     "@groupName": {},
-    "createGroupAndInviteUsers": "ساختن گروه و دعوت کاربران",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "گروه با جستجو قابل یافتن است",
-    "@groupCanBeFoundViaSearch": {},
     "wrongRecoveryKey": "متأسفیم... به نظر میرسد این کلید بازیابی درست نباشد.",
     "@wrongRecoveryKey": {},
     "startConversation": "آغاز گفتگو",
@@ -2582,16 +2358,10 @@
     "@passwordsDoNotMatch": {},
     "passwordIsWrong": "گذرواژه واردشده نادرست است",
     "@passwordIsWrong": {},
-    "publicChatAddresses": "نشانی‌های گپ عمومی",
-    "@publicChatAddresses": {},
-    "createNewAddress": "ساختن نشانی جدید",
-    "@createNewAddress": {},
     "joinSpace": "پیوستن به فضا",
     "@joinSpace": {},
     "publicSpaces": "فضاهای عمومی",
     "@publicSpaces": {},
-    "addChatOrSubSpace": "افزودن گپ یا زیرفضا",
-    "@addChatOrSubSpace": {},
     "subspace": "زیرفضا",
     "@subspace": {},
     "decline": "نپذیرفتن",
@@ -2613,30 +2383,6 @@
     "@gallery": {},
     "files": "پرونده‌ها",
     "@files": {},
-    "sessionLostBody": "نشست شما گم شده است. لطفاً این خطا را به توسعه‌دهندگان در {url} گزارش دهید. پیام خطا: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "برنامه اکنون سعی میکند نشست شما را از پشتیبان بازیابی کند. لطفاً این خطا را به توسعه‌دهندگان در {url} گزارش دهید. پیام خطا: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendReadReceipts": "فرستادن رسیدهای خواندن",
     "@sendReadReceipts": {},
     "sendTypingNotificationsDescription": "دیگر شرکت‌کنندگان در گپ میتوانند ببینند که شما در حال تایپ پیام جدید هستید.",
@@ -2647,10 +2393,6 @@
     "@formattedMessages": {},
     "formattedMessagesDescription": "نمایش محتوای پیام غنی مانند متن پررنگ با استفاده از مارک‌داون.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 بازبینی کاربر دیگر",
-    "@verifyOtherUser": {},
-    "verifyOtherUserDescription": "اگر کاربر دیگری را بازبینی کنید، میتوانید مطمئن شوید که واقعاً با چه کسی در حال نوشتن هستید. 💪\n\nهنگام شروع بازبینی، شما و کاربر دیگر پنجره‌ای در برنامه خواهید دید. در آنجا مجموعه‌ای از شکلک‌ها یا اعداد را مشاهده میکنید که باید با یکدیگر مقایسه کنید.\n\nبهترین راه برای این کار دیدار حضوری یا شروع تماس تصویری است. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDevice": "🔐 بازبینی دستگاه دیگر",
     "@verifyOtherDevice": {},
     "verifyOtherDeviceDescription": "هنگام بازبینی دستگاه دیگر، آن دستگاه‌ها میتوانند کلیدها را تبادل کنند و امنیت کلی شما را افزایش دهند. 💪 هنگام شروع بازبینی، پنجره‌ای در برنامه روی هر دو دستگاه ظاهر میشود. در آنجا مجموعه‌ای از شکلک‌ها یا اعداد را مشاهده میکنید که باید با یکدیگر مقایسه کنید. بهتر است پیش از شروع بازبینی، هر دو دستگاه در دسترس باشند. 🤳",
@@ -2807,14 +2549,6 @@
     "@changelog": {},
     "sendCanceled": "فرستادن رد شد",
     "@sendCanceled": {},
-    "loginWithMatrixId": "ورود با شناسه ماتریکس",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "کشف سرورهای خانگی",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "سرور خانگی چیست؟",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "همه داده‌های شما روی سرور خانگی نگه‌داری میشوند، مانند یک فراهم‌کننده رایانامه. میتوانید سرور خانگی مورد نظر خود را انتخاب کنید، در حالی که همچنان میتوانید با هر کسی گفتگو کنید. اطلاعات بیشتر در https://matrix.org.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "به نظر نمیرسد سرور خانگی سازگاری داشته باشد. نشانی اشتباه است؟",
     "@doesNotSeemToBeAValidHomeserver": {},
     "calculatingFileSize": "در حال محاسبه اندازه پرونده...",
@@ -2854,16 +2588,12 @@
     "@noticeChatBackupDeviceVerification": {},
     "continueText": "ادامه",
     "@continueText": {},
-    "welcomeText": "درود درود 👋 این فلافی‌چت است. میتوانید به هر سرور خانگی سازگار با https://matrix.org وارد شوید و با هر کسی گپ بزنید. این یک شبکه پیام‌رسانی غیرمتمرکز بزرگ است!",
-    "@welcomeText": {},
     "blur": "محو کردن:",
     "@blur": {},
     "opacity": "شفافیت:",
     "@opacity": {},
     "setWallpaper": "تنظیم کاغذدیواری",
     "@setWallpaper": {},
-    "manageAccount": "مدیریت حساب",
-    "@manageAccount": {},
     "noContactInformationProvided": "سرور هیچ اطلاعات تماس معتبری نمیدهد",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "تماس با مدیر سرور",
@@ -2900,23 +2630,10 @@
     "@previous": {},
     "otherPartyNotLoggedIn": "طرف مقابل اکنون وارد نشده است و بنابراین نمیتواند پیام دریافت کند!",
     "@otherPartyNotLoggedIn": {},
-    "appWantsToUseForLogin": "برای ورود از '{server}' استفاده کنید",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "شما بدین‌وسیله به برنامه و وبگاه اجازه میدهید اطلاعات شما را هم‌رسانی کنند.",
-    "@appWantsToUseForLoginDescription": {},
     "open": "باز کردن",
     "@open": {},
     "waitingForServer": "در انتظار سرور...",
     "@waitingForServer": {},
-    "appIntroduction": "فلافی‌چت به شما امکان گپ با دوستانتان در پیام‌رسان‌های مختلف را میدهد. اطلاعات بیشتر در https://matrix.org یا فقط روی *ادامه* بزنید.",
-    "@appIntroduction": {},
     "newChatRequest": "📩 درخواست گپ جدید",
     "@newChatRequest": {},
     "contentNotificationSettings": "تنظیمات آگاه‌ساز محتوا",
@@ -3080,11 +2797,9 @@
     "taTooltip": "استفاده از L2 با کمک ترجمه",
     "interactiveTranslatorSliderHeader": "مترجم تعاملی",
     "interactiveGrammarSliderHeader": "بررسیگر گرامر تعاملی",
-    "interactiveTranslatorRequired": "الزامی",
     "waTooltip": "استفاده از L2 بدون کمک",
     "interactiveTranslator": "کمک ترجمه",
     "noIdenticalLanguages": "لطفاً زبان پایه و هدف را متفاوت انتخاب کنید",
-    "searchBy": "جستجو بر اساس کشور و زبان‌ها",
     "joinWithClassCode": "پیوستن به دوره",
     "languageLevelPreA1": "نوآموز پایین (پیش A1)",
     "languageLevelA1": "نوآموز میانه (A1)",
@@ -3105,19 +2820,14 @@
     "saveChanges": "ذخیره تغییرات",
     "publicProfileTitle": "اجازه دهید پروفایل من در جستجو پیدا شود",
     "publicProfileDesc": "با فعال کردن، به دیگر کاربران اجازه می‌دهید پروفایل شما را در نوار جستجوی جهانی پیدا کرده و درخواست چت ارسال کنند. در این مرحله، می‌توانید درخواست را بپذیرید یا رد کنید.",
-    "errorDisableIT": "کمک ترجمه خاموش است.",
-    "errorDisableIGC": "کمک گرامر خاموش است.",
     "errorDisableITUserDesc": "برای به‌روزرسانی تنظیمات کمک ترجمه اینجا کلیک کنید",
     "errorDisableIGCUserDesc": "برای به‌روزرسانی تنظیمات کمک گرامر اینجا کلیک کنید",
     "errorDisableITClassDesc": "کمک ترجمه برای دوره‌ای که این چت در آن است غیرفعال شده است.",
     "errorDisableIGCClassDesc": "کمک گرامر برای دوره‌ای که این چت در آن است غیرفعال شده است.",
-    "error405Title": "زبان‌ها تنظیم نشده‌اند",
     "error405Desc": "لطفاً زبان‌های خود را در منوی اصلی > تنظیمات یادگیری تنظیم کنید.",
     "termsAndConditions": "شرایط و ضوابط",
     "andCertifyIAmAtLeast13YearsOfAge": " و گواهی می‌دهم که حداقل ۱۳ سال سن دارم.",
-    "error502504Title": "وای، تعداد زیادی دانش‌آموز آنلاین هستند!",
     "error502504Desc": "ابزارهای ترجمه و گرامر ممکن است کند یا در دسترس نباشند در حالی که ربات‌های پنگئا جبران می‌کنند.",
-    "error404Title": "خطای ترجمه!",
     "error404Desc": "ربات پنگئا مطمئن نیست چگونه آن را ترجمه کند...",
     "errorPleaseRefresh": "در حال بررسی مشکل هستیم! لطفاً صفحه را مجدداً بارگذاری کنید و دوباره تلاش کنید.",
     "connectedToStaging": "متصل به استیجینگ",
@@ -3155,13 +2865,9 @@
     "definitionsToolName": "تعاریف کلمات",
     "definitionsToolDescription": "وقتی فعال باشد، کلمات زیر خط آبی قابل کلیک برای مشاهده تعاریف هستند. برای دسترسی به تعاریف، پیام‌ها را کلیک کنید.",
     "welcomeBack": "خوش آمدید! اگر بخشی از آزمایش ۲۰۲۳-۲۰۲۴ بودید، لطفاً برای اشتراک ویژه آزمایشی با ما تماس بگیرید. اگر معلم هستید و یا مؤسسه‌تان مجوزهای آموزشی خریداری کرده است، برای اشتراک معلم با ما تماس بگیرید.",
-    "downloadTxtFile": "دانلود فایل متنی",
-    "downloadCSVFile": "دانلود فایل CSV",
     "promotionalSubscriptionDesc": "در حال حاضر اشتراک تبلیغاتی دائمی دارید. برای کمک به تغییر اشتراک خود با support@pangea.chat تماس بگیرید.",
     "originalSubscriptionPlatform": "اشتراک از طریق {purchasePlatform} خریداری شده است",
     "oneWeekTrial": "آزمایش یک هفته‌ای",
-    "downloadXLSXFile": "دانلود فایل اکسل",
-    "unkDisplayName": "نامشخص",
     "wwCountryDisplayName": "جهان‌و‌جهان",
     "afCountryDisplayName": "افغانستان",
     "axCountryDisplayName": "جزایر آلند",
@@ -3456,7 +3162,6 @@
     "chatCapacityHasBeenChanged": "ظرفیت چت تغییر یافته است",
     "chatCapacitySetTooLow": "ظرفیت چت باید حداقل {count} باشد.",
     "chatCapacityExplanation": "ظرفیت چت تعداد اعضای مجاز در یک چت را محدود می‌کند.",
-    "tooManyRequest": "تعداد درخواست‌ها زیاد است، لطفاً بعداً تلاش کنید.",
     "enterNumber": "لطفاً یک مقدار عدد صحیح وارد کنید.",
     "practice": "تمرین",
     "versionNotFound": "نسخه پیدا نشد",
@@ -3466,7 +3171,6 @@
     "deleteSubscriptionWarningTitle": "اشتراک فعال دارید",
     "deleteSubscriptionWarningBody": "حذف حساب شما به طور خودکار اشتراک شما را لغو نمی‌کند.",
     "manageSubscription": "مدیریت اشتراک",
-    "error520Title": "لطفاً دوباره تلاش کنید.",
     "error520Desc": "متأسفیم، نتوانستیم پیام شما را درک کنیم...",
     "wordsUsed": "کلمات استفاده شده",
     "level": "سطح",
@@ -3484,7 +3188,6 @@
     "other": "دیگر",
     "levelShort": "سطح {level}",
     "noCapacityLimit": "محدودیت ظرفیت ندارد",
-    "downloadGroupText": "دانلود متن گروه",
     "notificationsOn": "اعلان‌ها فعال است",
     "notificationsOff": "اعلان‌ها غیرفعال است",
     "joinWithCode": "پیوستن با کد",
@@ -3548,24 +3251,12 @@
     "whatIsTheMorphTag": "مورد {morphologicalFeature} از '{wordForm}' چیست؟",
     "dataAvailable": "در دسترس بودن داده‌ها",
     "available": "در دسترس",
-    "pangeaBotIsFallible": "ربات پانگئا هم اشتباه می‌کند!",
-    "whatIsMeaning": "معنای '{lemma}' چیست؟",
     "chooseLemmaMeaningInstructionsBody": "معانی را با کلمات در پیام مطابقت دهید!",
-    "doubleClickToEdit": "برای ویرایش، دو بار کلیک کنید.",
-    "topicLabel": "موضوع",
-    "topicPlaceholder": "یک موضوع انتخاب کنید...",
-    "modePlaceholder": "یک حالت انتخاب کنید...",
-    "learningObjectiveLabel": "هدف یادگیری",
-    "learningObjectivePlaceholder": "یک هدف یادگیری انتخاب کنید...",
-    "targetLanguageLabel": "زبان هدف",
     "cefrLevelLabel": "سطح CEFR",
     "image": "تصویر",
     "video": "ویدئو",
     "nan": "مربوط نمی‌شود",
-    "addVocabulary": "افزودن واژگان",
     "instructions": "دستورالعمل‌ها",
-    "numberOfLearners": "تعداد یادگیرندگان",
-    "mustBeInteger": "باید عدد صحیح باشد مثلاً ۱، ۲، ۳، ...",
     "constructUsePvmDesc": "تولید شده در پیام صوتی",
     "leaveSpaceDescription": "با ترک دوره، تمام چت‌های درون آن را ترک خواهید کرد. کاربران دیگر خواهند دید که شما دوره را ترک کرده‌اید.",
     "constructUseCorMmDesc": "معنای پیام صحیح",
@@ -3580,7 +3271,6 @@
     "ttsDisabledBody": "می‌توانید تبدیل متن به گفتار را در تنظیمات یادگیری خود فعال کنید",
     "noSpaceDescriptionYet": "تاکنون توضیح دوره‌ای ایجاد نشده است.",
     "tooLargeToSend": "این پیام بسیار بزرگ است و نمی‌تواند ارسال شود",
-    "exitWithoutSaving": "آیا مطمئن هستید که می‌خواهید بدون ذخیره خارج شوید؟",
     "enableAutocorrectPopupTitle": "با رفتن به تنظیمات صفحه کلید زبان هدف خود را اضافه کنید:",
     "enableAutocorrectPopupSteps": "  • تنظیمات\n  • عمومی\n  • صفحه کلید\n  • صفحه کلیدها\n  • افزودن صفحه کلید جدید",
     "enableAutocorrectPopupDescription": "پس از انتخاب زبان، می‌توانید روی آیکون کوچک کره در پایین سمت چپ صفحه کلید خود کلیک کنید تا صفحه کلید نصب شده جدید فعال شود.",
@@ -3591,11 +3281,8 @@
     "displayName": "نام نمایشی",
     "leaveRoomDescription": "در حال خروج از این چت هستید. سایر کاربران خواهند دید که شما چت را ترک کرده‌اید.",
     "confirmUserId": "لطفاً نام کاربری چت پنگئا خود را تأیید کنید تا حساب کاربری خود را حذف کنید.",
-    "startingToday": "از امروز شروع می‌شود",
-    "oneWeekFreeTrial": "یک هفته آزمایش رایگان",
     "paidSubscriptionStarts": "از {startDate} شروع می‌شود",
     "cancelInSubscriptionSettings": "• در هر زمان در تنظیمات اشتراک لغو کنید",
-    "cancelToAvoidCharges": "• قبل از {trialEnds} لغو کنید تا از هزینه‌ها جلوگیری شود",
     "downloadGboard": "دانلود Gboard",
     "autocorrectNotAvailable": "متأسفانه پلتفرم شما در حال حاضر برای این ویژگی پشتیبانی نمی‌شود. منتظر توسعه‌های بیشتر باشید!",
     "pleaseUpdateApp": "لطفاً برنامه را به‌روزرسانی کنید تا ادامه دهید.",
@@ -3605,17 +3292,12 @@
     "knockSpaceSuccess": "درخواست شما برای پیوستن به این دوره ارسال شده است! مدیر در صورت دریافت درخواست، پاسخ خواهد داد 😄",
     "chooseWordAudioInstructionsBody": "به پیام کامل گوش دهید. سپس صداها را با کلمات مطابقت دهید.",
     "chooseMorphsInstructionsBody": "برای سوالات گرامری، قطعات پازل را کلیک کنید!",
-    "pleaseEnterInt": "لطفاً یک عدد وارد کنید",
     "home": "خانه",
     "join": "پیوستن",
     "resetInstructionTooltipsTitle": "بازنشانی راهنمای ابزار",
     "resetInstructionTooltipsDesc": "برای نمایش راهنمای ابزار مانند کاربر جدید، کلیک کنید.",
-    "randomize": "تصادفی کردن",
     "clear": "پاک کردن",
-    "featuredActivities": "برگزیده",
     "save": "ذخیره",
-    "startChat": "شروع چت",
-    "translationProblem": "مشکل ترجمه",
     "askToJoin": "درخواست پیوستن",
     "emptyChatWarningTitle": "چت خالی است",
     "emptyChatWarningDesc": "شما کسی را به چت خود دعوت نکرده‌اید. برای دعوت از مخاطبین یا ربات به تنظیمات چت بروید. همچنین می‌توانید این کار را بعداً انجام دهید.",
@@ -3645,17 +3327,13 @@
     "timesUsedIndependently": "تعداد دفعات استفاده مستقل",
     "timesUsedWithAssistance": "تعداد دفعات استفاده با کمک",
     "shareInviteCode": "کد دعوت را به اشتراک بگذارید: {code}",
-    "leaderboard": "جدول رده‌بندی",
     "skipForNow": "فعلاً رد شو",
     "permissions": "مجوزها",
     "spaceChildPermission": "چه کسی می‌تواند چت‌های جدید به این دوره اضافه کند",
-    "addEnvironmentOverride": "افزودن جایگزین محیط",
     "defaultOption": "پیش‌فرض",
     "deleteChatDesc": "آیا مطمئن هستید که می‌خواهید این چت را حذف کنید؟ این کار برای همه شرکت‌کنندگان انجام می‌شود و تمام پیام‌های داخل چت دیگر برای تمرین یا تحلیل‌های یادگیری در دسترس نخواهند بود.",
     "deleteSpaceDesc": "دوره و هر چت انتخاب شده برای همه شرکت‌کنندگان حذف خواهد شد و تمام پیام‌های داخل چت دیگر برای تمرین یا تحلیل‌های یادگیری در دسترس نخواهند بود. این عملیات قابل بازگشت نیست.",
     "launch": "راه‌اندازی",
-    "searchChats": "جستجوی چت‌ها",
-    "maxFifty": "حداکثر ۵۰",
     "configureSpace": "پیکربندی دوره",
     "pinMessages": "سنجاق پیام‌ها",
     "setJoinRules": "تنظیم قوانین پیوستن",
@@ -3689,9 +3367,6 @@
     "failedToFetchTranscription": "خطا در دریافت متن تبدیل شده",
     "deleteEmptySpaceDesc": "این دوره برای همه شرکت‌کنندگان حذف خواهد شد. این عملیات قابل بازگشت نیست.",
     "regenerate": "بازتولید",
-    "mySavedActivities": "فعالیت‌های ذخیره شده من",
-    "noSavedActivities": "هیچ فعالیت ذخیره شده‌ای وجود ندارد",
-    "saveActivity": "ذخیره این فعالیت",
     "failedToPlayVideo": "پخش ویدیو ناموفق بود",
     "done": "تمام شد",
     "inThisSpace": "در این دوره",
@@ -3702,13 +3377,9 @@
     "numInvited": "{count} دعوت شده",
     "saved": "ذخیره شده",
     "reset": "بازنشانی",
-    "errorFetchingActivitiesMessage": "خطا در دریافت فعالیت‌ها",
     "errorFetchingDefinition": "خطا در دریافت تعاریف",
     "errorProcessAnalytics": "خطا در پردازش تحلیل‌ها",
     "errorDownloading": "دانلود ناموفق بود",
-    "errorLoadingSpaceChildren": "خطا در بارگذاری چت‌های این دوره",
-    "unexpectedError": "خطای غیرمنتظره.",
-    "pleaseReload": "لطفاً صفحه را مجدداً بارگذاری کنید و دوباره تلاش کنید.",
     "translationError": "خطای ترجمه",
     "check": "بررسی",
     "unableToFindRoom": "چت یا دوره‌ای با این کد پیدا نشد. لطفاً دوباره تلاش کنید.",
@@ -3717,19 +3388,14 @@
     "request": "درخواست",
     "requestAll": "درخواست همه",
     "confirmMessageUnpin": "آیا مطمئن هستید که می‌خواهید این پیام را از پین خارج کنید؟",
-    "saveAndLaunch": "ذخیره و راه‌اندازی",
-    "launchToSpace": "راه‌اندازی در دوره",
     "pending": "در انتظار",
     "inactive": "غیرفعال",
-    "confirmRole": "تایید نقش",
     "openRoleLabel": "باز",
     "finishedTheActivity": "🎯 {username} این فعالیت را پایان داد",
     "activitySummaryError": "خلاصه فعالیت‌ها در دسترس نیست",
     "requestSummaries": "درخواست خلاصه‌ها",
-    "generatingNewActivities": "شما اولین کاربر این جفت زبان هستید! لطفاً یک دقیقه صبر کنید، در حال آماده‌سازی فعالیت‌ها مخصوص شما هستیم.",
     "requestAccessTitle": "درخواست دسترسی به تجزیه و تحلیل؟",
     "requestAccessDesc": "آیا مایلید درخواست دسترسی برای مشاهده تحلیل‌های شرکت‌کنندگان را بدهید؟\n\nاگر شرکت‌کنندگان موافقت کنند، مدیران این دوره قادر خواهند بود موارد زیر را مشاهده کنند:\n    • کل واژگان\n    • کل مفاهیم گرامری\n    • کل جلسات فعالیت انجام شده\n    • مفاهیم گرامری خاص استفاده شده، صحیح و نادرست\n\nآن‌ها قادر نخواهند بود موارد زیر را مشاهده کنند:\n    • پیام‌ها در چت‌های خارج از دوره\n    • فهرست واژگان",
-    "requestAccess": "درخواست دسترسی ({count})",
     "analyticsInactiveTitle": "درخواست‌ها برای کاربران غیرفعال ارسال نشدند",
     "analyticsInactiveDesc": "کاربران غیرفعال که از زمان معرفی این ویژگی وارد نشده‌اند، درخواست شما را نخواهند دید.\n\nدکمه درخواست زمانی ظاهر می‌شود که آن‌ها برگردند. می‌توانید درخواست را بعداً با کلیک بر روی دکمه درخواست زیر نام آن‌ها مجدداً ارسال کنید زمانی که در دسترس باشد.",
     "accessRequestedTitle": "درخواست دسترسی به تحلیل‌ها",
@@ -3752,8 +3418,6 @@
     "accessDesc": "می‌توانید دوره خود را برای جهان باز کنید! یا، دوره خود را خصوصی و امن کنید.",
     "createGroupChatDesc": "در حالی که جلسات فعالیت شروع و پایان می‌یابند، چت‌های گروهی برای ارتباط روتین باقی خواهند ماند.",
     "deleteDesc": "فقط مدیران می‌توانند دوره را حذف کنند. این یک اقدام مخرب است که تمام کاربران را حذف می‌کند و تمام چت‌های انتخاب شده درون دوره را حذف می‌کند. با احتیاط اقدام کنید.",
-    "noCourseFound": "اوه، این دوره نیاز به برنامه دارد!\n\nبرنامه‌های دوره مجموعه‌ای از موضوعات و فعالیت‌های گفتگو هستند.",
-    "additionalParticipants": "+ {num} نفر دیگر",
     "whatNow": "حالا چه؟",
     "chooseNextActivity": "انتخاب فعالیت بعدی شما!",
     "letsGo": "برویم",
@@ -3766,13 +3430,11 @@
     "waitNotDone": "صبر کن، من هنوز تمام نکرده‌ام!",
     "waitingForOthersToFinish": "در انتظار پایان دیگران...",
     "generatingSummary": "در حال تحلیل چت و تولید نتایج",
-    "findCourse": "پیدا کردن دوره",
     "pingParticipantsNotification": "{user} در حال جستجوی کاربران برای پیوستن به جلسه فعالیت در {room} است",
     "course": "دوره",
     "courses": "دوره‌ها",
     "goToCourse": "برو به دوره: {course}",
     "activityComplete": "این فعالیت کامل شده است. خلاصه فعالیت باید در زیر در دسترس باشد.",
-    "startNewSession": "شروع جلسه جدید",
     "joinOpenSession": "پیوستن به جلسه باز",
     "activityNotFound": "فعالیت یافت نشد",
     "myActivities": "فعالیت‌های من",
@@ -3847,10 +3509,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3860,10 +3518,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -3951,14 +3605,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -3975,10 +3621,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -3991,15 +3633,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4151,14 +3785,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4172,14 +3798,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5402,10 +5020,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5446,10 +5060,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5522,10 +5132,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5795,47 +5401,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5855,19 +5421,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -5931,10 +5485,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -5975,14 +5525,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -5994,14 +5536,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6039,10 +5573,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6059,27 +5589,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6203,10 +5717,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6216,10 +5726,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6236,14 +5742,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6383,18 +5881,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6443,10 +5929,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6456,18 +5938,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6510,23 +5980,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6550,10 +6008,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6561,14 +6015,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6673,18 +6119,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6737,10 +6171,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6767,10 +6197,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -6951,7 +6377,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "فردا برای به‌روزرسانی‌های فعالیت بررسی کنید.",
-    "activityDropdownDesc": "وقتی کارتان با این فعالیت تمام شد، روی دکمه زیر کلیک کنید",
     "languageMismatchTitle": "تفاوت زبان",
     "languageMismatchDesc": "زبان هدف شما با زبان این فعالیت مطابقت ندارد. می‌خواهید زبان هدف خود را به‌روزرسانی کنید؟",
     "reportWordIssueTooltip": "گزارش مشکل در اطلاعات کلمه",
@@ -6964,10 +6389,6 @@
     "selectAll": "انتخاب همه",
     "deselectAll": "لغو انتخاب همه",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7016,17 +6437,11 @@
         "placeholders": {}
     },
     "startOwn": "شروع کردن خودم",
-    "joinCourseDesc": "هر دوره شامل 8-10 موضوع متوالی با مجموعه‌ای از فعالیت‌های یادگیری زبان مبتنی بر وظایف است.",
     "newMessageInPangeaChat": "📩 پیام جدید در چت پنگئا",
     "shareCourse": "اشتراک‌گذاری دوره",
     "addCourse": "افزودن دوره",
-    "joinPublicCourse": "پیوستن به دوره عمومی",
     "vocabLevelsDesc": "اینجا جایی است که کلمات واژگان پس از ارتقاء سطح قرار می‌گیرند!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7039,10 +6454,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7061,7 +6472,6 @@
     "emojiView": "نمایش ایموجی",
     "feedbackDialogDesc": "من هم اشتباه می‌کنم! آیا چیزی هست که به من کمک کند بهتر شوم؟",
     "contactHasBeenInvitedToTheCourse": "تماس به دوره دعوت شده است",
-    "activityStatsButtonTooltip": "اطلاعات فعالیت",
     "allow": "اجازه دادن",
     "deny": "رد کردن",
     "enabledRenewal": "فعال کردن تمدید اشتراک",
@@ -7329,10 +6739,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8388,16 +7794,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "فعالیت‌ها برای باز کردن موضوع بعدی",
-    "activitiesToUnlockTopicDesc": "تعداد فعالیت‌ها را برای باز کردن موضوع بعدی دوره تنظیم کنید",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "تمرین تعریف واژه صحیح",
     "constructUseIncLMDesc": "تمرین تعریف واژه نادرست",
     "constructUseCorLADesc": "تمرین صوتی واژه صحیح",
@@ -8405,7 +7801,6 @@
     "constructUseBonus": "پاداش در حین تمرین واژه",
     "practiceVocab": "تمرین واژگان",
     "selectMeaning": "معنی را انتخاب کنید",
-    "selectAudio": "صوت مطابقتی را انتخاب کنید",
     "anotherRound": "یک دور دیگر",
     "activitySettingsOverrideWarning": "زبان و سطح زبان تعیین شده توسط برنامه فعالیت",
     "voice": "صدا",
@@ -8437,10 +7832,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8458,12 +7849,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "دانلود آغاز شد",
     "webDownloadPermissionMessage": "اگر مرورگر شما دانلودها را مسدود می‌کند، لطفاً دانلودها را برای این سایت فعال کنید.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8558,11 +7944,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "مشکلی پیش آمده و ما در حال تلاش برای رفع آن هستیم. بعداً دوباره بررسی کنید.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "فعال‌سازی کمک‌نویس",
     "autoIGCToolDescription": "به‌طور خودکار ابزارهای چت پانژیا را برای اصلاح پیام‌های ارسال‌شده به زبان هدف اجرا کنید.",
     "@autoIGCToolName": {
@@ -8618,24 +7999,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "قواعد",
-    "spanTypeWordChoice": "انتخاب واژه",
     "spanTypeSpelling": "هجی",
     "spanTypePunctuation": "نقطه‌گذاری",
     "spanTypeStyle": "سبک",
     "spanTypeFluency": "روانی",
     "spanTypeAccents": "لهجه‌ها",
     "spanTypeCapitalization": "حروف بزرگ",
-    "spanTypeCorrection": "تصحیح",
     "spanFeedbackTitle": "گزارش مشکل تصحیح",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8660,10 +8030,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8675,13 +8041,7 @@
     "longPressToRecordVoiceMessage": "برای ضبط پیام صوتی، طولانی فشار دهید.",
     "pause": "توقف",
     "resume": "ادامه",
-    "newSubSpace": "زیر فضای جدید",
-    "moveToDifferentSpace": "انتقال به فضای دیگر",
-    "removeFromSpaceDescription": "چت از فضا حذف خواهد شد اما هنوز در لیست چت‌های شما ظاهر می‌شود.",
     "countChats": "{chats} چت",
-    "spaceMemberOf": "عضو فضا {spaces}",
-    "spaceMemberOfCanKnock": "عضو فضا {spaces} می‌تواند در بزند",
-    "donate": "اهدا کنید",
     "startedAPoll": "{username} یک نظرسنجی شروع کرد.",
     "poll": "نظرسنجی",
     "startPoll": "شروع نظرسنجی",
@@ -8705,23 +8065,15 @@
     "newStickerPack": "بسته برچسب جدید",
     "stickerPackName": "نام بسته برچسب",
     "attribution": "اعتبارسنجی",
-    "skipChatBackup": "صرف نظر از پشتیبان‌گیری چت",
-    "skipChatBackupWarning": "آیا مطمئن هستید؟ بدون فعال کردن پشتیبان‌گیری چت، ممکن است دسترسی به پیام‌های خود را در صورت تغییر دستگاه از دست بدهید.",
-    "loadingMessages": "در حال بارگذاری پیام‌ها",
-    "setupChatBackup": "تنظیم پشتیبان‌گیری چت",
     "noMoreResultsFound": "نتیجه‌ای پیدا نشد",
     "chatSearchedUntil": "چت تا {time} جستجو شد",
     "federationBaseUrl": "آدرس پایه فدراسیون",
     "clientWellKnownInformation": "اطلاعات شناخته شده کلاینت:",
     "baseUrl": "آدرس پایه",
     "identityServer": "سرور هویت:",
-    "versionWithNumber": "نسخه: {version}",
     "logs": "لاگ‌ها",
-    "advancedConfigs": "تنظیمات پیشرفته",
     "advancedConfigurations": "پیکربندی‌های پیشرفته",
-    "signInWithLabel": "با استفاده از وارد شوید:",
     "selectAllWords": "تمام کلمات را که در صدا می‌شنوید انتخاب کنید",
-    "joinCourseForActivities": "به یک دوره بپیوندید تا فعالیت‌ها را امتحان کنید.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -8754,18 +8106,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -8773,26 +8113,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -8898,22 +8218,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8942,19 +8246,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8962,15 +8254,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9171,11 +8455,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "در یک کلاس هستید؟ کد پیوستن خود را اینجا وارد کنید.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "به‌طور خودکار پیام‌های صوتی را هایلایت کنید",
     "selectAudioMessagesOnPlayDescription": "به‌طور خودکار پیام‌های صوتی را هنگام پخش هایلایت کنید",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9219,18 +8498,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "این دوره موضوعاتی دارد که کمتر از {input} فعالیت دارند. لطفاً عددی وارد کنید که کمتر از یا برابر با {minValue} باشد.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "اینجا کلیک کنید تا دوباره وارد شوید.",
     "@clickToLogin": {
@@ -9647,17 +8914,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "یک خرس زرد کارتونی با دستانی بالا برده در هیجان.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "کلمات را برای یادگیری بیشتر انتخاب کنید",
     "requireAnalyticsAccessTitle": "برای پیوستن به دسترسی به تجزیه و تحلیل نیاز است",
     "requireAnalyticsAccessDesc": "شرکت‌کنندگان باید دسترسی به تجزیه و تحلیل یادگیری خود را برای پیوستن به این دوره اعطا کنند",
     "analyticsAccessNoticeTitle": "دسترسی به تجزیه و تحلیل مورد نیاز است",
     "analyticsAccessNoticeDesc": "با پیوستن به این دوره، شما موافقت می‌کنید که به مدیران دسترسی به تجزیه و تحلیل یادگیری خود را اعطا کنید.",
-    "skipOnboardingClassCodeDesc": "به‌طور مستقل یاد می‌گیرید؟ نگران نباشید، شما می‌توانید:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9675,10 +8936,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9707,7 +8964,6 @@
     "pickCefrLevelTeacherStepTitle": "شما در چه سطحی تدریس می‌کنید؟",
     "pickCefrLevelStudentStepTitle": "شما در چه سطحی هستید؟",
     "customCourseStepTitle": "این فرم را پر کنید تا یک دوره سفارشی دریافت کنید",
-    "aboutYourClass": "درباره کلاس شما",
     "courseCodeStepErrorMessage": "لطفاً کد خود را بررسی کرده و دوباره تلاش کنید",
     "institution": "موسسه",
     "courseGoals": "اهداف دوره",
@@ -9750,10 +9006,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9870,12 +9122,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "لوگوی چت پانگه‌آ",
     "introChatDetails": "سلام بگویید! خود را به سایر شرکت‌کنندگان دوره معرفی کنید، دوستانی پیدا کنید و خارج از فعالیت‌ها چت کنید.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9919,11 +9166,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "عملیات فعالیت",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "ابزارهای تلفظ",
     "audioTranscription": "تبدیل صوت به متن با هوش مصنوعی",
     "visualLearnerSupport": "پشتیبانی از یادگیرندگان بصری",
@@ -9964,7 +9206,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "به یک دوره بپیوندید که این فعالیت را شامل می‌شود تا بتوانید آن را بازی کنید.",
     "resizeCoursePanel": "اندازه پنل دوره را تغییر دهید",
     "undo": "بازگشت",
     "unlock": "باز کردن",
@@ -9978,7 +9219,6 @@
     "addCourseBrowsePublic": "دوره‌های عمومی را مرور کنید",
     "browsePublicCourses": "دوره‌های عمومی را مرور کنید",
     "editProfile": "ویرایش پروفایل",
-    "numObjectives": "{count} هدف",
     "mapSearchHint": "جستجوی فعالیت‌ها",
     "mapSearchNoResults": "هیچ تطابقی در نمای فعلی وجود ندارد",
     "mapFilterAllLanguages": "تمام زبان‌ها",
@@ -9987,7 +9227,6 @@
     "mapFilterCompleted": "تکمیل شده",
     "mapFilterReset": "تنظیم مجدد",
     "activityTypeConversation": "گفتگو",
-    "lockedMissionRequirement": "برای باز کردن، مأموریت قبلی را تمام کنید",
     "playAgain": "دوباره بازی کنید",
     "reviewActivity": "بررسی",
     "mapEmptyInView": "هیچ چیزی در سطح یا زبان شما وجود ندارد. فیلترهای خود را گسترش دهید یا زوم کنید.",
@@ -10002,14 +9241,9 @@
     "scrollToBottom": "به پایین صفحه بروید",
     "courseImage": "تصویر دوره",
     "avatarPreview": "پیش‌نمایش آواتار",
-    "activityPhoto": "عکس فعالیت",
     "emotePreview": "پیش‌نمایش ایموجی: {name}",
     "activityLabel": "فعالیت: {title}",
     "resetMapView": "بازنشانی نمای نقشه",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10062,14 +9296,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10099,10 +9325,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10159,10 +9381,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_fi.arb
+++ b/lib/l10n/intl_fi.arb
@@ -90,11 +90,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Sallitaanko vieraiden liittyminen",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSureYouWantToLogout": "Haluatko varmasti kirjautua ulos?",
     "@areYouSureYouWantToLogout": {
         "type": "String",
@@ -338,15 +333,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "Keskustelujesi varmuuskopiointi on asetettu.",
-    "@yourChatBackupHasBeenSetUp": {},
     "chatBackup": "Keskustelun varmuuskopiointi",
     "@chatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "Vanhat viestisi on suojattu palautusavaimella. Varmistathan ettet hävitä sitä.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -428,11 +416,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Uusi tila",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Aktiivinen nyt",
     "@currentlyActive": {
@@ -561,11 +544,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Et voi poistaa salausta myöhemmin. Oletko varma?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encryptionNotEnabled": "Salaus ei ole käytössä",
     "@encryptionNotEnabled": {
         "type": "String",
@@ -596,11 +574,6 @@
             }
         }
     },
-    "everythingReady": "Kaikki on valmista!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Erittäin loukkaavaa",
     "@extremeOffensive": {
         "type": "String",
@@ -623,11 +596,6 @@
     },
     "group": "Ryhmä",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Ryhmä on julkinen",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -804,15 +772,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Lataa vielä {count} osallistujaa",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadMore": "Lataa lisää…",
     "@loadMore": {
         "type": "String",
@@ -832,15 +791,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Kirjaudu sisään palvelimelle {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Kirjaudu ulos",
     "@logout": {
@@ -894,11 +844,6 @@
     },
     "noConnectionToTheServer": "Ei yhteyttä palvelimeen",
     "@noConnectionToTheServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Voit ottaa salauksen käyttöön vasta kun huone ei ole julkisesti liityttävissä.",
-    "@noEncryptionForPublicRooms": {
         "type": "String",
         "placeholders": {}
     },
@@ -1085,11 +1030,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Yhteystieto on kutsuttu ryhmään",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Sisältö on ilmoitettu palvelimen ylläpitäjille",
     "@contentHasBeenReported": {
         "type": "String",
@@ -1123,15 +1063,6 @@
     "@inoffensive": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Kutsu yhteystieto ryhmään {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "isTyping": "kirjoittaa…",
     "@isTyping": {
@@ -1197,18 +1128,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "noGoogleServicesWarning": "Firebase Cloud Messaging -palvelu ei vaikuta olevan saatavilla laitteellasi. Saadaksesi push-ilmoituksia silti, suosittelemme Ntfy-sovelluksen asentamista. Käyttämällä Ntfy-sovellusta tai muuta Unified Push -tarjoajaa, saat push-ilmoitukset tietoturvallisella tavalla. Voit ladata Ntfy-sovelluksen Play Kaupasta tai F-Droidista.",
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "noPermission": "Ei lupaa",
     "@noPermission": {
         "type": "String",
         "placeholders": {}
     },
-    "enableMultiAccounts": "(BETA) Ota käyttöön tuki usealle tilille tällä laitteella",
-    "@enableMultiAccounts": {},
     "onlineKeyBackupEnabled": "Verkkkoavainvarmuuskopio on käytössä",
     "@onlineKeyBackupEnabled": {
         "type": "String",
@@ -1236,8 +1160,6 @@
     },
     "oneClientLoggedOut": "Yksi tunnuksistasi on kirjattu ulos",
     "@oneClientLoggedOut": {},
-    "addAccount": "Lisää tili",
-    "@addAccount": {},
     "editBundlesForAccount": "Muokkaa tämän tilin kääröjä",
     "@editBundlesForAccount": {},
     "addToBundle": "Lisää kääreeseen",
@@ -1268,11 +1190,6 @@
     },
     "passwordHasBeenChanged": "Salasana on vaihdettu",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Salasanan palautus",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1397,11 +1314,6 @@
             }
         }
     },
-    "removeDevice": "Poista laite",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "unbanFromChat": "Poista porttikielto keskusteluun",
     "@unbanFromChat": {
         "type": "String",
@@ -1446,11 +1358,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Aseta oikeustasot",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Aseta tila",
     "@setStatus": {
         "type": "String",
@@ -1482,16 +1389,6 @@
     },
     "sourceCode": "Lähdekoodi",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Tila on julkinen",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Tilan nimi",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1528,11 +1425,6 @@
     },
     "tooManyRequestsWarning": "Liikaa pyyntöjä. Yritä myöhemmin uudelleen!",
     "@tooManyRequestsWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "transferFromAnotherDevice": "Siirrä toiselta laitteelta",
-    "@transferFromAnotherDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -1653,11 +1545,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "visibilityOfTheChatHistory": "Keskusteluhistorian näkyvyys",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Näkyy kaikille osallistujille",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1703,23 +1590,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Kuka voi suorittaa minkä toimenpiteen",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Kenen on sallittua liittyä ryhmään",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Miksi haluat ilmoittaa tämän?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Pyyhi keskusteluvarmuuskopio luodaksesi uuden palautusavaimen?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1738,8 +1610,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "removeFromSpace": "Poista tilasta",
-    "@removeFromSpace": {},
     "start": "Aloita",
     "@start": {},
     "serverRequiresEmail": "Tämän palvelimen täytyy tarkistaa sähköposti-osoitteesi rekisteröitymistä varten.",
@@ -1910,20 +1780,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unreadChats": "{unreadCount, plural, =1{1 lukematon keskustelu} other{{unreadCount} lukematonta keskustelua}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
-    "videoCall": "Videopuhelu",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "sender": "Lähettäjä",
     "@sender": {},
     "startedACall": "{senderName} aloitti puhelun",
@@ -2022,10 +1878,6 @@
     "@unsupportedAndroidVersion": {},
     "reportUser": "Ilmianna käyttäjä",
     "@reportUser": {},
-    "voiceCall": "Äänipuhelu",
-    "@voiceCall": {},
-    "videoCallsBetaWarning": "Huomaathan videopuheluiden ovan beta-asteella. Ne eivät ehkä toimi odotetusti tai toimi ollenkaan kaikilla alustoilla.",
-    "@videoCallsBetaWarning": {},
     "placeCall": "Soita",
     "@placeCall": {},
     "reactedWith": "{sender} reagoi {reaction}",
@@ -2060,8 +1912,6 @@
     "@errorAddingWidget": {},
     "experimentalVideoCalls": "Kokeelliset videopuhelut",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "Sähköposti-osoite tai käyttäjätunnus",
-    "@emailOrUsername": {},
     "widgetEtherpad": "Tekstimuotoinen muistiinpano",
     "@widgetEtherpad": {},
     "widgetNameError": "Syötä näyttönimi.",
@@ -2135,12 +1985,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "pleaseEnterRecoveryKey": "Syötä palautusavaimesi:",
-    "@pleaseEnterRecoveryKey": {},
-    "recoveryKey": "Palautusavain",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Kadonnut palautusavain?",
-    "@recoveryKeyLost": {},
     "hydrate": "Palauta varmuuskopiotiedostosta",
     "@hydrate": {},
     "dehydrate": "Vie istunto ja tyhjennä laite",
@@ -2149,18 +1993,6 @@
     "@dehydrateWarning": {},
     "users": "Käyttäjät",
     "@users": {},
-    "storeSecurlyOnThisDevice": "Tallenna turvallisesti tälle laitteelle",
-    "@storeSecurlyOnThisDevice": {},
-    "pleaseEnterRecoveryKeyDescription": "Avataksesi vanhojen viestiesi salauksen, syötä palautusavaimesi, joka luotiin edellisessä istunnossa. Palautusavaimesi EI OLE salasanasi.",
-    "@pleaseEnterRecoveryKeyDescription": {},
-    "unlockOldMessages": "Pura vanhojen viestien salaus",
-    "@unlockOldMessages": {},
-    "saveKeyManuallyDescription": "Tallenna tämä avain manuaalisesti käyttäen järjestelmän jakodialogia tai leikepöytää.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "Tallenna Android KeyStoreen",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Tallenna Applen avainnippuun",
-    "@storeInAppleKeyChain": {},
     "countFiles": "{count} tiedostoa",
     "@countFiles": {
         "placeholders": {
@@ -2169,8 +2001,6 @@
             }
         }
     },
-    "storeInSecureStorageDescription": "Tallenna palautusavain tämän laitteen turvavarastoon.",
-    "@storeInSecureStorageDescription": {},
     "user": "Käyttäjä",
     "@user": {},
     "custom": "Mukautettu",
@@ -2194,20 +2024,12 @@
     "@noKeyForThisMessage": {},
     "commandHint_markasdm": "Merkitse yksityiskeskusteluksi syötetyn Matrix IDn kanssa",
     "@commandHint_markasdm": {},
-    "foregroundServiceRunning": "Tämä ilmoitus näkyy etualapalvelun ollessa käynnissä.",
-    "@foregroundServiceRunning": {},
     "newSpace": "Uusi tila",
     "@newSpace": {},
-    "enterSpace": "Siirry tilaan",
-    "@enterSpace": {},
     "allSpaces": "Kaikki tilat",
     "@allSpaces": {},
-    "screenSharingTitle": "ruudunjako",
-    "@screenSharingTitle": {},
     "newGroup": "Uusi ryhmä",
     "@newGroup": {},
-    "screenSharingDetail": "Jaat ruutuasi FluffyChatissä",
-    "@screenSharingDetail": {},
     "hugContent": "{senderName} halaa sinua",
     "@hugContent": {
         "type": "String",
@@ -2252,10 +2074,6 @@
             }
         }
     },
-    "disableEncryptionWarning": "Turvallisuuden vuoksi et voi poistaa salausta käytöstä huoneista, joissa se on aiemmin otettu käyttöön.",
-    "@disableEncryptionWarning": {},
-    "newSpaceDescription": "Tilat mahdollistavat keskusteluidesi keräämisen ja yksityisten tai julkisten yhteisöjen rakentamisen.",
-    "@newSpaceDescription": {},
     "deviceKeys": "Laite-avaimet:",
     "@deviceKeys": {},
     "reopenChat": "Avaa keskustelu uudelleen",
@@ -2272,8 +2090,6 @@
     "@openLinkInBrowser": {},
     "report": "ilmoita",
     "@report": {},
-    "encryptThisChat": "Salaa tämä keskustelu",
-    "@encryptThisChat": {},
     "noBackupWarning": "Varoitus! Ilman avainvarmuuskopion käyttöönottoa menetät pääsyn salattuihin viesteihisi. Suosittelemme ehdottomasti avainvarmuuskopion käyttöönottoa ennen uloskirjautumista.",
     "@noBackupWarning": {},
     "fileIsTooBigForServer": "Ei voi lähettää! Palvelin tukee liitetiedostoja vain enintään {max}.",
@@ -2289,16 +2105,12 @@
             }
         }
     },
-    "sorryThatsNotPossible": "Anteeksi... se ei ole mahdollista",
-    "@sorryThatsNotPossible": {},
     "setColorTheme": "Aseta väriteema:",
     "@setColorTheme": {},
     "tryAgain": "Yritä uudelleen",
     "@tryAgain": {},
     "messagesStyle": "Viestit:",
     "@messagesStyle": {},
-    "chatDescription": "Keskustelun kuvaus",
-    "@chatDescription": {},
     "invalidServerName": "Virheellinen palvelimen nimi",
     "@invalidServerName": {},
     "chatPermissions": "Keskustelun oikeudet",
@@ -2380,8 +2192,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "Aseta teema:",
-    "@setTheme": {},
     "replace": "Korvaa",
     "@replace": {},
     "createGroup": "Luo ryhmä",
@@ -2392,8 +2202,6 @@
     "@invite": {},
     "swipeRightToLeftToReply": "Vastaa pyyhkäisemällä oikealta vasemmalle",
     "@swipeRightToLeftToReply": {},
-    "accessAndVisibility": "Pääsy ja näkyvyys",
-    "@accessAndVisibility": {},
     "unread": "Lukemattomat",
     "@unread": {},
     "noMoreChatsFound": "Lisää keskusteluja ei löytynyt...",
@@ -2426,8 +2234,6 @@
     "@changelog": {},
     "continueText": "Jatka",
     "@continueText": {},
-    "welcomeText": "Hei 👋, Tämä on FluffyChat. Voit kirjautua sisään mihin tahansa kotipalvelimeen, joka on yhteensopiva https:/matrix.org:in kanssa. Sitten jutellaan kenen kanssa tahansa. Se on hajautettu viestiverkosto!",
-    "@welcomeText": {},
     "serverInformation": "Palvelimen tiedot:",
     "@serverInformation": {},
     "name": "Nimi",
@@ -2485,19 +2291,6 @@
     "@spaces": {},
     "checkList": "Tarkistuslista",
     "@checkList": {},
-    "countInvited": "{count} kutsuttu",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "globalChatId": "Yleisesti pätevä keskustelutunnus",
-    "@globalChatId": {},
-    "accessAndVisibilityDescription": "Kuka voi liittyä tähän pikakeskusteluun ja miten pikakeskustelun voi löytää.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Puhelut",
     "@calls": {},
     "customEmojisAndStickers": "Mukautetut emojit ja tarrat",
@@ -2549,10 +2342,6 @@
             }
         }
     },
-    "usersMustKnock": "Käyttäjien on koputettava",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Kukaan ei voi liittyä",
-    "@noOneCanJoin": {},
     "knock": "Koputa",
     "@knock": {},
     "hidePresences": "Piilotetaanko tilaluettelo?",
@@ -2584,25 +2373,10 @@
     },
     "knocking": "Koputetaan",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Pikakeskustelu löytyy haulla {server}:lta",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "searchChatsRooms": "Hae #pikakeskustelut, @käyttäjät...",
-    "@searchChatsRooms": {},
     "nothingFound": "Mitään ei löytynyt...",
     "@nothingFound": {},
     "groupName": "Ryhmän nimi",
     "@groupName": {},
-    "createGroupAndInviteUsers": "Luo ryhmä ja kutsu käyttäjiä",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "Ryhmä löytyy haun kautta",
-    "@groupCanBeFoundViaSearch": {},
     "wrongRecoveryKey": "Pahoittelut... tämä ei vaikuta olevan oikea palautusavain.",
     "@wrongRecoveryKey": {},
     "startConversation": "Aloita keskustelu",
@@ -2615,16 +2389,10 @@
     "@databaseMigrationBody": {},
     "leaveEmptyToClearStatus": "Jätä tyhjäksi tyhjentääksesi tilasi.",
     "@leaveEmptyToClearStatus": {},
-    "publicChatAddresses": "Julkiset keskusteluosoitteet",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Luo uusi osoite",
-    "@createNewAddress": {},
     "joinSpace": "Liity tilaan",
     "@joinSpace": {},
     "publicSpaces": "Julkiset tilat",
     "@publicSpaces": {},
-    "addChatOrSubSpace": "Lisää pikakeskustelu tai alitila",
-    "@addChatOrSubSpace": {},
     "subspace": "Alitila",
     "@subspace": {},
     "decline": "Hylkää",
@@ -2642,30 +2410,6 @@
     },
     "searchMore": "Hae lisää...",
     "@searchMore": {},
-    "sessionLostBody": "Istuntosi on menetetty. Ilmoita tästä virheestä kehittäjille osoitteessa {url}. Virheviesti on: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Sovellus yrittää nyt palauttaa istuntosi varmuuskopiosta. Ilmoita tästä virheestä kehittäjille osoitteessa {url}. Virheviesti on: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendReadReceipts": "Lähetä lukukuittaukset",
     "@sendReadReceipts": {},
     "sendTypingNotificationsDescription": "Muut keskustelun osallistujat näkevät, milloin olet kirjoittamassa uutta viestiä.",
@@ -2676,10 +2420,6 @@
     "@formattedMessages": {},
     "formattedMessagesDescription": "Näytä rikasta viestisisältöä, kuten lihavoitua tekstiä, käyttämällä Markdownia.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Vahvista toinen käyttäjä",
-    "@verifyOtherUser": {},
-    "verifyOtherUserDescription": "Jos vahvistat toisen käyttäjän, voit olla varma, että tiedät kenelle todella kirjoitat. 💪\n\nKun aloitat vahvistuksen, sinä ja toinen käyttäjä näette sovelluksessa ponnahdusikkunan. Siellä näette sitten sarjan emojeja tai numeroita, joita teidän on verrattava toisiinsa.\n\nParas tapa tehdä tämä on tavata heidät tai aloittaa videopuhelu. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDevice": "🔐 Vahvista toinen laite",
     "@verifyOtherDevice": {},
     "verifyOtherDeviceDescription": "Kun vahvistat toisen laitteen, kyseiset laitteet voivat vaihtaa avaimia, mikä lisää yleistä turvallisuuttasi. 💪 Kun aloitat vahvistuksen, molempien laitteiden sovellukseen ilmestyy ponnahdusikkuna. Siellä näet sitten sarjan emojeja tai numeroita, joita sinun on verrattava toisiinsa. On parasta pitää molemmat laitteet käsillä ennen vahvistuksen aloittamista. 🤳",
@@ -2834,14 +2574,6 @@
     },
     "sendCanceled": "Lähetys peruttu",
     "@sendCanceled": {},
-    "loginWithMatrixId": "Kirjaudu sisään Matrix-tunnuksella",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Tutustu kotipalvelimiin",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Mikä on kotipalvelin?",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "Kaikki tietosi tallennetaan kotipalvelimelle, aivan kuten sähköpostipalveluntarjoaja. Voit valita, mitä kotipalvelinta haluat käyttää, ja silti kommunikoida kaikkien kanssa. Lisätietoja osoitteessa https://matrix.org.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "Ei näytä olevan yhteensopiva kotipalvelin. Väärä URL-osoite?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "calculatingFileSize": "Lasketaan tiedoston kokoa...",
@@ -2885,8 +2617,6 @@
     "@opacity": {},
     "setWallpaper": "Aseta taustakuva",
     "@setWallpaper": {},
-    "manageAccount": "Hallinnoi tiliä",
-    "@manageAccount": {},
     "noContactInformationProvided": "Palvelin ei ilmoittaa mitään kelvollisia yhteystietoja",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "Ota yhteyttä palvelimen ylläpitäjään",
@@ -2913,21 +2643,8 @@
     "@unableToJoinChat": {},
     "otherPartyNotLoggedIn": "Toinen osapuoli ei ole tällä hetkellä kirjautuneena sisään, joten ei voi vastaanottaa viestejä!",
     "@otherPartyNotLoggedIn": {},
-    "appWantsToUseForLogin": "Kirjaudu sisään käyttämällä '{server}':ta",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Annat täten sovellukselle ja verkkosivustolle luvan jakaa tietoja sinusta.",
-    "@appWantsToUseForLoginDescription": {},
     "waitingForServer": "Odotetaan palvelinta...",
     "@waitingForServer": {},
-    "appIntroduction": "FluffyChatin avulla voit keskustella ystäviesi kanssa eri pikaviestimien kautta. Lue lisää osoitteesta https://matrix.org tai napauta *Jatka*.",
-    "@appIntroduction": {},
     "newChatRequest": "📩 Uusi pikakeskustelupyyntö",
     "@newChatRequest": {},
     "contentNotificationSettings": "Sisältöilmoitusten asetukset",
@@ -3083,12 +2800,6 @@
     "@noMessagesYet": {},
     "longPressToRecordVoiceMessage": "Pitkä painallus ääniviestin tallentamiseksi.",
     "@longPressToRecordVoiceMessage": {},
-    "newSubSpace": "Uusi alitila",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Siirry eri tilaan",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "Pikakeskustelu poistetaan tilasta, mutta se näkyy edelleen pikakeskusteluluettelossasi.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} pikakeskustelua",
     "@countChats": {
         "type": "String",
@@ -3098,26 +2809,6 @@
             }
         }
     },
-    "spaceMemberOf": "{spaces}:jen tilanjäsen",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "{spaces}:jen tilanjäsen saa koputtaa",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "Lahjoita",
-    "@donate": {},
     "startedAPoll": "{username} aloitti kyselyn.",
     "@startedAPoll": {
         "type": "String",
@@ -3176,11 +2867,9 @@
     "taTooltip": "L2:n käyttö käännösavustuksella",
     "interactiveTranslatorSliderHeader": "Vuorovaikutteinen kääntäjä",
     "interactiveGrammarSliderHeader": "Vuorovaikutteinen kielioppitarkistin",
-    "interactiveTranslatorRequired": "Pakollinen",
     "waTooltip": "L2 ilman apua",
     "interactiveTranslator": "Käännöstuki",
     "noIdenticalLanguages": "Valitse eri perus- ja kohdekielet",
-    "searchBy": "Etsi maasta ja kielistä",
     "joinWithClassCode": "Liity kurssille",
     "languageLevelPreA1": "Aloittelija Matala (Pre A1)",
     "languageLevelA1": "Aloittelija Keskitaso (A1)",
@@ -3201,19 +2890,14 @@
     "saveChanges": "Tallenna muutokset",
     "publicProfileTitle": "Salli profiilini löytyä haussa",
     "publicProfileDesc": "Kytkemällä päälle mahdollistat muiden käyttäjien löytävän profiilisi globaalissa haussa ja lähettävän chat-pyyntöjä. Tällä hetkellä voit hyväksyä tai hylätä pyynnön.",
-    "errorDisableIT": "Käännösohjeita ei ole käytössä.",
-    "errorDisableIGC": "Kielioppiohjeita ei ole käytössä.",
     "errorDisableITUserDesc": "Klikkaa tästä päivittääksesi käännösohjeiden asetukset",
     "errorDisableIGCUserDesc": "Klikkaa tästä päivittääksesi kielioppiohjeiden asetukset",
     "errorDisableITClassDesc": "Käännösohjeita ei ole käytössä tämän kurssin chatissä.",
     "errorDisableIGCClassDesc": "Kielenhuollon apu on pois päältä tämän keskustelun kurssille.",
-    "error405Title": "Kielet eivät ole asetettu",
     "error405Desc": "Aseta kielesi Päävalikosta > Oppimisasetukset.",
     "termsAndConditions": "käyttöehdot",
     "andCertifyIAmAtLeast13YearsOfAge": " ja vahvistan, että olen vähintään 16-vuotias.",
-    "error502504Title": "Vau, verkossa on paljon oppilaita!",
     "error502504Desc": "Käännös- ja kielioppityökalut saattavat olla hitaita tai poissa käytöstä, kun Pangea-botit saavat kiinni.",
-    "error404Title": "Käännösvirhe!",
     "error404Desc": "Pangea-botti ei ole varma, miten tämä tulisi kääntää...",
     "errorPleaseRefresh": "Tarkistamme asiaa! Lataa sivu uudelleen ja yritä uudelleen.",
     "connectedToStaging": "Yhdistetty esikatseluun",
@@ -3251,13 +2935,9 @@
     "definitionsToolName": "Sanojen määritelmät",
     "definitionsToolDescription": "Kun tämä on käytössä, sininen alleviivatut sanat voidaan klikata määritelmiä varten. Klikkaa viestejä saadaksesi määritelmät.",
     "welcomeBack": "Tervetuloa takaisin! Jos olit osa pilottia vuosina 2023-2024, ota yhteyttä saadaksesi erityisen pilottitilauksesi. Jos olet opettaja, joka on ostanut (tai oppilaitoksesi on ostanut) lisenssejä luokkaasi varten, ota yhteyttä saadaksesi opettajatilauksesi.",
-    "downloadTxtFile": "Lataa tekstitiedosto",
-    "downloadCSVFile": "Lataa CSV-tiedosto",
     "promotionalSubscriptionDesc": "Sinulla on tällä hetkellä elinikäinen kampanjatilaus. Lähetä viesti osoitteeseen support@pangea.chat saadaksesi apua tilauksesi muuttamiseen.",
     "originalSubscriptionPlatform": "Tilauksen ostit {purchasePlatform} kautta",
     "oneWeekTrial": "Yhden viikon kokeilujakso",
-    "downloadXLSXFile": "Lataa Excel-tiedosto",
-    "unkDisplayName": "Tuntematon",
     "wwCountryDisplayName": "Maailmanlaajuinen",
     "afCountryDisplayName": "Afganistan",
     "axCountryDisplayName": "Ahvenanmaa",
@@ -3552,7 +3232,6 @@
     "chatCapacityHasBeenChanged": "Chatin kapasiteetti on muuttunut",
     "chatCapacitySetTooLow": "Chatin kapasiteetti on oltava vähintään {count}.",
     "chatCapacityExplanation": "Chatin kapasiteetti rajoittaa chatissa sallittujen jäsenten määrää.",
-    "tooManyRequest": "Liian monta pyyntöä, yritä uudelleen myöhemmin.",
     "enterNumber": "Syötä kokonaisluku.",
     "practice": "Harjoitus",
     "versionNotFound": "Versiota ei löytynyt",
@@ -3562,7 +3241,6 @@
     "deleteSubscriptionWarningTitle": "Sinulla on aktiivinen tilaus",
     "deleteSubscriptionWarningBody": "Tilisi poistaminen ei automaattisesti peruuta tilaustasi.",
     "manageSubscription": "Hallitse tilausta",
-    "error520Title": "Yritä uudelleen.",
     "error520Desc": "Valitettavasti emme ymmärtäneet viestiäsi...",
     "wordsUsed": "Käytetyt sanat",
     "level": "Taso",
@@ -3580,7 +3258,6 @@
     "other": "Muu",
     "levelShort": "TASO {level}",
     "noCapacityLimit": "Ei kapasiteettirajaa",
-    "downloadGroupText": "Lataa ryhmäteksti",
     "notificationsOn": "Ilmoitukset päällä",
     "notificationsOff": "Ilmoitukset pois päältä",
     "joinWithCode": "Liity koodilla",
@@ -3644,24 +3321,12 @@
     "whatIsTheMorphTag": "Mikä on '{wordForm}' {morphologicalFeature}?",
     "dataAvailable": "Tietojen saatavuus",
     "available": "Saatavilla",
-    "pangeaBotIsFallible": "Pangea Bot tekee myös virheitä!",
-    "whatIsMeaning": "Mitä '{lemma}' tarkoittaa?",
     "chooseLemmaMeaningInstructionsBody": "Vastaa sanojen merkityksiin viestissä!",
-    "doubleClickToEdit": "Muokkaa kaksoisnapsauttamalla.",
-    "topicLabel": "Aihe",
-    "topicPlaceholder": "Valitse aihe...",
-    "modePlaceholder": "Valitse tila...",
-    "learningObjectiveLabel": "Oppimistavoite",
-    "learningObjectivePlaceholder": "Valitse oppimistavoite...",
-    "targetLanguageLabel": "Kohdekieli",
     "cefrLevelLabel": "CEFR-taso",
     "image": "Kuva",
     "video": "Video",
     "nan": "Ei sovellettavissa",
-    "addVocabulary": "Lisää sanasto",
     "instructions": "Ohjeet",
-    "numberOfLearners": "Oppijoiden määrä",
-    "mustBeInteger": "Täytyy olla kokonaisluku esim. 1, 2, 3, ...",
     "constructUsePvmDesc": "Tuotettu ääniviestissä",
     "leaveSpaceDescription": "Lähdettäessä kurssilta, poistut kaikista keskusteluista siinä. Muut käyttäjät näkevät, että olet poistunut kurssilta.",
     "constructUseCorMmDesc": "Oikea viestin merkitys",
@@ -3676,7 +3341,6 @@
     "ttsDisabledBody": "Voit ottaa tekstistä puheeksi -toiminnon käyttöön oppimisasetuksissasi",
     "noSpaceDescriptionYet": "Kurssin kuvausta ei ole vielä luotu.",
     "tooLargeToSend": "Tämä viesti on liian suuri lähetettäväksi",
-    "exitWithoutSaving": "Oletko varma, että haluat poistua tallentamatta?",
     "enableAutocorrectPopupTitle": "Lisää kohdekielesi näppäimistö seuraavasti:",
     "enableAutocorrectPopupSteps": "  • Asetukset\n  • Yleiset\n  • Näppäimistö\n  • Näppäimistöt\n  • Lisää uusi näppäimistö",
     "enableAutocorrectPopupDescription": "Kun kieli on valittu, voit klikata pienen maapallon kuvaketta näppäimistön alakulmassa ottaaksesi käyttöön juuri asennetun näppäimistön.",
@@ -3687,11 +3351,8 @@
     "displayName": "Näytön nimi",
     "leaveRoomDescription": "Olet poistumassa tästä keskustelusta. Muut käyttäjät näkevät, että olet poistunut keskustelusta.",
     "confirmUserId": "Vahvista Pangea Chat -käyttäjänimesi poistaaksesi tilisi.",
-    "startingToday": "Alkaen tänään",
-    "oneWeekFreeTrial": "Viikon ilmainen kokeilujakso",
     "paidSubscriptionStarts": "Alkaen {startDate}",
     "cancelInSubscriptionSettings": "  • Peruuta milloin tahansa tilauksen asetuksissa",
-    "cancelToAvoidCharges": "• Peruuta ennen {trialEnds} välttääksesi veloitukset",
     "downloadGboard": "Lataa Gboard",
     "autocorrectNotAvailable": "Valitettavasti alustasi ei tällä hetkellä tue tätä ominaisuutta. Pysy kuulolla jatkokehityksestä!",
     "pleaseUpdateApp": "Päivitä sovellus jatkaaksesi.",
@@ -3701,17 +3362,12 @@
     "knockSpaceSuccess": "Olet pyytänyt liittymistä tähän kurssiin! Järjestelmänvalvoja vastaa pyyntöön, kun se on vastaanotettu 😊",
     "chooseWordAudioInstructionsBody": "Kuuntele koko viesti. Sitten yhdistä äänitiedostot sanoihin.",
     "chooseMorphsInstructionsBody": "Klikkaa palapelin paloja kielioppikysymyksiin!",
-    "pleaseEnterInt": "Syötä numero",
     "home": "Koti",
     "join": "Liity",
     "resetInstructionTooltipsTitle": "Nollaa ohjeiden työkaluvihjeet",
     "resetInstructionTooltipsDesc": "Klikkaa näyttääksesi ohjeiden työkaluvihjeet kuten uudelle käyttäjälle.",
-    "randomize": "Satunnaista",
     "clear": "Tyhjennä",
-    "featuredActivities": "Suositellut",
     "save": "Tallenna",
-    "startChat": "Aloita keskustelu",
-    "translationProblem": "Käännösongelma",
     "askToJoin": "Kysy liittymistä",
     "emptyChatWarningTitle": "Chat on tyhjä",
     "emptyChatWarningDesc": "Et ole kutsunut ketään chattiisi. Mene Chat-asetuksiin kutsuaksesi yhteystietosi tai Botin. Voit tehdä tämän myös myöhemmin.",
@@ -3741,17 +3397,13 @@
     "timesUsedIndependently": "Kertojen määrä itsenäisesti käytettynä",
     "timesUsedWithAssistance": "Kertojen määrä avustuksella käytettynä",
     "shareInviteCode": "Jaa kutsukoodi: {code}",
-    "leaderboard": "Sijoituslista",
     "skipForNow": "Ohita nyt",
     "permissions": "Oikeudet",
     "spaceChildPermission": "Kuka voi lisätä uusia keskusteluja tähän kurssiin",
-    "addEnvironmentOverride": "Lisää ympäristöylitys",
     "defaultOption": "Oletus",
     "deleteChatDesc": "Oletko varma, että haluat poistaa tämän keskustelun? Se poistetaan kaikilta osallistujilta ja kaikki keskustelun viestit eivät ole enää käytettävissä harjoitteluun tai oppimisanalytiikkaan.",
     "deleteSpaceDesc": "Kurssi ja kaikki valitut keskustelut poistetaan kaikilta osallistujilta ja kaikki keskustelun viestit eivät ole enää käytettävissä harjoitteluun tai oppimisanalytiikkaan. Tätä toimintoa ei voi peruuttaa.",
     "launch": "Käynnistä",
-    "searchChats": "Etsi keskusteluja",
-    "maxFifty": "Maks 50",
     "configureSpace": "Määritä kurssi",
     "pinMessages": "Kiinnitä viestit",
     "setJoinRules": "Aseta liittymissäännöt",
@@ -3785,9 +3437,6 @@
     "failedToFetchTranscription": "Äänityksen hakeminen epäonnistui",
     "deleteEmptySpaceDesc": "Kurssi poistetaan kaikilta osallistujilta. Tätä toimintoa ei voi peruuttaa.",
     "regenerate": "Luo uudelleen",
-    "mySavedActivities": "Tallentamani aktiviteetit",
-    "noSavedActivities": "Ei tallennettuja aktiviteetteja",
-    "saveActivity": "Tallenna tämä aktiviteetti",
     "failedToPlayVideo": "Videon toistaminen epäonnistui",
     "done": "Valmis",
     "inThisSpace": "Tässä kurssissa",
@@ -3798,13 +3447,9 @@
     "numInvited": "{count} kutsuttu",
     "saved": "Tallennettu",
     "reset": "Nollaa",
-    "errorFetchingActivitiesMessage": "Virhe haettaessa aktiviteetteja",
     "errorFetchingDefinition": "Virhe haettaessa määritelmää",
     "errorProcessAnalytics": "Virhe analytiikan käsittelyssä",
     "errorDownloading": "Lataus epäonnistui",
-    "errorLoadingSpaceChildren": "Virhe ladataessa keskusteluja tämän kurssin sisällä",
-    "unexpectedError": "Odottamaton virhe.",
-    "pleaseReload": "Lataa sivu uudelleen ja yritä uudelleen.",
     "translationError": "Käännösvirhe",
     "check": "Tarkista",
     "unableToFindRoom": "Ei löydetty keskustelua tai kurssia tällä koodilla. Yritä uudelleen.",
@@ -3813,19 +3458,14 @@
     "request": "Pyyntö",
     "requestAll": "Pyydä kaikki",
     "confirmMessageUnpin": "Oletko varma, että haluat irrottaa tämän viestin?",
-    "saveAndLaunch": "Tallenna ja käynnistä",
-    "launchToSpace": "Käynnistä kurssille",
     "pending": "Odottaa",
     "inactive": "Ei aktiivinen",
-    "confirmRole": "Vahvista rooli",
     "openRoleLabel": "AVOIN",
     "finishedTheActivity": "🎯 {username} saatteli aktiviteetin päätökseen",
     "activitySummaryError": "Aktiviteettien yhteenvetoja ei saatavilla",
     "requestSummaries": "Pyydä yhteenvetoja",
-    "generatingNewActivities": "Olet tämän kieliparin ensimmäinen käyttäjä! Odota hetki, valmistelemme aktiviteetteja juuri sinulle.",
     "requestAccessTitle": "Pyydä analytiikkapääsyä?",
     "requestAccessDesc": "Haluatko pyytää pääsyä nähdäksesi osallistujien analytiikan?\n\nJos osallistujat suostuvat, kurssin ylläpitäjät voivat nähdä heidän:\n    • kokonaissanaston\n    • kokonaiskielioppikonseptit\n    • kokonaisaktiviteettisessiot, jotka on suoritettu\n    • käytetyt, oikein ja väärin, kielioppikonseptit\n\nHe eivät voi nähdä heidän:\n    • viestejä keskusteluissa kurssin ulkopuolella\n    • sanastoluetteloa",
-    "requestAccess": "Pyydä pääsyä ({count})",
     "analyticsInactiveTitle": "Ei voitu lähettää pyyntöjä inaktiivisille käyttäjille",
     "analyticsInactiveDesc": "Inaktiiviset käyttäjät, jotka eivät ole kirjautuneet sisään tämän ominaisuuden käyttöönoton jälkeen, eivät näe pyyntöäsi.\n\nPyyntöpainike ilmestyy, kun he palaavat. Voit lähettää pyynnön uudelleen myöhemmin napsauttamalla Pyyntö-painiketta heidän nimensä alla, kun se on saatavilla.",
     "accessRequestedTitle": "Analytiikan pääsypyyntö",
@@ -3848,8 +3488,6 @@
     "accessDesc": "Voit tehdä kurssistasi avoimen maailmalle! Tai tehdä siitä yksityisen ja turvallisen.",
     "createGroupChatDesc": "Sillä aikaa kun aktiviteettisessiot alkavat ja päättyvät, ryhmäkeskustelut pysyvät avoimina säännöllistä viestintää varten.",
     "deleteDesc": "Vain ylläpitäjät voivat poistaa kurssin. Tämä on tuhoava toimenpide, joka poistaa kaikki käyttäjät ja poistaa kaikki valitut keskustelut kurssin sisällä. Toimi varoen.",
-    "noCourseFound": "Voi, tämä kurssi tarvitsee suunnitelman!\n\nKurssisuunnitelmat ovat aiheiden ja keskustelutoimintojen sarja.",
-    "additionalParticipants": "+ {num} muuta",
     "whatNow": "Mitä nyt?",
     "chooseNextActivity": "Valitse seuraava toimintosi!",
     "letsGo": "Lähdetään",
@@ -3862,13 +3500,11 @@
     "waitNotDone": "Odota, en ole vielä valmis!",
     "waitingForOthersToFinish": "Odotetaan muiden valmistumista...",
     "generatingSummary": "Analysoidaan keskustelua ja luodaan tuloksia",
-    "findCourse": "Etsi kurssi",
     "pingParticipantsNotification": "{user} etsii käyttäjiä liittymään aktiviteettisessioon {room}",
     "course": "Kurssi",
     "courses": "Kurssit",
     "goToCourse": "Siirry kurssiin: {course}",
     "activityComplete": "Tämä aktiviteetti on suoritettu. Yhteenveto aktiviteetista pitäisi olla saatavilla alla.",
-    "startNewSession": "Aloita uusi istunto",
     "joinOpenSession": "Liity avoimeen istuntoon",
     "activityNotFound": "Toimintoa ei löytynyt",
     "myActivities": "Omat aktiviteetit",
@@ -3948,10 +3584,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3961,10 +3593,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4052,14 +3680,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4076,10 +3696,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4092,15 +3708,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4252,14 +3860,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4273,14 +3873,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5503,10 +5095,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5547,10 +5135,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5623,10 +5207,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5896,47 +5476,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5956,19 +5496,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6032,10 +5560,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6076,14 +5600,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6095,14 +5611,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6140,10 +5648,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6160,27 +5664,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6304,10 +5792,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6317,10 +5801,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6337,14 +5817,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6484,18 +5956,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6544,10 +6004,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6557,18 +6013,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6611,23 +6055,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6651,10 +6083,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6662,14 +6090,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6774,18 +6194,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6838,10 +6246,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6868,10 +6272,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7052,7 +6452,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Tarkista huomenna aktiviteettipäivitykset.",
-    "activityDropdownDesc": "Kun olet valmis tämän aktiviteetin kanssa, napsauta alla",
     "languageMismatchTitle": "Kielivirhe",
     "languageMismatchDesc": "Kohdekielesi ei vastaa tämän aktiviteetin kieltä. Haluatko päivittää kohdekielesi?",
     "reportWordIssueTooltip": "Ilmoita sanan tiedoista ongelmasta",
@@ -7065,10 +6464,6 @@
     "selectAll": "Valitse kaikki",
     "deselectAll": "Poista valinta kaikista",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7117,17 +6512,11 @@
         "placeholders": {}
     },
     "startOwn": "Aloita oma",
-    "joinCourseDesc": "Jokaisessa kurssissa on 8-10 jäsenneltyä aihetta, joissa on erilaisia tehtävien pohjaisia kielioppiharjoituksia.",
     "newMessageInPangeaChat": "💬 Uusi viesti Pangea-chatissa",
     "shareCourse": "Jaa kurssi",
     "addCourse": "Lisää kurssi",
-    "joinPublicCourse": "Liity julkiseen kurssiin",
     "vocabLevelsDesc": "Tässä kohtaa sanat menevät, kun olet nostanut niiden tasoa!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7140,10 +6529,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7162,7 +6547,6 @@
     "emojiView": "Emojinäkymä",
     "feedbackDialogDesc": "Teen myös virheitä! Onko jotain, mikä auttaisi minua parantamaan?",
     "contactHasBeenInvitedToTheCourse": "Yhteyshenkilö on kutsuttu kurssille",
-    "activityStatsButtonTooltip": "Toimintatiedot",
     "allow": "Salli",
     "deny": "Hylkää",
     "enabledRenewal": "Ota käyttöön tilauksen uusiminen",
@@ -7430,10 +6814,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8489,16 +7869,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Toiminnot seuraavan aiheen avaamiseksi",
-    "activitiesToUnlockTopicDesc": "Aseta toimintojen määrä seuraavan kurssiaiheen avaamiseksi",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Oikea sanaston määritelmän harjoittelu",
     "constructUseIncLMDesc": "Väärä sanaston määritelmän harjoittelu",
     "constructUseCorLADesc": "Oikea sanaston ääniharjoittelu",
@@ -8506,7 +7876,6 @@
     "constructUseBonus": "Bonus sanaharjoittelun aikana",
     "practiceVocab": "Harjoittele sanastoa",
     "selectMeaning": "Valitse merkitys",
-    "selectAudio": "Valitse vastaava ääni",
     "anotherRound": "Toinen kierros",
     "activitySettingsOverrideWarning": "Kieli ja kielitaso määräytyvät aktiviteettisuunnitelman mukaan",
     "voice": "Ääni",
@@ -8538,10 +7907,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8559,12 +7924,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Lataus aloitettu",
     "webDownloadPermissionMessage": "Jos selaimesi estää lataukset, ota lataukset käyttöön tälle sivustolle.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8659,11 +8019,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Jotain meni pieleen, ja teemme kovasti töitä sen korjaamiseksi. Tarkista myöhemmin uudelleen.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Ota käyttöön kirjoitusapu",
     "autoIGCToolDescription": "Suorita automaattisesti Pangea Chat -työkaluja korjataksesi lähetetyt viestit kohdekielelle.",
     "@autoIGCToolName": {
@@ -8700,30 +8055,20 @@
     "newStickerPack": "Uusi tarrapaketti",
     "stickerPackName": "Tarrapakkauksen nimi",
     "attribution": "Kuvaus",
-    "skipChatBackup": "Ohita keskustelun varmuuskopiointi",
-    "skipChatBackupWarning": "Oletko varma? Ilman keskustelun varmuuskopiointia voit menettää pääsyn viesteihisi, jos vaihdat laitetta.",
-    "loadingMessages": "Ladataan viestejä",
-    "setupChatBackup": "Aseta keskustelun varmuuskopiointi",
     "noMoreResultsFound": "Ei enää tuloksia",
     "chatSearchedUntil": "Chat etsitty asti {time}",
     "federationBaseUrl": "Federation-perus-URL",
     "clientWellKnownInformation": "Asiakkaan tunnetut tiedot:",
     "baseUrl": "Perus-URL",
     "identityServer": "Tunnistautumispalvelin:",
-    "versionWithNumber": "Versio: {version}",
     "logs": "Lokit",
-    "advancedConfigs": "Edistyneet asetukset",
     "advancedConfigurations": "Edistyneet asetukset",
-    "signInWithLabel": "Kirjaudu sisään käyttäen:",
-    "spanTypeGrammar": "Kielioppi",
-    "spanTypeWordChoice": "Sananvalinta",
     "spanTypeSpelling": "Oikeinkirjoitus",
     "spanTypePunctuation": "Piste- ja välimerkkeet",
     "spanTypeStyle": "Tyyli",
     "spanTypeFluency": "Sujuvuus",
     "spanTypeAccents": "Äänteet",
     "spanTypeCapitalization": "Iso alkukirjaimet",
-    "spanTypeCorrection": "Korjaus",
     "spanFeedbackTitle": "Ilmoita korjausongelmasta",
     "selectAllWords": "Valitse kaikki äänestä kuulemasi sanat",
     "aboutMeHint": "Minusta",
@@ -8734,7 +8079,6 @@
     "greatPractice": "Loistava harjoitus!",
     "usedNoHints": "Hyvin tehty, et käyttänyt vihjeitä!",
     "youveCompletedPractice": "Olet suorittanut harjoituksen, jatka samaan malliin kehittyäksesi!",
-    "joinCourseForActivities": "Liity kurssille kokeillaksesi aktiviteetteja.",
     "@createSticker": {
         "type": "String",
         "placeholders": {}
@@ -8760,22 +8104,6 @@
         "placeholders": {}
     },
     "@attribution": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -8807,35 +8135,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
         "type": "String",
         "placeholders": {}
     },
-    "@advancedConfigs": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@advancedConfigurations": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
         "type": "String",
         "placeholders": {}
     },
@@ -8860,10 +8164,6 @@
         "placeholders": {}
     },
     "@spanTypeCapitalization": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeCorrection": {
         "type": "String",
         "placeholders": {}
     },
@@ -8904,10 +8204,6 @@
         "placeholders": {}
     },
     "@youveCompletedPractice": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9108,11 +8404,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Oletko luokassa? Laita liittymiskoodisi tänne.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Korosta ääniviestejä automaattisesti",
     "selectAudioMessagesOnPlayDescription": "Korosta ääniviestejä automaattisesti, kun niitä toistetaan",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9156,18 +8447,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Tässä kurssissa on aiheita, joissa on alle {input} aktiviteettia. Ole hyvä ja syötä numero, joka on pienempi tai yhtä suuri kuin {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Napsauta täällä kirjautuaksesi takaisin sisään.",
     "@clickToLogin": {
@@ -9584,17 +8863,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Sarjakuvamainen keltainen karhu, jonka kädet ovat nostettuina innostuksesta.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Valitse sanoja oppiaksesi niistä lisää",
     "requireAnalyticsAccessTitle": "Vaadi analytiikkapääsy liittymiseen",
     "requireAnalyticsAccessDesc": "Osallistujien on myönnettävä pääsy oppimisanalyyseihinsa liittyäkseen tähän kurssiin",
     "analyticsAccessNoticeTitle": "Analytiikkapääsy vaaditaan",
     "analyticsAccessNoticeDesc": "Liittymällä tähän kurssiin hyväksyt, että ylläpitäjät saavat pääsyn oppimisanalyyseihisi.",
-    "skipOnboardingClassCodeDesc": "Opitko itsenäisesti? Älä huoli, voit:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9612,10 +8885,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9644,7 +8913,6 @@
     "pickCefrLevelTeacherStepTitle": "Mitä tasoa opetat?",
     "pickCefrLevelStudentStepTitle": "Mitä tasoa olet?",
     "customCourseStepTitle": "Täytä tämä lomake saadaksesi räätälöidyn kurssin",
-    "aboutYourClass": "Tietoa luokastasi",
     "courseCodeStepErrorMessage": "Tarkista koodisi ja yritä uudelleen",
     "institution": "Oppilaitos",
     "courseGoals": "Kurssin tavoitteet",
@@ -9687,10 +8955,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9807,12 +9071,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat -logo",
     "introChatDetails": "Sano hei! Esittele itsesi muille kurssin osallistujille, etsi ystäviä ja keskustele aktiviteettien ulkopuolella.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9856,11 +9115,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Toimintatoimet",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Äänteentunnistustyökalut",
     "audioTranscription": "AI-äänitallennus",
     "visualLearnerSupport": "Visuaalisen oppijan tuki",
@@ -9901,7 +9155,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Liity kurssille, joka sisältää tämän aktiviteetin pelataksesi sitä.",
     "resizeCoursePanel": "Muuta kurssipaneelin kokoa",
     "undo": "Kumoa",
     "unlock": "Avaa lukitus",
@@ -9915,7 +9168,6 @@
     "addCourseBrowsePublic": "Selaa julkisia kursseja",
     "browsePublicCourses": "Selaa julkisia kursseja",
     "editProfile": "Muokkaa profiilia",
-    "numObjectives": "{count} tavoitetta",
     "mapSearchHint": "Etsi aktiviteetteja",
     "mapSearchNoResults": "Ei osumia näkymässä",
     "mapFilterAllLanguages": "Kaikki kielet",
@@ -9924,7 +9176,6 @@
     "mapFilterCompleted": "Valmis",
     "mapFilterReset": "Nollaa",
     "activityTypeConversation": "Keskustelu",
-    "lockedMissionRequirement": "Suorita edellinen tehtävä avatakseksi",
     "playAgain": "Pelaa uudelleen",
     "reviewActivity": "Arvioi",
     "mapEmptyInView": "Täällä ei ole mitään tasollasi tai kielelläsi. Laajenna suodattimiasi tai zoomaa ulos.",
@@ -9939,14 +9190,9 @@
     "scrollToBottom": "Vieritä alas",
     "courseImage": "Kurssikuva",
     "avatarPreview": "Avatarin esikatselu",
-    "activityPhoto": "Toimintakuva",
     "emotePreview": "Emote-esikatselu: {name}",
     "activityLabel": "Toiminta: {title}",
     "resetMapView": "Nollaa karttanäkymä",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9999,14 +9245,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10036,10 +9274,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10096,10 +9330,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_fil.arb
+++ b/lib/l10n/intl_fil.arb
@@ -86,11 +86,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Pwede ba sumali ang mga bisita",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Sigurado ka?",
     "@areYouSure": {
         "type": "String",
@@ -448,13 +443,6 @@
             }
         }
     },
-    "yourChatBackupHasBeenSetUp": "Na-set up na ang iyong chat backup.",
-    "@yourChatBackupHasBeenSetUp": {},
-    "chatBackupDescription": "Naka-secure ang iyong mga lumang mensahe gamit ng recovery key. Siguraduhing hindi mo ito mawalan.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "commandHint_markasdm": "Markahan bilang direktang mensahe na room para sa ibinigay na Matrix ID",
     "@commandHint_markasdm": {},
     "changedTheGuestAccessRulesTo": "Pinalitan ni {username} ang mga tuntunin sa pag-access ng bisita sa: {rules}",
@@ -534,11 +522,6 @@
     },
     "createGroup": "Gumawa ng grupo",
     "@createGroup": {},
-    "createNewSpace": "Bagong space",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "currentlyActive": "Kasalukuyang aktibo",
     "@currentlyActive": {
         "type": "String",
@@ -618,11 +601,6 @@
     },
     "encryptionNotEnabled": "Hindi naka-enable ang encryption",
     "@encryptionNotEnabled": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "Handa na ang lahat!",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -816,11 +794,6 @@
         },
         "description": "State that {command} is not a valid /command."
     },
-    "contactHasBeenInvitedToTheGroup": "Inimbita ang contact sa group",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Inulat ang nilalaman sa mga pangangasiwa ng server",
     "@contentHasBeenReported": {
         "type": "String",
@@ -852,17 +825,6 @@
     },
     "emoteSettings": "Mga Setting ng Emote",
     "@emoteSettings": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "globalChatId": "Global chat ID",
-    "@globalChatId": {},
-    "accessAndVisibility": "Pag-access at visibility",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Sino ang pinapayagang sumali sa chat at paano matutuklas ang chat.",
-    "@accessAndVisibilityDescription": {},
-    "enableEncryptionWarning": "Hindi mo madi-disable ang encryption. Sigurado ka ba?",
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -943,11 +905,6 @@
     "@unread": {},
     "spaces": "Mga Espasyo",
     "@spaces": {},
-    "groupIsPublic": "Pampubliko ang grupo",
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "groups": "Mga grupo",
     "@groups": {
         "type": "String",
@@ -957,8 +914,6 @@
     "@alwaysUse24HourFormat": {
         "description": "Set to true to always display time of day in 24 hour format."
     },
-    "chatDescription": "Paglalarawan ng chat",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "Nabago ang paglalarawan ng chat",
     "@chatDescriptionHasBeenChanged": {},
     "groupWith": "Grupo kasama kay/sa {displayname}",
@@ -976,7 +931,6 @@
     "normalUser": "Normal na gumagamit",
     "commandHint_roomupgrade": "I-upgrade ang kuwartong ito sa ibinigay na bersyon ng kuwarto",
     "checkList": "Listahan ng tseke",
-    "countInvited": "{count} imbitado",
     "hasWithdrawnTheInvitationFor": "{username} ay nag-withdraw ng paanyaya para kay {targetName}",
     "help": "Tulong",
     "hideRedactedEvents": "Itago ang mga tinanggal na kaganapan",
@@ -994,7 +948,6 @@
     "incorrectPassphraseOrKey": "Maling passphrase o recovery key",
     "inoffensive": "Hindi nakakasakit",
     "inviteContact": "Imbitahan ang contact",
-    "inviteContactToGroup": "Imbitahan ang contact sa {groupName}",
     "noChatDescriptionYet": "Walang deskripsyon ng chat na nalikha pa.",
     "tryAgain": "Subukan muli",
     "invalidServerName": "Di-wastong pangalan ng server",
@@ -1015,7 +968,6 @@
     "leave": "Umalis",
     "leftTheChat": "Umalis sa chat",
     "lightTheme": "Maaliwalas",
-    "loadCountMoreParticipants": "Mag-load ng {count} pang kalahok",
     "dehydrate": "I-export ang sesyon at burahin ang device",
     "dehydrateWarning": "Hindi maaaring ibalik ang aksyong ito. Siguraduhing ligtas mong naiimbak ang backup na file.",
     "hydrate": "I-restore mula sa backup na file",
@@ -1024,7 +976,6 @@
     "locationDisabledNotice": "Nakapatay ang mga serbisyo ng lokasyon. Paki-enable upang maibahagi ang iyong lokasyon.",
     "locationPermissionDeniedNotice": "Tinanggihan ang pahintulot sa lokasyon. Paki-bigay ito upang maibahagi ang iyong lokasyon.",
     "login": "Mag-login",
-    "logInTo": "Mag-log in sa {homeserver}",
     "logout": "Mag-logout",
     "mention": "Banggitin",
     "messages": "Mga mensahe",
@@ -1039,8 +990,6 @@
     "no": "Hindi",
     "noConnectionToTheServer": "Walang koneksyon sa server",
     "noEmotesFound": "Walang nahanap na emotes. 😕",
-    "noEncryptionForPublicRooms": "Maaari mo lamang i-activate ang encryption kapag ang silid ay hindi na pampubliko.",
-    "noGoogleServicesWarning": "Mukhang hindi available ang Firebase Cloud Messaging sa iyong device. Upang makatanggap pa rin ng push notifications, inirerekomenda naming i-install ang ntfy. Sa ntfy o ibang Unified Push provider, maaari kang makatanggap ng push notifications sa isang secure na paraan ng datos. Maaaring i-download ang ntfy mula sa PlayStore o F-Droid.",
     "noMatrixServer": "{server1} ay hindi isang matrix server, gagamitin ba ang {server2} sa halip?",
     "shareInviteLink": "Ibahagi ang link ng imbitasyon",
     "scanQrCode": "I-scan ang QR code",
@@ -1062,12 +1011,10 @@
     "openCamera": "Buksan ang kamera",
     "openVideoCamera": "Buksan ang kamera para sa isang video",
     "oneClientLoggedOut": "Isa sa iyong mga kliyente ay na-log out",
-    "addAccount": "Magdagdag ng account",
     "editBundlesForAccount": "I-edit ang mga bundle para sa account na ito",
     "addToBundle": "Idagdag sa bundle",
     "removeFromBundle": "Alisin mula sa bundle na ito",
     "bundleName": "Pangalan ng bundle",
-    "enableMultiAccounts": "(BETA) Pahintulutan ang maraming account sa device na ito",
     "openInMaps": "Buksan sa maps",
     "link": "Link",
     "serverRequiresEmail": "Kailangan i-validate ng server na ito ang iyong email address para sa pagpaparehistro.",
@@ -1079,7 +1026,6 @@
     "passwordHasBeenChanged": "Napalitan na ang password",
     "overview": "Pangkalahatang-ideya",
     "passwordRecoverySettings": "Mga setting ng pagbawi ng password",
-    "passwordRecovery": "Pagbawi ng password",
     "people": "Mga tao",
     "pickImage": "Pumili ng larawan",
     "pin": "Pin",
@@ -1088,7 +1034,6 @@
     "pleaseChooseAPasscode": "Mangyaring pumili ng isang pass code",
     "pleaseClickOnLink": "Mangyaring i-click ang link sa email at magpatuloy.",
     "pleaseEnter4Digits": "Mangyaring magpasok ng 4 na digit o iwanang blangko upang i-disable ang app lock.",
-    "pleaseEnterRecoveryKey": "Mangyaring ipasok ang iyong recovery key:",
     "pleaseEnterYourPassword": "Mangyaring ipasok ang iyong password",
     "pleaseEnterYourPin": "Mangyaring ipasok ang iyong pin",
     "pleaseEnterYourUsername": "Mangyaring ipasok ang iyong username",
@@ -1108,7 +1053,6 @@
     "rejectedTheInvitation": "Tinanggihan ni {username} ang imbitasyon",
     "removeAllOtherDevices": "Tanggalin ang lahat ng iba pang device",
     "removedBy": "Inalis ni {username}",
-    "removeDevice": "Tanggalin ang device",
     "unbanFromChat": "Alisin sa ban mula sa chat",
     "removeYourAvatar": "Tanggalin ang iyong avatar",
     "replaceRoomWithNewerVersion": "Palitan ang silid ng mas bagong bersyon",
@@ -1120,8 +1064,6 @@
     "saveFile": "I-save ang file",
     "search": "Maghanap",
     "security": "Seguridad",
-    "recoveryKey": "Susi ng pagbawi",
-    "recoveryKeyLost": "Nawala ang susi ng pagbawi?",
     "send": "Ipadala",
     "sendAMessage": "Magpadala ng mensahe",
     "sendAsText": "Ipadala bilang teksto",
@@ -1140,7 +1082,6 @@
     "separateChatTypes": "Hatiin ang Direktang Usap at mga Grupo",
     "setAsCanonicalAlias": "Itakda bilang pangunahing alias",
     "setChatDescription": "Itakda ang paglalarawan ng usapan",
-    "setPermissionsLevel": "Itakda ang antas ng mga pahintulot",
     "setStatus": "Itakda ang status",
     "settings": "Mga Setting",
     "share": "Ibahagi",
@@ -1150,8 +1091,6 @@
     "presencesToggle": "Ipakita ang mga mensahe ng status mula sa ibang mga user",
     "skip": "Laktawan",
     "sourceCode": "Source code",
-    "spaceIsPublic": "Ang espasyo ay pampubliko",
-    "spaceName": "Pangalan ng Espasyo",
     "startedACall": "Nagsimula si {senderName} ng tawag",
     "status": "Katayuan",
     "statusExampleMessage": "Kumusta ka ngayon?",
@@ -1163,7 +1102,6 @@
     "theyMatch": "Magkatugma Silang Dalawa",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "Sobrang dami ng mga kahilingan. Pakisubukang muli mamaya!",
-    "transferFromAnotherDevice": "Ilipat mula sa ibang device",
     "tryToSendAgain": "Subukang muli ang pagpapadala",
     "unavailable": "Hindi magagamit",
     "unbannedUser": "{username} ay na-unban {targetName}",
@@ -1173,7 +1111,6 @@
     "unknownEvent": "Hindi kilalang kaganapan '{type}'",
     "unmuteChat": "I-unmute ang chat",
     "unpin": "I-unpin",
-    "unreadChats": "{unreadCount, plural, =1{1 hindi nabasang chat} other{{unreadCount} hindi nabasang chat}}",
     "userAndOthersAreTyping": "{username} at {count} pang iba ay nagta-type…",
     "userAndUserAreTyping": "{username} at {username2} ay nagta-type…",
     "userIsTyping": "{username} ay nagta-type…",
@@ -1186,8 +1123,6 @@
     "verifyStart": "Simulan ang Pagberipika",
     "verifySuccess": "Matagumpay kang na-verify!",
     "verifyTitle": "Pag-verify ng ibang account",
-    "videoCall": "Video tawag",
-    "visibilityOfTheChatHistory": "Kahalagahan ng kasaysayan ng chat",
     "visibleForAllParticipants": "Makikita ng lahat ng kalahok",
     "visibleForEveryone": "Makikita ng lahat",
     "voiceMessage": "Boses na mensahe",
@@ -1197,10 +1132,7 @@
     "wallpaper": "Wallpaper:",
     "warning": "Babala!",
     "weSentYouAnEmail": "Nagpadala kami sa iyo ng isang email",
-    "whoCanPerformWhichAction": "Sino ang maaaring magsagawa ng anong aksyon",
-    "whoIsAllowedToJoinThisGroup": "Sino ang pinapayagang sumali sa grupong ito",
     "whyDoYouWantToReportThis": "Bakit mo nais i-report ito?",
-    "wipeChatBackup": "Burahin ang iyong backup ng chat upang lumikha ng isang bagong susi sa pagbawi?",
     "withTheseAddressesRecoveryDescription": "Sa mga address na ito maaari mong mabawi ang iyong password.",
     "writeAMessage": "Isulat ang isang mensahe…",
     "yes": "Oo",
@@ -1213,9 +1145,7 @@
     "messageType": "Uri ng Mensahe",
     "sender": "Nagpadala",
     "openGallery": "Buksan ang gallery",
-    "removeFromSpace": "Alisin mula sa espasyo",
     "start": "Simulan",
-    "pleaseEnterRecoveryKeyDescription": "Upang ma-unlock ang iyong mga lumang mensahe, mangyaring ilagay ang iyong recovery key na nilikha sa isang nakaraang sesyon. Ang iyong recovery key ay HINDI ang iyong password.",
     "publish": "I-publish",
     "openChat": "Buksan ang Chat",
     "markAsRead": "Markahan bilang nabasa",
@@ -1226,12 +1156,9 @@
     "confirmEventUnpin": "Sigurado ka bang i-unpin nang permanente ang kaganapan?",
     "emojis": "Mga Emojis",
     "placeCall": "Tawagan",
-    "voiceCall": "Tawag sa boses",
     "unsupportedAndroidVersion": "Hindi suportadong bersyon ng Android",
     "unsupportedAndroidVersionLong": "Ang tampok na ito ay nangangailangan ng mas bagong bersyon ng Android. Mangyaring suriin ang mga update o suporta mula sa Lineage OS.",
-    "videoCallsBetaWarning": "Pakitandaan na ang mga video call ay kasalukuyang nasa beta. Maaaring hindi ito gumana nang inaasahan o hindi gumana sa lahat ng mga platform.",
     "experimentalVideoCalls": "Eksperimental na mga video call",
-    "emailOrUsername": "Email o username",
     "addWidget": "Magdagdag ng widget",
     "widgetVideo": "Video",
     "widgetEtherpad": "Tala ng teksto",
@@ -1253,35 +1180,19 @@
     "youKickedAndBanned": "🙅‍♀️ Inalis at binansagan mo si {user}",
     "youUnbannedUser": "Binawi mo ang ban kay {user}",
     "hasKnocked": "🚪 Numanong si {user}",
-    "usersMustKnock": "Kailangan magpatunog ang mga user",
-    "noOneCanJoin": "Walang pwedeng sumali",
     "knock": "Tumunog",
     "users": "Mga User",
-    "unlockOldMessages": "Buksan ang lumang mga mensahe",
-    "storeInSecureStorageDescription": "I-store ang recovery key sa secure na imbakan ng device na ito.",
-    "saveKeyManuallyDescription": "Manu-manong i-save ang susi na ito sa pamamagitan ng pag-trigger sa system share dialog o clipboard.",
-    "storeInAndroidKeystore": "I-store sa Android KeyStore",
-    "storeInAppleKeyChain": "I-store sa Apple KeyChain",
-    "storeSecurlyOnThisDevice": "I-store nang ligtas sa device na ito",
     "countFiles": "{count} mga file",
     "user": "Gumagamit",
     "custom": "Pasadya",
-    "foregroundServiceRunning": "Lumilitaw ang notipikasyong ito kapag tumatakbo ang foreground service.",
-    "screenSharingTitle": "paghahati ng screen",
-    "screenSharingDetail": "Ibinabahagi mo ang iyong screen sa FuffyChat",
     "whyIsThisMessageEncrypted": "Bakit hindi mabasa ang mensaheng ito?",
     "noKeyForThisMessage": "Maaaring mangyari ito kung ang mensahe ay naipadala bago ka mag-sign in sa iyong account sa device na ito.\n\nPosible rin na hinarang ng sender ang iyong device o may nangyaring mali sa koneksyon sa internet.\n\nMaaari mo bang basahin ang mensahe sa ibang session? Pagkatapos ay maaari mong ilipat ang mensahe mula dito! Pumunta sa Settings > Devices at tiyaking na-verify ang iyong mga device sa isa't isa. Kapag binuksan mo ang kwarto sa susunod na pagkakataon at parehong mga session ay nasa foreground, awtomatikong ipapadala ang mga susi.\n\nAyaw mo bang mawala ang mga susi kapag nag-logout o nagpalit ng device? Tiyakin na na-enable mo ang chat backup sa mga setting.",
     "newGroup": "Bagong grupo",
     "newSpace": "Bagong espasyo",
-    "enterSpace": "Pumasok sa espasyo",
     "allSpaces": "Lahat ng espasyo",
     "hidePresences": "Itago ang Listahan ng Status?",
     "doNotShowAgain": "Huwag na ipakita muli",
     "wasDirectChatDisplayName": "Puwang na usapan (dating {oldDisplayName})",
-    "newSpaceDescription": "Pinapayagan ka ng mga Espasyo na pagsamahin ang iyong mga usapan at bumuo ng mga pribado o pampublikong komunidad.",
-    "encryptThisChat": "I-encrypt ang usapang ito",
-    "disableEncryptionWarning": "Para sa seguridad, hindi mo maaaring i-disable ang encryption sa isang usapan, kung saan ito ay na-enable na dati.",
-    "sorryThatsNotPossible": "Paumanhin... hindi ito posible",
     "deviceKeys": "Mga susi ng device:",
     "reopenChat": "Muling buksan ang usapan",
     "noBackupWarning": "Babala! Kung hindi i-enable ang backup ng usapan, mawawala ang access mo sa iyong mga naka-encrypt na mensahe. Lubos na inirerekomenda na i-enable ang backup ng usapan bago mag-logout.",
@@ -1294,7 +1205,6 @@
     "openLinkInBrowser": "Buksan ang link sa browser",
     "reportErrorDescription": "😢 Naku. May nangyaring mali. Kung nais mo, maaari mong i-report ang bug na ito sa mga developer.",
     "report": "iulat",
-    "setTheme": "Itakda ang tema:",
     "setColorTheme": "Itakda ang kulay na tema:",
     "invite": "Imbitahan",
     "inviteGroupChat": "📝 Imbitahan sa group chat",
@@ -1313,12 +1223,8 @@
     "yourGlobalUserIdIs": "Ang iyong global na user-ID ay: ",
     "noUsersFoundWithQuery": "Sa kasamaang palad, walang user na mahanap gamit ang \"{query}\". Mangyaring suriin kung nagkamali ka sa pag-type.",
     "knocking": "Nagtatanong",
-    "chatCanBeDiscoveredViaSearchOnServer": "Maaaring mahanap ang chat sa pamamagitan ng paghahanap sa {server}",
-    "searchChatsRooms": "Maghanap ng #chats, @users...",
     "nothingFound": "Walang nahanap...",
     "groupName": "Pangalan ng grupo",
-    "createGroupAndInviteUsers": "Lumikha ng grupo at anyayahan ang mga user",
-    "groupCanBeFoundViaSearch": "Maaaring mahanap ang grupo sa pamamagitan ng paghahanap",
     "wrongRecoveryKey": "Paumanhin... mukhang hindi ito ang tamang recovery key.",
     "startConversation": "Simulan ang pag-uusap",
     "commandHint_sendraw": "Magpadala ng raw json",
@@ -1332,11 +1238,8 @@
     "pleaseChooseAStrongPassword": "Mangyaring pumili ng malakas na password",
     "passwordsDoNotMatch": "Hindi magkatugma ang mga password",
     "passwordIsWrong": "Mali ang iyong ipinasok na password",
-    "publicChatAddresses": "Mga pampublikong address ng chat",
-    "createNewAddress": "Lumikha ng bagong address",
     "joinSpace": "Sumali sa espasyo",
     "publicSpaces": "Mga pampublikong espasyo",
-    "addChatOrSubSpace": "Magdagdag ng chat o sub space",
     "subspace": "Subspace",
     "decline": "Tanggihan",
     "thisDevice": "Ang device na ito:",
@@ -1345,15 +1248,11 @@
     "searchMore": "Maghanap pa...",
     "gallery": "Galleries",
     "files": "Mga File",
-    "sessionLostBody": "Nawawala ang iyong session. Mangyaring i-report ang error na ito sa mga developer sa {url}. Ang mensahe ng error ay: {error}",
-    "restoreSessionBody": "Sinusubukan ng app na i-restore ang iyong session mula sa backup. Mangyaring i-report ang error na ito sa mga developer sa {url}. Ang mensahe ng error ay: {error}",
     "sendReadReceipts": "Magpadala ng mga resibo ng pagbasa",
     "sendTypingNotificationsDescription": "Makikita ng ibang kalahok sa chat kapag nagta-type ka ng bagong mensahe.",
     "sendReadReceiptsDescription": "Makikita ng ibang kalahok sa chat kapag nabasa mo na ang isang mensahe.",
     "formattedMessages": "Na-format na mga mensahe",
     "formattedMessagesDescription": "Ipakita ang mayamang nilalaman ng mensahe tulad ng naka-bold na teksto gamit ang markdown.",
-    "verifyOtherUser": "🔐 I-verify ang ibang user",
-    "verifyOtherUserDescription": "Kung i-verify mo ang ibang user, makakasiguro ka na alam mo kung sino talaga ang kausap mo. 💪\n\nKapag nagsimula ka ng verification, makakakita kayo ng popup sa app. Doon makikita ninyo ang isang serye ng mga emojis o numero na kailangang ikumpara sa isa't isa.\n\nPinakamainam na magkita o magsimula ng video call. 👭",
     "verifyOtherDevice": "🔐 I-verify ang ibang device",
     "verifyOtherDeviceDescription": "Kapag i-verify mo ang ibang device, maaaring magpalitan ng mga susi ang mga device na iyon, na nagpapataas ng iyong pangkalahatang seguridad. 💪 Kapag nagsimula ka ng verification, lalabas ang isang popup sa app sa parehong mga device. Doon makikita ninyo ang isang serye ng mga emojis o numero na kailangang ikumpara sa isa't isa. Mainam na handa ang parehong device bago magsimula ng verification. 🤳",
     "acceptedKeyVerification": "{sender} tinanggap ang verification ng susi",
@@ -1389,10 +1288,6 @@
     "updateInstalled": "🎉 Na-update ang {version}!",
     "changelog": "Changelog",
     "sendCanceled": "Kinansela ang pagpapadala",
-    "loginWithMatrixId": "Mag-login gamit ang Matrix-ID",
-    "discoverHomeservers": "Tuklasin ang mga homeserver",
-    "whatIsAHomeserver": "Ano ang isang homeserver?",
-    "homeserverDescription": "Lahat ng iyong data ay naka-imbak sa homeserver, katulad ng isang email provider. Maaari kang pumili kung aling homeserver ang nais mong gamitin, habang maaari ka pa ring makipag-ugnayan sa lahat. Matuto pa sa https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Mukhang hindi isang compatible na homeserver. Mali ang URL?",
     "calculatingFileSize": "Kinakalkula ang laki ng file...",
     "prepareSendingAttachment": "Ihanda ang pagpapadala ng attachment...",
@@ -1404,11 +1299,9 @@
     "oneOfYourDevicesIsNotVerified": "Isa sa iyong mga device ay hindi na-verify",
     "noticeChatBackupDeviceVerification": "Tandaan: Kapag ikinonekta mo ang lahat ng iyong device sa chat backup, awtomatiko silang na-verify.",
     "continueText": "Magpatuloy",
-    "welcomeText": "Hey Hey 👋 Ito ang FluffyChat. Maaari kang mag-sign in sa kahit anong homeserver, na compatible sa https://matrix.org. At pagkatapos ay makipag-chat sa kahit sino. Ito ay isang malaking decentralized messaging network!",
     "blur": "Blur:",
     "opacity": "Opacity:",
     "setWallpaper": "Itakda ang wallpaper",
-    "manageAccount": "Pamahalaan ang account",
     "noContactInformationProvided": "Walang ibinigay na balidong impormasyon ng contact ang server",
     "contactServerAdmin": "Makipag-ugnayan sa admin ng server",
     "contactServerSecurity": "Makipag-ugnayan sa seguridad ng server",
@@ -1427,11 +1320,8 @@
     "unableToJoinChat": "Hindi makasali sa usapan. Marahil ang kabilang panig ay nagsara na ng pag-uusap.",
     "previous": "Nakaraan",
     "otherPartyNotLoggedIn": "Hindi kasalukuyang naka-log in ang kabilang panig kaya hindi makakatanggap ng mga mensahe!",
-    "appWantsToUseForLogin": "Gamitin ang '{server}' para mag-log in",
-    "appWantsToUseForLoginDescription": "Pinapayagan mo ang app at website na magbahagi ng impormasyon tungkol sa iyo.",
     "open": "Buksan",
     "waitingForServer": "Naghihintay sa server...",
-    "appIntroduction": "Pinapayagan ka ng FluffyChat na makipag-chat sa iyong mga kaibigan sa iba't ibang messenger. Matuto pa sa https://matrix.org o pindutin lang ang *Continue*.",
     "newChatRequest": "📩 Bagong kahilingan sa chat",
     "contentNotificationSettings": "Mga setting ng notipikasyon sa nilalaman",
     "generalNotificationSettings": "Pangkalahatang mga setting ng notipikasyon",
@@ -1508,11 +1398,9 @@
     "taTooltip": "L2 gamitin kasama ang tulong sa pagsasalin",
     "interactiveTranslatorSliderHeader": "Interaktibong Tagasalin",
     "interactiveGrammarSliderHeader": "Interaktibong Tagasuri ng Gramatika",
-    "interactiveTranslatorRequired": "Kinakailangan",
     "waTooltip": "L2 gamitin nang walang tulong",
     "interactiveTranslator": "Tulong sa Pagsasalin",
     "noIdenticalLanguages": "Mangyaring pumili ng iba't ibang pangunahing at target na mga wika",
-    "searchBy": "Maghanap ayon sa bansa at mga wika",
     "joinWithClassCode": "Sumali sa kurso",
     "languageLevelPreA1": "Baguhan Mababa (Pre A1)",
     "languageLevelA1": "Baguhang Mid (A1)",
@@ -1533,19 +1421,14 @@
     "saveChanges": "Laging tandaan ang mga pagbabago",
     "publicProfileTitle": "Payagan ang aking profile na mahanap sa paghahanap",
     "publicProfileDesc": "Sa pag-on nito, pinapayagan mong makita ng ibang user ang iyong profile sa global search bar at magpadala ng mga kahilingan sa chat. Sa puntong ito, maaari mong piliing tanggapin o tanggihan ang kahilingan.",
-    "errorDisableIT": "Naka-off ang tulong sa pagsasalin.",
-    "errorDisableIGC": "Naka-off ang tulong sa gramatika.",
     "errorDisableITUserDesc": "I-click dito upang i-update ang mga setting ng tulong sa pagsasalin",
     "errorDisableIGCUserDesc": "I-click dito upang i-update ang mga setting ng tulong sa gramatika",
     "errorDisableITClassDesc": "Naka-off ang tulong sa pagsasalin para sa kurso kung saan naroroon ang chat na ito.",
     "errorDisableIGCClassDesc": "Naka-off ang tulong sa gramatika para sa kurso kung saan naroroon ang chat na ito.",
-    "error405Title": "Hindi naka-set ang mga Wika",
     "error405Desc": "Mangyaring itakda ang iyong mga wika sa Main Menu > Learning Settings.",
     "termsAndConditions": "Mga Tuntunin at Kondisyon",
     "andCertifyIAmAtLeast13YearsOfAge": " at certipikadong ako ay hindi bababa sa 16 na taong gulang.",
-    "error502504Title": "Wow, maraming estudyante online!",
     "error502504Desc": "Maaaring maging mabagal o hindi magagamit ang mga translation at grammar tools habang nakakaabante ang mga Pangea bots.",
-    "error404Title": "Error sa Pagsasalin!",
     "error404Desc": "Hindi sigurado ang Pangea Bot kung paano isasalin iyon...",
     "errorPleaseRefresh": "Tinitingnan namin ito! Mangyaring i-reload at subukan muli.",
     "connectedToStaging": "Nakakonekta sa Staging",
@@ -1583,13 +1466,9 @@
     "definitionsToolName": "Mga Kahulugan ng Salita",
     "definitionsToolDescription": "Kapag naka-enable, ang mga salitang naka-underline sa asul ay maaaring i-click para sa mga kahulugan. I-click ang mga mensahe upang ma-access ang mga kahulugan.",
     "welcomeBack": "Maligayang pagbabalik! Kung ikaw ay bahagi ng pilot noong 2023-2024, makipag-ugnayan sa amin para sa iyong espesyal na pilot na subscription. Kung ikaw ay isang guro na bumili ng mga lisensya para sa iyong klase (o ang iyong institusyon ay bumili), makipag-ugnayan sa amin para sa iyong guro na subscription.",
-    "downloadTxtFile": "I-download ang Text File",
-    "downloadCSVFile": "I-download ang CSV File",
     "promotionalSubscriptionDesc": "Sa kasalukuyan ay mayroon kang panghabang-buhay na promosyonal na subscription. Makipag-ugnayan sa support@pangea.chat para sa tulong sa pagbabago ng iyong subscription.",
     "originalSubscriptionPlatform": "Subscription na binili sa pamamagitan ng {purchasePlatform}",
     "oneWeekTrial": "Isang Linggong Pagsubok",
-    "downloadXLSXFile": "I-download ang Excel File",
-    "unkDisplayName": "Unknown",
     "wwCountryDisplayName": "Sa Buong Mundo",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Aland Islands",
@@ -1884,7 +1763,6 @@
     "chatCapacityHasBeenChanged": "Nailipat ang kapasidad ng chat",
     "chatCapacitySetTooLow": "Ang kapasidad ng chat ay dapat hindi bababa sa {count}.",
     "chatCapacityExplanation": "Ang kapasidad ng chat ay naglilimita sa bilang ng mga miyembro na pinapayagan sa isang chat.",
-    "tooManyRequest": "Sobrang dami ng kahilingan, subukan muli mamaya.",
     "enterNumber": "Mangyaring magpasok ng isang buong bilang.",
     "practice": "Praktis",
     "versionNotFound": "Hindi Nahanap ang Bersyon",
@@ -1894,7 +1772,6 @@
     "deleteSubscriptionWarningTitle": "May aktibong subscription ka",
     "deleteSubscriptionWarningBody": "Ang pagtanggal ng iyong account ay hindi awtomatikong magcancela ng iyong subscription.",
     "manageSubscription": "Pamahalaan ang Subscription",
-    "error520Title": "Mangyaring subukan muli.",
     "error520Desc": "Paumanhin, hindi namin maintindihan ang iyong mensahe...",
     "wordsUsed": "Mga Salitang Ginamit",
     "level": "Antas",
@@ -1912,7 +1789,6 @@
     "other": "Iba pa",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "Walang limitasyon sa kapasidad",
-    "downloadGroupText": "I-download ang teksto ng grupo",
     "notificationsOn": "Naka-on ang mga notipikasyon",
     "notificationsOff": "Naka-off ang mga notipikasyon",
     "joinWithCode": "Sumali gamit ang code",
@@ -1976,24 +1852,12 @@
     "whatIsTheMorphTag": "Ano ang {morphologicalFeature} ng '{wordForm}'?",
     "dataAvailable": "Available ang datos",
     "available": "Available",
-    "pangeaBotIsFallible": "Nagkakamali rin ang Pangea Bot!",
-    "whatIsMeaning": "Ano ang ibig sabihin ng '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Itugma ang mga kahulugan sa mga salita sa mensahe!",
-    "doubleClickToEdit": "Mag-double click para i-edit.",
-    "topicLabel": "Paksa",
-    "topicPlaceholder": "Pumili ng paksa...",
-    "modePlaceholder": "Pumili ng uri...",
-    "learningObjectiveLabel": "Layunin sa Pagkatuto",
-    "learningObjectivePlaceholder": "Pumili ng layunin sa pagkatuto...",
-    "targetLanguageLabel": "Target na wika",
     "cefrLevelLabel": "Antas ng CEFR",
     "image": "Larawan",
     "video": "Bidyo",
     "nan": "Hindi naaangkop",
-    "addVocabulary": "Magdagdag ng bokabularyo",
     "instructions": "Mga tagubilin",
-    "numberOfLearners": "Bilang ng mga mag-aaral",
-    "mustBeInteger": "Dapat isang buong numero hal. 1, 2, 3, ...",
     "constructUsePvmDesc": "Ginawa sa mensahe ng boses",
     "leaveSpaceDescription": "Sa pag-alis sa kurso, iiwan mo ang lahat ng mga chat dito. Makikita ng ibang mga user na umalis ka na sa kurso.",
     "constructUseCorMmDesc": "Tamang kahulugan ng mensahe",
@@ -2008,7 +1872,6 @@
     "ttsDisabledBody": "Maaari mong paganahin ang text-to-speech sa iyong mga setting sa pag-aaral",
     "noSpaceDescriptionYet": "Walang nilikhang paglalarawan ng kurso hanggang ngayon.",
     "tooLargeToSend": "Ang mensaheng ito ay masyadong malaki upang ipadala",
-    "exitWithoutSaving": "Sigurado ka bang nais mong umalis nang hindi nagsa-save?",
     "enableAutocorrectPopupTitle": "Idagdag ang iyong target na keyboard sa wika sa pamamagitan ng pagpunta sa:",
     "enableAutocorrectPopupSteps": "  • Mga Setting\n  • Pangkalahatan\n  • Keyboard\n  • Mga Keyboard\n  • Magdagdag ng Bagong Keyboard",
     "enableAutocorrectPopupDescription": "Kapag napili na ang wika, maaari mong i-click ang maliit na icon ng globe sa ibabang kaliwa ng iyong keyboard upang i-activate ang bagong na-install na keyboard.",
@@ -2019,11 +1882,8 @@
     "displayName": "Pangalan na ipapakita",
     "leaveRoomDescription": "Malapit ka nang umalis sa chat na ito. Makikita ng ibang mga user na umalis ka na sa chat.",
     "confirmUserId": "Mangyaring kumpirmahin ang iyong Pangea Chat username upang ma-delete ang iyong account.",
-    "startingToday": "Simula ngayon",
-    "oneWeekFreeTrial": "Isang linggong libreng pagsubok",
     "paidSubscriptionStarts": "Nagsisimula {startDate}",
     "cancelInSubscriptionSettings": "• Kanselahin anumang oras sa mga setting ng subscription",
-    "cancelToAvoidCharges": "• Kanselahin bago ang {trialEnds} upang maiwasan ang mga singil",
     "downloadGboard": "I-download ang Gboard",
     "autocorrectNotAvailable": "Sa kasamaang palad, ang iyong platform ay kasalukuyang hindi sinusuportahan para sa tampok na ito. Abangan ang karagdagang pag-unlad!",
     "pleaseUpdateApp": "Mangyaring i-update ang app upang magpatuloy.",
@@ -2033,17 +1893,12 @@
     "knockSpaceSuccess": "Nais mong sumali sa kursong ito! Sasagot ang isang admin sa iyong kahilingan kapag natanggap nila ito 😄",
     "chooseWordAudioInstructionsBody": "Makinig sa buong mensahe. Pagkatapos, itugma ang mga audio sa mga salita.",
     "chooseMorphsInstructionsBody": "I-click ang mga piraso ng puzzle para sa mga tanong sa gramatika!",
-    "pleaseEnterInt": "Mangyaring magpasok ng isang numero",
     "home": "Home",
     "join": "Sumali",
     "resetInstructionTooltipsTitle": "I-reset ang mga tooltip ng instruksyon",
     "resetInstructionTooltipsDesc": "I-click upang ipakita ang mga tooltip ng instruksyon tulad ng para sa isang bagong user.",
-    "randomize": "Randomin",
     "clear": "I-clear",
-    "featuredActivities": "Itinatampok",
     "save": "I-save",
-    "startChat": "Simulan ang chat",
-    "translationProblem": "Problema sa pagsasalin",
     "askToJoin": "Humingi ng paglahok",
     "emptyChatWarningTitle": "Walang laman ang chat",
     "emptyChatWarningDesc": "Hindi ka pa nag-imbita ng sinuman sa iyong chat. Pumunta sa mga setting ng Chat upang mag-imbita ng iyong mga contact o ang Bot. Maaari mo rin itong gawin mamaya.",
@@ -2073,17 +1928,13 @@
     "timesUsedIndependently": "Mga beses na ginamit nang mag-isa",
     "timesUsedWithAssistance": "Mga beses na ginamit kasama ang tulong",
     "shareInviteCode": "Ibahagi ang code ng imbitasyon: {code}",
-    "leaderboard": "Talaan ng mga Nangunguna",
     "skipForNow": "Laktawan muna",
     "permissions": "Mga Pahintulot",
     "spaceChildPermission": "Sino ang maaaring magdagdag ng mga bagong chat sa kursong ito",
-    "addEnvironmentOverride": "Magdagdag ng override sa kapaligiran",
     "defaultOption": "Default",
     "deleteChatDesc": "Sigurado ka bang nais mong i-delete ang chat na ito? Ito ay matatanggal para sa lahat ng kalahok at ang lahat ng mensahe sa loob ng chat ay hindi na magagamit para sa praktis o analytics sa pag-aaral.",
     "deleteSpaceDesc": "Ang kurso at anumang napiling mga chat ay matatanggal para sa lahat ng kalahok at ang lahat ng mensahe sa loob ng chat ay hindi na magagamit para sa praktis o analytics sa pag-aaral. Hindi na maibabalik ang aksyong ito.",
     "launch": "Ilunsad",
-    "searchChats": "Maghanap ng mga chat",
-    "maxFifty": "Maximum na 50",
     "configureSpace": "I-configure ang kurso",
     "pinMessages": "I-pin ang mga mensahe",
     "setJoinRules": "Itakda ang mga patakaran sa pagsali",
@@ -2117,9 +1968,6 @@
     "failedToFetchTranscription": "Nabigong makuha ang transkripsyon",
     "deleteEmptySpaceDesc": "Ang kurso ay tatanggalin para sa lahat ng kalahok. Hindi maaaring baligtarin ang aksyong ito.",
     "regenerate": "Muling buuin",
-    "mySavedActivities": "Aking Naitabing Gawain",
-    "noSavedActivities": "Walang naitabing gawain",
-    "saveActivity": "I-save ang gawain na ito",
     "failedToPlayVideo": "Nabigong i-play ang video",
     "done": "Tapos na",
     "inThisSpace": "Sa kurso na ito",
@@ -2130,13 +1978,9 @@
     "numInvited": "{count} naimbitahan",
     "saved": "Naitabi",
     "reset": "I-reset",
-    "errorFetchingActivitiesMessage": "Nabigong makuha ang mga aktibidad",
     "errorFetchingDefinition": "Nabigong makuha ang depinisyon",
     "errorProcessAnalytics": "Nabigong iproseso ang analytics",
     "errorDownloading": "Nabigo ang pag-download",
-    "errorLoadingSpaceChildren": "Nabigong i-load ang mga chat sa loob ng kursong ito",
-    "unexpectedError": "Hindi inaasahang error.",
-    "pleaseReload": "Pakiload muli at subukan muli.",
     "translationError": "Error sa pagsasalin",
     "check": "Suriin",
     "unableToFindRoom": "Walang chat o kurso na nahanap gamit ang code na iyon. Pakisubukan muli.",
@@ -2145,19 +1989,14 @@
     "request": "Hilingin",
     "requestAll": "Hilingin Lahat",
     "confirmMessageUnpin": "Sigurado ka bang nais mong alisin ang pindutan sa mensaheng ito?",
-    "saveAndLaunch": "I-save at Ilunsad",
-    "launchToSpace": "Ilunsad sa kurso",
     "pending": "Naghihintay",
     "inactive": "Hindi Aktibo",
-    "confirmRole": "Kumpirmahin ang papel",
     "openRoleLabel": "BUKAS",
     "finishedTheActivity": "🎯 {username} ay nagtapos sa gawaing ito",
     "activitySummaryError": "Hindi magagamit ang mga buod ng gawain",
     "requestSummaries": "Humiling ng mga buod",
-    "generatingNewActivities": "Ikaw ang unang user ng pares ng wikang ito! Pakiusap, maghintay ng isang minuto, naghahanda kami ng mga gawain para sa iyo.",
     "requestAccessTitle": "Humiling ng access sa analytics?",
     "requestAccessDesc": "Nais mo bang humiling ng access upang makita ang analytics ng kalahok?\n\nKung pumayag ang mga kalahok, magagawa ng mga admin ng kursong ito na makita ang kanilang:\n    • kabuuang bokabularyo\n    • kabuuang mga konsepto sa gramatika\n    • kabuuang mga sesyon ng gawain na natapos\n    • ang mga partikular na konsepto sa gramatika na ginamit, tama at mali\n\nHindi nila magagawang makita ang kanilang:\n    • mga mensahe sa mga chat sa labas ng kurso\n    • listahan ng bokabularyo",
-    "requestAccess": "Hilingin ang access ({count})",
     "analyticsInactiveTitle": "Hindi maipapadala ang mga kahilingan sa hindi aktibong mga gumagamit",
     "analyticsInactiveDesc": "Ang mga hindi aktibong gumagamit na hindi nag-login mula nang ipakilala ang tampok na ito ay hindi makakakita ng iyong kahilingan.\n\nAng pindutan ng Hiling ay lalabas kapag sila ay bumalik. Maaari mong muling ipadala ang kahilingan sa pamamagitan ng pag-click sa pindutan ng Hiling sa ilalim ng kanilang pangalan kapag available na ito.",
     "accessRequestedTitle": "Hiling sa Access sa Analytics",
@@ -2180,8 +2019,6 @@
     "accessDesc": "Maaari mong gawing bukas ang iyong kurso sa buong mundo! O, gawing pribado at ligtas ang iyong kurso.",
     "createGroupChatDesc": "Kung saan nagsisimula at nagtatapos ang mga sesyon ng aktibidad, mananatiling bukas ang mga pangkat na usapan para sa pang-araw-araw na komunikasyon.",
     "deleteDesc": "Tanging mga admin lamang ang maaaring magtanggal ng kurso. Ito ay isang mapanirang aksyon na nag-aalis ng lahat ng mga user at nagtatanggal ng lahat ng napiling usapan sa loob ng kurso. Mag-ingat sa pagproseso.",
-    "noCourseFound": "Naku, kailangan ng planong ito ng kurso!\n\nAng mga plano ng kurso ay isang sunod-sunod na mga paksa at aktibidad ng pag-uusap.",
-    "additionalParticipants": "+ {num} iba pa",
     "whatNow": "Ano na ngayon?",
     "chooseNextActivity": "Piliin ang iyong susunod na aktibidad!",
     "letsGo": "Tara na",
@@ -2193,13 +2030,11 @@
     "waitNotDone": "Hintayin mo, hindi pa ako tapos!",
     "waitingForOthersToFinish": "Naghihintay na matapos ang iba...",
     "generatingSummary": "Sinusuri ang chat at bumubuo ng mga resulta",
-    "findCourse": "Maghanap ng kurso",
     "pingParticipantsNotification": "{user} ay naghahanap ng mga user na sumali sa sesyon ng aktibidad sa {room}",
     "course": "Kurso",
     "courses": "Mga kurso",
     "goToCourse": "Pumunta sa kurso: {course}",
     "activityComplete": "Tapos na ang aktibidad na ito. Dapat ay makikita ang buod ng aktibidad sa ibaba.",
-    "startNewSession": "Simulan ang bagong sesyon",
     "joinOpenSession": "Sumali sa bukas na sesyon",
     "activityNotFound": "Hindi nahanap ang aktibidad",
     "myActivities": "Aking mga aktibidad",
@@ -2243,7 +2078,6 @@
     "inviteYourFriends": "Anyayahan ang iyong mga kaibigan",
     "playWithAI": "Maglaro muna kasama ang AI",
     "courseStartDesc": "Handa na ang Pangea Bot anumang oras!\n\n...pero mas maganda ang pag-aaral kasama ang mga kaibigan!",
-    "activityDropdownDesc": "Kapag tapos ka na sa aktibidad na ito, i-click sa ibaba",
     "languageMismatchTitle": "Hindi tugma ang wika",
     "languageMismatchDesc": "Ang iyong target na wika ay hindi tumutugma sa wika ng aktibidad na ito. Nais mong i-update ang iyong target na wika?",
     "reportWordIssueTooltip": "Iulat ang isyu sa impormasyon ng salita",
@@ -2280,14 +2114,6 @@
     "@checkList": {
         "type": "String",
         "placeholders": {}
-    },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@hasWithdrawnTheInvitationFor": {
         "type": "String",
@@ -2363,14 +2189,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "@noChatDescriptionYet": {
         "type": "String",
@@ -2488,14 +2306,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@dehydrate": {
         "type": "String",
         "placeholders": {}
@@ -2527,14 +2337,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@logout": {
         "type": "String",
@@ -2589,14 +2391,6 @@
         "placeholders": {}
     },
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2695,10 +2489,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addAccount": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@editBundlesForAccount": {
         "type": "String",
         "placeholders": {}
@@ -2712,10 +2502,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableMultiAccounts": {
         "type": "String",
         "placeholders": {}
     },
@@ -2763,10 +2549,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@people": {
         "type": "String",
         "placeholders": {}
@@ -2800,10 +2582,6 @@
         "placeholders": {}
     },
     "@pleaseEnter4Digits": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKey": {
         "type": "String",
         "placeholders": {}
     },
@@ -2906,10 +2684,6 @@
             }
         }
     },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unbanFromChat": {
         "type": "String",
         "placeholders": {}
@@ -2951,14 +2725,6 @@
         "placeholders": {}
     },
     "@security": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
         "type": "String",
         "placeholders": {}
     },
@@ -3062,10 +2828,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@setStatus": {
         "type": "String",
         "placeholders": {}
@@ -3103,14 +2865,6 @@
         "placeholders": {}
     },
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -3166,10 +2920,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@tryToSendAgain": {
         "type": "String",
         "placeholders": {}
@@ -3216,14 +2966,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -3302,14 +3044,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@visibleForAllParticipants": {
         "type": "String",
         "placeholders": {}
@@ -3346,19 +3080,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -3410,15 +3132,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3469,10 +3183,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3481,15 +3191,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3613,43 +3315,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3669,18 +3339,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
@@ -3694,10 +3352,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3720,22 +3374,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3790,10 +3428,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3877,31 +3511,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3957,23 +3571,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4013,28 +3615,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4052,14 +3632,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4252,22 +3824,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4323,10 +3879,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4336,10 +3888,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4415,27 +3963,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4761,10 +4293,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4774,10 +4302,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4865,14 +4389,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4889,10 +4405,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4905,15 +4417,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5065,14 +4569,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5086,14 +4582,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6316,10 +5804,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6360,10 +5844,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6436,10 +5916,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6709,47 +6185,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6769,19 +6205,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6845,10 +6269,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6889,14 +6309,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6908,14 +6320,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6953,10 +6357,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6973,27 +6373,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7117,10 +6501,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7130,10 +6510,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7150,14 +6526,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7297,18 +6665,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7357,10 +6713,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7370,18 +6722,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7424,23 +6764,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7464,10 +6792,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7475,14 +6799,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7587,18 +6903,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7647,10 +6951,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7677,10 +6977,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7864,10 +7160,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@activityDropdownDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@languageMismatchTitle": {
         "type": "String",
         "placeholders": {}
@@ -7913,17 +7205,11 @@
         "placeholders": {}
     },
     "startOwn": "Simulan ang sarili kong kurso",
-    "joinCourseDesc": "Ang bawat kurso ay may 8-10 na sunud-sunod na paksa na may iba't ibang gawain sa pag-aaral ng wika batay sa mga gawain.",
     "newMessageInPangeaChat": "🗨️ Bagong mensahe sa Pangea Chat",
     "shareCourse": "Ibahagi ang kurso",
     "addCourse": "Magdagdag ng kurso",
-    "joinPublicCourse": "Sumali sa pampublikong kurso",
     "vocabLevelsDesc": "Dito mapupunta ang mga salita sa bokabularyo kapag na-level up mo na sila!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7936,10 +7222,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7958,7 +7240,6 @@
     "emojiView": "Tingin ng emoji",
     "feedbackDialogDesc": "Nagkakamali din ako! Mayroon bang anumang makakatulong sa akin na mag-improve?",
     "contactHasBeenInvitedToTheCourse": "Ang contact ay naimbitahan sa kurso",
-    "activityStatsButtonTooltip": "Impormasyon ng aktibidad",
     "allow": "Pahintulutan",
     "deny": "Tanggihan",
     "enabledRenewal": "Paganahin ang Pag-renew ng Subscription",
@@ -8226,10 +7507,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9285,16 +8562,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Mga Aktibidad upang I-unlock ang Susunod na Paksa",
-    "activitiesToUnlockTopicDesc": "Itakda ang bilang ng mga aktibidad upang i-unlock ang susunod na paksa ng kurso",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Tamang pagsasanay sa kahulugan ng bokabularyo",
     "constructUseIncLMDesc": "Maling pagsasanay sa kahulugan ng bokabularyo",
     "constructUseCorLADesc": "Tamang pagsasanay sa audio ng bokabularyo",
@@ -9302,7 +8569,6 @@
     "constructUseBonus": "Bonus sa panahon ng pagsasanay sa bokabularyo",
     "practiceVocab": "Magsanay ng bokabularyo",
     "selectMeaning": "Pumili ng kahulugan",
-    "selectAudio": "Pumili ng katugmang audio",
     "anotherRound": "Isa pang round",
     "activitySettingsOverrideWarning": "Wika at antas ng wika na tinutukoy ng plano ng aktibidad",
     "voice": "Boses",
@@ -9334,10 +8600,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9355,12 +8617,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Nagsimula ang pag-download",
     "webDownloadPermissionMessage": "Kung hinaharang ng iyong browser ang mga pag-download, mangyaring paganahin ang mga pag-download para sa site na ito.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9455,11 +8712,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "May nangyaring mali, at abala kami sa pag-aayos nito. Suriin muli mamaya.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Paganahin ang tulong sa pagsusulat",
     "autoIGCToolDescription": "Awtomatikong patakbuhin ang mga tool ng Pangea Chat upang ituwid ang mga ipinadalang mensahe sa target na wika.",
     "@autoIGCToolName": {
@@ -9515,24 +8767,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Balarila",
-    "spanTypeWordChoice": "Pagpili ng Salita",
     "spanTypeSpelling": "Pagbaybay",
     "spanTypePunctuation": "Bantas",
     "spanTypeStyle": "Estilo",
     "spanTypeFluency": "Kadaluyan",
     "spanTypeAccents": "Mga Tono",
     "spanTypeCapitalization": "Pagkakapital",
-    "spanTypeCorrection": "Pagwawasto",
     "spanFeedbackTitle": "Iulat ang isyu sa pagwawasto",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9557,10 +8798,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9573,13 +8810,7 @@
     "longPressToRecordVoiceMessage": "Mahabang pindutin upang mag-record ng voice message.",
     "pause": "Pansamantala",
     "resume": "Ipatuloy",
-    "newSubSpace": "Bagong sub space",
-    "moveToDifferentSpace": "Lumipat sa ibang space",
-    "removeFromSpaceDescription": "Ang chat ay aalisin mula sa espasyo ngunit mananatili sa iyong listahan ng chat.",
     "countChats": "{chats} na chat",
-    "spaceMemberOf": "Kabilang sa espasyo ng {spaces}",
-    "spaceMemberOfCanKnock": "Kabilang sa espasyo ng {spaces} ay maaaring kumatok",
-    "donate": "Mag-donate",
     "startedAPoll": "Nagsimula ng isang poll si {username}.",
     "poll": "Poll",
     "startPoll": "Magsimula ng poll",
@@ -9603,23 +8834,15 @@
     "newStickerPack": "Bagong sticker pack",
     "stickerPackName": "Pangalan ng sticker pack",
     "attribution": "Pagkilala",
-    "skipChatBackup": "Laktawan ang backup ng chat",
-    "skipChatBackupWarning": "Sigurado ka? Kung hindi mo i-enable ang backup ng chat, maaaring mawalan ka ng access sa iyong mga mensahe kung magpapalit ka ng device.",
-    "loadingMessages": "Naglo-load ng mga mensahe",
-    "setupChatBackup": "I-set up ang backup ng chat",
     "noMoreResultsFound": "Walang natagpuang iba pang resulta",
     "chatSearchedUntil": "Chat na hinanap hanggang {time}",
     "federationBaseUrl": "Federation Base URL",
     "clientWellKnownInformation": "Impormasyon ng Client-Well-Known:",
     "baseUrl": "Base URL",
     "identityServer": "Identity Server:",
-    "versionWithNumber": "Bersyon: {version}",
     "logs": "Mga Log",
-    "advancedConfigs": "Mga Advanced na Configs",
     "advancedConfigurations": "Mga Advanced na Konfigurasyon",
-    "signInWithLabel": "Mag-sign in gamit ang:",
     "selectAllWords": "Pumili ng lahat ng mga salitang naririnig mo sa audio",
-    "joinCourseForActivities": "Sumali sa isang kurso upang subukan ang mga aktibidad.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9656,18 +8879,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9675,26 +8886,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9800,22 +8991,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9844,19 +9019,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9864,15 +9027,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10078,11 +9233,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Sa isang klase? Ilagay ang iyong join code dito.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Awtomatikong i-highlight ang mga mensaheng audio",
     "selectAudioMessagesOnPlayDescription": "Awtomatikong i-highlight ang mga mensaheng audio kapag pinatugtog",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10126,18 +9276,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Ang kursong ito ay may mga paksa na may mas kaunti sa {input} na mga aktibidad. Mangyaring maglagay ng isang numero na mas mababa o katumbas ng {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "I-click dito upang muling mag-sign in.",
     "@clickToLogin": {
@@ -10554,17 +9692,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Isang kartunistikong dilaw na oso na may mga braso na itinaas sa kasiyahan.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Pumili ng mga salita upang matuto pa tungkol sa mga ito",
     "requireAnalyticsAccessTitle": "Kailangan ng access sa analytics upang sumali",
     "requireAnalyticsAccessDesc": "Dapat bigyan ng access ng mga kalahok ang kanilang learning analytics upang makasali sa kursong ito",
     "analyticsAccessNoticeTitle": "Kinakailangan ang Access sa Analytics",
     "analyticsAccessNoticeDesc": "Sa pagsali sa kursong ito, sumasang-ayon kang bigyan ng access ang mga admin sa iyong learning analytics.",
-    "skipOnboardingClassCodeDesc": "Nag-aaral nang mag-isa? Huwag mag-alala, maaari mong:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10582,10 +9714,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10614,7 +9742,6 @@
     "pickCefrLevelTeacherStepTitle": "Anong antas ang itinuturo mo?",
     "pickCefrLevelStudentStepTitle": "Anong antas ka?",
     "customCourseStepTitle": "Punan ang form na ito upang makakuha ng pasadyang kurso",
-    "aboutYourClass": "Tungkol sa iyong klase",
     "courseCodeStepErrorMessage": "Pakisuri ang iyong code at subukan muli",
     "institution": "Institusyon",
     "courseGoals": "Mga Layunin ng Kurso",
@@ -10657,10 +9784,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10777,12 +9900,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logo",
     "introChatDetails": "Mag-salita ng hello! Ipakilala ang iyong sarili sa iyong mga kapwa kalahok ng kurso, maghanap ng mga kaibigan, at makipag-chat sa labas ng mga aktibidad.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10826,11 +9944,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Mga aksyon sa aktibidad",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Mga kasangkapan sa pagbigkas",
     "audioTranscription": "AI na transkripsyon ng audio",
     "visualLearnerSupport": "Suporta para sa mga visual na mag-aaral",
@@ -10871,7 +9984,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Sumali sa isang kurso na kasama ang aktibidad na ito upang maglaro.",
     "resizeCoursePanel": "I-resize ang panel ng kurso",
     "undo": "I-undo",
     "unlock": "I-unlock",
@@ -10885,7 +9997,6 @@
     "addCourseBrowsePublic": "Mag-browse ng mga pampublikong kurso",
     "browsePublicCourses": "Mag-browse ng mga pampublikong kurso",
     "editProfile": "I-edit ang profile",
-    "numObjectives": "{count} mga layunin",
     "mapSearchHint": "Maghanap ng mga aktibidad",
     "mapSearchNoResults": "Walang tugma sa view",
     "mapFilterAllLanguages": "Lahat ng wika",
@@ -10894,7 +10005,6 @@
     "mapFilterCompleted": "Natapos",
     "mapFilterReset": "I-reset",
     "activityTypeConversation": "Usapan",
-    "lockedMissionRequirement": "Kumpletuhin ang nakaraang misyon upang i-unlock",
     "playAgain": "Maglaro muli",
     "reviewActivity": "Suriin",
     "mapEmptyInView": "Walang nandito sa iyong antas o wika. Palawakin ang iyong mga filter o mag-zoom out.",
@@ -10909,14 +10019,9 @@
     "scrollToBottom": "Mag-scroll sa ibaba",
     "courseImage": "Larawan ng kurso",
     "avatarPreview": "Preview ng avatar",
-    "activityPhoto": "Larawan ng aktibidad",
     "emotePreview": "Preview ng emote: {name}",
     "activityLabel": "Aktibidad: {title}",
     "resetMapView": "I-reset ang view ng mapa",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10969,14 +10074,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11006,10 +10103,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11066,10 +10159,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -85,11 +85,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Les invités peuvent-i·e·ls rejoindre",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Êtes-vous sûr·e ?",
     "@areYouSure": {
         "type": "String",
@@ -366,11 +361,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Vos anciens messages sont sécurisés par une clé de récupération. Veillez à ne pas la perdre.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Détails de la discussion",
     "@chatDetails": {
         "type": "String",
@@ -502,11 +492,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Le contact a été invité au groupe",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Le contenu a été signalé aux administrateurs du serveur",
     "@contentHasBeenReported": {
         "type": "String",
@@ -558,11 +543,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Nouvel espace",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Actif en ce moment",
     "@currentlyActive": {
@@ -706,11 +686,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Vous ne pourrez plus désactiver le chiffrement. Êtes-vous sûr(e) ?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Chiffré",
     "@encrypted": {
         "type": "String",
@@ -749,11 +724,6 @@
             }
         }
     },
-    "everythingReady": "Tout est prêt !",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Extrêmement offensant",
     "@extremeOffensive": {
         "type": "String",
@@ -791,11 +761,6 @@
     },
     "group": "Groupe",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Le groupe est public",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -889,15 +854,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Inviter un contact dans {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Invité·e",
     "@invited": {
@@ -1010,15 +966,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Charger {count} participant·es de plus",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Chargement… Veuillez patienter.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -1043,15 +990,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Se connecter à {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Se déconnecter",
     "@logout": {
@@ -1115,16 +1053,6 @@
     },
     "noEmotesFound": "Aucune émoticône trouvée. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Vous pouvez activer le chiffrement seulement quand le salon n'est plus accessible au public.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Firebase Cloud Messaging ne semble pas être disponible sur votre appareil. Pour continuer à recevoir des notifications poussées, nous vous recommandons d'installer ntfy. Avec ntfy ou un autre fournisseur Unified Push, vous pouvez recevoir des notifications poussées de manière sécurisée. Vous pouvez télécharger ntfy sur le PlayStore ou sur F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1256,11 +1184,6 @@
     },
     "passwordHasBeenChanged": "Le mot de passe a été modifié",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Récupération du mot de passe",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1404,11 +1327,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Supprimer l'appareil",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Débannissement de la discussion",
     "@unbanFromChat": {
@@ -1563,11 +1481,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Définir le niveau de permissions",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Définir le statut",
     "@setStatus": {
         "type": "String",
@@ -1609,16 +1522,6 @@
     },
     "sourceCode": "Code source",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "L'espace est public",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Nom de l'espace",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1677,11 +1580,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Transfert à partir d'un autre appareil",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Retenter l'envoi",
     "@tryToSendAgain": {
         "type": "String",
@@ -1737,15 +1635,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 discussion non lue} other{{unreadCount} discussions non lues}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} et {count} autres sont en train d'écrire…",
     "@userAndOthersAreTyping": {
@@ -1831,16 +1720,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Appel vidéo",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Visibilité de l'historique de la discussion",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Visible pour tous les participant·es",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1886,23 +1765,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Qui peut faire quelle action",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Qui est autorisé·e à rejoindre ce groupe",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Pourquoi voulez-vous le signaler ?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Effacer la sauvegarde de votre discussion pour créer une nouvelle clé de récupération ?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1949,8 +1813,6 @@
     "@homeserver": {},
     "serverRequiresEmail": "Ce serveur doit valider votre adresse électronique pour l'inscription.",
     "@serverRequiresEmail": {},
-    "enableMultiAccounts": "(BETA) Activer les comptes multiples sur cet appareil",
-    "@enableMultiAccounts": {},
     "bundleName": "Nom du groupe",
     "@bundleName": {},
     "removeFromBundle": "Retirer de ce groupe",
@@ -1959,14 +1821,10 @@
     "@addToBundle": {},
     "editBundlesForAccount": "Modifier les groupes pour ce compte",
     "@editBundlesForAccount": {},
-    "addAccount": "Ajouter un compte",
-    "@addAccount": {},
     "oneClientLoggedOut": "Un de vos clients a été déconnecté",
     "@oneClientLoggedOut": {},
     "link": "Lien",
     "@link": {},
-    "yourChatBackupHasBeenSetUp": "Votre sauvegarde de la discussion a été mise en place.",
-    "@yourChatBackupHasBeenSetUp": {},
     "unverified": "Non vérifié",
     "@unverified": {},
     "repeatPassword": "Répétez le mot de passe",
@@ -1981,8 +1839,6 @@
     "@sender": {},
     "messageInfo": "Informations sur le message",
     "@messageInfo": {},
-    "removeFromSpace": "Supprimer de l’espace",
-    "@removeFromSpace": {},
     "start": "Commencer",
     "@start": {},
     "commandHint_create": "Créer un groupe de discussion vide\nUtilisez --no-encryption pour désactiver le chiffrement",
@@ -2036,8 +1892,6 @@
     "@emojis": {},
     "placeCall": "Passer un appel",
     "@placeCall": {},
-    "voiceCall": "Appel vocal",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "Version d'Android non prise en charge",
     "@unsupportedAndroidVersion": {},
     "unsupportedAndroidVersionLong": "Cette fonctionnalité nécessite une nouvelle version d'Android. Veuillez vérifier les mises à jour ou la prise en charge de Lineage OS.",
@@ -2046,12 +1900,8 @@
     "@pinMessage": {},
     "confirmEventUnpin": "Voulez-vous vraiment désépingler définitivement l'événement ?",
     "@confirmEventUnpin": {},
-    "videoCallsBetaWarning": "Veuillez noter que les appels vidéo sont actuellement en version bêta. Ils peuvent ne pas fonctionner comme prévu ou ne oas fonctionner du tout sur toutes les plateformes.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "Appels vidéo expérimentaux",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "Courriel ou identifiant",
-    "@emailOrUsername": {},
     "widgetJitsi": "Jitsi Meet",
     "@widgetJitsi": {},
     "widgetCustom": "Personnalisé",
@@ -2139,10 +1989,6 @@
     },
     "users": "Utilisateurs/trices",
     "@users": {},
-    "storeInAndroidKeystore": "Stocker dans Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Stocker dans Apple KeyChain",
-    "@storeInAppleKeyChain": {},
     "user": "Utilisateur/trice",
     "@user": {},
     "custom": "Personnalisé",
@@ -2151,24 +1997,8 @@
     "@hydrate": {},
     "dehydrateWarning": "Cette action ne peut pas être annulée. Assurez-vous d'enregistrer convenablement le fichier de sauvegarde.",
     "@dehydrateWarning": {},
-    "recoveryKey": "Clé de récupération",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Clé de récupération perdue ?",
-    "@recoveryKeyLost": {},
-    "saveKeyManuallyDescription": "Enregistrer cette clé manuellement en déclenchant la boîte de dialogue de partage du système ou le presse-papiers.",
-    "@saveKeyManuallyDescription": {},
-    "storeInSecureStorageDescription": "Stocker la clé de récupération dans un espace sécurisé de cet appareil.",
-    "@storeInSecureStorageDescription": {},
     "dehydrate": "Exporter la session et effacer l'appareil",
     "@dehydrate": {},
-    "pleaseEnterRecoveryKey": "Veuillez saisir votre clé de récupération :",
-    "@pleaseEnterRecoveryKey": {},
-    "pleaseEnterRecoveryKeyDescription": "Pour déverrouiller vos anciens messages, veuillez entrer votre clé de récupération qui a été générée lors d'une session précédente. Votre clé de récupération n'est PAS votre mot de passe.",
-    "@pleaseEnterRecoveryKeyDescription": {},
-    "unlockOldMessages": "Déverrouiller les anciens messages",
-    "@unlockOldMessages": {},
-    "storeSecurlyOnThisDevice": "Stocker de manière sécurisé sur cet appareil",
-    "@storeSecurlyOnThisDevice": {},
     "countFiles": "{count} fichiers",
     "@countFiles": {
         "placeholders": {
@@ -2198,18 +2028,10 @@
     },
     "whyIsThisMessageEncrypted": "Pourquoi ce message est-il illisible ?",
     "@whyIsThisMessageEncrypted": {},
-    "foregroundServiceRunning": "Cette notification s’affiche lorsque le service au premier plan est en cours d’exécution.",
-    "@foregroundServiceRunning": {},
-    "screenSharingTitle": "Partage d'écran",
-    "@screenSharingTitle": {},
-    "screenSharingDetail": "Vous partagez votre écran dans FuffyChat",
-    "@screenSharingDetail": {},
     "newGroup": "Nouveau groupe",
     "@newGroup": {},
     "newSpace": "Nouvel espace",
     "@newSpace": {},
-    "enterSpace": "Entrer dans l’espace",
-    "@enterSpace": {},
     "doNotShowAgain": "Ne plus afficher",
     "@doNotShowAgain": {},
     "commandHint_googly": "Envoyer des yeux écarquillés",
@@ -2254,16 +2076,8 @@
             }
         }
     },
-    "encryptThisChat": "Chiffrer cette discussion",
-    "@encryptThisChat": {},
-    "sorryThatsNotPossible": "Désolé, ce n'est pas possible",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "Clés de l’appareil :",
     "@deviceKeys": {},
-    "newSpaceDescription": "Les espaces vous permettent de consolider vos conversations et de construire des communautés privées ou publiques.",
-    "@newSpaceDescription": {},
-    "disableEncryptionWarning": "Pour des raisons de sécurité, vous ne pouvez pas désactiver le chiffrement dans une discussion s'il a été activé avant.",
-    "@disableEncryptionWarning": {},
     "reopenChat": "Rouvrir la discussion",
     "@reopenChat": {},
     "noOtherDevicesFound": "Aucun autre appareil trouvé",
@@ -2331,16 +2145,12 @@
     },
     "nothingFound": "Rien n'a été trouvé...",
     "@nothingFound": {},
-    "chatDescription": "Description de la discussion",
-    "@chatDescription": {},
     "invalidServerName": "Nom de serveur invalide",
     "@invalidServerName": {},
     "shareInviteLink": "Partager un lien d'invitation",
     "@shareInviteLink": {},
     "openLinkInBrowser": "Ouvrir le lien dans le navigateur",
     "@openLinkInBrowser": {},
-    "setTheme": "Définir le thème :",
-    "@setTheme": {},
     "setColorTheme": "Définir la couleur du thème :",
     "@setColorTheme": {},
     "databaseMigrationBody": "Veuillez patienter. Cela peut prendre un moment.",
@@ -2355,8 +2165,6 @@
     "@joinSpace": {},
     "publicSpaces": "Espaces publics",
     "@publicSpaces": {},
-    "addChatOrSubSpace": "Ajouter une discussion ou un sous-espace",
-    "@addChatOrSubSpace": {},
     "thisDevice": "Cet appareil :",
     "@thisDevice": {},
     "sendReadReceipts": "Envoyer des accusés de réception",
@@ -2437,22 +2245,12 @@
     },
     "discover": "Découvrir",
     "@discover": {},
-    "usersMustKnock": "Les utilisateurs/trices doivent frapper",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Personne ne peut rejoindre",
-    "@noOneCanJoin": {},
     "knock": "Frapper à la porte",
     "@knock": {},
     "hidePresences": "Cacher la liste des statuts ?",
     "@hidePresences": {},
     "appLockDescription": "Verrouiller l'application avec un code PIN lorsqu'elle n'est pas utilisée",
     "@appLockDescription": {},
-    "globalChatId": "Identifiant global de la discussion",
-    "@globalChatId": {},
-    "accessAndVisibility": "Accès et visibilité",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Qui est autorisé à rejoindre cette discussion et comment la discussion peut être découverte.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Appels",
     "@calls": {},
     "customEmojisAndStickers": "Émoticônes et autocollants personnalisés",
@@ -2502,18 +2300,6 @@
     "@gallery": {},
     "files": "Fichiers",
     "@files": {},
-    "sessionLostBody": "Votre session est perdue. Veuillez signaler cette erreur aux développeurs à {url}. Le message d'erreur est le suivant : {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "searchIn": "Rechercher dans la discussion \"{chat}\"...",
     "@searchIn": {
         "type": "String",
@@ -2527,12 +2313,8 @@
     "@sendReadReceiptsDescription": {},
     "formattedMessages": "Messages formatés",
     "@formattedMessages": {},
-    "verifyOtherUser": "🔐 Vérifier l'autre utilisateur/trice",
-    "@verifyOtherUser": {},
     "searchMore": "Rechercher davantage...",
     "@searchMore": {},
-    "verifyOtherUserDescription": "Si vous vérifiez un autre utilisateur/trice, vous pouvez être sûr de savoir à qui vous écrivez réellement. 💪\n\nLorsque vous lancez une vérification, vous et l'autre utilisateur/trice verrez une fenêtre contextuelle dans l'application. Vous y verrez alors une série d'émoticônes ou de chiffres que vous devrez comparer.\n\nLa meilleure façon de procéder est de se rencontrer ou de lancer un appel vidéo. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDeviceDescription": "Lorsque vous vérifiez un autre appareil, ces appareils peuvent échanger des clés, ce qui augmente votre sécurité globale. 💪 Lorsque vous lancez une vérification, une fenêtre contextuelle s'affiche dans l'application sur les deux appareils. Vous y verrez alors une série d'émoticônes ou de chiffres que vous devrez comparer. Il est préférable d'avoir les deux appareils à portée de main avant de lancer la vérification. 🤳",
     "@verifyOtherDeviceDescription": {},
     "completedKeyVerification": "{sender} a terminé la vérification de clé",
@@ -2572,8 +2354,6 @@
     "@restricted": {},
     "knockRestricted": "Frapper à la porte limité",
     "@knockRestricted": {},
-    "groupCanBeFoundViaSearch": "Le groupe peut être trouvé via la recherche",
-    "@groupCanBeFoundViaSearch": {},
     "groupName": "Nom du groupe",
     "@groupName": {},
     "invalidInput": "Entrée invalide !",
@@ -2582,10 +2362,6 @@
     "@block": {},
     "removeDevicesDescription": "Vous serez déconnecté de cet appareil et ne pourrez plus recevoir de messages.",
     "@removeDevicesDescription": {},
-    "createNewAddress": "Créer une nouvelle adresse",
-    "@createNewAddress": {},
-    "publicChatAddresses": "Addresses de discussion publiques",
-    "@publicChatAddresses": {},
     "space": "Espace",
     "@space": {},
     "spaces": "Espaces",
@@ -2621,15 +2397,6 @@
     "@pushNotificationsNotAvailable": {},
     "yourGlobalUserIdIs": "Votre identifiant utilisateur global est : ",
     "@yourGlobalUserIdIs": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "La discussion peut être découverte via la recherche sur {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "knocking": "Frapper",
     "@knocking": {},
     "banUserDescription": "L'utilisateur/trice sera banni de la discussion et ne pourra plus y accéder jusqu'à ce qu'il/elle soit débanni.",
@@ -2652,10 +2419,6 @@
     "@markAsUnread": {},
     "wrongRecoveryKey": "Désolé... il ne semble pas s'agir de la bonne clé de récupération.",
     "@wrongRecoveryKey": {},
-    "searchChatsRooms": "Rechercher des #discussions, @utilisateurs/trices...",
-    "@searchChatsRooms": {},
-    "createGroupAndInviteUsers": "Créer un groupe et inviter des utilisateurs/trices",
-    "@createGroupAndInviteUsers": {},
     "goToSpace": "Aller dans l'espace : {space}",
     "@goToSpace": {
         "type": "String",
@@ -2673,18 +2436,6 @@
     "@roomUpgradeDescription": {},
     "learnMore": "En savoir plus",
     "@learnMore": {},
-    "restoreSessionBody": "L'application tente maintenant de restaurer votre session depuis la sauvegarde. Veuillez signaler cette erreur aux développeurs à {url}. Le message d'erreur est le suivant : {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "archiveRoomDescription": "La discussion sera déplacée dans les archives. Les autres utilisateurs/trices pourront voir que vous avez quitté la discussion.",
     "@archiveRoomDescription": {},
     "noUsersFoundWithQuery": "Malheureusement, aucun utilisateur/trice n'a pu être trouvé avec \"{query}\". Veuillez vérifier si vous n'avez pas fait de faute de frappe.",
@@ -2778,8 +2529,6 @@
             }
         }
     },
-    "loginWithMatrixId": "Connexion avec l'identifiant Matrix",
-    "@loginWithMatrixId": {},
     "setCustomPermissionLevel": "Définir un niveau d’autorisation",
     "@setCustomPermissionLevel": {},
     "setPermissionsLevelDescription": "Veuillez choisir un rôle prédéfini ci-dessous ou saisir un niveau d’autorisation entre 0 et 100.",
@@ -2790,15 +2539,6 @@
     "@normalUser": {},
     "checkList": "Check-list",
     "@checkList": {},
-    "countInvited": "{count} invité(e/s)",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "sendImages": "Envoyer {count} image(s)",
     "@sendImages": {
         "type": "String",
@@ -2808,8 +2548,6 @@
             }
         }
     },
-    "homeserverDescription": "Toutes vos données sont stockées sur le serveur de votre fournisseur matrix, comme chez un fournisseur d'e-mails. Vous pouvez choisir le serveur que vous souhaitez utiliser, tout en pouvant communiquer avec tout le monde. Pour en savoir plus, rendez-vous sur https://matrix.org.",
-    "@homeserverDescription": {},
     "calculatingFileSize": "Calcul en cours...",
     "@calculatingFileSize": {},
     "prepareSendingAttachment": "Préparation à l'envoi...",
@@ -2857,16 +2595,12 @@
     "@allowMultipleAnswers": {},
     "commandHint_roomupgrade": "Mettre à niveau cette salle vers la version de salle donnée",
     "sendRoomNotifications": "Envoyer une notification @room",
-    "discoverHomeservers": "Découvrir les serveurs principaux",
-    "whatIsAHomeserver": "Qu'est-ce qu'un serveur principal ?",
     "doesNotSeemToBeAValidHomeserver": "Il ne semble pas s'agir d'un serveur principal compatible. Mauvaise URL ?",
     "noticeChatBackupDeviceVerification": "Remarque : lorsque vous connectez tous vos appareils à la sauvegarde de chat, ils sont automatiquement vérifiés.",
     "continueText": "Continuer",
-    "welcomeText": "Hé Hé 👋 C'est FluffyChat. Vous pouvez vous connecter à n'importe quel serveur domestique, compatible avec https://matrix.org. Et ensuite discuter avec n'importe qui. C'est un réseau de messagerie décentralisé énorme !",
     "blur": "Flou :",
     "opacity": "Opacité :",
     "setWallpaper": "Définir le fond d'écran",
-    "manageAccount": "Gérer le compte",
     "noContactInformationProvided": "Le serveur ne fournit aucune information de contact valide",
     "contactServerAdmin": "Contacter l'administrateur du serveur",
     "contactServerSecurity": "Contacter la sécurité du serveur",
@@ -2883,11 +2617,8 @@
     "unableToJoinChat": "Impossible de rejoindre la conversation. Peut-être que l'autre partie a déjà fermé la discussion.",
     "previous": "Précédent",
     "otherPartyNotLoggedIn": "L'autre partie n'est pas actuellement connectée et ne peut donc pas recevoir de messages !",
-    "appWantsToUseForLogin": "Utilisez '{server}' pour vous connecter",
-    "appWantsToUseForLoginDescription": "Vous autorisez par la présente l'application et le site web à partager des informations vous concernant.",
     "open": "Ouvrir",
     "waitingForServer": "En attente du serveur...",
-    "appIntroduction": "FluffyChat vous permet de discuter avec vos amis via différents messagers. En savoir plus sur https://matrix.org ou appuyez simplement sur *Continuer*.",
     "newChatRequest": "📩 Nouvelle demande de chat",
     "contentNotificationSettings": "Paramètres de notification du contenu",
     "generalNotificationSettings": "Paramètres de notification généraux",
@@ -2961,11 +2692,9 @@
     "taTooltip": "L2 utilisation avec assistance à la traduction",
     "interactiveTranslatorSliderHeader": "Traducteur interactif",
     "interactiveGrammarSliderHeader": "Vérificateur de grammaire interactif",
-    "interactiveTranslatorRequired": "Obligatoire",
     "waTooltip": "L2 utilisation sans assistance",
     "interactiveTranslator": "Assistance à la traduction",
     "noIdenticalLanguages": "Veuillez choisir des langues de base et cibles différentes",
-    "searchBy": "Rechercher par pays et langues",
     "joinWithClassCode": "Rejoindre le cours",
     "languageLevelPreA1": "Novice Bas (Pré A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -2986,19 +2715,14 @@
     "saveChanges": "Enregistrer les modifications",
     "publicProfileTitle": "Permettre à mon profil d'être trouvé dans la recherche",
     "publicProfileDesc": "En activant cette option, vous permettez à d'autres utilisateurs de trouver votre profil dans la barre de recherche globale et d'envoyer des demandes de chat. À ce stade, vous pouvez choisir d'accepter ou de refuser la demande.",
-    "errorDisableIT": "L'assistance à la traduction est désactivée.",
-    "errorDisableIGC": "L'assistance à la grammaire est désactivée.",
     "errorDisableITUserDesc": "Cliquez ici pour mettre à jour les paramètres d'assistance à la traduction",
     "errorDisableIGCUserDesc": "Cliquez ici pour mettre à jour les paramètres d'assistance à la grammaire",
     "errorDisableITClassDesc": "L'assistance à la traduction est désactivée pour le cours dans lequel cette discussion a lieu.",
     "errorDisableIGCClassDesc": "L'assistance à la grammaire est désactivée pour le cours dans lequel cette discussion a lieu.",
-    "error405Title": "Langues non définies",
     "error405Desc": "Veuillez définir vos langues dans le menu principal > Paramètres d'apprentissage.",
     "termsAndConditions": "Termes et Conditions",
     "andCertifyIAmAtLeast13YearsOfAge": " et je certifie que j'ai au moins 16 ans.",
-    "error502504Title": "Wow, il y a beaucoup d'étudiants en ligne !",
     "error502504Desc": "Les outils de traduction et de grammaire peuvent être lents ou indisponibles pendant que les bots Pangea rattrapent leur retard.",
-    "error404Title": "Erreur de traduction !",
     "error404Desc": "Le bot Pangea n'est pas sûr de comment traduire cela...",
     "errorPleaseRefresh": "Nous étudions le problème ! Veuillez recharger et réessayer.",
     "connectedToStaging": "Connecté à la mise en scène",
@@ -3036,13 +2760,9 @@
     "definitionsToolName": "Définitions des mots",
     "definitionsToolDescription": "Lorsqu'il est activé, les mots soulignés en bleu peuvent être cliqués pour obtenir leurs définitions. Cliquez sur les messages pour accéder aux définitions.",
     "welcomeBack": "Bon retour ! Si vous faisiez partie du pilote 2023-2024, veuillez nous contacter pour votre abonnement pilote spécial. Si vous êtes un enseignant qui a (ou dont l'institution a) acheté des licences pour votre classe, contactez-nous pour votre abonnement enseignant.",
-    "downloadTxtFile": "Télécharger le fichier texte",
-    "downloadCSVFile": "Télécharger le fichier CSV",
     "promotionalSubscriptionDesc": "Vous avez actuellement un abonnement promotionnel à vie. Contactez support@pangea.chat pour obtenir de l'aide pour changer votre abonnement.",
     "originalSubscriptionPlatform": "Abonnement acheté via {purchasePlatform}",
     "oneWeekTrial": "Essai d'une semaine",
-    "downloadXLSXFile": "Télécharger le fichier Excel",
-    "unkDisplayName": "Inconnu",
     "wwCountryDisplayName": "Monde entier",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Îles Åland",
@@ -3337,7 +3057,6 @@
     "chatCapacityHasBeenChanged": "Capacité de la discussion modifiée",
     "chatCapacitySetTooLow": "La capacité de la discussion doit être d'au moins {count}.",
     "chatCapacityExplanation": "La capacité de la discussion limite le nombre de membres autorisés dans une discussion.",
-    "tooManyRequest": "Trop de demandes, veuillez réessayer plus tard.",
     "enterNumber": "Veuillez entrer une valeur numérique entière.",
     "practice": "Pratique",
     "versionNotFound": "Version non trouvée",
@@ -3347,7 +3066,6 @@
     "deleteSubscriptionWarningTitle": "Vous avez un abonnement actif",
     "deleteSubscriptionWarningBody": "La suppression de votre compte n'annulera pas automatiquement votre abonnement.",
     "manageSubscription": "Gérer l'abonnement",
-    "error520Title": "Veuillez réessayer.",
     "error520Desc": "Désolé, nous n'avons pas compris votre message...",
     "wordsUsed": "Mots utilisés",
     "level": "Niveau",
@@ -3365,7 +3083,6 @@
     "other": "Autre",
     "levelShort": "NIV {level}",
     "noCapacityLimit": "Aucune limite de capacité",
-    "downloadGroupText": "Télécharger le texte du groupe",
     "notificationsOn": "Notifications activées",
     "notificationsOff": "Notifications désactivées",
     "joinWithCode": "Rejoindre avec un code",
@@ -3429,24 +3146,12 @@
     "whatIsTheMorphTag": "Quelle est la {morphologicalFeature} de '{wordForm}' ?",
     "dataAvailable": "Disponibilité des données",
     "available": "Disponible",
-    "pangeaBotIsFallible": "Pangea Bot fait aussi des erreurs !",
-    "whatIsMeaning": "Que signifie '{lemma}' ?",
     "chooseLemmaMeaningInstructionsBody": "Associez les significations avec les mots du message !",
-    "doubleClickToEdit": "Double-cliquez pour modifier.",
-    "topicLabel": "Sujet",
-    "topicPlaceholder": "Choisissez un sujet...",
-    "modePlaceholder": "Choisissez un mode...",
-    "learningObjectiveLabel": "Objectif d'apprentissage",
-    "learningObjectivePlaceholder": "Choisissez un objectif d'apprentissage...",
-    "targetLanguageLabel": "Langue cible",
     "cefrLevelLabel": "Niveau CEFR",
     "image": "Image",
     "video": "Vidéo",
     "nan": "Non applicable",
-    "addVocabulary": "Ajouter du vocabulaire",
     "instructions": "Instructions",
-    "numberOfLearners": "Nombre d'apprenants",
-    "mustBeInteger": "Doit être un entier, par exemple 1, 2, 3, ...",
     "constructUsePvmDesc": "Produite en message vocal",
     "leaveSpaceDescription": "En quittant le cours, vous quitterez toutes les discussions qui s'y trouvent. Les autres utilisateurs verront que vous avez quitté le cours.",
     "constructUseCorMmDesc": "Signification du message correct",
@@ -3461,7 +3166,6 @@
     "ttsDisabledBody": "Vous pouvez activer la synthèse vocale dans vos paramètres d'apprentissage",
     "noSpaceDescriptionYet": "Aucune description de cours créée pour le moment.",
     "tooLargeToSend": "Ce message est trop volumineux pour être envoyé",
-    "exitWithoutSaving": "Êtes-vous sûr de vouloir quitter sans enregistrer ?",
     "enableAutocorrectPopupTitle": "Ajoutez votre clavier de langue cible en allant sur :",
     "enableAutocorrectPopupSteps": "  • Paramètres\n  • Général\n  • Clavier\n  • Claviers\n  • Ajouter un nouveau clavier",
     "enableAutocorrectPopupDescription": "Une fois la langue sélectionnée, vous pouvez cliquer sur la petite icône de globe en bas à gauche de votre clavier pour activer le clavier nouvellement installé.",
@@ -3472,11 +3176,8 @@
     "displayName": "Nom d'affichage",
     "leaveRoomDescription": "Vous êtes sur le point de quitter cette conversation. Les autres utilisateurs verront que vous avez quitté la discussion.",
     "confirmUserId": "Veuillez confirmer votre nom d'utilisateur Pangea Chat pour supprimer votre compte.",
-    "startingToday": "À partir d'aujourd'hui",
-    "oneWeekFreeTrial": "Une semaine d'essai gratuite",
     "paidSubscriptionStarts": "À partir du {startDate}",
     "cancelInSubscriptionSettings": " • Annuler à tout moment dans les paramètres d'abonnement",
-    "cancelToAvoidCharges": " • Annuler avant {trialEnds} pour éviter les frais",
     "downloadGboard": "Télécharger Gboard",
     "autocorrectNotAvailable": "Malheureusement, votre plateforme n'est pas actuellement prise en charge pour cette fonctionnalité. Restez à l'écoute pour de futures améliorations !",
     "pleaseUpdateApp": "Veuillez mettre à jour l'application pour continuer.",
@@ -3486,17 +3187,12 @@
     "knockSpaceSuccess": "Vous avez demandé à rejoindre ce cours ! Un administrateur répondra à votre demande lorsqu'il la recevra 😊",
     "chooseWordAudioInstructionsBody": "Écoutez le message complet. Ensuite, associez les audios aux mots.",
     "chooseMorphsInstructionsBody": "Cliquez sur les pièces du puzzle pour les questions de grammaire !",
-    "pleaseEnterInt": "Veuillez entrer un nombre",
     "home": "Accueil",
     "join": "Rejoindre",
     "resetInstructionTooltipsTitle": "Réinitialiser les astuces d'instructions",
     "resetInstructionTooltipsDesc": "Cliquez pour afficher les astuces d'instructions comme pour un nouvel utilisateur.",
-    "randomize": "Aléatoire",
     "clear": "Effacer",
-    "featuredActivities": "En vedette",
     "save": "Enregistrer",
-    "startChat": "Démarrer un chat",
-    "translationProblem": "Problème de traduction",
     "askToJoin": "Demander à rejoindre",
     "emptyChatWarningTitle": "Chat vide",
     "emptyChatWarningDesc": "Vous n'avez invité personne dans votre chat. Allez dans les paramètres du chat pour inviter vos contacts ou le Bot. Vous pouvez aussi faire cela plus tard.",
@@ -3526,17 +3222,13 @@
     "timesUsedIndependently": "Fois utilisé de manière indépendante",
     "timesUsedWithAssistance": "Fois utilisé avec assistance",
     "shareInviteCode": "Partager le code d'invitation : {code}",
-    "leaderboard": "Classement",
     "skipForNow": "Passer pour l'instant",
     "permissions": "Autorisations",
     "spaceChildPermission": "Qui peut ajouter de nouvelles discussions à ce cours",
-    "addEnvironmentOverride": "Ajouter une surcharge d'environnement",
     "defaultOption": "Par défaut",
     "deleteChatDesc": "Voulez-vous vraiment supprimer cette conversation ? Elle sera supprimée pour tous les participants et tous les messages de la conversation ne seront plus disponibles pour la pratique ou l'analyse d'apprentissage.",
     "deleteSpaceDesc": "Le cours et toutes les conversations sélectionnées seront supprimés pour tous les participants et tous les messages de la conversation ne seront plus disponibles pour la pratique ou l'analyse d'apprentissage. Cette action ne peut pas être annulée.",
     "launch": "Lancer",
-    "searchChats": "Rechercher des conversations",
-    "maxFifty": "Maximum 50",
     "configureSpace": "Configurer le cours",
     "pinMessages": "Épingler les messages",
     "setJoinRules": "Définir les règles de participation",
@@ -3570,9 +3262,6 @@
     "failedToFetchTranscription": "Échec de la récupération de la transcription",
     "deleteEmptySpaceDesc": "Le cours sera supprimé pour tous les participants. Cette action est irréversible.",
     "regenerate": "Régénérer",
-    "mySavedActivities": "Mes activités enregistrées",
-    "noSavedActivities": "Aucune activité enregistrée",
-    "saveActivity": "Enregistrer cette activité",
     "failedToPlayVideo": "Échec de la lecture de la vidéo",
     "done": "Terminé",
     "inThisSpace": "Dans ce cours",
@@ -3583,13 +3272,9 @@
     "numInvited": "{count} invité",
     "saved": "Enregistré",
     "reset": "Réinitialiser",
-    "errorFetchingActivitiesMessage": "Échec de la récupération des activités",
     "errorFetchingDefinition": "Échec de la récupération de la définition",
     "errorProcessAnalytics": "Échec du traitement des analyses",
     "errorDownloading": "Échec du téléchargement",
-    "errorLoadingSpaceChildren": "Échec du chargement des discussions dans ce cours",
-    "unexpectedError": "Erreur inattendue.",
-    "pleaseReload": "Veuillez recharger et réessayer.",
     "translationError": "Erreur de traduction",
     "check": "Vérifier",
     "unableToFindRoom": "Aucune discussion ou cours trouvé avec ce code. Veuillez réessayer.",
@@ -3598,19 +3283,14 @@
     "request": "Demande",
     "requestAll": "Tout demander",
     "confirmMessageUnpin": "Êtes-vous sûr de vouloir désépingler ce message ?",
-    "saveAndLaunch": "Enregistrer et lancer",
-    "launchToSpace": "Lancer dans le cours",
     "pending": "En attente",
     "inactive": "Inactif",
-    "confirmRole": "Confirmer le rôle",
     "openRoleLabel": "OUVERT",
     "finishedTheActivity": "🎯 {username} a terminé cette activité",
     "activitySummaryError": "Résumé des activités indisponible",
     "requestSummaries": "Demander des résumés",
-    "generatingNewActivities": "Vous êtes le premier utilisateur de cette paire de langues ! Veuillez patienter une minute, nous préparons des activités rien que pour vous.",
     "requestAccessTitle": "Demander l'accès aux analyses ?",
     "requestAccessDesc": "Souhaitez-vous demander l'accès pour voir l'analyse des participants ?\n\nSi les participants acceptent, les administrateurs de ce cours pourront voir leurs :\n    • vocabulaire total\n    • concepts grammaticaux totaux\n    • sessions d'activité terminées\n    • concepts grammaticaux spécifiques utilisés, correctement et incorrectement\n\nIls ne pourront pas voir leurs :\n    • messages dans les chats en dehors du cours\n    • liste de vocabulaire",
-    "requestAccess": "Demander l'accès ({count})",
     "analyticsInactiveTitle": "Les demandes aux utilisateurs inactifs n'ont pas pu être envoyées",
     "analyticsInactiveDesc": "Les utilisateurs inactifs qui ne se sont pas connectés depuis l'introduction de cette fonctionnalité ne verront pas votre demande.\n\nLe bouton Demander apparaîtra lorsqu'ils reviendront. Vous pouvez renvoyer la demande plus tard en cliquant sur le bouton Demander sous leur nom lorsqu'il sera disponible.",
     "accessRequestedTitle": "Demande d'accès à l'analyse",
@@ -3633,8 +3313,6 @@
     "accessDesc": "Vous pouvez rendre votre cours accessible au monde entier ! Ou, rendre votre cours privé et sécurisé.",
     "createGroupChatDesc": "Alors que les sessions d'activité commencent et se terminent, les discussions de groupe resteront ouvertes pour la communication de routine.",
     "deleteDesc": "Seuls les administrateurs peuvent supprimer un cours. Il s'agit d'une action destructive qui supprime tous les utilisateurs et supprime toutes les discussions sélectionnées dans le cours. Proceed with caution.",
-    "noCourseFound": "Oh, ce cours a besoin d'un plan !\n\nLes plans de cours sont une séquence de sujets et d'activités de conversation.",
-    "additionalParticipants": "+ {num} autres",
     "whatNow": "Et maintenant ?",
     "chooseNextActivity": "Choisissez votre prochaine activité !",
     "letsGo": "Allons-y",
@@ -3647,13 +3325,11 @@
     "waitNotDone": "Attendez, je n'ai pas fini !",
     "waitingForOthersToFinish": "En attente que les autres terminent...",
     "generatingSummary": "Analyse de la conversation et génération des résultats",
-    "findCourse": "Trouver un cours",
     "pingParticipantsNotification": "{user} cherche des utilisateurs pour rejoindre la session d'activité dans {room}",
     "course": "Cours",
     "courses": "Cours",
     "goToCourse": "Aller au cours : {course}",
     "activityComplete": "Cette activité est terminée. Le résumé de l'activité devrait être disponible ci-dessous.",
-    "startNewSession": "Démarrer une nouvelle session",
     "joinOpenSession": "Rejoindre une session ouverte",
     "activityNotFound": "Activité non trouvée",
     "myActivities": "Mes activités",
@@ -3704,14 +3380,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -3724,10 +3392,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -3737,10 +3401,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -3808,27 +3468,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4142,10 +3786,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4155,10 +3795,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4246,14 +3882,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4270,10 +3898,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4286,15 +3910,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4446,14 +4062,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4467,14 +4075,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5697,10 +5297,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5741,10 +5337,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5817,10 +5409,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6090,47 +5678,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6150,19 +5698,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6226,10 +5762,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6270,14 +5802,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6289,14 +5813,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6334,10 +5850,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6354,27 +5866,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6498,10 +5994,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6511,10 +6003,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6531,14 +6019,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6678,18 +6158,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6738,10 +6206,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6751,18 +6215,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6805,23 +6257,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6845,10 +6285,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6856,14 +6292,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6968,18 +6396,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7032,10 +6448,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7062,10 +6474,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7246,7 +6654,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Revenez demain pour les mises à jour de l'activité.",
-    "activityDropdownDesc": "Lorsque vous avez terminé cette activité, cliquez ci-dessous",
     "languageMismatchTitle": "Incompatibilité de langue",
     "languageMismatchDesc": "La langue cible ne correspond pas à la langue de cette activité. Mettre à jour votre langue cible ?",
     "reportWordIssueTooltip": "Signaler un problème d'information sur le mot",
@@ -7259,10 +6666,6 @@
     "selectAll": "Tout sélectionner",
     "deselectAll": "Tout désélectionner",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7311,17 +6714,11 @@
         "placeholders": {}
     },
     "startOwn": "Démarrer mon propre",
-    "joinCourseDesc": "Chaque cours comporte 8 à 10 sujets séquencés avec une gamme d'activités d'apprentissage linguistique basées sur des tâches.",
     "newMessageInPangeaChat": "💬 Nouveau message dans le chat Pangea",
     "shareCourse": "Partager le cours",
     "addCourse": "Ajouter un cours",
-    "joinPublicCourse": "Rejoindre un cours public",
     "vocabLevelsDesc": "C'est ici que les mots de vocabulaire seront placés une fois que vous les aurez améliorés !",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7334,10 +6731,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7356,7 +6749,6 @@
     "emojiView": "Vue emoji",
     "feedbackDialogDesc": "Je fais aussi des erreurs ! Quelque chose pour m'aider à m'améliorer ?",
     "contactHasBeenInvitedToTheCourse": "Le contact a été invité au cours",
-    "activityStatsButtonTooltip": "Informations sur l'activité",
     "allow": "Autoriser",
     "deny": "Refuser",
     "enabledRenewal": "Activer le renouvellement de l'abonnement",
@@ -7624,10 +7016,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8683,16 +8071,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Activités à débloquer pour le prochain sujet",
-    "activitiesToUnlockTopicDesc": "Définissez le nombre d'activités pour débloquer le prochain sujet de cours",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Pratique de définition de vocabulaire correcte",
     "constructUseIncLMDesc": "Pratique de définition de vocabulaire incorrecte",
     "constructUseCorLADesc": "Pratique audio de vocabulaire correcte",
@@ -8700,7 +8078,6 @@
     "constructUseBonus": "Bonus pendant la pratique de vocabulaire",
     "practiceVocab": "Pratiquer le vocabulaire",
     "selectMeaning": "Sélectionner la signification",
-    "selectAudio": "Sélectionner l'audio correspondant",
     "anotherRound": "Un autre tour",
     "activitySettingsOverrideWarning": "Langue et niveau de langue déterminés par le plan d'activité",
     "voice": "Voix",
@@ -8732,10 +8109,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8753,12 +8126,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Téléchargement initié",
     "webDownloadPermissionMessage": "Si votre navigateur bloque les téléchargements, veuillez activer les téléchargements pour ce site.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8853,11 +8221,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Quelque chose a mal tourné, et nous travaillons dur pour le réparer. Vérifiez à nouveau plus tard.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Activer l'assistance à l'écriture",
     "autoIGCToolDescription": "Exécutez automatiquement les outils de Pangea Chat pour corriger les messages envoyés dans la langue cible.",
     "@autoIGCToolName": {
@@ -8913,24 +8276,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Grammaire",
-    "spanTypeWordChoice": "Choix des mots",
     "spanTypeSpelling": "Orthographe",
     "spanTypePunctuation": "Ponctuation",
     "spanTypeStyle": "Style",
     "spanTypeFluency": "Fluidité",
     "spanTypeAccents": "Accents",
     "spanTypeCapitalization": "Capitalisation",
-    "spanTypeCorrection": "Correction",
     "spanFeedbackTitle": "Signaler un problème de correction",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8955,10 +8307,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8970,13 +8318,7 @@
     "longPressToRecordVoiceMessage": "Appuyez longuement pour enregistrer un message vocal.",
     "pause": "Pause",
     "resume": "Reprendre",
-    "newSubSpace": "Nouvel espace secondaire",
-    "moveToDifferentSpace": "Déplacer vers un espace différent",
-    "removeFromSpaceDescription": "Le chat sera retiré de l'espace mais apparaîtra toujours dans votre liste de chats.",
     "countChats": "{chats} chats",
-    "spaceMemberOf": "Membre de l'espace {spaces}",
-    "spaceMemberOfCanKnock": "Membre de l'espace {spaces} peut frapper",
-    "donate": "Faire un don",
     "startedAPoll": "{username} a lancé un sondage.",
     "poll": "Sondage",
     "startPoll": "Démarrer le sondage",
@@ -8998,23 +8340,15 @@
     "newStickerPack": "Nouveau pack d'autocollants",
     "stickerPackName": "Nom du pack d'autocollants",
     "attribution": "Attribution",
-    "skipChatBackup": "Ignorer la sauvegarde de chat",
-    "skipChatBackupWarning": "Êtes-vous sûr ? Sans activer la sauvegarde de chat, vous pourriez perdre l'accès à vos messages si vous changez d'appareil.",
-    "loadingMessages": "Chargement des messages",
-    "setupChatBackup": "Configurer la sauvegarde de chat",
     "noMoreResultsFound": "Aucun résultat supplémentaire trouvé",
     "chatSearchedUntil": "Chat recherché jusqu'à {time}",
     "federationBaseUrl": "URL de base de la fédération",
     "clientWellKnownInformation": "Informations Client-Bien-Connu :",
     "baseUrl": "URL de base",
     "identityServer": "Serveur d'identité :",
-    "versionWithNumber": "Version : {version}",
     "logs": "Journaux",
-    "advancedConfigs": "Configurations avancées",
     "advancedConfigurations": "Configurations avancées",
-    "signInWithLabel": "Se connecter avec :",
     "selectAllWords": "Sélectionnez tous les mots que vous entendez dans l'audio",
-    "joinCourseForActivities": "Rejoignez un cours pour essayer des activités.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9047,18 +8381,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9066,26 +8388,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9183,22 +8485,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9227,19 +8513,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9247,15 +8521,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9456,11 +8722,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Dans une classe ? Mettez votre code d'accès ici.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Mise en surbrillance automatique des messages audio",
     "selectAudioMessagesOnPlayDescription": "Mettre automatiquement en surbrillance les messages audio lorsqu'ils sont lus",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9504,18 +8765,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Ce cours a des sujets avec moins de {input} activités. Veuillez entrer un nombre inférieur ou égal à {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Cliquez ici pour vous reconnecter.",
     "@clickToLogin": {
@@ -9932,17 +9181,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Un ours jaune de style cartoon avec les bras levés d'excitation.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Sélectionnez des mots pour en savoir plus à leur sujet",
     "requireAnalyticsAccessTitle": "Accès aux analyses requis pour rejoindre",
     "requireAnalyticsAccessDesc": "Les participants doivent accorder l'accès à leurs analyses d'apprentissage pour rejoindre ce cours",
     "analyticsAccessNoticeTitle": "Accès aux analyses requis",
     "analyticsAccessNoticeDesc": "En rejoignant ce cours, vous acceptez d'accorder aux administrateurs l'accès à vos analyses d'apprentissage.",
-    "skipOnboardingClassCodeDesc": "Apprenez de manière autonome ? Ne vous inquiétez pas, vous pouvez :",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9960,10 +9203,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9992,7 +9231,6 @@
     "pickCefrLevelTeacherStepTitle": "Quel niveau enseignez-vous ?",
     "pickCefrLevelStudentStepTitle": "Quel niveau êtes-vous ?",
     "customCourseStepTitle": "Remplissez ce formulaire pour obtenir un cours personnalisé",
-    "aboutYourClass": "À propos de votre classe",
     "courseCodeStepErrorMessage": "Veuillez vérifier votre code et réessayer",
     "institution": "Institution",
     "courseGoals": "Objectifs du cours",
@@ -10035,10 +9273,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10155,12 +9389,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logo de Pangea Chat",
     "introChatDetails": "Dites bonjour ! Présentez-vous à vos camarades participants au cours, trouvez des amis et discutez en dehors des activités.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10204,11 +9433,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Actions d'activité",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Outils de prononciation",
     "audioTranscription": "Transcription audio IA",
     "visualLearnerSupport": "Soutien aux apprenants visuels",
@@ -10249,7 +9473,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Rejoignez un cours qui inclut cette activité pour y jouer.",
     "resizeCoursePanel": "Redimensionner le panneau de cours",
     "undo": "Annuler",
     "unlock": "Déverrouiller",
@@ -10263,7 +9486,6 @@
     "addCourseBrowsePublic": "Parcourir les cours publics",
     "browsePublicCourses": "Parcourir les cours publics",
     "editProfile": "Modifier le profil",
-    "numObjectives": "{count} objectifs",
     "mapSearchHint": "Rechercher des activités",
     "mapSearchNoResults": "Aucun résultat dans la vue",
     "mapFilterAllLanguages": "Toutes les langues",
@@ -10272,7 +9494,6 @@
     "mapFilterCompleted": "Terminé",
     "mapFilterReset": "Réinitialiser",
     "activityTypeConversation": "Conversation",
-    "lockedMissionRequirement": "Terminez la mission précédente pour déverrouiller",
     "playAgain": "Jouer à nouveau",
     "reviewActivity": "Réviser",
     "mapEmptyInView": "Rien ici à votre niveau ou langue. Élargissez vos filtres ou dézoomez.",
@@ -10287,14 +9508,9 @@
     "scrollToBottom": "Faire défiler vers le bas",
     "courseImage": "Image du cours",
     "avatarPreview": "Aperçu de l'avatar",
-    "activityPhoto": "Photo d'activité",
     "emotePreview": "Aperçu de l'émoticône : {name}",
     "activityLabel": "Activité : {title}",
     "resetMapView": "Réinitialiser la vue de la carte",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10347,14 +9563,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10384,10 +9592,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10444,10 +9648,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_ga.arb
+++ b/lib/l10n/intl_ga.arb
@@ -175,11 +175,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "createNewSpace": "Spás nua",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "countParticipants": "{count} rannpháirtithe",
     "@countParticipants": {
         "type": "String",
@@ -559,11 +554,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "An bhfuil cead ag aoi-úsáideoirí a bheith páirteach",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "invitedUser": "📩 thug {username} cuireadh do {targetName}",
     "@invitedUser": {
         "type": "String",
@@ -599,11 +589,6 @@
                 "type": "String"
             }
         }
-    },
-    "groupIsPublic": "Tá an grúpa poiblí",
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
     },
     "fromTheInvitation": "Ón gcuireadh",
     "@fromTheInvitation": {
@@ -642,11 +627,6 @@
     },
     "unblockDevice": "Díbhlocáil Gléas",
     "@unblockDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "Tugadh cuireadh don theagmháil a thar isteach sa grúpa",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -712,11 +692,6 @@
     },
     "chooseAStrongPassword": "Roghnaigh pasfhocal láidir",
     "@chooseAStrongPassword": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "Tá do theachtaireachtaí slán le heochair aisghabhála. Déan cinnte nach gcaillfidh tú í.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -903,11 +878,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Físghlao",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "verifyStart": "Tosaigh Fíorú",
     "@verifyStart": {
         "type": "String",
@@ -925,11 +895,6 @@
     },
     "theyMatch": "Tá siad céanna",
     "@theyMatch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Ainm an spáis",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -998,11 +963,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "removeDevice": "Bain gléas",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "redactMessage": "Bain teachtaireacht amach",
     "@redactMessage": {
         "type": "String",
@@ -1031,11 +991,6 @@
                 "type": "String"
             }
         }
-    },
-    "passwordRecovery": "Aisfháil pasfhocail",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
     },
     "passwordForgotten": "Pasfhocal dearmadta",
     "@passwordForgotten": {
@@ -1119,11 +1074,6 @@
     },
     "fileName": "Ainm an chomhaid",
     "@fileName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "Gach rud réidh!",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -1218,16 +1168,6 @@
             }
         }
     },
-    "noGoogleServicesWarning": "Is cosúil nach bhfuil Firebase Cloud Messaging ar fáil ar do ghléas. Chun fógraí brú a fháil fós, molaimid ntfy a shuiteáil. Le ntfy nó soláthraí Unified Push eile is féidir leat fógraí brú a fháil ar bhealach atá slán ó thaobh sonraí. Is féidir leat ntfy a íoslódáil ón PlayStore nó ó F-Droid.",
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Ní féidir leat criptiú a ghníomhachtú ach a luaithe nach bhfuil an seomra inrochtana go poiblí a thuilleadh.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "noEmotesFound": "Níor aimsíodh aon straoiseoga. 😕",
     "@noEmotesFound": {
         "type": "String",
@@ -1253,15 +1193,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "logInTo": "Logáil isteach chuig {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
-    },
     "locationPermissionDeniedNotice": "Diúltaíodh cead suímh. Deonaigh dóibh le do thoil go mbeidh tú in ann do shuíomh a roinnt.",
     "@locationPermissionDeniedNotice": {
         "type": "String",
@@ -1276,15 +1207,6 @@
     "@loadingPleaseWait": {
         "type": "String",
         "placeholders": {}
-    },
-    "loadCountMoreParticipants": "Lódáil {count} níos mó rannpháirtithe",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "leftTheChat": "Fágadh an comhrá",
     "@leftTheChat": {
@@ -1343,15 +1265,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "inviteContactToGroup": "Tabhair cuireadh do theagmháil chuig {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
     "incorrectPassphraseOrKey": "Pasfhrása nó eochair téarnaimh mícheart",
     "@incorrectPassphraseOrKey": {
         "type": "String",
@@ -1409,11 +1322,6 @@
     },
     "encryptionNotEnabled": "Ní chumasaítear criptiú",
     "@encryptionNotEnabled": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "enableEncryptionWarning": "Ní bheidh in ann an criptiú a dhíchumasú níos mó. An bhfuil tú cinnte?",
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1519,23 +1427,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "wipeChatBackup": "An bhfuil fonn ort cúltaca do chomhrá a scriosadh chun eochair athshlánaithe nua a chruthú?",
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Cén fáth ar mhaith leat é seo a thuairisciú?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Cé a bhfuil cead aige/aici dul isteach sa ghrúpa seo",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoCanPerformWhichAction": "Cé atá in ann an gníomh a dhéanamh",
-    "@whoCanPerformWhichAction": {
         "type": "String",
         "placeholders": {}
     },
@@ -1577,15 +1470,6 @@
             }
         }
     },
-    "unreadChats": "{unreadCount, plural, =1{1 comhrá neamhléite} other{{unreadCount} comhráite neamhléite}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "unknownEncryptionAlgorithm": "Algartam criptithe anaithnid",
     "@unknownEncryptionAlgorithm": {
         "type": "String",
@@ -1608,11 +1492,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Aistriú ó ghléas eile",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tooManyRequestsWarning": "An iomarca iarratas. Bain triail eile as níos déanaí!",
     "@tooManyRequestsWarning": {
         "type": "String",
@@ -1631,11 +1510,6 @@
                 "type": "String"
             }
         }
-    },
-    "setPermissionsLevel": "Socraigh leibhéal ceadanna",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
     },
     "setAsCanonicalAlias": "Socraigh mar phríomh-ailias",
     "@setAsCanonicalAlias": {
@@ -1856,11 +1730,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "visibilityOfTheChatHistory": "Infheictheacht stair na comhrá",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "verifyTitle": "Ag fíorú cuntas eile",
     "@verifyTitle": {
         "type": "String",
@@ -1910,11 +1779,6 @@
             }
         }
     },
-    "spaceIsPublic": "Tá an spás poiblí",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "sentAnAudio": "🎤 sheol {username} fuaim",
     "@sentAnAudio": {
         "type": "String",
@@ -1947,10 +1811,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "addAccount": "Breisigh cuntas",
-    "@addAccount": {},
-    "enableMultiAccounts": "(BÉITE) Cumasaigh cuntais iomadúla ar an gléas seo",
-    "@enableMultiAccounts": {},
     "commandHint_create": "Cruthaigh comhrá grúpa folamh\nÚsáid --no-encryption chun criptiúchán a dhíchumasú",
     "@commandHint_create": {
         "type": "String",
@@ -1963,14 +1823,8 @@
         "type": "String",
         "description": "Usage hint for the command /clearcache"
     },
-    "videoCallsBetaWarning": "Tabhair faoi deara go bhfuil físglaonna i béite. B'fhéidir nach bhfeidhmíonn siad ar gach ardán chomh atá súil aige ná ar bith.",
-    "@videoCallsBetaWarning": {},
-    "emailOrUsername": "Ríomhphost nó ainm úsáideora",
-    "@emailOrUsername": {},
     "repeatPassword": "Scríobh an pasfhocal arís",
     "@repeatPassword": {},
-    "yourChatBackupHasBeenSetUp": "Bunaíodh do chúltaca comhrá.",
-    "@yourChatBackupHasBeenSetUp": {},
     "openVideoCamera": "Oscail físcheamara",
     "@openVideoCamera": {
         "type": "String",
@@ -1987,22 +1841,14 @@
     },
     "editBundlesForAccount": "Cuir cuachta in eagar don chuntas seo",
     "@editBundlesForAccount": {},
-    "globalChatId": "Aitheantas comhrá domhanda",
-    "@globalChatId": {},
-    "pleaseEnterRecoveryKey": "Cuir isteach d'eochair athshlánaithe le do thoil:",
-    "@pleaseEnterRecoveryKey": {},
     "sender": "Seoltóir",
     "@sender": {},
-    "noOneCanJoin": "Ní féidir le duine ar bith páirt a ghlacadh",
-    "@noOneCanJoin": {},
     "noOtherDevicesFound": "Níor aimsíodh aon ghléas eile",
     "@noOtherDevicesFound": {},
     "inviteGroupChat": "📨 Cuireadh chuig comhrá grúpa",
     "@inviteGroupChat": {},
     "knocking": "Cnagadh",
     "@knocking": {},
-    "addChatOrSubSpace": "Cuir comhrá nó fo-spás leis",
-    "@addChatOrSubSpace": {},
     "thisDevice": "An gléas seo:",
     "@thisDevice": {},
     "formattedMessages": "Teachtaireachtaí formáidithe",
@@ -2054,8 +1900,6 @@
     "@searchForUsers": {},
     "removeFromBundle": "Bain as an mbeart seo",
     "@removeFromBundle": {},
-    "recoveryKeyLost": "Eochair athshlánaithe caillte?",
-    "@recoveryKeyLost": {},
     "reactedWith": "D'fhreagair {sender} le {reaction}",
     "@reactedWith": {
         "type": "String",
@@ -2094,16 +1938,12 @@
     "@sendReadReceipts": {},
     "formattedMessagesDescription": "Taispeáin ábhar saibhir teachtaireachta cosúil le téacs trom ag baint úsáide as marcáil síos.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Fíoraigh úsáideoir eile",
-    "@verifyOtherUser": {},
     "hidePresences": "Folaigh Liosta Stádais?",
     "@hidePresences": {},
     "jump": "Léim",
     "@jump": {},
     "reportErrorDescription": "😭 Ó, a mhac go deo. Chuaigh rud éigin mícheart. Más mian leat, is féidir leat an fabht seo a thuairisciú do na forbróirí.",
     "@reportErrorDescription": {},
-    "setTheme": "Socraigh téama:",
-    "@setTheme": {},
     "invalidInput": "Ionchur neamhbhailí!",
     "@invalidInput": {},
     "kickUserDescription": "Ciceáiltear an t-úsáideoir as an gcomhrá ach níl cosc air. I gcomhráite poiblí, is féidir leis an úsáideoir teacht ar ais ag am ar bith.",
@@ -2133,8 +1973,6 @@
     "@incomingMessages": {},
     "transparent": "Trédhearcach",
     "@transparent": {},
-    "voiceCall": "Glao gutha",
-    "@voiceCall": {},
     "widgetVideo": "Físeán",
     "@widgetVideo": {},
     "errorAddingWidget": "Earráid agus an ghiuirléid á cur leis.",
@@ -2188,8 +2026,6 @@
     "@messageInfo": {},
     "messageType": "Cineál Teachtaireachta",
     "@messageType": {},
-    "pleaseEnterRecoveryKeyDescription": "Chun do sheanteachtaireachtaí a dhíghlasáil, cuir isteach d'eochair athshlánaithe a gineadh i seisiún eile. NÍ do phasfhocal í d'eochair athshlánaithe.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "openChat": "Oscail Comhrá",
     "@openChat": {},
     "unsupportedAndroidVersionLong": "Éilíonn an ghné seo leagan Android níos nuaí. Seiceáil le haghaidh nuashonruithe nó tacaíocht Lineage OS.",
@@ -2226,8 +2062,6 @@
     },
     "knock": "Cnoc Mhuire",
     "@knock": {},
-    "storeInSecureStorageDescription": "Stóráil an eochair aisghabhála i stóráil slán an ghléis seo.",
-    "@storeInSecureStorageDescription": {},
     "countFiles": "Comhaid {count}",
     "@countFiles": {
         "placeholders": {
@@ -2236,14 +2070,6 @@
             }
         }
     },
-    "foregroundServiceRunning": "Tá an fógra seo le feiceáil nuair atá an tseirbhís tulra ag rith.",
-    "@foregroundServiceRunning": {},
-    "screenSharingDetail": "Tá do scáileán á roinnt agat i FuffyChat",
-    "@screenSharingDetail": {},
-    "disableEncryptionWarning": "Ar chúiseanna slándála ní féidir leat criptiú a dhíchumasú i gcomhrá, áit ar cumasaíodh é roimhe seo.",
-    "@disableEncryptionWarning": {},
-    "sorryThatsNotPossible": "Tá brón orm... nach féidir a dhéanamh",
-    "@sorryThatsNotPossible": {},
     "reopenChat": "Comhrá a athoscailt",
     "@reopenChat": {},
     "noBackupWarning": "Rabhadh! Gan cúltaca comhrá a chumasú, caillfidh tú rochtain ar do theachtaireachtaí criptithe. Moltar go mór an cúltaca comhrá a chumasú ar dtús sula logálann tú amach.",
@@ -2295,12 +2121,6 @@
             }
         }
     },
-    "searchChatsRooms": "Cuardaigh #chats, @users...",
-    "@searchChatsRooms": {},
-    "createGroupAndInviteUsers": "Cruthaigh grúpa agus tabhair cuireadh d'úsáideoirí",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "Is féidir teacht ar ghrúpa trí chuardach",
-    "@groupCanBeFoundViaSearch": {},
     "wrongRecoveryKey": "Tá brón orm... Ní cosúil gurb é seo an eochair aisghabhála ceart.",
     "@wrongRecoveryKey": {},
     "databaseMigrationBody": "Fan, le do thoil. B'fhéidir go dtógfaidh sé seo nóiméad.",
@@ -2322,32 +2142,6 @@
     "@passwordIsWrong": {},
     "files": "Comhaid",
     "@files": {},
-    "sessionLostBody": "Cailltear do sheisiún. Tuairiscigh an earráid seo do na forbróirí ag {url}. Is í an teachtaireacht earráide: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Déanann an aip iarracht anois do sheisiún a chur ar ais ón gcúltaca. Tuairiscigh an earráid seo do na forbróirí ag {url}. Is í an teachtaireacht earráide: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "verifyOtherUserDescription": "Má fhíoraíonn tú úsáideoir eile, is féidir leat a bheith cinnte go bhfuil a fhios agat cé leis a bhfuil tú ag scríobh i ndáiríre. 💪\n\nNuair a thosaíonn tú fíorú, feicfidh tú féin agus an t-úsáideoir eile aníos san aip. Ansin feicfidh tú sraith emojis nó uimhreacha a chaithfidh tú a chur i gcomparáid lena chéile.\n\nIs é an bealach is fearr chun é seo a dhéanamh ná bualadh le chéile nó glao físe a thosú. 👭",
-    "@verifyOtherUserDescription": {},
     "sendTypingNotificationsDescription": "Is féidir le rannpháirtithe eile i gcomhrá a fheiceáil nuair atá teachtaireacht nua á clóscríobh agat.",
     "@sendTypingNotificationsDescription": {},
     "verifyOtherDeviceDescription": "Nuair a fhíoraíonn tú gléas eile, is féidir leis na gléasanna sin eochracha a mhalartú, do shlándáil fhoriomlán a mhéadú. 💪 Nuair a thosaíonn tú fíorú, beidh preabfhuinneog le feiceáil san aip ar an dá ghléas. Ansin feicfidh tú sraith emojis nó uimhreacha a chaithfidh tú a chur i gcomparáid lena chéile. Is fearr an dá ghléas a bheith áisiúil sula dtosaíonn tú ar an bhfíorú. 🤳",
@@ -2411,14 +2205,6 @@
     "@changelog": {},
     "sendCanceled": "Cealaíodh seoladh",
     "@sendCanceled": {},
-    "loginWithMatrixId": "Logáil isteach le Matrix-ID",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Faigh amach faoi fhreastalaithe baile",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Cad is freastalaí baile ann?",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "Stóráiltear do chuid sonraí go léir ar an bhfreastalaí baile, díreach cosúil le soláthraí ríomhphoist. Is féidir leat an freastalaí baile is mian leat a úsáid a roghnú, agus is féidir leat cumarsáid a dhéanamh le gach duine fós. Foghlaim níos mó ag https://matrix.org.",
-    "@homeserverDescription": {},
     "calculatingFileSize": "Méid an chomhaid á ríomh...",
     "@calculatingFileSize": {},
     "sendingAttachment": "Iatán á sheoladh...",
@@ -2456,16 +2242,12 @@
     "@noticeChatBackupDeviceVerification": {},
     "continueText": "Lean ar aghaidh",
     "@continueText": {},
-    "welcomeText": "Hey Hey 👋 Is é seo FluffyChat. Is féidir leat síniú isteach in aon fhreastalaí baile, atá comhoiriúnach leis https://matrix.org. Agus ansin comhrá a dhéanamh le duine ar bith. Is líonra teachtaireachtaí díláraithe ollmhór é!",
-    "@welcomeText": {},
     "blur": "Doiléirigh:",
     "@blur": {},
     "opacity": "Teimhneacht:",
     "@opacity": {},
     "setWallpaper": "Socraigh cúlbhrat",
     "@setWallpaper": {},
-    "manageAccount": "Bainistigh cuntas",
-    "@manageAccount": {},
     "noContactInformationProvided": "Ní sholáthraíonn an freastalaí aon fhaisnéis teagmhála bhailí",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "Déan teagmháil le admin an fhreastalaí",
@@ -2535,8 +2317,6 @@
     "@commandHint_cuddle": {},
     "commandHint_hug": "Seol barróg",
     "@commandHint_hug": {},
-    "encryptThisChat": "Criptigh an comhrá seo",
-    "@encryptThisChat": {},
     "importNow": "Iompórtáil anois",
     "@importNow": {},
     "sendTypingNotifications": "Seol fógraí clóscríofa",
@@ -2600,8 +2380,6 @@
             }
         }
     },
-    "recoveryKey": "Eochair athshlánaithe",
-    "@recoveryKey": {},
     "setChatDescription": "Socraigh cur síos ar an gcomhrá",
     "@setChatDescription": {},
     "presencesToggle": "Taispeáin teachtaireachtaí stádais ó úsáideoirí eile",
@@ -2611,8 +2389,6 @@
     },
     "time": "Am",
     "@time": {},
-    "removeFromSpace": "Bain as spás",
-    "@removeFromSpace": {},
     "placeCall": "Cuir glaoch",
     "@placeCall": {},
     "unsupportedAndroidVersion": "Leagan Android gan tacaíocht",
@@ -2623,10 +2399,6 @@
     "@widgetCustom": {},
     "widgetName": "Ainm",
     "@widgetName": {},
-    "usersMustKnock": "Ní mór d'úsáideoirí cnag a chur ar",
-    "@usersMustKnock": {},
-    "storeSecurlyOnThisDevice": "Stóráil go daingean ar an ngléas seo",
-    "@storeSecurlyOnThisDevice": {},
     "userLevel": "{level} - Úsáideoir",
     "@userLevel": {
         "type": "String",
@@ -2667,16 +2439,10 @@
             }
         }
     },
-    "publicChatAddresses": "Seoltaí comhrá poiblí",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Cruthaigh seoladh nua",
-    "@createNewAddress": {},
     "groupName": "Ainm an ghrúpa",
     "@groupName": {},
     "bundleName": "Ainm an bheartáin",
     "@bundleName": {},
-    "enterSpace": "Iontráil spás",
-    "@enterSpace": {},
     "wasDirectChatDisplayName": "Comhrá folamh (bhí {oldDisplayName})",
     "@wasDirectChatDisplayName": {
         "type": "String",
@@ -2708,25 +2474,6 @@
     "@youInvitedUser": {
         "placeholders": {
             "user": {
-                "type": "String"
-            }
-        }
-    },
-    "unlockOldMessages": "Díghlasáil seanteachtaireachtaí",
-    "@unlockOldMessages": {},
-    "saveKeyManuallyDescription": "Sábháil an eochair seo de láimh trí dialóg nó gearrthaisce comhroinnte an chórais a spreagadh.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "Stóráil i Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Stóráil i Apple KeyChain",
-    "@storeInAppleKeyChain": {},
-    "newSpaceDescription": "Ligeann spásanna duit do chomhráite a chomhdhlúthú agus pobail phríobháideacha nó phoiblí a thógáil.",
-    "@newSpaceDescription": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Is féidir comhrá a aimsiú tríd an gcuardach ar {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
                 "type": "String"
             }
         }
@@ -2823,20 +2570,12 @@
     "@youJoinedTheChat": {},
     "youAcceptedTheInvitation": "👍 Ghlac tú leis an gcuireadh",
     "@youAcceptedTheInvitation": {},
-    "screenSharingTitle": "comhroinnt scáileáin",
-    "@screenSharingTitle": {},
-    "accessAndVisibility": "Rochtain agus infheictheacht",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Cé a bhfuil cead aige páirt a ghlacadh sa chomhrá seo agus conas is féidir an comhrá a aimsiú.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Glaonna",
     "@calls": {},
     "customEmojisAndStickers": "Emojis agus greamáin saincheaptha",
     "@customEmojisAndStickers": {},
     "customEmojisAndStickersBody": "Cuir leis nó roinn emojis nó greamáin saincheaptha is féidir a úsáid in aon chomhrá.",
     "@customEmojisAndStickersBody": {},
-    "chatDescription": "Cur síos ar an gcomhrá",
-    "@chatDescription": {},
     "hideRedactedMessages": "Folaigh teachtaireachtaí curtha in eagar",
     "@hideRedactedMessages": {},
     "hideRedactedMessagesBody": "Má athghníomhaíonn duine éigin teachtaireacht, ní bheidh an teachtaireacht seo le feiceáil sa chomhrá a thuilleadh.",
@@ -2874,24 +2613,11 @@
             }
         }
     },
-    "appIntroduction": "Ligeann FluffyChat duit comhrá a dhéanamh le do chairde thar theachtairí éagsúla. Foghlaim tuilleadh ag https://matrix.org nó tapáil *Ar aghaidh*.",
-    "@appIntroduction": {},
-    "appWantsToUseForLoginDescription": "Ligeann tú leis seo don aip agus don suíomh Gréasáin faisnéis a roinnt fút.",
-    "@appWantsToUseForLoginDescription": {},
     "synchronizingPleaseWaitCounter": " Ag sioncronú… ({percentage}%)",
     "@synchronizingPleaseWaitCounter": {
         "type": "String",
         "placeholders": {
             "percentage": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLogin": "Úsáid '{server}' chun logáil isteach",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
                 "type": "String"
             }
         }
@@ -3049,15 +2775,6 @@
     "@pleaseWaitUntilInvited": {},
     "checkList": "Liosta seiceála",
     "@checkList": {},
-    "countInvited": "cuireadh chuig {count}",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "sentVoiceMessage": "🎙️ {duration} - Teachtaireacht ghutha ó {sender}",
     "@sentVoiceMessage": {
         "type": "String",
@@ -3090,12 +2807,6 @@
     "@pause": {},
     "resume": "Atosú",
     "@resume": {},
-    "newSubSpace": "Fo-spás nua",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Bog go spás difriúil",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "Bainfear an comhrá as an spás ach beidh sé fós le feiceáil i do liosta comhrá.",
-    "@removeFromSpaceDescription": {},
     "countChats": "comhráite {chats}",
     "@countChats": {
         "type": "String",
@@ -3105,26 +2816,6 @@
             }
         }
     },
-    "spaceMemberOf": "Ball spáis de {spaces}",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "Is féidir le ball spáis de {spaces} cnagadh",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "Tabhair Síntiús",
-    "@donate": {},
     "startedAPoll": "Chuir {username} tús le pobalbhreith.",
     "@startedAPoll": {
         "type": "String",
@@ -3194,14 +2885,6 @@
     "@stickerPackName": {},
     "attribution": "Atribution",
     "@attribution": {},
-    "skipChatBackup": "Seachain cúltaca comhrá",
-    "@skipChatBackup": {},
-    "skipChatBackupWarning": "An bhfuil tú cinnte? Mura gcumasaíonn tú an cúltaca comhrá, d’fhéadfá rochtain ar do theachtaireachtaí a chailleadh má athraíonn tú do ghléas.",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "Ag lódáil teachtaireachtaí",
-    "@loadingMessages": {},
-    "setupChatBackup": "Socraigh cúltaca comhrá",
-    "@setupChatBackup": {},
     "changedTheChatDescription": "D'athraigh {username} cur síos an chomhrá",
     "@changedTheChatDescription": {},
     "changedTheChatName": "D'athraigh {username} ainm an chomhrá",
@@ -3212,11 +2895,9 @@
     "taTooltip": "Úsáid L2 le cabhair aistriúcháin",
     "interactiveTranslatorSliderHeader": "Aistritheoir Idirghníomhach",
     "interactiveGrammarSliderHeader": "Seiceáil Foghraíochta Idirghníomhach",
-    "interactiveTranslatorRequired": "De dhíth",
     "waTooltip": "Úsáid L2 gan chabhair",
     "interactiveTranslator": "Cabhair Aistriúcháin",
     "noIdenticalLanguages": "Roghnaigh le do thoil teangacha bunúsacha agus spriocdhírithe difriúla",
-    "searchBy": "Cuardaigh de réir tír agus teangacha",
     "joinWithClassCode": "Cláraigh leis an gcód rang",
     "languageLevelPreA1": "Novice Low (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -3236,19 +2917,14 @@
     "whatIsYourBaseLanguage": "Cén teanga bhunúsach atá agat?",
     "publicProfileTitle": "Ceadaigh go bhféadfaidh daoine mo phróifíl a aimsiú sa chuardach",
     "publicProfileDesc": "Trí chumasú, ligfidh tú do dhaoine eile do phróifíl a fháil sa bharra cuardaigh domhanda agus iarratais a sheoladh chun comhrá. Sa phointe seo, is féidir leat glacadh nó diúltú leis an iarratas.",
-    "errorDisableIT": "Tá cabhair aistriúcháin dícheangailte.",
-    "errorDisableIGC": "Tá cabhair gramadála dícheangailte.",
     "errorDisableITUserDesc": "Cliceáil anseo chun socruithe cabhrach aistriúcháin a nuashonrú",
     "errorDisableIGCUserDesc": "Cliceáil anseo chun socruithe cabhrach gramadála a nuashonrú",
     "errorDisableITClassDesc": "Tá cabhair aistriúcháin dícheangailte don chúrsa ina bhfuil an comhrá seo.",
     "errorDisableIGCClassDesc": "Tá cabhair gramadála dícheangailte don chúrsa ina bhfuil an comhrá seo.",
-    "error405Title": "Níor socraíodh teangacha",
     "error405Desc": "Le do thoil, socraigh do chuid teangacha sa Bhealach Príomh > Socruithe Foghlama.",
     "termsAndConditions": "Tearmaí agus Coinníollacha",
     "andCertifyIAmAtLeast13YearsOfAge": " agus deimhním go bhfuil mé ar a laghad 16 bliain d'aois.",
-    "error502504Title": "Wow, tá a lán daltaí ar líne!",
     "error502504Desc": "D'fhéadfadh go mbeadh na huirlisí aistriúcháin agus gramadach mall nó neamh-inmhianaithe agus na bots Pangea ag teacht chun cinn.",
-    "error404Title": "Earráid aistriúcháin!",
     "error404Desc": "Níl a fhios ag Bot Pangea conas é a aistriú...",
     "errorPleaseRefresh": "Táimid ag déileáil leis! Le do thoil, luchtú arís agus bain triail eile as.",
     "connectedToStaging": "Ceangailte le Staging",
@@ -3286,13 +2962,9 @@
     "definitionsToolName": "Sainmhínithe Focal",
     "definitionsToolDescription": "Nuair a bhíonn sé cumasaithe, is féidir cliceáil ar fhocail faoi bhun línte gorma le haghaidh sainmhínithe. Cliceáil ar theachtaireachtaí chun rochtain a fháil ar shainmhínithe.",
     "welcomeBack": "Fáilte ar ais! Mura raibh tú rannpháirteach sa phainéal 2023-2024, déan teagmháil linn le haghaidh do shíntiús speisialta. Má tá tú múinteoir a cheannaigh ceadúnas do do rang, déan teagmháil linn le haghaidh do shíntiús múinteora.",
-    "downloadTxtFile": "Íoslódáil Comhad Téacs",
-    "downloadCSVFile": "Íoslódáil Comhad CSV",
     "promotionalSubscriptionDesc": "Tá síntiús promóiseach saoil agat faoi láthair. Seol teachtaireacht chuig support@pangea.chat le haghaidh cabhrach maidir le do shíntiús a athrú.",
     "originalSubscriptionPlatform": "Síntiús ceannaíodh trí {purchasePlatform}",
     "oneWeekTrial": "Triail Seachtain amháin",
-    "downloadXLSXFile": "Íoslódáil Comhad Excel",
-    "unkDisplayName": "Neamartha",
     "wwCountryDisplayName": "Domhanda",
     "afCountryDisplayName": "An Afganastáin",
     "axCountryDisplayName": "Oileáin Åland",
@@ -3587,7 +3259,6 @@
     "chatCapacityHasBeenChanged": "Athraíodh cumas an chomhrá",
     "chatCapacitySetTooLow": "Ní mór do chumas an chomhrá a bheith ar a laghad {count}.",
     "chatCapacityExplanation": "Cuireann cumas an chomhrá teorainn ar líon na mbaill a cheadaítear i gcomhrá.",
-    "tooManyRequest": "Rogha ró-ard, déan iarracht arís níos déanaí.",
     "enterNumber": "Cuir luach uimhriúil iomlán isteach le do thoil.",
     "practice": "Cleachtadh",
     "versionNotFound": "Níor aimsíodh leagan",
@@ -3597,7 +3268,6 @@
     "deleteSubscriptionWarningTitle": "Tá síntiús gníomhach agat",
     "deleteSubscriptionWarningBody": "Ní chuirfidh scriosadh do chuntais do shíntiús go huathoibríoch ar ceal.",
     "manageSubscription": "Bainistigh Síntiús",
-    "error520Title": "Déan iarracht arís le do thoil.",
     "error520Desc": "Tá brón orm, níor thuig muid do theachtaireacht...",
     "wordsUsed": "Focail Úsáidte",
     "level": "Leibhéal",
@@ -3615,7 +3285,6 @@
     "other": "Eile",
     "levelShort": "LEIBHÉAL {level}",
     "noCapacityLimit": "Gan teorainn acmhainne",
-    "downloadGroupText": "Íoslódáil téacs an ghrúpa",
     "notificationsOn": "Fógraí ar siúl",
     "notificationsOff": "Fógraí as",
     "joinWithCode": "Bí páirteach le cód",
@@ -3679,24 +3348,12 @@
     "whatIsTheMorphTag": "Cad é an {morphologicalFeature} de '{wordForm}'?",
     "dataAvailable": "Fáil ar shonraí",
     "available": "Ar fáil",
-    "pangeaBotIsFallible": "Tá bot Pangea bréagach freisin!",
-    "whatIsMeaning": "Cad is brí le '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Comhoiriúnigh bríonna leis na focail sa teachtaireacht!",
-    "doubleClickToEdit": "Cliceáil dé-uaire chun eagarthóireacht.",
-    "topicLabel": "Ábhar",
-    "topicPlaceholder": "Roghnaigh ábhar...",
-    "modePlaceholder": "Roghnaigh mód...",
-    "learningObjectiveLabel": "Cuspóir foghlama",
-    "learningObjectivePlaceholder": "Roghnaigh cuspóir foghlama...",
-    "targetLanguageLabel": "Teanga sprioc",
     "cefrLevelLabel": "Leveál CEFR",
     "image": "Íomhá",
     "video": "Físeán",
     "nan": "Níl infheidhmithe",
-    "addVocabulary": "Cuir foclóir leis",
     "instructions": "Treoracha",
-    "numberOfLearners": "Líon na bhfoghlaimeoirí",
-    "mustBeInteger": "Ní mór a bheith ina uimhir iomlán m.sh. 1, 2, 3, ...",
     "constructUsePvmDesc": "Déanta i gceist guth",
     "leaveSpaceDescription": "Trí fhágáil an chúrsa, fágfaidh tú na comhráite go léir laistigh de. Feicfidh úsáideoirí eile go bhfuil tú imithe as an gcúrsa.",
     "constructUseCorMmDesc": "Brí teachtaireachta ceart",
@@ -3711,7 +3368,6 @@
     "ttsDisabledBody": "Is féidir leat téacs go guth a chumasú sna socruithe foghlama agat",
     "noSpaceDescriptionYet": "Níl cur síos ar an gcúrsa cruthaithe fós.",
     "tooLargeToSend": "Tá an teachtaireacht seo ró-mhór le seoladh",
-    "exitWithoutSaving": "An bhfuil tú cinnte go bhfuil tú ag iarraidh imeacht gan sábáil?",
     "enableAutocorrectPopupTitle": "Cuir do eochairfhocal teanga sprioc leis trí dul go:",
     "enableAutocorrectPopupSteps": "  • Socruithe\n  • Ginearálta\n  • Eochairfhocal\n  • Eochairfhocail\n  • Cuir Eochairfhocal Nua leis",
     "enableAutocorrectPopupDescription": "Nuair a roghnaítear an teanga, is féidir leat cliceáil ar an gcloch beag domhain ar chlé bun do do eochairfhocal chun an eochairfhocal nua a ghníomhachtú.",
@@ -3722,11 +3378,8 @@
     "displayName": "Ainm le feiceáil",
     "leaveRoomDescription": "Tá tú faoi láthair ag dul i dtaithí ar an gcomhrá seo. Feicfidh úsáideoirí eile go bhfuil tú imithe as an gcomhrá.",
     "confirmUserId": "Déan cinnte de do ainm úsáideora Pangea Chat chun do chuntas a scriosadh.",
-    "startingToday": "Ag tosú inniu",
-    "oneWeekFreeTrial": "Triail saor in aisce ar feadh seachtain",
     "paidSubscriptionStarts": "Ag tosú {startDate}",
     "cancelInSubscriptionSettings": "• Cuir ar ceal ag am ar bith sna socruithe síntiúis",
-    "cancelToAvoidCharges": "• Cuir ar ceal roimh {trialEnds} chun na muirir a sheachaint",
     "downloadGboard": "Íoslódáil Gboard",
     "autocorrectNotAvailable": "Ar an drochuair, níl do chóras reatha tacaíocht don ghné seo faoi láthair. Fan ar an eolas le haghaidh forbairtí eile!",
     "pleaseUpdateApp": "Le do thoil, déan nuashonrú ar an aip chun leanúint ar aghaidh.",
@@ -3736,17 +3389,12 @@
     "knockSpaceSuccess": "Tá tú tar éis iarraidh a bheith páirteach sa chúrsa seo! Freagróidh riarthóir do iarratas nuair a fhaigheann sé é 😀",
     "chooseWordAudioInstructionsBody": "Éist leis an teachtaireacht iomlán. Ansin, déan comparáid idir na fuaimeanna agus na focail.",
     "chooseMorphsInstructionsBody": "Cliceáil ar na píosaí puzail le haghaidh ceisteanna gramadaí!",
-    "pleaseEnterInt": "Cuir isteach uimhir le do thoil",
     "home": "Baile",
     "join": "Bí páirteach",
     "resetInstructionTooltipsTitle": "Athshocraigh na téacsleabhair treorach",
     "resetInstructionTooltipsDesc": "Cliceáil chun na téacsleabhair treorach a thaispeáint ar nós do úsáideoir nua.",
-    "randomize": "Randamach",
     "clear": "Glan",
-    "featuredActivities": "Réamh-mholta",
     "save": "Sábháil",
-    "startChat": "Tosaigh comhrá",
-    "translationProblem": "Fadhb aistriúcháin",
     "askToJoin": "Iarr le bheith páirteach",
     "emptyChatWarningTitle": "Tá an comhrá folamh",
     "emptyChatWarningDesc": "Níl aon duine á thabhairt cuireadh duit sa chomhrá seo. Téigh go Socruithe Comhrá chun do chairde nó an Bot a thabhairt cuireadh. Is féidir leat é seo a dhéanamh níos déanaí freisin.",
@@ -3776,17 +3424,13 @@
     "timesUsedIndependently": "Uaireanta úsáide go neamhspleách",
     "timesUsedWithAssistance": "Uaireanta úsáide le cabhair",
     "shareInviteCode": "Roinn cód cuireadh: {code}",
-    "leaderboard": "Bord na n-iomaitheoirí",
     "skipForNow": "Scipeáil faoi láthair",
     "permissions": "Ceadanna",
     "spaceChildPermission": "Cé hiad is féidir leo cuntais nua a chur leis an gcúrsa seo",
-    "addEnvironmentOverride": "Cuir i bhfeidhm foréigean comhshaoil",
     "defaultOption": "Réamhshocrú",
     "deleteChatDesc": "An bhfuil tú cinnte gur mhaith leat an comhrá seo a scriosadh? Scriosfar é do gach rannpháirtí agus ní bheidh aon teachtaireachtaí laistigh den chomhrá ar fáil níos mó le haghaidh cleachtadh nó anailís foghlama.",
     "deleteSpaceDesc": "Scriosfar an cúrsa agus aon chomhrá roghnaithe do gach rannpháirtí agus ní bheidh aon teachtaireachtaí laistigh den chomhrá ar fáil níos mó le haghaidh cleachtadh nó anailís foghlama. Ní féidir an gníomh seo a chur ar ceal.",
     "launch": "Seol",
-    "searchChats": "Cuardaigh comhráite",
-    "maxFifty": "Max 50",
     "configureSpace": "Cumraigh cúrsa",
     "pinMessages": "Greamaigh teachtaireachtaí",
     "setJoinRules": "Socraigh rialacha rannpháirtíochta",
@@ -3820,9 +3464,6 @@
     "failedToFetchTranscription": "Theip ar an taifeadadh a fháil",
     "deleteEmptySpaceDesc": "Scriosfar an cúrsa do na rannpháirtithe go léir. Ní féidir an gníomh seo a chur ar ceal.",
     "regenerate": "Athghiniúint",
-    "mySavedActivities": "Mo Gníomhaíochtaí Sábháilte",
-    "noSavedActivities": "Níl aon ghníomhaíochtaí sábáilte",
-    "saveActivity": "Sábháil an gníomhaíocht seo",
     "failedToPlayVideo": "Theip ar sheinm an fhíseáin",
     "done": "Déanta",
     "inThisSpace": "Sa chúrsa seo",
@@ -3833,13 +3474,9 @@
     "numInvited": "{count} cuireadh",
     "saved": "Sábháilte",
     "reset": "Athshocraigh",
-    "errorFetchingActivitiesMessage": "Theip ar fháil na ngníomhaíochtaí",
     "errorFetchingDefinition": "Theip ar fáil an sainmhíniú",
     "errorProcessAnalytics": "Theip ar phróiseáil anailíseachtaí",
     "errorDownloading": "Theip ar iarraidh",
-    "errorLoadingSpaceChildren": "Theip ar luchtú comhráite laistigh den chúrsa seo",
-    "unexpectedError": "Earráid neamhshocraithe.",
-    "pleaseReload": "Le do thoil, luchtigh arís agus bain triail eile astu.",
     "translationError": "Earráid aistriúcháin",
     "check": "Seiceáil",
     "unableToFindRoom": "Níor aimsíodh comhrá nó cúrsa leis an gcód sin. Déan iarracht arís le do thoil.",
@@ -3848,19 +3485,14 @@
     "request": "Iarratas",
     "requestAll": "Iarr gach rud",
     "confirmMessageUnpin": "An bhfuil tú cinnte gur mhaith leat an teachtaireacht seo a bhaint den phin?",
-    "saveAndLaunch": "Sábháil agus tús a chur",
-    "launchToSpace": "Tús a chur chuig an gcúrsa",
     "pending": "Iontach",
     "inactive": "Neamhghníomhach",
-    "confirmRole": "Deimhnigh ról",
     "openRoleLabel": "OSCAIL",
     "finishedTheActivity": "🎯 {username} chríochnaigh an gníomhaíocht seo",
     "activitySummaryError": "Ní féidir achoimrigh gníomhaíochta a fháil",
     "requestSummaries": "Iarr achoimrigh",
-    "generatingNewActivities": "Is tú an chéad úsáideoir den phair teanga seo! Tabhair cúpla nóiméad dúinn, táimid ag ullmhú gníomhaíochtaí díreach duitse.",
     "requestAccessTitle": "An bhfuil tú ag iarraidh rochtain ar an anailís?",
     "requestAccessDesc": "Ar mhaith leat rochtain a fháil chun anailísíocht rannpháirtithe a fheiceáil?\n\nMura n-aontaíonn rannpháirtithe, beidh na riarthóirí den chúrsa seo in ann a fheiceáil:\n    • an t-uimhir fhoclóra iomlán\n    • na coincheapa gramadaí iomlána\n    • na seisiúin gníomhaíochta iomlána a chríochnaigh\n    • na coincheapa gramadaí sonracha a úsáid, i gceart agus i gceart mícheart\n\nNí bheidh siad in ann a fheiceáil:\n    • teachtaireachtaí i gcomhráite lasmuigh den chúrsa\n    • liosta fhoclóra",
-    "requestAccess": "Iarr rochtain ({count})",
     "analyticsInactiveTitle": "Níor féidir iarratais ar úsáideoirí neamhghníomhacha a sheoladh",
     "analyticsInactiveDesc": "Ní fheicfidh úsáideoirí neamhghníomhacha nach ndearna siad logáil isteach ó thús na gné seo do do iarratas.\n\nTiocfaidh an cnaipe Iarr ar ais nuair a bheidh siad ar ais. Is féidir leat an iarraidh a sheoladh arís níos déanaí trí chliceáil ar an gcnaipe Iarr ar ais faoi a n-ainm nuair a bheidh sé ar fáil.",
     "accessRequestedTitle": "Iarratas ar rochtain ar anailísí",
@@ -3883,8 +3515,6 @@
     "accessDesc": "Is féidir leat do chúrsa a dhéanamh oscailte don domhan! Nó, déan do chúrsa príobháideach agus slán.",
     "createGroupChatDesc": "De réir mar a thosaíonn agus a chríochnaíonn seisiúin gníomhaíochta, fanfaidh comhráite grúpa oscailte le haghaidh cumarsáide rialta.",
     "deleteDesc": "Ní féidir le haon riarthóirí cúrsa a scriosadh ach amháin. Is gníomh díobhálach é seo a bhaint go léir na húsáideoirí agus a scriosadh na comhráite uile roghnaithe laistigh den chúrsa. Bí cúramach le do thoil.",
-    "noCourseFound": "Ó, tá gá le plean don chúrsa seo!\n\nIs sraith téacs agus gníomhaíochtaí comhrá iad pleananna cúrsa.",
-    "additionalParticipants": "+ {num} eile",
     "whatNow": "Cad atá le déanamh anois?",
     "chooseNextActivity": "Roghnaigh do chéad ghníomhaíocht eile!",
     "letsGo": "Téimis",
@@ -3897,13 +3527,11 @@
     "waitNotDone": "Fan, níl mé críochnaithe!",
     "waitingForOthersToFinish": "Ag fanacht ar na daoine eile chun críochnú...",
     "generatingSummary": "Ag anailísiú comhrá agus torthaí a ghiniúint",
-    "findCourse": "Féach ar chúrsa",
     "pingParticipantsNotification": "{user} ag lorg úsáideoirí chun rannpháirtíocht sa seisiún gníomhaíochta i {room}",
     "course": "Cúrsa",
     "courses": "Cúrsaí",
     "goToCourse": "Téigh go cúrsa: {course}",
     "activityComplete": "Tá an ghníomhaíocht seo críochnaithe. Ba chóir go mbeadh achoimre na gníomhaíochta ar fáil thíos.",
-    "startNewSession": "Tús a chur le seisiún nua",
     "joinOpenSession": "Cláraigh le haghaidh seisiún oscailte",
     "activityNotFound": "Níor aimsíodh an gníomhaíocht",
     "myActivities": "Mo ghníomhaíochtaí",
@@ -3979,10 +3607,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3992,10 +3616,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4079,14 +3699,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4103,10 +3715,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4119,15 +3727,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4279,14 +3879,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4300,14 +3892,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5530,10 +5114,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5574,10 +5154,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5650,10 +5226,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5923,47 +5495,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5983,19 +5515,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6059,10 +5579,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6103,14 +5619,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6122,14 +5630,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6167,10 +5667,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6187,27 +5683,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6331,10 +5811,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6344,10 +5820,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6364,14 +5836,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6511,18 +5975,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6571,10 +6023,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6584,18 +6032,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6638,23 +6074,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6678,10 +6102,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6689,14 +6109,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6801,18 +6213,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6865,10 +6265,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6895,10 +6291,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7079,7 +6471,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Seiceáil ar ais amárach le haghaidh nuashonruithe ar ghníomhaíocht.",
-    "activityDropdownDesc": "Nuair a bheidh tú críochnaithe leis an ngníomhaíocht seo, cliceáil thíos",
     "languageMismatchTitle": "Míchothrom na teangacha",
     "languageMismatchDesc": "Ní oireann do theanga sprioc an gníomhaíochta seo do theanga na gníomhaíochta. An bhfuil tú ag iarraidh do theanga sprioc a nuashonrú?",
     "reportWordIssueTooltip": "Tuairiscigh fadhb eolas focal",
@@ -7092,10 +6483,6 @@
     "selectAll": "Roghnaigh gach rud",
     "deselectAll": "Dí-roghnaigh gach rud",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7144,17 +6531,11 @@
         "placeholders": {}
     },
     "startOwn": "Tosaigh mo chuid féin",
-    "joinCourseDesc": "Tá 8-10 topaicí sraithmharma i ngach cúrsa le raon gníomhaíochtaí foghlama teanga bunaithe ar thascanna.",
     "newMessageInPangeaChat": "🔊 Teachtaireacht nua i gComhrá Pangea",
     "shareCourse": "Comhroinn cúrsa",
     "addCourse": "Cuir cúrsa leis",
-    "joinPublicCourse": "Cláraigh i gcúrsa poiblí",
     "vocabLevelsDesc": "Seo áit a dtéann focail fhocail a bhfuil leibhéal acu nuair a dhéantar iad a leibhéalú!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7167,10 +6548,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7189,7 +6566,6 @@
     "emojiView": "Radharc emoji",
     "feedbackDialogDesc": "Déanaim botúin freisin! An bhfuil aon rud a chabhróidh liom feabhsú?",
     "contactHasBeenInvitedToTheCourse": "Cuireadh an teagmháil chuig an gcúrsa",
-    "activityStatsButtonTooltip": "Eolas gníomhaíochta",
     "allow": "Ceadaigh",
     "deny": "Diúltaigh",
     "enabledRenewal": "Cuir Athnuachan Suibscríofa ar Siúl",
@@ -7457,10 +6833,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8516,16 +7888,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Gníomhaíochtaí le hOscail an Topaic Seo chugainn",
-    "activitiesToUnlockTopicDesc": "Socraigh an líon gníomhaíochtaí le hOscail an topaic chúrsa seo chugainn",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Cleachtadh ar shainmhíniú ceart foclóra",
     "constructUseIncLMDesc": "Cleachtadh ar shainmhíniú mícheart foclóra",
     "constructUseCorLADesc": "Cleachtadh ar chluastuiscint ceart foclóra",
@@ -8533,7 +7895,6 @@
     "constructUseBonus": "Bónas le linn cleachtaidh foclóra",
     "practiceVocab": "Cleachtadh foclóra",
     "selectMeaning": "Roghnaigh an bhrí",
-    "selectAudio": "Roghnaigh an chluastuiscint comhoiriúnach",
     "anotherRound": "Ciorcal eile",
     "activitySettingsOverrideWarning": "Teanga agus leibhéal teanga a chinneadh de réir plean gníomhaíochta",
     "voice": "Guth",
@@ -8565,10 +7926,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8586,12 +7943,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Tosaíodh an íoslódáil",
     "webDownloadPermissionMessage": "Más blocann do bhrabhsálaí íoslódálacha, le do thoil, gníomhachtaigh íoslódálacha don suíomh seo.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8686,11 +8038,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Tharla rud éigin mícheart, agus táimid ag obair go dian chun é a shocrú. Seiceáil arís níos déanaí.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Cuir ar chumas cúnamh scríbhneoireachta",
     "autoIGCToolDescription": "Rith uathoibríoch uirlisí Pangea Chat chun teachtaireachtaí a sheoladh a cheartú go teanga sprioc.",
     "@autoIGCToolName": {
@@ -8746,24 +8093,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramadach",
-    "spanTypeWordChoice": "Rogha Focal",
     "spanTypeSpelling": "Litriú",
     "spanTypePunctuation": "Póntú",
     "spanTypeStyle": "Stíl",
     "spanTypeFluency": "Sreabhadh",
     "spanTypeAccents": "Guthanna",
     "spanTypeCapitalization": "Caipitleadh",
-    "spanTypeCorrection": "Córas",
     "spanFeedbackTitle": "Tuairisc a dhéanamh ar fhadhb le ceartú",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8788,10 +8124,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8802,13 +8134,9 @@
     "clientWellKnownInformation": "Eolas Éagsúil Chustaiméara:",
     "baseUrl": "URL Bunúsach",
     "identityServer": "Freastalaí Aitheantais:",
-    "versionWithNumber": "Leagan: {version}",
     "logs": "Cláracha",
-    "advancedConfigs": "Cumraíochtaí Casta",
     "advancedConfigurations": "Cumraíochtaí Casta",
-    "signInWithLabel": "Cláraigh le:",
     "selectAllWords": "Roghnaigh na focail go léir a chloiseann tú sa gháire",
-    "joinCourseForActivities": "Cláraigh i gcúrsa chun iarrachtaí a dhéanamh.",
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8837,19 +8165,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8857,15 +8173,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9070,11 +8378,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "I rang? Cuir do chód comhoibrithe anseo.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Bailigh teachtaireachtaí gutháin go huathoibríoch",
     "selectAudioMessagesOnPlayDescription": "Bailigh teachtaireachtaí gutháin go huathoibríoch nuair a chluineann tú iad",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9118,18 +8421,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Tá ábhair sa chúrsa seo le níos lú ná {input} gníomhaíochtaí. Le do thoil, cuir isteach uimhir atá níos lú ná nó comhoiriúnach le {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Cliceáil anseo chun logáil isteach arís.",
     "@clickToLogin": {
@@ -9546,17 +8837,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Bear cartoonach buí le a lámha ardaithe i gciont.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Roghnaigh focail chun tuilleadh eolais a fháil fúthu",
     "requireAnalyticsAccessTitle": "Teastaíonn rochtain ar anailísí chun páirt a ghlacadh",
     "requireAnalyticsAccessDesc": "Caithfidh rannpháirtithe rochtain a thabhairt ar a n-anailísí foghlama chun páirt a ghlacadh sa chúrsa seo",
     "analyticsAccessNoticeTitle": "Teastaíonn Rochtain ar Anailísí",
     "analyticsAccessNoticeDesc": "Trí pháirt a ghlacadh sa chúrsa seo, aontaíonn tú rochtain a thabhairt do na hoifigigh ar do n-anailísí foghlama.",
-    "skipOnboardingClassCodeDesc": "Ag foghlaim go neamhspleách? Ná bí buartha, is féidir leat:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9574,10 +8859,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9606,7 +8887,6 @@
     "pickCefrLevelTeacherStepTitle": "Cén leibhéal a mhúineann tú?",
     "pickCefrLevelStudentStepTitle": "Cén leibhéal atá tú?",
     "customCourseStepTitle": "Líon an foirm seo chun cúrsa saincheaptha a fháil",
-    "aboutYourClass": "Maidir le do rang",
     "courseCodeStepErrorMessage": "Le do thoil, seiceáil do chód agus déan iarracht arís",
     "institution": "Institiúid",
     "courseGoals": "Cuspóirí an chúrsa",
@@ -9649,10 +8929,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9769,12 +9045,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Lógó Pangea Chat",
     "introChatDetails": "Abair dia dhuit! Cuir aithne ort féin do do chomh-rannpháirtithe cúrsa, faigh cairde, agus comhrá lasmuigh de na gníomhaíochtaí.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9818,11 +9089,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Gníomhartha gníomhaíochta",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Uirlisí fuaime",
     "audioTranscription": "Trascríobhadh fuaime AI",
     "visualLearnerSupport": "Tacaíocht do learners amhairc",
@@ -9863,7 +9129,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Bí i gcúrsa a chuimsíonn an gníomhaíocht seo chun é a imirt.",
     "resizeCoursePanel": "Athraigh méid painéil an chúrsa",
     "undo": "Athraigh",
     "unlock": "Díghlas",
@@ -9877,7 +9142,6 @@
     "addCourseBrowsePublic": "Brabhsáil cúrsaí poiblí",
     "browsePublicCourses": "Brabhsáil cúrsaí poiblí",
     "editProfile": "Cuir in eagar próifíl",
-    "numObjectives": "{count} cuspóirí",
     "mapSearchHint": "Cuardaigh gníomhaíochtaí",
     "mapSearchNoResults": "Níl aon comhoiriúnachtaí le feiceáil",
     "mapFilterAllLanguages": "Gach teanga",
@@ -9886,7 +9150,6 @@
     "mapFilterCompleted": "Críochnaithe",
     "mapFilterReset": "Athshocraigh",
     "activityTypeConversation": "Comhrá",
-    "lockedMissionRequirement": "Críochnaigh an misean roimhe seo chun é a dhíghlasáil",
     "playAgain": "Imir arís",
     "reviewActivity": "Athbhreithniú",
     "mapEmptyInView": "Níl aon rud anseo ag do leibhéal nó do theanga. Leathnaigh do scagairí nó déan an radharc níos mó.",
@@ -9901,14 +9164,9 @@
     "scrollToBottom": "Scrollaigh go bun",
     "courseImage": "Íomhá cúrsa",
     "avatarPreview": "Réamhamharc ar avatar",
-    "activityPhoto": "Grianghraf gníomhaíochta",
     "emotePreview": "Réamhamharc ar emote: {name}",
     "activityLabel": "Gníomhaíocht: {title}",
     "resetMapView": "Athshocraigh an léarscáil",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9961,14 +9219,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9998,10 +9248,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10058,10 +9304,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_gl.arb
+++ b/lib/l10n/intl_gl.arb
@@ -83,11 +83,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Permitir o acceso de convidadas",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Tes a certeza?",
     "@areYouSure": {
         "type": "String",
@@ -364,11 +359,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "As mensaxes están protexidas cunha clave de recuperación. Pon coidado e non a perdas.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Detalles da conversa",
     "@chatDetails": {
         "type": "String",
@@ -500,11 +490,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "O contacto foi convidado ao grupo",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "O contido foi denunciado á administración do servidor",
     "@contentHasBeenReported": {
         "type": "String",
@@ -556,11 +541,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Novo espazo",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Actualmente activo",
     "@currentlyActive": {
@@ -704,11 +684,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Non poderás desactivar a cifraxe posteriormente, tes certeza?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Cifrado",
     "@encrypted": {
         "type": "String",
@@ -747,11 +722,6 @@
             }
         }
     },
-    "everythingReady": "Todo preparado!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Extremadamente ofensivo",
     "@extremeOffensive": {
         "type": "String",
@@ -789,11 +759,6 @@
     },
     "group": "Grupo",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "O grupo é público",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -887,15 +852,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Convidar contacto a {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Convidado",
     "@invited": {
@@ -1008,15 +964,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Cargar {count} participantes máis",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Cargando... Agarda.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -1041,15 +988,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Entrar en {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Pechar sesión",
     "@logout": {
@@ -1113,16 +1051,6 @@
     },
     "noEmotesFound": "Non hai emotes. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Só podes activar a cifraxe tan pronto como a sala non sexa públicamente accesible.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Semella que non tes Firebase Cloud Messaging dispoñible no teu dispositivo. Para recibir notificacións push recomendamos que instales ntfy. Con ntfy ou outro provedor Unified Push podes recibir notificacións push de xeito seguro. Podes descargar ntfy desde a PlayStore ou F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1254,11 +1182,6 @@
     },
     "passwordHasBeenChanged": "Cambiouse o contrasinal",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Recuperación do contrasinal",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1402,11 +1325,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Quitar dispositivo",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Retirar veto na conversa",
     "@unbanFromChat": {
@@ -1561,11 +1479,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Establecer nivel de permisos",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Establecer estado",
     "@setStatus": {
         "type": "String",
@@ -1607,16 +1520,6 @@
     },
     "sourceCode": "Código fonte",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "O Espazo é público",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Nome do Espazo",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1675,11 +1578,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Transferir desde outro dispositivo",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Inténtao outra vez",
     "@tryToSendAgain": {
         "type": "String",
@@ -1735,15 +1633,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 conversa sen ler} other{{unreadCount} conversas sen ler}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} e {count} máis están escribindo…",
     "@userAndOthersAreTyping": {
@@ -1829,16 +1718,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Chamada de vídeo",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Visibilidade do historial da conversa",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Visible para todas as participantes",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1884,23 +1763,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Quen pode realizar determinada acción",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Quen se pode unir a este grupo",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Por que queres denunciar esto?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Queres eliminar a copia de apoio e crear unha nova chave de recuperación?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1949,16 +1813,10 @@
     "@homeserver": {},
     "serverRequiresEmail": "O servidor precisa validar o teu enderezo de email para rexistrarte.",
     "@serverRequiresEmail": {},
-    "enableMultiAccounts": "(BETA) Activar varias contas neste dispositivo",
-    "@enableMultiAccounts": {},
-    "addAccount": "Engadir conta",
-    "@addAccount": {},
     "oneClientLoggedOut": "Un dos teus clientes foi desconectado",
     "@oneClientLoggedOut": {},
     "link": "Ligazón",
     "@link": {},
-    "yourChatBackupHasBeenSetUp": "Configurouse a copia de apoio da charla.",
-    "@yourChatBackupHasBeenSetUp": {},
     "unverified": "Sen verificar",
     "@unverified": {},
     "repeatPassword": "Repite o contrasinal",
@@ -1973,8 +1831,6 @@
     "@openGallery": {},
     "messageType": "Tipo de mensaxe",
     "@messageType": {},
-    "removeFromSpace": "Retirar do espazo",
-    "@removeFromSpace": {},
     "start": "Comezar",
     "@start": {},
     "commandHint_discardsession": "Descartar sesión",
@@ -2012,16 +1868,12 @@
     "@reportUser": {},
     "openChat": "Abrir Conversa",
     "@openChat": {},
-    "voiceCall": "Chamada de voz",
-    "@voiceCall": {},
     "emojis": "Emojis",
     "@emojis": {},
     "placeCall": "Chamar",
     "@placeCall": {},
     "unsupportedAndroidVersionLong": "Esta característica require unha vesión máis recente de Android. Mira se hai actualizacións ou soporte de LineageOS.",
     "@unsupportedAndroidVersionLong": {},
-    "videoCallsBetaWarning": "Ten en conta que as chamadas de vídeo están en fase beta. Poderían non funcionar correctamente ou non funcionar nalgunhas plataformas.",
-    "@videoCallsBetaWarning": {},
     "unsupportedAndroidVersion": "Version de Android non soportada",
     "@unsupportedAndroidVersion": {},
     "reactedWith": "{sender} reaccionou con {reaction}",
@@ -2042,8 +1894,6 @@
     "@confirmEventUnpin": {},
     "experimentalVideoCalls": "Chamadas de vídeo en probas",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "Email ou nome de usuaria",
-    "@emailOrUsername": {},
     "bundleName": "Nome do feixe",
     "@bundleName": {},
     "widgetVideo": "Vídeo",
@@ -2137,26 +1987,8 @@
             }
         }
     },
-    "saveKeyManuallyDescription": "Garda esta chave manualmente usando o sistema para compartir do dispositivo ou portapapeis.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "Gardar en Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Gardar en Apple KeyChain",
-    "@storeInAppleKeyChain": {},
-    "recoveryKeyLost": "Perdeches a chave de recuperación?",
-    "@recoveryKeyLost": {},
-    "pleaseEnterRecoveryKey": "Escribe a túa chave de recuperación:",
-    "@pleaseEnterRecoveryKey": {},
-    "recoveryKey": "Chave de recuperación",
-    "@recoveryKey": {},
-    "storeSecurlyOnThisDevice": "Gardar de xeito seguro no dispositivo",
-    "@storeSecurlyOnThisDevice": {},
-    "pleaseEnterRecoveryKeyDescription": "Para desbloquear as mensaxes antigas, escribe a chave de recuperación creada nunha sesión existente. A chave de recuperación NON é o teu contrasinal.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "users": "Usuarias",
     "@users": {},
-    "storeInSecureStorageDescription": "Gardar a chave de recuperación na almacenaxe segura deste dispositivo.",
-    "@storeInSecureStorageDescription": {},
     "countFiles": "{count} ficheiros",
     "@countFiles": {
         "placeholders": {
@@ -2165,8 +1997,6 @@
             }
         }
     },
-    "unlockOldMessages": "Desbloquear mensaxes antigas",
-    "@unlockOldMessages": {},
     "hydrate": "Restablecer desde copia de apoio",
     "@hydrate": {},
     "dehydrateWarning": "Esta acción non é reversible. Pon coidado en gardar o ficheiro de apoio.",
@@ -2200,16 +2030,8 @@
     "@newGroup": {},
     "newSpace": "Novo espazo",
     "@newSpace": {},
-    "foregroundServiceRunning": "Esta notificación aparece cando se está a executar o servizo en segundo plano.",
-    "@foregroundServiceRunning": {},
-    "screenSharingTitle": "compartición da pantalla",
-    "@screenSharingTitle": {},
-    "enterSpace": "Entrar no espazo",
-    "@enterSpace": {},
     "allSpaces": "Todos os espazos",
     "@allSpaces": {},
-    "screenSharingDetail": "Estás a compartir a túa pantalla en FluffyChat",
-    "@screenSharingDetail": {},
     "doNotShowAgain": "Non mostrar outra vez",
     "@doNotShowAgain": {},
     "commandHint_googly": "Envía uns ollos desos grandes",
@@ -2245,16 +2067,8 @@
             }
         }
     },
-    "encryptThisChat": "Cifrar esta conversa",
-    "@encryptThisChat": {},
-    "disableEncryptionWarning": "Por razóns de seguridade non podes desactivar a cifraxe dunha conversa onde foi activada previamente.",
-    "@disableEncryptionWarning": {},
-    "sorryThatsNotPossible": "Lamentámolo... iso non é posible",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "Chaves do dispositivo:",
     "@deviceKeys": {},
-    "newSpaceDescription": "Os Espazos permítenche consolidar as túas conversas e construir comunidades públicas ou privadas.",
-    "@newSpaceDescription": {},
     "wasDirectChatDisplayName": "Conversa baleira (era {oldDisplayName})",
     "@wasDirectChatDisplayName": {
         "type": "String",
@@ -2315,8 +2129,6 @@
     "@shareInviteLink": {},
     "setColorTheme": "Cor do decorado:",
     "@setColorTheme": {},
-    "setTheme": "Establecer decorado:",
-    "@setTheme": {},
     "tryAgain": "Intentar outra vez",
     "@tryAgain": {},
     "optionalRedactReason": "(Optativo) Razón para editar a mensaxe...",
@@ -2348,8 +2160,6 @@
     "@invite": {},
     "chatPermissions": "Permisos da conversa",
     "@chatPermissions": {},
-    "chatDescription": "Descrición da conversa",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "Cambiou a descrición da conversa",
     "@chatDescriptionHasBeenChanged": {},
     "noChatDescriptionYet": "Aínda non se escribeu a descrición da conversa.",
@@ -2406,10 +2216,6 @@
     "@pleaseEnterANumber": {},
     "kickUserDescription": "A usuaria foi expulsada pero non vetada. En conversas públicas a usuaria pode volver cando queira.",
     "@kickUserDescription": {},
-    "createGroupAndInviteUsers": "Crear un grupo e convidar usuarias",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "O grupo pódese atopar ao buscar",
-    "@groupCanBeFoundViaSearch": {},
     "noUsersFoundWithQuery": "Lamentamos non atopar ningunha usuaria con \"{query}\". Comproba se está ben escrito.",
     "@noUsersFoundWithQuery": {
         "type": "String",
@@ -2423,8 +2229,6 @@
     "@yourGlobalUserIdIs": {},
     "groupName": "Nome do grupo",
     "@groupName": {},
-    "searchChatsRooms": "Buscar #conversas, @usuarias...",
-    "@searchChatsRooms": {},
     "startConversation": "Iniciar conversa",
     "@startConversation": {},
     "commandHint_sendraw": "Enviar json sen editar",
@@ -2461,8 +2265,6 @@
     "@select": {},
     "pleaseChooseAStrongPassword": "Elixe un contrasinal forte",
     "@pleaseChooseAStrongPassword": {},
-    "addChatOrSubSpace": "Engadir charla ou sub espazo",
-    "@addChatOrSubSpace": {},
     "leaveEmptyToClearStatus": "Deixa baleiro para limpar o teu estado.",
     "@leaveEmptyToClearStatus": {},
     "joinSpace": "Únete ao espazo",
@@ -2475,30 +2277,6 @@
     "@databaseMigrationBody": {},
     "initAppError": "Houbo un fallo ao iniciar a app",
     "@initAppError": {},
-    "sessionLostBody": "Estragouse a túa sesión. Por favor informa deste fallo ás desenvolvedoras en {url}. A mensaxe do erro é: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "A app vai intentar restablecer a sesión desde a copia de apoio. Por favor informa deste erro ás desenvolvedoras en {url}. A mensaxe do erro é: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "transparent": "Transparente",
     "@transparent": {},
     "sendReadReceipts": "Enviar confirmación de lectura",
@@ -2509,8 +2287,6 @@
     "@formattedMessages": {},
     "verifyOtherDevice": "🔐 Verificar outro dispositivo",
     "@verifyOtherDevice": {},
-    "verifyOtherUser": "🔐 Verificar outra usuaria",
-    "@verifyOtherUser": {},
     "verifyOtherDeviceDescription": "Ao verificar outro dispositivo estás compartindo as chaves, aumentando a túa seguridade 💪. Ao iniciar a verificación aparecerá unha xanela emerxente nos dous dispositivos. Nesa xanela verás varios emojis ou números que tes que comparar entre eles. O mellor xeito de facelo é ter os dous dispositivos contigo cando inicias o proceso de verificación. 🤳",
     "@verifyOtherDeviceDescription": {},
     "canceledKeyVerification": "{sender} desbotou a verificación da chave",
@@ -2535,8 +2311,6 @@
     "@sendTypingNotificationsDescription": {},
     "formattedMessagesDescription": "Mostrar texto enriquecido nas mensaxes como letra grosa usando markdown.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUserDescription": "Se verificas a outra usuaria, podes ter a certeza de que sabes con quen estás a conversar. 💪\n\nAo iniciar a verificación, ti mais a outra usuaria veredes unha xanela emerxente na app onde aparecerán varios emojis ou números que teredes que comparar entre vós.\n\nO mellor xeito de facelo é en persoa o cunha chamada de vídeo. 👭",
-    "@verifyOtherUserDescription": {},
     "requestedKeyVerification": "{sender} solicitou verificar a chave",
     "@requestedKeyVerification": {
         "type": "String",
@@ -2604,10 +2378,6 @@
     },
     "noDatabaseEncryption": "Nesta plataforma non temos soporte para cifrar a base de datos",
     "@noDatabaseEncryption": {},
-    "accessAndVisibility": "Acceso e Visibilidade",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Quen pode unirse a esta charla e de que xeito e como poden atopala.",
-    "@accessAndVisibilityDescription": {},
     "customEmojisAndStickers": "Emojis personais e adhesivos",
     "@customEmojisAndStickers": {},
     "calls": "Chamadas",
@@ -2618,25 +2388,10 @@
     "@hideRedactedMessagesBody": {},
     "hideInvalidOrUnknownMessageFormats": "Agochar formatos de mensaxe non válidos ou descoñecidos",
     "@hideInvalidOrUnknownMessageFormats": {},
-    "usersMustKnock": "As usuarias teñen que pedir entrar",
-    "@usersMustKnock": {},
     "knocking": "A solicitar",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "A charla pode ser atopada ao buscar en {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "createNewAddress": "Crear novos enderezos",
-    "@createNewAddress": {},
     "appLockDescription": "Bloquear a app cun código PIN cando non a uses",
     "@appLockDescription": {},
-    "globalChatId": "ID Global da charla",
-    "@globalChatId": {},
     "customEmojisAndStickersBody": "Engade ou comparte emojis personais e adhesivos que poden usarse nas charlas.",
     "@customEmojisAndStickersBody": {},
     "overview": "Vista xeral",
@@ -2645,15 +2400,11 @@
     "@passwordRecoverySettings": {},
     "knock": "Solicitar acceso",
     "@knock": {},
-    "noOneCanJoin": "Ninguén pode unirse",
-    "@noOneCanJoin": {},
     "thereAreCountUsersBlocked": "Agora mesmo hai {count} usuarias bloqueadas.",
     "@thereAreCountUsersBlocked": {
         "type": "String",
         "count": {}
     },
-    "publicChatAddresses": "Enderezos públicos da charla",
-    "@publicChatAddresses": {},
     "searchIn": "Buscar na conversa \"{chat}\"...",
     "@searchIn": {
         "type": "String",
@@ -2762,14 +2513,6 @@
     "@sendCanceled": {},
     "noChatsFoundHere": "Aínda non hai conversas. Comeza a conversar con alguén premendo no botón de abaixo. ⤵️",
     "@noChatsFoundHere": {},
-    "discoverHomeservers": "Atopar servidores",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Que é un servidor de inicio?",
-    "@whatIsAHomeserver": {},
-    "loginWithMatrixId": "Acceder co ID-Matrix",
-    "@loginWithMatrixId": {},
-    "homeserverDescription": "Todos os teus datos quedan gardados no servidor de inicio, igual que co teu provedor de correo electrónico. Podes elexir o servidor que queres usar e poderás comunicarte con todos os demais. Aprende máis en https://matrix.org.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "Non semella ser un servidor de inicio compatible. É o URL correcto?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "calculatingFileSize": "Calculando o tamaño do ficheiro…",
@@ -2822,12 +2565,8 @@
             }
         }
     },
-    "welcomeText": "Ola! 👋 Isto é FluffyChat. Podes iniciar sesión en calquera servidor compatible con https://matrix.org. Poderás conversar con calquera. Unha enorme rede de mensaxería descentralizada!",
-    "@welcomeText": {},
     "setWallpaper": "Establecer fondo",
     "@setWallpaper": {},
-    "manageAccount": "Xestionar conta",
-    "@manageAccount": {},
     "noContactInformationProvided": "O servidor non proporciona información de contacto válida",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "Contacto con Admin do servidor",
@@ -2875,15 +2614,6 @@
     "@otherPartyNotLoggedIn": {},
     "open": "Abrir",
     "@open": {},
-    "appWantsToUseForLogin": "Usar '{server}' para acceder",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "contentNotificationSettings": "Axustes de notificación de contido",
     "@contentNotificationSettings": {},
     "generalNotificationSettings": "Axustes xerais das notificacións",
@@ -2999,12 +2729,8 @@
     "@verifiedDevicesOnly": {},
     "waitingForServer": "Agardando polo servidor…",
     "@waitingForServer": {},
-    "appIntroduction": "FluffyChat permíteche laretar coas túas amizades entre diferentes mensaxerías. Coñece máis en https://matrix.org ou toca en *Continuar*.",
-    "@appIntroduction": {},
     "notificationRuleMasterDescription": "Sobrescribe todas as outras regras e desactiva todas as notificacións.",
     "@notificationRuleMasterDescription": {},
-    "appWantsToUseForLoginDescription": "Por tanto permites que a app e o sitio web compartan información sobre ti.",
-    "@appWantsToUseForLoginDescription": {},
     "notificationRuleMemberEventDescription": "Suprime as notificacións dos eventos de participación.",
     "@notificationRuleMemberEventDescription": {},
     "synchronizingPleaseWaitCounter": " Sincronizando…({percentage}%)",
@@ -3054,15 +2780,6 @@
             }
         }
     },
-    "countInvited": "{count} convidadas",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "commandHint_logoutall": "Fechar a sesión en todos os dispositivos activos",
     "@commandHint_logoutall": {},
     "commandHint_logout": "Fechar a sesión no dispositivo actual",
@@ -3085,38 +2802,12 @@
     "@pause": {},
     "resume": "Continuar",
     "@resume": {},
-    "newSubSpace": "Novo sub espazo",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Mover a outro espazo",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "Vaise quitar a conversa do espazo pero seguirá aparecendo na túa lista de conversas.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} conversas",
     "@countChats": {
         "type": "String",
         "placeholders": {
             "chats": {
                 "type": "int"
-            }
-        }
-    },
-    "donate": "Doar",
-    "@donate": {},
-    "spaceMemberOf": "Participa no espazo {spaces}",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "Os membros de {spaces} poden petar á porta",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
             }
         }
     },
@@ -3189,14 +2880,6 @@
     "@newStickerPack": {},
     "stickerPackName": "Nome do paquete de adhesivos",
     "@stickerPackName": {},
-    "skipChatBackup": "Omitir copia da conversa",
-    "@skipChatBackup": {},
-    "skipChatBackupWarning": "Tes certeza? A non activar a copia de apoio da conversa poderías perder o acceso ás mensaxes se cambias de dispositivo.",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "Cargando mensaxes",
-    "@loadingMessages": {},
-    "setupChatBackup": "Configurar copia de apoio",
-    "@setupChatBackup": {},
     "changedTheChatDescription": "{username} cambiou a descrición da sala",
     "@changedTheChatDescription": {},
     "changedTheChatName": "{username} cambiou o nome da sala",
@@ -3207,11 +2890,9 @@
     "taTooltip": "L2 con asistencia de tradución",
     "interactiveTranslatorSliderHeader": "Tradutor interactivo",
     "interactiveGrammarSliderHeader": "Comprobador gramatical interactivo",
-    "interactiveTranslatorRequired": "Necesario",
     "waTooltip": "L2 sen asistencia",
     "interactiveTranslator": "Asistencia na tradución",
     "noIdenticalLanguages": "Por favor, escolla idiomas base e destino diferentes",
-    "searchBy": "Buscar por país e idiomas",
     "joinWithClassCode": "Unirse ao curso",
     "languageLevelPreA1": "Novato Baixo (Pre A1)",
     "languageLevelA1": "Novato Medio (A1)",
@@ -3231,19 +2912,14 @@
     "whatIsYourBaseLanguage": "Cal é a tua linguaxe base?",
     "publicProfileTitle": "Permitir que meu perfil se atope na busca",
     "publicProfileDesc": "Ao activalo, permites que outros usuarios atopen o teu perfil na barra de busca global e envien solicitudes para chatear. Neste momento, podes escoller aceptar ou denegar a solicitude.",
-    "errorDisableIT": "A axuda de tradución está desactivada.",
-    "errorDisableIGC": "A axuda de gramática está desactivada.",
     "errorDisableITUserDesc": "Fai clic aquí para actualizar as configuracións de axuda de tradución",
     "errorDisableIGCUserDesc": "Fai clic aquí para actualizar as configuracións de axuda de gramática",
     "errorDisableITClassDesc": "A axuda de tradución está desactivada para o curso neste que se atopa este chat.",
     "errorDisableIGCClassDesc": "A axuda de gramática está desactivada para o curso neste que se atopa este chat.",
-    "error405Title": "Idiomas non configurados",
     "error405Desc": "Por favor, configure os seus idiomas no Menú Principal > Configuración de Aprendizaxe.",
     "termsAndConditions": "Termos e Condicións",
     "andCertifyIAmAtLeast13YearsOfAge": " e certifico que teño polo menos 16 anos de idade.",
-    "error502504Title": "Vaya, hai moitos estudantes en liña!",
     "error502504Desc": "As ferramentas de tradución e gramática poden ser lentas ou non estar dispoñibles mentres os bots de Pangea se poñen ao día.",
-    "error404Title": "Erro de tradución!",
     "error404Desc": "O bot de Pangea non está seguro de como traducir iso...",
     "errorPleaseRefresh": "Estamos a investigalo! Por favor, actualice e intente de novo.",
     "connectedToStaging": "Conectado a Staging",
@@ -3281,13 +2957,9 @@
     "definitionsToolName": "Definicións de palabras",
     "definitionsToolDescription": "Cando está activado, as palabras subliñadas en azul poden ser clicadas para obter definicións. Clica nas mensaxes para acceder ás definicións.",
     "welcomeBack": "¡Benvido de novo! Se formaches parte do piloto 2023-2024, contacta con nós para a túa subscrición especial de piloto. Se es profesor e a túa institución comprou licenzas para a túa clase, contacta con nós para a túa subscrición de profesor.",
-    "downloadTxtFile": "Descargar ficheiro de texto",
-    "downloadCSVFile": "Descargar ficheiro CSV",
     "promotionalSubscriptionDesc": "Actualmente tes unha subscrición promocional de por vida. Envía unha mensaxe a support@pangea.chat para obter axuda para cambiar a túa subscrición.",
     "originalSubscriptionPlatform": "Subscripción adquirida a través de {purchasePlatform}",
     "oneWeekTrial": "Proba dunha semana",
-    "downloadXLSXFile": "Descargar ficheiro Excel",
-    "unkDisplayName": "Descoñecido",
     "wwCountryDisplayName": "Mundial",
     "afCountryDisplayName": "Afganistán",
     "axCountryDisplayName": "Illas Åland",
@@ -3582,7 +3254,6 @@
     "chatCapacityHasBeenChanged": "Capacidade de chat modificada",
     "chatCapacitySetTooLow": "A capacidade de chat debe ser polo menos {count}.",
     "chatCapacityExplanation": "A capacidade de chat limita o número de membros permitidos nun chat.",
-    "tooManyRequest": "Demasiadas solicitudes, por favor inténteo de novo máis tarde.",
     "enterNumber": "Por favor, introduce un valor numérico enteiro.",
     "practice": "Practicar",
     "versionNotFound": "Versión non atopada",
@@ -3592,7 +3263,6 @@
     "deleteSubscriptionWarningTitle": "Tes unha subscrición activa",
     "deleteSubscriptionWarningBody": "Eliminar a túa conta non cancelará automaticamente a túa subscrición.",
     "manageSubscription": "Xestionar a subscrición",
-    "error520Title": "Por favor, inténtao de novo.",
     "error520Desc": "Desculpa, non puidemos entender a túa mensaxe...",
     "wordsUsed": "Palabras utilizadas",
     "level": "Nivel",
@@ -3610,7 +3280,6 @@
     "other": "Outro",
     "levelShort": "NIV {level}",
     "noCapacityLimit": "Sen límite de capacidade",
-    "downloadGroupText": "Descargar texto do grupo",
     "notificationsOn": "Notificacións activadas",
     "notificationsOff": "Notificacións desactivadas",
     "joinWithCode": "Unirse con código",
@@ -3674,24 +3343,12 @@
     "whatIsTheMorphTag": "Cal é o {morphologicalFeature} de '{wordForm}'?",
     "dataAvailable": "Dispoñibilidade de datos",
     "available": "Dispoñible",
-    "pangeaBotIsFallible": "¡O Pangea Bot tamén comete erros!",
-    "whatIsMeaning": "Que significa '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "¡Coincide os significados coas palabras na mensaxe!",
-    "doubleClickToEdit": "Fai dobre clic para editar.",
-    "topicLabel": "Tema",
-    "topicPlaceholder": "Elixe un tema...",
-    "modePlaceholder": "Elixe un modo...",
-    "learningObjectiveLabel": "Obxectivo de aprendizaxe",
-    "learningObjectivePlaceholder": "Elixe un obxectivo de aprendizaxe...",
-    "targetLanguageLabel": "Idioma obxectivo",
     "cefrLevelLabel": "Nivel CEFR",
     "image": "Imaxe",
     "video": "Vídeo",
     "nan": "Non aplicable",
-    "addVocabulary": "Engadir vocabulario",
     "instructions": "Instrucións",
-    "numberOfLearners": "Número de alumnos",
-    "mustBeInteger": "Debe ser un número enteiro, por exemplo, 1, 2, 3, ...",
     "constructUsePvmDesc": "Producido en mensaxe de voz",
     "leaveSpaceDescription": "Ao saír do curso, abandonarás todos os chats dentro del. Outros usuarios verán que saíste do curso.",
     "constructUseCorMmDesc": "Significado correcto da mensaxe",
@@ -3706,7 +3363,6 @@
     "ttsDisabledBody": "Podes activar o texto a fala nas túas configuracións de aprendizaxe",
     "noSpaceDescriptionYet": "Aínda non se creou unha descrición do curso.",
     "tooLargeToSend": "Este mensaxe é demasiado grande para enviar",
-    "exitWithoutSaving": "Estás seguro de que queres saír sen gardar?",
     "enableAutocorrectPopupTitle": "Engade o teu teclado de idioma obxectivo indo a:",
     "enableAutocorrectPopupSteps": "  • Configuración\n  • Xeral\n  • Teclado\n  • Teclados\n  • Engadir novo teclado",
     "enableAutocorrectPopupDescription": "Unha vez que se seleccione o idioma, podes facer clic na pequena icona do globo na parte inferior esquerda do teu teclado para activar o teclado recentemente instalado.",
@@ -3717,11 +3373,8 @@
     "displayName": "Nome para amosar",
     "leaveRoomDescription": "Estás a piques de abandonar este chat. Outros usuarios verán que saíste do chat.",
     "confirmUserId": "Por favor, confirma o teu nome de usuario de Pangea Chat para eliminar a túa conta.",
-    "startingToday": "Comezando hoxe",
-    "oneWeekFreeTrial": "Proba gratuíta dunha semana",
     "paidSubscriptionStarts": "Comeza o {startDate}",
     "cancelInSubscriptionSettings": "• Cancelar en calquera momento na configuración da subscrición",
-    "cancelToAvoidCharges": "• Cancelar antes de {trialEnds} para evitar cargos",
     "downloadGboard": "Descargar Gboard",
     "autocorrectNotAvailable": "Lamentablemente, a túa plataforma actualmente non é compatible con esta función. ¡Mantente atento para máis desenvolvementos!",
     "pleaseUpdateApp": "Actualiza a aplicación para continuar.",
@@ -3731,17 +3384,12 @@
     "knockSpaceSuccess": "Solicitaches unirte a este curso! Un administrador responderache cando o reciba 😊",
     "chooseWordAudioInstructionsBody": "Escoita a mensaxe completa. Logo combina os audios coas palabras.",
     "chooseMorphsInstructionsBody": "Fai clic nas pezas do puzzle para preguntas de gramática!",
-    "pleaseEnterInt": "Por favor, introduce un número",
     "home": "Inicio",
     "join": "Unirse",
     "resetInstructionTooltipsTitle": "Restablecer dicas de instrución",
     "resetInstructionTooltipsDesc": "Fai clic para amosar as dicas de instrución como se fose un novo usuario.",
-    "randomize": "Aleatorizar",
     "clear": "Limpar",
-    "featuredActivities": "Destacadas",
     "save": "Gardar",
-    "startChat": "Comezar un chat",
-    "translationProblem": "Problema de tradución",
     "askToJoin": "Pide unirte",
     "emptyChatWarningTitle": "O chat está baleiro",
     "emptyChatWarningDesc": "Non invitaches a ninguén ao teu chat. Vai a Configuración do chat para convidar aos teus contactos ou ao Bot. Tamén podes facelo despois.",
@@ -3771,17 +3419,13 @@
     "timesUsedIndependently": "Veces usado de forma independente",
     "timesUsedWithAssistance": "Veces usado con axuda",
     "shareInviteCode": "Compartir código de invitación: {code}",
-    "leaderboard": "Clasificación",
     "skipForNow": "Omitir por agora",
     "permissions": "Permisos",
     "spaceChildPermission": "Quen pode engadir novas conversas a este curso",
-    "addEnvironmentOverride": "Engadir substitución de ambiente",
     "defaultOption": "Predeterminado",
     "deleteChatDesc": "Estás seguro de que queres eliminar esta conversa? Será eliminada para todos os participantes e todos os mensaxes dentro da conversa xa non estarán dispoñibles para práctica ou análise de aprendizaxe.",
     "deleteSpaceDesc": "O curso e calquera conversa seleccionada serán eliminados para todos os participantes e todos os mensaxes dentro da conversa xa non estarán dispoñibles para práctica ou análise de aprendizaxe. Esta acción non se pode deshacer.",
     "launch": "Iniciar",
-    "searchChats": "Buscar conversas",
-    "maxFifty": "Máximo 50",
     "configureSpace": "Configurar o curso",
     "pinMessages": "Fixar mensaxes",
     "setJoinRules": "Establecer regras de incorporación",
@@ -3815,9 +3459,6 @@
     "failedToFetchTranscription": "Fallou ao obter a transcrición",
     "deleteEmptySpaceDesc": "A curso eliminarase para todos os participantes. Esta acción non se pode deshacer.",
     "regenerate": " Rexenerar",
-    "mySavedActivities": "As miñas actividades gardadas",
-    "noSavedActivities": "Non hai actividades gardadas",
-    "saveActivity": "Gardar esta actividade",
     "failedToPlayVideo": "Non se puido reproducir o vídeo",
     "done": "Rematado",
     "inThisSpace": "Neste curso",
@@ -3828,13 +3469,9 @@
     "numInvited": "{count} invitado",
     "saved": "Gardado",
     "reset": "Restablecer",
-    "errorFetchingActivitiesMessage": "Non se puido obter as actividades",
     "errorFetchingDefinition": "Fallo ao obter a definición",
     "errorProcessAnalytics": "Fallo ao procesar a análise",
     "errorDownloading": "Fallou a descarga",
-    "errorLoadingSpaceChildren": "Fallou ao cargar os chats dentro deste curso",
-    "unexpectedError": "Erro inesperado.",
-    "pleaseReload": "Por favor, recargue e intente de novo.",
     "translationError": "Erro de tradución",
     "check": "Comprobar",
     "unableToFindRoom": "Non se atopou ningún chat ou curso con ese código. Por favor, inténteo de novo.",
@@ -3843,19 +3480,14 @@
     "request": "Solicitude",
     "requestAll": "Solicitar todo",
     "confirmMessageUnpin": "¿Estás seguro de que queres desanclar esta mensaxe?",
-    "saveAndLaunch": "Gardar e lanzar",
-    "launchToSpace": "Lanzar ao curso",
     "pending": "Pendiente",
     "inactive": "Inactivo",
-    "confirmRole": "Confirmar rol",
     "openRoleLabel": "ABERTO",
     "finishedTheActivity": "🎯 {username} rematou esta actividade",
     "activitySummaryError": "Resúmenes de actividade non dispoñibles",
     "requestSummaries": "Solicitar resúmenes",
-    "generatingNewActivities": "Es o primeiro usuario nesta parella de idiomas! Por favor, dame un minuto, estamos preparando actividades só para ti.",
     "requestAccessTitle": "Solicitar acceso á analítica?",
     "requestAccessDesc": "¿Queres solicitar acceso para ver as análises dos participantes?\n\nSe os participantes están de acordo, os administradores deste curso poderán ver:\n    • vocabulario total\n    • conceptos gramaticais totais\n    • sesións de actividade completadas\n    • os conceptos gramaticais específicos utilizados, correctos e incorrectos\n\nNon poderán ver:\n    • mensaxes en chats fóra do curso\n    • lista de vocabulario",
-    "requestAccess": "Solicitar acceso ({count})",
     "analyticsInactiveTitle": "As solicitudes a usuarios inactivos non se puideron enviar",
     "analyticsInactiveDesc": "Os usuarios inactivos que non iniciaron sesión desde que se introduciu esta función non verán a túa solicitude.\n\nO botón de Solicitar aparecerá unha vez que regresen. Podes reenviar a solicitude máis tarde facendo clic no botón de Solicitar baixo o seu nome cando estea dispoñible.",
     "accessRequestedTitle": "Solicitude de acceso a análises",
@@ -3878,8 +3510,6 @@
     "accessDesc": "Podes facer que o teu curso sexa aberto ao mundo! Ou, facer que o teu curso sexa privado e seguro.",
     "createGroupChatDesc": "Mentres as sesións de actividade comezan e rematan, os chats de grupo permanecerán abertos para comunicación de rutina.",
     "deleteDesc": "Só os administradores poden eliminar un curso. Esta é unha acción destructiva que elimina a todos os usuarios e elimina todos os chats seleccionados dentro do curso. Procede con precaución.",
-    "noCourseFound": "Oh, este curso necesita un plan!\n\nOs plans de curso son unha secuencia de temas e actividades de conversa.",
-    "additionalParticipants": "+ {num} outros",
     "whatNow": "E agora?",
     "chooseNextActivity": "Elixe a túa próxima actividade!",
     "letsGo": "Vamos alá",
@@ -3892,13 +3522,11 @@
     "waitNotDone": "Espera, non rematei!",
     "waitingForOthersToFinish": "Agardando que o resto remate...",
     "generatingSummary": "Analizando o chat e xerando resultados",
-    "findCourse": "Atopa un curso",
     "pingParticipantsNotification": "{user} está a buscar usuarios para unirse á sesión de actividade en {room}",
     "course": "Curso",
     "courses": "Cursos",
     "goToCourse": "Ir ao curso: {course}",
     "activityComplete": "Esta actividade foi completada. O resumo da actividade debería estar dispoñible a continuación.",
-    "startNewSession": "Comezar nova sesión",
     "joinOpenSession": "Unirse á sesión aberta",
     "activityNotFound": "Actividade non atopada",
     "myActivities": "As miñas actividades",
@@ -3972,10 +3600,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3985,10 +3609,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4072,14 +3692,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4096,10 +3708,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4112,15 +3720,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4272,14 +3872,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4293,14 +3885,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5523,10 +5107,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5567,10 +5147,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5643,10 +5219,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5916,47 +5488,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5976,19 +5508,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6052,10 +5572,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6096,14 +5612,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6115,14 +5623,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6160,10 +5660,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6180,27 +5676,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6324,10 +5804,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6337,10 +5813,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6357,14 +5829,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6504,18 +5968,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6564,10 +6016,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6577,18 +6025,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6631,23 +6067,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6671,10 +6095,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6682,14 +6102,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6794,18 +6206,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6858,10 +6258,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6888,10 +6284,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7072,7 +6464,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Volva a consultar mañá para actualizacións da actividade.",
-    "activityDropdownDesc": "Cando remates con esta actividade, clica abaixo",
     "languageMismatchTitle": "Incompatibilidade de idioma",
     "languageMismatchDesc": "O teu idioma obxectivo non coincide co idioma desta actividade. Queres actualizar o teu idioma obxectivo?",
     "reportWordIssueTooltip": "Informar de problema coa información da palabra",
@@ -7085,10 +6476,6 @@
     "selectAll": "Seleccionar todo",
     "deselectAll": "Desmarcar todo",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7137,17 +6524,11 @@
         "placeholders": {}
     },
     "startOwn": "Comezar a miña propia",
-    "joinCourseDesc": "Cada curso ten entre 8 e 10 temas en sequence con unha variedade de actividades de aprendizaxe de idiomas baseadas en tarefas.",
     "newMessageInPangeaChat": "🗨️ Novo mensaxe en Pangea Chat",
     "shareCourse": "Compartir curso",
     "addCourse": "Engadir un curso",
-    "joinPublicCourse": "Unirse ao curso público",
     "vocabLevelsDesc": "Aquí é onde as palabras de vocabulario irán unha vez que as mellores de nivel!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7160,10 +6541,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7182,7 +6559,6 @@
     "emojiView": "Vista de emoji",
     "feedbackDialogDesc": "Eu tamén cometo erros! Algo que me axude a mellorar?",
     "contactHasBeenInvitedToTheCourse": "O contacto foi convidado ao curso",
-    "activityStatsButtonTooltip": "Información da actividade",
     "allow": "Permitir",
     "deny": "Denegar",
     "enabledRenewal": "Activar a renovación da subscrición",
@@ -7450,10 +6826,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8509,16 +7881,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Actividades para Desbloquear o Próximo Tema",
-    "activitiesToUnlockTopicDesc": "Establece o número de actividades para desbloquear o próximo tema do curso",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Práctica correcta da definición de vocabulario",
     "constructUseIncLMDesc": "Práctica incorrecta da definición de vocabulario",
     "constructUseCorLADesc": "Práctica correcta do audio de vocabulario",
@@ -8526,7 +7888,6 @@
     "constructUseBonus": "Bonificación durante a práctica de vocabulario",
     "practiceVocab": "Practica de vocabulario",
     "selectMeaning": "Selecciona o significado",
-    "selectAudio": "Selecciona o audio correspondente",
     "anotherRound": "Outra ronda",
     "activitySettingsOverrideWarning": "Idioma e nivel de idioma determinados polo plan de actividade",
     "voice": "Voz",
@@ -8558,10 +7919,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8579,12 +7936,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Descarga iniciada",
     "webDownloadPermissionMessage": "Se o teu navegador bloquea descargas, por favor, habilita as descargas para este sitio.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8679,11 +8031,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Algo saíu mal e estamos traballando duro para solucionalo. Comproba de novo máis tarde.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Activar a asistencia de escritura",
     "autoIGCToolDescription": "Executar automaticamente as ferramentas de Pangea Chat para corrixir os mensaxes enviados á lingua de destino.",
     "@autoIGCToolName": {
@@ -8739,24 +8086,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramática",
-    "spanTypeWordChoice": "Escolma de Palabras",
     "spanTypeSpelling": "Ortografía",
     "spanTypePunctuation": "Pontuación",
     "spanTypeStyle": "Estilo",
     "spanTypeFluency": "Fluidez",
     "spanTypeAccents": "Acentos",
     "spanTypeCapitalization": "Capitalización",
-    "spanTypeCorrection": "Corrección",
     "spanFeedbackTitle": "Informar de problemas de corrección",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8781,10 +8117,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8795,13 +8127,9 @@
     "clientWellKnownInformation": "Información coñecida ben do cliente:",
     "baseUrl": "URL base",
     "identityServer": "Servidor de identidade:",
-    "versionWithNumber": "Versión: {version}",
     "logs": " rexistros",
-    "advancedConfigs": "Configuracións avanzadas",
     "advancedConfigurations": "Configuracións avanzadas",
-    "signInWithLabel": "Iniciar sesión con:",
     "selectAllWords": "Selecciona todas as palabras que escoitas no audio",
-    "joinCourseForActivities": "Únete a un curso para probar actividades.",
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8830,19 +8158,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8850,15 +8166,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9059,11 +8367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Nunha clase? Pon o teu código de unión aquí.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Destacar automaticamente os mensaxes de audio",
     "selectAudioMessagesOnPlayDescription": "Destacar automaticamente os mensaxes de audio cando se reproducen",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9107,18 +8410,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Este curso ten temas con menos de {input} actividades. Por favor, introduce un número menor ou igual a {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Fai clic aquí para volver a iniciar sesión.",
     "@clickToLogin": {
@@ -9535,17 +8826,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Un oso amarelo de estilo de debuxo animado coas súas mans levantadas en emoción.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Selecciona palabras para aprender máis sobre elas",
     "requireAnalyticsAccessTitle": "Require acceso á analítica para unirse",
     "requireAnalyticsAccessDesc": "Os participantes deben conceder acceso á súa analítica de aprendizaxe para unirse a este curso",
     "analyticsAccessNoticeTitle": "Acceso á analítica requirido",
     "analyticsAccessNoticeDesc": "Ao unirte a este curso, aceptas conceder acceso aos administradores á túa analítica de aprendizaxe.",
-    "skipOnboardingClassCodeDesc": "Aprendendo de forma independente? Non te preocupes, podes:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9563,10 +8848,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9595,7 +8876,6 @@
     "pickCefrLevelTeacherStepTitle": "Que nivel enseñas?",
     "pickCefrLevelStudentStepTitle": "Que nivel tes?",
     "customCourseStepTitle": "Completa este formulario para obter un curso personalizado",
-    "aboutYourClass": "Sobre a túa clase",
     "courseCodeStepErrorMessage": "Por favor, verifica o teu código e intenta de novo",
     "institution": "Institución",
     "courseGoals": "Obxectivos do curso",
@@ -9638,10 +8918,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9758,12 +9034,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logotipo de Pangea Chat",
     "introChatDetails": "Di hola! Preséntate aos teus compañeiros de curso, atopa amigos e charla fóra das actividades.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9807,11 +9078,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Accións de actividade",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Ferramentas de pronunciación",
     "audioTranscription": "Transcrición de audio por IA",
     "visualLearnerSupport": "Soporte para aprendices visuais",
@@ -9852,7 +9118,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Únete a un curso que inclúa esta actividade para xogar.",
     "resizeCoursePanel": "Redimensionar paneis do curso",
     "undo": "Desfacer",
     "unlock": "Desbloquear",
@@ -9866,7 +9131,6 @@
     "addCourseBrowsePublic": "Explorar cursos públicos",
     "browsePublicCourses": "Explorar cursos públicos",
     "editProfile": "Editar perfil",
-    "numObjectives": "{count} obxectivos",
     "mapSearchHint": "Buscar actividades",
     "mapSearchNoResults": "Sen coincidencias na vista",
     "mapFilterAllLanguages": "Todas as linguas",
@@ -9875,7 +9139,6 @@
     "mapFilterCompleted": "Completo",
     "mapFilterReset": "Restablecer",
     "activityTypeConversation": "Conversación",
-    "lockedMissionRequirement": "Termina a misión anterior para desbloquear",
     "playAgain": "Xogar de novo",
     "reviewActivity": "Revisión",
     "mapEmptyInView": "Nada aquí no teu nivel ou idioma. Amplía os teus filtros ou afasta.",
@@ -9890,14 +9153,9 @@
     "scrollToBottom": "Desprázate ata o fondo",
     "courseImage": "Imaxe do curso",
     "avatarPreview": "Previsualización do avatar",
-    "activityPhoto": "Foto da actividade",
     "emotePreview": "Previsualización do emote: {name}",
     "activityLabel": "Actividade: {title}",
     "resetMapView": "Restablecer vista do mapa",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9950,14 +9208,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9987,10 +9237,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10047,10 +9293,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_he.arb
+++ b/lib/l10n/intl_he.arb
@@ -62,11 +62,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "האם משתמשים אורחים מורשים להצטרף",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "האם אתה בטוח?",
     "@areYouSure": {
         "type": "String",
@@ -362,8 +357,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "גיבוי הצ'אט שלך הוגדר.",
-    "@yourChatBackupHasBeenSetUp": {},
     "chatBackup": "גיבוי צ'אט",
     "@chatBackup": {
         "type": "String",
@@ -426,11 +419,6 @@
     },
     "chatDetails": "פרטי צ'אט",
     "@chatDetails": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "גיבוי הצ'אט שלך מאובטח באמצעות מפתח אבטחה. אנא וודא שאתה לא מאבד אותו.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -583,11 +571,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "everythingReady": "הכל מוכן!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "fileName": "שם קובץ",
     "@fileName": {
         "type": "String",
@@ -615,11 +598,6 @@
     },
     "fromTheInvitation": "מההזמנה",
     "@fromTheInvitation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "הקבוצה ציבורית",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -808,24 +786,10 @@
         "type": "String",
         "description": "Usage hint for the command /react"
     },
-    "createNewSpace": "חלל חדש",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "enableEncryption": "אפשר הצפנה",
     "@enableEncryption": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "הזמן איש קשר אל {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "deactivateAccountWarning": "פעולה זו תשבית את חשבון המשתמש שלך. אי אפשר לבטל את זה! האם אתה בטוח?",
     "@deactivateAccountWarning": {
@@ -871,11 +835,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "לא תוכל לבטל את ההצפנה יותר. האם אתה בטוח?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encryption": "הצפנה",
     "@encryption": {
         "type": "String",
@@ -916,15 +875,6 @@
     "@extremeOffensive": {
         "type": "String",
         "placeholders": {}
-    },
-    "loadCountMoreParticipants": "טען {count} משתתפים נוספים",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "homeserver": "שרת בית",
     "@homeserver": {},
@@ -970,11 +920,6 @@
     },
     "connect": "התחבר",
     "@connect": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "איש הקשר הוזמן לקבוצה",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1081,11 +1026,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "noEncryptionForPublicRooms": "אתה יכול להפעיל הצפנה רק כשהחדר כבר לא נגיש לציבור.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "noRoomsFound": "לא נמצאו חדרים…",
     "@noRoomsFound": {
         "type": "String",
@@ -1132,8 +1072,6 @@
     },
     "oneClientLoggedOut": "אחד מהמכשירים שלך התנתק",
     "@oneClientLoggedOut": {},
-    "addAccount": "הוסף חשבון",
-    "@addAccount": {},
     "editBundlesForAccount": "ערוך חבילות עבור חשבון זה",
     "@editBundlesForAccount": {},
     "participant": "משתתף",
@@ -1175,11 +1113,6 @@
     },
     "passwordHasBeenChanged": "הסיסמה שונתה",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "שחזור סיסמה",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1237,11 +1170,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "noGoogleServicesWarning": "נראה שאין לך שירותי גוגל בטלפון שלך. זו החלטה טובה לפרטיות שלך! כדי לקבל התרעות ב- FluffyChat אנו ממליצים להשתמש https://microg.org/ או https://unifiedpush.org/.",
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "noMatrixServer": "{server1} אינו שרת מטריקס, השתמש ב-{server2} במקום זאת?",
     "@noMatrixServer": {
         "type": "String",
@@ -1283,8 +1211,6 @@
     },
     "removeFromBundle": "הסר מחבילה זו",
     "@removeFromBundle": {},
-    "enableMultiAccounts": "(בטא) אפשר ריבוי חשבונות במכשיר זה",
-    "@enableMultiAccounts": {},
     "openInMaps": "פתיחה במפות",
     "@openInMaps": {
         "type": "String",
@@ -1315,15 +1241,6 @@
     "@or": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "היכנס אל {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "mention": "הזכיר",
     "@mention": {
@@ -1378,22 +1295,17 @@
     "commandHint_markasdm": "סמן כחלל הודעה ישירה עבור מזהה Matrix הנתון",
     "commandHint_markasgroup": "סמן כקבוצה",
     "checkList": "רשימת בדיקה",
-    "countInvited": "{count} מוזמנים",
     "createGroup": "צור קבוצה",
     "chatPermissions": "הרשאות שיחה",
     "emoteInvalid": "קוד רגש לא חוקי!",
     "emoteKeyboardNoRecents": "רגשות שהיו בשימוש לאחרונה יופיעו כאן...",
     "emotePacks": "חבילות אימוג'י לחדר",
     "emoteSettings": "הגדרות אימוג'י",
-    "globalChatId": "מזהה שיחת גלובלית",
-    "accessAndVisibility": "גישה ונראות",
-    "accessAndVisibilityDescription": "מי מורשה להצטרף לשיחה זו ואיך ניתן לגלות את השיחה.",
     "calls": "שיחות",
     "customEmojisAndStickers": "אמוג'י מדומים וסטיקרים מותאמים אישית",
     "customEmojisAndStickersBody": "הוסף או שתף אמוג'י מותאם אישית או סטיקרים שניתן להשתמש בהם בכל שיחה.",
     "emoteShortcode": "קוד קצר של אימוג'י",
     "enableEmotesGlobally": "הפעלת חבילת אימוג'י באופן גלובלי",
-    "chatDescription": "תיאור השיחה",
     "chatDescriptionHasBeenChanged": "תיאור השיחה שונה",
     "hideRedactedMessages": "הסתר הודעות מצונזרות",
     "hideRedactedMessagesBody": "אם מישהו מצנזר הודעה, ההודעה הזו לא תהיה נראית יותר בשיחה.",
@@ -1416,7 +1328,6 @@
     "ok": "אישור",
     "overview": "סקירה",
     "passwordRecoverySettings": "הגדרות שחזור סיסמה",
-    "pleaseEnterRecoveryKey": "אנא הזן את מפתח השחזור שלך:",
     "pleaseFollowInstructionsOnWeb": "אנא עקוב אחר ההוראות באתר ולחץ על הבא.",
     "privacy": "פרטיות",
     "publicRooms": "חדרים ציבוריים",
@@ -1433,7 +1344,6 @@
     "rejectedTheInvitation": "{username} דחה את ההזמנה",
     "removeAllOtherDevices": "הסר את כל המכשירים האחרים",
     "removedBy": "הוסר על ידי {username}",
-    "removeDevice": "הסר מכשיר",
     "unbanFromChat": "בטל חסימה מהשיחה",
     "removeYourAvatar": "הסר את הסמל האישי שלך",
     "replaceRoomWithNewerVersion": "החלף את החדר בגרסה חדשה יותר",
@@ -1445,8 +1355,6 @@
     "saveFile": "שמור קובץ",
     "search": "חיפוש",
     "security": "אבטחה",
-    "recoveryKey": "מפתח שחזור",
-    "recoveryKeyLost": "איבדת את מפתח השחזור?",
     "send": "שלח",
     "sendAMessage": "שלח הודעה",
     "sendAsText": "שלח כטקסט",
@@ -1465,7 +1373,6 @@
     "separateChatTypes": "הפרד שיחות ישירות וקבוצות",
     "setAsCanonicalAlias": "הגדר ככינוי ראשי",
     "setChatDescription": "הגדר תיאור שיחה",
-    "setPermissionsLevel": "הגדר רמת הרשאות",
     "setStatus": "הגדר מצב",
     "settings": "הגדרות",
     "share": "שתף",
@@ -1475,8 +1382,6 @@
     "presencesToggle": "הצג הודעות סטטוס ממשתמשים אחרים",
     "skip": "דלג",
     "sourceCode": "קוד מקור",
-    "spaceIsPublic": "המקום ציבורי",
-    "spaceName": "שם המקום",
     "startedACall": "{senderName} התחיל שיחה",
     "status": "סטטוס",
     "statusExampleMessage": "איך אתה היום?",
@@ -1488,7 +1393,6 @@
     "theyMatch": "הם תואמים",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "יותר מדי בקשות. אנא נסה שוב מאוחר יותר!",
-    "transferFromAnotherDevice": "העבר ממכשיר אחר",
     "tryToSendAgain": "נסה לשלוח שוב",
     "unavailable": "לא זמין",
     "unbannedUser": "{username} הוסר המניעה מ-{targetName}",
@@ -1498,7 +1402,6 @@
     "unknownEvent": "אירוע לא ידוע '{type}'",
     "unmuteChat": "בטל השתקת שיחה",
     "unpin": "בטל קיבוע",
-    "unreadChats": "{unreadCount, plural, =1{שיחה לא נקראה אחת} other{{unreadCount} שיחות לא נקראו}}",
     "userAndOthersAreTyping": "{username} ו-{count} אחרים מקלידים…",
     "userAndUserAreTyping": "{username} ו-{username2} מקלידים…",
     "userIsTyping": "{username} מקליד…",
@@ -1511,8 +1414,6 @@
     "verifyStart": "התחל אימות",
     "verifySuccess": "אימות הצליח!",
     "verifyTitle": "מאמת חשבון אחר",
-    "videoCall": "שיחת וידאו",
-    "visibilityOfTheChatHistory": "נראות היסטוריית השיחה",
     "visibleForAllParticipants": "נראה לכל המשתתפים",
     "visibleForEveryone": "נראה לכולם",
     "voiceMessage": "הודעת קול",
@@ -1522,10 +1423,7 @@
     "wallpaper": "רקע:",
     "warning": "אזהרה!",
     "weSentYouAnEmail": "שלחנו לך אימייל",
-    "whoCanPerformWhichAction": "מי יכול לבצע איזו פעולה",
-    "whoIsAllowedToJoinThisGroup": "מי מורשה להצטרף לקבוצה זו",
     "whyDoYouWantToReportThis": "מדוע אתה רוצה לדווח על זה?",
-    "wipeChatBackup": "למחוק את גיבוי הצ'אט שלך כדי ליצור מפתח שחזור חדש?",
     "withTheseAddressesRecoveryDescription": "עם כתובות אלה תוכל לשחזר את הסיסמה שלך.",
     "writeAMessage": "כתוב הודעה…",
     "yes": "כן",
@@ -1538,9 +1436,7 @@
     "messageType": "סוג ההודעה",
     "sender": "שולח ההודעה",
     "openGallery": "פתח גלריה",
-    "removeFromSpace": "הסר מהחלל",
     "start": "התחל",
-    "pleaseEnterRecoveryKeyDescription": "כדי לפתוח את ההודעות הישנות שלך, הזן את מפתח השחזור שלך שנוצר בפגישה קודמת. מפתח השחזור שלך אינו הסיסמה שלך.",
     "publish": "פרסם",
     "openChat": "פתח שיחה",
     "markAsRead": "סמן כנקרא",
@@ -1551,12 +1447,9 @@
     "confirmEventUnpin": "האם אתה בטוח שברצונך להסיר את נעיצת האירוע באופן קבוע?",
     "emojis": "אימוג'ים",
     "placeCall": "התקשר",
-    "voiceCall": "שיחת קול",
     "unsupportedAndroidVersion": "גרסת אנדרואיד לא נתמכת",
     "unsupportedAndroidVersionLong": "תכונה זו דורשת גרסת אנדרואיד חדשה יותר. אנא בדוק עדכונים או תמיכה ב-Lineage OS.",
-    "videoCallsBetaWarning": "שים לב ששיחות וידאו נמצאות כרגע בגרסת בטא. ייתכן שהן לא יעבדו כראוי או בכלל בכל הפלטפורמות.",
     "experimentalVideoCalls": "שיחות וידאו ניסיוניות",
-    "emailOrUsername": "דוא\"ל או שם משתמש",
     "addWidget": "הוסף ווידג'ט",
     "widgetVideo": "וידאו",
     "widgetEtherpad": "הערת טקסט",
@@ -1578,35 +1471,19 @@
     "youKickedAndBanned": "🙅 הוצאת והחרמת את {user}",
     "youUnbannedUser": "שיחררת את {user}",
     "hasKnocked": "🚪 {user} דפק בדלת",
-    "usersMustKnock": "המשתמשים חייבים לדפוק בדלת",
-    "noOneCanJoin": "אף אחד לא יכול להצטרף",
     "knock": "דפוק",
     "users": "משתמשים",
-    "unlockOldMessages": "פתח הודעות ישנות",
-    "storeInSecureStorageDescription": "אחסן את מפתח השחזור באחסון המאובטח של המכשיר הזה.",
-    "saveKeyManuallyDescription": "שמור את המפתח הזה ידנית על ידי הפעלת תיבת השיתוף של המערכת או הלוח.",
-    "storeInAndroidKeystore": "אחסן ב-Android KeyStore",
-    "storeInAppleKeyChain": "אחסן ב-Apple KeyChain",
-    "storeSecurlyOnThisDevice": "אחסן באופן מאובטח במכשיר זה",
     "countFiles": "{count} קבצים",
     "user": "משתמש",
     "custom": "מותאם אישית",
-    "foregroundServiceRunning": "התראה זו מופיעה כאשר השירות הקדמי פועל.",
-    "screenSharingTitle": "שיתוף מסך",
-    "screenSharingDetail": "אתה משתף את המסך שלך ב-FuffyChat",
     "whyIsThisMessageEncrypted": "מדוע ההודעה הזו בלתי קריאה?",
     "noKeyForThisMessage": "זה יכול לקרות אם ההודעה נשלחה לפני שהתחברת לחשבונך במכשיר זה.\n\nיכול גם להיות שהשולח חסם את המכשיר שלך או שמשהו השתבש בחיבור לאינטרנט.\n\nהאם אתה יכול לקרוא את ההודעה בסשן אחר? אז תוכל להעביר את ההודעה ממנו! עבור להגדרות > מכשירים וודא שהמכשירים שלך אושרו זה את זה. כאשר תפתח את החדר בפעם הבאה ושני הסשנים יהיו בחזית, המפתחות יועברו אוטומטית.\n\nלא רוצה לאבד את המפתחות בעת יציאה או החלפת מכשירים? ודא שהפעלת את גיבוי הצ'אט בהגדרות.",
     "newGroup": "קבוצה חדשה",
     "newSpace": "מרחב חדש",
-    "enterSpace": "היכנס למרחב",
     "allSpaces": "כל המרחבים",
     "hidePresences": "הסתר רשימת סטטוס?",
     "doNotShowAgain": "אל תציג שוב",
     "wasDirectChatDisplayName": "שיחה ריקה (הייתה {oldDisplayName})",
-    "newSpaceDescription": "מרחבים מאפשרים לך לאחד את השיחות שלך ולבנות קהילות פרטיות או ציבוריות.",
-    "encryptThisChat": "הצפן שיחה זו",
-    "disableEncryptionWarning": "מסיבות אבטחה, אינך יכול לבטל את ההצפנה בשיחה שבה היא הופעלה קודם לכן.",
-    "sorryThatsNotPossible": "סליחה... זה לא אפשרי",
     "deviceKeys": "מפתחות מכשיר:",
     "reopenChat": "פתח מחדש את השיחה",
     "noBackupWarning": "אזהרה! ללא הפעלת גיבוי שיחה, תאבד גישה להודעות המוצפנות שלך. מומלץ מאוד להפעיל את גיבוי השיחה לפני יציאה מהחשבון.",
@@ -1619,7 +1496,6 @@
     "openLinkInBrowser": "פתח את הקישור בדפדפן",
     "reportErrorDescription": "😞 אוי לא. קרה משהו. אם תרצה, תוכל לדווח על באג זה למפתחים.",
     "report": "דווח",
-    "setTheme": "הגדר נושא:",
     "setColorTheme": "הגדר נושא צבע:",
     "invite": "הזמן",
     "inviteGroupChat": "📨 הזמנת שיחת קבוצה",
@@ -1638,12 +1514,8 @@
     "yourGlobalUserIdIs": "זיהוי המשתמש הגלובלי שלך הוא: ",
     "noUsersFoundWithQuery": "לצערנו לא נמצא משתמש עם \"{query}\". אנא בדוק אם טעות בהקלדה.",
     "knocking": "דופק",
-    "chatCanBeDiscoveredViaSearchOnServer": "הצ'אט ניתן לגילוי באמצעות החיפוש ב-{server}",
-    "searchChatsRooms": "חפש ב-#שיחות, @משתמשים...",
     "nothingFound": "לא נמצא כלום...",
     "groupName": "שם הקבוצה",
-    "createGroupAndInviteUsers": "צור קבוצה והזמן משתמשים",
-    "groupCanBeFoundViaSearch": "הקבוצה ניתנת למציאה באמצעות חיפוש",
     "wrongRecoveryKey": "סליחה... זה לא נראה מפתח השחזור הנכון.",
     "startConversation": "התחל שיחה",
     "commandHint_sendraw": "שלח json גולמי",
@@ -1657,11 +1529,8 @@
     "pleaseChooseAStrongPassword": "אנא בחר סיסמה חזקה",
     "passwordsDoNotMatch": "הסיסמאות אינן תואמות",
     "passwordIsWrong": "הסיסמה שהזנת שגויה",
-    "publicChatAddresses": "כתובות שיחות ציבוריות",
-    "createNewAddress": "צור כתובת חדשה",
     "joinSpace": "הצטרף למרחב",
     "publicSpaces": "מרחבים ציבוריים",
-    "addChatOrSubSpace": "הוסף שיחה או תת-מרחב",
     "subspace": "תת-מרחב",
     "decline": "דחה",
     "thisDevice": "התקן זה:",
@@ -1670,15 +1539,11 @@
     "searchMore": "חפש עוד...",
     "gallery": "גלריה",
     "files": "קבצים",
-    "sessionLostBody": "הסשן שלך אבד. אנא דווח על שגיאה זו למפתחים ב-{url}. הודעת השגיאה היא: {error}",
-    "restoreSessionBody": "האפליקציה מנסה לשחזר את הסשן שלך מהגיבוי. אנא דווח על שגיאה זו למפתחים ב-{url}. הודעת השגיאה היא: {error}",
     "sendReadReceipts": "שלח אישורי קריאה",
     "sendTypingNotificationsDescription": "משתתפי השיחה האחרים יכולים לראות מתי אתה מקליד הודעה חדשה.",
     "sendReadReceiptsDescription": "משתתפי השיחה האחרים יכולים לראות מתי קראת הודעה.",
     "formattedMessages": "הודעות מעוצבות",
     "formattedMessagesDescription": "הצג תוכן הודעות עשיר כמו טקסט מודגש באמצעות מרקרד.",
-    "verifyOtherUser": "🔐 אימות משתמש אחר",
-    "verifyOtherUserDescription": "אם תאמת משתמש אחר, תוכל להיות בטוח שאתה באמת כותב לאדם הנכון. 💪\n\nכאשר תתחיל תהליך אימות, אתה והמשתמש האחר תראו חלון קופץ באפליקציה. שם תראו סדרת אמויות או מספרים שעליכם להשוות ביניהם.\n\nהדרך הטובה ביותר לעשות זאת היא להיפגש או להתחיל שיחת וידאו. 👭",
     "verifyOtherDevice": "🔐 אימות מכשיר אחר",
     "verifyOtherDeviceDescription": "כאשר תאמת מכשיר אחר, מכשירים אלה יוכלו להחליף מפתחות, מה שישפר את האבטחה הכוללת שלך. 💪 כאשר תתחיל תהליך אימות, יופיע חלון קופץ באפליקציה בשני המכשירים. שם תראו סדרת אמויות או מספרים שעליכם להשוות ביניהם. עדיף שיהיו שני המכשירים זמינים לפני שתתחיל את תהליך האימות. 🤳",
     "acceptedKeyVerification": "{sender} אישר אימות מפתח",
@@ -1714,10 +1579,6 @@
     "updateInstalled": "🎉 עדכון {version} הותקן!",
     "changelog": "שינויים",
     "sendCanceled": "השליחה בוטלה",
-    "loginWithMatrixId": "התחבר עם מזהה Matrix",
-    "discoverHomeservers": "גלה שרתי בית",
-    "whatIsAHomeserver": "מהו שרת בית?",
-    "homeserverDescription": "כל הנתונים שלך נשמרים בשרת הבית, בדיוק כמו ספק דואר אלקטרוני. תוכל לבחור באיזה שרת בית להשתמש, ועדיין לתקשר עם כולם. למידע נוסף בכתובת https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "נראה שזה לא שרת בית תואם. כתובת URL שגויה?",
     "calculatingFileSize": "חישוב גודל הקובץ...",
     "prepareSendingAttachment": "הכן שליחת קובץ מצורף...",
@@ -1729,11 +1590,9 @@
     "oneOfYourDevicesIsNotVerified": "אחד מהמכשירים שלך לא מאומת",
     "noticeChatBackupDeviceVerification": "הערה: כאשר אתה מחבר את כל המכשירים לגיבוי הצ'אט, הם מאומתים אוטומטית.",
     "continueText": "המשך",
-    "welcomeText": "היי היי 👋 זה FluffyChat. תוכל להתחבר לכל שרת בית שתואם ל-https://matrix.org. ואז לתקשר עם כל אחד. זה רשת הודעות מבוזרת עצומה!",
     "blur": "טשטוש:",
     "opacity": "אטימות:",
     "setWallpaper": "הגדר רקע",
-    "manageAccount": "נהל את החשבון",
     "noContactInformationProvided": "השרת לא מספק פרטי יצירת קשר תקפים",
     "contactServerAdmin": "צור קשר עם מנהל השרת",
     "contactServerSecurity": "צור קשר עם אבטחת השרת",
@@ -1752,11 +1611,8 @@
     "unableToJoinChat": "לא ניתן להצטרף לשיחה. ייתכן שהצד השני סגר את השיחה כבר.",
     "previous": "קודם",
     "otherPartyNotLoggedIn": "הצד השני כרגע לא מחובר ולכן לא יכול לקבל הודעות!",
-    "appWantsToUseForLogin": "השתמש ב'{server}' כדי להתחבר",
-    "appWantsToUseForLoginDescription": "אתה מאשר בזאת שהאפליקציה והאתר ישתפו מידע עליך.",
     "open": "פתח",
     "waitingForServer": "מחכה לשרת...",
-    "appIntroduction": "FluffyChat מאפשר לך לתקשר עם החברים שלך דרך אפליקציות מסרים שונות. למידע נוסף בכתובת https://matrix.org או פשוט לחץ *המשך*.",
     "newChatRequest": "📩 בקשת שיחה חדשה",
     "contentNotificationSettings": "הגדרות התראות תוכן",
     "generalNotificationSettings": "הגדרות התראות כלליות",
@@ -1831,11 +1687,9 @@
     "taTooltip": "שימוש ב-L2 עם סיוע תרגום",
     "interactiveTranslatorSliderHeader": "מתרגם אינטראקטיבי",
     "interactiveGrammarSliderHeader": "בודק דקדוק אינטראקטיבי",
-    "interactiveTranslatorRequired": "נדרש",
     "waTooltip": "שימוש ב-L2 ללא סיוע",
     "interactiveTranslator": "סיוע בתרגום",
     "noIdenticalLanguages": "אנא בחר שפות בסיסיות ומטרה שונות",
-    "searchBy": "חפש לפי מדינה ושפות",
     "joinWithClassCode": "הצטרף לקורס",
     "languageLevelPreA1": "מתחיל נמוך (פרה A1)",
     "languageLevelA1": "מתחיל בינוני (A1)",
@@ -1856,19 +1710,14 @@
     "saveChanges": "שמור שינויים",
     "publicProfileTitle": "אפשר למצוא את הפרופיל שלי בחיפוש",
     "publicProfileDesc": "על ידי הפעלה, אתה מאפשר למשתמשים אחרים למצוא את הפרופיל שלך בשורת החיפוש הגלובלית ולשלוח בקשות לשיחה. בשלב זה, תוכל לבחור לקבל או לדחות את הבקשה.",
-    "errorDisableIT": "עזרה בתרגום מושבתת.",
-    "errorDisableIGC": "עזרה בדקדוק מושבתה.",
     "errorDisableITUserDesc": "לחץ כאן לעדכון הגדרות עזרה בתרגום",
     "errorDisableIGCUserDesc": "לחץ כאן לעדכון הגדרות עזרה בדקדוק",
     "errorDisableITClassDesc": "עזרה בתרגום מושבתת עבור הקורס שבו נמצא הצ'אט הזה.",
     "errorDisableIGCClassDesc": "עזרה בדקדוק מושבתת עבור הקורס שבו נמצא הצ'אט הזה.",
-    "error405Title": "שפות לא מוגדרות",
     "error405Desc": "אנא הגדר את שפותיך בתפריט הראשי > הגדרות למידה.",
     "termsAndConditions": "תנאים והגבלות",
     "andCertifyIAmAtLeast13YearsOfAge": "ומאשר שאני בן לפחות 16 שנים.",
-    "error502504Title": "וואו, יש הרבה תלמידים באינטרנט!",
     "error502504Desc": "כלי תרגום ודקדוק עלולים להיות איטיים או לא זמינים בזמן שהבוטים של פנגיאה מעדכנים.",
-    "error404Title": "שגיאת תרגום!",
     "error404Desc": "בוט פנגיאה לא בטוח איך לתרגם את זה...",
     "errorPleaseRefresh": "אנחנו בודקים את זה! אנא טען מחדש ונסה שוב.",
     "connectedToStaging": "מחובר לסביבת בדיקה",
@@ -1906,13 +1755,9 @@
     "definitionsToolName": "הגדרות מילים",
     "definitionsToolDescription": "כאשר מופעל, מילים שמודגשות בכחול ניתנות ללחיצה לקבלת הגדרות. לחץ על ההודעות כדי לגשת להגדרות.",
     "welcomeBack": "ברוכים השבים! אם היית חלק מניסוי 2023-2024, אנא צור איתנו קשר לקבלת המנוי המיוחד שלך לניסוי. אם אתה מורה שרכש (או המוסד שלך רכש) רישיונות לכיתה שלך, צור איתנו קשר למנוי המורה שלך.",
-    "downloadTxtFile": "הורד קובץ טקסט",
-    "downloadCSVFile": "הורד קובץ CSV",
     "promotionalSubscriptionDesc": "יש לך כרגע מנוי קידום מכירות לכל החיים. שלח הודעה ל-support@pangea.chat לעזרה בשינוי המנוי שלך.",
     "originalSubscriptionPlatform": "המנוי נרכש דרך {purchasePlatform}",
     "oneWeekTrial": "ניסיון לשבוע אחד",
-    "downloadXLSXFile": "הורד קובץ אקסל",
-    "unkDisplayName": "לא ידוע",
     "wwCountryDisplayName": "עולם רחב",
     "afCountryDisplayName": "אפגניסטן",
     "axCountryDisplayName": "איי אלנד",
@@ -2207,7 +2052,6 @@
     "chatCapacityHasBeenChanged": "קיבולת השיחה שונתה",
     "chatCapacitySetTooLow": "קיבולת השיחה חייבת להיות לפחות {count}.",
     "chatCapacityExplanation": "קיבולת שיחה מגבילה את מספר החברים המורשים בשיחה.",
-    "tooManyRequest": "יותר מדי בקשות, אנא נסה שוב מאוחר יותר.",
     "enterNumber": "אנא הזן ערך מספר שלם.",
     "practice": "תרגול",
     "versionNotFound": "הגרסה לא נמצאה",
@@ -2217,7 +2061,6 @@
     "deleteSubscriptionWarningTitle": "יש לך מנוי פעיל",
     "deleteSubscriptionWarningBody": "מחיקת החשבון שלך לא תבטל אוטומטית את המנוי שלך.",
     "manageSubscription": "ניהול המנוי",
-    "error520Title": "אנא נסה שוב.",
     "error520Desc": "סליחה, לא הצלחנו להבין את ההודעה שלך...",
     "wordsUsed": "מילים בשימוש",
     "level": "רמה",
@@ -2235,7 +2078,6 @@
     "other": "אחר",
     "levelShort": "רמה {level}",
     "noCapacityLimit": "אין מגבלת קיבולת",
-    "downloadGroupText": "הורד טקסט מקבוצה",
     "notificationsOn": "התראות מופעלות",
     "notificationsOff": "ההתראות כבויות",
     "joinWithCode": "הצטרף עם קוד",
@@ -2299,24 +2141,12 @@
     "whatIsTheMorphTag": "מה ה-{morphologicalFeature} של '{wordForm}'?",
     "dataAvailable": "זמינות נתונים",
     "available": "זמין",
-    "pangeaBotIsFallible": "גם ביג בוט עלול לטעות!",
-    "whatIsMeaning": "מה המשמעות של '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "התאם בין המשמעויות למילים בהודעה!",
-    "doubleClickToEdit": "לחץ פעמיים כדי לערוך.",
-    "topicLabel": "נושא",
-    "topicPlaceholder": "בחר נושא...",
-    "modePlaceholder": "בחר מצב...",
-    "learningObjectiveLabel": "מטרה ללמידה",
-    "learningObjectivePlaceholder": "בחר מטרה ללמידה...",
-    "targetLanguageLabel": "שפת היעד",
     "cefrLevelLabel": "רמת CEFR",
     "image": "תמונה",
     "video": "וידאו",
     "nan": "לא רלוונטי",
-    "addVocabulary": "הוסף אוצר מילים",
     "instructions": "הוראות",
-    "numberOfLearners": "מספר הלומדים",
-    "mustBeInteger": "Must be an integer e.g. 1, 2, 3, ...",
     "constructUsePvmDesc": "מיוצר בהודעת קול",
     "leaveSpaceDescription": "על ידי יציאה מהקורס, תעזוב את כל השיחות בתוכו. משתמשים אחרים יראו שהיית בחוץ.",
     "constructUseCorMmDesc": "משמעות ההודעה הנכונה",
@@ -2331,7 +2161,6 @@
     "ttsDisabledBody": "אתה יכול להפעיל את תכונת ההמרה לטקסט לדיבור בהגדרות הלמידה שלך",
     "noSpaceDescriptionYet": "עדיין לא נוצר תיאור לקורס.",
     "tooLargeToSend": "ההודעה הזו גדולה מדי לשליחה",
-    "exitWithoutSaving": "האם אתה בטוח שברצונך לצאת מבלי לשמור?",
     "enableAutocorrectPopupTitle": "הוסף את מקלדת שפת היעד שלך על ידי כניסה ל:",
     "enableAutocorrectPopupSteps": "  • הגדרות\n  • כללי\n  • מקלדת\n  • מקלדות\n  • הוסף מקלדת חדשה",
     "enableAutocorrectPopupDescription": "לאחר בחירת השפה, תוכל ללחוץ על סמל הגלובוס הקטן בפינה השמאלית התחתונה של המקלדת כדי להפעיל את המקלדת שהותקנה לאחרונה.",
@@ -2342,11 +2171,8 @@
     "displayName": "שם תצוגה",
     "leaveRoomDescription": "אתה עומד לעזוב את השיחה הזו. משתמשים אחרים יראו שהייתה לך יציאה מהשיחה.",
     "confirmUserId": "אנא אשר את שם המשתמש שלך ב-Pangea Chat כדי למחוק את החשבון שלך.",
-    "startingToday": "החל מהיום",
-    "oneWeekFreeTrial": "ניסיון חינם לשבוע אחד",
     "paidSubscriptionStarts": "החל מ-{startDate}",
     "cancelInSubscriptionSettings": "• בטל בכל עת בהגדרות המנוי",
-    "cancelToAvoidCharges": "• בטל לפני {trialEnds} כדי להימנע מחיובים",
     "downloadGboard": "הורד את Gboard",
     "autocorrectNotAvailable": "לצערנו הפלטפורמה שלך כרגע לא נתמכת לתכונה זו. המשך לעקוב לפיתוח עתידי!",
     "pleaseUpdateApp": "אנא עדכן את האפליקציה כדי להמשיך.",
@@ -2356,17 +2182,12 @@
     "knockSpaceSuccess": "ביקשת להצטרף לקורס זה! מנהל יענה לבקשתך כאשר יקבל אותה 😀",
     "chooseWordAudioInstructionsBody": "האזן להודעה המלאה. לאחר מכן, התאם את ההקלטות למילים.",
     "chooseMorphsInstructionsBody": "לחץ על חלקי הפאזל לשאלות דקדוק!",
-    "pleaseEnterInt": "אנא הזן מספר",
     "home": "בית",
     "join": "הצטרף",
     "resetInstructionTooltipsTitle": "אפס טיפים להנחיות",
     "resetInstructionTooltipsDesc": "לחץ כדי להציג טיפים להנחיות כמו למשתמש חדש.",
-    "randomize": "אקראי",
     "clear": "נקה",
-    "featuredActivities": "פעילויות מובילות",
     "save": "שמור",
-    "startChat": "התחל שיחה",
-    "translationProblem": "בעיה בתרגום",
     "askToJoin": "בקש להצטרף",
     "emptyChatWarningTitle": "השיחה ריקה",
     "emptyChatWarningDesc": "לא הזמנת אף אחד לשיחה שלך. עבור להגדרות שיחה כדי להזמין את אנשי הקשר שלך או את הבוט. אפשר גם לעשות זאת מאוחר יותר.",
@@ -2396,17 +2217,13 @@
     "timesUsedIndependently": "פעמים בשימוש עצמאי",
     "timesUsedWithAssistance": "פעמים בשימוש עם סיוע",
     "shareInviteCode": "שתף קוד הזמנה: {code}",
-    "leaderboard": "טבלת מובילים",
     "skipForNow": "דלג לעכשיו",
     "permissions": "הרשאות",
     "spaceChildPermission": "מי יכול להוסיף שיחות חדשות לקורס זה",
-    "addEnvironmentOverride": "הוסף שינוי סביבה",
     "defaultOption": "ברירת מחדל",
     "deleteChatDesc": "האם אתה בטוח שברצונך למחוק שיחה זו? היא תימחק לכל המשתתפים וכל ההודעות בתוך השיחה לא יהיו זמינות עוד לתרגול או לניתוחי למידה.",
     "deleteSpaceDesc": "הקורס וכל השיחות שנבחרו יימחקו לכל המשתתפים וכל ההודעות בתוך השיחה לא יהיו זמינות עוד לתרגול או לניתוחי למידה. פעולה זו אינה ניתנת לביטול.",
     "launch": "הפעל",
-    "searchChats": "חפש שיחות",
-    "maxFifty": "מקסימום 50",
     "configureSpace": "הגדר קורס",
     "pinMessages": "נעץ הודעות",
     "setJoinRules": "הגדר כללי הצטרפות",
@@ -2440,9 +2257,6 @@
     "failedToFetchTranscription": "הטעינה של ההמרה נכשלה",
     "deleteEmptySpaceDesc": "הקורס יימחק לכל המשתתפים. פעולה זו אינה ניתנת לביטול.",
     "regenerate": "ליצור מחדש",
-    "mySavedActivities": "הפעילויות שמורים שלי",
-    "noSavedActivities": "אין פעילויות שמורות",
-    "saveActivity": "שמור פעילות זו",
     "failedToPlayVideo": "נכשלה ההפעלה של הווידאו",
     "done": "הושלם",
     "inThisSpace": "במקום זה",
@@ -2453,13 +2267,9 @@
     "numInvited": "{count} הוזמן/ה",
     "saved": "שמור",
     "reset": "אפס",
-    "errorFetchingActivitiesMessage": "נכשל באחזור פעילויות",
     "errorFetchingDefinition": "נכשל באחזור ההגדרה",
     "errorProcessAnalytics": "נכשל בעיבוד ניתוחים",
     "errorDownloading": "ההורדה נכשלה",
-    "errorLoadingSpaceChildren": "נכשל בטעינת הצ'אטים בתוך קורס זה",
-    "unexpectedError": "שגיאה בלתי צפויה.",
-    "pleaseReload": "אנא טען מחדש ונסה שוב.",
     "translationError": "שגיאת תרגום",
     "check": "בדוק",
     "unableToFindRoom": "לא נמצא שיחה או קורס עם קוד זה. אנא נסה שוב.",
@@ -2468,19 +2278,14 @@
     "request": "בקשה",
     "requestAll": "בקש את הכל",
     "confirmMessageUnpin": "האם אתה בטוח שברצונך להסיר את ההצמדה של הודעה זו?",
-    "saveAndLaunch": "שמור והפעל",
-    "launchToSpace": "הפעל לקורס",
     "pending": "בהמתנה",
     "inactive": "לא פעיל",
-    "confirmRole": "אשר תפקיד",
     "openRoleLabel": "פתוח",
     "finishedTheActivity": "🎯 {username} סיים את הפעילות הזו",
     "activitySummaryError": "סיכומי הפעילות אינם זמינים",
     "requestSummaries": "בקש סיכומים",
-    "generatingNewActivities": "אתה המשתמש הראשון בזוג שפות זה! אנא המתן דקה, אנו מכינים פעילויות במיוחד בשבילך.",
     "requestAccessTitle": "לבקש גישה לניתוחי נתונים?",
     "requestAccessDesc": "האם תרצה לבקש גישה לצפייה בנתוני המשתתפים?\n\nאם המשתתפים יסכימו, מנהלי הקורס יוכלו לצפות ב:\n    • אוצר מילים כולל\n    • מושגי דקדוק כוללים\n    • סך כל מפגשי הפעילות שהושלמו\n    • המושגים הדקדוקיים הספציפיים שהשתמשו בהם, נכון ולא נכון\n\nהם לא יוכלו לצפות ב:\n    • הודעות בצ'אט מחוץ לקורס\n    • רשימת אוצר מילים",
-    "requestAccess": "בקש גישה ({count})",
     "analyticsInactiveTitle": "בקשות למשתמשים לא פעילים לא נשלחות",
     "analyticsInactiveDesc": "משתמשים לא פעילים שלא התחברו מאז הוספת תכונה זו לא יראו את הבקשה שלך.\n\nכפתור הבקשה יופיע כאשר הם יחזרו. תוכל לשלוח את הבקשה מחדש מאוחר יותר על ידי לחיצה על כפתור הבקשה תחת שמם כאשר הוא זמין.",
     "accessRequestedTitle": "בקשת גישה לנתוני אנליטיקה",
@@ -2503,8 +2308,6 @@
     "accessDesc": "אתה יכול להפוך את הקורס שלך לגלוי לעולם! או, להפוך את הקורס לפרטי ומאובטח.",
     "createGroupChatDesc": "בעוד שמפגשי הפעילות מתחילים ומסתיימים, שיחות קבוצתיות יישארו פתוחות לתקשורת שוטפת.",
     "deleteDesc": "רק מנהלים יכולים למחוק קורס. זוהי פעולה הרסנית שמסירה את כל המשתמשים ומוחקת את כל השיחות שנבחרו בתוך הקורס. המשך בזהירות.",
-    "noCourseFound": "אה, הקורס הזה צריך תכנית!\n\nתכניות קורס הן רצף של נושאים ופעילויות שיחה.",
-    "additionalParticipants": "+ {num} אחרים",
     "whatNow": "מה עכשיו?",
     "chooseNextActivity": "בחר את הפעילות הבאה שלך!",
     "letsGo": "בוא נתחיל",
@@ -2517,13 +2320,11 @@
     "waitNotDone": "חכה, אני לא סיימתי!",
     "waitingForOthersToFinish": "מחכה לשאר לסיים...",
     "generatingSummary": "אנליזת שיחה ויצירת תוצאות",
-    "findCourse": "מצא קורס",
     "pingParticipantsNotification": "{user} מחפש משתמשים להצטרף למפגש הפעילות ב-{room}",
     "course": "קורס",
     "courses": "קורסים",
     "goToCourse": "עבור לקורס: {course}",
     "activityComplete": "הפעילות הזו הושלמה. סיכום הפעילות אמור להיות זמין למטה.",
-    "startNewSession": "התחל מפגש חדש",
     "joinOpenSession": "הצטרף למפגש פתוח",
     "activityNotFound": "הפעילות לא נמצאה",
     "myActivities": "הפעילויות שלי",
@@ -2715,14 +2516,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@createGroup": {
         "type": "String",
         "placeholders": {}
@@ -2747,18 +2540,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -2776,10 +2557,6 @@
         "placeholders": {}
     },
     "@enableEmotesGlobally": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -2871,10 +2648,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterRecoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pleaseFollowInstructionsOnWeb": {
         "type": "String",
         "placeholders": {}
@@ -2962,10 +2735,6 @@
             }
         }
     },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unbanFromChat": {
         "type": "String",
         "placeholders": {}
@@ -3007,14 +2776,6 @@
         "placeholders": {}
     },
     "@security": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
         "type": "String",
         "placeholders": {}
     },
@@ -3118,10 +2879,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@setStatus": {
         "type": "String",
         "placeholders": {}
@@ -3159,14 +2916,6 @@
         "placeholders": {}
     },
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -3222,10 +2971,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@tryToSendAgain": {
         "type": "String",
         "placeholders": {}
@@ -3272,14 +3017,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -3358,14 +3095,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@visibleForAllParticipants": {
         "type": "String",
         "placeholders": {}
@@ -3402,19 +3131,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -3466,15 +3183,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3525,10 +3234,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3537,15 +3242,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3669,43 +3366,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3725,18 +3390,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
@@ -3750,10 +3403,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3776,22 +3425,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3846,10 +3479,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3933,31 +3562,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -4013,23 +3622,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4069,28 +3666,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4108,14 +3683,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4308,22 +3875,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4379,10 +3930,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4392,10 +3939,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4471,27 +4014,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4809,10 +4336,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4822,10 +4345,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4913,14 +4432,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4937,10 +4448,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4953,15 +4460,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5113,14 +4612,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5134,14 +4625,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6364,10 +5847,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6408,10 +5887,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6484,10 +5959,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6757,47 +6228,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6817,19 +6248,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6893,10 +6312,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6937,14 +6352,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6956,14 +6363,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -7001,10 +6400,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7021,27 +6416,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7165,10 +6544,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7178,10 +6553,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7198,14 +6569,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7345,18 +6708,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7405,10 +6756,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7418,18 +6765,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7472,23 +6807,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7512,10 +6835,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7523,14 +6842,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7635,18 +6946,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7699,10 +6998,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7729,10 +7024,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7913,7 +7204,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Повращайте наповращане за приятие на активности завтра",
-    "activityDropdownDesc": "Когато ви завершите свою активность, нажмите на подобно",
     "languageMismatchTitle": "Неподолятность езика",
     "languageMismatchDesc": "Ваше потелно е неподолятно на езика на этото активность. Измените наше потелно езика?",
     "reportWordIssueTooltip": "Оповещайте за проблема информация за слово",
@@ -7926,10 +7216,6 @@
     "selectAll": "Выбрати все",
     "deselectAll": "Отмените все",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7978,17 +7264,11 @@
         "placeholders": {}
     },
     "startOwn": "התחל את שלי",
-    "joinCourseDesc": "לכל קורס יש 8-10 נושאים מסודרים עם מגוון פעילויות למידה מבוססות משימות בשפה.",
     "newMessageInPangeaChat": "📩 הודעה חדשה בצ'אט פאנגיאה",
     "shareCourse": "שתף קורס",
     "addCourse": "הוסף קורס",
-    "joinPublicCourse": "הצטרף לקורס ציבורי",
     "vocabLevelsDesc": "זה המקום שבו מילות אוצר המילים יופיעו לאחר שהעלית את רמתן!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8001,10 +7281,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8023,7 +7299,6 @@
     "emojiView": "תצוגת אימוג'י",
     "feedbackDialogDesc": "גם אני עושה טעויות! יש משהו שיכול לעזור לי להשתפר?",
     "contactHasBeenInvitedToTheCourse": "הקשר הוזמן לקורס",
-    "activityStatsButtonTooltip": "מידע על פעילות",
     "allow": "אפשר",
     "deny": "סירב",
     "enabledRenewal": "אפשר חידוש מנוי",
@@ -8291,10 +7566,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9350,16 +8621,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "פעילויות לפתיחת נושא הבא",
-    "activitiesToUnlockTopicDesc": "קבע את מספר הפעילויות לפתיחת נושא הקורס הבא",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "תרגול הגדרה נכונה של אוצר מילים",
     "constructUseIncLMDesc": "תרגול הגדרה שגויה של אוצר מילים",
     "constructUseCorLADesc": "תרגול שמע נכון של אוצר מילים",
@@ -9367,7 +8628,6 @@
     "constructUseBonus": "בונוס במהלך תרגול אוצר מילים",
     "practiceVocab": "תרגל אוצר מילים",
     "selectMeaning": "בחר את המשמעות",
-    "selectAudio": "בחר את השמע התואם",
     "anotherRound": "סיבוב נוסף",
     "activitySettingsOverrideWarning": "שפה ורמת שפה נקבעות על ידי תוכנית הפעילות",
     "voice": "קול",
@@ -9399,10 +8659,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9420,12 +8676,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "ההורדה החלה",
     "webDownloadPermissionMessage": "אם הדפדפן שלך חוסם הורדות, אנא אפשר הורדות לאתר זה.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9520,11 +8771,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "משהו השתבש, ואנחנו עובדים קשה על תיקון זה. בדוק שוב מאוחר יותר.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "אפשר סיוע בכתיבה",
     "autoIGCToolDescription": "הרץ אוטומטית את כלי Pangea Chat כדי לתקן הודעות שנשלחו לשפה היעד.",
     "@autoIGCToolName": {
@@ -9580,24 +8826,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "דקדוק",
-    "spanTypeWordChoice": "בחירת מילים",
     "spanTypeSpelling": "איות",
     "spanTypePunctuation": "פיסוק",
     "spanTypeStyle": "סגנון",
     "spanTypeFluency": "שפה רהוטה",
     "spanTypeAccents": "הטעמה",
     "spanTypeCapitalization": "הגדלת אותיות",
-    "spanTypeCorrection": "תיקון",
     "spanFeedbackTitle": "דווח על בעיית תיקון",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9622,10 +8857,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9638,13 +8869,7 @@
     "longPressToRecordVoiceMessage": "לחץ ארוך כדי להקליט הודעת קול.",
     "pause": "השהה",
     "resume": "המשך",
-    "newSubSpace": "מרחב משנה חדש",
-    "moveToDifferentSpace": "מעבר למרחב שונה",
-    "removeFromSpaceDescription": "הצ'אט יוסר מהמרחב אך עדיין יופיע ברשימת הצ'אטים שלך.",
     "countChats": "{chats} צ'אטים",
-    "spaceMemberOf": "חבר מרחב של {spaces}",
-    "spaceMemberOfCanKnock": "חבר מרחב של {spaces} יכול לדפוק",
-    "donate": "תרום",
     "startedAPoll": "{username} התחיל סקר.",
     "poll": "סקר",
     "startPoll": "התחל סקר",
@@ -9668,23 +8893,15 @@
     "newStickerPack": "חבילת מדבקות חדשה",
     "stickerPackName": "שם חבילת המדבקות",
     "attribution": "אטריבוציה",
-    "skipChatBackup": "דלג על גיבוי צ'אט",
-    "skipChatBackupWarning": "האם אתה בטוח? ללא הפעלת גיבוי הצ'אט, ייתכן שתאבד גישה להודעות שלך אם תחליף את המכשיר שלך.",
-    "loadingMessages": "טוען הודעות",
-    "setupChatBackup": "הגדר גיבוי צ'אט",
     "noMoreResultsFound": "לא נמצאו תוצאות נוספות",
     "chatSearchedUntil": "הצ'אט חיפש עד {time}",
     "federationBaseUrl": "כתובת URL בסיסית של פדרציה",
     "clientWellKnownInformation": "מידע ידוע על לקוח:",
     "baseUrl": "כתובת URL בסיסית",
     "identityServer": "שרת זהות:",
-    "versionWithNumber": "גרסה: {version}",
     "logs": "יומנים",
-    "advancedConfigs": "הגדרות מתקדמות",
     "advancedConfigurations": "הגדרות מתקדמות",
-    "signInWithLabel": "התחבר עם:",
     "selectAllWords": "בחר את כל המילים שאתה שומע בהקלטה",
-    "joinCourseForActivities": "הצטרף לקורס כדי לנסות פעילויות.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9721,18 +8938,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9740,26 +8945,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9865,22 +9050,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9909,19 +9078,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9929,15 +9086,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10138,11 +9287,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "בכיתה? הכנס את קוד ההצטרפות שלך כאן.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "הדגש אוטומטית הודעות קוליות",
     "selectAudioMessagesOnPlayDescription": "הדגש אוטומטית הודעות קוליות כאשר הן מנוגנות",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10186,18 +9330,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "לקורס זה יש נושאים עם פחות מ-{input} פעילויות. אנא הזן מספר קטן או שווה ל-{minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "לחץ כאן כדי להיכנס שוב.",
     "@clickToLogin": {
@@ -10614,17 +9746,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "דוב צהוב בסגנון קריקטורה עם ידיים מורמות בהתלהבות.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "בחר מילים כדי ללמוד עליהן יותר",
     "requireAnalyticsAccessTitle": "דרוש גישה לניתוחי נתונים כדי להצטרף",
     "requireAnalyticsAccessDesc": "משתתפים חייבים להעניק גישה לניתוחי הלמידה שלהם כדי להצטרף לקורס זה",
     "analyticsAccessNoticeTitle": "דרושה גישה לניתוחי נתונים",
     "analyticsAccessNoticeDesc": "בהצטרפות לקורס זה, אתה מסכים להעניק למנהלים גישה לניתוחי הלמידה שלך.",
-    "skipOnboardingClassCodeDesc": "לומד באופן עצמאי? אל תדאג, אתה יכול:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10642,10 +9768,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10674,7 +9796,6 @@
     "pickCefrLevelTeacherStepTitle": "איזה רמה אתה מלמד?",
     "pickCefrLevelStudentStepTitle": "איזה רמה אתה?",
     "customCourseStepTitle": "מלא את הטופס הזה כדי לקבל קורס מותאם אישית",
-    "aboutYourClass": "על הכיתה שלך",
     "courseCodeStepErrorMessage": "אנא בדוק את הקוד שלך ונסה שוב",
     "institution": "מוסד",
     "courseGoals": "מטרות הקורס",
@@ -10717,10 +9838,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10837,12 +9954,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "לוגו פנגיאה צ'אט",
     "introChatDetails": "תגיד שלום! הצג את עצמך למשתתפי הקורס שלך, מצא חברים וצ'אט מחוץ לפעילויות.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10886,11 +9998,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "פעולות פעילות",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "כלי הגייה",
     "audioTranscription": "תמלול אודיו בעזרת AI",
     "visualLearnerSupport": "תמיכה בלומדים חזותיים",
@@ -10931,7 +10038,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "הצטרף לקורס שכולל את הפעילות הזו כדי לשחק בה.",
     "resizeCoursePanel": "שנה גודל פאנל הקורס",
     "undo": "בטל",
     "unlock": "שחרר",
@@ -10945,7 +10051,6 @@
     "addCourseBrowsePublic": "עיין בקורסים ציבוריים",
     "browsePublicCourses": "עיין בקורסים ציבוריים",
     "editProfile": "ערוך פרופיל",
-    "numObjectives": "{count} מטרות",
     "mapSearchHint": "חפש פעילויות",
     "mapSearchNoResults": "אין תוצאות בתצוגה",
     "mapFilterAllLanguages": "כל השפות",
@@ -10954,7 +10059,6 @@
     "mapFilterCompleted": "הושלם",
     "mapFilterReset": "אפס",
     "activityTypeConversation": "שיחה",
-    "lockedMissionRequirement": "סיים את המשימה הקודמת כדי לפתוח",
     "playAgain": "שחק שוב",
     "reviewActivity": "סקירה",
     "mapEmptyInView": "אין כאן כלום ברמתך או בשפתך. הרחב את המסננים שלך או התקרב.",
@@ -10969,14 +10073,9 @@
     "scrollToBottom": "גלול לתחתית",
     "courseImage": "תמונת קורס",
     "avatarPreview": "תצוגה מקדימה של אווטאר",
-    "activityPhoto": "תמונת פעילות",
     "emotePreview": "תצוגה מקדימה של אמוט: {name}",
     "activityLabel": "פעילות: {title}",
     "resetMapView": "אפס את תצוגת המפה",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11029,14 +10128,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11066,10 +10157,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11126,10 +10213,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_hi.arb
+++ b/lib/l10n/intl_hi.arb
@@ -51,10 +51,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@admin": {
         "type": "String",
         "placeholders": {}
@@ -64,19 +60,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
-    "@addAccount": {},
     "@close": {
         "type": "String",
         "placeholders": {}
@@ -228,10 +211,6 @@
             }
         }
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youAcceptedTheInvitation": {},
     "@banFromChat": {
         "type": "String",
@@ -342,10 +321,6 @@
         "placeholders": {}
     },
     "@tryAgain": {},
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blocked": {
         "type": "String",
         "placeholders": {}
@@ -356,10 +331,6 @@
                 "type": "String"
             }
         }
-    },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "@unbanUserDescription": {},
     "@userAndUserAreTyping": {
@@ -410,9 +381,6 @@
     },
     "@link": {},
     "@widgetUrlError": {},
-    "@emailOrUsername": {},
-    "@newSpaceDescription": {},
-    "@chatDescription": {},
     "@next": {
         "type": "String",
         "placeholders": {}
@@ -433,8 +401,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@enterSpace": {},
-    "@encryptThisChat": {},
     "@fileName": {
         "type": "String",
         "placeholders": {}
@@ -460,7 +426,6 @@
         "placeholders": {}
     },
     "@reopenChat": {},
-    "@pleaseEnterRecoveryKey": {},
     "@create": {
         "type": "String",
         "placeholders": {}
@@ -487,10 +452,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@addWidget": {},
     "@all": {
         "type": "String",
@@ -512,10 +473,6 @@
         }
     },
     "@noKeyForThisMessage": {},
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@inviteText": {
         "type": "String",
         "placeholders": {
@@ -545,11 +502,6 @@
         }
     },
     "@pushNotificationsNotAvailable": {},
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {},
     "@replaceRoomWithNewerVersion": {
         "type": "String",
         "placeholders": {}
@@ -572,10 +524,6 @@
             }
         }
     },
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@cantOpenUri": {
         "type": "String",
         "placeholders": {
@@ -585,7 +533,6 @@
         }
     },
     "@sender": {},
-    "@storeInAndroidKeystore": {},
     "@hideRedactedEvents": {
         "type": "String",
         "placeholders": {}
@@ -646,10 +593,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@passwordHasBeenChanged": {
         "type": "String",
         "placeholders": {}
@@ -670,7 +613,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveKeyManuallyDescription": {},
     "@none": {
         "type": "String",
         "placeholders": {}
@@ -681,14 +623,6 @@
         "placeholders": {}
     },
     "@whyIsThisMessageEncrypted": {},
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "@rejectedTheInvitation": {
         "type": "String",
         "placeholders": {
@@ -706,10 +640,6 @@
             }
         }
     },
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "importFromZipFile": ".zip फ़ाइल से आयात करें",
     "@importFromZipFile": {},
     "@or": {
@@ -718,16 +648,10 @@
     },
     "@dehydrateWarning": {},
     "@noOtherDevicesFound": {},
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@emptyChat": {
         "type": "String",
         "placeholders": {}
     },
-    "@storeSecurlyOnThisDevice": {},
-    "@yourChatBackupHasBeenSetUp": {},
     "@chatBackup": {
         "type": "String",
         "placeholders": {}
@@ -744,7 +668,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {},
     "@unmuteChat": {
         "type": "String",
         "placeholders": {}
@@ -776,14 +699,6 @@
     "@participant": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@yes": {
         "type": "String",
@@ -870,7 +785,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@unlockOldMessages": {},
     "@identity": {
         "type": "String",
         "placeholders": {}
@@ -1049,7 +963,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterRecoveryKeyDescription": {},
     "@guestsAreForbidden": {
         "type": "String",
         "placeholders": {}
@@ -1214,7 +1127,6 @@
         "description": "State that {command} is not a valid /command."
     },
     "@redactMessageDescription": {},
-    "@recoveryKey": {},
     "@redactMessage": {
         "type": "String",
         "placeholders": {}
@@ -1289,10 +1201,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@verifyStart": {
         "type": "String",
         "placeholders": {}
@@ -1311,7 +1219,6 @@
         "placeholders": {}
     },
     "@serverRequiresEmail": {},
-    "@screenSharingTitle": {},
     "@widgetCustom": {},
     "@sentCallInformations": {
         "type": "String",
@@ -1411,7 +1318,6 @@
         "placeholders": {}
     },
     "@messageInfo": {},
-    "@disableEncryptionWarning": {},
     "@directChat": {},
     "@encryptionNotEnabled": {
         "type": "String",
@@ -1435,21 +1341,15 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {},
     "@enterAnEmailAddress": {
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {},
     "@commandHint_kick": {
         "type": "String",
         "description": "Usage hint for the command /kick"
     },
     "@copiedToClipboard": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1497,10 +1397,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@confirmMatrixId": {},
     "@learnMore": {},
     "@iHaveClickedOnLink": {
@@ -1522,7 +1418,6 @@
     },
     "@newGroup": {},
     "@bundleName": {},
-    "@removeFromSpace": {},
     "@dateAndTimeOfDay": {
         "type": "String",
         "placeholders": {
@@ -1568,10 +1463,6 @@
         "placeholders": {}
     },
     "@pleaseEnterANumber": {},
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youKicked": {
         "placeholders": {
             "user": {
@@ -1618,22 +1509,12 @@
             }
         }
     },
-    "@sorryThatsNotPossible": {},
     "@oopsSomethingWentWrong": {
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@shareInviteLink": {},
     "@commandHint_markasdm": {},
-    "@recoveryKeyLost": {},
     "@cuddleContent": {
         "type": "String",
         "placeholders": {
@@ -1660,14 +1541,6 @@
     },
     "@deviceKeys": {},
     "@waitingPartnerNumbers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -1699,15 +1572,10 @@
         "type": "String",
         "placeholders": {}
     },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@settings": {
         "type": "String",
         "placeholders": {}
     },
-    "@setTheme": {},
     "@changeTheHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -1728,10 +1596,6 @@
                 "type": "String"
             }
         }
-    },
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
     },
     "@changeDeviceName": {
         "type": "String",
@@ -1884,7 +1748,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@storeInSecureStorageDescription": {},
     "@openChat": {},
     "@kickUserDescription": {},
     "@sendAMessage": {
@@ -1902,13 +1765,11 @@
         "placeholders": {}
     },
     "@pinMessage": {},
-    "@screenSharingDetail": {},
     "@muteChat": {
         "type": "String",
         "placeholders": {}
     },
     "@invite": {},
-    "@enableMultiAccounts": {},
     "@anyoneCanJoin": {
         "type": "String",
         "placeholders": {}
@@ -1957,7 +1818,6 @@
     "appLock": "एप्लिकेशन लॉक",
     "appLockDescription": "पिन कोड के साथ उपयोग न करने पर एप्लिकेशन को लॉक करें",
     "archive": "आर्काइव",
-    "areGuestsAllowedToJoin": "क्या अतिथि उपयोगकर्ताओं को शामिल होने की अनुमति है",
     "areYouSure": "क्या आप सुनिश्चित हैं?",
     "areYouSureYouWantToLogout": "क्या आप सुनिश्चित हैं कि आप लॉग आउट करना चाहते हैं?",
     "askSSSSSign": "दूसरे व्यक्ति पर हस्ताक्षर करने में सक्षम होने के लिए, कृपया अपना सुरक्षित स्टोर पासफ़्रेज़ या रिकवरी कुंजी दर्ज करें।",
@@ -2002,9 +1862,7 @@
     "changeYourAvatar": "अपना अवतार बदलें",
     "channelCorruptedDecryptError": "एन्क्रिप्शन करप्ट हो गया है",
     "chat": "चैट",
-    "yourChatBackupHasBeenSetUp": "आपका चैट बैकअप सेटअप हो चुका है।",
     "chatBackup": "चैट बैकअप",
-    "chatBackupDescription": "आपके पुराने संदेशों को एक रिकवरी की के साथ सुरक्षित किया गया है। कृपया सुनिश्चित करें कि आप इसे न खोएं।",
     "chatDetails": "चैट विवरण",
     "chats": "चैट्स",
     "chooseAStrongPassword": "एक मजबूत पासवर्ड चुनें",
@@ -2037,7 +1895,6 @@
     "configureChat": "चैट कॉन्फ़िगर करें",
     "confirm": "पुष्टि करें",
     "connect": "कनेक्ट करें",
-    "contactHasBeenInvitedToTheGroup": "संपर्क को समूह में आमंत्रित किया गया है",
     "contentHasBeenReported": "सामग्री को सर्वर व्यवस्थापकों को रिपोर्ट किया गया है",
     "copiedToClipboard": "क्लिपबोर्ड पर कॉपी किया गया",
     "copy": "कॉपी करें",
@@ -2045,11 +1902,9 @@
     "couldNotDecryptMessage": "संदेश डिक्रिप्ट नहीं किया जा सका: {error}",
     "checkList": "चेकलिस्ट",
     "countParticipants": "{count} प्रतिभागी",
-    "countInvited": "{count} आमंत्रित",
     "create": "बनाएँ",
     "createdTheChat": "💬 {username} ने चैट बनाई",
     "createGroup": "समूह बनाएं",
-    "createNewSpace": "नई जगह",
     "currentlyActive": "वर्तमान में सक्रिय",
     "darkTheme": "गहरा",
     "dateAndTimeOfDay": "{date}, {timeOfDay}",
@@ -2075,9 +1930,6 @@
     "emoteKeyboardNoRecents": "हाल ही में उपयोग किए गए इमोट यहाँ दिखाई देंगे...",
     "emotePacks": "कक्ष के लिए इमोट पैक",
     "emoteSettings": "इमोट सेटिंग्स",
-    "globalChatId": "वैश्विक चैट आईडी",
-    "accessAndVisibility": "पहुँच और दृश्यता",
-    "accessAndVisibilityDescription": "कौन इस चैट में शामिल होने की अनुमति है और चैट को कैसे खोजा जा सकता है।",
     "calls": "कॉल",
     "customEmojisAndStickers": "कस्टम इमोजी और स्टिकर",
     "customEmojisAndStickersBody": "ऐसे कस्टम इमोजी या स्टिकर जोड़ें या साझा करें जिन्हें किसी भी चैट में इस्तेमाल किया जा सकता है।",
@@ -2085,7 +1937,6 @@
     "emptyChat": "खाली चैट",
     "enableEmotesGlobally": "ग्लोबली इमोट पैक सक्षम करें",
     "enableEncryption": "एन्क्रिप्शन सक्षम करें",
-    "enableEncryptionWarning": "आप अब एन्क्रिप्शन को अक्षम नहीं कर पाएंगे। क्या आप सुनिश्चित हैं?",
     "encrypted": "एन्क्रिप्टेड",
     "encryption": "एन्क्रिप्शन",
     "encryptionNotEnabled": "एन्क्रिप्शन सक्षम नहीं है",
@@ -2093,7 +1944,6 @@
     "enterAnEmailAddress": "एक ईमेल पता दर्ज करें",
     "homeserver": "होमसर्वर",
     "errorObtainingLocation": "स्थान प्राप्त करने में त्रुटि: {error}",
-    "everythingReady": "सब कुछ तैयार है!",
     "extremeOffensive": "अत्यंत अपमानजनक",
     "fileName": "फ़ाइल का नाम",
     "fluffychat": "फ्लफीचैट",
@@ -2102,9 +1952,7 @@
     "fromJoining": "शामिल होने से",
     "fromTheInvitation": "आमंत्रण से",
     "group": "समूह",
-    "chatDescription": "चैट विवरण",
     "chatDescriptionHasBeenChanged": "चैट विवरण बदल दिया गया है",
-    "groupIsPublic": "समूह सार्वजनिक है",
     "groups": "समूह",
     "groupWith": "{displayname} के साथ समूह",
     "guestsAreForbidden": "अतिथि मना है",
@@ -2126,7 +1974,6 @@
     "incorrectPassphraseOrKey": "गलत पासफ़्रेज़ या रिकवरी कुंजी",
     "inoffensive": "अप्रभावशाली",
     "inviteContact": "संपर्क को आमंत्रित करें",
-    "inviteContactToGroup": "संपर्क को {groupName} में आमंत्रित करें",
     "noChatDescriptionYet": "अभी तक कोई चैट विवरण नहीं बनाया गया है।",
     "tryAgain": "फिर से प्रयास करें",
     "invalidServerName": "अमान्य सर्वर नाम",
@@ -2147,7 +1994,6 @@
     "leave": "छोड़ें",
     "leftTheChat": "चैट छोड़ दिया",
     "lightTheme": "प्रकाश",
-    "loadCountMoreParticipants": "{count} अधिक प्रतिभागियों को लोड करें",
     "dehydrate": "सत्र निर्यात करें और डिवाइस को साफ़ करें",
     "dehydrateWarning": "यह क्रिया पूर्ववत नहीं की जा सकती। सुनिश्चित करें कि आप बैकअप फ़ाइल को सुरक्षित रूप से संग्रहित करें।",
     "hydrate": "बैकअप फ़ाइल से पुनर्स्थापित करें",
@@ -2156,7 +2002,6 @@
     "locationDisabledNotice": "स्थान सेवाएँ अक्षम हैं। कृपया उन्हें सक्षम करें ताकि आप अपना स्थान साझा कर सकें।",
     "locationPermissionDeniedNotice": "स्थान अनुमति अस्वीकृत। कृपया उन्हें अनुमति दें ताकि आप अपना स्थान साझा कर सकें।",
     "login": "लॉगिन",
-    "logInTo": "{homeserver} में लॉग इन करें",
     "logout": "लॉगआउट",
     "mention": "उल्लेख",
     "messages": "संदेश",
@@ -2171,8 +2016,6 @@
     "no": "नहीं",
     "noConnectionToTheServer": "सर्वर से कनेक्शन नहीं",
     "noEmotesFound": "कोई इमोट नहीं मिला। 😕",
-    "noEncryptionForPublicRooms": "आप केवल तभी एन्क्रिप्शन सक्रिय कर सकते हैं जब कमरा अब सार्वजनिक रूप से उपलब्ध न हो।",
-    "noGoogleServicesWarning": "Firebase क्लाउड मैसेजिंग आपके डिवाइस पर उपलब्ध नहीं लगती। पुश सूचनाएं प्राप्त करने के लिए, हम ntfy इंस्टॉल करने की सलाह देते हैं। ntfy या किसी अन्य यूनिफाइड पुश प्रदाता के साथ आप डेटा सुरक्षित तरीके से पुश सूचनाएं प्राप्त कर सकते हैं। आप ntfy को PlayStore या F-Droid से डाउनलोड कर सकते हैं।",
     "noMatrixServer": "{server1} कोई मैट्रिक्स सर्वर नहीं है, क्या आप {server2} का उपयोग करना चाहेंगे?",
     "shareInviteLink": "आमंत्रण लिंक साझा करें",
     "scanQrCode": "QR कोड स्कैन करें",
@@ -2194,12 +2037,10 @@
     "openCamera": "कैमरा खोलें",
     "openVideoCamera": "वीडियो के लिए कैमरा खोलें",
     "oneClientLoggedOut": "आपके एक क्लाइंट को लॉग आउट कर दिया गया है",
-    "addAccount": "खाता जोड़ें",
     "editBundlesForAccount": "इस खाते के लिए बंडल संपादित करें",
     "addToBundle": "बंडल में जोड़ें",
     "removeFromBundle": "इस बंडल से हटाएँ",
     "bundleName": "बंडल का नाम",
-    "enableMultiAccounts": "(बीटा) इस डिवाइस पर मल्टी अकाउंट्स सक्षम करें",
     "openInMaps": "मानचित्र में खोलें",
     "link": "लिंक",
     "serverRequiresEmail": "इस सर्वर को पंजीकरण के लिए आपका ईमेल पता सत्यापित करने की आवश्यकता है।",
@@ -2211,7 +2052,6 @@
     "passwordHasBeenChanged": "पासवर्ड बदल दिया गया है",
     "overview": "समीक्षा",
     "passwordRecoverySettings": "पासवर्ड रिकवरी सेटिंग्स",
-    "passwordRecovery": "पासवर्ड रिकवरी",
     "people": "लोग",
     "pickImage": "एक छवि चुनें",
     "pin": "पिन",
@@ -2220,7 +2060,6 @@
     "pleaseChooseAPasscode": "कृपया एक पासकोड चुनें",
     "pleaseClickOnLink": "कृपया ईमेल में लिंक पर क्लिक करें और फिर आगे बढ़ें।",
     "pleaseEnter4Digits": "कृपया 4 अंक दर्ज करें या ऐप लॉक को अक्षम करने के लिए खाली छोड़ें।",
-    "pleaseEnterRecoveryKey": "कृपया अपनी रिकवरी की दर्ज करें:",
     "pleaseEnterYourPassword": "कृपया अपना पासवर्ड दर्ज करें",
     "pleaseEnterYourPin": "कृपया अपना पिन दर्ज करें",
     "pleaseEnterYourUsername": "कृपया अपना उपयोगकर्ता नाम दर्ज करें",
@@ -2240,7 +2079,6 @@
     "rejectedTheInvitation": "{username} ने निमंत्रण अस्वीकार कर दिया",
     "removeAllOtherDevices": "सभी अन्य उपकरणों को हटा दें",
     "removedBy": "{username} द्वारा हटाया गया",
-    "removeDevice": "डिवाइस हटाएँ",
     "unbanFromChat": "चैट से अनबैन करें",
     "removeYourAvatar": "अपना अवतार हटाएँ",
     "replaceRoomWithNewerVersion": "कक्ष को नए संस्करण के साथ बदलें",
@@ -2252,8 +2090,6 @@
     "saveFile": "फ़ाइल सहेजें",
     "search": "खोजें",
     "security": "सुरक्षा",
-    "recoveryKey": "रिकवरी कुंजी",
-    "recoveryKeyLost": "रिकवरी कुंजी खो गई?",
     "send": "भेजें",
     "sendAMessage": "एक संदेश भेजें",
     "sendAsText": "पाठ के रूप में भेजें",
@@ -2272,7 +2108,6 @@
     "separateChatTypes": "प्रत्यक्ष चैट और समूह अलग करें",
     "setAsCanonicalAlias": "मुख्य उपनाम के रूप में सेट करें",
     "setChatDescription": "चैट विवरण सेट करें",
-    "setPermissionsLevel": "अधिकार स्तर सेट करें",
     "setStatus": "स्थिति सेट करें",
     "settings": "सेटिंग्स",
     "share": "साझा करें",
@@ -2282,8 +2117,6 @@
     "presencesToggle": "अन्य उपयोगकर्ताओं से स्थिति संदेश दिखाएँ",
     "skip": "छोड़ें",
     "sourceCode": "स्रोत कोड",
-    "spaceIsPublic": "स्थान सार्वजनिक है",
-    "spaceName": "स्थान का नाम",
     "startedACall": "{senderName} ने कॉल शुरू की",
     "status": "स्थिति",
     "statusExampleMessage": "आज आप कैसे हैं?",
@@ -2295,7 +2128,6 @@
     "theyMatch": "वे मेल खाते हैं",
     "title": "फ्लफीचैट",
     "tooManyRequestsWarning": "बहुत अधिक अनुरोध। कृपया बाद में पुनः प्रयास करें!",
-    "transferFromAnotherDevice": "किसी अन्य डिवाइस से स्थानांतरण करें",
     "tryToSendAgain": "फिर से भेजने का प्रयास करें",
     "unavailable": "उपलब्ध नहीं",
     "unbannedUser": "{username} ने {targetName} को अनबैन किया",
@@ -2305,7 +2137,6 @@
     "unknownEvent": "अज्ञात घटना '{type}'",
     "unmuteChat": "चैट अनम्यूट करें",
     "unpin": "अनपिन करें",
-    "unreadChats": "{unreadCount, plural, =1{1 अपठित चैट} other{{unreadCount} अपठित चैट्स}}",
     "userAndOthersAreTyping": "{username} और {count} अन्य टाइप कर रहे हैं…",
     "userAndUserAreTyping": "{username} और {username2} टाइप कर रहे हैं…",
     "userIsTyping": "{username} टाइप कर रहे हैं…",
@@ -2318,8 +2149,6 @@
     "verifyStart": "सत्यापन शुरू करें",
     "verifySuccess": "आपने सफलतापूर्वक सत्यापित किया!",
     "verifyTitle": "अन्य खाते का सत्यापन कर रहे हैं",
-    "videoCall": "वीडियो कॉल",
-    "visibilityOfTheChatHistory": "चैट इतिहास की दृश्यता",
     "visibleForAllParticipants": "सभी प्रतिभागियों के लिए दृश्य",
     "visibleForEveryone": "सभी के लिए दृश्य",
     "voiceMessage": "आवाज संदेश",
@@ -2329,10 +2158,7 @@
     "wallpaper": "वॉलपेपर:",
     "warning": "चेतावनी!",
     "weSentYouAnEmail": "हमने आपको एक ईमेल भेजा है",
-    "whoCanPerformWhichAction": "कौन कौन सा कार्य कर सकता है",
-    "whoIsAllowedToJoinThisGroup": "इस समूह में कौन शामिल हो सकता है",
     "whyDoYouWantToReportThis": "आप इसे रिपोर्ट क्यों करना चाहते हैं?",
-    "wipeChatBackup": "क्या आप अपने चैट बैकअप को मिटाकर एक नई रिकवरी कुंजी बनाना चाहते हैं?",
     "withTheseAddressesRecoveryDescription": "इन पतों के साथ आप अपना पासवर्ड पुनः प्राप्त कर सकते हैं।",
     "writeAMessage": "एक संदेश लिखें…",
     "yes": "हाँ",
@@ -2345,9 +2171,7 @@
     "messageType": "संदेश प्रकार",
     "sender": "प्रेषक",
     "openGallery": "गैलरी खोलें",
-    "removeFromSpace": "स्थान से हटाएँ",
     "start": "शुरू करें",
-    "pleaseEnterRecoveryKeyDescription": "अपनी पुरानी संदेशों को अनलॉक करने के लिए, कृपया अपनी रिकवरी कुंजी दर्ज करें जो पिछले सत्र में जेनरेट की गई है। आपकी रिकवरी कुंजी आपका पासवर्ड नहीं है।",
     "publish": "प्रकाशित करें",
     "openChat": "चैट खोलें",
     "markAsRead": "पढ़े गए के रूप में चिह्नित करें",
@@ -2358,12 +2182,9 @@
     "confirmEventUnpin": "क्या आप सुनिश्चित हैं कि आप स्थायी रूप से ईवेंट को अनपिन करना चाहते हैं?",
     "emojis": "इमोजी",
     "placeCall": "कॉल करें",
-    "voiceCall": "वॉयस कॉल",
     "unsupportedAndroidVersion": "असमर्थित Android संस्करण",
     "unsupportedAndroidVersionLong": "इस सुविधा के लिए एक नए Android संस्करण की आवश्यकता है। कृपया अपडेट या Lineage OS समर्थन के लिए जांचें।",
-    "videoCallsBetaWarning": "कृपया ध्यान दें कि वीडियो कॉल वर्तमान में बीटा में हैं। ये अपेक्षा के अनुसार काम नहीं कर सकते हैं या सभी प्लेटफार्मों पर बिल्कुल भी काम नहीं कर सकते हैं।",
     "experimentalVideoCalls": "प्रयोगात्मक वीडियो कॉल",
-    "emailOrUsername": "ईमेल या उपयोगकर्ता नाम",
     "addWidget": "विजेट जोड़ें",
     "widgetVideo": "वीडियो",
     "widgetEtherpad": "पाठ नोट",
@@ -2385,35 +2206,19 @@
     "youKickedAndBanned": "🙅 आप {user} को बाहर किया और प्रतिबंधित किया",
     "youUnbannedUser": "आपने {user} को अनबैन किया",
     "hasKnocked": "🚪 {user} ने दस्तक दी है",
-    "usersMustKnock": "उपयोगकर्ताओं को दस्तक देनी चाहिए",
-    "noOneCanJoin": "कोई भी शामिल नहीं हो सकता",
     "knock": "दस्तक",
     "users": "उपयोगकर्ता",
-    "unlockOldMessages": "पुराने संदेश अनलॉक करें",
-    "storeInSecureStorageDescription": "इस डिवाइस के सुरक्षित भंडारण में रिकवरी कुंजी सहेजें।",
-    "saveKeyManuallyDescription": "सिस्टम शेयर डायलॉग या क्लिपबोर्ड को ट्रिगर करके इस कुंजी को मैनुअल रूप से सहेजें।",
-    "storeInAndroidKeystore": "एंड्रॉइड कीस्टोर में सहेजें",
-    "storeInAppleKeyChain": "एप्पल की चेन में सहेजें",
-    "storeSecurlyOnThisDevice": "इस डिवाइस पर सुरक्षित रूप से सहेजें",
     "countFiles": "{count} फ़ाइलें",
     "user": "उपयोगकर्ता",
     "custom": "कस्टम",
-    "foregroundServiceRunning": "यह नोटिफिकेशन तब दिखाई देता है जब फोरग्राउंड सेवा चल रही हो।",
-    "screenSharingTitle": "स्क्रीन शेयरिंग",
-    "screenSharingDetail": "आप FuffyChat में अपनी स्क्रीन साझा कर रहे हैं",
     "whyIsThisMessageEncrypted": "यह संदेश पढ़ने में असमर्थ क्यों है?",
     "noKeyForThisMessage": "यह तब हो सकता है जब संदेश भेजा गया हो इससे पहले कि आपने इस डिवाइस पर अपने खाते में साइन इन किया हो।\n\nयह भी संभव है कि भेजने वाले ने आपके डिवाइस को ब्लॉक कर दिया हो या इंटरनेट कनेक्शन में कुछ गलत हो गया हो।\n\nक्या आप दूसरे सत्र में संदेश पढ़ सकते हैं? फिर आप इसे उससे ट्रांसफर कर सकते हैं! सेटिंग्स > डिवाइसेस पर जाएं और सुनिश्चित करें कि आपके डिवाइसेस ने एक-दूसरे को सत्यापित किया है। जब आप अगली बार कमरे को खोलेंगे और दोनों सत्र अग्रभूमि में होंगे, तो कुंजी स्वचालित रूप से ट्रांसमिट हो जाएगी।\n\nक्या आप लॉगआउट या डिवाइस स्विच करने पर कुंजी खोना नहीं चाहते हैं? सुनिश्चित करें कि आपने सेटिंग्स में चैट बैकअप सक्षम किया है।",
     "newGroup": "नई समूह",
     "newSpace": "नई जगह",
-    "enterSpace": "स्थान में प्रवेश करें",
     "allSpaces": "सभी स्थान",
     "hidePresences": "स्थिति सूची छुपाएं?",
     "doNotShowAgain": "फिर से न दिखाएं",
     "wasDirectChatDisplayName": "खाली चैट (था {oldDisplayName})",
-    "newSpaceDescription": "स्पेस आपको अपने चैट को समेकित करने और निजी या सार्वजनिक समुदाय बनाने की अनुमति देता है।",
-    "encryptThisChat": "इस चैट को एन्क्रिप्ट करें",
-    "disableEncryptionWarning": "सुरक्षा कारणों से आप उस चैट में एन्क्रिप्शन को अक्षम नहीं कर सकते, जिसमें इसे पहले सक्षम किया गया हो।",
-    "sorryThatsNotPossible": "माफ़ कीजिए... यह संभव नहीं है",
     "deviceKeys": "डिवाइस कुंजी:",
     "reopenChat": "चैट फिर से खोलें",
     "noBackupWarning": "चेतावनी! चैट बैकअप को सक्षम किए बिना, आप अपने एन्क्रिप्टेड संदेशों तक पहुंच खो देंगे। लॉग आउट करने से पहले चैट बैकअप को सक्षम करना अत्यंत अनुशंसित है।",
@@ -2426,7 +2231,6 @@
     "openLinkInBrowser": "ब्राउज़र में लिंक खोलें",
     "reportErrorDescription": "😢 ओह नहीं। कुछ गलत हो गया है। यदि आप चाहें तो आप इस बग की रिपोर्ट डेवलपर्स को कर सकते हैं।",
     "report": "रिपोर्ट करें",
-    "setTheme": "थीम सेट करें:",
     "setColorTheme": "रंग थीम सेट करें:",
     "invite": "आमंत्रित करें",
     "inviteGroupChat": "ग्रुप चैट आमंत्रित करें",
@@ -2445,12 +2249,8 @@
     "yourGlobalUserIdIs": "आपका वैश्विक उपयोगकर्ता-आईडी है: ",
     "noUsersFoundWithQuery": "दुर्भाग्यवश \"{query}\" के साथ कोई उपयोगकर्ता नहीं मिला। कृपया जांचें कि आपने टाइपो तो नहीं किया है।",
     "knocking": " knocking",
-    "chatCanBeDiscoveredViaSearchOnServer": "चैट को {server} पर खोज के माध्यम से खोजा जा सकता है",
-    "searchChatsRooms": "#चैट्स, @उपयोगकर्ताओं के लिए खोजें...",
     "nothingFound": "कुछ नहीं मिला...",
     "groupName": "समूह का नाम",
-    "createGroupAndInviteUsers": "एक समूह बनाएं और उपयोगकर्ताओं को आमंत्रित करें",
-    "groupCanBeFoundViaSearch": "खोज के माध्यम से समूह पाया जा सकता है",
     "wrongRecoveryKey": "माफ़ कीजिए... यह सही रिकवरी कुंजी नहीं लगती।",
     "startConversation": "संवाद शुरू करें",
     "commandHint_sendraw": "कच्चा JSON भेजें",
@@ -2464,11 +2264,8 @@
     "pleaseChooseAStrongPassword": "कृपया एक मजबूत पासवर्ड चुनें",
     "passwordsDoNotMatch": "पासवर्ड मेल नहीं खाते",
     "passwordIsWrong": "आपका दर्ज किया गया पासवर्ड गलत है",
-    "publicChatAddresses": "सार्वजनिक चैट पते",
-    "createNewAddress": "नई पता बनाएं",
     "joinSpace": "स्थान में शामिल हों",
     "publicSpaces": "सार्वजनिक स्थान",
-    "addChatOrSubSpace": "चैट या उप-स्थान जोड़ें",
     "subspace": "उप-स्थान",
     "decline": "अस्वीकार करें",
     "thisDevice": "यह उपकरण:",
@@ -2477,15 +2274,11 @@
     "searchMore": "और खोजें...",
     "gallery": "गैलरी",
     "files": "फ़ाइलें",
-    "sessionLostBody": "आपका सत्र खो गया है। कृपया इस त्रुटि की रिपोर्ट डेवलपर्स को {url} पर करें। त्रुटि संदेश है: {error}",
-    "restoreSessionBody": "अब ऐप आपके बैकअप से आपका सत्र पुनः स्थापित करने का प्रयास कर रहा है। कृपया इस त्रुटि की रिपोर्ट डेवलपर्स को {url} पर करें। त्रुटि संदेश है: {error}",
     "sendReadReceipts": "पढ़ने की रसीदें भेजें",
     "sendTypingNotificationsDescription": "अन्य प्रतिभागी देख सकते हैं कि आप नई संदेश टाइप कर रहे हैं।",
     "sendReadReceiptsDescription": "अन्य प्रतिभागी देख सकते हैं कि आपने संदेश पढ़ा है।",
     "formattedMessages": "संकुचित संदेश",
     "formattedMessagesDescription": "मर्कडाउन का उपयोग करके बोल्ड टेक्स्ट जैसी समृद्ध संदेश सामग्री दिखाएँ।",
-    "verifyOtherUser": "🔐 अन्य उपयोगकर्ता को सत्यापित करें",
-    "verifyOtherUserDescription": "यदि आप किसी अन्य उपयोगकर्ता को सत्यापित करते हैं, तो आप सुनिश्चित कर सकते हैं कि आप वास्तव में किसके साथ लिख रहे हैं। 💪\n\nजब आप सत्यापन शुरू करते हैं, तो आप और दूसरा उपयोगकर्ता ऐप में एक पॉपअप देखेंगे। वहाँ आप एक श्रृंखला इमोजी या संख्याएँ देखेंगे जिन्हें आपको एक-दूसरे के साथ तुलना करनी होगी।\n\nइसे करने का सबसे अच्छा तरीका मिलना या वीडियो कॉल शुरू करना है। 👩‍💻",
     "verifyOtherDevice": "🔐 अन्य डिवाइस को सत्यापित करें",
     "verifyOtherDeviceDescription": "जब आप किसी अन्य डिवाइस को सत्यापित करते हैं, तो वे डिवाइस कुंजी का आदान-प्रदान कर सकते हैं, जिससे आपकी समग्र सुरक्षा बढ़ती है। 💪 जब आप सत्यापन शुरू करते हैं, तो दोनों डिवाइस पर ऐप में एक पॉपअप दिखाई देगा। वहाँ आप एक श्रृंखला इमोजी या संख्याएँ देखेंगे जिन्हें आपको तुलना करनी होगी। सत्यापन शुरू करने से पहले दोनों डिवाइस को पास में रखना सबसे अच्छा है। 🤳",
     "acceptedKeyVerification": "{sender} ने कुंजी सत्यापन स्वीकार किया",
@@ -2521,10 +2314,6 @@
     "updateInstalled": "🎉 {version} अपडेट स्थापित!",
     "changelog": "परिवर्तन सूची",
     "sendCanceled": "भेजना रद्द कर दिया गया",
-    "loginWithMatrixId": "Matrix-ID के साथ लॉगिन करें",
-    "discoverHomeservers": "होमसर्वर खोजें",
-    "whatIsAHomeserver": "होमसर्वर क्या है?",
-    "homeserverDescription": "आपका सारा डेटा होमसर्वर पर संग्रहित होता है, जैसे एक ईमेल प्रदाता। आप चुन सकते हैं कि आप कौन सा होमसर्वर उपयोग करना चाहते हैं, जबकि आप अभी भी सभी के साथ संवाद कर सकते हैं। अधिक जानने के लिए https://matrix.org पर जाएं।",
     "doesNotSeemToBeAValidHomeserver": "यह एक उपयुक्त होमसर्वर प्रतीत नहीं होता। क्या URL गलत है?",
     "calculatingFileSize": "फ़ाइल का आकार गणना कर रहा है...",
     "prepareSendingAttachment": "संलग्नक भेजने की तैयारी कर रहा है...",
@@ -2536,11 +2325,9 @@
     "oneOfYourDevicesIsNotVerified": "आपके एक उपकरण का सत्यापन नहीं हुआ है",
     "noticeChatBackupDeviceVerification": "ध्यान दें: जब आप अपने सभी उपकरणों को चैट बैकअप से जोड़ते हैं, तो वे स्वचालित रूप से सत्यापित हो जाते हैं।",
     "continueText": "जारी रखें",
-    "welcomeText": "अरे अरे 👋 यह फ्लफीचैट है। आप किसी भी होमसर्वर में साइन इन कर सकते हैं, जो https://matrix.org के साथ संगत है। और फिर किसी के साथ भी चैट करें। यह एक विशाल विकेंद्रीकृत संदेश नेटवर्क है!",
     "blur": "धुंधलापन:",
     "opacity": "अस्पष्टता:",
     "setWallpaper": "वॉलपेपर सेट करें",
-    "manageAccount": "खाता प्रबंधित करें",
     "noContactInformationProvided": "सर्वर कोई मान्य संपर्क जानकारी प्रदान नहीं करता है",
     "contactServerAdmin": "सर्वर व्यवस्थापक से संपर्क करें",
     "contactServerSecurity": "सर्वर सुरक्षा से संपर्क करें",
@@ -2559,11 +2346,8 @@
     "unableToJoinChat": "चैट में शामिल नहीं हो सकता। हो सकता है कि दूसरी पार्टी ने पहले ही बातचीत बंद कर दी हो।",
     "previous": "पिछला",
     "otherPartyNotLoggedIn": "दूसरी पार्टी वर्तमान में लॉग इन नहीं है और इसलिए संदेश प्राप्त नहीं कर सकती!",
-    "appWantsToUseForLogin": "'{server}' का उपयोग लॉगिन के लिए करें",
-    "appWantsToUseForLoginDescription": "आप यहाँ अनुमति देते हैं कि ऐप और वेबसाइट आपके बारे में जानकारी साझा करें।",
     "open": "खुला",
     "waitingForServer": "सर्वर का इंतजार कर रहा है...",
-    "appIntroduction": "फ्लफीचैट आपको विभिन्न मैसेंजरों के साथ अपने दोस्तों के साथ चैट करने की अनुमति देता है। अधिक जानने के लिए https://matrix.org पर जाएं या बस *जारी रखें* टैप करें।",
     "newChatRequest": "📩 नई चैट अनुरोध",
     "contentNotificationSettings": "सामग्री सूचनाएँ सेटिंग्स",
     "generalNotificationSettings": "सामान्य सूचनाएँ सेटिंग्स",
@@ -2640,11 +2424,9 @@
     "taTooltip": "अनुवाद सहायता के साथ L2 का उपयोग करें",
     "interactiveTranslatorSliderHeader": "इंटरैक्टिव अनुवादक",
     "interactiveGrammarSliderHeader": "इंटरैक्टिव व्याकरण जांचक",
-    "interactiveTranslatorRequired": "आवश्यक",
     "waTooltip": "बिना सहायता के L2 उपयोग",
     "interactiveTranslator": "अनुवाद सहायता",
     "noIdenticalLanguages": "कृपया अलग आधार और लक्ष्य भाषाएँ चुनें",
-    "searchBy": "देश और भाषाओं द्वारा खोजें",
     "joinWithClassCode": "कोर्स में शामिल हों",
     "languageLevelPreA1": "नवीनतम निम्न (पूर्व A1)",
     "languageLevelA1": "नवोदित मध्य (A1)",
@@ -2665,19 +2447,14 @@
     "saveChanges": "परिवर्तनों को सहेजें",
     "publicProfileTitle": "मेरी प्रोफ़ाइल को खोज में पाया जा सके",
     "publicProfileDesc": "ऑन करने पर, आप अन्य उपयोगकर्ताओं को अपने प्रोफ़ाइल को ग्लोबल सर्च बार में खोजने और चैट के लिए अनुरोध भेजने में सक्षम बनाते हैं। इस बिंदु पर, आप अनुरोध को स्वीकार करने या अस्वीकार करने का विकल्प चुन सकते हैं।",
-    "errorDisableIT": "अनुवाद सहायता बंद कर दी गई है।",
-    "errorDisableIGC": "व्याकरण सहायता बंद कर दी गई है।",
     "errorDisableITUserDesc": "अनुवाद सहायता सेटिंग्स अपडेट करने के लिए यहां क्लिक करें",
     "errorDisableIGCUserDesc": "व्याकरण सहायता सेटिंग्स अपडेट करने के लिए यहां क्लिक करें",
     "errorDisableITClassDesc": "इस चैट के कक्षा के लिए अनुवाद सहायता बंद कर दी गई है।",
     "errorDisableIGCClassDesc": "इस चैट के कक्षा के लिए व्याकरण सहायता बंद कर दी गई है।",
-    "error405Title": "भाषाएँ सेट नहीं हैं",
     "error405Desc": "कृपया अपने भाषाओं को मेनू > सीखने की सेटिंग्स में सेट करें।",
     "termsAndConditions": "शर्तें और नियम",
     "andCertifyIAmAtLeast13YearsOfAge": " और प्रमाणित करता हूँ कि मेरी उम्र कम से कम 16 वर्ष है।",
-    "error502504Title": "वाह, बहुत सारे छात्र ऑनलाइन हैं!",
     "error502504Desc": "जब तक पांगेआ बॉट्स अपडेट नहीं हो जाते, तब तक अनुवाद और व्याकरण उपकरण धीमे या अनुपलब्ध हो सकते हैं।",
-    "error404Title": "अनुवाद त्रुटि!",
     "error404Desc": "पांगेआ बॉट को यह अनुवाद करने का तरीका नहीं पता...",
     "errorPleaseRefresh": "हम इसे देख रहे हैं! कृपया पुनः लोड करें और फिर से प्रयास करें।",
     "connectedToStaging": "स्टेजिंग से जुड़ा हुआ",
@@ -2715,13 +2492,9 @@
     "definitionsToolName": "शब्द परिभाषाएँ",
     "definitionsToolDescription": "जब सक्षम किया जाता है, तो नीले रंग में रेखांकित शब्दों पर क्लिक करके परिभाषाएँ देखी जा सकती हैं। परिभाषाएँ देखने के लिए संदेश पर क्लिक करें।",
     "welcomeBack": "वापस स्वागत है! यदि आप 2023-2024 पायलट का हिस्सा थे, तो कृपया अपनी विशेष पायलट सदस्यता के लिए हमसे संपर्क करें। यदि आप एक शिक्षक हैं जिन्होंने (या जिनके संस्थान ने) अपनी कक्षा के लिए लाइसेंस खरीदे हैं, तो कृपया अपनी शिक्षक सदस्यता के लिए हमसे संपर्क करें।",
-    "downloadTxtFile": "टेक्स्ट फ़ाइल डाउनलोड करें",
-    "downloadCSVFile": "CSV फ़ाइल डाउनलोड करें",
     "promotionalSubscriptionDesc": "आपके पास वर्तमान में एक जीवनकाल प्रचार सदस्यता है। अपनी सदस्यता बदलने में मदद के लिए support@pangea.chat पर संदेश भेजें।",
     "originalSubscriptionPlatform": "खरीदी गई सदस्यता {purchasePlatform} के माध्यम से",
     "oneWeekTrial": "एक सप्ताह का परीक्षण",
-    "downloadXLSXFile": "एक्सेल फ़ाइल डाउनलोड करें",
-    "unkDisplayName": "अज्ञात",
     "wwCountryDisplayName": "विश्वव्यापी",
     "afCountryDisplayName": "अफगानिस्तान",
     "axCountryDisplayName": "आलैंड द्वीपसमूह",
@@ -3016,7 +2789,6 @@
     "chatCapacityHasBeenChanged": "चैट क्षमता बदल गई है",
     "chatCapacitySetTooLow": "चैट क्षमता कम से कम {count} होनी चाहिए।",
     "chatCapacityExplanation": "चैट क्षमता उस सदस्यों की संख्या को सीमित करती है जो एक चैट में अनुमति प्राप्त हैं।",
-    "tooManyRequest": "बहुत अधिक अनुरोध, कृपया बाद में पुनः प्रयास करें।",
     "enterNumber": "कृपया एक पूर्ण संख्या मान दर्ज करें।",
     "practice": "अभ्यास",
     "versionNotFound": "संस्करण नहीं मिला",
@@ -3026,7 +2798,6 @@
     "deleteSubscriptionWarningTitle": "आपकी एक सक्रिय सदस्यता है",
     "deleteSubscriptionWarningBody": "आपका खाता हटाने से आपकी सदस्यता अपने आप रद्द नहीं होगी।",
     "manageSubscription": "सदस्यता प्रबंधित करें",
-    "error520Title": "कृपया पुनः प्रयास करें।",
     "error520Desc": "माफ़ कीजिए, हम आपका संदेश समझ नहीं सके...",
     "wordsUsed": "शब्दों का उपयोग किया गया",
     "level": "स्तर",
@@ -3044,7 +2815,6 @@
     "other": "अन्य",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "कोई क्षमता सीमा नहीं",
-    "downloadGroupText": "समूह टेक्स्ट डाउनलोड करें",
     "notificationsOn": "सूचनाएँ चालू हैं",
     "notificationsOff": "सूचनाएँ बंद हैं",
     "joinWithCode": "कोड के साथ जुड़ें",
@@ -3108,24 +2878,12 @@
     "whatIsTheMorphTag": "'{wordForm}' का {morphologicalFeature} क्या है?",
     "dataAvailable": "डेटा उपलब्धता",
     "available": "उपलब्ध",
-    "pangeaBotIsFallible": "पांगेआ बॉट भी गलतियाँ करता है!",
-    "whatIsMeaning": "'{lemma}' का अर्थ क्या है?",
     "chooseLemmaMeaningInstructionsBody": "संदेश में शब्दों के साथ अर्थ मिलाएँ!",
-    "doubleClickToEdit": "संपादित करने के लिए डबल-क्लिक करें।",
-    "topicLabel": "विषय",
-    "topicPlaceholder": "एक विषय चुनें...",
-    "modePlaceholder": "एक मोड चुनें...",
-    "learningObjectiveLabel": "अधिगम उद्देश्य",
-    "learningObjectivePlaceholder": "एक अधिगम उद्देश्य चुनें...",
-    "targetLanguageLabel": "लक्षित भाषा",
     "cefrLevelLabel": "CEFR स्तर",
     "image": "छवि",
     "video": "वीडियो",
     "nan": "लागू नहीं",
-    "addVocabulary": "शब्दावली जोड़ें",
     "instructions": "निर्देश",
-    "numberOfLearners": "सीखने वालों की संख्या",
-    "mustBeInteger": "यह एक पूर्णांक होना चाहिए जैसे 1, 2, 3, ...",
     "constructUsePvmDesc": "आवाज संदेश में उत्पादित",
     "leaveSpaceDescription": "कोर्स छोड़ने पर, आप इसमें सभी चैट छोड़ देंगे। अन्य उपयोगकर्ता देखेंगे कि आपने कोर्स छोड़ दिया है।",
     "constructUseCorMmDesc": "सही संदेश का अर्थ",
@@ -3140,7 +2898,6 @@
     "ttsDisabledBody": "आप अपने सीखने की सेटिंग्स में टेक्स्ट-टू-स्पीच सक्षम कर सकते हैं",
     "noSpaceDescriptionYet": "अभी तक कोई कोर्स विवरण नहीं बनाया गया है।",
     "tooLargeToSend": "यह संदेश भेजने के लिए बहुत बड़ा है",
-    "exitWithoutSaving": "क्या आप सुनिश्चित हैं कि आप बिना सहेजे छोड़ना चाहते हैं?",
     "enableAutocorrectPopupTitle": "अपनी लक्षित भाषा की कीबोर्ड जोड़ने के लिए जाएं:",
     "enableAutocorrectPopupSteps": "  • सेटिंग्स\n  • सामान्य\n  • कीबोर्ड\n  • कीबोर्ड्स\n  • नया कीबोर्ड जोड़ें",
     "enableAutocorrectPopupDescription": "एक बार भाषा का चयन करने के बाद, आप अपने कीबोर्ड के नीचे बाएं कोने में छोटे ग्लोब आइकन पर क्लिक कर सकते हैं ताकि नए इंस्टॉल किए गए कीबोर्ड को सक्रिय किया जा सके।",
@@ -3151,11 +2908,8 @@
     "displayName": "प्रदर्शन नाम",
     "leaveRoomDescription": "आप इस चैट को छोड़ने वाले हैं। अन्य उपयोगकर्ता देखेंगे कि आपने चैट छोड़ दी है।",
     "confirmUserId": "कृपया अपना पांगेआ चैट उपयोगकर्ता नाम की पुष्टि करें ताकि आपना खाता हटा सकें।",
-    "startingToday": "आज से शुरू",
-    "oneWeekFreeTrial": "एक सप्ताह मुफ्त परीक्षण",
     "paidSubscriptionStarts": "{startDate} से शुरू",
     "cancelInSubscriptionSettings": "• सदस्यता सेटिंग्स में कभी भी रद्द करें",
-    "cancelToAvoidCharges": "• शुल्क से बचने के लिए {trialEnds} से पहले रद्द करें",
     "downloadGboard": "Gboard डाउनलोड करें",
     "autocorrectNotAvailable": "दुर्भाग्यवश, आपका प्लेटफ़ॉर्म इस सुविधा के लिए वर्तमान में समर्थित नहीं है। आगे के विकास के लिए जुड़े रहें!",
     "pleaseUpdateApp": "कृपया ऐप को अपडेट करें ताकि आप जारी रख सकें।",
@@ -3165,17 +2919,12 @@
     "knockSpaceSuccess": "आपने इस कोर्स में शामिल होने का अनुरोध किया है! जब उन्हें यह प्राप्त होगा तो एक व्यवस्थापक आपकी प्रतिक्रिया देगा 😄",
     "chooseWordAudioInstructionsBody": "पूर्ण संदेश सुनें। फिर ऑडियो को शब्दों के साथ मिलाएं।",
     "chooseMorphsInstructionsBody": "व्याकरण प्रश्नों के लिए पज़ल टुकड़ों पर क्लिक करें!",
-    "pleaseEnterInt": "कृपया एक संख्या दर्ज करें",
     "home": "होम",
     "join": "शामिल हों",
     "resetInstructionTooltipsTitle": "निर्देश टूलटिप्स रीसेट करें",
     "resetInstructionTooltipsDesc": "कृपया निर्देश टूलटिप्स दिखाने के लिए क्लिक करें जैसे कि एक नए उपयोगकर्ता के लिए।",
-    "randomize": "यादृच्छिक करें",
     "clear": "साफ़ करें",
-    "featuredActivities": "विशेषताएँ",
     "save": "सहेजें",
-    "startChat": "चैट शुरू करें",
-    "translationProblem": "अनुवाद समस्या",
     "askToJoin": "शामिल होने के लिए पूछें",
     "emptyChatWarningTitle": "चैट खाली है",
     "emptyChatWarningDesc": "आपने अपने चैट में किसी को आमंत्रित नहीं किया है। संपर्क या बॉट को आमंत्रित करने के लिए चैट सेटिंग्स पर जाएं। आप इसे बाद में भी कर सकते हैं।",
@@ -3205,17 +2954,13 @@
     "timesUsedIndependently": "स्वतंत्र रूप से उपयोग किए गए समय",
     "timesUsedWithAssistance": "सहायता के साथ उपयोग किए गए समय",
     "shareInviteCode": "आमंत्रण कोड साझा करें: {code}",
-    "leaderboard": "लीडरबोर्ड",
     "skipForNow": "अभी के लिए छोड़ें",
     "permissions": "अनुमतियां",
     "spaceChildPermission": "यह कोर्स में नए चैट जोड़ने वाला कौन है",
-    "addEnvironmentOverride": "पर्यावरण ओवरराइड जोड़ें",
     "defaultOption": "डिफ़ॉल्ट",
     "deleteChatDesc": "क्या आप सुनिश्चित हैं कि आप इस चैट को हटाना चाहते हैं? यह सभी प्रतिभागियों के लिए हटा दिया जाएगा और चैट के सभी संदेश अब अभ्यास या सीखने के विश्लेषण के लिए उपलब्ध नहीं होंगे।",
     "deleteSpaceDesc": "कोर्स और कोई भी चयनित चैट सभी प्रतिभागियों के लिए हटा दी जाएगी और चैट के सभी संदेश अब अभ्यास या सीखने के विश्लेषण के लिए उपलब्ध नहीं होंगे। इस क्रिया को पूर्ववत नहीं किया जा सकता।",
     "launch": "लॉन्च करें",
-    "searchChats": "चैट खोजें",
-    "maxFifty": "अधिकतम 50",
     "configureSpace": "कोर्स कॉन्फ़िगर करें",
     "pinMessages": "संदेश पिन करें",
     "setJoinRules": "सदस्यता नियम सेट करें",
@@ -3249,9 +2994,6 @@
     "failedToFetchTranscription": "ट्रांसक्रिप्शन प्राप्त करने में विफल",
     "deleteEmptySpaceDesc": "कोर्स सभी प्रतिभागियों के लिए हटा दिया जाएगा। यह क्रिया पूर्ववत नहीं की जा सकती।",
     "regenerate": "पुनः उत्पन्न करें",
-    "mySavedActivities": "मेरी सहेजी गई गतिविधियां",
-    "noSavedActivities": "कोई सहेजी गई गतिविधि नहीं",
-    "saveActivity": "इस गतिविधि को सहेजें",
     "failedToPlayVideo": "वीडियो चलाने में विफल",
     "done": "पूर्ण",
     "inThisSpace": "इस कोर्स में",
@@ -3262,13 +3004,9 @@
     "numInvited": "{count} आमंत्रित",
     "saved": "सहेजा गया",
     "reset": "रीसेट करें",
-    "errorFetchingActivitiesMessage": "गतिविधियों को प्राप्त करने में विफल",
     "errorFetchingDefinition": "परिभाषा प्राप्त करने में विफल",
     "errorProcessAnalytics": "विश्लेषण प्रक्रिया में विफल",
     "errorDownloading": "डाउनलोड विफल",
-    "errorLoadingSpaceChildren": "इस कोर्स के चैट लोड करने में विफल",
-    "unexpectedError": "अप्रत्याशित त्रुटि।",
-    "pleaseReload": "कृपया पुनः लोड करें और पुनः प्रयास करें।",
     "translationError": "अनुवाद त्रुटि",
     "check": "जांचें",
     "unableToFindRoom": "उस कोड के साथ कोई चैट या कोर्स नहीं मिला। कृपया पुनः प्रयास करें।",
@@ -3277,19 +3015,14 @@
     "request": "अनुरोध",
     "requestAll": "सभी का अनुरोध करें",
     "confirmMessageUnpin": "क्या आप सुनिश्चित हैं कि आप इस संदेश को अनपिन करना चाहते हैं?",
-    "saveAndLaunch": "सहेजें और शुरू करें",
-    "launchToSpace": "कोर्स में लॉन्च करें",
     "pending": "लंबित",
     "inactive": "निष्क्रिय",
-    "confirmRole": "भूमिका की पुष्टि करें",
     "openRoleLabel": "खुली",
     "finishedTheActivity": "🎯 {username} ने इस गतिविधि को पूरा किया",
     "activitySummaryError": "गतिविधि सारांश उपलब्ध नहीं है",
     "requestSummaries": "सारांश अनुरोध करें",
-    "generatingNewActivities": "आप इस भाषा जोड़े के पहले उपयोगकर्ता हैं! कृपया एक मिनट दें, हम आपके लिए गतिविधियों की तैयारी कर रहे हैं।",
     "requestAccessTitle": "विश्लेषण पहुंच का अनुरोध करें?",
     "requestAccessDesc": "क्या आप प्रतिभागियों के विश्लेषण देखने के लिए पहुंच का अनुरोध करना चाहेंगे?\n\nयदि प्रतिभागी सहमत हैं, तो इस कोर्स के व्यवस्थापक उनकी देख सकेंगे:\n    • कुल शब्दावली\n    • कुल व्याकरण अवधारणाएँ\n    • कुल गतिविधि सत्र पूरे किए गए\n    • उपयोग किए गए विशिष्ट व्याकरण अवधारणाएँ, सही और गलत\n\nवे अपनी देख नहीं सकेंगे:\n    • कोर्स के बाहर चैट में संदेश\n    • शब्दावली सूची",
-    "requestAccess": "अनुरोध करें ({count})",
     "analyticsInactiveTitle": "निष्क्रिय उपयोगकर्ताओं को अनुरोध नहीं भेजा जा सका",
     "analyticsInactiveDesc": "निष्क्रिय उपयोगकर्ता जिन्होंने इस सुविधा के शुरू होने के बाद लॉग इन नहीं किया है, वे आपका अनुरोध नहीं देखेंगे।\n\nजैसे ही वे वापस आएंगे, अनुरोध बटन दिखाई देगा। आप बाद में उनके नाम के नीचे अनुरोध बटन पर क्लिक करके पुनः अनुरोध भेज सकते हैं।",
     "accessRequestedTitle": "विश्लेषण पहुंच का अनुरोध",
@@ -3312,8 +3045,6 @@
     "accessDesc": "आप अपने कोर्स को दुनिया के लिए खोल सकते हैं! या, अपने कोर्स को निजी और सुरक्षित बना सकते हैं।",
     "createGroupChatDesc": "जहां गतिविधि सत्र शुरू और समाप्त होते हैं, वहीं समूह चैट नियमित संचार के लिए खुली रहेगी।",
     "deleteDesc": "केवल व्यवस्थापक ही कोर्स हटा सकते हैं। यह एक विनाशकारी क्रिया है जो सभी उपयोगकर्ताओं को हटा देती है और कोर्स के भीतर सभी चुनी गई चैट को हटा देती है। सावधानी से आगे बढ़ें।",
-    "noCourseFound": "अरे, इस कोर्स के लिए एक योजना की आवश्यकता है!\n\nकोर्स योजनाएँ विषयों और बातचीत गतिविधियों का एक क्रम हैं।",
-    "additionalParticipants": "+ {num} अन्य",
     "whatNow": "अब क्या?",
     "chooseNextActivity": "अपनी अगली गतिविधि चुनें!",
     "letsGo": "चलो शुरू करें",
@@ -3326,13 +3057,11 @@
     "waitNotDone": "रुको, मैं अभी खत्म नहीं हुआ हूँ!",
     "waitingForOthersToFinish": "बाकियों के समाप्त होने का इंतजार कर रहा हूँ...",
     "generatingSummary": "चैट का विश्लेषण कर रहे हैं और परिणाम उत्पन्न कर रहे हैं",
-    "findCourse": "कोर्स खोजें",
     "pingParticipantsNotification": "{user} गतिविधि सत्र में शामिल होने के लिए उपयोगकर्ताओं की तलाश कर रहा है {room}",
     "course": "कोर्स",
     "courses": "कोर्स",
     "goToCourse": "कोर्स पर जाएं: {course}",
     "activityComplete": "यह गतिविधि पूरी हो गई है। गतिविधि का सारांश नीचे उपलब्ध होना चाहिए।",
-    "startNewSession": "नई सत्र शुरू करें",
     "joinOpenSession": "खुले सत्र में शामिल हों",
     "activityNotFound": "गतिविधि नहीं मिली",
     "myActivities": "मेरी गतिविधियाँ",
@@ -3445,26 +3174,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -3541,14 +3250,6 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
@@ -3573,31 +3274,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3653,23 +3334,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3709,28 +3378,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -3748,14 +3395,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3948,22 +3587,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4019,10 +3642,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4032,10 +3651,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4111,27 +3726,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4449,10 +4048,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4462,10 +4057,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4553,14 +4144,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4577,10 +4160,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4593,15 +4172,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4753,14 +4324,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4774,14 +4337,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6004,10 +5559,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6048,10 +5599,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6124,10 +5671,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6397,47 +5940,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6457,19 +5960,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6533,10 +6024,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6577,14 +6064,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6596,14 +6075,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6641,10 +6112,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6661,27 +6128,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6805,10 +6256,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6818,10 +6265,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6838,14 +6281,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6985,18 +6420,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7045,10 +6468,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7058,18 +6477,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7112,23 +6519,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7152,10 +6547,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7163,14 +6554,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7275,18 +6658,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7339,10 +6710,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7369,10 +6736,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7553,7 +6916,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "कल फिर से जांचें गतिविधि अपडेट के लिए।",
-    "activityDropdownDesc": "जब आप इस गतिविधि को पूरा कर लें, तो नीचे क्लिक करें",
     "languageMismatchTitle": "भाषा मेल नहीं खाती",
     "languageMismatchDesc": "आपकी लक्षित भाषा इस गतिविधि की भाषा से मेल नहीं खाती। क्या आप अपनी लक्षित भाषा अपडेट करना चाहेंगे?",
     "reportWordIssueTooltip": "शब्द जानकारी समस्या रिपोर्ट करें",
@@ -7566,10 +6928,6 @@
     "selectAll": "सभी चुनें",
     "deselectAll": "सभी अनचुनें",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7618,17 +6976,11 @@
         "placeholders": {}
     },
     "startOwn": "अपना खुद का शुरू करें",
-    "joinCourseDesc": "प्रत्येक कोर्स में 8-10 अनुक्रमित विषय होते हैं जिनके साथ कार्य-आधारित भाषा सीखने की गतिविधियों की श्रृंखला होती है।",
     "newMessageInPangeaChat": "💬 पांगेआ चैट में नया संदेश",
     "shareCourse": "कोर्स साझा करें",
     "addCourse": "कोर्स जोड़ें",
-    "joinPublicCourse": "सार्वजनिक कोर्स में शामिल हों",
     "vocabLevelsDesc": "यहां वे शब्द जाएंगे जब आप उन्हें स्तर देंगे!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7641,10 +6993,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7663,7 +7011,6 @@
     "emojiView": "इमोजी दृश्य",
     "feedbackDialogDesc": "मैं भी गलतियाँ करता हूँ! मुझे सुधारने में मदद करने के लिए कुछ है?",
     "contactHasBeenInvitedToTheCourse": "संपर्क को पाठ्यक्रम में आमंत्रित किया गया है",
-    "activityStatsButtonTooltip": "गतिविधि जानकारी",
     "allow": "अनुमति दें",
     "deny": "अस्वीकृत करें",
     "enabledRenewal": "सदस्यता नवीनीकरण सक्षम करें",
@@ -7931,10 +7278,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8990,16 +8333,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "अगले विषय को अनलॉक करने के लिए गतिविधियाँ",
-    "activitiesToUnlockTopicDesc": "अगले पाठ्यक्रम विषय को अनलॉक करने के लिए गतिविधियों की संख्या निर्धारित करें",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "सही शब्दावली परिभाषा अभ्यास",
     "constructUseIncLMDesc": "गलत शब्दावली परिभाषा अभ्यास",
     "constructUseCorLADesc": "सही शब्दावली ऑडियो अभ्यास",
@@ -9007,7 +8340,6 @@
     "constructUseBonus": "शब्दावली अभ्यास के दौरान बोनस",
     "practiceVocab": "शब्दावली का अभ्यास करें",
     "selectMeaning": "अर्थ चुनें",
-    "selectAudio": "मेल खाने वाला ऑडियो चुनें",
     "anotherRound": "एक और राउंड",
     "activitySettingsOverrideWarning": "भाषा और भाषा स्तर गतिविधि योजना द्वारा निर्धारित किया गया है",
     "voice": "स्वर",
@@ -9039,10 +8371,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9060,12 +8388,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "डाउनलोड शुरू किया गया",
     "webDownloadPermissionMessage": "यदि आपका ब्राउज़र डाउनलोड को ब्लॉक करता है, तो कृपया इस साइट के लिए डाउनलोड सक्षम करें।",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9160,11 +8483,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "कुछ गलत हो गया है, और हम इसे ठीक करने में कड़ी मेहनत कर रहे हैं। बाद में फिर से जांचें।",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "लेखन सहायता सक्षम करें",
     "autoIGCToolDescription": "लक्षित भाषा में भेजे गए संदेशों को सही करने के लिए स्वचालित रूप से Pangea चैट उपकरण चलाएँ।",
     "@autoIGCToolName": {
@@ -9220,24 +8538,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "व्याकरण",
-    "spanTypeWordChoice": "शब्द चयन",
     "spanTypeSpelling": "वर्तनी",
     "spanTypePunctuation": "विराम चिह्न",
     "spanTypeStyle": "शैली",
     "spanTypeFluency": "धाराप्रवाहता",
     "spanTypeAccents": "उच्चारण",
     "spanTypeCapitalization": "बड़े अक्षर",
-    "spanTypeCorrection": "सुधार",
     "spanFeedbackTitle": "सुधार समस्या की रिपोर्ट करें",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9262,10 +8569,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9278,13 +8581,7 @@
     "longPressToRecordVoiceMessage": "वॉयस संदेश रिकॉर्ड करने के लिए लंबे समय तक दबाएं।",
     "pause": "रोकें",
     "resume": "जारी रखें",
-    "newSubSpace": "नया उप स्थान",
-    "moveToDifferentSpace": "विभिन्न स्थान पर जाएं",
-    "removeFromSpaceDescription": "चैट स्पेस से हटा दी जाएगी लेकिन आपकी चैट सूची में अभी भी दिखाई देगी।",
     "countChats": "{chats} चैट",
-    "spaceMemberOf": "{spaces} का स्पेस सदस्य",
-    "spaceMemberOfCanKnock": "{spaces} का स्पेस सदस्य दस्तक दे सकता है",
-    "donate": "दान करें",
     "startedAPoll": "{username} ने एक मतदान शुरू किया।",
     "poll": "मतदान",
     "startPoll": "मतदान शुरू करें",
@@ -9308,23 +8605,15 @@
     "newStickerPack": "नया स्टिकर पैक",
     "stickerPackName": "स्टिकर पैक का नाम",
     "attribution": "अट्रिब्यूशन",
-    "skipChatBackup": "चैट बैकअप छोड़ें",
-    "skipChatBackupWarning": "क्या आप सुनिश्चित हैं? चैट बैकअप सक्षम किए बिना, यदि आप अपना डिवाइस बदलते हैं तो आप अपने संदेशों तक पहुंच खो सकते हैं।",
-    "loadingMessages": "संदेश लोड हो रहे हैं",
-    "setupChatBackup": "चैट बैकअप सेट करें",
     "noMoreResultsFound": "कोई और परिणाम नहीं मिला",
     "chatSearchedUntil": "चैट {time} तक खोजी गई",
     "federationBaseUrl": "फेडरेशन बेस यूआरएल",
     "clientWellKnownInformation": "क्लाइंट-वेलेन जानकारी:",
     "baseUrl": "बेस यूआरएल",
     "identityServer": "पहचान सर्वर:",
-    "versionWithNumber": "संस्करण: {version}",
     "logs": "लॉग",
-    "advancedConfigs": "उन्नत कॉन्फ़िग्स",
     "advancedConfigurations": "उन्नत कॉन्फ़िगरेशन",
-    "signInWithLabel": "साइन इन करें:",
     "selectAllWords": "ऑडियो में सुनाई देने वाले सभी शब्दों का चयन करें",
-    "joinCourseForActivities": "गतिविधियों को आजमाने के लिए एक पाठ्यक्रम में शामिल हों।",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9361,18 +8650,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9380,26 +8657,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9505,22 +8762,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9549,19 +8790,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9569,15 +8798,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9778,11 +8999,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "क्लास में हैं? अपना जॉइन कोड यहाँ डालें।",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "ऑटो-हाइलाइट ऑडियो संदेश",
     "selectAudioMessagesOnPlayDescription": "जब ऑडियो संदेश चलाए जाएं तो स्वचालित रूप से ऑडियो संदेशों को हाइलाइट करें",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9826,18 +9042,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "इस पाठ्यक्रम में ऐसे विषय हैं जिनमें {input} गतिविधियों से कम हैं। कृपया {minValue} से कम या उसके बराबर एक संख्या दर्ज करें।",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "यहाँ क्लिक करें फिर से साइन इन करने के लिए।",
     "@clickToLogin": {
@@ -10254,17 +9458,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "एक कार्टून जैसा पीला भालू जो उत्साह में अपने हाथ उठाए हुए है।",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "शब्दों का चयन करें ताकि उनके बारे में अधिक जान सकें",
     "requireAnalyticsAccessTitle": "शामिल होने के लिए एनालिटिक्स एक्सेस की आवश्यकता है",
     "requireAnalyticsAccessDesc": "भागीदारों को इस पाठ्यक्रम में शामिल होने के लिए अपने शिक्षण एनालिटिक्स तक पहुंच प्रदान करनी होगी",
     "analyticsAccessNoticeTitle": "एनालिटिक्स एक्सेस आवश्यक",
     "analyticsAccessNoticeDesc": "इस पाठ्यक्रम में शामिल होकर, आप प्रशासकों को अपने शिक्षण एनालिटिक्स तक पहुंच प्रदान करने के लिए सहमत होते हैं।",
-    "skipOnboardingClassCodeDesc": "स्वतंत्र रूप से सीख रहे हैं? चिंता न करें, आप:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10282,10 +9480,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10314,7 +9508,6 @@
     "pickCefrLevelTeacherStepTitle": "आप किस स्तर को सिखाते हैं?",
     "pickCefrLevelStudentStepTitle": "आप किस स्तर पर हैं?",
     "customCourseStepTitle": "कस्टम पाठ्यक्रम प्राप्त करने के लिए यह फॉर्म भरें",
-    "aboutYourClass": "आपकी कक्षा के बारे में",
     "courseCodeStepErrorMessage": "कृपया अपना कोड जांचें और फिर से प्रयास करें",
     "institution": "संस्थान",
     "courseGoals": "कोर्स के लक्ष्य",
@@ -10357,10 +9550,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10477,12 +9666,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "पैंगिया चैट लोगो",
     "introChatDetails": "नमस्ते कहें! अपने सहपाठियों से परिचय करें, दोस्तों को खोजें, और गतिविधियों के बाहर चैट करें।",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10526,11 +9710,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "गतिविधि क्रियाएँ",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "उच्चारण उपकरण",
     "audioTranscription": "एआई ऑडियो ट्रांसक्रिप्शन",
     "visualLearnerSupport": "दृश्य शिक्षार्थी समर्थन",
@@ -10571,7 +9750,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "इस गतिविधि को खेलने के लिए एक पाठ्यक्रम में शामिल हों।",
     "resizeCoursePanel": "पाठ्यक्रम पैनल का आकार बदलें",
     "undo": "पूर्ववत करें",
     "unlock": "अनलॉक करें",
@@ -10585,7 +9763,6 @@
     "addCourseBrowsePublic": "सार्वजनिक पाठ्यक्रम ब्राउज़ करें",
     "browsePublicCourses": "सार्वजनिक पाठ्यक्रम ब्राउज़ करें",
     "editProfile": "प्रोफ़ाइल संपादित करें",
-    "numObjectives": "{count} उद्देश्य",
     "mapSearchHint": "गतिविधियों की खोज करें",
     "mapSearchNoResults": "दृश्य में कोई मेल नहीं",
     "mapFilterAllLanguages": "सभी भाषाएँ",
@@ -10594,7 +9771,6 @@
     "mapFilterCompleted": "पूर्ण",
     "mapFilterReset": "रीसेट",
     "activityTypeConversation": "संवाद",
-    "lockedMissionRequirement": "अनलॉक करने के लिए पिछले मिशन को पूरा करें",
     "playAgain": "फिर से खेलें",
     "reviewActivity": "समीक्षा करें",
     "mapEmptyInView": "आपके स्तर या भाषा में यहाँ कुछ नहीं है। अपने फ़िल्टर को चौड़ा करें या ज़ूम आउट करें।",
@@ -10609,14 +9785,9 @@
     "scrollToBottom": "नीचे स्क्रॉल करें",
     "courseImage": "कोर्स छवि",
     "avatarPreview": "अवतार पूर्वावलोकन",
-    "activityPhoto": "गतिविधि फोटो",
     "emotePreview": "इमोट पूर्वावलोकन: {name}",
     "activityLabel": "गतिविधि: {title}",
     "resetMapView": "मानचित्र दृश्य रीसेट करें",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10669,14 +9840,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10706,10 +9869,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10766,10 +9925,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_hr.arb
+++ b/lib/l10n/intl_hr.arb
@@ -78,11 +78,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Smiju li se gosti pridružiti",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Stvarno to želiš?",
     "@areYouSure": {
         "type": "String",
@@ -354,11 +349,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Tvoje poruke su osigurane s ključem za obnavljanje. Pazi da ga ne izgubiš.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Detalji razgovora",
     "@chatDetails": {
         "type": "String",
@@ -490,11 +480,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Kontakt je pozvan u grupu",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Sadržaj je prijavljen administratorima poslužitelja",
     "@contentHasBeenReported": {
         "type": "String",
@@ -546,11 +531,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Novi prostor",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Trenutačno aktivni",
     "@currentlyActive": {
@@ -694,11 +674,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Više nećeš moći deaktivirati šifriranje. Stvarno to želiš?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Šifrirano",
     "@encrypted": {
         "type": "String",
@@ -725,11 +700,6 @@
     },
     "enterAnEmailAddress": "Upiši e-adressu",
     "@enterAnEmailAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "Sve je spremno!",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -770,11 +740,6 @@
     },
     "group": "Grupiraj",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Grupa je javna",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -868,15 +833,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Pozovi kontakt u {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Pozvan/a",
     "@invited": {
@@ -989,15 +945,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Učitaj još {count} sudionika",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Učitava se … Pričekaj.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -1012,15 +959,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Prijavi se na {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Odjava",
     "@logout": {
@@ -1084,11 +1022,6 @@
     },
     "noEmotesFound": "Nema emotikona. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Šifriranje možeš aktivirati samo nakon što soba više nije javno dostupna.",
-    "@noEncryptionForPublicRooms": {
         "type": "String",
         "placeholders": {}
     },
@@ -1198,11 +1131,6 @@
     },
     "passwordHasBeenChanged": "Lozinka je promijenjena",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Obnavljanje lozinke",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1346,11 +1274,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Ukloni uređaj",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Ponovo uključi u razgovor",
     "@unbanFromChat": {
@@ -1505,11 +1428,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Postavi razinu dozvola",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Postavi stanje",
     "@setStatus": {
         "type": "String",
@@ -1546,16 +1464,6 @@
     },
     "sourceCode": "Izvorni kȏd",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Prostor je javan",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Ime prostora",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1614,11 +1522,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Prenesi s jednog drugog uređaja",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Pokušaj ponovo poslati",
     "@tryToSendAgain": {
         "type": "String",
@@ -1674,15 +1577,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 nepročitan razgovor} few{{unreadCount} nepročitana razgovora} other{{unreadCount} nepročitanih razgovora}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} i još {count} korisnika pišu …",
     "@userAndOthersAreTyping": {
@@ -1768,16 +1662,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Video poziv",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Vidljivost povijesti razgovora",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Vidljivo za sve sudionike",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1823,23 +1707,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Tko može izvršiti koju radnju",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Tko se smije pridružiti grupi",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Zašto želiš ovo prijaviti?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Izbrisati sigurnosnu kopiju razgovora za stvaranje novog sigurnosnog ključa za obnavljanje?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1946,8 +1815,6 @@
     "@sendOnEnter": {},
     "link": "Poveznica",
     "@link": {},
-    "enableMultiAccounts": "(BETA) Omogući korištenje više računa na ovom uređaju",
-    "@enableMultiAccounts": {},
     "bundleName": "Ime paketa",
     "@bundleName": {},
     "removeFromBundle": "Ukloni iz ovog paketa",
@@ -1956,14 +1823,10 @@
     "@addToBundle": {},
     "editBundlesForAccount": "Uredi pakete za ovaj račun",
     "@editBundlesForAccount": {},
-    "addAccount": "Dodaj račun",
-    "@addAccount": {},
     "oneClientLoggedOut": "Jedan od tvojih klijenata je odjavljen",
     "@oneClientLoggedOut": {},
     "unverified": "Nepotvrđeno",
     "@unverified": {},
-    "yourChatBackupHasBeenSetUp": "Sigurnosna kopija tvog razgovora je postavljena.",
-    "@yourChatBackupHasBeenSetUp": {},
     "repeatPassword": "Ponovi lozinku",
     "@repeatPassword": {},
     "messageInfo": "Informacija poruke",
@@ -1976,8 +1839,6 @@
     "@openGallery": {},
     "time": "Vrijeme",
     "@time": {},
-    "removeFromSpace": "Ukloni iz prostora",
-    "@removeFromSpace": {},
     "start": "Početak",
     "@start": {},
     "commandHint_clearcache": "Isprazni predmemoriju",
@@ -2027,14 +1888,8 @@
     "@widgetName": {},
     "widgetUrlError": "Ovo nije valjan URL.",
     "@widgetUrlError": {},
-    "emailOrUsername": "E-mail ili korisničko ime",
-    "@emailOrUsername": {},
     "unsupportedAndroidVersionLong": "Ova funkcija zahtijeva noviju verziju Androida. Provjeri, postoje li nove verzije ili podrška za Lineage OS.",
     "@unsupportedAndroidVersionLong": {},
-    "recoveryKey": "Ključ za obnavljanje",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Izgubio/la si ključ za obnavljanje?",
-    "@recoveryKeyLost": {},
     "youKickedAndBanned": "🙅 Izbacio/la si i blokirao/la korisnika {user}",
     "@youKickedAndBanned": {
         "placeholders": {
@@ -2047,8 +1902,6 @@
     "@dehydrateWarning": {},
     "emojis": "Emojiji",
     "@emojis": {},
-    "storeSecurlyOnThisDevice": "Spremi sigurno na ovom uređaju",
-    "@storeSecurlyOnThisDevice": {},
     "countFiles": "Broj datoteka: {count}",
     "@countFiles": {
         "placeholders": {
@@ -2073,12 +1926,8 @@
     "@pinMessage": {},
     "confirmEventUnpin": "Stvarno želiš trajno otkvačiti događaj?",
     "@confirmEventUnpin": {},
-    "voiceCall": "Glasovni poziv",
-    "@voiceCall": {},
     "placeCall": "Nazovi",
     "@placeCall": {},
-    "videoCallsBetaWarning": "Napominjemo da se funkcija videopoziva trenutačno nalazi u beta stanju. Možda neće raditi ispravno ili uopće neće raditi na svim platformama.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "Eksperimentalni videopozivi",
     "@experimentalVideoCalls": {},
     "widgetJitsi": "Jitsi Meet",
@@ -2137,14 +1986,6 @@
     },
     "dehydrate": "Izvezi sesiju i izbriši uređaj",
     "@dehydrate": {},
-    "unlockOldMessages": "Otključaj stare poruke",
-    "@unlockOldMessages": {},
-    "storeInSecureStorageDescription": "Ključ za obnavljanje spremi u sigurno spremište na ovom uređaju.",
-    "@storeInSecureStorageDescription": {},
-    "saveKeyManuallyDescription": "Spremi ovaj ključ ručno pokretanjem dijaloga za dijeljenje sustava ili međuspremnika.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "Spremi u Android KeyStore",
-    "@storeInAndroidKeystore": {},
     "separateChatTypes": "Odvojeni izravni razgovori, grupe i prostori",
     "@separateChatTypes": {
         "type": "String",
@@ -2152,12 +1993,8 @@
     },
     "hydrate": "Obnovi pomoću sigurnosne kopije",
     "@hydrate": {},
-    "pleaseEnterRecoveryKey": "Upiši svoj ključ za obnavljanje:",
-    "@pleaseEnterRecoveryKey": {},
     "users": "Korisnici",
     "@users": {},
-    "pleaseEnterRecoveryKeyDescription": "Za otključavanje starih poruka upiši ključ za obnavljanje koji je generiran u prethodnoj sesiji. Tvoj ključ za obnavljanje NIJE tvoja lozinka.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "youBannedUser": "Isključio/la si korisnika {user}",
     "@youBannedUser": {
         "placeholders": {
@@ -2166,8 +2003,6 @@
             }
         }
     },
-    "storeInAppleKeyChain": "Spremi u Apple KeyChain",
-    "@storeInAppleKeyChain": {},
     "user": "Korisnik",
     "@user": {},
     "custom": "Prilagođeno",
@@ -2210,14 +2045,8 @@
     "@whyIsThisMessageEncrypted": {},
     "jump": "Skoči",
     "@jump": {},
-    "newSpaceDescription": "Prostori omogućuju konsolidiranje tvojih razgovora i izgradnju privatne ili javne zajednice.",
-    "@newSpaceDescription": {},
-    "encryptThisChat": "Šifiraj ovaj razgovor",
-    "@encryptThisChat": {},
     "deviceKeys": "Ključevi uređaja:",
     "@deviceKeys": {},
-    "foregroundServiceRunning": "Ova se obavijest pojavljuje kada se pokreće usluga u prvom planu.",
-    "@foregroundServiceRunning": {},
     "commandHint_hug": "Pošalji grljenje",
     "@commandHint_hug": {},
     "commandHint_googly": "Pošalji kotrljajuće oči",
@@ -2235,22 +2064,12 @@
             }
         }
     },
-    "screenSharingDetail": "Dijeliš svoj ekran u FuffyChatu",
-    "@screenSharingDetail": {},
     "newGroup": "Nova grupa",
     "@newGroup": {},
     "allSpaces": "Svi prostori",
     "@allSpaces": {},
-    "screenSharingTitle": "dijeljenje ekrana",
-    "@screenSharingTitle": {},
-    "enterSpace": "Uđi u prostor",
-    "@enterSpace": {},
     "newSpace": "Novi prostor",
     "@newSpace": {},
-    "sorryThatsNotPossible": "Žao nam je … to nije moguće",
-    "@sorryThatsNotPossible": {},
-    "disableEncryptionWarning": "Iz sigurnosnih razloga ne možeš deaktivirati šifriranje u razgovoru u kojem je prije bilo aktivirano.",
-    "@disableEncryptionWarning": {},
     "googlyEyesContent": "{senderName} ti šalje kotrljajuće oči",
     "@googlyEyesContent": {
         "type": "String",
@@ -2308,8 +2127,6 @@
     "@tryAgain": {},
     "messagesStyle": "Poruke:",
     "@messagesStyle": {},
-    "chatDescription": "Opis razgovora",
-    "@chatDescription": {},
     "invalidServerName": "Neispravno ime servera",
     "@invalidServerName": {},
     "chatPermissions": "Dozvole za razgovor",
@@ -2356,8 +2173,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "Postavi temu:",
-    "@setTheme": {},
     "createGroup": "Stvori grupu",
     "@createGroup": {},
     "invite": "Pozovi",
@@ -2387,14 +2202,10 @@
     "@pushNotificationsNotAvailable": {},
     "learnMore": "Saznaj više",
     "@learnMore": {},
-    "createGroupAndInviteUsers": "Stvori grupu i pozovi korisnike",
-    "@createGroupAndInviteUsers": {},
     "startConversation": "Pokreni konverzaciju",
     "@startConversation": {},
     "blockedUsers": "Blokirani korisnici",
     "@blockedUsers": {},
-    "groupCanBeFoundViaSearch": "Grupa se može pronaći putem pretrage",
-    "@groupCanBeFoundViaSearch": {},
     "block": "Blokiraj",
     "@block": {},
     "yourGlobalUserIdIs": "Tvoj globalni korisnički ID je: ",
@@ -2409,8 +2220,6 @@
     "@groupName": {},
     "databaseMigrationTitle": "Baza podataka je optimirana",
     "@databaseMigrationTitle": {},
-    "searchChatsRooms": "Traži #chats, @users …",
-    "@searchChatsRooms": {},
     "databaseMigrationBody": "Pričekaj. Ovo može potrajati.",
     "@databaseMigrationBody": {},
     "transparent": "Prozirno",
@@ -2421,16 +2230,12 @@
     "@incomingMessages": {},
     "passwordsDoNotMatch": "Lozinke se ne poklapaju",
     "@passwordsDoNotMatch": {},
-    "accessAndVisibility": "Pristup i vidljivost",
-    "@accessAndVisibility": {},
     "calls": "Pozivi",
     "@calls": {},
     "customEmojisAndStickers": "Prilagođeni emojiji i naljepnice",
     "@customEmojisAndStickers": {},
     "customEmojisAndStickersBody": "Dodaj ili dijeli prilagođene emojije ili naljepnice koje se mogu koristiti u bilo kojem razgovoru.",
     "@customEmojisAndStickersBody": {},
-    "accessAndVisibilityDescription": "Tko se smije pridružiti ovom razgovoru i kako se razgovor može otkriti.",
-    "@accessAndVisibilityDescription": {},
     "stickers": "Naljepnice",
     "@stickers": {},
     "discover": "Otkrij",
@@ -2470,12 +2275,8 @@
     "@hideRedactedMessagesBody": {},
     "kickUserDescription": "Korisnik je izbačen iz razgovora, ali nije blokiran. U javnim razgovorima se korisnik može ponovo pridružiti u bilo kojem trenutku.",
     "@kickUserDescription": {},
-    "addChatOrSubSpace": "Dodaj razgovor ili podpodručje",
-    "@addChatOrSubSpace": {},
     "appLockDescription": "Zaključaj aplikaciju kada je ne koristiš s PIN kodom",
     "@appLockDescription": {},
-    "globalChatId": "Globalni ID razgovora",
-    "@globalChatId": {},
     "hideRedactedMessages": "Sakrij redigirane poruke",
     "@hideRedactedMessages": {},
     "hideInvalidOrUnknownMessageFormats": "Sakrij nevažeće ili nepoznate formate poruka",
@@ -2484,35 +2285,16 @@
     "@overview": {},
     "passwordRecoverySettings": "Postavke za obnavljanje lozinke",
     "@passwordRecoverySettings": {},
-    "usersMustKnock": "Korisnici moraju pokucati",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Nitko se ne može pridružiti",
-    "@noOneCanJoin": {},
     "knock": "Pokucaj",
     "@knock": {},
     "knocking": "Kucanje",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Razgovor se može otkriti pretraživanjem servera {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "searchForUsers": "Traži @users...",
     "@searchForUsers": {},
     "pleaseChooseAStrongPassword": "Odaberi snažnu lozinku",
     "@pleaseChooseAStrongPassword": {},
     "joinSpace": "Pridruži se prostoru",
     "@joinSpace": {},
-    "publicChatAddresses": "Adrese javnih razgovora",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Stvori novu adresu",
-    "@createNewAddress": {},
-    "verifyOtherUser": "🔐 Potvrdi drugog korisnika",
-    "@verifyOtherUser": {},
     "sendTypingNotificationsDescription": "Drugi sudionici u razgovoru mogu vidjeti kada pišeš novu poruku.",
     "@sendTypingNotificationsDescription": {},
     "sendReadReceiptsDescription": "Drugi sudionici u raygovoru mogu vidjeti kada pročitaš poruku.",
@@ -2561,18 +2343,6 @@
     },
     "banUserDescription": "Korisnik će biti isključen iz razgovora i moći će ponovo prisustvovati razgovoru kad ga se deblokira.",
     "@banUserDescription": {},
-    "sessionLostBody": "Tvoja je sesija izgubljena. Prijavi ovu grešku programerima na {url}. Poruka o grešci glasi: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "completedKeyVerification": "{sender} je dovršio/la potvrđivanje ključa",
     "@completedKeyVerification": {
         "type": "String",
@@ -2595,18 +2365,6 @@
             }
         }
     },
-    "restoreSessionBody": "Aplikacija sada pokušava obnoviti tvoju sesiju iz sigurnosne kopije. Prijavi ovu grešku programerima na {url}. Poruka o grešci glasi: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "requestedKeyVerification": "{sender} je zatražio/la potvrđivanje ključa",
     "@requestedKeyVerification": {
         "type": "String",
@@ -2620,15 +2378,8 @@
     "@restricted": {},
     "roomUpgradeDescription": "Razgovor će se tada ponovo stvoriti s novom verzijom sobe. Svi sudionici će biti obaviješteni da se moraju prebaciti na novi razgovor. Više o verzijama soba možeš saznati na https://spec.matrix.org/latest/rooms/",
     "@roomUpgradeDescription": {},
-    "noGoogleServicesWarning": "Čini se da Firebase Cloud Messaging nije dostupan na tvom uređaju. Za daljnje primanje push obavijesti, preporučujemo da instaliraš ntfy. S ntfy ili drugim pružateljem Unified Push usluge možeš primati push obavijesti na podatkovno siguran način. Ntfy možeš preuzeti s PlayStorea ili s F-Droida.",
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "verifyOtherDeviceDescription": "Kada potvrdiš jedan drugi uređaj, ti uređaji mogu razmjenjivati ključeve, povećavajući tvoju ukupnu sigurnost. 💪 Kada pokreneš provjeru, pojavit će se skočni prozor u aplikaciji na oba uređaja. Tamo ćeš tada vidjeti niz emojija ili brojeve koje moraš međusobno usporediti. Najbolje je imati oba uređaja pri ruci prije nego što započneš provjeru. 🤳",
     "@verifyOtherDeviceDescription": {},
-    "verifyOtherUserDescription": "Ako potvrdiš jednog drugog korisnika, možeš biti siguran/na da znaš kome zapravo pišeš. 💪\n\nKada pokreneš provjeru, vi i drugi korisnik vidjet ćete skočni prozor u aplikaciji. Tamo ćeš tada vidjeti niz emojija ili brojeve koje morate međusobno usporediti.\n\nNajbolji način za to je da se nađete zajedno ili započnete videopoziv. 👭",
-    "@verifyOtherUserDescription": {},
     "knockRestricted": "Pokucaj na ograničene sobe",
     "@knockRestricted": {},
     "makeAdminDescription": "Nakon postavljanja ovog korisnika kao administratora, to možda nećeš moći poništiti jer će on tada imati iste dozvole kao i ti.",
@@ -2721,7 +2472,6 @@
     "space": "Prostor",
     "spaces": "Prostori",
     "checkList": "Popis za provjeru",
-    "countInvited": "Pozvani: {count}",
     "sendImages": "Pošalji {count} sliku",
     "synchronizingPleaseWaitCounter": "Sinkronizacija… ({percentage}%)",
     "invitedBy": "📩 Pozvao {user}",
@@ -2741,10 +2491,6 @@
     "updateInstalled": "🎉 Instalirana je nadogradnja {version}!",
     "changelog": "Dnevnik promjena",
     "sendCanceled": "Slanje otkazano",
-    "loginWithMatrixId": "Prijava s Matrix-ID-jem",
-    "discoverHomeservers": "Otkrij domove servera",
-    "whatIsAHomeserver": "Što je dom server?",
-    "homeserverDescription": "Svi vaši podaci pohranjeni su na domu serveru, baš kao i kod pružatelja e-pošte. Možete odabrati koji dom servera želite koristiti, dok i dalje možete komunicirati sa svima. Saznajte više na https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Čini se da nije kompatibilan dom server. Pogrešan URL?",
     "calculatingFileSize": "Računanje veličine datoteke...",
     "generatingVideoThumbnail": "Generiranje minijature videa...",
@@ -2753,11 +2499,9 @@
     "oneOfYourDevicesIsNotVerified": "Jedan od vaših uređaja nije verificiran",
     "noticeChatBackupDeviceVerification": "Napomena: Kada povežete sve svoje uređaje na sigurnosnu kopiju chata, oni se automatski verificiraju.",
     "continueText": "Nastavi",
-    "welcomeText": "Hej Hej 👋 Ovo je FluffyChat. Možete se prijaviti na bilo koji kućni poslužitelj koji je kompatibilan s https://matrix.org. I zatim razgovarajte s bilo kim. To je velika decentralizirana mreža za razmjenu poruka!",
     "blur": "Zamućenje:",
     "opacity": "Prozirnost:",
     "setWallpaper": "Postavi pozadinu",
-    "manageAccount": "Upravljanje računom",
     "noContactInformationProvided": "Poslužitelj ne pruža valjane kontakt informacije",
     "contactServerAdmin": "Kontaktirajte administratora poslužitelja",
     "contactServerSecurity": "Kontaktirajte sigurnost poslužitelja",
@@ -2776,11 +2520,8 @@
     "unableToJoinChat": "Nemoguće se pridružiti razgovoru. Možda je druga strana već zatvorila razgovor.",
     "previous": "Prethodno",
     "otherPartyNotLoggedIn": "Druga strana trenutno nije prijavljena i stoga ne može primati poruke!",
-    "appWantsToUseForLogin": "Koristi '{server}' za prijavu",
-    "appWantsToUseForLoginDescription": "Ovim dopuštate aplikaciji i web stranici dijeljenje informacija o vama.",
     "open": "Otvoriti",
     "waitingForServer": "Čekanje na poslužitelj...",
-    "appIntroduction": "FluffyChat vam omogućava da razgovarate s prijateljima putem različitih posrednika. Saznajte više na https://matrix.org ili jednostavno dodirnite *Nastavi*.",
     "newChatRequest": "📩 Novi zahtjev za razgovor",
     "contentNotificationSettings": "Postavke obavijesti o sadržaju",
     "generalNotificationSettings": "Opće postavke obavijesti",
@@ -2855,11 +2596,9 @@
     "taTooltip": "L2 korištenje s prijevodnom pomoći",
     "interactiveTranslatorSliderHeader": "Interaktivni prevoditelj",
     "interactiveGrammarSliderHeader": "Interaktivni provjerivač gramatike",
-    "interactiveTranslatorRequired": "Obavezno",
     "waTooltip": "L2 korištenje bez pomoći",
     "interactiveTranslator": "Pomoć pri prevođenju",
     "noIdenticalLanguages": "Molimo odaberite različite izvornu i ciljnu jezike",
-    "searchBy": "Pretraži po zemlji i jezicima",
     "joinWithClassCode": "Pridruži se tečaju",
     "languageLevelPreA1": "Novak Nizak (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -2880,19 +2619,14 @@
     "saveChanges": "Spremi promjene",
     "publicProfileTitle": "Dozvoli da moj profil bude pronađen u pretraživanju",
     "publicProfileDesc": "Uključivanjem omogućujete drugim korisnicima da pronađu vaš profil u globalnoj tražilici i pošalju zahtjeve za chat. U ovom trenutku možete odabrati prihvatiti ili odbiti zahtjev.",
-    "errorDisableIT": "Pomoć pri prevođenju je isključena.",
-    "errorDisableIGC": "Pomoć pri gramatici je isključena.",
     "errorDisableITUserDesc": "Kliknite ovdje za ažuriranje postavki pomoći pri prevođenju",
     "errorDisableIGCUserDesc": "Kliknite ovdje za ažuriranje postavki pomoći pri gramatici",
     "errorDisableITClassDesc": "Pomoć pri prevođenju je isključena za tečaj u kojem se nalazi ovaj chat.",
     "errorDisableIGCClassDesc": "Pomoć pri gramatici je isključena za tečaj u kojem se nalazi ovaj chat.",
-    "error405Title": "Jezici nisu postavljeni",
     "error405Desc": "Molimo postavite svoje jezike u Glavnom izborniku > Postavke učenja.",
     "termsAndConditions": "Uvjetima i odredbama",
     "andCertifyIAmAtLeast13YearsOfAge": " i potvrđujem da imam najmanje 16 godina.",
-    "error502504Title": "Vau, puno je učenika online!",
     "error502504Desc": "Alati za prijevod i gramatiku mogu biti spori ili nedostupni dok Pangea botovi ne uhvate korak.",
-    "error404Title": "Greška u prijevodu!",
     "error404Desc": "Pangea Bot nije siguran kako to prevesti...",
     "errorPleaseRefresh": "Radimo na tome! Molimo osvježite i pokušajte ponovno.",
     "connectedToStaging": "Povezano sa Stagingom",
@@ -2930,13 +2664,9 @@
     "definitionsToolName": "Definicije riječi",
     "definitionsToolDescription": "Kad je omogućeno, riječi podvučene plavom bojom mogu se kliknuti za definicije. Kliknite na poruke za pristup definicijama.",
     "welcomeBack": "Dobro došli nazad! Ako ste sudjelovali u pilot projektu 2023-2024, kontaktirajte nas za vašu posebnu pilot pretplatu. Ako ste učitelj koji je (ili vaša institucija je) kupio licence za vašu razred, kontaktirajte nas za učiteljevu pretplatu.",
-    "downloadTxtFile": "Preuzmi tekstualnu datoteku",
-    "downloadCSVFile": "Preuzmi CSV datoteku",
     "promotionalSubscriptionDesc": "Trenutno imate doživotnu promotivnu pretplatu. Pošaljite poruku na support@pangea.chat za pomoć pri promjeni pretplate.",
     "originalSubscriptionPlatform": "Pretplata kupljena putem {purchasePlatform}",
     "oneWeekTrial": "Tjedan dana probnog razdoblja",
-    "downloadXLSXFile": "Preuzmi Excel datoteku",
-    "unkDisplayName": "Nepoznato",
     "wwCountryDisplayName": "Cijeli svijet",
     "afCountryDisplayName": "Afganistan",
     "axCountryDisplayName": "Olandski otoci",
@@ -3231,7 +2961,6 @@
     "chatCapacityHasBeenChanged": "Kapacitet chata je promijenjen",
     "chatCapacitySetTooLow": "Kapacitet chata mora biti najmanje {count}.",
     "chatCapacityExplanation": "Kapacitet chata ograničava broj članova koji smiju biti u chatu.",
-    "tooManyRequest": "Previše zahtjeva, molimo pokušajte kasnije.",
     "enterNumber": "Molimo unesite cijeli broj.",
     "practice": "Vježba",
     "versionNotFound": "Verzija nije pronađena",
@@ -3241,7 +2970,6 @@
     "deleteSubscriptionWarningTitle": "Imate aktivnu pretplatu",
     "deleteSubscriptionWarningBody": "Brisanje vašeg računa neće automatski otkazati vašu pretplatu.",
     "manageSubscription": "Upravljanje pretplatom",
-    "error520Title": "Pokušajte ponovno.",
     "error520Desc": "Oprostite, nismo mogli razumjeti vašu poruku...",
     "wordsUsed": "Riječi korištene",
     "level": "Razina",
@@ -3259,7 +2987,6 @@
     "other": "Ostalo",
     "levelShort": "RAV {level}",
     "noCapacityLimit": "Nema ograničenja kapaciteta",
-    "downloadGroupText": "Preuzmi tekst grupe",
     "notificationsOn": "Obavijesti uključene",
     "notificationsOff": "Obavijesti isključene",
     "joinWithCode": "Pridruži se s kodom",
@@ -3323,24 +3050,12 @@
     "whatIsTheMorphTag": "Što je {morphologicalFeature} od '{wordForm}'?",
     "dataAvailable": "Dostupnost podataka",
     "available": "Dostupno",
-    "pangeaBotIsFallible": "Pangea Bot također pravi pogreške!",
-    "whatIsMeaning": "Što znači '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Uskladite značenja s riječima u poruci!",
-    "doubleClickToEdit": "Dvostruki klik za uređivanje.",
-    "topicLabel": "Tema",
-    "topicPlaceholder": "Odaberite temu...",
-    "modePlaceholder": "Odaberite način...",
-    "learningObjectiveLabel": "Cilj učenja",
-    "learningObjectivePlaceholder": "Odaberite cilj učenja...",
-    "targetLanguageLabel": "Ciljani jezik",
     "cefrLevelLabel": "Razina CEFR-a",
     "image": "Slika",
     "video": "Video",
     "nan": "Nije primjenjivo",
-    "addVocabulary": "Dodaj vokabular",
     "instructions": "Upute",
-    "numberOfLearners": "Broj učenika",
-    "mustBeInteger": "Mora biti cijeli broj, npr. 1, 2, 3, ...",
     "constructUsePvmDesc": "Proizvedeno u glasovnoj poruci",
     "leaveSpaceDescription": "Napustite tečaj, napustit ćete sve razgovore unutar njega. Ostali korisnici će vidjeti da ste napustili tečaj.",
     "constructUseCorMmDesc": "Točno značenje poruke",
@@ -3355,7 +3070,6 @@
     "ttsDisabledBody": "Možete omogućiti pretvaranje teksta u govor u postavkama učenja",
     "noSpaceDescriptionYet": "Još nije kreiran opis tečaja.",
     "tooLargeToSend": "Ova poruka je prevelika za slanje",
-    "exitWithoutSaving": "Jeste li sigurni da želite izaći bez spremanja?",
     "enableAutocorrectPopupTitle": "Dodajte tipkovnicu za ciljani jezik tako da odete na:",
     "enableAutocorrectPopupSteps": "  • Postavke\n  • Općenito\n  • Tipkovnica\n  • Tipkovnice\n  • Dodaj novu tipkovnicu",
     "enableAutocorrectPopupDescription": "Kad odaberete jezik, možete kliknuti na malu globus ikonu u donjem lijevom kutu vaše tipkovnice za aktiviranje nove instalirane tipkovnice.",
@@ -3366,11 +3080,8 @@
     "displayName": "Prikazno ime",
     "leaveRoomDescription": "Upravo napuštate ovaj chat. Ostali korisnici će vidjeti da ste napustili chat.",
     "confirmUserId": "Molimo potvrdite svoje korisničko ime na Pangea Chatu kako biste izbrisali svoj račun.",
-    "startingToday": "Počevši od danas",
-    "oneWeekFreeTrial": "Tjedan dana besplatnog probnog razdoblja",
     "paidSubscriptionStarts": "Počinje {startDate}",
     "cancelInSubscriptionSettings": "• Otkažite u bilo kojem trenutku u postavkama pretplate",
-    "cancelToAvoidCharges": "• Otkažite prije {trialEnds} kako biste izbjegli naplate",
     "downloadGboard": "Preuzmi Gboard",
     "autocorrectNotAvailable": "Nažalost, vaša platforma trenutno nije podržana za ovu značajku. Ostanite s nama za daljnji razvoj!",
     "pleaseUpdateApp": "Molimo ažurirajte aplikaciju za nastavak.",
@@ -3380,17 +3091,12 @@
     "knockSpaceSuccess": "Zatražili ste pridruživanje ovom tečaju! Administrator će odgovoriti na vaš zahtjev kada ga primi. 😀",
     "chooseWordAudioInstructionsBody": "Slušajte cijelu poruku. Zatim uskladite audiozapise s riječima.",
     "chooseMorphsInstructionsBody": "Kliknite na komade slagalice za gramatička pitanja!",
-    "pleaseEnterInt": "Unesite broj",
     "home": "Početna",
     "join": "Pridruži se",
     "resetInstructionTooltipsTitle": "Resetiraj upute za alatne trake",
     "resetInstructionTooltipsDesc": "Kliknite za prikaz uputa poput za potpuno novog korisnika.",
-    "randomize": "Nasumično",
     "clear": "Očisti",
-    "featuredActivities": "Istaknuto",
     "save": "Spremi",
-    "startChat": "Započni chat",
-    "translationProblem": "Problem s prijevodom",
     "askToJoin": "Zatraži pridruživanje",
     "emptyChatWarningTitle": "Chat je prazan",
     "emptyChatWarningDesc": "Niste pozvali nikoga u svoj chat. Idite na postavke chata da pozovete svoje kontakte ili Bota. To možete učiniti i kasnije.",
@@ -3420,17 +3126,13 @@
     "timesUsedIndependently": "Broj korištenja neovisno",
     "timesUsedWithAssistance": "Broj korištenja uz pomoć",
     "shareInviteCode": "Podijeli pozivni kod: {code}",
-    "leaderboard": "Ljestvica",
     "skipForNow": "Preskoči za sada",
     "permissions": "Dozvole",
     "spaceChildPermission": "Tko može dodati nove razgovore u ovaj tečaj",
-    "addEnvironmentOverride": "Dodaj nadjačavanje okruženja",
     "defaultOption": "Zadano",
     "deleteChatDesc": "Jeste li sigurni da želite izbrisati ovaj razgovor? On će biti izbrisan za sve sudionike, a sve poruke unutar razgovora više neće biti dostupne za vježbanje ili analitiku učenja.",
     "deleteSpaceDesc": "Tečaj i svi odabrani razgovori bit će izbrisani za sve sudionike, a sve poruke unutar razgovora više neće biti dostupne za vježbanje ili analitiku učenja. Ova radnja se ne može poništiti.",
     "launch": "Pokreni",
-    "searchChats": "Pretraži razgovore",
-    "maxFifty": "Maksimalno 50",
     "configureSpace": "Konfiguriraj tečaj",
     "pinMessages": "Prikači poruke",
     "setJoinRules": "Postavi pravila pridruživanja",
@@ -3464,9 +3166,6 @@
     "failedToFetchTranscription": "Neuspjelo dohvaćanje transkripcije",
     "deleteEmptySpaceDesc": "Tečaj će biti izbrisan za sve sudionike. Ova radnja se ne može poništiti.",
     "regenerate": "Ponovno generiraj",
-    "mySavedActivities": "Moje spremljene aktivnosti",
-    "noSavedActivities": "Nema spremljenih aktivnosti",
-    "saveActivity": "Spremi ovu aktivnost",
     "failedToPlayVideo": "Neuspješno reproduciranje videa",
     "done": "Gotovo",
     "inThisSpace": "U ovom tečaju",
@@ -3477,13 +3176,9 @@
     "numInvited": "{count} pozvano",
     "saved": "Spremljeno",
     "reset": "Resetiraj",
-    "errorFetchingActivitiesMessage": "Neuspješno dohvaćanje aktivnosti",
     "errorFetchingDefinition": "Neuspješno dohvaćanje definicije",
     "errorProcessAnalytics": "Neuspješno procesiranje analitike",
     "errorDownloading": "Preuzimanje nije uspjelo",
-    "errorLoadingSpaceChildren": "Neuspješno učitavanje razgovora unutar ovog tečaja",
-    "unexpectedError": "Neočekivana pogreška.",
-    "pleaseReload": "Molimo vas da ponovno učitate i pokušate ponovo.",
     "translationError": "Pogreška u prijevodu",
     "check": "Provjeri",
     "unableToFindRoom": "Nije pronađen razgovor ili tečaj s tim kodom. Molimo pokušajte ponovno.",
@@ -3492,19 +3187,14 @@
     "request": "Zahtjev",
     "requestAll": "Zatraži sve",
     "confirmMessageUnpin": "Jeste li sigurni da želite odvojiti ovu poruku?",
-    "saveAndLaunch": "Spremi i pokreni",
-    "launchToSpace": "Pokreni u tečaju",
     "pending": "Na čekanju",
     "inactive": "Neaktivno",
-    "confirmRole": "Potvrdi ulogu",
     "openRoleLabel": "OTVORENO",
     "finishedTheActivity": "🎯 {username} završio ovu aktivnost",
     "activitySummaryError": "Sažeci aktivnosti nisu dostupni",
     "requestSummaries": "Zatraži sažetke",
-    "generatingNewActivities": "Vi ste prvi korisnik ovog para jezika! Molimo vas pričekajte minutu, pripremamo aktivnosti baš za vas.",
     "requestAccessTitle": "Zatraži pristup analitici?",
     "requestAccessDesc": "Želite li zatražiti pristup za prikaz analitike sudionika?\n\nAko se sudionici slože, administratori ovog tečaja moći će vidjeti njihove:\n    • ukupni vokabular\n    • ukupne gramatičke koncepte\n    • ukupne završene sesije aktivnosti\n    • specifične gramatičke koncepte korištene, ispravno i pogrešno\n\nNeće moći vidjeti njihove:\n    • poruke u chatovima izvan tečaja\n    • popis vokabulara",
-    "requestAccess": "Zatraži pristup ({count})",
     "analyticsInactiveTitle": "Zahtjevi za neaktivne korisnike nisu mogli biti poslani",
     "analyticsInactiveDesc": "Neaktivni korisnici koji se nisu prijavili od kada je ova značajka uvedena neće vidjeti vaš zahtjev.\n\nGumb Zahtjev pojavit će se nakon njihovog povratka. Možete ponovno poslati zahtjev kasnije klikom na gumb Zahtjev ispod njihovog imena kada bude dostupan.",
     "accessRequestedTitle": "Zahtjev za pristup analitici",
@@ -3527,8 +3217,6 @@
     "accessDesc": "Možete učiniti svoj tečaj otvorenim za svijet! Ili, učiniti svoj tečaj privatnim i sigurnim.",
     "createGroupChatDesc": "Dok sesije aktivnosti počinju i završavaju, grupni chatovi će ostati otvoreni za rutinsku komunikaciju.",
     "deleteDesc": "Samo administratori mogu izbrisati tečaj. Ovo je destruktivna radnja koja uklanja sve korisnike i briše sve odabrane chatove unutar tečaja. Budite oprezni.",
-    "noCourseFound": "O, ovaj tečaj treba plan!\n\nPlanovi tečaja su niz tema i aktivnosti razgovora.",
-    "additionalParticipants": "+ {num} drugih",
     "whatNow": "Što sada?",
     "chooseNextActivity": "Odaberite svoju sljedeću aktivnost!",
     "letsGo": "Krenimo",
@@ -3541,13 +3229,11 @@
     "waitNotDone": "Čekaj, još nisam gotov!",
     "waitingForOthersToFinish": "Čekam da ostali završe...",
     "generatingSummary": "Analiziranje chata i generiranje rezultata",
-    "findCourse": "Pronađi tečaj",
     "pingParticipantsNotification": "{user} traži korisnike za pridruživanje sesiji aktivnosti u {room}",
     "course": "Tečaj",
     "courses": "Tečajevi",
     "goToCourse": "Idi na tečaj: {course}",
     "activityComplete": "Ova aktivnost je završena. Sažetak aktivnosti trebao bi biti dostupan u nastavku.",
-    "startNewSession": "Započni novu sesiju",
     "joinOpenSession": "Pridruži se otvorenoj sesiji",
     "activityNotFound": "Aktivnost nije pronađena",
     "myActivities": "Moje aktivnosti",
@@ -3617,14 +3303,6 @@
     "@checkList": {
         "type": "String",
         "placeholders": {}
-    },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@sendImages": {
         "type": "String",
@@ -3732,22 +3410,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -3784,10 +3446,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -3797,10 +3455,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -3876,27 +3530,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4214,10 +3852,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4227,10 +3861,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4318,14 +3948,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4342,10 +3964,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4358,15 +3976,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4518,14 +4128,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4539,14 +4141,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5769,10 +5363,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5813,10 +5403,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5889,10 +5475,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6162,47 +5744,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6222,19 +5764,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6298,10 +5828,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6342,14 +5868,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6361,14 +5879,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6406,10 +5916,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6426,27 +5932,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6570,10 +6060,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6583,10 +6069,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6603,14 +6085,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6750,18 +6224,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6810,10 +6272,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6823,18 +6281,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6877,23 +6323,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6917,10 +6351,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6928,14 +6358,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7040,18 +6462,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7104,10 +6514,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7134,10 +6540,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7318,7 +6720,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Vratite se sutra za ažuriranja aktivnosti.",
-    "activityDropdownDesc": "Kad završite s ovom aktivnošću, kliknite ispod",
     "languageMismatchTitle": "Neusklađenost jezika",
     "languageMismatchDesc": "Vaš ciljni jezik ne odgovara jeziku ove aktivnosti. Želite li ažurirati svoj ciljni jezik?",
     "reportWordIssueTooltip": "Prijavite problem s informacijama o riječi",
@@ -7331,10 +6732,6 @@
     "selectAll": "Odaberi sve",
     "deselectAll": "Odznači sve",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7383,17 +6780,11 @@
         "placeholders": {}
     },
     "startOwn": "Započni svoj vlastiti",
-    "joinCourseDesc": "Svaki tečaj ima 8-10 sekvenciranih tema s nizom aktivnosti za učenje jezika temeljenih na zadacima.",
     "newMessageInPangeaChat": "💬 Nova poruka u Pangea chatu",
     "shareCourse": "Podijeli tečaj",
     "addCourse": "Dodaj tečaj",
-    "joinPublicCourse": "Pridruži se javnom tečaju",
     "vocabLevelsDesc": "Ovdje će ići riječi vokabulara nakon što ih podignete na višu razinu!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7406,10 +6797,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7428,7 +6815,6 @@
     "emojiView": "Prikaz emojija",
     "feedbackDialogDesc": "I ja griješim! Ima li nešto što bi mi pomoglo da se poboljšam?",
     "contactHasBeenInvitedToTheCourse": "Kontakt je pozvan na tečaj",
-    "activityStatsButtonTooltip": "Informacije o aktivnosti",
     "allow": "Dopusti",
     "deny": "Odbij",
     "enabledRenewal": "Omogući obnavljanje pretplate",
@@ -7696,10 +7082,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8755,16 +8137,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktivnosti za otključavanje sljedeće teme",
-    "activitiesToUnlockTopicDesc": "Postavite broj aktivnosti za otključavanje sljedeće teme tečaja",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Ispravna praksa definicije vokabulara",
     "constructUseIncLMDesc": "Neispravna praksa definicije vokabulara",
     "constructUseCorLADesc": "Ispravna praksa audio vokabulara",
@@ -8772,7 +8144,6 @@
     "constructUseBonus": "Bonus tijekom prakse vokabulara",
     "practiceVocab": "Vježbajte vokabular",
     "selectMeaning": "Odaberite značenje",
-    "selectAudio": "Odaberite odgovarajući audio",
     "anotherRound": "Još jedan krug",
     "activitySettingsOverrideWarning": "Jezik i razina jezika određeni planom aktivnosti",
     "voice": "Glas",
@@ -8804,10 +8175,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8825,12 +8192,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Preuzimanje pokrenuto",
     "webDownloadPermissionMessage": "Ako vaš preglednik blokira preuzimanja, molimo omogućite preuzimanja za ovu stranicu.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8925,11 +8287,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Nešto je pošlo po zlu i marljivo radimo na rješavanju problema. Provjerite ponovo kasnije.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Omogući pomoć pri pisanju",
     "autoIGCToolDescription": "Automatski pokreni Pangea Chat alate za ispravljanje poslanih poruka na ciljni jezik.",
     "@autoIGCToolName": {
@@ -8985,24 +8342,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatika",
-    "spanTypeWordChoice": "Odabir riječi",
     "spanTypeSpelling": "Pravopis",
     "spanTypePunctuation": "Interpunkcija",
     "spanTypeStyle": "Stil",
     "spanTypeFluency": "Tečnost",
     "spanTypeAccents": "Naglasci",
     "spanTypeCapitalization": "Velika slova",
-    "spanTypeCorrection": "Ispravak",
     "spanFeedbackTitle": "Prijavi problem s ispravkom",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9027,10 +8373,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9043,13 +8385,7 @@
     "longPressToRecordVoiceMessage": "Dugo pritisnite za snimanje glasovne poruke.",
     "pause": "Pauza",
     "resume": "Nastavi",
-    "newSubSpace": "Novi podprostor",
-    "moveToDifferentSpace": "Premjesti u drugi prostor",
-    "removeFromSpaceDescription": "Razgovor će biti uklonjen iz prostora, ali će se i dalje pojavljivati na vašem popisu razgovora.",
     "countChats": "{chats} razgovora",
-    "spaceMemberOf": "Član prostora {spaces}",
-    "spaceMemberOfCanKnock": "Član prostora {spaces} može pokucati",
-    "donate": "Doniraj",
     "startedAPoll": "{username} je započeo anketu.",
     "poll": "Anketa",
     "startPoll": "Započni anketu",
@@ -9073,23 +8409,15 @@
     "newStickerPack": "Novi paket naljepnica",
     "stickerPackName": "Ime paketa naljepnica",
     "attribution": "Priznanje",
-    "skipChatBackup": "Preskoči sigurnosnu kopiju chata",
-    "skipChatBackupWarning": "Jeste li sigurni? Bez omogućavanja sigurnosne kopije chata možete izgubiti pristup svojim porukama ako promijenite uređaj.",
-    "loadingMessages": "Učitavanje poruka",
-    "setupChatBackup": "Postavi sigurnosnu kopiju chata",
     "noMoreResultsFound": "Nema više pronađenih rezultata",
     "chatSearchedUntil": "Chat pretražen do {time}",
     "federationBaseUrl": "Osnovna URL adresa federacije",
     "clientWellKnownInformation": "Informacije o klijentu:",
     "baseUrl": "Osnovna URL adresa",
     "identityServer": "Identitet Server:",
-    "versionWithNumber": "Verzija: {version}",
     "logs": "Dnevnici",
-    "advancedConfigs": "Napredne postavke",
     "advancedConfigurations": "Napredne konfiguracije",
-    "signInWithLabel": "Prijavite se s:",
     "selectAllWords": "Odaberite sve riječi koje čujete u audiozapisu",
-    "joinCourseForActivities": "Pridružite se tečaju kako biste isprobali aktivnosti.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9126,18 +8454,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9145,26 +8461,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9270,22 +8566,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9314,19 +8594,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9334,15 +8602,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9543,11 +8803,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "U razredu? Stavite svoj kod za pridruživanje ovdje.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automatski istakni audio poruke",
     "selectAudioMessagesOnPlayDescription": "Automatski istakni audio poruke kada se reproduciraju",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9591,18 +8846,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Ovaj tečaj ima teme s manje od {input} aktivnosti. Molimo unesite broj manji ili jednak {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Kliknite ovdje da se ponovno prijavite.",
     "@clickToLogin": {
@@ -10019,17 +9262,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Kartonasti žuti medvjed s podignutim rukama u uzbuđenju.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Odaberite riječi kako biste saznali više o njima",
     "requireAnalyticsAccessTitle": "Zahtijeva pristup analitici za pridruživanje",
     "requireAnalyticsAccessDesc": "Sudionici moraju odobriti pristup svojim analitikama učenja kako bi se pridružili ovom tečaju",
     "analyticsAccessNoticeTitle": "Potrebna analitika",
     "analyticsAccessNoticeDesc": "Pridruživanjem ovom tečaju, slažete se da administratorima omogućite pristup vašim analitikama učenja.",
-    "skipOnboardingClassCodeDesc": "Učite neovisno? Ne brinite, možete:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10047,10 +9284,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10079,7 +9312,6 @@
     "pickCefrLevelTeacherStepTitle": "Koju razinu podučavate?",
     "pickCefrLevelStudentStepTitle": "Koja ste razina?",
     "customCourseStepTitle": "Ispunite ovaj obrazac za prilagođeni tečaj",
-    "aboutYourClass": "O vašem razredu",
     "courseCodeStepErrorMessage": "Molimo provjerite svoj kod i pokušajte ponovo",
     "institution": "Institucija",
     "courseGoals": "Ciljevi tečaja",
@@ -10122,10 +9354,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10242,12 +9470,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logo",
     "introChatDetails": "Pozdravite se! Predstavite se svojim kolegama sudionicima tečaja, pronađite prijatelje i razgovarajte izvan aktivnosti.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10291,11 +9514,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Akcije aktivnosti",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Alati za izgovor",
     "audioTranscription": "AI transkripcija zvuka",
     "visualLearnerSupport": "Podrška za vizualne učenike",
@@ -10336,7 +9554,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Pridružite se tečaju koji uključuje ovu aktivnost da biste je igrali.",
     "resizeCoursePanel": "Promijeni veličinu panela tečaja",
     "undo": "Poništi",
     "unlock": "Otključaj",
@@ -10350,7 +9567,6 @@
     "addCourseBrowsePublic": "Pretraži javne tečajeve",
     "browsePublicCourses": "Pretraži javne tečajeve",
     "editProfile": "Uredi profil",
-    "numObjectives": "{count} ciljeva",
     "mapSearchHint": "Pretraži aktivnosti",
     "mapSearchNoResults": "Nema podudaranja u prikazu",
     "mapFilterAllLanguages": "Svi jezici",
@@ -10359,7 +9575,6 @@
     "mapFilterCompleted": "Završeno",
     "mapFilterReset": "Ponovno postavi",
     "activityTypeConversation": "Razgovor",
-    "lockedMissionRequirement": "Završi prethodnu misiju da bi otključao",
     "playAgain": "Igraj ponovo",
     "reviewActivity": "Pregledaj",
     "mapEmptyInView": "Nema ništa ovdje na tvojoj razini ili jeziku. Proširi svoje filtre ili odmakni se.",
@@ -10374,14 +9589,9 @@
     "scrollToBottom": "Pomakni se do dna",
     "courseImage": "Slika tečaja",
     "avatarPreview": "Pregled avatara",
-    "activityPhoto": "Fotografija aktivnosti",
     "emotePreview": "Pregled emota: {name}",
     "activityLabel": "Aktivnost: {title}",
     "resetMapView": "Poništi prikaz karte",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10434,14 +9644,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10471,10 +9673,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10531,10 +9729,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_hu.arb
+++ b/lib/l10n/intl_hu.arb
@@ -63,11 +63,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Csatlakozhatnak-e vendégek",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Biztos benne?",
     "@areYouSure": {
         "type": "String",
@@ -333,11 +328,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Kapcsolat meghívásra került a csoportba",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "copiedToClipboard": "Vágólapra másolva",
     "@copiedToClipboard": {
         "type": "String",
@@ -482,11 +472,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Többé nem fogja tudni kikapcsolni a titkosítást. Biztos benne?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encryption": "Titkosítás",
     "@encryption": {
         "type": "String",
@@ -533,11 +518,6 @@
     },
     "group": "Csoport",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "A csoport nyilvános",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -606,15 +586,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Ismerős meghívása a(z) {groupName} csoportba",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Meghívott",
     "@invited": {
@@ -722,15 +693,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "További {count} résztvevő betöltése",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Betöltés… Kérem, várjon.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -745,15 +707,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Bejelentkezés a(z) {homeserver} Matrix-kiszolgálóra",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Kijelentkezés",
     "@logout": {
@@ -797,11 +750,6 @@
     },
     "noEmotesFound": "Nem találhatóak hangulatjelek. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Úgy tűnik a Firebase Cloud Messaging nem elérhető a készülékén. Ha mégis push értesítéseket kíván kapni, javasoljuk a ntfy telepítését. A ntfy vagy más egyéb Egyesített Push szolgáltató esetében úgy kaphat értesítést, hogy adatai biztonságban maradnak. Letöltheti a ntfy-t a PlayStore-ból, vagy F-Droid-ról is.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -955,11 +903,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Eszköz eltávolítása",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Csevegés kitiltás feloldása",
     "@unbanFromChat": {
@@ -1195,15 +1138,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unreadChats": "{unreadCount, plural, =1{1 olvasatlan csevegés} other{{unreadCount} olvasatlan csevegés}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "userAndOthersAreTyping": "{username} és {count} másik résztvevő gépel…",
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -1283,16 +1217,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Videóhívás",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Csevegési előzmény láthatósága",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Minden résztvevő számára látható",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1333,11 +1257,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoIsAllowedToJoinThisGroup": "Ki csatlakozhat a csoporthoz",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "writeAMessage": "Írjon egy üzenetet…",
     "@writeAMessage": {
         "type": "String",
@@ -1370,11 +1289,6 @@
     },
     "weSentYouAnEmail": "Küldtünk Önnek egy emailt",
     "@weSentYouAnEmail": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Jelszó visszaállítás",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1540,11 +1454,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "everythingReady": "Minden kész!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "groups": "Csoportok",
     "@groups": {
         "type": "String",
@@ -1614,20 +1523,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "A csevegés biztonsági mentés beállításra került.",
-    "@yourChatBackupHasBeenSetUp": {},
-    "chatBackupDescription": "A régebbi beszélgetései egy biztonsági kulccsal vannak védve. Bizonyosodjon meg róla, hogy nem veszíti el.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "noConnectionToTheServer": "Nem elérhető a szerver",
     "@noConnectionToTheServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Csak akkor kapcsolható be a titkosítás, ha a szoba nem nyilvánosan hozzáférhető.",
-    "@noEncryptionForPublicRooms": {
         "type": "String",
         "placeholders": {}
     },
@@ -1694,11 +1591,6 @@
     },
     "configureChat": "Csevegés konfigurálása",
     "@configureChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "createNewSpace": "Új tér",
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1816,8 +1708,6 @@
     },
     "commandHint_markasgroup": "Jelölés csoportnak",
     "@commandHint_markasgroup": {},
-    "addAccount": "Fiók hozzáadása",
-    "@addAccount": {},
     "search": "Keresés",
     "@search": {
         "type": "String",
@@ -1929,11 +1819,6 @@
     "@dismiss": {},
     "reportErrorDescription": "😭 Sajnos, valami félresiklott. Ha kívánja, jelezheti a bugot a fejlesztőknek.",
     "@reportErrorDescription": {},
-    "setPermissionsLevel": "Engedélyszint beállítása",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "removeYourAvatar": "Profilképének törlése",
     "@removeYourAvatar": {
         "type": "String",
@@ -2006,34 +1891,17 @@
     "@messagesStyle": {},
     "widgetUrlError": "Helytelen hivatkozás.",
     "@widgetUrlError": {},
-    "emailOrUsername": "Email vagy felhasználónév",
-    "@emailOrUsername": {},
-    "newSpaceDescription": "A terek lehetővé teszik a csevegések konszolidációját, ezáltal létrehozva publikus vagy privát közösségeket.",
-    "@newSpaceDescription": {},
-    "chatDescription": "Csevegés leírás",
-    "@chatDescription": {},
     "pleaseFollowInstructionsOnWeb": "Kérem, kövesse az instrukciókat az oldalon, és nyomjon a tovább gombra.",
     "@pleaseFollowInstructionsOnWeb": {
         "type": "String",
         "placeholders": {}
     },
-    "enterSpace": "Belépés a térre",
-    "@enterSpace": {},
-    "encryptThisChat": "A csevegés titkosítása",
-    "@encryptThisChat": {},
     "reopenChat": "Csevegés újranyitása",
     "@reopenChat": {},
-    "pleaseEnterRecoveryKey": "Kérem, adja meg a visszaállító kódját:",
-    "@pleaseEnterRecoveryKey": {},
     "widgetNameError": "Kérem adjon meg egy megjelenítendő nevet.",
     "@widgetNameError": {},
     "addToBundle": "Hozzáadás fiókcsoporthoz",
     "@addToBundle": {},
-    "spaceIsPublic": "A tér publikus",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "addWidget": "Widget hozzáadása",
     "@addWidget": {},
     "countFiles": "{count} fájl",
@@ -2053,8 +1921,6 @@
     },
     "pushNotificationsNotAvailable": "Push értesítések nem elérhetőek",
     "@pushNotificationsNotAvailable": {},
-    "storeInAppleKeyChain": "Tárolás az Apple KeyChain-be",
-    "@storeInAppleKeyChain": {},
     "replaceRoomWithNewerVersion": "Szoba cserélése egy újabb verzióra",
     "@replaceRoomWithNewerVersion": {
         "type": "String",
@@ -2064,24 +1930,12 @@
     "@invalidServerName": {},
     "chatPermissions": "Csevegés engedélyek",
     "@chatPermissions": {},
-    "wipeChatBackup": "Le kívánja törölni a chat mentését, hogy létrehozhasson egy új visszaállítási kulcsot?",
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "sender": "Küldő",
     "@sender": {},
-    "storeInAndroidKeystore": "Tárolás az Android KeyStore-ba",
-    "@storeInAndroidKeystore": {},
     "makeAdminDescription": "Miután a felhasználót aminisztrátorrá lépteti elő, nem fogja tudni visszavonni döntését, mivel azonos jogosultsági szinttel fognak rendelkezni.",
     "@makeAdminDescription": {},
     "synchronizingPleaseWait": "Szinkronizálás... Kérem, várjon.",
     "@synchronizingPleaseWait": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "transferFromAnotherDevice": "Átvitel másik eszközről",
-    "@transferFromAnotherDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -2090,19 +1944,12 @@
         "type": "String",
         "placeholders": {}
     },
-    "saveKeyManuallyDescription": "A kulcs manuális mentése rendszer megosztás vagy vágólap másolás segítségével.",
-    "@saveKeyManuallyDescription": {},
     "editBundlesForAccount": "Fiókcsoportok szerkesztése ehhez a fiókhoz",
     "@editBundlesForAccount": {},
     "whyIsThisMessageEncrypted": "Miért olvashatatlan ez az üzenet?",
     "@whyIsThisMessageEncrypted": {},
     "setChatDescription": "Csevegés leírás beállítása",
     "@setChatDescription": {},
-    "spaceName": "Tér név",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "importFromZipFile": "Importálás zip fájlból",
     "@importFromZipFile": {},
     "noOtherDevicesFound": "Nem található más eszköz",
@@ -2116,8 +1963,6 @@
             }
         }
     },
-    "videoCallsBetaWarning": "Kérem vegye figyelembe, hogy a videó hívások jelenleg béta fázisban vannak. Nem biztos, hogy megfelelően fognak működni, vagy egyáltalán elindulnak egyes platformokon.",
-    "@videoCallsBetaWarning": {},
     "fileIsTooBigForServer": "Nem küldhető el! A szerver csak {max} határig enged csatolmányokat.",
     "@fileIsTooBigForServer": {},
     "verified": "Hitelesített",
@@ -2129,8 +1974,6 @@
     "@readUpToHere": {},
     "start": "Kezdés",
     "@start": {},
-    "unlockOldMessages": "Régi üzenetek feloldása",
-    "@unlockOldMessages": {},
     "optionalRedactReason": "(Választható) A szerkesztés oka...",
     "@optionalRedactReason": {},
     "sendAsText": "Küldés szövegként",
@@ -2153,8 +1996,6 @@
     },
     "experimentalVideoCalls": "Kísérleti videó hívások",
     "@experimentalVideoCalls": {},
-    "pleaseEnterRecoveryKeyDescription": "A régi üzenetei feloldásához adja meg a korábban generált visszaállítási jelszavát. A visszaállítási jelszó NEM EGYEZIK MEG a jelszóval.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "redactedByBecause": "{username} által szerkesztve, mivel: \"{reason}\"",
     "@redactedByBecause": {
         "type": "String",
@@ -2203,8 +2044,6 @@
     },
     "redactMessageDescription": "A társalgásban összes résztvevője számára módosításra kerül az üzenet. Ez nem visszavonható.",
     "@redactMessageDescription": {},
-    "recoveryKey": "Visszaállító kulcs",
-    "@recoveryKey": {},
     "invalidInput": "Hibás bevitel!",
     "@invalidInput": {},
     "yourPublicKey": "A publikus kulcsa",
@@ -2230,8 +2069,6 @@
     "@unverified": {},
     "serverRequiresEmail": "Ehhez a szerverhez szükséges az email címének visszaigazolása.",
     "@serverRequiresEmail": {},
-    "screenSharingTitle": "képernyő megosztás",
-    "@screenSharingTitle": {},
     "widgetCustom": "Egyedi",
     "@widgetCustom": {},
     "youBannedUser": "Letitotta {user} felhasználót",
@@ -2256,8 +2093,6 @@
     "@openLinkInBrowser": {},
     "messageInfo": "Üzenet információ",
     "@messageInfo": {},
-    "disableEncryptionWarning": "Biztonsági okokból nem kapcsolható ki egy korábban bekapcsolt csevegés titkosítás.",
-    "@disableEncryptionWarning": {},
     "directChat": "Privát csevegés",
     "@directChat": {},
     "wrongPinEntered": "Hibás pinkódot adott meg! Próbálja újra {seconds} mp múlva...",
@@ -2273,10 +2108,6 @@
     "@sendTypingNotifications": {},
     "inviteGroupChat": "📨 Meghívó a csoportba",
     "@inviteGroupChat": {},
-    "foregroundServiceRunning": "Ez az értesítés akkor jelenik meg ha az előtéri szolgáltatás fut.",
-    "@foregroundServiceRunning": {},
-    "voiceCall": "Hang hívás",
-    "@voiceCall": {},
     "importEmojis": "Emojik importálása",
     "@importEmojis": {},
     "wasDirectChatDisplayName": "Üres csevegés (korábban {oldDisplayName})",
@@ -2292,11 +2123,6 @@
     "@noChatDescriptionYet": {},
     "removeFromBundle": "Eltávolítás a fiókcsoportból",
     "@removeFromBundle": {},
-    "whoCanPerformWhichAction": "Ki milyen műveletet végezhet",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "learnMore": "Tudjon meg többet",
     "@learnMore": {},
     "users": "Felhasználók",
@@ -2309,8 +2135,6 @@
     "@newGroup": {},
     "bundleName": "Fiókcsoport neve",
     "@bundleName": {},
-    "removeFromSpace": "Eltávolítás a térről",
-    "@removeFromSpace": {},
     "roomUpgradeDescription": "A csevegés újra elkészül az új szoba verzióval. Minden résztvevő értesítést kap, hogy át kell állniuk az új csevegésre. További információkért a szoba verziókról látogasson el a https://spec.matrix.org/latest/rooms/ címre",
     "@roomUpgradeDescription": {},
     "pleaseEnterANumber": "Adjon meg egy 0-nál nagyobb számot",
@@ -2337,14 +2161,10 @@
             }
         }
     },
-    "sorryThatsNotPossible": "Ez sajnos nem lehetséges",
-    "@sorryThatsNotPossible": {},
     "shareInviteLink": "Meghívó link megosztása",
     "@shareInviteLink": {},
     "commandHint_markasdm": "Szoba megjelölése mint közvetlen csevegő szoba az adott Matrix ID-nél",
     "@commandHint_markasdm": {},
-    "recoveryKeyLost": "Elveszett visszaállító kulcs?",
-    "@recoveryKeyLost": {},
     "deviceKeys": "Eszköz kulcsok:",
     "@deviceKeys": {},
     "emoteKeyboardNoRecents": "A nemrég használt hangulatjelek fognak itt megjelenni...",
@@ -2352,8 +2172,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "Téma beállítása:",
-    "@setTheme": {},
     "youJoinedTheChat": "Becsatlakozott a csevegésbe",
     "@youJoinedTheChat": {},
     "markAsRead": "Olvasottként megjelölés",
@@ -2384,8 +2202,6 @@
     "@custom": {},
     "noBackupWarning": "Figyelem! Ha nem kapcsolja be a csevegés mentést, elveszíti a hozzáférést a tikosított üzeneteihez. Erősen ajánlott a csevegés mentés bekapcsolása kijelentkezés előtt.",
     "@noBackupWarning": {},
-    "storeInSecureStorageDescription": "Tárolja a visszaállítási kulcsot az eszköz biztonsági tárjában.",
-    "@storeInSecureStorageDescription": {},
     "openChat": "Csevegés megnyitása",
     "@openChat": {},
     "kickUserDescription": "A felhasználó kirúgásra került a csevegésből, de nincs kitiltva. Publikus csevegés esetén a felhasználó bármikor visszatérhet.",
@@ -2396,14 +2212,8 @@
     "@pinMessage": {},
     "invite": "Meghívás",
     "@invite": {},
-    "enableMultiAccounts": "(BÉTA) Több fiók bekapcsolása az eszközön",
-    "@enableMultiAccounts": {},
     "unsupportedAndroidVersionLong": "Ehhez a funkcióhoz egy újabb Android verzió kell. Kérem ellenőrizze be van e frissítve teljesen készüléke, esetlegesen van e LineageOS támogatás hozzá.",
     "@unsupportedAndroidVersionLong": {},
-    "storeSecurlyOnThisDevice": "Biztonságos tárolás az eszközön",
-    "@storeSecurlyOnThisDevice": {},
-    "screenSharingDetail": "Megosztja a képernyőjét a FluffyChat-ben",
-    "@screenSharingDetail": {},
     "placeCall": "Tér hívás",
     "@placeCall": {},
     "block": "Blokkolás",
@@ -2455,8 +2265,6 @@
     "@pleaseEnterYourCurrentPassword": {},
     "newPassword": "Új jelszó",
     "@newPassword": {},
-    "addChatOrSubSpace": "Csevegés vagy al-tér hozzáadása",
-    "@addChatOrSubSpace": {},
     "pleaseChooseAStrongPassword": "Kérem válasszon egy erős jelszót",
     "@pleaseChooseAStrongPassword": {},
     "passwordsDoNotMatch": "A jelszavak nem egyeznek",
@@ -2477,38 +2285,10 @@
     "@formattedMessages": {},
     "formattedMessagesDescription": "Formázott szöveg - mint például félkövér - megjelenítése \"markdown\"-al.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Más felhasználó igazolása",
-    "@verifyOtherUser": {},
     "verifyOtherDevice": "🔐 Más eszköz hitelesítése",
     "@verifyOtherDevice": {},
-    "sessionLostBody": "A munkamenete elvesződött. Kérem jelentse ezt a fejlesztőknek a {url} címen. A hiba szövege a következő: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Megpróbálkozunk visszaállítani a munkamenetét egy korábbi mentésből. Kérem jelezze a hibát a fejlesztőknek a {url} címen. A hiba szövege a következő: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "hidePresences": "El kívánja rejteni a státusz listát?",
     "@hidePresences": {},
-    "searchChatsRooms": "Keressen #csevegéseket, @felhasználókat...",
-    "@searchChatsRooms": {},
     "wrongRecoveryKey": "Sajnos, úgy tűnik hibásan adta meg a visszaállítási kulcsot.",
     "@wrongRecoveryKey": {},
     "startConversation": "Társalgás kezdése",
@@ -2578,35 +2358,14 @@
     "@discover": {},
     "groupName": "Csoport név",
     "@groupName": {},
-    "createGroupAndInviteUsers": "Hozzon létre egy csoportot és hívjon meg felhasználókat",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "A csoportokat kereséssel találhatja meg",
-    "@groupCanBeFoundViaSearch": {},
-    "verifyOtherUserDescription": "Ha megerősít egy másik felhasználót, akkor teljesen biztos lehet abban kivel cseveg. 💪\n\nA megerősítési folyamat kezdetekor megjelenik egy felugró ablak mindkettőjüknél. Ekkor egy hangulatjel vagy szám sor összehasonlítási folyamat veszi kezdetét.\n\nA legpraktikusabb módja ennek, hogy találkozzanak, vagy videó hívás során beszéljék meg. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDeviceDescription": "Amikor egy másik eszközt hitelesít, az eszközök kulcsokat cserélnek egymás között, ezáltal növelve az összbiztonságot. 💪 Amikor megkezdődik a folyamat, mind a két eszközön megjelenik egy felugró üzenet. Hangulatjelek és számok sorozata fog megjelenni, amit össze tud hasonlítani a két eszközön. Érdemes tehát mind a két eszközt a közelben tartani. 🤳",
     "@verifyOtherDeviceDescription": {},
-    "accessAndVisibility": "Hozzáférés és láthatóság",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Ki számára engedélyezett a csevegéshez való csatlakozás, és hogyan találhatja azt meg.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Hívások",
     "@calls": {},
     "hideInvalidOrUnknownMessageFormats": "Érvénytelen vagy ismeretlen üzenetformátum elrejtése",
     "@hideInvalidOrUnknownMessageFormats": {},
     "passwordRecoverySettings": "Jelszó-helyreállítási beállítások",
     "@passwordRecoverySettings": {},
-    "noOneCanJoin": "Senki sem csatlakozhat",
-    "@noOneCanJoin": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Csevegés felfedezhető a {server} szerveren történő kereséssel",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "appLockDescription": "Applikáció zárolása PIN kóddal használaton kívül",
     "@appLockDescription": {},
     "customEmojisAndStickers": "Egyedi hangulatjelek és matricák",
@@ -2615,10 +2374,6 @@
     "@customEmojisAndStickersBody": {},
     "overview": "Áttekintés",
     "@overview": {},
-    "publicChatAddresses": "Nyilvános csevegés címek",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Új cím létrehozása",
-    "@createNewAddress": {},
     "noDatabaseEncryption": "Adatbázis titkosítás nem támogatott ezen a platformon",
     "@noDatabaseEncryption": {},
     "thereAreCountUsersBlocked": "Jelenleg {count} felhasználó van letiltva.",
@@ -2655,16 +2410,12 @@
     "@restricted": {},
     "knockRestricted": "Kopogás korlátozva",
     "@knockRestricted": {},
-    "globalChatId": "Átfogó csevegő ID",
-    "@globalChatId": {},
     "hideRedactedMessages": "Szerkesztett üzenetek elrejtése",
     "@hideRedactedMessages": {},
     "hideRedactedMessagesBody": "Ha valaki szerkeszti az üzenetét, ez az üzenet nem jelenik meg a csevegés során.",
     "@hideRedactedMessagesBody": {},
     "knocking": "Bekopogás",
     "@knocking": {},
-    "usersMustKnock": "A felhasználóknak be kell kopogniuk",
-    "@usersMustKnock": {},
     "knock": "Kopogás",
     "@knock": {},
     "searchMore": "További keresés...",
@@ -2724,10 +2475,6 @@
     "@changeTheCanonicalRoomAlias": {},
     "chatPermissionsDescription": "Adja meg milyen erősségi szint kell egyes csevegési művelethez. A 0, 50 és 100-as szintek általában felhasználókat, moderátorokat és adminisztrátorokat jelölnek de bármilyen szintezés lehetséges.",
     "@chatPermissionsDescription": {},
-    "whatIsAHomeserver": "Mi az a Matrix-kiszolgáló?",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "Az összes adata a Mátrix-kiszolgálón tárolódik, pont mint egy e-mail kiszolgálón. Kiválaszthatja melyik Matrix-kiszolgálót akarja használni, miközben tud kommunikálni mindenkivel. Tudjon meg többet a https://matrix.org címen.",
-    "@homeserverDescription": {},
     "userLevel": "{level} - Felhasználó",
     "@userLevel": {
         "type": "String",
@@ -2762,10 +2509,6 @@
     "@alwaysUse24HourFormat": {
         "description": "Set to true to always display time of day in 24 hour format."
     },
-    "loginWithMatrixId": "Bejelentkezés Matrix-ID-vel",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Matrix-kiszolgálók felfedezése",
-    "@discoverHomeservers": {},
     "doesNotSeemToBeAValidHomeserver": "Nem tűnik kompatibilisnek a Mátrix-kiszolgálónak. Hibás a hivatkozás?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "noMoreChatsFound": "Nem található több csevegés...",
@@ -2774,15 +2517,6 @@
     "@joinedChats": {},
     "checkList": "Tennivalók listája",
     "@checkList": {},
-    "countInvited": "{count} meghívott",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "sendImages": "{count} kép küldése",
     "@sendImages": {
         "type": "String",
@@ -2902,23 +2636,10 @@
     "@italicText": {},
     "strikeThrough": "Áthúzott",
     "@strikeThrough": {},
-    "appWantsToUseForLogin": "Használja a '{server}' szervert a bejelentkezéshez",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "otherPartyNotLoggedIn": "A másik fél jelenleg nincs bejelentkezve, emiatt nem fogadhat üzeneteket!",
     "@otherPartyNotLoggedIn": {},
-    "appWantsToUseForLoginDescription": "Ezennel engedélyezi az applikáció és weboldal számára, hogy információkat gyűjtsön Önről.",
-    "@appWantsToUseForLoginDescription": {},
     "waitingForServer": "Várakozás a szerverre...",
     "@waitingForServer": {},
-    "appIntroduction": "A FluffyChat segítségével cseveghet barátaival, akár más üzenetküldő alkalmazásokon keresztül is. Tudjon meg erről többet a https://matrix.org oldalon, vagy nyomjon a \"Folytatás\" gombra.",
-    "@appIntroduction": {},
     "open": "Megnyitás",
     "@open": {},
     "notificationRuleSuppressNotices": "Minden automata üzenetet némít",
@@ -2993,8 +2714,6 @@
     },
     "deletePushRuleCanNotBeUndone": "Ha törli ezt az értesítési beállítást, később nem vonható vissza.",
     "@deletePushRuleCanNotBeUndone": {},
-    "manageAccount": "Fiók kezelése",
-    "@manageAccount": {},
     "enterNewChat": "Belépés új csevegésbe",
     "@enterNewChat": {},
     "blur": "Homályosít:",
@@ -3005,8 +2724,6 @@
     "@continueText": {},
     "opacity": "Átlátszóság:",
     "@opacity": {},
-    "welcomeText": "Üdv 👋 Ez a FluffyChat. Bejelentkezhet bármely matrix-kiszolgálóhoz amely kompatibilis a https://matrix.org címmel. Ezután cseveghet bárkivel. Így képez egy óriási decentralizált üzenetküldő hálózatot!",
-    "@welcomeText": {},
     "addLink": "Hivatkozás hozzáadása",
     "@addLink": {},
     "invalidUrl": "Helytelen hivatkozás",
@@ -3075,11 +2792,9 @@
     "taTooltip": "L2 használata fordítási segítséggel",
     "interactiveTranslatorSliderHeader": "Interaktív Fordító",
     "interactiveGrammarSliderHeader": "Interaktív Nyelvtani Ellenőrző",
-    "interactiveTranslatorRequired": "Kötelező",
     "waTooltip": "L2 segítség nélkül",
     "interactiveTranslator": "Fordítási segítség",
     "noIdenticalLanguages": "Kérjük, válasszon különböző alap- és célnyelvet",
-    "searchBy": "Keresés ország és nyelv szerint",
     "joinWithClassCode": "Csatlakozás kurzushoz",
     "languageLevelPreA1": "Novice Low (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -3100,19 +2815,14 @@
     "saveChanges": "Módosítások mentése",
     "publicProfileTitle": "Engedélyezem, hogy profilomat keresésben megtalálják",
     "publicProfileDesc": "Bekapcsolásával lehetővé teszed más felhasználók számára, hogy megtalálják profilodat a globális keresősávban, és kérjenek csevegést. Ekkor dönthetsz arról, hogy elfogadod vagy elutasítod a kérést.",
-    "errorDisableIT": "A Fordítási segítség kikapcsolva van.",
-    "errorDisableIGC": "A Nyelvtani segítség kikapcsolva van.",
     "errorDisableITUserDesc": "Kattints ide a fordítási segítség beállításainak frissítéséhez",
     "errorDisableIGCUserDesc": "Kattints ide a nyelvtani segítség beállításainak frissítéséhez",
     "errorDisableITClassDesc": "A fordítási segítség kikapcsolva van az adott kurzushoz tartozó csevegésben.",
     "errorDisableIGCClassDesc": "A nyelvtani segítség kikapcsolva van az adott kurzushoz tartozó csevegésben.",
-    "error405Title": "Nyelvek nincsenek beállítva",
     "error405Desc": "Kérjük, állítsa be nyelveit a Főmenü > Tanulási Beállítások menüpontban.",
     "termsAndConditions": "Felhasználási feltételeket",
     "andCertifyIAmAtLeast13YearsOfAge": " és igazolom, hogy legalább 16 éves vagyok.",
-    "error502504Title": "Hűha, sok diák van online!",
     "error502504Desc": "A fordítási és nyelvtani eszközök lehetnek lassúak vagy nem elérhetők, amíg a Pangea botok utolérik magukat.",
-    "error404Title": "Fordítási hiba!",
     "error404Desc": "A Pangea Bot nem biztos benne, hogyan fordítsa ezt...",
     "errorPleaseRefresh": "Ellenőrizzük a problémát! Kérjük, frissítse az oldalt és próbálja újra.",
     "connectedToStaging": "Csatlakozva a Staginghez",
@@ -3150,13 +2860,9 @@
     "definitionsToolName": "Szódefiníciók",
     "definitionsToolDescription": "Amikor be van kapcsolva, a kék színnel aláhúzott szavakat kattintással lehet megtekinteni definícióikat. Kattints az üzenetekre a definíciók eléréséhez.",
     "welcomeBack": "Üdvözlünk vissza! Ha részt vettél a 2023-2024-es pilot programban, kérjük, vedd fel velünk a kapcsolatot a különleges pilot előfizetésedért. Ha te vagy az oktató, aki (vagy az intézményed) vásárolt licencet az osztályod számára, kérjük, vedd fel velünk a kapcsolatot az oktatói előfizetésedért.",
-    "downloadTxtFile": "Szövegfájl letöltése",
-    "downloadCSVFile": "CSV fájl letöltése",
     "promotionalSubscriptionDesc": "Jelenleg életre szóló promóciós előfizetésed van. Segítségért írj az support@pangea.chat címre az előfizetés módosításához.",
     "originalSubscriptionPlatform": "Előfizetés a {purchasePlatform} platformon vásárolva",
     "oneWeekTrial": "Egynapos próbaverzió",
-    "downloadXLSXFile": "Excel fájl letöltése",
-    "unkDisplayName": "Ismeretlen",
     "wwCountryDisplayName": "Világszerte",
     "afCountryDisplayName": "Afganisztán",
     "axCountryDisplayName": "Aland-szigetek",
@@ -3451,7 +3157,6 @@
     "chatCapacityHasBeenChanged": "A csevegési kapacitás megváltozott",
     "chatCapacitySetTooLow": "A csevegési kapacitásnak legalább {count} kell legyen.",
     "chatCapacityExplanation": "A csevegési kapacitás korlátozza a csevegésben részt vevő tagok számát.",
-    "tooManyRequest": "Túl sok kérés, kérjük, próbálja meg később.",
     "enterNumber": "Kérjük, írjon be egy egész szám értéket.",
     "practice": "Gyakorlat",
     "versionNotFound": "Verzió nem található",
@@ -3461,7 +3166,6 @@
     "deleteSubscriptionWarningTitle": "Aktív előfizetésed van",
     "deleteSubscriptionWarningBody": "Fiókod törlése nem törli automatikusan az előfizetésedet.",
     "manageSubscription": "Előfizetés kezelése",
-    "error520Title": "Kérjük, próbáld újra.",
     "error520Desc": "Sajnáljuk, nem értettük üzenetedet...",
     "wordsUsed": "Használt szavak",
     "level": "Szint",
@@ -3479,7 +3183,6 @@
     "other": "Egyéb",
     "levelShort": "SZINT {level}",
     "noCapacityLimit": "Nincs kapacitáskorlát",
-    "downloadGroupText": "Csoport szöveg letöltése",
     "notificationsOn": "Értesítések be",
     "notificationsOff": "Értesítések ki",
     "joinWithCode": "Csatlakozás kóddal",
@@ -3543,24 +3246,12 @@
     "whatIsTheMorphTag": "Mi a {morphologicalFeature} '{wordForm}' esetében?",
     "dataAvailable": "Adat elérhetőség",
     "available": "Elérhető",
-    "pangeaBotIsFallible": "A Pangea Bot is hibázik!",
-    "whatIsMeaning": "Mit jelent '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Egyeztesd a jelentéseket a szavakkal az üzenetben!",
-    "doubleClickToEdit": "Dupla kattintással szerkesztheted.",
-    "topicLabel": "Téma",
-    "topicPlaceholder": "Válassz egy témát...",
-    "modePlaceholder": "Válassz egy módot...",
-    "learningObjectiveLabel": "Tanulási cél",
-    "learningObjectivePlaceholder": "Válassz egy tanulási célt...",
-    "targetLanguageLabel": "Cél nyelv",
     "cefrLevelLabel": "CEFR szint",
     "image": "Kép",
     "video": "Videó",
     "nan": "Nem alkalmazható",
-    "addVocabulary": "Szókincs hozzáadása",
     "instructions": "Utasítások",
-    "numberOfLearners": "Tanulók száma",
-    "mustBeInteger": "Egész szám kell legyen, pl. 1, 2, 3, ...",
     "constructUsePvmDesc": "Hangüzenetben készült",
     "leaveSpaceDescription": "Ha elhagyod a kurzust, minden benne lévő csevegést elhagyasz. A többi felhasználó látni fogja, hogy elhagytad a kurzust.",
     "constructUseCorMmDesc": "Helyes üzenet jelentése",
@@ -3575,7 +3266,6 @@
     "ttsDisabledBody": "A szöveg-beszéd funkciót engedélyezheti a tanulási beállításokban",
     "noSpaceDescriptionYet": "Még nincs létrehozva kurzusleírás.",
     "tooLargeToSend": "Ez az üzenet túl nagy ahhoz, hogy elküldje",
-    "exitWithoutSaving": "Biztosan el akarja hagyni mentés nélkül?",
     "enableAutocorrectPopupTitle": "Adja hozzá a célnyelvi billentyűzetet a következő lépésekkel:",
     "enableAutocorrectPopupSteps": "  • Beállítások\n  • Általános\n  • Billentyűzet\n  • Billentyűzetek\n  • Új billentyűzet hozzáadása",
     "enableAutocorrectPopupDescription": "Miután kiválasztotta a nyelvet, kattintson a billentyűzet bal alsó sarkában lévő kis földgömb ikonra az újonnan telepített billentyűzet aktiválásához.",
@@ -3586,11 +3276,8 @@
     "displayName": "Megjelenítendő név",
     "leaveRoomDescription": "El fogja hagyni ezt a csevegést. A többi felhasználó látni fogja, hogy elhagyta a csevegést.",
     "confirmUserId": "Kérjük, erősítse meg Pangea Chat felhasználónevét a fiók törléséhez.",
-    "startingToday": "Ma kezdődik",
-    "oneWeekFreeTrial": "Egy hét ingyenes próbaidőszak",
     "paidSubscriptionStarts": "Kezdete {startDate}",
     "cancelInSubscriptionSettings": "• Lemondás bármikor az előfizetési beállításokban",
-    "cancelToAvoidCharges": "• Lemondás {trialEnds} előtt a díjak elkerülése érdekében",
     "downloadGboard": "Gboard letöltése",
     "autocorrectNotAvailable": "Sajnáljuk, jelenleg nem támogatott ez a funkció a platformján. Maradjon velünk a további fejlesztésekért!",
     "pleaseUpdateApp": "Kérjük, frissítse az alkalmazást a folytatáshoz.",
@@ -3600,17 +3287,12 @@
     "knockSpaceSuccess": "Kérte, hogy csatlakozzon ehhez a kurzushoz! Egy admin válaszol a kérésére, amint megkapja azt 😊",
     "chooseWordAudioInstructionsBody": "Hallgassa meg az üzenet teljes változatát. Ezután párosítsa az audiókat a szavakkal.",
     "chooseMorphsInstructionsBody": "Kattintson a puzzle darabokra a nyelvtani kérdésekhez!",
-    "pleaseEnterInt": "Kérjük, írjon be egy számot",
     "home": "Kezdőlap",
     "join": "Csatlakozás",
     "resetInstructionTooltipsTitle": "Útmutató eszköztippek visszaállítása",
     "resetInstructionTooltipsDesc": "Kattints az útmutató eszköztippek megjelenítéséhez, mint egy teljesen új felhasználó esetén.",
-    "randomize": "Véletlenszerű sorrend",
     "clear": "Törlés",
-    "featuredActivities": "Kiemelt",
     "save": "Mentés",
-    "startChat": "Indíts el egy beszélgetést",
-    "translationProblem": "Fordítási probléma",
     "askToJoin": "Kérj csatlakozást",
     "emptyChatWarningTitle": "Üres a chat",
     "emptyChatWarningDesc": "Senkit sem hívtál meg a chatbe. Menj a Chat beállításokhoz, hogy meghívhasd a kontaktjaidat vagy a Botot. Ezt később is megteheted.",
@@ -3640,17 +3322,13 @@
     "timesUsedIndependently": "Önállóan használt alkalmak száma",
     "timesUsedWithAssistance": "Segítséggel használt alkalmak száma",
     "shareInviteCode": "Meghívó kód megosztása: {code}",
-    "leaderboard": "Rangsoroló lista",
     "skipForNow": "Átmenetileg kihagyom",
     "permissions": "Engedélyek",
     "spaceChildPermission": "Ki adhat hozzá új csevegéseket ehhez a kurzushoz",
-    "addEnvironmentOverride": "Környezet felülbírálás hozzáadása",
     "defaultOption": "Alapértelmezett",
     "deleteChatDesc": "Biztosan törölni szeretné ezt a csevegést? Minden résztvevő számára törlődik, és minden üzenet nem lesz többé elérhető gyakorláshoz vagy tanulási elemzésekhez.",
     "deleteSpaceDesc": "A kurzus és a kiválasztott csevegések minden résztvevő számára törlődnek, és minden üzenet nem lesz többé elérhető gyakorláshoz vagy tanulási elemzésekhez. Ez a művelet nem vonható vissza.",
     "launch": "Indítás",
-    "searchChats": "Csevegések keresése",
-    "maxFifty": "Maximum 50",
     "configureSpace": "Kurzus konfigurálása",
     "pinMessages": "Üzenetek rögzítése",
     "setJoinRules": "Csatlakozási szabályok beállítása",
@@ -3684,9 +3362,6 @@
     "failedToFetchTranscription": "Nem sikerült letölteni a átírást",
     "deleteEmptySpaceDesc": "A kurzus minden résztvevő számára törlésre kerül. Ez a művelet nem vonható vissza.",
     "regenerate": "Újragenerálás",
-    "mySavedActivities": "Mentett tevékenységeim",
-    "noSavedActivities": "Nincsenek mentett tevékenységek",
-    "saveActivity": "Mentse ezt a tevékenységet",
     "failedToPlayVideo": "Nem sikerült lejátszani a videót",
     "done": "Kész",
     "inThisSpace": "Ebben a kurzusban",
@@ -3697,13 +3372,9 @@
     "numInvited": "{count} meghívott",
     "saved": "Mentett",
     "reset": "Visszaállítás",
-    "errorFetchingActivitiesMessage": "Nem sikerült lekérni a tevékenységeket",
     "errorFetchingDefinition": "Nem sikerült lekérni a definíciót",
     "errorProcessAnalytics": "Nem sikerült feldolgozni az elemzéseket",
     "errorDownloading": "Letöltés sikertelen",
-    "errorLoadingSpaceChildren": "Nem sikerült betölteni a csoport beszélgetéseit ebben a kurzusban",
-    "unexpectedError": "Váratlan hiba.",
-    "pleaseReload": "Kérjük, töltsd újra az oldalt, és próbáld újra.",
     "translationError": "Fordítási hiba",
     "check": "Ellenőrizze",
     "unableToFindRoom": "Nem található csevegés vagy kurzus ezzel a kóddal. Kérjük, próbálja újra.",
@@ -3712,19 +3383,14 @@
     "request": "Kérés",
     "requestAll": "Összes kérés",
     "confirmMessageUnpin": "Biztos benne, hogy fel szeretné oldani ezt az üzenetet?",
-    "saveAndLaunch": "Mentés és indítás",
-    "launchToSpace": "Indítás a kurzusra",
     "pending": "Függőben",
     "inactive": "Inaktív",
-    "confirmRole": "Szerep megerősítése",
     "openRoleLabel": "NYITOTT",
     "finishedTheActivity": "🎯 {username} befejezte ezt a tevékenységet",
     "activitySummaryError": "A tevékenység összegzések nem elérhetők",
     "requestSummaries": "Összegzések kérés",
-    "generatingNewActivities": "Ez az első felhasználó ebben a nyelvpárban! Kérjük, adj egy percet, készítjük a tevékenységeket csak neked.",
     "requestAccessTitle": "Kérjük az elemzési hozzáférést?",
     "requestAccessDesc": "Szeretnél hozzáférést kérni a résztvevők elemzéseinek megtekintéséhez?\n\nHa a résztvevők egyetértenek, a kurzus adminjai megtekinthetik:\n    • az összes szókincset\n    • az összes nyelvtani fogalmat\n    • az elvégzett tevékenységi ülések összes számát\n    • a használt, helyes és helytelen nyelvtani fogalmakat\n\nNem fogják látni:\n    • az üzeneteket a kurzuson kívüli chatben\n    • a szókincs listát",
-    "requestAccess": "Kérelem hozzáféréshez ({count})",
     "analyticsInactiveTitle": "Az inaktív felhasználóknak nem küldhetők kérések",
     "analyticsInactiveDesc": "Az inaktív felhasználók, akik nem jelentkeztek be azóta, hogy ez a funkció bevezetésre került, nem fogják látni a kérését.\n\nA Kérelem gomb akkor jelenik meg, amikor visszatérnek. Később újra küldheti a kérést a nevük alatt található Kérelem gombra kattintva, amikor az elérhetővé válik.",
     "accessRequestedTitle": "Elemzési hozzáférési kérés",
@@ -3747,8 +3413,6 @@
     "accessDesc": "Nyilvánossá teheted a kurzusodat a világ számára! Vagy, tedd priváttá és biztonságossá.",
     "createGroupChatDesc": "Míg az aktivitási ülések kezdete és vége, a csoportos beszélgetések nyitva maradnak a rutinszerű kommunikációhoz.",
     "deleteDesc": "Csak az adminok törölhetnek kurzust. Ez egy destruktív művelet, amely minden felhasználót eltávolít és törli az összes kiválasztott csoportot a kurzuson belül. Légy óvatos.",
-    "noCourseFound": "Ó, ennek a kurzusnak tervre van szüksége!\n\nA kurzustervek témák és beszélgetési tevékenységek sorozata.",
-    "additionalParticipants": "+ {num} mások",
     "whatNow": "Most mi?",
     "chooseNextActivity": "Válaszd ki a következő tevékenységet!",
     "letsGo": "Indulj el",
@@ -3761,13 +3425,11 @@
     "waitNotDone": "Várj, még nem végeztem!",
     "waitingForOthersToFinish": "Várakozás a többiek befejezésére...",
     "generatingSummary": "Chat elemzése és eredmények generálása",
-    "findCourse": "Kurzus keresése",
     "pingParticipantsNotification": "{user} keres felhasználókat a {room} szobában a tevékenységhez",
     "course": "Kurzus",
     "courses": "Kurzusok",
     "goToCourse": "Ugrás a kurzusra: {course}",
     "activityComplete": "Ez a tevékenység befejeződött. Az összefoglaló az alábbiakban érhető el.",
-    "startNewSession": "Új szekció indítása",
     "joinOpenSession": "Csatlakozás nyitott szekcióhoz",
     "activityNotFound": "Nem található tevékenység",
     "myActivities": "Saját tevékenységeim",
@@ -3857,10 +3519,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3870,10 +3528,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -3961,14 +3615,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -3985,10 +3631,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4001,15 +3643,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4161,14 +3795,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4182,14 +3808,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5412,10 +5030,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5456,10 +5070,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5532,10 +5142,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5805,47 +5411,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5865,19 +5431,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -5941,10 +5495,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -5985,14 +5535,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6004,14 +5546,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6049,10 +5583,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6069,27 +5599,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6213,10 +5727,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6226,10 +5736,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6246,14 +5752,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6393,18 +5891,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6453,10 +5939,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6466,18 +5948,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6520,23 +5990,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6560,10 +6018,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6571,14 +6025,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6683,18 +6129,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6747,10 +6181,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6777,10 +6207,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -6961,7 +6387,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Jövőre nézz vissza az aktivitás frissítéseiért.",
-    "activityDropdownDesc": "Amikor befejezed ezt az aktivitást, kattints az alábbi gombra",
     "languageMismatchTitle": "Nyelvi eltérés",
     "languageMismatchDesc": "A célnyelved nem egyezik ezzel az aktivitással. Frissíted a célnyelvet?",
     "reportWordIssueTooltip": "Szóinformációs probléma jelentése",
@@ -6974,10 +6399,6 @@
     "selectAll": "Összes kiválasztása",
     "deselectAll": "Összes kijelölés megszüntetése",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7026,17 +6447,11 @@
         "placeholders": {}
     },
     "startOwn": "Indítsa el sajátját",
-    "joinCourseDesc": "Minden kurzusnak 8-10 egymásra épülő témája van, különféle feladat-alapú nyelvtanulási tevékenységekkel.",
     "newMessageInPangeaChat": "💬 Új üzenet a Pangea Csevegésben",
     "shareCourse": "Kurzus megosztása",
     "addCourse": "Kurzus hozzáadása",
-    "joinPublicCourse": "Csatlakozás nyilvános kurzushoz",
     "vocabLevelsDesc": "Itt jelennek meg a szókincs szavai, amint szintet lépnek!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7049,10 +6464,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7071,7 +6482,6 @@
     "emojiView": "Emoji nézet",
     "feedbackDialogDesc": "Én is hibázom! Van valami, amivel segíthetnél a fejlődésemben?",
     "contactHasBeenInvitedToTheCourse": "A kapcsolatot meghívták a tanfolyamra",
-    "activityStatsButtonTooltip": "Tevékenységi információ",
     "allow": "Engedélyez",
     "deny": "Elutasít",
     "enabledRenewal": "Előfizetés megújításának engedélyezése",
@@ -7339,10 +6749,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8398,16 +7804,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Tevékenységek a következő téma feloldásához",
-    "activitiesToUnlockTopicDesc": "Állítsa be a tevékenységek számát a következő tanfolyam téma feloldásához",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Helyes szókincs definíció gyakorlás",
     "constructUseIncLMDesc": "Helytelen szókincs definíció gyakorlás",
     "constructUseCorLADesc": "Helyes szókincs audio gyakorlás",
@@ -8415,7 +7811,6 @@
     "constructUseBonus": "Bónusz a szókincs gyakorlás során",
     "practiceVocab": "Szókincs gyakorlás",
     "selectMeaning": "Jelöld ki a jelentést",
-    "selectAudio": "Válaszd ki a megfelelő audiót",
     "anotherRound": "Még egy kör",
     "activitySettingsOverrideWarning": "A nyelvet és a nyelvi szintet az aktivitási terv határozza meg",
     "voice": "Hang",
@@ -8447,10 +7842,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8468,12 +7859,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Letöltés megkezdődött",
     "webDownloadPermissionMessage": "Ha a böngésződ blokkolja a letöltéseket, kérlek engedélyezd a letöltéseket ezen az oldalon.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8568,11 +7954,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Valami hiba történt, és keményen dolgozunk a javításon. Kérlek, nézd meg később.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Írássegítő engedélyezése",
     "autoIGCToolDescription": "Automatikusan futtassa a Pangea Chat eszközöket a küldött üzenetek célnyelvre történő javításához.",
     "@autoIGCToolName": {
@@ -8628,24 +8009,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Nyelvtan",
-    "spanTypeWordChoice": "Szóválasztás",
     "spanTypeSpelling": "Helyesírás",
     "spanTypePunctuation": "Írásjelek",
     "spanTypeStyle": "Stílus",
     "spanTypeFluency": "Folyékonyság",
     "spanTypeAccents": "Akcentusok",
     "spanTypeCapitalization": "Nagybetűs írás",
-    "spanTypeCorrection": "Javítás",
     "spanFeedbackTitle": "Javítási probléma jelentése",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8670,10 +8040,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8686,13 +8052,7 @@
     "longPressToRecordVoiceMessage": "Hosszan nyomja meg a hangüzenet rögzítéséhez.",
     "pause": "Szünet",
     "resume": "Folytatás",
-    "newSubSpace": "Új alhely",
-    "moveToDifferentSpace": "Áthelyezés másik helyre",
-    "removeFromSpaceDescription": "A csevegés eltávolításra kerül a térből, de továbbra is megjelenik a csevegési listádban.",
     "countChats": "{chats} csevegés",
-    "spaceMemberOf": "{spaces} tér tagja",
-    "spaceMemberOfCanKnock": "{spaces} tér tagja kopoghat",
-    "donate": "Adományozás",
     "startedAPoll": "{username} szavazást indított.",
     "poll": "Szavazás",
     "startPoll": "Szavazás indítása",
@@ -8716,23 +8076,15 @@
     "newStickerPack": "Új matrica csomag",
     "stickerPackName": "Matrica csomag neve",
     "attribution": "Hozzárendelés",
-    "skipChatBackup": "Csevegés biztonsági mentésének kihagyása",
-    "skipChatBackupWarning": "Biztos benne? A csevegés biztonsági mentésének engedélyezése nélkül elveszítheti a hozzáférést az üzeneteihez, ha vált a készüléke.",
-    "loadingMessages": "Üzenetek betöltése",
-    "setupChatBackup": "Csevegés biztonsági mentésének beállítása",
     "noMoreResultsFound": "Nincs több találat",
     "chatSearchedUntil": "Csevegés keresve: {time} -ig",
     "federationBaseUrl": "Szövetségi alap URL",
     "clientWellKnownInformation": "Kliens-jól ismert információ:",
     "baseUrl": "Alap URL",
     "identityServer": "Identitás Szolgáltató:",
-    "versionWithNumber": "Verzió: {version}",
     "logs": "Naplók",
-    "advancedConfigs": "Haladó Beállítások",
     "advancedConfigurations": "Haladó konfigurációk",
-    "signInWithLabel": "Bejelentkezés ezzel:",
     "selectAllWords": "Válaszd ki az összes szót, amit hallasz a hanganyagban",
-    "joinCourseForActivities": "Csatlakozz egy kurzushoz, hogy kipróbálhasd a tevékenységeket.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -8769,18 +8121,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -8788,26 +8128,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -8913,22 +8233,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8957,19 +8261,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8977,15 +8269,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9186,11 +8470,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Osztályban? Írd be ide a csatlakozási kódodat.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automatikusan kiemeli az audio üzeneteket",
     "selectAudioMessagesOnPlayDescription": "Automatikusan kiemeli az audio üzeneteket, amikor lejátszásra kerülnek",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9234,18 +8513,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Ez a kurzus olyan témákat tartalmaz, amelyek kevesebb mint {input} tevékenységgel rendelkeznek. Kérjük, adjon meg egy számot, amely kisebb vagy egyenlő {minValue}-val.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Kattintson ide a visszajelentkezéshez.",
     "@clickToLogin": {
@@ -9662,17 +8929,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Egy rajzfilmszerű sárga medve, amely izgalmában felemelte a karjait.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Válassza ki a szavakat, hogy többet tudjon meg róluk",
     "requireAnalyticsAccessTitle": "Elemzési hozzáférés szükséges a csatlakozáshoz",
     "requireAnalyticsAccessDesc": "A résztvevőknek engedélyezniük kell az elemzési adataikhoz való hozzáférést a kurzushoz való csatlakozáshoz",
     "analyticsAccessNoticeTitle": "Elemzési hozzáférés szükséges",
     "analyticsAccessNoticeDesc": "A kurzushoz való csatlakozással beleegyezését adja, hogy az adminisztrátorok hozzáférjenek az elemzési adataihoz.",
-    "skipOnboardingClassCodeDesc": "Önállóan tanul? Ne aggódjon, megteheti:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9690,10 +8951,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9722,7 +8979,6 @@
     "pickCefrLevelTeacherStepTitle": "Milyen szinten tanítasz?",
     "pickCefrLevelStudentStepTitle": "Milyen szinten vagy?",
     "customCourseStepTitle": "Töltsd ki ezt a űrlapot, hogy egyedi kurzust kapj",
-    "aboutYourClass": "Az osztályodról",
     "courseCodeStepErrorMessage": "Kérjük, ellenőrizd a kódodat, és próbáld újra",
     "institution": "Intézmény",
     "courseGoals": "Tanfolyami célok",
@@ -9765,10 +9021,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9885,12 +9137,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logó",
     "introChatDetails": "Köszönts! Mutatkozz be a kurzus többi résztvevőjének, találj barátokat, és csevegj a tevékenységeken kívül.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9934,11 +9181,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Tevékenységi műveletek",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Kiejtési eszközök",
     "audioTranscription": "AI hangátírás",
     "visualLearnerSupport": "Vizuális tanulók támogatása",
@@ -9979,7 +9221,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Csatlakozz egy olyan kurzushoz, amely tartalmazza ezt a tevékenységet, hogy játszhass vele.",
     "resizeCoursePanel": "Kurzuspanel átméretezése",
     "undo": "Visszavonás",
     "unlock": "Feloldás",
@@ -9993,7 +9234,6 @@
     "addCourseBrowsePublic": "Böngésszen a nyilvános kurzusok között",
     "browsePublicCourses": "Böngésszen a nyilvános kurzusok között",
     "editProfile": "Profil szerkesztése",
-    "numObjectives": "{count} cél",
     "mapSearchHint": "Tevékenységek keresése",
     "mapSearchNoResults": "Nincsenek találatok a nézetben",
     "mapFilterAllLanguages": "Minden nyelv",
@@ -10002,7 +9242,6 @@
     "mapFilterCompleted": "Befejezett",
     "mapFilterReset": "Visszaállítás",
     "activityTypeConversation": "Beszélgetés",
-    "lockedMissionRequirement": "Fejezd be az előző küldetést a feloldáshoz",
     "playAgain": "Játssz újra",
     "reviewActivity": "Áttekintés",
     "mapEmptyInView": "Itt semmi sincs a szintedhez vagy nyelvedhez. Szélesítsd a szűrőidet vagy nagyíts ki.",
@@ -10017,14 +9256,9 @@
     "scrollToBottom": "Görgetés az aljára",
     "courseImage": "Tanfolyam kép",
     "avatarPreview": "Avatar előnézet",
-    "activityPhoto": "Tevékenység fénykép",
     "emotePreview": "Emote előnézet: {name}",
     "activityLabel": "Tevékenység: {title}",
     "resetMapView": "Térkép nézet visszaállítása",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10077,14 +9311,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10114,10 +9340,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10174,10 +9396,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_ia.arb
+++ b/lib/l10n/intl_ia.arb
@@ -85,7 +85,6 @@
     "appLock": "Clavetta del application",
     "appLockDescription": "Claudar le application quando non es usate con un codice PIN",
     "archive": "Archivar",
-    "areGuestsAllowedToJoin": "Es permittite a hospites junger?",
     "areYouSure": "Es tu secur?",
     "areYouSureYouWantToLogout": "Es tu secur que vole tu disconnector te?",
     "askSSSSSign": "Pro poter signar le altere persona, per favor introduce tu phrase de securitate o clave de recuperation.",
@@ -130,9 +129,7 @@
     "changeYourAvatar": "Cambiar tu avatar",
     "channelCorruptedDecryptError": "Le encryption ha essite corrompite",
     "chat": "Chat",
-    "yourChatBackupHasBeenSetUp": "Tu copia de securitate del chat ha essite configurate.",
     "chatBackup": "Copia de securitate del chat",
-    "chatBackupDescription": "Tu message antiquate es securitate con un clave de recuperation. Per favor assecurate que tu non lo perde.",
     "chatDetails": "Details del chat",
     "chats": "Chats",
     "chooseAStrongPassword": "Selige un forte contrasigno",
@@ -165,7 +162,6 @@
     "configureChat": "Configura le chat",
     "confirm": "Confirma",
     "connect": "Conecta",
-    "contactHasBeenInvitedToTheGroup": "Le contacto ha essite invitate al gruppo",
     "contentHasBeenReported": "Le contento ha essite reportate a le administratores del server",
     "copiedToClipboard": "Copiato in le portapapeles",
     "copy": "Copia",
@@ -173,11 +169,9 @@
     "couldNotDecryptMessage": "Non poteva decriptar le message: {error}",
     "checkList": "Lista de verification",
     "countParticipants": "{count} participantes",
-    "countInvited": "{count} invitate",
     "create": "Create",
     "createdTheChat": "💬} {username} create le chat",
     "createGroup": "Create gruppo",
-    "createNewSpace": " nove spatio",
     "currentlyActive": "Activa actualmenente",
     "darkTheme": "Dark",
     "dateAndTimeOfDay": "{date}, {timeOfDay}",
@@ -203,9 +197,6 @@
     "emoteKeyboardNoRecents": "Le emot usate recenter apparira hic...",
     "emotePacks": "Packs de emot pro le camera",
     "emoteSettings": "Configurationes de emot",
-    "globalChatId": "ID global de chat",
-    "accessAndVisibility": "Accesso e visibilitate",
-    "accessAndVisibilityDescription": "Qui ha le permission de aderir a iste chat e como le chat pote esser discoperite.",
     "calls": "Appellos",
     "customEmojisAndStickers": "Emojis e stickers personalisate",
     "customEmojisAndStickersBody": "Adder o compartir emojis o stickers personalisate que pote esser usate in qualunque chat.",
@@ -213,7 +204,6 @@
     "emptyChat": "Chat vacue",
     "enableEmotesGlobally": "Habilitar le pack de emotes globalmente",
     "enableEncryption": "Habilitar le encryption",
-    "enableEncryptionWarning": "Tu non potera disactivar le encryption plus. Es tu secur?",
     "encrypted": "Cifrate",
     "encryption": "Cifration",
     "encryptionNotEnabled": "Le encryption non es activate",
@@ -221,7 +211,6 @@
     "enterAnEmailAddress": "Entera un adresse de email",
     "homeserver": "Servitor principal",
     "errorObtainingLocation": "Error durante le obtention del position: {error}",
-    "everythingReady": "Tutto es in ordine!",
     "extremeOffensive": "Extrememente offendente",
     "fileName": "Nomen del file",
     "fluffychat": "FluffyChat",
@@ -230,9 +219,7 @@
     "fromJoining": "De le inscription",
     "fromTheInvitation": "De le invitation",
     "group": "Grupo",
-    "chatDescription": "Description del chat",
     "chatDescriptionHasBeenChanged": "Le description del chat ha essite cambiate",
-    "groupIsPublic": "Le grupo es publice",
     "groups": "Groupes",
     "groupWith": "Grupo con {displayname}",
     "guestsAreForbidden": "Le hospites es prohibite",
@@ -254,7 +241,6 @@
     "incorrectPassphraseOrKey": "Phrase de securitate o clave de recuperation incorrecte",
     "inoffensive": "Inoffensive",
     "inviteContact": "Invitar contacto",
-    "inviteContactToGroup": "Invitar contacto a {groupName}",
     "noChatDescriptionYet": "Nulle description de chat ha essite create ancora.",
     "tryAgain": "Prova ancora",
     "invalidServerName": "Nomen de servitor invalide",
@@ -275,7 +261,6 @@
     "leave": "Lassar",
     "leftTheChat": "Lassó le chat",
     "lightTheme": "Lucente",
-    "loadCountMoreParticipants": "Carga {count} participantes plus",
     "dehydrate": "Exportar session e netar le dispositivo",
     "dehydrateWarning": "Iste action non pote esser revertite. Assegura te que tu ha securemente storate le file de respaldo.",
     "hydrate": "Restaurar ab file de respaldo",
@@ -284,7 +269,6 @@
     "locationDisabledNotice": "Servitios de localisacion es disactivate. Per favor, active los pro poter compartir tu localisacion.",
     "locationPermissionDeniedNotice": "Permission de localisacion es refusate. Per favor, concede los pro poter compartir tu localisacion.",
     "login": "Login",
-    "logInTo": "Intra a {homeserver}",
     "logout": "Salir",
     "mention": "Mentionar",
     "messages": "Messas",
@@ -299,8 +283,6 @@
     "no": "Nulle",
     "noConnectionToTheServer": "Nulle connection a le servitor",
     "noEmotesFound": "Nulle emoticon trovate. 😝",
-    "noEncryptionForPublicRooms": "Tu pote solmente activar le encryption quando le camera non es plus accessible publicamente.",
-    "noGoogleServicesWarning": "Le Service de Messagiero Cloud de Firebase non pare esser disponibile in tu dispositivo. Pro ancora reciper notificationes push, nos recommenda installar ntfy. Con ntfy o un altere proveedor de Push Unificate, tu pote reciper notificationes push de un maniera secur de datos. Tu pote descargar ntfy ab le PlayStore o ab F-Droid.",
     "noMatrixServer": "{server1} non es un servo matrix, usa {server2} in su vice?",
     "shareInviteLink": "Compartir ligamine de invitation",
     "scanQrCode": "Scanar codice QR",
@@ -322,12 +304,10 @@
     "openCamera": "Aperir camera",
     "openVideoCamera": "Aperir camera pro un video",
     "oneClientLoggedOut": "Un de tu clientes ha essite disconnectate",
-    "addAccount": "Adder conto",
     "editBundlesForAccount": "Modificar bundle pro iste conto",
     "addToBundle": "Adder a bundle",
     "removeFromBundle": "Remove de iste bundle",
     "bundleName": "Nomen del bundle",
-    "enableMultiAccounts": "(BETA) Active multiple cuentas in iste dispositivo",
     "openInMaps": "Aperir in mappas",
     "link": "Ligamine",
     "serverRequiresEmail": "Iste servitor necessita de validar tu adresse de email pro registration.",
@@ -339,7 +319,6 @@
     "passwordHasBeenChanged": "Contrasse ha essite cambiate",
     "overview": "Visu",
     "passwordRecoverySettings": "Configurationes de recuperation de parola",
-    "passwordRecovery": "Recuperation de parola",
     "people": "Personas",
     "pickImage": "Selige un imagine",
     "pin": "Pin",
@@ -348,7 +327,6 @@
     "pleaseChooseAPasscode": "Per favor, selige un codice de accesso",
     "pleaseClickOnLink": "Per favor, clicca super le ligamine in le email e poi procede.",
     "pleaseEnter4Digits": "Per favor, entra 4 cifras o lascia vacue pro disactivar le lock del application",
-    "pleaseEnterRecoveryKey": "Per favor, entra tu clave de recuperation:",
     "pleaseEnterYourPassword": "Per favor, entra tu parola de pass",
     "pleaseEnterYourPin": "Per favor, entra tu PIN",
     "pleaseEnterYourUsername": "Per favor, entra tu nomine de usator",
@@ -368,7 +346,6 @@
     "rejectedTheInvitation": "{username} ha rejecite le invitation",
     "removeAllOtherDevices": "Remove tote le altere dispositivos",
     "removedBy": "Removite per {username}",
-    "removeDevice": "Remover dispositivo",
     "unbanFromChat": "Desbanir de le chat",
     "removeYourAvatar": "Remover tu avatar",
     "replaceRoomWithNewerVersion": "Replace le sala con un version plus recente",
@@ -380,8 +357,6 @@
     "saveFile": "Salva file",
     "search": "Cercar",
     "security": "Securitate",
-    "recoveryKey": "Clav de recuperation",
-    "recoveryKeyLost": "Clav de recuperation perdite?",
     "send": "Manda",
     "sendAMessage": "Manda un message",
     "sendAsText": "Manda como texto",
@@ -400,7 +375,6 @@
     "separateChatTypes": "Separa chat direct e gruppos",
     "setAsCanonicalAlias": "Stellar como alias principal",
     "setChatDescription": "Stellar description del chat",
-    "setPermissionsLevel": "Stellar nivele de permissiones",
     "setStatus": "Stellar stato",
     "settings": "Configurationes",
     "share": "Compartir",
@@ -410,8 +384,6 @@
     "presencesToggle": "Monstrar messages de stato de altere usatores",
     "skip": "Salta",
     "sourceCode": "Code fonte",
-    "spaceIsPublic": "Le spatio es publice",
-    "spaceName": "Nomen del spatio",
     "startedACall": "{senderName} ha comenciato un appel",
     "status": "Stato",
     "statusExampleMessage": "Como tu es hodie?",
@@ -423,7 +395,6 @@
     "theyMatch": "Illes coincide",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "Troppo request. Per favor prova ancora plus tarde!",
-    "transferFromAnotherDevice": "Transferar de un altere dispositivo",
     "tryToSendAgain": "Prova remitter",
     "unavailable": "Inaccessibile",
     "unbannedUser": "{username} ha levate le restrictiones a {targetName}",
@@ -433,7 +404,6 @@
     "unknownEvent": "Evenimento ignote '{type}'",
     "unmuteChat": "Dismute chat",
     "unpin": "Disfixar",
-    "unreadChats": "{unreadCount, plural, =1{1 chat non legite} other{{unreadCount} chat non legite}}",
     "userAndOthersAreTyping": "{username} e {count} alteres sta scribente…",
     "userAndUserAreTyping": "{username} e {username2} sta scribente…",
     "userIsTyping": "{username} sta scribente…",
@@ -446,8 +416,6 @@
     "verifyStart": "Iniciar verification",
     "verifySuccess": "Tu ha verificat con successo!",
     "verifyTitle": "Verificando altere conto",
-    "videoCall": "Appello video",
-    "visibilityOfTheChatHistory": "Visibilitate del historia del chat",
     "visibleForAllParticipants": "Visibile pro tote le participantes",
     "visibleForEveryone": "Visibile pro omne",
     "voiceMessage": "Messeggia de voce",
@@ -457,10 +425,7 @@
     "wallpaper": "Fond de pantalla:",
     "warning": "Periculo!",
     "weSentYouAnEmail": "Nos ha inviate un email",
-    "whoCanPerformWhichAction": "Qui pote facer qual action",
-    "whoIsAllowedToJoinThisGroup": "Qui ha le permission de aderir a iste gruppo",
     "whyDoYouWantToReportThis": "Proque vole tu reportar isto?",
-    "wipeChatBackup": "Eliminar tu copia de securitate del chat pro crear un nove clave de recupero?",
     "withTheseAddressesRecoveryDescription": "Con iste addresses tu pote recuperar tu contrasigno.",
     "writeAMessage": "Scribe un messagio…",
     "yes": "Si",
@@ -473,9 +438,7 @@
     "messageType": "Tipo de message",
     "sender": "Scribente",
     "openGallery": "Derrer galeria",
-    "removeFromSpace": "Remove de spazio",
     "start": "Iniciar",
-    "pleaseEnterRecoveryKeyDescription": "Pro desbloquear tu antigas messages, per favor introduce tu clave de recuperation que ha essite generate in un session anterior. Tu clave de recuperation NON es tu contrasigno.",
     "publish": "Publicar",
     "openChat": "Derrer chat",
     "markAsRead": " Marca como lege",
@@ -486,12 +449,9 @@
     "confirmEventUnpin": "Es tu secur de despinnear permanentemente le evento?",
     "emojis": "Emojis",
     "placeCall": " Face un appel",
-    "voiceCall": "Appel de voce",
     "unsupportedAndroidVersion": "Version Android non supportate",
     "unsupportedAndroidVersionLong": "Iste function necessita un version plus recente de Android. Per favor verifica pro actualisationes o supporto de Lineage OS.",
-    "videoCallsBetaWarning": "Per favor nota que le appel video es actualmente in beta. Illes pote non functionar como expectate o non functionar a tot in tote le plataformas.",
     "experimentalVideoCalls": "Appellos video experimental",
-    "emailOrUsername": "Email o nomine de usator",
     "addWidget": "Adder widget",
     "widgetVideo": "Video",
     "widgetEtherpad": "Nota de texto",
@@ -513,35 +473,19 @@
     "youKickedAndBanned": "🙅‍♂️ Tu ha kickate e bannate {user}",
     "youUnbannedUser": "Tu ha levate le banno a {user}",
     "hasKnocked": "🚪 {user} ha frappate",
-    "usersMustKnock": "Le usatores debe frappare",
-    "noOneCanJoin": "Nulle pote juncer",
     "knock": "Toccar",
     "users": "Usatores",
-    "unlockOldMessages": "Debloquear messages ancient",
-    "storeInSecureStorageDescription": "Stoque le clave de recuperation in le stoccage secur del dispositivo.",
-    "saveKeyManuallyDescription": "Salve iste clave manualmente per activar le dialogo de partage del systema o le portapapeles.",
-    "storeInAndroidKeystore": "Stoque in le Keystore de Android",
-    "storeInAppleKeyChain": "Stoque in le KeyChain de Apple",
-    "storeSecurlyOnThisDevice": "Stoque securmente in iste dispositivo",
     "countFiles": "{count} files",
     "user": "Usator",
     "custom": "Personalizzate",
-    "foregroundServiceRunning": "Iste notification appare quando le servicio in primer plano es active.",
-    "screenSharingTitle": "partage de pantalla",
-    "screenSharingDetail": "Tu es partagiante tu pantalla in FuffyChat",
     "whyIsThisMessageEncrypted": "Proque iste message es illisible?",
     "noKeyForThisMessage": "Isto pote evenir si le message esseva inviate ante que tu te connectava a tu conto in iste dispositivo.\n\nIl es etiam possibile que le inviante ha bloccate tu dispositivo o que alcun cosa ha fallite con le connexion a le internet.\n\nEs tu capace de leger le message in un altere session? Alora tu pote transferer le message de illa! Vade a Settings > Dispositivos e assecurate que tu dispositivos ha verifyate se. Quando tu aperi le sala le proxime vice e ambes sessiones es in le foreground, le claves essera transmittite automaticamente.\n\nNoli voler perder le claves quando te disconecta o cambia de dispositivos? Assecura te que tu ha activate le backup del chat in le settings.",
     "newGroup": "Nove grupo",
     "newSpace": "Nove spatio",
-    "enterSpace": "Entera spatio",
     "allSpaces": "Tote le spacios",
     "hidePresences": "Celar lista de statuts?",
     "doNotShowAgain": "Non monstrar ancora",
     "wasDirectChatDisplayName": "Chat vacue (era {oldDisplayName})",
-    "newSpaceDescription": "Le spacios permitte te de consolidar tu chats e construir communitates private o publice.",
-    "encryptThisChat": "Scrypta iste chat",
-    "disableEncryptionWarning": "Pro securitate, tu non pote disactivar le scryptation in un chat ubi illa ha essite activate antea.",
-    "sorryThatsNotPossible": "Pardona... isto non es possibile",
     "deviceKeys": "Claves del dispositivo:",
     "reopenChat": "Re-aperir le chat",
     "noBackupWarning": "Aviso! Sin activar le backup del chat, tu perdera accesso a tu messages scryptate. Es altamente recommandate activar le backup del chat prime de disconectarte.",
@@ -554,7 +498,6 @@
     "openLinkInBrowser": "Derrer le ligamine in le navigator",
     "reportErrorDescription": "😢 Oh non. Alicuno cosa ha fallite. Si vole, tu pote reportar iste bug a le developpatores.",
     "report": "reportar",
-    "setTheme": "Configurar thema:",
     "setColorTheme": "Configurar thema de colore:",
     "invite": "Invitar",
     "inviteGroupChat": "📝 Invitar al chat de gruppo",
@@ -573,12 +516,8 @@
     "yourGlobalUserIdIs": "Tu ID global de usator es: ",
     "noUsersFoundWithQuery": "Infelicemente, nemo usator poteva esser trovate con \"{query}\". Per favor, verifica si tu ha facite un typo.",
     "knocking": "Batte",
-    "chatCanBeDiscoveredViaSearchOnServer": "Le chat pote esser discoperite via le recerca super {server}",
-    "searchChatsRooms": "Recerca pro #chats, @usatores...",
     "nothingFound": "Nulle cosa trovate...",
     "groupName": "Nomen del gruppo",
-    "createGroupAndInviteUsers": "Create un gruppo e invitar usatores",
-    "groupCanBeFoundViaSearch": "Le grupo pote esser trovate via recerca",
     "wrongRecoveryKey": "Pardon... isto non pare esser le clave de recuperation correcte.",
     "startConversation": "Comenciar conversation",
     "commandHint_sendraw": "Invia JSON brute",
@@ -592,11 +531,8 @@
     "pleaseChooseAStrongPassword": "Per favor, selige un contrasigno forte",
     "passwordsDoNotMatch": "Le contrasignos non coincide",
     "passwordIsWrong": "Le contrasigno que tu ha introducite es incorrecte",
-    "publicChatAddresses": "Adresses de chat publice",
-    "createNewAddress": "Create un nove adresse",
     "joinSpace": "Join space",
     "publicSpaces": "Spaces publice",
-    "addChatOrSubSpace": "Adder un chat o sub-space",
     "subspace": "Sub-space",
     "decline": "Refusa",
     "thisDevice": "Iste dispositivo:",
@@ -605,15 +541,11 @@
     "searchMore": "Cercar plus...",
     "gallery": "Galeria",
     "files": "Files",
-    "sessionLostBody": "Tu session es perdite. Per favor reporta iste error a le developpatores a {url}. Le message de error es: {error}",
-    "restoreSessionBody": "Le applicato ora tenta restore tu session a partir del backup. Per favor reporta iste error a le developpatores a {url}. Le message de error es: {error}",
     "sendReadReceipts": "Manda recipis de lectura",
     "sendTypingNotificationsDescription": "Altri participantes in un chat pote vider quando tu es typpando un nove message.",
     "sendReadReceiptsDescription": "Altri participantes in un chat pote vider quando tu ha lege un message.",
     "formattedMessages": "Message formattate",
     "formattedMessagesDescription": "Monstra contento de message ric de texto in bold usando markdown.",
-    "verifyOtherUser": "🔐 Verificar altere usator",
-    "verifyOtherUserDescription": "Si tu verifica un altere usator, tu pote esser certe que tu sape a qui tu realmente escribe. 💪\n\nQuando tu comencia un verification, tu e le altere usator vide un popup in le app. Illo te monstrara un serie de emojis o numeros que tu ha de comparar con illes.\n\nLe melior maniera de facer isto es incontrar o comenciar un video call. 👩‍💻",
     "verifyOtherDevice": "🔐 Verificar altere dispositivo",
     "verifyOtherDeviceDescription": "Quando tu verifica un altere dispositivo, illes dispositivos pote intercambiar claves, augmentante tu securitate global. 💪 Quando tu comencia un verification, un popup apparera in le application in tamben dispositivos. Illo te monstra un serie de emojis o numeros que tu debe comparar inter se. Es melior haber ambes dispositivos a mano ante que tu comencia le verification. 🤳",
     "acceptedKeyVerification": "{sender} acceptava le verification de clave",
@@ -649,10 +581,6 @@
     "updateInstalled": "🎉 Actualisation {version} installate!",
     "changelog": "Historico de cambios",
     "sendCanceled": "Le invio ha essite cancellate",
-    "loginWithMatrixId": "Login con Matrix-ID",
-    "discoverHomeservers": "Discoverer servitores principal",
-    "whatIsAHomeserver": "Que es un servitor principal?",
-    "homeserverDescription": "Tote tu datos es stoccate in le servitor principal, similar a un proveedor de email. Tu pote seliger qual servitor principal tu vole usar, e tu pote ancora communicar con omnes. Discerca de plus a https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Non pare esser un servitor principal compatible. URL incorrecte?",
     "calculatingFileSize": "Calculante le grandezza del file...",
     "prepareSendingAttachment": "Prepara inviar attachment...",
@@ -664,11 +592,9 @@
     "oneOfYourDevicesIsNotVerified": "Un de tu dispositivos non es verificat",
     "noticeChatBackupDeviceVerification": "Nota: Quando tu conecta tote tu dispositivos al backup de chat, illes es automaticemente verificat.",
     "continueText": "Continer",
-    "welcomeText": "Hodie! 😊 Iste es FluffyChat. Tu pote signar in a qualunque servitor de casas, que es compatible con https://matrix.org. E postea chatta con omne. Es un grande rete de message decentralisate!",
     "blur": "Blurring:",
     "opacity": "Opacitate:",
     "setWallpaper": "Stabilir fondo de pantalla",
-    "manageAccount": "Gerir conto",
     "noContactInformationProvided": "Le servitor non provide information de contacto valide",
     "contactServerAdmin": "Contactar le administrator del servitor",
     "contactServerSecurity": "Contactar le securitate del servitor",
@@ -687,11 +613,8 @@
     "unableToJoinChat": "Non pote assumer in le chat. Forse le alter parte ha ja clausurate le conversation.",
     "previous": "Anterior",
     "otherPartyNotLoggedIn": "Le alter parte actualmente non es connectate e quindi non pote ricever messages!",
-    "appWantsToUseForLogin": "Usar '{server}' pro login",
-    "appWantsToUseForLoginDescription": "Tu permitte hic le app e sito web de compartir informationes super te.",
     "open": "Aperir",
     "waitingForServer": "Expectante pro le servitor...",
-    "appIntroduction": "FluffyChat te permitte de chat with tu amicos trans differente messager. Discoperi plus a https://matrix.org o simplemente tappa *Continua*.",
     "newChatRequest": "📩 Requesta de nove chat",
     "contentNotificationSettings": "Configuration de notification de contento",
     "generalNotificationSettings": "Configuration general de notification",
@@ -768,11 +691,9 @@
     "taTooltip": "L2 usance con adjuta de traduction",
     "interactiveTranslatorSliderHeader": "Traductor Interactive",
     "interactiveGrammarSliderHeader": "Verificador de Grammatica Interactive",
-    "interactiveTranslatorRequired": "Requisito",
     "waTooltip": "L2 usance sin adjuta",
     "interactiveTranslator": "Assistente de translation",
     "noIdenticalLanguages": "Per favor, selige linguas de base e de destino differente",
-    "searchBy": "Cerca per pais e linguas",
     "joinWithClassCode": "Joinar le curso",
     "languageLevelPreA1": "Novice Low (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -793,19 +714,14 @@
     "saveChanges": "Salva le modificationes",
     "publicProfileTitle": "Permitte que mi profilo sia trovate in le recerca",
     "publicProfileDesc": "Per activar, tu permitte a altere usatores de trovar tu profilo in le barra de recerca global e de inviar requestas de chat. A iste puncto, tu pote seliger acceptar o negar le requesta.",
-    "errorDisableIT": "Le assistentia de traduction es disactivate.",
-    "errorDisableIGC": "Le assistentia de grammatica es disactivate.",
     "errorDisableITUserDesc": "Clicca hic pro actualizar le configuration de assistentia de traduction",
     "errorDisableIGCUserDesc": "Clicca hic pro actualizar le configuration de assistentia de grammatica",
     "errorDisableITClassDesc": "Le assistance de traduction es disactivate pro le curso in le qual iste chat es.",
     "errorDisableIGCClassDesc": "Le assistance de grammatica es disactivate pro le curso in le qual iste chat es.",
-    "error405Title": "Linguas non definite",
     "error405Desc": "Per favor, definite tuas linguas in le Menu Principal > Configuration de Aprendimento.",
     "termsAndConditions": "Terminos e Condiciones",
     "andCertifyIAmAtLeast13YearsOfAge": " e certifica que io ha al minus 16 annos de etate.",
-    "error502504Title": "Wow, il ha multe students online!",
     "error502504Desc": "Le instrumentos de translation e grammatica pote esser lente o non disponibile durante que le bots Pangea se actualisa.",
-    "error404Title": "Error de translation!",
     "error404Desc": "Le Bot Pangea non es secur de como traducer isto...",
     "errorPleaseRefresh": "Nos es in le processus de investigar! Per favor, re-intra e tenta ancora.",
     "connectedToStaging": " Conectate a le Staging",
@@ -843,13 +759,9 @@
     "definitionsToolName": "Definitiones de Parolas",
     "definitionsToolDescription": "Quando activate, le parolas sublineate in azul pote esser cliccabile pro definitiones. Clicca super messages pro accedere a le definitiones.",
     "welcomeBack": "Ben retornate! Si tu ha essite parte del pilot 2023-2024, per favor contacta nos pro tu subscription special de pilot. Si tu es un professor qui ha (o que su institution ha) comprate licentias pro tu classe, contacta nos pro tu subscription de professor.",
-    "downloadTxtFile": "Downloadar file de texto",
-    "downloadCSVFile": "Downloadar file CSV",
     "promotionalSubscriptionDesc": "Tu ha actualmente un subscription promotional de vita. Mesage supporto@pangea.chat pro adjutar te a cambiar tu subscription.",
     "originalSubscriptionPlatform": "Subscription comprate per medio de {purchasePlatform}",
     "oneWeekTrial": "Período de proba de un septimana",
-    "downloadXLSXFile": "Downloadar file Excel",
-    "unkDisplayName": "Inconnu",
     "wwCountryDisplayName": "Mundo Wide",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Insulas Aland",
@@ -1144,7 +1056,6 @@
     "chatCapacityHasBeenChanged": "Le capacitate de chat ha essite cambiate",
     "chatCapacitySetTooLow": "Le capacitate de chat debe esser al minus {count}.",
     "chatCapacityExplanation": "Le capacitate de chat limita le numero de membros permitite in un chat.",
-    "tooManyRequest": "Troppo request, per favor prova de novo plus tarde.",
     "enterNumber": "Per favor, entra un valor de numero entier.",
     "practice": "Practica",
     "versionNotFound": "Version non trovate",
@@ -1154,7 +1065,6 @@
     "deleteSubscriptionWarningTitle": "Tu ha un subscription active",
     "deleteSubscriptionWarningBody": "Le delition de tu conto non cancelara automaticamente tu subscription.",
     "manageSubscription": "Manage le subscription",
-    "error520Title": "Per favor, prova ancora.",
     "error520Desc": "Disculpa, nos non poteva comprender tu message...",
     "wordsUsed": "Parolas usate",
     "level": "Nivel",
@@ -1172,7 +1082,6 @@
     "other": "Altere",
     "levelShort": "NIV {level}",
     "noCapacityLimit": "Nulle limite de capacitate",
-    "downloadGroupText": "Download le texto del gruppo",
     "notificationsOn": "Notificationes activate",
     "notificationsOff": "Notificationes disactivate",
     "joinWithCode": "Aderir con codice",
@@ -1236,24 +1145,12 @@
     "whatIsTheMorphTag": "Qual es le {morphologicalFeature} de '{wordForm}'?",
     "dataAvailable": "Disponibilitate de datos",
     "available": "Disponibile",
-    "pangeaBotIsFallible": "Pangea Bot face errores tamben!",
-    "whatIsMeaning": "Qual es le significato de '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Corresponda le significatos con le parolas in le message!",
-    "doubleClickToEdit": "Dubla clic pro modificar.",
-    "topicLabel": "Topic",
-    "topicPlaceholder": "Selige un topic...",
-    "modePlaceholder": "Selige un modo...",
-    "learningObjectiveLabel": "Objectivo de apprendimento",
-    "learningObjectivePlaceholder": "Selige un objectivo de apprendimento...",
-    "targetLanguageLabel": "Lingua de destino",
     "cefrLevelLabel": "Nivello CEFR",
     "image": "Imagine",
     "video": "Video",
     "nan": "Nulle applicabile",
-    "addVocabulary": "Adder vocabulario",
     "instructions": "Instrucciones",
-    "numberOfLearners": "Numero de discentes",
-    "mustBeInteger": "Debe esser un numero integer, ex. 1, 2, 3, ...",
     "constructUsePvmDesc": "Producte in message de voce",
     "leaveSpaceDescription": "Per abandonar le curso, tu abandonar le totalitate del chats in illo. Altri usatores videbit que tu ha abandonate le curso.",
     "constructUseCorMmDesc": "Signification correcte del message",
@@ -1268,7 +1165,6 @@
     "ttsDisabledBody": "Tu pote activar le texto-a-parola in tu configuration de apprendimento",
     "noSpaceDescriptionYet": "Nulle description de curso create ancora.",
     "tooLargeToSend": "Iste message es troppo grande pro inviar",
-    "exitWithoutSaving": "Es tu secur que tu vole partir sin salvar?",
     "enableAutocorrectPopupTitle": "Adder tu clavier de lingua target per ir a:",
     "enableAutocorrectPopupSteps": "  • Configuration\n  • General\n  • Claviatura\n  • Claviaturas\n  • Adder nove clavier",
     "enableAutocorrectPopupDescription": "Post le selection de le lingua, tu pote cliccar le icono de globulo in le basso sinistre de tu clavier pro activar le clavier installate recentemente.",
@@ -1279,11 +1175,8 @@
     "displayName": "Nom de display",
     "leaveRoomDescription": "Tu es circa de partir de iste chat. Altri usatores vide que tu ha partite le chat.",
     "confirmUserId": "Per favor confirma tu nomine de usator in Pangea Chat pro eliminar tu conto.",
-    "startingToday": "A partir de hodie",
-    "oneWeekFreeTrial": "Un septimana de prova gratuite",
     "paidSubscriptionStarts": "A partir de {startDate}",
     "cancelInSubscriptionSettings": "• Cancellar in le configuration de subscription",
-    "cancelToAvoidCharges": "• Cancellar ante {trialEnds} pro evitar charges",
     "downloadGboard": "Downloadar Gboard",
     "autocorrectNotAvailable": "Infelicemente, tu piattaforma actualmente non es supportate pro iste function. Sta attentive pro ulteriore developpamento!",
     "pleaseUpdateApp": "Per favor, actualisa le application pro continuar.",
@@ -1293,17 +1186,12 @@
     "knockSpaceSuccess": "Tu ha requestate de aderir a iste curso! Un administrator responde a tu requesto quando lo recive 😄",
     "chooseWordAudioInstructionsBody": "Audi le message complete. Postea, compatra le audio con le parolas.",
     "chooseMorphsInstructionsBody": "Clicca le piezas de puzzle pro questiones grammatical!",
-    "pleaseEnterInt": "Per favor, entra un numero",
     "home": "Casa",
     "join": "Aderir",
     "resetInstructionTooltipsTitle": "Resettar le dicas de instructiones",
     "resetInstructionTooltipsDesc": "Clique pro mostrar dicas de instructiones como pro un usator nove.",
-    "randomize": "Randomisar",
     "clear": "Clara",
-    "featuredActivities": "Featured",
     "save": "Salva",
-    "startChat": "Iniciar un conversation",
-    "translationProblem": "Problema de translation",
     "askToJoin": "Pedir de junger",
     "emptyChatWarningTitle": "Le chat es vacue",
     "emptyChatWarningDesc": "Tu ha invitate nulle uno a tu chat. Vade a configuration de chat pro invitar tu contactos o le Bot. Tu pote etiam facer isto plus tarde.",
@@ -1333,17 +1221,13 @@
     "timesUsedIndependently": "Tiempos usate independentemente",
     "timesUsedWithAssistance": "Tiempos usate con assistance",
     "shareInviteCode": "Partage le codice de invitation: {code}",
-    "leaderboard": "Classifica",
     "skipForNow": "Saltar pro nunc",
     "permissions": "Permissiones",
     "spaceChildPermission": "Qui pote adder nove chats a iste curso",
-    "addEnvironmentOverride": "Adder override de ambiente",
     "defaultOption": "Default",
     "deleteChatDesc": "Es tu secur de vole eliminar iste chat? Il essera eliminat pro tote le participantes e tote le message in le chat non essera plus disponibile pro practica o analytics de apprendimento.",
     "deleteSpaceDesc": "Le curso e omne chats selectate essera eliminat pro tote le participantes e tote le message in le chat non essera plus disponibile pro practica o analytics de apprendimento. Iste action non pote esser annullate.",
     "launch": "Lance",
-    "searchChats": "Cercar chats",
-    "maxFifty": "Maximo 50",
     "configureSpace": "Configurar le curso",
     "pinMessages": "Fixar message",
     "setJoinRules": "Stabilir le regules de admission",
@@ -1377,9 +1261,6 @@
     "failedToFetchTranscription": "Fallite a reciper le transcription",
     "deleteEmptySpaceDesc": "Le curso essera delite pro tote le participantes. Iste action non pote esser annullate.",
     "regenerate": "Regenerar",
-    "mySavedActivities": "Mi activitates salvat",
-    "noSavedActivities": "Nulle activitate salvat",
-    "saveActivity": "Salva iste activitate",
     "failedToPlayVideo": "Fallite a jocar le video",
     "done": "Finite",
     "inThisSpace": "In iste curso",
@@ -1390,13 +1271,9 @@
     "numInvited": "{count} invitate",
     "saved": "Salvate",
     "reset": "Reinitialisar",
-    "errorFetchingActivitiesMessage": "Fallite a reciper le activities",
     "errorFetchingDefinition": "Fallite a reciper le definition",
     "errorProcessAnalytics": "Fallite a processar le analytics",
     "errorDownloading": "Fallite durante le descarga",
-    "errorLoadingSpaceChildren": "Fallite a cargar le chats in iste curso",
-    "unexpectedError": "Error unexpected.",
-    "pleaseReload": "Per favor, re-in cargar e tentar de novo.",
     "translationError": "Error de translation",
     "check": "Verificar",
     "unableToFindRoom": "Nulle chat o curso trovate con iste codice. Per favor, tenta de novo.",
@@ -1405,19 +1282,14 @@
     "request": "Requesta",
     "requestAll": "Requesta Tote",
     "confirmMessageUnpin": "Es tu secur que tu vole desunpinir iste message?",
-    "saveAndLaunch": "Salva e lance",
-    "launchToSpace": "Lance a curso",
     "pending": "Pending",
     "inactive": "Inactiv",
-    "confirmRole": "Confirma le rolo",
     "openRoleLabel": "APERTE",
     "finishedTheActivity": "🎯 {username} ha completate iste activitate",
     "activitySummaryError": "Summarios de activitate non disponibile",
     "requestSummaries": "Requerer summarios",
-    "generatingNewActivities": "Tu es le prime usator de iste parie de linguas! Per favor, da nos un minuto, nos es preparante actividades solmente pro te.",
     "requestAccessTitle": "Demanar accès a l'analítica?",
     "requestAccessDesc": "Vole tu requestar accesso a vider le analytics de participantes?\n\nSi le participantes agree, le administratores de iste curso potera vider lor:\n    • total vocabulario\n    • total conceptos de grammatica\n    • total sessiones de activitate complete\n    • le conceptos de grammatica specificate, correctemente e incorrectemente\n\nIlles non potera vider lor:\n    • messages in chats extra le curso\n    • lista de vocabulario",
-    "requestAccess": "Requestar accesso ({count})",
     "analyticsInactiveTitle": "Le requestes a usatores inactive non pote esser inviate",
     "analyticsInactiveDesc": "Usatores inactive que non ha login ab le introduccione de iste caracteristica non vide tu requesta.\n\nLe button Requesta apparira una vice illes returna. Tu pote renvocar le requesta postea cliccando le button Requesta sub lor nomine quando illo es disponibile.",
     "accessRequestedTitle": "Requesta de accesso a analytics",
@@ -1440,8 +1312,6 @@
     "accessDesc": "Tu pote face tu curso aperte al mundo! O, face tu curso private e secure.",
     "createGroupChatDesc": "Dove le sessiones de activitate comencia e termina, le chats de grupo remanera aperte pro communication routine.",
     "deleteDesc": "Solo le administratores pote delere un curso. Iste es un action destructive que remove tote le usatores e delere tote le chats selectate in le curso. Procede con cautela.",
-    "noCourseFound": "Oh, iste curso ha besonio de un plano!\n\nLe planos del curso es un sequencia de themas e actividades de conversation.",
-    "additionalParticipants": "+ {num} alteres",
     "whatNow": "Que face ora?",
     "chooseNextActivity": "Selige tu proxime activitate!",
     "letsGo": "Iscamos",
@@ -1454,13 +1324,11 @@
     "waitNotDone": "Aguarda, no he terminado!",
     "waitingForOthersToFinish": "Spere que le alios finisca...",
     "generatingSummary": "Analizando le chat e generate resultatos",
-    "findCourse": "Trova un curso",
     "pingParticipantsNotification": "{user} cerca usatores pro aderir a le session de activitate in {room}",
     "course": "Curso",
     "courses": "Cursus",
     "goToCourse": "Irr a curso: {course}",
     "activityComplete": "Iste activitate ha essite completate. Le summario del activitate debe esser disponibile infra.",
-    "startNewSession": "Iniciar nove session",
     "joinOpenSession": "Joiner session aperte",
     "activityNotFound": "Activitate non trovate",
     "myActivities": "Mie actividades",
@@ -1626,10 +1494,6 @@
         "placeholders": {}
     },
     "@archive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@areGuestsAllowedToJoin": {
         "type": "String",
         "placeholders": {}
     },
@@ -1905,15 +1769,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@yourChatBackupHasBeenSetUp": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@chatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -2049,10 +1905,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@contentHasBeenReported": {
         "type": "String",
         "placeholders": {}
@@ -2089,14 +1941,6 @@
             }
         }
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@create": {
         "type": "String",
         "placeholders": {}
@@ -2110,10 +1954,6 @@
         }
     },
     "@createGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -2224,18 +2064,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -2261,10 +2089,6 @@
         "placeholders": {}
     },
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2304,10 +2128,6 @@
             }
         }
     },
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@extremeOffensive": {
         "type": "String",
         "placeholders": {}
@@ -2340,15 +2160,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@chatDescriptionHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -2446,14 +2258,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "@noChatDescriptionYet": {
         "type": "String",
@@ -2571,14 +2375,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@dehydrate": {
         "type": "String",
         "placeholders": {}
@@ -2610,14 +2406,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@logout": {
         "type": "String",
@@ -2672,14 +2460,6 @@
         "placeholders": {}
     },
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2778,10 +2558,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addAccount": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@editBundlesForAccount": {
         "type": "String",
         "placeholders": {}
@@ -2795,10 +2571,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableMultiAccounts": {
         "type": "String",
         "placeholders": {}
     },
@@ -2846,10 +2618,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@people": {
         "type": "String",
         "placeholders": {}
@@ -2883,10 +2651,6 @@
         "placeholders": {}
     },
     "@pleaseEnter4Digits": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKey": {
         "type": "String",
         "placeholders": {}
     },
@@ -2989,10 +2753,6 @@
             }
         }
     },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unbanFromChat": {
         "type": "String",
         "placeholders": {}
@@ -3034,14 +2794,6 @@
         "placeholders": {}
     },
     "@security": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
         "type": "String",
         "placeholders": {}
     },
@@ -3145,10 +2897,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@setStatus": {
         "type": "String",
         "placeholders": {}
@@ -3186,14 +2934,6 @@
         "placeholders": {}
     },
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -3249,10 +2989,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@tryToSendAgain": {
         "type": "String",
         "placeholders": {}
@@ -3299,14 +3035,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -3385,14 +3113,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@visibleForAllParticipants": {
         "type": "String",
         "placeholders": {}
@@ -3429,19 +3149,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -3493,15 +3201,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3552,10 +3252,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3564,15 +3260,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3696,43 +3384,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3745,18 +3401,6 @@
         }
     },
     "@user": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
         "type": "String",
         "placeholders": {}
     },
@@ -3773,10 +3417,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3799,22 +3439,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3869,10 +3493,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3956,31 +3576,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -4036,23 +3636,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4092,28 +3680,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4131,14 +3697,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4331,22 +3889,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4402,10 +3944,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4415,10 +3953,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4494,27 +4028,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4840,10 +4358,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4853,10 +4367,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4944,14 +4454,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4968,10 +4470,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4984,15 +4482,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5144,14 +4634,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5165,14 +4647,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6395,10 +5869,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6439,10 +5909,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6515,10 +5981,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6788,47 +6250,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6848,19 +6270,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6924,10 +6334,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6968,14 +6374,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6987,14 +6385,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -7032,10 +6422,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7052,27 +6438,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7196,10 +6566,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7209,10 +6575,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7229,14 +6591,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7376,18 +6730,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7436,10 +6778,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7449,18 +6787,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7503,23 +6829,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7543,10 +6857,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7554,14 +6864,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7666,18 +6968,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7730,10 +7020,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7760,10 +7046,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7944,7 +7226,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Revisita demanano pro actualizaciones de activity.",
-    "activityDropdownDesc": "Quando tu ha finite con iste activity, clicca infra",
     "languageMismatchTitle": "Discrepantie de lingua",
     "languageMismatchDesc": "Le lingua de destino tu non coincide con le lingua de iste activity. Actualisa tu lingua de destino?",
     "reportWordIssueTooltip": "Reportar un problema de information de parola",
@@ -7957,10 +7238,6 @@
     "selectAll": "Selige tote",
     "deselectAll": "Deselecte tote",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8009,17 +7286,11 @@
         "placeholders": {}
     },
     "startOwn": "Comencia mi proprie",
-    "joinCourseDesc": "Cata curso ha 8-10 temas sequente con un gamma de actividades de apprendimento de lingua basate in task.",
     "newMessageInPangeaChat": "🗨️ Novy message in Pangea Chat",
     "shareCourse": "Partagear curso",
     "addCourse": "Adder un curso",
-    "joinPublicCourse": "Joiner curso publice",
     "vocabLevelsDesc": "Isto es le loco ubi le vocabularies va in post una vice que tu ha levelate los!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8032,10 +7303,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8054,7 +7321,6 @@
     "emojiView": "Visualizzazione emoji",
     "feedbackDialogDesc": "Anch'io faccio errori! Qualcosa per aiutarmi a migliorare?",
     "contactHasBeenInvitedToTheCourse": "Kontak telah diundang ke kursus",
-    "activityStatsButtonTooltip": "Info aktivitas",
     "allow": "Izinkan",
     "deny": "Tolak",
     "enabledRenewal": "Aktifkan Pembaruan Langganan",
@@ -8322,10 +7588,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9381,16 +8643,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Actividades para Desbloquear el Siguiente Tema",
-    "activitiesToUnlockTopicDesc": "Establecer el número de actividades para desbloquear el siguiente tema del curso",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Praktiko de ĝusta vortaro difino",
     "constructUseIncLMDesc": "Praktiko de malĝusta vortaro difino",
     "constructUseCorLADesc": "Praktiko de ĝusta vortaro aŭdio",
@@ -9398,7 +8650,6 @@
     "constructUseBonus": "Bonus dum vortaro praktiko",
     "practiceVocab": "Praktiki vortaron",
     "selectMeaning": "Elekti la signifon",
-    "selectAudio": "Elekti la kongruan aŭdion",
     "anotherRound": "Alia rundo",
     "activitySettingsOverrideWarning": "Idioma y nivel de idioma determinados por el plan de actividad",
     "voice": "Voz",
@@ -9430,10 +8681,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9451,12 +8698,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Download inisiati",
     "webDownloadPermissionMessage": "Se o teu navegador bloqueia descargas, por favor habilita descargas para este site.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9551,11 +8793,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "N'ayen a fau, e n'ayen a t'awen a t'awen a t'awen. T'awen a t'awen a t'awen.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Abilita l'assistenza alla scrittura",
     "autoIGCToolDescription": "Esegui automaticamente gli strumenti di Pangea Chat per correggere i messaggi inviati nella lingua target.",
     "@autoIGCToolName": {
@@ -9611,24 +8848,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatika",
-    "spanTypeWordChoice": "Escolha de Palavras",
     "spanTypeSpelling": "Ortografia",
     "spanTypePunctuation": "Pontuação",
     "spanTypeStyle": "Estilo",
     "spanTypeFluency": "Fluência",
     "spanTypeAccents": "Acentos",
     "spanTypeCapitalization": "Capitalização",
-    "spanTypeCorrection": "Correção",
     "spanFeedbackTitle": "Relatar problema de correção",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9653,10 +8879,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9669,13 +8891,7 @@
     "longPressToRecordVoiceMessage": "Mantén presionado para grabar un mensaje de voz.",
     "pause": "Pausa",
     "resume": "Reanudar",
-    "newSubSpace": "Nuevo subespacio",
-    "moveToDifferentSpace": "Mover a un espacio diferente",
-    "removeFromSpaceDescription": "La chat sarà rimossa dallo spazio ma apparirà ancora nella tua lista chat.",
     "countChats": "{chats} chat",
-    "spaceMemberOf": "Membro dello spazio di {spaces}",
-    "spaceMemberOfCanKnock": "Membro dello spazio di {spaces} può bussare",
-    "donate": "Dona",
     "startedAPoll": "{username} ha avviato un sondaggio.",
     "poll": "Sondaggio",
     "startPoll": "Avvia sondaggio",
@@ -9699,23 +8915,15 @@
     "newStickerPack": "Nouveau pack d'autocollants",
     "stickerPackName": "Nom du pack d'autocollants",
     "attribution": "Attribution",
-    "skipChatBackup": "Salta la copia de seguridad del chat",
-    "skipChatBackupWarning": "¿Estás seguro? Sin habilitar la copia de seguridad del chat, puedes perder el acceso a tus mensajes si cambias de dispositivo.",
-    "loadingMessages": "Cargando mensajes",
-    "setupChatBackup": "Configurar la copia de seguridad del chat",
     "noMoreResultsFound": "No se encontraron más resultados",
     "chatSearchedUntil": "Chat buscado hasta {time}",
     "federationBaseUrl": "URL base de la federación",
     "clientWellKnownInformation": "Información del cliente bien conocida:",
     "baseUrl": "URL base",
     "identityServer": "Identitātes serveris:",
-    "versionWithNumber": "Versija: {version}",
     "logs": "Žurnāli",
-    "advancedConfigs": "Papildu konfigurācijas",
     "advancedConfigurations": "Papildu konfigurācijas",
-    "signInWithLabel": "Piesakieties ar:",
     "selectAllWords": "Izvēlieties visus vārdus, kurus dzirdat audio",
-    "joinCourseForActivities": "Pievienojieties kursam, lai izmēģinātu aktivitātes.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9752,18 +8960,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9771,26 +8967,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9896,22 +9072,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9940,19 +9100,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9960,15 +9108,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10169,11 +9309,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "In un klas? Meti vian enir kodon ĉi tie.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Auto-sélectionner les messages audio",
     "selectAudioMessagesOnPlayDescription": "Mettre automatiquement en surbrillance les messages audio lorsqu'ils sont lus",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10217,18 +9352,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Iste cursu ha tópicos con menos de {input} actividades. Por favor, ingresa un número menor o igual a {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Clic aquí para volver a iniciar sesión.",
     "@clickToLogin": {
@@ -10645,17 +9768,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Un urso amarelo cartunizado com os braços levantados em excitação.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Selecciona palabras para aprender más sobre ellas",
     "requireAnalyticsAccessTitle": "Requiere acceso a análisis para unirse",
     "requireAnalyticsAccessDesc": "Los participantes deben otorgar acceso a sus análisis de aprendizaje para unirse a este curso",
     "analyticsAccessNoticeTitle": "Acceso a Análisis Requerido",
     "analyticsAccessNoticeDesc": "Al unirte a este curso, aceptas otorgar a los administradores acceso a tus análisis de aprendizaje.",
-    "skipOnboardingClassCodeDesc": "¿Aprendiendo de forma independiente? No te preocupes, puedes:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10673,10 +9790,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10705,7 +9818,6 @@
     "pickCefrLevelTeacherStepTitle": "Kiun nivelon vi instruas?",
     "pickCefrLevelStudentStepTitle": "Kiun nivelon vi estas?",
     "customCourseStepTitle": "Plenigu ĉi tiun formularon por ricevi personigitan kurson",
-    "aboutYourClass": "Despre clasa ta",
     "courseCodeStepErrorMessage": "Te rog verifică codul tău și încearcă din nou",
     "institution": "Instituție",
     "courseGoals": "Obiectivele cursului",
@@ -10748,10 +9860,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10868,12 +9976,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logo",
     "introChatDetails": "¡Di hola! Preséntate a tus compañeros participantes del curso, encuentra amigos y chatea fuera de las actividades.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10917,11 +10020,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Ações de atividade",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Alat pengucapan",
     "audioTranscription": "Transkripsi audio AI",
     "visualLearnerSupport": "Dukungan pembelajar visual",
@@ -10962,7 +10060,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Joi un cursu ke incluy esta actividad pa xugarlo.",
     "resizeCoursePanel": "Redimensionar panel de cursu",
     "undo": "Desfacer",
     "unlock": "Desbloquear",
@@ -10976,7 +10073,6 @@
     "addCourseBrowsePublic": "Brosu publikajn kursojn",
     "browsePublicCourses": "Brosu publikajn kursojn",
     "editProfile": "Redaktu profilon",
-    "numObjectives": "{count} objektivoj",
     "mapSearchHint": "Serĉu aktivecojn",
     "mapSearchNoResults": "Neniuj kongruoj en vido",
     "mapFilterAllLanguages": "Ĉiuj lingvoj",
@@ -10985,7 +10081,6 @@
     "mapFilterCompleted": "Completo",
     "mapFilterReset": "Resetar",
     "activityTypeConversation": "Conversa",
-    "lockedMissionRequirement": "Termine a missão anterior para desbloquear",
     "playAgain": "Jogar novamente",
     "reviewActivity": "Revisar",
     "mapEmptyInView": "Nada aqui no seu nível ou idioma. Amplie seus filtros ou afaste-se.",
@@ -11000,14 +10095,9 @@
     "scrollToBottom": "Desplazarse hasta el final",
     "courseImage": "Imagen del curso",
     "avatarPreview": "Vista previa del avatar",
-    "activityPhoto": "Foto de actividad",
     "emotePreview": "Vista previa de emote: {name}",
     "activityLabel": "Aktiviteet: {title}",
     "resetMapView": "Resetti kaardi vaade",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11060,14 +10150,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11097,10 +10179,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11157,10 +10235,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_id.arb
+++ b/lib/l10n/intl_id.arb
@@ -132,15 +132,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "inviteContactToGroup": "Undang kontak ke {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
     "inviteContact": "Undang kontak",
     "@inviteContact": {
         "type": "String",
@@ -212,11 +203,6 @@
             }
         }
     },
-    "groupIsPublic": "Grup bersifat publik",
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "group": "Grup",
     "@group": {
         "type": "String",
@@ -247,11 +233,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "everythingReady": "Semua siap!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "enterAnEmailAddress": "Masukkan alamat email",
     "@enterAnEmailAddress": {
         "type": "String",
@@ -273,11 +254,6 @@
     },
     "encrypted": "Terenkripsi",
     "@encrypted": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "enableEncryptionWarning": "Kamu tidak akan bisa menonaktifkan enkripsi. Apakah kamu yakin?",
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -703,11 +679,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Apakah pengguna tamu diizinkan untuk bergabung",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "appLock": "Kunci aplikasi",
     "@appLock": {
         "type": "String",
@@ -732,11 +703,6 @@
     },
     "encryptionNotEnabled": "Enkripsi tidak diaktifkan",
     "@encryptionNotEnabled": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "Kontak telah diundang ke grup",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -777,11 +743,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Pesan lamamu diamankan dengan sebuah kunci pemulihan. Pastikan kamu tidak menghilangkannya.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "activatedEndToEndEncryption": "🔐 {username} mengaktifkan enkripsi ujung ke ujung",
     "@activatedEndToEndEncryption": {
         "type": "String",
@@ -795,15 +756,6 @@
     "@loadingPleaseWait": {
         "type": "String",
         "placeholders": {}
-    },
-    "loadCountMoreParticipants": "Muat {count} anggota",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "leftTheChat": "Keluar dari obrolan",
     "@leftTheChat": {
@@ -887,16 +839,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "noGoogleServicesWarning": "Perpesanan Awan Firebase sepertinya tidak tersedia di perangkatmu. Untuk dapat menerima notifikasi dorongan, kami menyarankan memasang ntfy. Dengan ntfy atau penyedia UnifiedPush lainnya, kamu bisa menerima notifikasi dorongan dengan cara yang aman. Kamu bisa mengunduh ntfy dari Play Store atau F-Droid.",
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Kamu hanya bisa mengaktifkan enkripsi setelah ruangan tidak lagi dapat diakses secara publik.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "noEmotesFound": "Tidak ada emote yang ditemukan. 😕",
     "@noEmotesFound": {
         "type": "String",
@@ -947,15 +889,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "logInTo": "Masuk ke {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
-    },
     "login": "Masuk",
     "@login": {
         "type": "String",
@@ -982,11 +915,6 @@
     },
     "unavailable": "Tidak tersedia",
     "@unavailable": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "transferFromAnotherDevice": "Transfer dari perangkat lain",
-    "@transferFromAnotherDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -1085,23 +1013,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "wipeChatBackup": "Hapus cadangan obrolan untuk membuat kunci pemulihan baru?",
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Kenapa kamu ingin melaporkannya?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Siapa yang dapat bergabung ke grup ini",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoCanPerformWhichAction": "Siapa yang dapat melakukan tindakan apa",
-    "@whoCanPerformWhichAction": {
         "type": "String",
         "placeholders": {}
     },
@@ -1147,16 +1060,6 @@
     },
     "visibleForAllParticipants": "Terlihat untuk semua anggota",
     "@visibleForAllParticipants": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Visibilitas sejarah obrolan",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "videoCall": "Panggilan video",
-    "@videoCall": {
         "type": "String",
         "placeholders": {}
     },
@@ -1226,15 +1129,6 @@
                 "type": "String"
             },
             "count": {
-                "type": "int"
-            }
-        }
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 obrolan belum dibaca} other{{unreadCount} obrolan belum dibaca}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
                 "type": "int"
             }
         }
@@ -1345,16 +1239,6 @@
             }
         }
     },
-    "spaceName": "Nama space",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Space publik",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "sourceCode": "Kode sumber",
     "@sourceCode": {
         "type": "String",
@@ -1391,11 +1275,6 @@
     },
     "setStatus": "Tetapkan status",
     "@setStatus": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "setPermissionsLevel": "Tetapkan level izin",
-    "@setPermissionsLevel": {
         "type": "String",
         "placeholders": {}
     },
@@ -1550,11 +1429,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "passwordRecovery": "Pemulihan kata sandi",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "passwordHasBeenChanged": "Kata sandi telah diubah",
     "@passwordHasBeenChanged": {
         "type": "String",
@@ -1592,8 +1466,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableMultiAccounts": "(BETA) Aktifkan multi-akun di perangkat ini",
-    "@enableMultiAccounts": {},
     "bundleName": "Nama bundel",
     "@bundleName": {},
     "removeFromBundle": "Hilangkan dari bundel ini",
@@ -1602,8 +1474,6 @@
     "@addToBundle": {},
     "editBundlesForAccount": "Edit bundel untuk akun ini",
     "@editBundlesForAccount": {},
-    "addAccount": "Tambah akun",
-    "@addAccount": {},
     "oneClientLoggedOut": "Salah satu klienmu telah keluar",
     "@oneClientLoggedOut": {},
     "openCamera": "Buka kamera",
@@ -1742,11 +1612,6 @@
     },
     "darkTheme": "Gelap",
     "@darkTheme": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "createNewSpace": "Space baru",
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1903,11 +1768,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "removeDevice": "Hapus perangkat",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "removedBy": "Dihapus oleh {username}",
     "@removedBy": {
         "type": "String",
@@ -1964,8 +1824,6 @@
     },
     "link": "Tautan",
     "@link": {},
-    "yourChatBackupHasBeenSetUp": "Cadangan obrolanmu telah disiapkan.",
-    "@yourChatBackupHasBeenSetUp": {},
     "unverified": "Tidak terverifikasi",
     "@unverified": {},
     "repeatPassword": "Ulangi kata sandi",
@@ -1982,8 +1840,6 @@
     "@openGallery": {},
     "start": "Mulai",
     "@start": {},
-    "removeFromSpace": "Hilangkan dari space",
-    "@removeFromSpace": {},
     "commandHint_clearcache": "Bersihkan tembolok",
     "@commandHint_clearcache": {
         "type": "String",
@@ -2043,12 +1899,6 @@
     "@unsupportedAndroidVersion": {},
     "placeCall": "Lakukan panggilan",
     "@placeCall": {},
-    "voiceCall": "Panggilan suara",
-    "@voiceCall": {},
-    "videoCallsBetaWarning": "Dicatat bahwa panggilan video sedang dalam beta. Fitur ini mungkin tidak berkerja dengan benar atau tidak berkerja sama sekali pada semua platform.",
-    "@videoCallsBetaWarning": {},
-    "emailOrUsername": "Email atau nama pengguna",
-    "@emailOrUsername": {},
     "experimentalVideoCalls": "Panggilan video eksperimental",
     "@experimentalVideoCalls": {},
     "widgetEtherpad": "Catatan teks",
@@ -2136,28 +1986,8 @@
             }
         }
     },
-    "pleaseEnterRecoveryKeyDescription": "Untuk mengakses pesan lamamu, mohon masukkan kunci pemulihanmu yang telah dibuat di sesi sebelumnya. Kunci pemulihanmu BUKAN kata sandimu.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "users": "Pengguna",
     "@users": {},
-    "storeInSecureStorageDescription": "Simpan kunci pemulihan di penyimpanan aman perangkat ini.",
-    "@storeInSecureStorageDescription": {},
-    "saveKeyManuallyDescription": "Simpan kunci ini secara manual dengan memicu dialog pembagian atau papan klip sistem.",
-    "@saveKeyManuallyDescription": {},
-    "recoveryKey": "Kunci pemulihan",
-    "@recoveryKey": {},
-    "storeInAppleKeyChain": "Simpan di Apple KeyChain",
-    "@storeInAppleKeyChain": {},
-    "pleaseEnterRecoveryKey": "Mohon masukkan kunci pemulihanmu:",
-    "@pleaseEnterRecoveryKey": {},
-    "unlockOldMessages": "Akses pesan lama",
-    "@unlockOldMessages": {},
-    "recoveryKeyLost": "Kunci pemulihan hilang?",
-    "@recoveryKeyLost": {},
-    "storeInAndroidKeystore": "Simpan di Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeSecurlyOnThisDevice": "Simpan secara aman di perangkat ini",
-    "@storeSecurlyOnThisDevice": {},
     "countFiles": "{count} file",
     "@countFiles": {
         "placeholders": {
@@ -2191,24 +2021,16 @@
     "@commandHint_markasdm": {},
     "commandHint_markasgroup": "Tandai sebagai grup",
     "@commandHint_markasgroup": {},
-    "screenSharingTitle": "membagikan layar",
-    "@screenSharingTitle": {},
     "noKeyForThisMessage": "Hal ini bisa terjadi jika pesan dikirim sebelum kamu masuk ke akunmu di perangkat ini.\n\nMungkin juga pengirim telah memblokir perangkatmu atau ada yang tidak beres dengan koneksi internet.\n\nApakah kamu bisa membaca pesan pada sesi lain? Maka kamu bisa mentransfer pesan dari sesi tersebut! Buka Pengaturan > Perangkat dan pastikan bahwa perangkat Anda telah ditandatangani secara silang. Ketika kamu membuka ruangan di lain waktu dan kedua sesi berada di latar depan, kunci akan ditransmisikan secara otomatis.\n\nApakah kamu tidak mau kehilangan kunci saat keluar atau berpindah perangkat? Pastikan bahwa kamu telah mengaktifkan cadangan obrolan dalam pengaturan.",
     "@noKeyForThisMessage": {},
-    "foregroundServiceRunning": "Notifikasi ini ditampilkan ketika layanan latar depan berjalan.",
-    "@foregroundServiceRunning": {},
     "whyIsThisMessageEncrypted": "Mengapa pesan ini tidak bisa dibaca?",
     "@whyIsThisMessageEncrypted": {},
     "newGroup": "Grup baru",
     "@newGroup": {},
     "newSpace": "Space baru",
     "@newSpace": {},
-    "enterSpace": "Masuk space",
-    "@enterSpace": {},
     "allSpaces": "Semua space",
     "@allSpaces": {},
-    "screenSharingDetail": "Kamu membagikan layarmu di FluffyChat",
-    "@screenSharingDetail": {},
     "doNotShowAgain": "Jangan tampilkan lagi",
     "@doNotShowAgain": {},
     "hugContent": "{senderName} memeluk kamu",
@@ -2253,16 +2075,8 @@
             }
         }
     },
-    "newSpaceDescription": "Fitur space bisa membantu untuk memisahkan obrolanmu dan membuat komunitas pribadi atau publik.",
-    "@newSpaceDescription": {},
-    "sorryThatsNotPossible": "Maaf... itu tidak mungkin",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "Kunci perangkat:",
     "@deviceKeys": {},
-    "encryptThisChat": "Enkripsi obrolan ini",
-    "@encryptThisChat": {},
-    "disableEncryptionWarning": "Demi keamanan kamu tidak bisa menonaktifkan enkripsi dalam sebuah obrolan di mana sebelumbya sudah diaktifkan.",
-    "@disableEncryptionWarning": {},
     "reopenChat": "Buka obrolan lagi",
     "@reopenChat": {},
     "noBackupWarning": "Peringatan! Tanpa mengaktifkan cadangan percakapan, kamu akan kehilangan akses ke pesan terenkripsimu. Disarankan untuk mengaktifkan cadangan percakapan terlebih dahulu sebelum keluar dari akun.",
@@ -2314,14 +2128,10 @@
     "@messagesStyle": {},
     "shareInviteLink": "Bagikan tautan undangan",
     "@shareInviteLink": {},
-    "setTheme": "Atur tema:",
-    "@setTheme": {},
     "invalidServerName": "Nama server tidak valid",
     "@invalidServerName": {},
     "chatPermissions": "Perizinan obrolan",
     "@chatPermissions": {},
-    "chatDescription": "Deskripsi obrolan",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "Deskripsi obrolan diubah",
     "@chatDescriptionHasBeenChanged": {},
     "noChatDescriptionYet": "Deskripsi obrolan belum dibuat.",
@@ -2405,14 +2215,10 @@
     "@pleaseEnterANumber": {},
     "kickUserDescription": "Pengguna ini dikeluarkan dari percakapan tetapi tidak dicekal. Dalam percakapan publik, penggunanya dapat bergabung ulang kapan pun.",
     "@kickUserDescription": {},
-    "groupCanBeFoundViaSearch": "Grup dapat dicari melalui pencarian",
-    "@groupCanBeFoundViaSearch": {},
     "groupName": "Nama grup",
     "@groupName": {},
     "wrongRecoveryKey": "Maaf... ini sepertinya bukan kunci pemulihan yang benar.",
     "@wrongRecoveryKey": {},
-    "addChatOrSubSpace": "Tambahkan percakapan atau subspace",
-    "@addChatOrSubSpace": {},
     "pleaseChooseAStrongPassword": "Silakan pilih kata sandi yang kuat",
     "@pleaseChooseAStrongPassword": {},
     "joinSpace": "Bergabung ke space",
@@ -2477,10 +2283,6 @@
     },
     "passwordIsWrong": "Kata sandi yang kamu masukkan salah",
     "@passwordIsWrong": {},
-    "searchChatsRooms": "Cari #percakapan, @pengguna...",
-    "@searchChatsRooms": {},
-    "createGroupAndInviteUsers": "Buat sebuah grup dan undang pengguna",
-    "@createGroupAndInviteUsers": {},
     "pleaseEnterYourCurrentPassword": "Silakan masukkan kata sandimu saat ini",
     "@pleaseEnterYourCurrentPassword": {},
     "passwordsDoNotMatch": "Kata sandi tidak cocok",
@@ -2491,32 +2293,6 @@
     "@sendReadReceipts": {},
     "formattedMessages": "Pesan yang diformat",
     "@formattedMessages": {},
-    "verifyOtherUser": "🔐 Verifikasi pengguna lain",
-    "@verifyOtherUser": {},
-    "sessionLostBody": "Sesimu hilang. Silakan laporkan kesalahan ini kepada pengembang di {url}. Pesan kesalahannya adalah: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Aplikasi sekarang mencoba memulihkan sesimu dari cadangan. Silakan laporkan kesalahan ini kepada pengembang di {url}. Pesan kesalahannya adalah: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "presencesToggle": "Tampilkan pesan status dari pengguna lain",
     "@presencesToggle": {
         "type": "String",
@@ -2583,8 +2359,6 @@
     "@initAppError": {},
     "verifyOtherDeviceDescription": "Saat kamu memverifikasi perangkat lain, perangkat tersebut dapat bertukar kunci, sehingga meningkatkan keamananmu secara keseluruhan. 💪 Saat Anda memulai verifikasi, sebuah pemberitahuan akan muncul di aplikasi pada kedua perangkat. Di situ kemudian akan melihat serangkaian emoji atau angka yang harus dibandingkan satu sama lain. Sebaiknya siapkan kedua perangkat sebelum kamu memulai verifikasi. 🤳",
     "@verifyOtherDeviceDescription": {},
-    "verifyOtherUserDescription": "Jika kamu memverifikasi pengguna lain, kamu bisa yakin bahwa kamu tahu kepada siapa sebenarnya kamu menulis pesan kepadanya. 💪\n\nSaat kamu memulai verifikasi, kamu dan pengguna lain akan melihat pemberitahuan di aplikasi. Di sana kemudian akan melihat serangkaian emoji atau angka yang harus dibandingkan satu sama lain.\n\nCara terbaik untuk melakukannya adalah dengan bertemu secara langsung atau memulai panggilan video. 👭",
-    "@verifyOtherUserDescription": {},
     "commandHint_ignore": "Abaikan ID Matrix yang diberikan",
     "@commandHint_ignore": {},
     "commandHint_unignore": "Batalkan pengabaian ID Matrix yang diberikan",
@@ -2609,12 +2383,6 @@
     "@hideRedactedMessages": {},
     "appLockDescription": "Kunci aplikasi ketika tidak digunakan dengan kode PIN",
     "@appLockDescription": {},
-    "accessAndVisibility": "Akses dan keterlihatan",
-    "@accessAndVisibility": {},
-    "globalChatId": "ID obrolan global",
-    "@globalChatId": {},
-    "accessAndVisibilityDescription": "Siapa yang diperbolehkan bergabung ke obrolan ini dan bagaimana obrolannya dapat ditemukan.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Panggilan",
     "@calls": {},
     "customEmojisAndStickers": "Emoji dan stiker kustom",
@@ -2627,32 +2395,15 @@
     "@overview": {},
     "passwordRecoverySettings": "Pengaturan pemulihan kata sandi",
     "@passwordRecoverySettings": {},
-    "usersMustKnock": "Pengguna harus mengetuk",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Tidak ada siapa pun yang dapat bergabung",
-    "@noOneCanJoin": {},
     "knock": "Ketuk",
     "@knock": {},
     "knocking": "Mengetuk",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Obrolan dapat ditemukan melalui pencarian di {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "thereAreCountUsersBlocked": "Saat ini ada {count} pengguna yang diblokir.",
     "@thereAreCountUsersBlocked": {
         "type": "String",
         "count": {}
     },
-    "publicChatAddresses": "Alamat obrolan umum",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Buat alamat baru",
-    "@createNewAddress": {},
     "swipeRightToLeftToReply": "Usap dari kanan ke kiri untuk membalas",
     "@swipeRightToLeftToReply": {},
     "searchMore": "Cari lebih banyak...",
@@ -2754,10 +2505,6 @@
     },
     "changeGeneralChatSettings": "Ubah pengaturan chat umum",
     "@changeGeneralChatSettings": {},
-    "discoverHomeservers": "Jelajahi homeserver",
-    "@discoverHomeservers": {},
-    "loginWithMatrixId": "Masuk dengan ID Matrix",
-    "@loginWithMatrixId": {},
     "doesNotSeemToBeAValidHomeserver": "Sepertinya bukan homeserver yang kompatibel. URL salah?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "unread": "Tidak dibaca",
@@ -2774,8 +2521,6 @@
     "@generatingVideoThumbnail": {},
     "changelog": "Catatan perubahan",
     "@changelog": {},
-    "whatIsAHomeserver": "Apa itu homeserver?",
-    "@whatIsAHomeserver": {},
     "sendRoomNotifications": "Kirim notifikasi @room",
     "@sendRoomNotifications": {},
     "updateInstalled": "🎉 Pembaruan {version} terpasang!",
@@ -2800,14 +2545,10 @@
     },
     "chatPermissionsDescription": "Tentukan tingkat kekuasaan yang diperlukan untuk tindakan tertentu dalam chat ini. Tingkat kekuasaan 0, 50 dan 100 biasanya mewakili pengguna, moderator dan admin, tetapi gradasi apa pun dimungkinkan.",
     "@chatPermissionsDescription": {},
-    "homeserverDescription": "Semua data Anda disimpan di dalam server, seperti halnya penyedia email. Anda dapat memilih homeserver mana yang ingin Anda gunakan, sementara Anda masih dapat berkomunikasi dengan semua orang. Pelajari lebih lanjut di https://matrix.org.",
-    "@homeserverDescription": {},
     "oneOfYourDevicesIsNotVerified": "Salah satu perangkat Anda tidak terverifikasi",
     "@oneOfYourDevicesIsNotVerified": {},
     "noticeChatBackupDeviceVerification": "Catatan: Ketika Anda menghubungkan semua perangkat Anda ke cadangan chat, mereka akan diverifikasi secara otomatis.",
     "@noticeChatBackupDeviceVerification": {},
-    "welcomeText": "Halo 👋 Ini FluffyChat. Kamu bisa masuk ke homeserver mana pun, yang kompatibel dengan https://matrix.org. Lalu, chat dengan siapa pun. Ini merupakan jaringan perpesanan besar yang terdesentralisasi!",
-    "@welcomeText": {},
     "continueText": "Lanjutkan",
     "@continueText": {},
     "aboutHomeserver": "Tentang {homeserver}",
@@ -2837,8 +2578,6 @@
     "@version": {},
     "website": "Situs Web",
     "@website": {},
-    "manageAccount": "Kelola akun",
-    "@manageAccount": {},
     "contactServerSecurity": "Hubungi keamanan server",
     "@contactServerSecurity": {},
     "name": "Nama",
@@ -2977,8 +2716,6 @@
     "@crossVerifiedDevices": {},
     "waitingForServer": "Menunggu server...",
     "@waitingForServer": {},
-    "appIntroduction": "FluffyChat memungkinkanmu untuk mengobrol dengan teman-temanmu di berbagai perpesanan. Pelajari lebih lanjut di https://matrix.org atau ketuk *Lanjutkan* saja.",
-    "@appIntroduction": {},
     "notificationRuleContainsDisplayNameDescription": "Memberi tahu pengguna ketika pesan berisi nama tampilannya.",
     "@notificationRuleContainsDisplayNameDescription": {},
     "shareKeysWith": "Bagikan kunci dengan...",
@@ -3002,17 +2739,6 @@
     "@previous": {},
     "otherPartyNotLoggedIn": "Pihak lain belum masuk dan tidak dapat menerima pesan!",
     "@otherPartyNotLoggedIn": {},
-    "appWantsToUseForLogin": "Gunakan '{server}' untuk masuk",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Anda memperbolehkan aplikasi dan situs web membagikan informasi tentang Anda.",
-    "@appWantsToUseForLoginDescription": {},
     "open": "Buka",
     "@open": {},
     "takeAPhoto": "Ambil foto",
@@ -3055,15 +2781,6 @@
     },
     "checkList": "Ceklis",
     "@checkList": {},
-    "countInvited": "{count} diundang",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "commandHint_logout": "Keluar dari perangkatmu saat ini",
     "@commandHint_logout": {},
     "commandHint_logoutall": "Keluarkan semua perangkat aktif",
@@ -3090,11 +2807,9 @@
     "taTooltip": "Penggunaan L2 dengan bantuan terjemahan",
     "interactiveTranslatorSliderHeader": "Penerjemah Interaktif",
     "interactiveGrammarSliderHeader": "Pemeriksa Tata Bahasa Interaktif",
-    "interactiveTranslatorRequired": "Diperlukan",
     "waTooltip": "Penggunaan L2 tanpa bantuan",
     "interactiveTranslator": "Bantuan Terjemahan",
     "noIdenticalLanguages": "Harap pilih bahasa dasar dan target yang berbeda",
-    "searchBy": "Cari berdasarkan negara dan bahasa",
     "joinWithClassCode": "Gabung kursus",
     "languageLevelPreA1": "Pemula Rendah (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -3115,19 +2830,14 @@
     "saveChanges": "Simpan perubahan",
     "publicProfileTitle": "Izinkan profil saya ditemukan dalam pencarian",
     "publicProfileDesc": "Dengan mengaktifkan, Anda memungkinkan pengguna lain menemukan profil Anda di bilah pencarian global dan mengirim permintaan untuk mengobrol. Pada titik ini, Anda dapat memilih untuk menerima atau menolak permintaan tersebut.",
-    "errorDisableIT": "Bantuan terjemahan dimatikan.",
-    "errorDisableIGC": "Bantuan tata bahasa dimatikan.",
     "errorDisableITUserDesc": "Klik di sini untuk memperbarui pengaturan bantuan terjemahan",
     "errorDisableIGCUserDesc": "Klik di sini untuk memperbarui pengaturan bantuan tata bahasa",
     "errorDisableITClassDesc": "Bantuan terjemahan dimatikan untuk kursus tempat obrolan ini berada.",
     "errorDisableIGCClassDesc": "Bantuan tata bahasa dimatikan untuk kursus tempat obrolan ini berada.",
-    "error405Title": "Bahasa belum diatur",
     "error405Desc": "Silakan atur bahasa Anda di Menu Utama > Pengaturan Pembelajaran.",
     "termsAndConditions": "Syarat dan Ketentuan",
     "andCertifyIAmAtLeast13YearsOfAge": " dan menyatakan saya berusia minimal 16 tahun.",
-    "error502504Title": "Wow, banyak siswa online!",
     "error502504Desc": "Alat terjemahan dan tata bahasa mungkin lambat atau tidak tersedia sementara bot Pangea mengejar ketertinggalan.",
-    "error404Title": "Kesalahan terjemahan!",
     "error404Desc": "Bot Pangea tidak yakin bagaimana menerjemahkan itu...",
     "errorPleaseRefresh": "Kami sedang menelusurinya! Silakan muat ulang dan coba lagi.",
     "connectedToStaging": "Terhubung ke Staging",
@@ -3165,13 +2875,9 @@
     "definitionsToolName": "Definisi Kata",
     "definitionsToolDescription": "Ketika diaktifkan, kata yang digarisbawahi berwarna biru dapat diklik untuk melihat definisi. Klik pesan untuk mengakses definisi.",
     "welcomeBack": "Selamat datang kembali! Jika Anda bagian dari pilot 2023-2024, silakan hubungi kami untuk langganan pilot khusus Anda. Jika Anda seorang guru yang telah (atau institusi Anda telah) membeli lisensi untuk kelas Anda, hubungi kami untuk langganan guru.",
-    "downloadTxtFile": "Unduh File Teks",
-    "downloadCSVFile": "Unduh File CSV",
     "promotionalSubscriptionDesc": "Anda saat ini memiliki langganan promosi seumur hidup. Pesan ke support@pangea.chat untuk bantuan mengubah langganan Anda.",
     "originalSubscriptionPlatform": "Langganan dibeli melalui {purchasePlatform}",
     "oneWeekTrial": "Percobaan Seminggu",
-    "downloadXLSXFile": "Unduh Berkas Excel",
-    "unkDisplayName": "Tidak Diketahui",
     "wwCountryDisplayName": "Dunia",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Kepulauan Aland",
@@ -3466,7 +3172,6 @@
     "chatCapacityHasBeenChanged": "Kapasitas obrolan telah diubah",
     "chatCapacitySetTooLow": "Kapasitas obrolan harus minimal {count}.",
     "chatCapacityExplanation": "Kapasitas obrolan membatasi jumlah anggota yang diizinkan dalam obrolan.",
-    "tooManyRequest": "Terlalu banyak permintaan, silakan coba lagi nanti.",
     "enterNumber": "Silakan masukkan nilai angka bulat.",
     "practice": "Latihan",
     "versionNotFound": "Versi Tidak Ditemukan",
@@ -3476,7 +3181,6 @@
     "deleteSubscriptionWarningTitle": "Anda memiliki langganan aktif",
     "deleteSubscriptionWarningBody": "Menghapus akun Anda tidak akan secara otomatis membatalkan langganan Anda.",
     "manageSubscription": "Kelola Langganan",
-    "error520Title": "Silakan coba lagi.",
     "error520Desc": "Maaf, kami tidak dapat memahami pesan Anda...",
     "wordsUsed": "Kata yang Digunakan",
     "level": "Level",
@@ -3494,7 +3198,6 @@
     "other": "Lainnya",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "Tanpa batas kapasitas",
-    "downloadGroupText": "Unduh teks grup",
     "notificationsOn": "Notifikasi aktif",
     "notificationsOff": "Notifikasi mati",
     "joinWithCode": "Gabung dengan kode",
@@ -3558,24 +3261,12 @@
     "whatIsTheMorphTag": "Apa {morphologicalFeature} dari '{wordForm}'?",
     "dataAvailable": "Ketersediaan data",
     "available": "Tersedia",
-    "pangeaBotIsFallible": "Pangea Bot juga bisa membuat kesalahan!",
-    "whatIsMeaning": "Apa arti '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Cocokkan arti dengan kata-kata dalam pesan!",
-    "doubleClickToEdit": "Klik dua kali untuk mengedit.",
-    "topicLabel": "Topik",
-    "topicPlaceholder": "Pilih topik...",
-    "modePlaceholder": "Pilih mode...",
-    "learningObjectiveLabel": "Tujuan Pembelajaran",
-    "learningObjectivePlaceholder": "Pilih tujuan pembelajaran...",
-    "targetLanguageLabel": "Bahasa target",
     "cefrLevelLabel": "Level CEFR",
     "image": "Gambar",
     "video": "Video",
     "nan": "Tidak berlaku",
-    "addVocabulary": "Tambah kosakata",
     "instructions": "Instruksi",
-    "numberOfLearners": "Jumlah pelajar",
-    "mustBeInteger": "Harus berupa bilangan bulat misalnya 1, 2, 3, ...",
     "constructUsePvmDesc": "Diproduksi dalam pesan suara",
     "leaveSpaceDescription": "Dengan meninggalkan kursus, Anda akan meninggalkan semua obrolan di dalamnya. Pengguna lain akan melihat bahwa Anda telah meninggalkan kursus.",
     "constructUseCorMmDesc": "Makna pesan yang benar",
@@ -3590,7 +3281,6 @@
     "ttsDisabledBody": "Anda dapat mengaktifkan teks-ke-ucapan di pengaturan pembelajaran Anda",
     "noSpaceDescriptionYet": "Belum ada deskripsi kursus yang dibuat.",
     "tooLargeToSend": "Pesan ini terlalu besar untuk dikirim",
-    "exitWithoutSaving": "Apakah Anda yakin ingin meninggalkan tanpa menyimpan?",
     "enableAutocorrectPopupTitle": "Tambahkan keyboard bahasa target Anda dengan pergi ke:",
     "enableAutocorrectPopupSteps": "  • Pengaturan\n  • Umum\n  • Keyboard\n  • Keyboard\n  • Tambah Keyboard Baru",
     "enableAutocorrectPopupDescription": "Setelah bahasa dipilih, Anda dapat mengklik ikon globe kecil di kiri bawah keyboard Anda untuk mengaktifkan keyboard yang baru diinstal.",
@@ -3601,11 +3291,8 @@
     "displayName": "Nama tampilan",
     "leaveRoomDescription": "Anda akan meninggalkan obrolan ini. Pengguna lain akan melihat bahwa Anda telah meninggalkan obrolan.",
     "confirmUserId": "Harap konfirmasi nama pengguna Pangea Chat Anda untuk menghapus akun Anda.",
-    "startingToday": "Mulai hari ini",
-    "oneWeekFreeTrial": "Percobaan gratis satu minggu",
     "paidSubscriptionStarts": "Dimulai {startDate}",
     "cancelInSubscriptionSettings": "• Batalkan kapan saja di pengaturan langganan",
-    "cancelToAvoidCharges": "• Batalkan sebelum {trialEnds} untuk menghindari biaya",
     "downloadGboard": "Unduh Gboard",
     "autocorrectNotAvailable": "Sayangnya platform Anda saat ini tidak didukung untuk fitur ini. Nantikan pengembangan lebih lanjut!",
     "pleaseUpdateApp": "Harap perbarui aplikasi untuk melanjutkan.",
@@ -3615,17 +3302,12 @@
     "knockSpaceSuccess": "Anda telah meminta untuk bergabung dengan kursus ini! Seorang admin akan merespons permintaan Anda saat mereka menerimanya 😊",
     "chooseWordAudioInstructionsBody": "Dengarkan pesan lengkapnya. Kemudian cocokkan audio dengan kata-kata.",
     "chooseMorphsInstructionsBody": "Klik bagian puzzle untuk pertanyaan tata bahasa!",
-    "pleaseEnterInt": "Silakan masukkan angka",
     "home": "Beranda",
     "join": "Gabung",
     "resetInstructionTooltipsTitle": "Atur ulang tooltip instruksi",
     "resetInstructionTooltipsDesc": "Klik untuk menampilkan tooltip instruksi seperti untuk pengguna baru.",
-    "randomize": "Acak",
     "clear": "Hapus",
-    "featuredActivities": "Unggulan",
     "save": "Simpan",
-    "startChat": "Mulai obrolan",
-    "translationProblem": "Masalah terjemahan",
     "askToJoin": "Minta bergabung",
     "emptyChatWarningTitle": "Obrolan kosong",
     "emptyChatWarningDesc": "Anda belum mengundang siapa pun ke obrolan Anda. Pergi ke Pengaturan Obrolan untuk mengundang kontak Anda atau Bot. Anda juga dapat melakukannya nanti.",
@@ -3655,17 +3337,13 @@
     "timesUsedIndependently": "Jumlah digunakan secara mandiri",
     "timesUsedWithAssistance": "Jumlah digunakan dengan bantuan",
     "shareInviteCode": "Bagikan kode undangan: {code}",
-    "leaderboard": "Papan peringkat",
     "skipForNow": "Lewati untuk saat ini",
     "permissions": "Izin",
     "spaceChildPermission": "Siapa yang dapat menambahkan obrolan baru ke kursus ini",
-    "addEnvironmentOverride": "Tambahkan override lingkungan",
     "defaultOption": "Default",
     "deleteChatDesc": "Anda yakin ingin menghapus obrolan ini? Ini akan dihapus untuk semua peserta dan semua pesan dalam obrolan tidak akan lagi tersedia untuk latihan atau analitik pembelajaran.",
     "deleteSpaceDesc": "Kursus dan obrolan yang dipilih akan dihapus untuk semua peserta dan semua pesan dalam obrolan tidak akan lagi tersedia untuk latihan atau analitik pembelajaran. Tindakan ini tidak dapat dibatalkan.",
     "launch": "Luncurkan",
-    "searchChats": "Cari obrolan",
-    "maxFifty": "Maks 50",
     "configureSpace": "Konfigurasi kursus",
     "pinMessages": "Pin pesan",
     "setJoinRules": "Atur aturan bergabung",
@@ -3699,9 +3377,6 @@
     "failedToFetchTranscription": "Gagal mengambil transkripsi",
     "deleteEmptySpaceDesc": "Kursus akan dihapus untuk semua peserta. Tindakan ini tidak dapat dibatalkan.",
     "regenerate": "Hasilkan ulang",
-    "mySavedActivities": "Aktivitas Tersimpan Saya",
-    "noSavedActivities": "Tidak ada aktivitas tersimpan",
-    "saveActivity": "Simpan aktivitas ini",
     "failedToPlayVideo": "Gagal memutar video",
     "done": "Selesai",
     "inThisSpace": "Dalam kursus ini",
@@ -3712,13 +3387,9 @@
     "numInvited": "{count} diundang",
     "saved": "Tersimpan",
     "reset": "Atur ulang",
-    "errorFetchingActivitiesMessage": "Gagal mengambil aktivitas",
     "errorFetchingDefinition": "Gagal mengambil definisi",
     "errorProcessAnalytics": "Gagal memproses analitik",
     "errorDownloading": "Gagal mengunduh",
-    "errorLoadingSpaceChildren": "Gagal memuat obrolan dalam kursus ini",
-    "unexpectedError": "Kesalahan tak terduga.",
-    "pleaseReload": "Silakan muat ulang dan coba lagi.",
     "translationError": "Kesalahan terjemahan",
     "check": "Periksa",
     "unableToFindRoom": "Tidak ditemukan obrolan atau kursus dengan kode tersebut. Silakan coba lagi.",
@@ -3727,19 +3398,14 @@
     "request": "Permintaan",
     "requestAll": "Permintaan Semua",
     "confirmMessageUnpin": "Apakah Anda yakin ingin melepas pin pesan ini?",
-    "saveAndLaunch": "Simpan dan Luncurkan",
-    "launchToSpace": "Luncurkan ke kursus",
     "pending": "Menunggu",
     "inactive": "Tidak aktif",
-    "confirmRole": "Konfirmasi peran",
     "openRoleLabel": "TERBUKA",
     "finishedTheActivity": "🎯 {username} menyelesaikan aktivitas ini",
     "activitySummaryError": "Ringkasan aktivitas tidak tersedia",
     "requestSummaries": "Minta ringkasan",
-    "generatingNewActivities": "Anda adalah pengguna pertama dari pasangan bahasa ini! Mohon tunggu sebentar, kami sedang menyiapkan aktivitas khusus untuk Anda.",
     "requestAccessTitle": "Minta akses analitik?",
     "requestAccessDesc": "Apakah Anda ingin meminta akses untuk melihat analitik peserta?\n\nJika peserta setuju, admin kursus ini akan dapat melihat:\n    • total kosakata\n    • total konsep tata bahasa\n    • total sesi aktivitas yang diselesaikan\n    • konsep tata bahasa tertentu yang digunakan, dengan benar dan salah\n\nMereka tidak akan dapat melihat:\n    • pesan dalam obrolan di luar kursus\n    • daftar kosakata",
-    "requestAccess": "Permintaan akses ({count})",
     "analyticsInactiveTitle": "Permintaan ke pengguna tidak aktif tidak dapat dikirim",
     "analyticsInactiveDesc": "Pengguna tidak aktif yang belum masuk sejak fitur ini diperkenalkan tidak akan melihat permintaan Anda.\n\nTombol Permintaan akan muncul setelah mereka kembali. Anda dapat mengirim ulang permintaan nanti dengan mengklik tombol Permintaan di bawah nama mereka saat tersedia.",
     "accessRequestedTitle": "Permintaan Akses Analitik",
@@ -3762,8 +3428,6 @@
     "accessDesc": "Anda dapat membuat kursus Anda terbuka untuk dunia! Atau, buat kursus Anda pribadi dan aman.",
     "createGroupChatDesc": "Sedangkan sesi aktivitas dimulai dan berakhir, obrolan grup akan tetap terbuka untuk komunikasi rutin.",
     "deleteDesc": "Hanya admin yang dapat menghapus kursus. Ini adalah tindakan destruktif yang menghapus semua pengguna dan menghapus semua obrolan yang dipilih dalam kursus. Lanjutkan dengan hati-hati.",
-    "noCourseFound": "Oh, kursus ini membutuhkan rencana!\n\nRencana kursus adalah rangkaian topik dan aktivitas percakapan.",
-    "additionalParticipants": "+ {num} lainnya",
     "whatNow": "Apa sekarang?",
     "chooseNextActivity": "Pilih aktivitas berikutnya!",
     "letsGo": "Ayo mulai",
@@ -3776,13 +3440,11 @@
     "waitNotDone": "Tunggu, saya belum selesai!",
     "waitingForOthersToFinish": "Menunggu yang lain selesai...",
     "generatingSummary": "Menganalisis obrolan dan menghasilkan hasil",
-    "findCourse": "Cari kursus",
     "pingParticipantsNotification": "{user} sedang mencari pengguna untuk bergabung dalam sesi aktivitas di {room}",
     "course": "Kursus",
     "courses": "Kursus",
     "goToCourse": "Pergi ke kursus: {course}",
     "activityComplete": "Aktivitas ini telah selesai. Ringkasan aktivitas harus tersedia di bawah.",
-    "startNewSession": "Mulai sesi baru",
     "joinOpenSession": "Gabung sesi terbuka",
     "activityNotFound": "Aktivitas tidak ditemukan",
     "myActivities": "Aktivitas saya",
@@ -3857,10 +3519,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3870,10 +3528,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -3961,14 +3615,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -3985,10 +3631,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4001,15 +3643,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4161,14 +3795,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4182,14 +3808,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5412,10 +5030,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5456,10 +5070,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5532,10 +5142,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5805,47 +5411,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5865,19 +5431,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -5941,10 +5495,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -5985,14 +5535,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6004,14 +5546,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6049,10 +5583,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6069,27 +5599,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6213,10 +5727,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6226,10 +5736,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6246,14 +5752,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6393,18 +5891,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6453,10 +5939,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6466,18 +5948,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6520,23 +5990,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6560,10 +6018,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6571,14 +6025,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6683,18 +6129,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6747,10 +6181,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6777,10 +6207,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -6961,7 +6387,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Periksa kembali besok untuk pembaruan aktivitas.",
-    "activityDropdownDesc": "Ketika Anda selesai dengan aktivitas ini, klik di bawah",
     "languageMismatchTitle": "Ketidaksesuaian bahasa",
     "languageMismatchDesc": "Bahasa target Anda tidak cocok dengan bahasa aktivitas ini. Perbarui bahasa target Anda?",
     "reportWordIssueTooltip": "Laporkan masalah informasi kata",
@@ -6974,10 +6399,6 @@
     "selectAll": "Pilih semua",
     "deselectAll": "Batalkan pilihan semua",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7026,17 +6447,11 @@
         "placeholders": {}
     },
     "startOwn": "Mulai milik saya sendiri",
-    "joinCourseDesc": "Setiap kursus memiliki 8-10 topik berurutan dengan berbagai aktivitas pembelajaran bahasa berbasis tugas.",
     "newMessageInPangeaChat": "📝 Pesan baru di Pangea Chat",
     "shareCourse": "Bagikan kursus",
     "addCourse": "Tambahkan kursus",
-    "joinPublicCourse": "Gabung kursus publik",
     "vocabLevelsDesc": "Di sinilah kata-kata kosakata akan ditempatkan setelah Anda meningkatkannya!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7049,10 +6464,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7071,7 +6482,6 @@
     "emojiView": "Tampilan emoji",
     "feedbackDialogDesc": "Saya juga membuat kesalahan! Ada yang bisa membantu saya untuk memperbaiki?",
     "contactHasBeenInvitedToTheCourse": "Kontak telah diundang ke kursus",
-    "activityStatsButtonTooltip": "Info aktivitas",
     "allow": "Izinkan",
     "deny": "Tolak",
     "enabledRenewal": "Aktifkan Pembaruan Langganan",
@@ -7339,10 +6749,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8398,16 +7804,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Kegiatan untuk Membuka Topik Berikutnya",
-    "activitiesToUnlockTopicDesc": "Tentukan jumlah kegiatan untuk membuka topik kursus berikutnya",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Latihan definisi kosakata yang benar",
     "constructUseIncLMDesc": "Latihan definisi kosakata yang salah",
     "constructUseCorLADesc": "Latihan audio kosakata yang benar",
@@ -8415,7 +7811,6 @@
     "constructUseBonus": "Bonus selama latihan kosakata",
     "practiceVocab": "Latihan kosakata",
     "selectMeaning": "Pilih arti",
-    "selectAudio": "Pilih audio yang sesuai",
     "anotherRound": "Putaran lain",
     "activitySettingsOverrideWarning": "Bahasa dan tingkat bahasa ditentukan oleh rencana aktivitas",
     "voice": "Suara",
@@ -8447,10 +7842,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8468,12 +7859,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Unduhan dimulai",
     "webDownloadPermissionMessage": "Jika browser Anda memblokir unduhan, silakan aktifkan unduhan untuk situs ini.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8568,11 +7954,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Ada yang tidak beres, dan kami sedang bekerja keras untuk memperbaikinya. Periksa lagi nanti.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Aktifkan bantuan penulisan",
     "autoIGCToolDescription": "Secara otomatis menjalankan alat Pangea Chat untuk memperbaiki pesan yang dikirim ke bahasa target.",
     "@autoIGCToolName": {
@@ -8628,24 +8009,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Tata Bahasa",
-    "spanTypeWordChoice": "Pilihan Kata",
     "spanTypeSpelling": "Ejaan",
     "spanTypePunctuation": "Tanda Baca",
     "spanTypeStyle": "Gaya",
     "spanTypeFluency": "Kefasihan",
     "spanTypeAccents": "Aksen",
     "spanTypeCapitalization": "Kapitalisasi",
-    "spanTypeCorrection": "Koreksi",
     "spanFeedbackTitle": "Laporkan masalah koreksi",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8670,23 +8040,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
     },
     "changedTheChatDescription": "{username} mengubah deskripsi obrolan",
     "changedTheChatName": "{username} mengubah nama obrolan",
-    "newSubSpace": "Ruang sub baru",
-    "moveToDifferentSpace": "Pindah ke ruang yang berbeda",
-    "removeFromSpaceDescription": "Obrolan akan dihapus dari ruang tetapi masih muncul di daftar obrolan Anda.",
     "countChats": "{chats} obrolan",
-    "spaceMemberOf": "Anggota ruang {spaces}",
-    "spaceMemberOfCanKnock": "Anggota ruang {spaces} dapat mengetuk",
-    "donate": "Donasi",
     "startedAPoll": "{username} memulai sebuah jajak pendapat.",
     "poll": "Jajak pendapat",
     "startPoll": "Mulai jajak pendapat",
@@ -8710,23 +8070,15 @@
     "newStickerPack": "Paket stiker baru",
     "stickerPackName": "Nama paket stiker",
     "attribution": "Atribusi",
-    "skipChatBackup": "Lewati cadangan obrolan",
-    "skipChatBackupWarning": "Apakah Anda yakin? Tanpa mengaktifkan cadangan obrolan, Anda mungkin kehilangan akses ke pesan Anda jika Anda mengganti perangkat.",
-    "loadingMessages": "Memuat pesan",
-    "setupChatBackup": "Siapkan cadangan obrolan",
     "noMoreResultsFound": "Tidak ada hasil lagi yang ditemukan",
     "chatSearchedUntil": "Obrolan dicari hingga {time}",
     "federationBaseUrl": "URL Dasar Federasi",
     "clientWellKnownInformation": "Informasi Klien-Terkenal:",
     "baseUrl": "URL Dasar",
     "identityServer": "Server Identitas:",
-    "versionWithNumber": "Versi: {version}",
     "logs": "Log",
-    "advancedConfigs": "Konfigurasi Lanjutan",
     "advancedConfigurations": "Konfigurasi lanjutan",
-    "signInWithLabel": "Masuk dengan:",
     "selectAllWords": "Pilih semua kata yang Anda dengar dalam audio",
-    "joinCourseForActivities": "Bergabunglah dengan kursus untuk mencoba aktivitas.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -8739,18 +8091,6 @@
             "username": {}
         }
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -8758,26 +8098,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -8883,22 +8203,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8927,19 +8231,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8947,15 +8239,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9156,11 +8440,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Dalam kelas? Masukkan kode bergabung Anda di sini.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Sorot otomatis pesan audio",
     "selectAudioMessagesOnPlayDescription": "Secara otomatis sorot pesan audio saat diputar",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9204,18 +8483,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Kursus ini memiliki topik dengan kurang dari {input} aktivitas. Silakan masukkan angka yang kurang dari atau sama dengan {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Klik di sini untuk masuk kembali.",
     "@clickToLogin": {
@@ -9632,17 +8899,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Seekor beruang kuning kartun dengan lengan terangkat dalam kegembiraan.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Pilih kata untuk mempelajari lebih lanjut tentangnya",
     "requireAnalyticsAccessTitle": "Memerlukan akses analitik untuk bergabung",
     "requireAnalyticsAccessDesc": "Peserta harus memberikan akses ke analitik pembelajaran mereka untuk bergabung dengan kursus ini",
     "analyticsAccessNoticeTitle": "Akses Analitik Diperlukan",
     "analyticsAccessNoticeDesc": "Dengan bergabung dengan kursus ini, Anda setuju untuk memberikan akses kepada admin ke analitik pembelajaran Anda.",
-    "skipOnboardingClassCodeDesc": "Belajar secara mandiri? Jangan khawatir, Anda bisa:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9660,10 +8921,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9692,7 +8949,6 @@
     "pickCefrLevelTeacherStepTitle": "Tingkat apa yang Anda ajarkan?",
     "pickCefrLevelStudentStepTitle": "Tingkat apa Anda?",
     "customCourseStepTitle": "Isi formulir ini untuk mendapatkan kursus kustom",
-    "aboutYourClass": "Tentang kelas Anda",
     "courseCodeStepErrorMessage": "Silakan periksa kode Anda dan coba lagi",
     "institution": "Institusi",
     "courseGoals": "Tujuan Kursus",
@@ -9735,10 +8991,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9855,12 +9107,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logo Pangea Chat",
     "introChatDetails": "Sapa! Perkenalkan diri Anda kepada peserta kursus lainnya, temukan teman, dan mengobrol di luar kegiatan.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9904,11 +9151,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Tindakan aktivitas",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Alat pengucapan",
     "audioTranscription": "Transkripsi audio AI",
     "visualLearnerSupport": "Dukungan pembelajar visual",
@@ -9949,7 +9191,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Bergabunglah dengan kursus yang mencakup aktivitas ini untuk memainkannya.",
     "resizeCoursePanel": "Ubah ukuran panel kursus",
     "undo": "Batalkan",
     "unlock": "Buka kunci",
@@ -9963,7 +9204,6 @@
     "addCourseBrowsePublic": "Jelajahi kursus publik",
     "browsePublicCourses": "Jelajahi kursus publik",
     "editProfile": "Edit profil",
-    "numObjectives": "{count} tujuan",
     "mapSearchHint": "Cari aktivitas",
     "mapSearchNoResults": "Tidak ada kecocokan dalam tampilan",
     "mapFilterAllLanguages": "Semua bahasa",
@@ -9972,7 +9212,6 @@
     "mapFilterCompleted": "Selesai",
     "mapFilterReset": "Atur Ulang",
     "activityTypeConversation": "Percakapan",
-    "lockedMissionRequirement": "Selesaikan misi sebelumnya untuk membuka kunci",
     "playAgain": "Main lagi",
     "reviewActivity": "Tinjau",
     "mapEmptyInView": "Tidak ada di sini pada level atau bahasa Anda. Perluas filter Anda atau perbesar.",
@@ -9987,14 +9226,9 @@
     "scrollToBottom": "Gulir ke bawah",
     "courseImage": "Gambar kursus",
     "avatarPreview": "Prabaca avatar",
-    "activityPhoto": "Foto aktivitas",
     "emotePreview": "Prabaca emote: {name}",
     "activityLabel": "Aktivitas: {title}",
     "resetMapView": "Atur ulang tampilan peta",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10047,14 +9281,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10084,10 +9310,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10144,10 +9366,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_ie.arb
+++ b/lib/l10n/intl_ie.arb
@@ -48,11 +48,6 @@
             }
         }
     },
-    "createNewSpace": "Crear un spacie",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "currentlyActive": "Activ actualmen",
     "@currentlyActive": {
         "type": "String",
@@ -85,11 +80,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "everythingReady": "Omni es pret!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Extremmen offensiv",
     "@extremeOffensive": {
         "type": "String",
@@ -112,11 +102,6 @@
     },
     "fromTheInvitation": "Pro invitation",
     "@fromTheInvitation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Gruppe es public",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -246,11 +231,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "passwordRecovery": "Reganiar li contrasigne",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pleaseChoose": "Ples selecter",
     "@pleaseChoose": {
         "type": "String",
@@ -266,18 +246,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "removeDevice": "Remover li aparate",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "saveFile": "Gardar li file",
     "@saveFile": {
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKey": "Clave de regania",
-    "@recoveryKey": {},
     "sendMessages": "Inviar missages",
     "@sendMessages": {
         "type": "String",
@@ -290,11 +263,6 @@
     },
     "shareLocation": "Partir un localisation",
     "@shareLocation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Nómine de spacie",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -333,8 +301,6 @@
     "@openGallery": {},
     "reportUser": "Raportar li usator",
     "@reportUser": {},
-    "voiceCall": "Telefonada",
-    "@voiceCall": {},
     "countFiles": "{count} files",
     "@countFiles": {
         "placeholders": {
@@ -627,11 +593,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Videotelefonada",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "openChat": "Aperter li conversation",
     "@openChat": {},
     "reportMessage": "Raportar li missage",
@@ -681,8 +642,6 @@
     },
     "addWidget": "Adjunter un widget",
     "@addWidget": {},
-    "addAccount": "Adjunter un conto",
-    "@addAccount": {},
     "publicRooms": "Public chambres",
     "@publicRooms": {
         "type": "String",
@@ -827,8 +786,6 @@
     "@commandHint_markasgroup": {},
     "widgetJitsi": "Jitsi Meet",
     "@widgetJitsi": {},
-    "screenSharingTitle": "partir li ecran",
-    "@screenSharingTitle": {},
     "bannedUser": "{username} ha bannit {targetName}",
     "@bannedUser": {
         "type": "String",
@@ -1001,8 +958,6 @@
     "@newGroup": {},
     "newSpace": "Crear un spacie",
     "@newSpace": {},
-    "enterSpace": "Intrar li spacie",
-    "@enterSpace": {},
     "allSpaces": "Omni spacies",
     "@allSpaces": {},
     "logout": "Cluder li session",
@@ -1081,23 +1036,7 @@
     },
     "@jumpToLastReadMessage": {},
     "@commandHint_cuddle": {},
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@reportErrorDescription": {},
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
     "@removeYourAvatar": {
         "type": "String",
         "placeholders": {}
@@ -1248,10 +1187,6 @@
         "placeholders": {}
     },
     "@tryAgain": {},
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youKickedAndBanned": {
         "placeholders": {
             "user": {
@@ -1298,9 +1233,6 @@
         }
     },
     "@widgetUrlError": {},
-    "@emailOrUsername": {},
-    "@newSpaceDescription": {},
-    "@chatDescription": {},
     "@pleaseFollowInstructionsOnWeb": {
         "type": "String",
         "placeholders": {}
@@ -1313,28 +1245,18 @@
             }
         }
     },
-    "@encryptThisChat": {},
     "@incorrectPassphraseOrKey": {
         "type": "String",
         "placeholders": {}
     },
     "@reopenChat": {},
-    "@pleaseEnterRecoveryKey": {},
     "@widgetNameError": {},
     "@addToBundle": {},
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@removeAllOtherDevices": {
         "type": "String",
         "placeholders": {}
     },
     "@noKeyForThisMessage": {},
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@inviteText": {
         "type": "String",
         "placeholders": {
@@ -1355,7 +1277,6 @@
         }
     },
     "@pushNotificationsNotAvailable": {},
-    "@storeInAppleKeyChain": {},
     "@replaceRoomWithNewerVersion": {
         "type": "String",
         "placeholders": {}
@@ -1363,11 +1284,6 @@
     "@hydrate": {},
     "@invalidServerName": {},
     "@chatPermissions": {},
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {},
     "@hideRedactedEvents": {
         "type": "String",
         "placeholders": {}
@@ -1400,25 +1316,12 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@passwordHasBeenChanged": {
         "type": "String",
         "placeholders": {}
     },
-    "@saveKeyManuallyDescription": {},
     "@editBundlesForAccount": {},
     "@whyIsThisMessageEncrypted": {},
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "@rejectedTheInvitation": {
         "type": "String",
         "placeholders": {
@@ -1439,12 +1342,6 @@
     "@importFromZipFile": {},
     "@dehydrateWarning": {},
     "@noOtherDevicesFound": {},
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {},
-    "@yourChatBackupHasBeenSetUp": {},
     "@redactedBy": {
         "type": "String",
         "placeholders": {
@@ -1453,7 +1350,6 @@
             }
         }
     },
-    "@videoCallsBetaWarning": {},
     "@unmuteChat": {
         "type": "String",
         "placeholders": {}
@@ -1477,14 +1373,6 @@
     "@compareEmojiMatch": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@changedTheRoomAliases": {
         "type": "String",
@@ -1511,7 +1399,6 @@
         "placeholders": {}
     },
     "@readUpToHere": {},
-    "@unlockOldMessages": {},
     "@changedTheJoinRulesTo": {
         "type": "String",
         "placeholders": {
@@ -1614,7 +1501,6 @@
         }
     },
     "@experimentalVideoCalls": {},
-    "@pleaseEnterRecoveryKeyDescription": {},
     "@guestsAreForbidden": {
         "type": "String",
         "placeholders": {}
@@ -1852,7 +1738,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@disableEncryptionWarning": {},
     "@directChat": {},
     "@encryptionNotEnabled": {
         "type": "String",
@@ -1872,7 +1757,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {},
     "@enterAnEmailAddress": {
         "type": "String",
         "placeholders": {}
@@ -1916,10 +1800,6 @@
             }
         }
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@learnMore": {},
     "@iHaveClickedOnLink": {
         "type": "String",
@@ -1928,7 +1808,6 @@
     "@notAnImage": {},
     "@chatDescriptionHasBeenChanged": {},
     "@bundleName": {},
-    "@removeFromSpace": {},
     "@commandHint_op": {
         "type": "String",
         "description": "Usage hint for the command /op"
@@ -1954,10 +1833,6 @@
         }
     },
     "@pleaseEnterANumber": {},
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youKicked": {
         "placeholders": {
             "user": {
@@ -1985,22 +1860,12 @@
             }
         }
     },
-    "@sorryThatsNotPossible": {},
     "@oopsSomethingWentWrong": {
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@shareInviteLink": {},
     "@commandHint_markasdm": {},
-    "@recoveryKeyLost": {},
     "@cuddleContent": {
         "type": "String",
         "placeholders": {
@@ -2011,10 +1876,6 @@
     },
     "@deviceKeys": {},
     "@waitingPartnerNumbers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2034,17 +1895,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {},
     "@youJoinedTheChat": {},
     "@openVideoCamera": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -2118,7 +1970,6 @@
         "placeholders": {}
     },
     "@noBackupWarning": {},
-    "@storeInSecureStorageDescription": {},
     "@kickUserDescription": {},
     "@sendAMessage": {
         "type": "String",
@@ -2126,9 +1977,7 @@
     },
     "@importNow": {},
     "@pinMessage": {},
-    "@screenSharingDetail": {},
     "@invite": {},
-    "@enableMultiAccounts": {},
     "@emotePacks": {
         "type": "String",
         "placeholders": {}
@@ -2164,7 +2013,6 @@
     "answeredTheCall": "{senderName} respondeva la appel",
     "appLock": "Clavette de l'applicacion",
     "appLockDescription": "Clavette l'applicacion quando non es usate con un codice PIN",
-    "areGuestsAllowedToJoin": "Es permitite a los guest usatores de jontar",
     "askSSSSSign": "Pro poter signar le altere persona, per favor entra tu phrase de securitate o clave de recuperation del magazen secur",
     "sendTypingNotifications": "Manda notification de typage",
     "swipeRightToLeftToReply": "Glissa a dextra a sinistra pro responder",
@@ -2190,8 +2038,6 @@
     "changedTheRoomInvitationLink": "{username} changi li ligame de invitation",
     "changeTheNameOfTheGroup": "Changi li nomine del grupo",
     "channelCorruptedDecryptError": "Li encryption ha esset corrompete",
-    "yourChatBackupHasBeenSetUp": "Tu backup de chat ha esset configurate.",
-    "chatBackupDescription": "Li message ancian de tu es securisate con un clav de recuperation. Per favor, assecurate que tu non perde lo.",
     "chooseAStrongPassword": "Selige un forti clav",
     "commandHint_markasdm": "Marca como camara de message directe pro li ID Matrix dat",
     "commandHint_ban": "Bani li usator dat de iste camara",
@@ -2209,11 +2055,9 @@
     "commandMissing": "{command} ne es un commando.",
     "compareEmojiMatch": "Per favor compara los emojis",
     "compareNumbersMatch": "Per favor compara los numeres",
-    "contactHasBeenInvitedToTheGroup": "Contacto ha esset invitat a la grupo",
     "contentHasBeenReported": "Le contento ha esset reportat a los administratores del server",
     "couldNotDecryptMessage": "Ne poteva decifrar le message: {error}",
     "checkList": "Lista de verification",
-    "countInvited": "{count} invitates",
     "createdTheChat": "💬 {username} ha create le chat",
     "createGroup": "Create grupo",
     "deactivateAccountWarning": "Isto disactive tu conto de usator. Isto non pote esser revertite! Es tu secur?",
@@ -2223,19 +2067,14 @@
     "emoteInvalid": "Shortcode de emote invalide!",
     "emoteKeyboardNoRecents": "Emotes usate recentemente apparirà qua...",
     "emotePacks": "Paches de emote pro sala",
-    "globalChatId": "ID global de chat",
-    "accessAndVisibility": "Acces e visibilitate",
-    "accessAndVisibilityDescription": "Qui es permittit de jónar a ti chat e como le chat pote esser trovate.",
     "calls": "Appellos",
     "customEmojisAndStickers": "Emojis e stickers personalisate",
     "customEmojisAndStickersBody": "Aggiungi o comparte emojis o stickers personalisate que pote esser usate in omne chat.",
     "enableEmotesGlobally": "Activate le pack de emote globalmente",
-    "enableEncryptionWarning": "Tu non potera disactivar le encryption plus. Es tu secur?",
     "encryptionNotEnabled": "Le encryption non es activate",
     "endedTheCall": "{senderName} ha terminat le appel",
     "enterAnEmailAddress": "Enter un adresse de email",
     "errorObtainingLocation": "Error durante obtention del position: {error}",
-    "chatDescription": "Description del chat",
     "chatDescriptionHasBeenChanged": "La description del chat ha esset modificada",
     "guestsAreForbidden": "Li invitatos es prohibite",
     "guestsCanJoin": "Li invitatos pote jontar",
@@ -2251,7 +2090,6 @@
     "blockUsername": "Ignorar nomine de usator",
     "iHaveClickedOnLink": "Io ha cliccat sur le ligamine",
     "incorrectPassphraseOrKey": "Passphrase o clave de recuperation incorrecte",
-    "inviteContactToGroup": "Invitar contact a {groupName}",
     "noChatDescriptionYet": "Nulle description de chat create ancora.",
     "tryAgain": "Prova ancora",
     "invalidServerName": "Nomi de servitore invalide",
@@ -2262,20 +2100,16 @@
     "kicked": "👞 {username} ha expulsete {targetName}",
     "kickedAndBanned": "🙅 {username} ha expulsete e bannite {targetName}",
     "kickFromChat": "Expulser de chat",
-    "loadCountMoreParticipants": "Carga {count} participanti plu",
     "dehydrate": "Exportar session e netejar dispositive",
     "dehydrateWarning": "Iste action ne pote esser revertite. Assegura te que tu stoca securmente li copia de securitate.",
     "hydrate": "Restaurar de copia de securitate",
     "locationDisabledNotice": "Li servicies de localisacion es disactivate. Per favor, active los pro poter compartir tu localisacion.",
     "locationPermissionDeniedNotice": "Permesso de localisacion es denegate. Per favor, concede los pro poter compartir tu localisacion.",
-    "logInTo": "Intra in {homeserver}",
     "messagesStyle": "Messages:",
     "needPantalaimonWarning": "Per favor, es conscient que tu besona Pantalaimon pro usar cryptage de ponta a ponta pro ora.",
     "newMessageInFluffyChat": "💬 Nov message in FluffyChat",
     "noConnectionToTheServer": "Nulle connection a la servitor",
     "noEmotesFound": "Nulle emotes trovate. 😕",
-    "noEncryptionForPublicRooms": "Tu pote solmen activar cryptage quando la sala non es plus accessible publicamente.",
-    "noGoogleServicesWarning": "Firebase Cloud Messaging pare non esser disponibile in tu dispositivo. Pro ancora recebir notificationes push, nos recommanda installar ntfy. Con ntfy o un altere provider de Push Unificate tu pote recebir notificationes push in un maniera secure de datos. Tu pote descarregar ntfy del PlayStore o de F-Droid.",
     "noMatrixServer": "{server1} non es un servitor Matrix, usa {server2} in su loco?",
     "shareInviteLink": "Partagear ligamine de invito",
     "noPasswordRecoveryDescription": "Tu non ha ancora aggiunt un modo pro recuperar tu parola de pass.",
@@ -2290,7 +2124,6 @@
     "addToBundle": "Aggiunger a bundle",
     "removeFromBundle": "Remover de iste bundle",
     "bundleName": "Nom del bundle",
-    "enableMultiAccounts": "(BETA) Activar multicomptes sur cist dispositiv",
     "serverRequiresEmail": "Cist servitor besona validar tu adresse de corrièl pro registration.",
     "passphraseOrKey": "phrase de pass o clau de recuperation",
     "passwordHasBeenChanged": "Le contrasigno ha esset cambiat",
@@ -2300,7 +2133,6 @@
     "pleaseChooseAPasscode": "Per favor, selige un codice de pass",
     "pleaseClickOnLink": "Per favor, clicca sur le ligamine in le corrièl e prosegue.",
     "pleaseEnter4Digits": "Per favor, entra 4 cifras o lascia vacue pro disactivar le lock del app.",
-    "pleaseEnterRecoveryKey": "Per favor, entra tu clau de recuperation:",
     "pleaseEnterYourPassword": "Per favor, entra tu contrasigno",
     "pleaseEnterYourPin": "Per favor, entra tu PIN",
     "pleaseEnterYourUsername": "Per favor, entra tu nom de usator",
@@ -2316,7 +2148,6 @@
     "removeYourAvatar": "Remover tu avatar",
     "replaceRoomWithNewerVersion": "Reemplazar camera con version recent",
     "roomHasBeenUpgraded": "Camera ha esset actualisate",
-    "recoveryKeyLost": "Clav de recuperation perdite?",
     "sendAMessage": "Manda un message",
     "sendAsText": "Manda como texto",
     "sendImages": "Manda {count} imagine",
@@ -2329,23 +2160,19 @@
     "separateChatTypes": "Separa chats direct e gruppes",
     "setAsCanonicalAlias": "Stabilir como alias principal",
     "setChatDescription": "Stabilir description del chat",
-    "setPermissionsLevel": "Stabilir nivelle de permissiones",
     "sharedTheLocation": "{username} ha compartit su localisacion",
     "presencesToggle": "Monstra message de stato de altere usatores",
-    "spaceIsPublic": "Spatio es public",
     "startedACall": "{senderName} ha comenciat un appel",
     "statusExampleMessage": "Qual es tu hodie?",
     "synchronizingPleaseWait": "Synchronisante… Per favor, aspetta.",
     "synchronizingPleaseWaitCounter": " Synchronisante… ({percentage}%)",
     "theyDontMatch": "Il ne coincide pas",
     "tooManyRequestsWarning": "Tro má request. Per favor, tenta re-intrar pós tarde!",
-    "transferFromAnotherDevice": "Transferir de un altere dispositivo",
     "tryToSendAgain": "Prova de mandar ancora",
     "unbannedUser": "{username} ha desbanit {targetName}",
     "unknownEncryptionAlgorithm": "Algoritmo de encriptation incognite",
     "unknownEvent": "Evento incognite '{type}'",
     "unmuteChat": "Desmutar chat",
-    "unreadChats": "{unreadCount, plural, =1{1 chat non legite} other{{unreadCount} chats non legite}}",
     "userAndOthersAreTyping": "{username} e {count} alteres sta scrivente…",
     "userAndUserAreTyping": "{username} e {username2} sta scrivente…",
     "userIsTyping": "{username} sta scrivente…",
@@ -2353,24 +2180,18 @@
     "userSentUnknownEvent": "{username} ha mandate un evento {type}",
     "verifySuccess": "Tu ha verifyate con successo!",
     "verifyTitle": "Verificante altere conto",
-    "visibilityOfTheChatHistory": "Visibilità del historico del chat",
     "visibleForAllParticipants": "Visibile pro tote le participantes",
     "visibleForEveryone": "Visibile pro tote",
     "waitingPartnerAcceptRequest": "Spere de que le partner accepta le request…",
     "waitingPartnerEmoji": "Spere de que le partner accepta le emoji…",
     "waitingPartnerNumbers": "Spetant por acceptar los numeres del socio…",
     "weSentYouAnEmail": "Nos ha mandat un e-mail a tu",
-    "whoCanPerformWhichAction": "Qui pote facer cual accion",
-    "whoIsAllowedToJoinThisGroup": "Qui es permittet de jóngar a questa groupo",
     "whyDoYouWantToReportThis": "Proque vole reportar esto?",
-    "wipeChatBackup": "Eliminar tu backup de chat pro crear un nove clave de recupero?",
     "withTheseAddressesRecoveryDescription": "Con iste adresses tu pote recuperar tu parola de sólo.",
     "writeAMessage": "Scrive un message…",
     "youAreNoLongerParticipatingInThisChat": "Tu non participa plus in iste chat",
     "youHaveBeenBannedFromThisChat": "Tu ha esset bannit de iste chat",
     "yourPublicKey": "Tua clé publica",
-    "removeFromSpace": "Remove de space",
-    "pleaseEnterRecoveryKeyDescription": "Pro desbloquear tu vie messages, per favor entra tu clé de recupero que ha esset generate in un session anterior. Tu clé de recupero non es tu parola de sólo.",
     "markAsRead": "Marca como lege",
     "reactedWith": "{sender} reagió con {reaction}",
     "pinMessage": "Pin a la sala",
@@ -2378,9 +2199,7 @@
     "placeCall": "Fazer un appel",
     "unsupportedAndroidVersion": "Version Android non supportet",
     "unsupportedAndroidVersionLong": "Ta caracteristica requiere un version plu recent de Android. Per favor verifica pro actualisaciones o supporto de Lineage OS.",
-    "videoCallsBetaWarning": "Per favor nota que le appelos video es actualmente in beta. Illes pote non functionar como expectate o non functionar a omne en omne plataformas.",
     "experimentalVideoCalls": "Appellos video experimental",
-    "emailOrUsername": "Email o nomine de usator",
     "widgetUrlError": "Isto non es un URL valide.",
     "widgetNameError": "Per favor provide un nomine de display.",
     "errorAddingWidget": "Error durante le addition del widget.",
@@ -2396,26 +2215,12 @@
     "youKickedAndBanned": "🧑‍🦯 Tu ha expulsà e bannà {user}",
     "youUnbannedUser": "Tu ha disbannà {user}",
     "hasKnocked": "🚪 {user} ha tocà",
-    "usersMustKnock": "Usatores must tocà",
-    "noOneCanJoin": "Nulle pote jónar",
     "knock": "Tocà",
-    "unlockOldMessages": "Desblocca messages antigues",
-    "storeInSecureStorageDescription": "Stoca la clau de recuperation en le stocage securisate de iste dispositive.",
-    "saveKeyManuallyDescription": "Salva iste clau manualmente, triggerando le dialogo de partage del systema o le portapapeles.",
-    "storeInAndroidKeystore": "Stoca in le Android Keystore",
-    "storeInAppleKeyChain": "Stoca in le Apple KeyChain",
-    "storeSecurlyOnThisDevice": "Stoca securisate in iste dispositive",
-    "foregroundServiceRunning": "Iste notification appare quando le servizio in primer plano es execute.",
-    "screenSharingDetail": "Tu es partagiante tu pantalla in FuffyChat",
     "whyIsThisMessageEncrypted": "Perqu es que ta message es illisible?",
     "noKeyForThisMessage": "Isto pote suceder si la message ha esset inviata ante que tu ha signat in tu conto a iste dispositivo.\n\nEs etiam possibile que lo sender ha bloccat tu dispositivo o que alcun cosa ha fallit con le connexion a internet.\n\nEs tu capace de leger le message in un altere session? Alora tu pote transferer le message de illo! Vade a Settings > Devices e assecurate que tu dispositivos ha verifyate se. Quando tu aperi le camera le proxime vice e ambes sessiones es in le foreground, le claves essera transmittite automaticamente.\n\nNoli voler perder le claves quando te logga out o cambia dispositivos? Assecura que tu ha activate le backup del chat in le settings.",
     "hidePresences": "Celar lista de status?",
     "doNotShowAgain": "Non monstrar ancora",
     "wasDirectChatDisplayName": "Chat vacue (era {oldDisplayName})",
-    "newSpaceDescription": "Spaces permitte te de consolidar tu chats e construir communitates private o publice.",
-    "encryptThisChat": "Scrypta iste chat",
-    "disableEncryptionWarning": "Pro securitate, tu non pote disactivar le scryptamento in un chat ubi illo ha esset activate ante.",
-    "sorryThatsNotPossible": "Pardona... illo non es possibile",
     "deviceKeys": "Claves del dispositivo:",
     "reopenChat": "Re-aperir le chat",
     "noBackupWarning": "Aviso! Sin activar le backup del chat, tu perdera accesso a tu message scryptate. Es altamente recommandate activar le backup del chat prime de te loggar out.",
@@ -2428,7 +2233,6 @@
     "openLinkInBrowser": "Aperir le ligamine in le navigator",
     "reportErrorDescription": "😤 Oh no. Quicke ha mal passate. Si vuo, tu posse reportar ti bug a los developatores.",
     "report": "reportar",
-    "setTheme": "Stabilir tema:",
     "setColorTheme": "Stabilir tema de color:",
     "invite": "Invitar",
     "inviteGroupChat": "🗨️ Invitar chat de gruppo",
@@ -2447,12 +2251,8 @@
     "yourGlobalUserIdIs": "Your global user-ID is: ",
     "noUsersFoundWithQuery": "Unfortunately no user could be found with \"{query}\". Please check whether you made a typo.",
     "knocking": "Knocking",
-    "chatCanBeDiscoveredViaSearchOnServer": "Chat can be discovered via the search on {server}",
-    "searchChatsRooms": "Search for #chats, @users...",
     "nothingFound": "Nothing found...",
     "groupName": "Group name",
-    "createGroupAndInviteUsers": "Create a group and invite users",
-    "groupCanBeFoundViaSearch": "Group can be found via search",
     "wrongRecoveryKey": "Sorry... this does not seem to be the correct recovery key.",
     "startConversation": "Start conversation",
     "commandHint_sendraw": "Send raw json",
@@ -2466,11 +2266,8 @@
     "pleaseChooseAStrongPassword": "Per favor, selige un fort mot de pass",
     "passwordsDoNotMatch": "Li mot de pass non coincide",
     "passwordIsWrong": "Li mot de pass que tu intrad es incorrect",
-    "publicChatAddresses": "Adresses de chat public",
-    "createNewAddress": "Crea nove adresse",
     "joinSpace": "Joinar space",
     "publicSpaces": "Spaces public",
-    "addChatOrSubSpace": "Agiunger un chat o sub-space",
     "subspace": "Sub-space",
     "decline": "Refusar",
     "thisDevice": "Iste dispositiv:",
@@ -2479,15 +2276,11 @@
     "searchMore": "Cercar plue...",
     "gallery": "Galerea",
     "files": "Files",
-    "sessionLostBody": "Ta session es perduda. Per plasair reporta ta error a los desvolupatores a {url}. La messaage de error es: {error}",
-    "restoreSessionBody": "La app ora tenta restaurar ta session a partir del backup. Per plasair reporta ta error a los desvolupatores a {url}. La messaage de error es: {error}",
     "sendReadReceipts": "Mandar acuses de lectura",
     "sendTypingNotificationsDescription": "Altri participants en un chat pote vider quando tu es scrivent un nove messagio.",
     "sendReadReceiptsDescription": "Altri participants en un chat pote vider quando tu ha lege un messagio.",
     "formattedMessages": "Messagios formattate",
     "formattedMessagesDescription": "Mostra contento ric de messagios como texto gras usando markdown.",
-    "verifyOtherUser": "🔐 Verificar altere utente",
-    "verifyOtherUserDescription": "Si tu verifica un altere utente, tu pote esser certe que tu sape qui tu realmente escribe a. 💪\n\nQuando tu comencia un verification, tu e l'altere utente videra un popup in la app. Ibi tu videra un serie de emojis o numeros que tu ha de comparar con l'altere.\n\nLa melior maniera de farlo es incontrar o iniciar un chiamata video. 👩‍💻",
     "verifyOtherDevice": "🔐 Verificar altere dispositivo",
     "verifyOtherDeviceDescription": "Quando tu verifica un altere dispositivo, quei dispositivos pote intercambiar chaves, augmentando tu securitate generale. 💪 Quando tu comencia un verification, un popup apparira in la app in ambes dispositivos. Ibi tu videra un serie de emojis o numeros que tu ha de comparar con l'altere. Es melior de aver ambes dispositivos a mano prima de comenzar la verificazione. 🤳",
     "acceptedKeyVerification": "{sender} acceptò la verificazione de chaves",
@@ -2523,10 +2316,6 @@
     "updateInstalled": "🎉 Actualisation {version} installat!",
     "changelog": "Historico de cambios",
     "sendCanceled": "Manda cencelat",
-    "loginWithMatrixId": "Login con Matrix-ID",
-    "discoverHomeservers": "Descubre servitores domo",
-    "whatIsAHomeserver": "Quo es un servitore domo?",
-    "homeserverDescription": "Tutte tu datos es stoccat sur lo, similar a un proveedor de email. Tu pote seliger cual servitore domo tu vole usar, e tu pote communicar con omne. Apprende plu a https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Non pare esser un servitore domo compatible. URL incorrecte?",
     "calculatingFileSize": "Calculante le grandezza del file...",
     "prepareSendingAttachment": "Prepara le invio del attachment...",
@@ -2538,11 +2327,9 @@
     "oneOfYourDevicesIsNotVerified": "Un de tu dispositivos non es verifyt",
     "noticeChatBackupDeviceVerification": "Nota: Kande tu connecta toti tui dispositivs al backup de chat, illes es automaticmen verificat.",
     "continueText": "Contina",
-    "welcomeText": "Hej Hej 👋 To es FluffyChat. Tu posse signar en a cualsevol homeserver, qui es compatible con https://matrix.org. E poi chatta con cualquiere. Es un enorme rete de messageria decentralisada!",
     "blur": "Blure:",
     "opacity": "Opacitá:",
     "setWallpaper": "Stabilir fond d'ecran",
-    "manageAccount": "Gerir conto",
     "noContactInformationProvided": "Servidor no provida nulle information de contact valide",
     "contactServerAdmin": "Contactar admin del servidor",
     "contactServerSecurity": "Contactar securitá del servidor",
@@ -2561,11 +2348,8 @@
     "unableToJoinChat": "Nus pote ne entrar in chat. Forse l'autra partia ja ha claudet la conversation.",
     "previous": "Precedent",
     "otherPartyNotLoggedIn": "L'autra partia es actualmen ne connectet e per consequente ne pote acceptar messages!",
-    "appWantsToUseForLogin": "Usa '{server}' pro connectar",
-    "appWantsToUseForLoginDescription": "Tu permittis qua applica e sit ha condividi informationes de te.",
     "open": "Avertar",
     "waitingForServer": "Spere pro server...",
-    "appIntroduction": "FluffyChat permit te de chat con tui amicos trans differente messengers. Discoperi plui a https://matrix.org o simple tap *Continue*.",
     "newChatRequest": "📩 Nov request de chat",
     "contentNotificationSettings": "Configuraciones de notification de contento",
     "generalNotificationSettings": "Configuraciones general de notification",
@@ -2640,11 +2424,9 @@
     "taTooltip": "L2 usar con assistentia de translation",
     "interactiveTranslatorSliderHeader": "Traductor Interactiv",
     "interactiveGrammarSliderHeader": "Verificador Interactiv de Grammatica",
-    "interactiveTranslatorRequired": "Necessar",
     "waTooltip": "Usa L2 sin adjuta",
     "interactiveTranslator": "Assistenta de translation",
     "noIdenticalLanguages": "Per favor, selige differente bas e meta lingues",
-    "searchBy": "Rechercher per país e lingues",
     "joinWithClassCode": "Joinar al curso",
     "languageLevelPreA1": "Novice Low (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -2665,19 +2447,14 @@
     "saveChanges": "Salva modifiches",
     "publicProfileTitle": "Permette que mi perfil si trova in recerca",
     "publicProfileDesc": "Per turnar su, tu habilita altri usatores a trovar tu perfil in le barra de recerca global e inviar requestas pro chat. A iste puncto, tu pote seliger acceptar o negar le requesta.",
-    "errorDisableIT": "Le adjuta de traduction es disactivate.",
-    "errorDisableIGC": "Le adjuta de grammatica es disactivate.",
     "errorDisableITUserDesc": "Clicca hic pro actualizar le configuration de adjuta de traduction",
     "errorDisableIGCUserDesc": "Clicca hic pro actualizar le configuration de adjuta de grammatica",
     "errorDisableITClassDesc": "Le adjuta de traduction es disactivate pro le curso in le qual iste chat es.",
     "errorDisableIGCClassDesc": "Le adjuta de grammatica es disactivate pro le curso in le qual iste chat es.",
-    "error405Title": "Lingues non configurate",
     "error405Desc": "Per favor, configura tu linguas in le Menu Principal > Configuration de Aprendissage.",
     "termsAndConditions": "Termes e Condiciones",
     "andCertifyIAmAtLeast13YearsOfAge": " e certifies que ha minimum 16 annos de etate.",
-    "error502504Title": "Wow, il ha multo students online!",
     "error502504Desc": "Instrumentes de translation e grammatica pote esser lente o unavailable durante que le bots Pangea se actualisa.",
-    "error404Title": "Error de translation!",
     "error404Desc": "Le Bot Pangea non es secur de como traducer isto...",
     "errorPleaseRefresh": "Nos es in le processus de investigar! Per favor, re-iniciar e tentar ancora.",
     "connectedToStaging": "Conectate a Staging",
@@ -2715,13 +2492,9 @@
     "definitionsToolName": "Definiciones de Palavras",
     "definitionsToolDescription": "Quando activate, palavras sublinate in blue pote esser cliccabile pro definiciones. Clicca in messages pro accessar le definiciones.",
     "welcomeBack": "Ben retornate! Si tu esseva parte del pilot de 2023-2024, per favor contacta nos pro tu subscription special de pilot. Si tu es un professor qui ha (o que su institution ha) comprate licentias pro tu classe, contacta nos pro tu subscription de professor.",
-    "downloadTxtFile": "Downloadar File de Texto",
-    "downloadCSVFile": "Downloadar File CSV",
     "promotionalSubscriptionDesc": "Tu ha actualmente un subscription promotional de vita. Message support@pangea.chat pro adjuta a cambiar tu subscription.",
     "originalSubscriptionPlatform": "Subscription comprate per medio de {purchasePlatform}",
     "oneWeekTrial": "Período de Prova de Un Semane",
-    "downloadXLSXFile": "Downloadar File Excel",
-    "unkDisplayName": "Inconnu",
     "wwCountryDisplayName": "Mondial",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Îles Åland",
@@ -3016,7 +2789,6 @@
     "chatCapacityHasBeenChanged": "Capacity de conversa ha esset cambiate",
     "chatCapacitySetTooLow": "Capacity de conversa debe esser al minus {count}.",
     "chatCapacityExplanation": "Capacity de conversa limita le numero de membros permitite in un conversa.",
-    "tooManyRequest": " Troppo request, per favor prova ancora plus tarde.",
     "enterNumber": "Per favor entra un valor de numero entier.",
     "practice": "Practica",
     "versionNotFound": "Version non trovate",
@@ -3026,7 +2798,6 @@
     "deleteSubscriptionWarningTitle": "Tu ha un abun active",
     "deleteSubscriptionWarningBody": "Eliminar tu conto non cancelara automaticament tu abun.",
     "manageSubscription": "Gestionar abun",
-    "error520Title": "Per plasair, tenta de nove.",
     "error520Desc": "Disculpa, no pot comprene tu messag...",
     "wordsUsed": "Palabras usat",
     "level": "Nivèl",
@@ -3044,7 +2815,6 @@
     "other": "Altre",
     "levelShort": "NIV {level}",
     "noCapacityLimit": "Nulle limite de capacitate",
-    "downloadGroupText": "Download le texto del grupo",
     "notificationsOn": "Notificationes activate",
     "notificationsOff": "Notificationes disactivate",
     "joinWithCode": "Unir con code",
@@ -3108,24 +2878,12 @@
     "whatIsTheMorphTag": "Qual es la {morphologicalFeature} de '{wordForm}'?",
     "dataAvailable": "Disponibilitate de datos",
     "available": "Dispunibil",
-    "pangeaBotIsFallible": "Pangea Bot face erros tamben!",
-    "whatIsMeaning": "Qual significa '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Corresponda significatos con le parolas in le message!",
-    "doubleClickToEdit": "Dopp-clique pro modificar.",
-    "topicLabel": "Subjecto",
-    "topicPlaceholder": "Selige un subjecto...",
-    "modePlaceholder": "Selige un modo...",
-    "learningObjectiveLabel": "Objectivo de apprendimento",
-    "learningObjectivePlaceholder": "Choise un objectiv de apprendissage...",
-    "targetLanguageLabel": "Lingua de destino",
     "cefrLevelLabel": "Nivelle CEFR",
     "image": "Imagine",
     "video": "Video",
     "nan": "Nulle applicabile",
-    "addVocabulary": "Aggiunger vocabulari",
     "instructions": "Instructiones",
-    "numberOfLearners": "Numeru de apprendantes",
-    "mustBeInteger": "Deve esser un integer, p.ex. 1, 2, 3, ...",
     "constructUsePvmDesc": "Producte in messages vocale",
     "leaveSpaceDescription": "Per abandonar le curso, tu abandonara tote le chats in illo. Altri usatores videra que tu ha abandonate le curso.",
     "constructUseCorMmDesc": "Correcte messae significo",
@@ -3140,7 +2898,6 @@
     "ttsDisabledBody": "Tu pote habilitar le text-to-speech in tu configuration de apprendimento",
     "noSpaceDescriptionYet": "Nulle description de curso create ancora.",
     "tooLargeToSend": "Iste message es troppo grande pro inviar",
-    "exitWithoutSaving": "Es tu secur que vole tu partir sin salvar?",
     "enableAutocorrectPopupTitle": "Aggiungi tu teclado de lingua target per ir a:",
     "enableAutocorrectPopupSteps": "  • Configuration\n  • General\n  • Keyboard\n  • Keyboards\n  • Aggiungi Nove Keyboard",
     "enableAutocorrectPopupDescription": "Unu li lingue es electet, tu posse clicar la parve glob icon in le basso sinistre del tu clavier pro activar le nove installate clavier.",
@@ -3151,11 +2908,8 @@
     "displayName": "Nomen de visualisation",
     "leaveRoomDescription": "Tu es sur le puncto de partir de iste chat. Altri usatores vide que tu ha partite le chat.",
     "confirmUserId": "Per favor confirma tu nomine de usator in Pangea Chat pro eliminar tu conto.",
-    "startingToday": "A partir de hodie",
-    "oneWeekFreeTrial": "Un septimana de prova gratuite",
     "paidSubscriptionStarts": "A partir de {startDate}",
     "cancelInSubscriptionSettings": " • Cancellar in qualunque momento in le configuration de abbonamento",
-    "cancelToAvoidCharges": " • Cancellar ante {trialEnds} pro evitar charges",
     "downloadGboard": "Scarigar Gboard",
     "autocorrectNotAvailable": "Desolatamente, tu piattaforma non es supportate pro iste caracteristica. Restar attent pro ulteriore developpamento!",
     "pleaseUpdateApp": "Per favor actualisa le app pro continuar.",
@@ -3165,17 +2919,12 @@
     "knockSpaceSuccess": "Tu ha peti de jontar a questa corsa! Un admin respondara a tu peticion quando il la recive 😀",
     "chooseWordAudioInstructionsBody": "Ascolta le message complete. Poi combina le audios con le parolas.",
     "chooseMorphsInstructionsBody": "Clicca le pezze de puzzle pro questiones de grammatica!",
-    "pleaseEnterInt": "Per favor, entra un numero",
     "home": "Casa",
     "join": "Jontar",
     "resetInstructionTooltipsTitle": "Resetear le tooltip de instruction",
     "resetInstructionTooltipsDesc": "Clicca pro mostrar le tooltip de instruction como pro un nove usator.",
-    "randomize": "Randomizzâ",
     "clear": "Netar",
-    "featuredActivities": "In evidenza",
     "save": "Salvâ",
-    "startChat": " Cuminciare un discuors",
-    "translationProblem": "Problem di traduziôn",
     "askToJoin": "Domanâ di zontâ",
     "emptyChatWarningTitle": "Chat es vacue",
     "emptyChatWarningDesc": "Tu n'ha invitau nulleun al tu chat. Va a las configuraçions del chat pro invitá tuos contacts o lo Bot. Tu podé també farlo après.",
@@ -3205,17 +2954,13 @@
     "timesUsedIndependently": "Tiemps usate independentemente",
     "timesUsedWithAssistance": "Tiemps usate con assistance",
     "shareInviteCode": "Partagez le code d'invitation: {code}",
-    "leaderboard": "Clasament",
     "skipForNow": "Saltar per ora",
     "permissions": "Permissos",
     "spaceChildPermission": "Qui pote aggiunger nove chats a stu cursu",
-    "addEnvironmentOverride": "Aggiungi override de ambiente",
     "defaultOption": "Deffault",
     "deleteChatDesc": "Es tu secur de voler eliminar cist chat? I será eliminat per toti i participanti e toti i messaggi in cist chat non sarà più disponibile per pratica o analisi de apprendissatge.",
     "deleteSpaceDesc": "La corsa e omne chat selectet essera delete per toti participant e omne message in le chat non essera plus disponibile pro practica o analytics de apprendimento. Iste action non pote esser revertite.",
     "launch": "Lance",
-    "searchChats": "Cercar chats",
-    "maxFifty": "Max 50",
     "configureSpace": "Configurar corsa",
     "pinMessages": "Fixar message",
     "setJoinRules": "Stabilir regulas de admission",
@@ -3249,9 +2994,6 @@
     "failedToFetchTranscription": "Fallite a reciper le transcription",
     "deleteEmptySpaceDesc": "Le cors essera delite pro tote le participantes. Iste action non pote esser annullate.",
     "regenerate": "Regenerar",
-    "mySavedActivities": "Mi activitates salvate",
-    "noSavedActivities": "Nulle activitate salvate",
-    "saveActivity": "Salva iste activitate",
     "failedToPlayVideo": "N'a podet pas zugar la video",
     "done": "Finit",
     "inThisSpace": "En ta stu spazi",
@@ -3262,13 +3004,9 @@
     "numInvited": "{count} invitât",
     "saved": "Salvat",
     "reset": "Reiniciar",
-    "errorFetchingActivitiesMessage": "N'a podet pas cjapâr lis ativitâts",
     "errorFetchingDefinition": "N'a podet pas cjapâr la definicion",
     "errorProcessAnalytics": "N'a podet pas processar l'analitiche",
     "errorDownloading": "Il scaricament a fallit",
-    "errorLoadingSpaceChildren": "Il fallit a cargar lis discu in ta stu spazi",
-    "unexpectedError": "Erre unexpectat.",
-    "pleaseReload": "Per favor, re-incarrega e tenta ancora.",
     "translationError": "Error de traduction",
     "check": "Verifica",
     "unableToFindRoom": "Nulle chat o curso trovate con iste codice. Per favor, tenta ancora.",
@@ -3277,19 +3015,14 @@
     "request": "Requestar",
     "requestAll": "Requestar Tote",
     "confirmMessageUnpin": "Es tu secur que tu vole despinne iste message?",
-    "saveAndLaunch": "Salva e Lance",
-    "launchToSpace": "Lance a curso",
     "pending": "Pending",
     "inactive": "Inactiv",
-    "confirmRole": "Confirma le role",
     "openRoleLabel": "APERTE",
     "finishedTheActivity": "🎯 {username} ha finita iste activitate",
     "activitySummaryError": "Summarios de activitate non disponibile",
     "requestSummaries": "Requerer summarios",
-    "generatingNewActivities": "Tu es le prime usator de iste par de linguas! Per favor, da nos un minuto, nos prepara activitates juste pro te.",
     "requestAccessTitle": "¿Solicitar acceso a la analítica?",
     "requestAccessDesc": "Vole tu requerer accesso a vider le analytics de participantes?\n\nSi le participantes agree, le administratores de iste curso potera vider tu:\n    • total vocabulario\n    • total conceptos grammatical\n    • total sessiones de activitate complete\n    • le conceptos grammatical specific usate, correctemente e incorrectemente\n\nIlles non potera vider tu:\n    • messages in chat exterieur al curso\n    • lista de vocabulario",
-    "requestAccess": "Requerer accesso ({count})",
     "analyticsInactiveTitle": "Le requestas a usatores inactive non poteva esser inviate",
     "analyticsInactiveDesc": "Usatores inactive que non ha login desde que iste function ha essite introducite non videra tu requesta.\n\nLe button 'Requerer' apparira una vice que illes returna. Tu pote resendar le requesta postea cliccando le button 'Requerer' sub lor nomine quando illo es disponibile.",
     "accessRequestedTitle": "Requesta de accesso a analytics",
@@ -3312,8 +3045,6 @@
     "accessDesc": "Tu pote face tu cors aperta al mundo! O, face tu cors private e secur.",
     "createGroupChatDesc": "Dum que le sessiones de activitate comencia e termina, le chat de gruppo remanera aperta pro communication routine.",
     "deleteDesc": "Solmen administratores pote deletar un cors. Iste es un action destructive que remove tote usatores e delete tote le chats selectate in le cors. Procede con cautela.",
-    "noCourseFound": "Oh, iste cors ha besonho de un plan!\n\nLe planos del cors es un sequencia de themas e actividades de conversation.",
-    "additionalParticipants": "+ {num} alteres",
     "whatNow": "Que ora?",
     "chooseNextActivity": "Selige tu proxime activitate!",
     "letsGo": "Iva",
@@ -3326,13 +3057,11 @@
     "waitNotDone": "Acht, ich bin noch nicht fertig!",
     "waitingForOthersToFinish": "Spetant que los otros terminen...",
     "generatingSummary": "Analizando le chat e generant resultâts",
-    "findCourse": "Trovar un cors",
     "pingParticipantsNotification": "{user} es cercant usatôrs pro jontar a la session de activitât in {room}",
     "course": "Cors",
     "courses": "Cors",
     "goToCourse": "Andar a le cors: {course}",
     "activityComplete": "Chest activitât e stada completade. La resumé de l'activitât devess esser disponibil sota.",
-    "startNewSession": "Comenciar nove session",
     "joinOpenSession": "Joinar session aperta",
     "activityNotFound": "Activitate non trovada",
     "myActivities": "Mie activitâts",
@@ -3445,26 +3174,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -3541,14 +3250,6 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
@@ -3573,31 +3274,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3653,23 +3334,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3709,28 +3378,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -3748,14 +3395,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3948,22 +3587,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4019,10 +3642,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4032,10 +3651,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4111,27 +3726,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4449,10 +4048,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4462,10 +4057,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4553,14 +4144,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4577,10 +4160,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4593,15 +4172,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4753,14 +4324,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4774,14 +4337,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6004,10 +5559,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6048,10 +5599,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6124,10 +5671,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6397,47 +5940,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6457,19 +5960,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6533,10 +6024,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6577,14 +6064,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6596,14 +6075,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6641,10 +6112,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6661,27 +6128,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6805,10 +6256,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6818,10 +6265,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6838,14 +6281,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6985,18 +6420,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7045,10 +6468,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7058,18 +6477,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7112,23 +6519,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7152,10 +6547,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7163,14 +6554,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7275,18 +6658,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7339,10 +6710,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7369,10 +6736,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7553,7 +6916,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Revisa deman per actualisaziuns de l'activitate.",
-    "activityDropdownDesc": "Quan tu ha finì cun questa activitate, clicca ciutta",
     "languageMismatchTitle": "Discrepanza de lingue",
     "languageMismatchDesc": "La to target lingue no coincide cun la lingue de questa activitate. Voles actualizar la to target lingue?",
     "reportWordIssueTooltip": "Reportar un problema de informazions de paròla",
@@ -7566,10 +6928,6 @@
     "selectAll": "Selessiona tot",
     "deselectAll": "Deselessiona tot",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7618,17 +6976,11 @@
         "placeholders": {}
     },
     "startOwn": "Kumencar mieu",
-    "joinCourseDesc": "Ogn corsa ha 8-10 temas sequencià cun un gama de activitâts di scolastât basât sô tarefas.",
     "newMessageInPangeaChat": "📝 Nov messadi in Pangea Chat",
     "shareCourse": "Partagiar corsa",
     "addCourse": "Zontar un corsa",
-    "joinPublicCourse": "Kumencar corsa publice",
     "vocabLevelsDesc": "Chest è il loc dove i parôls di vocabulari a saran miss in plance une volte che tu o i às nivellâts!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7641,10 +6993,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7663,7 +7011,6 @@
     "emojiView": "Visualizzazione emoji",
     "feedbackDialogDesc": "Anch'io faccio errori! Qualcosa per aiutarmi a migliorare?",
     "contactHasBeenInvitedToTheCourse": "Kontak telah diundang ke kursus",
-    "activityStatsButtonTooltip": "Info aktivitas",
     "allow": "Izinkan",
     "deny": "Tolak",
     "enabledRenewal": "Aktifkan Pembaruan Langganan",
@@ -7931,10 +7278,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8990,16 +8333,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Gníomhaíochtaí le hOscail an Conradh Nua",
-    "activitiesToUnlockTopicDesc": "Socraigh an líon gníomhaíochtaí le hOscail an chéad ábhar cúrsa",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Praktiko de ĝusta vortodefino",
     "constructUseIncLMDesc": "Praktiko de malĝusta vortodefino",
     "constructUseCorLADesc": "Praktiko de ĝusta vortaudio",
@@ -9007,7 +8340,6 @@
     "constructUseBonus": "Bonus dum vortpraktiko",
     "practiceVocab": "Praktiki vortaron",
     "selectMeaning": "Elekti la signifon",
-    "selectAudio": "Elekti la kongruan audion",
     "anotherRound": "Alia rundo",
     "activitySettingsOverrideWarning": "Idioma y nivel de idioma determinados por el plan de actividad",
     "voice": "Voz",
@@ -9039,10 +8371,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9060,12 +8388,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Íoslódáil tosaíodh",
     "webDownloadPermissionMessage": "Más blocann do bhrabhsálaí íoslódálacha, le do thoil, gníomhachtaigh íoslódálacha don suíomh seo.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9160,11 +8483,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Níl aon rud ag dul i gceart, agus táimid ag obair go dian chun é a shocrú. Seiceáil arís níos déanaí.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Aktivoi kirjoitusavustaja",
     "autoIGCToolDescription": "Suorita automaattisesti Pangea Chat -työkaluja korjataksesi lähetetyt viestit kohdekielelle.",
     "@autoIGCToolName": {
@@ -9220,24 +8538,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatica",
-    "spanTypeWordChoice": "Elección de palabras",
     "spanTypeSpelling": "Ortografía",
     "spanTypePunctuation": "Puntuación",
     "spanTypeStyle": "Estilo",
     "spanTypeFluency": "Fluidez",
     "spanTypeAccents": "Acentos",
     "spanTypeCapitalization": "Capitalización",
-    "spanTypeCorrection": "Corrección",
     "spanFeedbackTitle": "Informar problema de corrección",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9262,10 +8569,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9278,13 +8581,7 @@
     "longPressToRecordVoiceMessage": "Longa premado por registri voĉan mesaĝon.",
     "pause": "Pauzi",
     "resume": "Daŭrigi",
-    "newSubSpace": "Nova subspaco",
-    "moveToDifferentSpace": "Movi al alia spaco",
-    "removeFromSpaceDescription": "O chat será removido do espaço, mas ainda aparecerá na sua lista de chats.",
     "countChats": "{chats} chats",
-    "spaceMemberOf": "Membro do espaço de {spaces}",
-    "spaceMemberOfCanKnock": "Membro do espaço de {spaces} pode bater",
-    "donate": "Doe",
     "startedAPoll": "{username} iniciou uma enquete.",
     "poll": "Enquete",
     "startPoll": "Iniciar enquete",
@@ -9308,23 +8605,15 @@
     "newStickerPack": "Pacáiste greamán nua",
     "stickerPackName": "Ainm an phacáiste greamán",
     "attribution": "Attribution",
-    "skipChatBackup": "Sskip chat backup",
-    "skipChatBackupWarning": "Are you sure? Without enabling the chat backup you may lose access to your messages if you switch your device.",
-    "loadingMessages": "Loading messages",
-    "setupChatBackup": "Set up chat backup",
     "noMoreResultsFound": "No more results found",
     "chatSearchedUntil": "Chat searched until {time}",
     "federationBaseUrl": "Federation Base URL",
     "clientWellKnownInformation": "Client-Well-Known Information:",
     "baseUrl": "Base URL",
     "identityServer": "Seirbhís Aitheantais:",
-    "versionWithNumber": "Leagan: {version}",
     "logs": "Lóganna",
-    "advancedConfigs": "Configuraíochtaí Casta",
     "advancedConfigurations": "Configuraíochtaí casta",
-    "signInWithLabel": "Sínigh isteach le:",
     "selectAllWords": "Roghnaigh na focail go léir a chloiseann tú sa chaint",
-    "joinCourseForActivities": "Bí páirteach i gcúrsa chun gníomhaíochtaí a thriail.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9361,18 +8650,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9380,26 +8657,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9505,22 +8762,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9549,19 +8790,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9569,15 +8798,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9778,11 +8999,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "In a class? Put your join code here.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Auto-highlight audio messages",
     "selectAudioMessagesOnPlayDescription": "Automatically highlight audio messages when played",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9826,18 +9042,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "An cúrsa seo tá ábhair le níos lú ná {input} gníomhaíochtaí. Le do thoil, cuir isteach uimhir atá níos lú ná nó comhoiriúnach le {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Cliceáil anseo chun logáil isteach arís.",
     "@clickToLogin": {
@@ -10254,17 +9458,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Un ursa giallo cartunesco cun i so brazz alzadi in eccitament.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Roghnaigh focail chun tuilleadh eolais a fháil fúthu",
     "requireAnalyticsAccessTitle": "Teastaíonn rochtain ar anailísí chun páirt a ghlacadh",
     "requireAnalyticsAccessDesc": "Caithfidh rannpháirtithe rochtain a thabhairt ar a n-anailísí foghlama chun páirt a ghlacadh sa chúrsa seo",
     "analyticsAccessNoticeTitle": "Rochtain ar anailísí riachtanach",
     "analyticsAccessNoticeDesc": "Trí pháirt a ghlacadh sa chúrsa seo, aontaíonn tú rochtain a thabhairt do na hoifigigh ar do n-anailísí foghlama.",
-    "skipOnboardingClassCodeDesc": "Ag foghlaim go neamhspleách? Ná bí buartha, is féidir leat:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10282,10 +9480,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10314,7 +9508,6 @@
     "pickCefrLevelTeacherStepTitle": "Cén leibhéal a theagascann tú?",
     "pickCefrLevelStudentStepTitle": "Cén leibhéal atá tú?",
     "customCourseStepTitle": "Líon an foirm seo chun cúrsa saincheaptha a fháil",
-    "aboutYourClass": "Faoi do rang",
     "courseCodeStepErrorMessage": "Seiceáil do chód agus déan iarracht arís",
     "institution": "Institiúid",
     "courseGoals": "Cuspóirí an chúrsa",
@@ -10357,10 +9550,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10477,12 +9666,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logo",
     "introChatDetails": "Abair dia dhuit! Cuir aithne ar do chomh-rannpháirtithe cúrsa, faigh cairde, agus comhrá a dhéanamh lasmuigh de na gníomhaíochtaí.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10526,11 +9710,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Gníomhachtaí gníomh",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Uttalstól",
     "audioTranscription": "AI hljóðritun",
     "visualLearnerSupport": "Stuðningur við sjónræna námsmenn",
@@ -10571,7 +9750,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Bain páirt i gcúrsa a chuimsíonn an gníomhaíocht seo chun é a imirt.",
     "resizeCoursePanel": "Athraigh méid painéil an chúrsa",
     "undo": "Athghairm",
     "unlock": "Díghlas",
@@ -10585,7 +9763,6 @@
     "addCourseBrowsePublic": "Parcourir les cours publics",
     "browsePublicCourses": "Parcourir les cours publics",
     "editProfile": "Modifier le profil",
-    "numObjectives": "{count} objectifs",
     "mapSearchHint": "Rechercher des activités",
     "mapSearchNoResults": "Aucun résultat dans la vue",
     "mapFilterAllLanguages": "Toutes les langues",
@@ -10594,7 +9771,6 @@
     "mapFilterCompleted": "Completado",
     "mapFilterReset": "Reiniciar",
     "activityTypeConversation": "Conversación",
-    "lockedMissionRequirement": "Termina la misión anterior para desbloquear",
     "playAgain": "Jugar de nuevo",
     "reviewActivity": "Revisar",
     "mapEmptyInView": "Nada aquí en tu nivel o idioma. Amplía tus filtros o aleja.",
@@ -10609,14 +9785,9 @@
     "scrollToBottom": "Role até o final",
     "courseImage": "Imagem do curso",
     "avatarPreview": "Pré-visualização do avatar",
-    "activityPhoto": "Foto da atividade",
     "emotePreview": "Pré-visualização do emote: {name}",
     "activityLabel": "Gníomhaíocht: {title}",
     "resetMapView": "Athshocraigh an léarscáil",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10669,14 +9840,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10706,10 +9869,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10766,10 +9925,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -77,11 +77,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Gli utenti ospiti possono partecipare",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Sei sicuro/a?",
     "@areYouSure": {
         "type": "String",
@@ -339,11 +334,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "I tuoi vecchi messaggi sono protetti da una chiave di sicurezza. Assicurati di non perderla.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Dettagli chat",
     "@chatDetails": {
         "type": "String",
@@ -386,11 +376,6 @@
     },
     "connect": "Connetti",
     "@connect": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "Il contatto è stato invitato nel gruppo",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -583,11 +568,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Non potrai disabilitare la crittografia in futuro. Sei sicuro?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Crittografato",
     "@encrypted": {
         "type": "String",
@@ -614,11 +594,6 @@
     },
     "enterAnEmailAddress": "Inserisci un indirizzo e-mail",
     "@enterAnEmailAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "Tutto pronto!",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -659,11 +634,6 @@
     },
     "group": "Gruppo",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Il gruppo è pubblico",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -757,15 +727,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Invita un contatto a {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Invitato/a",
     "@invited": {
@@ -878,15 +839,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Carica altri {count} partecipanti",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Caricamento… Attendere prego.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -901,15 +853,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Accedi a {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Esci",
     "@logout": {
@@ -973,16 +916,6 @@
     },
     "noEmotesFound": "Nessun emote trovato. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Puoi attivare la crittografia solo quando la stanza non è più accessibile pubblicamente.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Firebase Cloud Messaging non sembra essere disponibile sul tuo dispositivo. Per continuare a ricevere notifiche push, ti consigliamo di installare ntfy. Con ntfy o un altro provider Unified Push puoi ricevere notifiche push in modo sicuro per i dati. Puoi scaricare ntfy dal PlayStore o da F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1082,11 +1015,6 @@
     },
     "passwordHasBeenChanged": "La password è stata cambiata",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Recupero della password",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1215,11 +1143,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Rimuovi il dispositivo",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Rimuovi il ban dalla chat",
     "@unbanFromChat": {
@@ -1355,11 +1278,6 @@
             }
         }
     },
-    "setPermissionsLevel": "Imposta il livello di autorizzazione",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Imposta lo stato",
     "@setStatus": {
         "type": "String",
@@ -1449,11 +1367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Trasferimento da un altro dispositivo",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Prova a inviare di nuovo",
     "@tryToSendAgain": {
         "type": "String",
@@ -1509,15 +1422,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 discussione non letta} other{{unreadCount} discussioni non lette}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} e {count} altri stanno scrivendo…",
     "@userAndOthersAreTyping": {
@@ -1603,16 +1507,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Videochiamata",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Visibilità della cronologia della discussione",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Visibile a tutti i partecipanti",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1658,23 +1552,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Chi può eseguire quale azione",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Chi è autorizzato a unirsi a questo gruppo",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Perché vuoi segnalarlo?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Cancellare il backup della discussione per creare una nuova chiave di ripristino?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1811,8 +1690,6 @@
     },
     "scanQrCode": "Scansiona codice QR",
     "@scanQrCode": {},
-    "addAccount": "Aggiungi account",
-    "@addAccount": {},
     "unverified": "Non verificato",
     "@unverified": {},
     "sendAsText": "Invia come testo",
@@ -1846,8 +1723,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "Il tuo backup delle chat è stato configurato.",
-    "@yourChatBackupHasBeenSetUp": {},
     "hugContent": "{senderName} ti abbraccia",
     "@hugContent": {
         "type": "String",
@@ -1953,29 +1828,12 @@
     "@messagesStyle": {},
     "widgetUrlError": "Questo non è un URL valido.",
     "@widgetUrlError": {},
-    "emailOrUsername": "Email o nome utente",
-    "@emailOrUsername": {},
-    "newSpaceDescription": "Gli spazi ti permettono di consolidare le tue chat e di creare comunità private o pubbliche.",
-    "@newSpaceDescription": {},
-    "chatDescription": "Descrizione della chat",
-    "@chatDescription": {},
-    "enterSpace": "Unirsi allo spazio",
-    "@enterSpace": {},
-    "encryptThisChat": "Cifra questa chat",
-    "@encryptThisChat": {},
     "reopenChat": "Riapri la chat",
     "@reopenChat": {},
-    "pleaseEnterRecoveryKey": "Per favore inserisci la tua chiave di recupero:",
-    "@pleaseEnterRecoveryKey": {},
     "widgetNameError": "Per favore fornire un nome da visualizzare.",
     "@widgetNameError": {},
     "addToBundle": "Aggiungi al bundle",
     "@addToBundle": {},
-    "spaceIsPublic": "Lo spazio è pubblico",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "addWidget": "Aggiungi widget",
     "@addWidget": {},
     "countFiles": "{count} file",
@@ -2001,8 +1859,6 @@
     },
     "pushNotificationsNotAvailable": "Notifiche push non disponibili",
     "@pushNotificationsNotAvailable": {},
-    "storeInAppleKeyChain": "Salva nel portachiavi di Apple",
-    "@storeInAppleKeyChain": {},
     "hydrate": "Ripristina dal file di backup",
     "@hydrate": {},
     "invalidServerName": "Nome server non valido",
@@ -2011,8 +1867,6 @@
     "@chatPermissions": {},
     "sender": "Mittente",
     "@sender": {},
-    "storeInAndroidKeystore": "Salva nel KeyStore di Android",
-    "@storeInAndroidKeystore": {},
     "makeAdminDescription": "Una volta che fai questo utente amministratore, potresti non essere in grado di rimuoverlo, in quanto avrà i tuoi stessi privilegi.",
     "@makeAdminDescription": {},
     "synchronizingPleaseWait": "Sincronizzazione... Attendere prego.",
@@ -2025,19 +1879,12 @@
         "type": "String",
         "description": "Usage hint for the command /clearcache"
     },
-    "saveKeyManuallyDescription": "Salva questa chiave manualmente attivando la finestra di condivisione o gli appunti.",
-    "@saveKeyManuallyDescription": {},
     "editBundlesForAccount": "Modifica i bundle per questo account",
     "@editBundlesForAccount": {},
     "whyIsThisMessageEncrypted": "Perché questo messaggio è illeggibile?",
     "@whyIsThisMessageEncrypted": {},
     "setChatDescription": "Imposta la descrizione della chat",
     "@setChatDescription": {},
-    "spaceName": "Nome dello spazio",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "importFromZipFile": "Importa da file .zip",
     "@importFromZipFile": {},
     "dehydrateWarning": "Questa azione non può essere annullata. Assicurarsi di aver salvato il file di backup.",
@@ -2053,8 +1900,6 @@
             }
         }
     },
-    "videoCallsBetaWarning": "Nota che le video chiamate sono attualmente in beta. Potrebbero non funzionare come previsto o non funzionare del tutto su alcune piattaforme.",
-    "@videoCallsBetaWarning": {},
     "fileIsTooBigForServer": "Impossibile inviare! Il server supporta solo allegati fino a {max}.",
     "@fileIsTooBigForServer": {},
     "homeserver": "Homeserver",
@@ -2063,8 +1908,6 @@
     "@readUpToHere": {},
     "start": "Inizio",
     "@start": {},
-    "unlockOldMessages": "Sblocca i vecchi messaggi",
-    "@unlockOldMessages": {},
     "optionalRedactReason": "(Opzionale) Ragione per rimuovere questo messaggio...",
     "@optionalRedactReason": {},
     "dehydrate": "Esporta la sessione e cancella il dispositivo",
@@ -2080,8 +1923,6 @@
     "@exportEmotePack": {},
     "experimentalVideoCalls": "Video chiamate sperimentali",
     "@experimentalVideoCalls": {},
-    "pleaseEnterRecoveryKeyDescription": "Per sbloccare i tuoi vecchi messaggi, per favore inserisci la tua chiave di recupero che è stata generata nella tua sessione precedente. La tua chiave di recupero NON è la tua password.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "redactedByBecause": "Rimosso da {username} per: \"{reason}\"",
     "@redactedByBecause": {
         "type": "String",
@@ -2135,8 +1976,6 @@
     },
     "redactMessageDescription": "Questo messaggio sarà rimosso per tutti i partecipanti di questa conversazione. Questa operazione non può essere annullata.",
     "@redactMessageDescription": {},
-    "recoveryKey": "Chiave di recupero",
-    "@recoveryKey": {},
     "commandHint_discardsession": "Scarta sessione",
     "@commandHint_discardsession": {
         "type": "String",
@@ -2153,8 +1992,6 @@
     "@doNotShowAgain": {},
     "report": "segnala",
     "@report": {},
-    "screenSharingTitle": "condivisione schermo",
-    "@screenSharingTitle": {},
     "widgetCustom": "Personalizzati",
     "@widgetCustom": {},
     "googlyEyesContent": "{senderName} ti ha inviato degli occhi finti",
@@ -2203,8 +2040,6 @@
     },
     "messageInfo": "Informazioni del messaggio",
     "@messageInfo": {},
-    "disableEncryptionWarning": "Per motivi di sicurezza non puoi disabilitare la crittografia in una chat, se era stata abilitata in precedenza.",
-    "@disableEncryptionWarning": {},
     "directChat": "Chat diretta",
     "@directChat": {},
     "wrongPinEntered": "È stato inserito il pin sbagliato! Riprova tra {seconds} secondi...",
@@ -2220,19 +2055,10 @@
     "@sendTypingNotifications": {},
     "inviteGroupChat": "📨 Invita a una chat di gruppo",
     "@inviteGroupChat": {},
-    "foregroundServiceRunning": "Questa notifica viene mostrata quando il servizio in primo piano è in esecuzione.",
-    "@foregroundServiceRunning": {},
-    "voiceCall": "Chiamata vocale",
-    "@voiceCall": {},
     "commandHint_kick": "Rimuovi l'utente fornito da questa stanza",
     "@commandHint_kick": {
         "type": "String",
         "description": "Usage hint for the command /kick"
-    },
-    "createNewSpace": "Nuovo spazio",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "commandHint_unban": "Sbanna l'utente fornito da questa stanza",
     "@commandHint_unban": {
@@ -2270,8 +2096,6 @@
     "@newGroup": {},
     "bundleName": "Nome del bundle",
     "@bundleName": {},
-    "removeFromSpace": "Rimuovi dallo spazio",
-    "@removeFromSpace": {},
     "commandHint_op": "Imposta il livello di privilegi dell'utente specificato (predefinito: 50)",
     "@commandHint_op": {
         "type": "String",
@@ -2313,14 +2137,10 @@
             }
         }
     },
-    "sorryThatsNotPossible": "Scusa... questo non è possibile",
-    "@sorryThatsNotPossible": {},
     "shareInviteLink": "Condividi link d'invito",
     "@shareInviteLink": {},
     "commandHint_markasdm": "Contrassegna questo Matrix ID come stanza di messaggi diretti",
     "@commandHint_markasdm": {},
-    "recoveryKeyLost": "Chiave di recupero smarrita?",
-    "@recoveryKeyLost": {},
     "cuddleContent": "{senderName} ti coccola",
     "@cuddleContent": {
         "type": "String",
@@ -2337,8 +2157,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "Imposta tema:",
-    "@setTheme": {},
     "youJoinedTheChat": "Sei entrato/a nella chat",
     "@youJoinedTheChat": {},
     "openVideoCamera": "Apri la fotocamera per un video",
@@ -2383,8 +2201,6 @@
     "@custom": {},
     "noBackupWarning": "Attenzione! Senza abilitare il backup della chat, perderai l'accesso ai tuoi messaggi crittografati. Si consiglia vivamente di abilitare il backup della chat prima di disconnettersi.",
     "@noBackupWarning": {},
-    "storeInSecureStorageDescription": "Salva la chiave di recupero nell'archivio sicuro di questo dispositivo.",
-    "@storeInSecureStorageDescription": {},
     "openChat": "Apri la Chat",
     "@openChat": {},
     "kickUserDescription": "L'utente è stato rimosso, ma non bannato. Nelle chat pubbliche, l'utente potrà rientrare quando vuole.",
@@ -2395,14 +2211,8 @@
     "@pinMessage": {},
     "invite": "Invitare",
     "@invite": {},
-    "enableMultiAccounts": "(BETA) Abilita account multipli su questo dispositivo",
-    "@enableMultiAccounts": {},
     "unsupportedAndroidVersionLong": "Questa funzionalità richiede una versione di Android più recente. Si prega di verificare la presenza di aggiornamenti o supporto per Lineage OS.",
     "@unsupportedAndroidVersionLong": {},
-    "storeSecurlyOnThisDevice": "Salva in modo sicuro su questo dispositivo",
-    "@storeSecurlyOnThisDevice": {},
-    "screenSharingDetail": "Stai condividendo il tuo schermo in FuffyChat",
-    "@screenSharingDetail": {},
     "placeCall": "Fai una chiamata",
     "@placeCall": {},
     "blockListDescription": "Puoi bloccare gli utenti che ti disturbano. Non sarai più in grado di ricevere messaggi o inviti alle stanze dalle persone che hai bloccato.",
@@ -2411,12 +2221,8 @@
     "@blockedUsers": {},
     "blockUsername": "Nome utente da ignorare",
     "@blockUsername": {},
-    "createGroupAndInviteUsers": "Crea un gruppo e invita gli utenti",
-    "@createGroupAndInviteUsers": {},
     "startConversation": "Inizia una conversazione",
     "@startConversation": {},
-    "groupCanBeFoundViaSearch": "Il gruppo può essere cercato",
-    "@groupCanBeFoundViaSearch": {},
     "noUsersFoundWithQuery": "Sfortunatamente non è stato trovato nessun utente con \"{query}\". Per favore controlla se hai fatto un errore di battitura.",
     "@noUsersFoundWithQuery": {
         "type": "String",
@@ -2438,12 +2244,8 @@
     "@groupName": {},
     "databaseMigrationTitle": "Il database è ottimizzato",
     "@databaseMigrationTitle": {},
-    "searchChatsRooms": "Cerca per #chat, @utenti...",
-    "@searchChatsRooms": {},
     "databaseMigrationBody": "Attendere prego. L'operazione potrebbe richiedere un momento.",
     "@databaseMigrationBody": {},
-    "addChatOrSubSpace": "Aggiungi chat o sottospazio",
-    "@addChatOrSubSpace": {},
     "subspace": "Sottospazio",
     "@subspace": {},
     "publicSpaces": "Spazio pubblico",
@@ -2462,10 +2264,6 @@
     "@pleaseChooseAStrongPassword": {},
     "thisDevice": "Questo dispositivo:",
     "@thisDevice": {},
-    "verifyOtherUser": "🔐 Verifica altro utente",
-    "@verifyOtherUser": {},
-    "verifyOtherUserDescription": "Se verifichi un altro utente, puoi essere certo di sapere a chi stai realmente scrivendo. 💪\n\nQuando inizi una verifica, tu e l'altro utente vedrete un popup nell'app. Lì vedrai una serie di emoji o numeri che dovrai confrontare tra loro.\n\nIl modo migliore per farlo è incontrarsi o avviare una videochiamata. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDevice": "🔐 Verifica altro dispositivo",
     "@verifyOtherDevice": {},
     "verifyOtherDeviceDescription": "Quando verifichi un altro dispositivo, questi dispositivi possono scambiarsi le chiavi, aumentando la tua sicurezza complessiva. 💪 Quando inizi una verifica, apparirà un popup nell'app su entrambi i dispositivi. Lì vedrai una serie di emoji o numeri che dovrai confrontare tra loro. È meglio avere entrambi i dispositivi a portata di mano prima di iniziare la verifica. 🤳",
@@ -2511,22 +2309,12 @@
     "@overview": {},
     "swipeRightToLeftToReply": "Scorri da destra a sinistra per rispondere",
     "@swipeRightToLeftToReply": {},
-    "globalChatId": "ID chat globale",
-    "@globalChatId": {},
     "appLockDescription": "Blocca l'app con un codice PIN quando non è in uso",
     "@appLockDescription": {},
-    "noOneCanJoin": "Nessuno può unirsi",
-    "@noOneCanJoin": {},
-    "usersMustKnock": "Gli utenti devono bussare",
-    "@usersMustKnock": {},
     "alwaysUse24HourFormat": "disattivato",
     "@alwaysUse24HourFormat": {
         "description": "Set to true to always display time of day in 24 hour format."
     },
-    "accessAndVisibility": "Accesso e visibilità",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Chi è autorizzato a partecipare a questa chat e come è possibile scoprirla.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Chiamate",
     "@calls": {},
     "customEmojisAndStickers": "Emoji e adesivi personalizzati",
@@ -2545,18 +2333,6 @@
     "@stickers": {},
     "searchMore": "Cerca di più...",
     "@searchMore": {},
-    "sessionLostBody": "La tua sessione è andata persa. Segnala questo errore agli sviluppatori all'indirizzo {url}. Il messaggio di errore è: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "formattedMessagesDescription": "Visualizza contenuti di messaggi complessi, come testo in grassetto, utilizzando il markdown.",
     "@formattedMessagesDescription": {},
     "canceledKeyVerification": "{sender} ha annullato la verifica della chiave",
@@ -2579,15 +2355,6 @@
         "type": "String",
         "placeholders": {
             "sender": {
-                "type": "String"
-            }
-        }
-    },
-    "chatCanBeDiscoveredViaSearchOnServer": "La chat può essere trovata tramite la ricerca su {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
                 "type": "String"
             }
         }
@@ -2627,10 +2394,6 @@
     "@knockRestricted": {},
     "restricted": "Limitato",
     "@restricted": {},
-    "publicChatAddresses": "Indirizzi di chat pubblici",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Crea un nuovo indirizzo",
-    "@createNewAddress": {},
     "searchIn": "Cerca nella chat \"{chat}\"...",
     "@searchIn": {
         "type": "String",
@@ -2646,18 +2409,6 @@
     "@formattedMessages": {},
     "files": "File",
     "@files": {},
-    "restoreSessionBody": "L'app ora tenta di ripristinare la sessione dal backup. Segnala questo errore agli sviluppatori all'indirizzo {url}. Il messaggio di errore è: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "acceptedKeyVerification": "{sender} ha accettato la verifica della chiave",
     "@acceptedKeyVerification": {
         "type": "String",
@@ -2787,14 +2538,6 @@
     },
     "changeGeneralChatSettings": "Modifica le impostazioni generali della chat",
     "@changeGeneralChatSettings": {},
-    "loginWithMatrixId": "Accedi con il Matrix ID",
-    "@loginWithMatrixId": {},
-    "homeserverDescription": "Tutti i tuoi dati sono archiviati sull'homeserver, proprio come un provider di posta elettronica. Puoi scegliere quale homeserver vuoi usare, mentre puoi comunque comunicare con tutti. Scopri di più su https://matrix.org.",
-    "@homeserverDescription": {},
-    "discoverHomeservers": "Scopri gli homeserver",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Cos'è un homeserver?",
-    "@whatIsAHomeserver": {},
     "changelog": "Registro delle modifiche",
     "@changelog": {},
     "doesNotSeemToBeAValidHomeserver": "Non sembra essere un homeserver compatibile. URL sbagliato?",
@@ -2817,16 +2560,12 @@
     },
     "continueText": "Continua",
     "@continueText": {},
-    "welcomeText": "Hey Hey 👋 Questa è FluffyChat. Puoi accedere a qualsiasi homeserver compatibile con https://matrix.org. E poi chattare con chiunque. È un'enorme rete di messaggistica decentralizzata!",
-    "@welcomeText": {},
     "blur": "Sfocatura:",
     "@blur": {},
     "opacity": "Opacità:",
     "@opacity": {},
     "setWallpaper": "Imposta sfondo",
     "@setWallpaper": {},
-    "manageAccount": "Gestisci account",
-    "@manageAccount": {},
     "noContactInformationProvided": "Il server non fornisce alcuna informazione di contatto valida",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "Contatta l'amministratore del server",
@@ -2975,21 +2714,8 @@
     "@crossVerifiedDevices": {},
     "verifiedDevicesOnly": "Solo dispositivi verificati",
     "@verifiedDevicesOnly": {},
-    "appWantsToUseForLogin": "Usa '{server}' per accedere",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "open": "Apri",
     "@open": {},
-    "appWantsToUseForLoginDescription": "Con la presente consenti all'app e al sito web di condividere informazioni su di te.",
-    "@appWantsToUseForLoginDescription": {},
-    "appIntroduction": "FluffyChat ti consente di chattare con i tuoi amici attraverso diverse app di messaggistica. Ulteriori informazioni su https://matrix.org o semplicemente tocca *Continua*.",
-    "@appIntroduction": {},
     "waitingForServer": "In attesa del server...",
     "@waitingForServer": {},
     "synchronizingPleaseWaitCounter": " Sincronizzazione… ({percentage}%)",
@@ -3043,15 +2769,6 @@
     "@pleaseWaitUntilInvited": {},
     "checkList": "Checklist",
     "@checkList": {},
-    "countInvited": "{count} invitati",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "sentVoiceMessage": "🎙️ {duration} - Messaggio vocale da {sender}",
     "@sentVoiceMessage": {
         "type": "String",
@@ -3084,21 +2801,15 @@
     "@pause": {},
     "resume": "Riprendi",
     "@resume": {},
-    "newSubSpace": "Nuovo sotto sapzio",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Cambia spazio",
-    "@moveToDifferentSpace": {},
     "writeAMessageLangCodes": "Scrivi in {l1} o {l2}...",
     "holdForInfo": "Tieni premuto per informazioni sulla parola.",
     "gaTooltip": "L2 utilizzo con assistenza grammaticale",
     "taTooltip": "L2 utilizzo con assistenza alla traduzione",
     "interactiveTranslatorSliderHeader": "Traduttore Interattivo",
     "interactiveGrammarSliderHeader": "Controllo Grammaticale Interattivo",
-    "interactiveTranslatorRequired": "Obbligatorio",
     "waTooltip": "L2 utilizzo senza assistenza",
     "interactiveTranslator": "Assistenza alla traduzione",
     "noIdenticalLanguages": "Per favore scegli lingue di base e di destinazione diverse",
-    "searchBy": "Cerca per paese e lingue",
     "joinWithClassCode": "Unisciti al corso",
     "languageLevelPreA1": "Principiante Basso (Pre A1)",
     "languageLevelA1": "Novizio Mid (A1)",
@@ -3119,19 +2830,14 @@
     "saveChanges": "Salva le modifiche",
     "publicProfileTitle": "Consenti al mio profilo di essere trovato nella ricerca",
     "publicProfileDesc": "Attivando questa opzione, consenti ad altri utenti di trovare il tuo profilo nella barra di ricerca globale e di inviare richieste di chat. A questo punto, puoi scegliere di accettare o rifiutare la richiesta.",
-    "errorDisableIT": "L'assistenza alla traduzione è disattivata.",
-    "errorDisableIGC": "L'assistenza grammaticale è disattivata.",
     "errorDisableITUserDesc": "Clicca qui per aggiornare le impostazioni di assistenza alla traduzione",
     "errorDisableIGCUserDesc": "Clicca qui per aggiornare le impostazioni di assistenza grammaticale",
     "errorDisableITClassDesc": "L'assistenza alla traduzione è disattivata per il corso in cui si trova questa chat.",
     "errorDisableIGCClassDesc": "L'assistenza alla grammatica è disattivata per il corso in cui si trova questa chat.",
-    "error405Title": "Lingue non impostate",
     "error405Desc": "Imposta le tue lingue nel Menu Principale > Impostazioni di Apprendimento.",
     "termsAndConditions": "Termini e Condizioni",
     "andCertifyIAmAtLeast13YearsOfAge": " e certifico di avere almeno 16 anni.",
-    "error502504Title": "Wow, ci sono molti studenti online!",
     "error502504Desc": "Gli strumenti di traduzione e grammatica potrebbero essere lenti o non disponibili mentre i bot Pangea si aggiornano.",
-    "error404Title": "Errore di traduzione!",
     "error404Desc": "Il bot Pangea non è sicuro di come tradurre questo...",
     "errorPleaseRefresh": "Stiamo verificando! Ricarica e riprova.",
     "connectedToStaging": "Connesso a Staging",
@@ -3169,13 +2875,9 @@
     "definitionsToolName": "Definizioni delle Parole",
     "definitionsToolDescription": "Quando attivo, le parole sottolineate in blu possono essere cliccate per le definizioni. Clicca sui messaggi per accedere alle definizioni.",
     "welcomeBack": "Bentornato! Se hai partecipato al progetto pilota 2023-2024, contattaci per il tuo abbonamento speciale. Se sei un insegnante che ha (o la tua istituzione ha) acquistato licenze per la tua classe, contattaci per il tuo abbonamento insegnante.",
-    "downloadTxtFile": "Scarica il file di testo",
-    "downloadCSVFile": "Scarica il file CSV",
     "promotionalSubscriptionDesc": "Attualmente hai un abbonamento promozionale a vita. Contatta support@pangea.chat per assistenza nella modifica del tuo abbonamento.",
     "originalSubscriptionPlatform": "Abbonamento acquistato tramite {purchasePlatform}",
     "oneWeekTrial": "Prova di una settimana",
-    "downloadXLSXFile": "Scarica il file Excel",
-    "unkDisplayName": "Sconosciuto",
     "wwCountryDisplayName": "Worldwide",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Isole Aland",
@@ -3470,7 +3172,6 @@
     "chatCapacityHasBeenChanged": "Capacità della chat modificata",
     "chatCapacitySetTooLow": "La capacità della chat deve essere almeno {count}.",
     "chatCapacityExplanation": "La capacità della chat limita il numero di membri consentiti in una chat.",
-    "tooManyRequest": "Troppi richieste, riprova più tardi.",
     "enterNumber": "Per favore inserisci un valore numerico intero.",
     "practice": "Pratica",
     "versionNotFound": "Versione non trovata",
@@ -3480,7 +3181,6 @@
     "deleteSubscriptionWarningTitle": "Hai un abbonamento attivo",
     "deleteSubscriptionWarningBody": "L'eliminazione del tuo account non annullerà automaticamente il tuo abbonamento.",
     "manageSubscription": "Gestisci abbonamento",
-    "error520Title": "Per favore riprova.",
     "error520Desc": "Spiacenti, non abbiamo capito il tuo messaggio...",
     "wordsUsed": "Parole usate",
     "level": "Livello",
@@ -3498,7 +3198,6 @@
     "other": "Altro",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "Nessun limite di capacità",
-    "downloadGroupText": "Scarica il testo del gruppo",
     "notificationsOn": "Notifiche attivate",
     "notificationsOff": "Notifiche disattivate",
     "joinWithCode": "Unisciti con il codice",
@@ -3562,24 +3261,12 @@
     "whatIsTheMorphTag": "Qual è il {morphologicalFeature} di '{wordForm}'?",
     "dataAvailable": "Disponibilità dei dati",
     "available": "Disponibile",
-    "pangeaBotIsFallible": "Anche Pangea Bot può commettere errori!",
-    "whatIsMeaning": "Cosa significa '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Abbina i significati con le parole nel messaggio!",
-    "doubleClickToEdit": "Fai doppio clic per modificare.",
-    "topicLabel": "Argomento",
-    "topicPlaceholder": "Scegli un argomento...",
-    "modePlaceholder": "Scegli una modalità...",
-    "learningObjectiveLabel": "Obiettivo di apprendimento",
-    "learningObjectivePlaceholder": "Scegli un obiettivo di apprendimento...",
-    "targetLanguageLabel": "Lingua target",
     "cefrLevelLabel": "Livello CEFR",
     "image": "Immagine",
     "video": "Video",
     "nan": "Non applicabile",
-    "addVocabulary": "Aggiungi vocabolario",
     "instructions": "Istruzioni",
-    "numberOfLearners": "Numero di studenti",
-    "mustBeInteger": "Deve essere un numero intero, ad esempio 1, 2, 3, ...",
     "constructUsePvmDesc": "Prodotto nel messaggio vocale",
     "leaveSpaceDescription": "Lasciando il corso, lascerai tutte le chat al suo interno. Gli altri utenti vedranno che hai lasciato il corso.",
     "constructUseCorMmDesc": "Significato del messaggio corretto",
@@ -3594,7 +3281,6 @@
     "ttsDisabledBody": "Puoi attivare la sintesi vocale nelle impostazioni di apprendimento",
     "noSpaceDescriptionYet": "Nessuna descrizione del corso ancora creata.",
     "tooLargeToSend": "Questo messaggio è troppo grande per essere inviato",
-    "exitWithoutSaving": "Sei sicuro di voler uscire senza salvare?",
     "enableAutocorrectPopupTitle": "Aggiungi la tastiera della lingua di destinazione andando su:",
     "enableAutocorrectPopupSteps": "  • Impostazioni\n  • Generali\n  • Tastiera\n  • Tastiere\n  • Aggiungi nuova tastiera",
     "enableAutocorrectPopupDescription": "Una volta selezionata la lingua, puoi cliccare sull'icona del globo in basso a sinistra della tastiera per attivare la tastiera appena installata.",
@@ -3605,11 +3291,8 @@
     "displayName": "Nome visualizzato",
     "leaveRoomDescription": "Stai per uscire da questa chat. Gli altri utenti vedranno che hai lasciato la chat.",
     "confirmUserId": "Per favore conferma il tuo nome utente Pangea Chat per eliminare il tuo account.",
-    "startingToday": "A partire da oggi",
-    "oneWeekFreeTrial": "Una settimana di prova gratuita",
     "paidSubscriptionStarts": "Inizio {startDate}",
     "cancelInSubscriptionSettings": "Annulla in qualsiasi momento nelle impostazioni di abbonamento",
-    "cancelToAvoidCharges": "Annulla prima di {trialEnds} per evitare addebiti",
     "downloadGboard": "Scarica Gboard",
     "autocorrectNotAvailable": "Sfortunatamente, la tua piattaforma non è attualmente supportata per questa funzione. Resta sintonizzato per ulteriori sviluppi!",
     "pleaseUpdateApp": "Aggiorna l'app per continuare.",
@@ -3619,17 +3302,12 @@
     "knockSpaceSuccess": "Hai richiesto di unirti a questo corso! Un amministratore risponderà alla tua richiesta quando la riceverà 😊",
     "chooseWordAudioInstructionsBody": "Ascolta il messaggio completo. Poi abbina gli audio alle parole.",
     "chooseMorphsInstructionsBody": "Clicca sui pezzi del puzzle per le domande di grammatica!",
-    "pleaseEnterInt": "Per favore inserisci un numero",
     "home": "Home",
     "join": "Unisciti",
     "resetInstructionTooltipsTitle": "Reimposta suggerimenti delle istruzioni",
     "resetInstructionTooltipsDesc": "Clicca per mostrare i suggerimenti delle istruzioni come per un utente nuovo.",
-    "randomize": "Randomizza",
     "clear": "Pulisci",
-    "featuredActivities": "In evidenza",
     "save": "Salva",
-    "startChat": "Inizia una chat",
-    "translationProblem": "Problema di traduzione",
     "askToJoin": "Chiedi di unirti",
     "emptyChatWarningTitle": "Chat vuota",
     "emptyChatWarningDesc": "Non hai invitato nessuno nella tua chat. Vai alle impostazioni della chat per invitare i tuoi contatti o il Bot. Puoi farlo anche più tardi.",
@@ -3659,17 +3337,13 @@
     "timesUsedIndependently": "Volte usato in modo indipendente",
     "timesUsedWithAssistance": "Volte usato con assistenza",
     "shareInviteCode": "Condividi il codice di invito: {code}",
-    "leaderboard": "Classifica",
     "skipForNow": "Salta per ora",
     "permissions": "Permessi",
     "spaceChildPermission": "Chi può aggiungere nuove chat a questo corso",
-    "addEnvironmentOverride": "Aggiungi override dell'ambiente",
     "defaultOption": "Predefinito",
     "deleteChatDesc": "Sei sicuro di voler eliminare questa chat? Verrà eliminata per tutti i partecipanti e tutti i messaggi all'interno della chat non saranno più disponibili per la pratica o le analisi di apprendimento.",
     "deleteSpaceDesc": "Il corso e tutte le chat selezionate verranno eliminati per tutti i partecipanti e tutti i messaggi all'interno della chat non saranno più disponibili per la pratica o le analisi di apprendimento. Questa azione non può essere annullata.",
     "launch": "Avvia",
-    "searchChats": "Cerca chat",
-    "maxFifty": "Massimo 50",
     "configureSpace": "Configura corso",
     "pinMessages": "Blocca messaggi",
     "setJoinRules": "Imposta regole di ingresso",
@@ -3703,9 +3377,6 @@
     "failedToFetchTranscription": "Impossibile recuperare la trascrizione",
     "deleteEmptySpaceDesc": "Il corso verrà eliminato per tutti i partecipanti. Questa azione non può essere annullata.",
     "regenerate": "Rigenera",
-    "mySavedActivities": "Le mie attività salvate",
-    "noSavedActivities": "Nessuna attività salvata",
-    "saveActivity": "Salva questa attività",
     "failedToPlayVideo": "Impossibile riprodurre il video",
     "done": "Fatto",
     "inThisSpace": "In questo corso",
@@ -3716,13 +3387,9 @@
     "numInvited": "{count} invitati",
     "saved": "Salvato",
     "reset": "Reimposta",
-    "errorFetchingActivitiesMessage": "Impossibile recuperare le attività",
     "errorFetchingDefinition": "Impossibile recuperare la definizione",
     "errorProcessAnalytics": "Impossibile elaborare l'analisi",
     "errorDownloading": "Download fallito",
-    "errorLoadingSpaceChildren": "Impossibile caricare le chat all'interno di questo corso",
-    "unexpectedError": "Errore imprevisto.",
-    "pleaseReload": "Ricarica e riprova.",
     "translationError": "Errore di traduzione",
     "check": "Controlla",
     "unableToFindRoom": "Nessuna chat o corso trovata con quel codice. Per favore riprova.",
@@ -3731,19 +3398,14 @@
     "request": "Richiesta",
     "requestAll": "Richiedi tutto",
     "confirmMessageUnpin": "Sei sicuro di voler staccare questa notifica?",
-    "saveAndLaunch": "Salva e avvia",
-    "launchToSpace": "Lancia nel corso",
     "pending": "In attesa",
     "inactive": "Inattivo",
-    "confirmRole": "Conferma ruolo",
     "openRoleLabel": "APERTO",
     "finishedTheActivity": "🎯 {username} ha concluso questa attività",
     "activitySummaryError": "Riepiloghi dell'attività non disponibili",
     "requestSummaries": "Richiedi riepiloghi",
-    "generatingNewActivities": "Sei il primo utente di questa coppia di lingue! Per favore, prenditi un minuto, stiamo preparando attività appositamente per te.",
     "requestAccessTitle": "Richiedi accesso alle analisi?",
     "requestAccessDesc": "Desideri richiedere l'accesso per visualizzare le analisi dei partecipanti?\n\nSe i partecipanti sono d'accordo, gli amministratori di questo corso potranno visualizzare i loro:\n    • vocabolario totale\n    • concetti grammaticali totali\n    • sessioni di attività completate\n    • i concetti grammaticali specifici usati, correttamente e erroneamente\n\nNon potranno visualizzare i loro:\n    • messaggi nelle chat fuori dal corso\n    • lista di vocabolario",
-    "requestAccess": "Richiedi accesso ({count})",
     "analyticsInactiveTitle": "Le richieste agli utenti inattivi non sono state inviate",
     "analyticsInactiveDesc": "Gli utenti inattivi che non hanno effettuato l'accesso da quando questa funzione è stata introdotta non vedranno la tua richiesta.\n\nIl pulsante Richiedi apparirà quando torneranno. Puoi reinviare la richiesta in seguito cliccando sul pulsante Richiedi sotto il loro nome quando sarà disponibile.",
     "accessRequestedTitle": "Richiesta di accesso alle analisi",
@@ -3766,8 +3428,6 @@
     "accessDesc": "Puoi rendere il tuo corso accessibile a tutti! Oppure, rendilo privato e sicuro.",
     "createGroupChatDesc": "Mentre le sessioni di attività iniziano e finiscono, le chat di gruppo rimarranno aperte per comunicazioni di routine.",
     "deleteDesc": "Solo gli amministratori possono eliminare un corso. Questa è un'azione distruttiva che rimuove tutti gli utenti e elimina tutte le chat selezionate all'interno del corso. Procedi con cautela.",
-    "noCourseFound": "Oh, questo corso ha bisogno di un piano!\n\nI piani del corso sono una sequenza di argomenti e attività di conversazione.",
-    "additionalParticipants": "+ {num} altri",
     "whatNow": "E ora?",
     "chooseNextActivity": "Scegli la tua prossima attività!",
     "letsGo": "Andiamo",
@@ -3780,13 +3440,11 @@
     "waitNotDone": "Aspetta, non ho finito!",
     "waitingForOthersToFinish": "In attesa che gli altri finiscano...",
     "generatingSummary": "Analizzando la chat e generando risultati",
-    "findCourse": "Trova un corso",
     "pingParticipantsNotification": "{user} sta cercando utenti per unirsi alla sessione dell'attività in {room}",
     "course": "Corso",
     "courses": "Corsi",
     "goToCourse": "Vai al corso: {course}",
     "activityComplete": "Questa attività è stata completata. Il riepilogo dell'attività dovrebbe essere disponibile qui sotto.",
-    "startNewSession": "Inizia una nuova sessione",
     "joinOpenSession": "Unisciti a una sessione aperta",
     "activityNotFound": "Attività non trovata",
     "myActivities": "Le mie attività",
@@ -3861,10 +3519,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3874,10 +3528,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -3965,14 +3615,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -3989,10 +3631,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4005,15 +3643,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4165,14 +3795,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4186,14 +3808,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5416,10 +5030,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5460,10 +5070,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5536,10 +5142,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5809,47 +5411,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5869,19 +5431,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -5945,10 +5495,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -5989,14 +5535,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6008,14 +5546,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6053,10 +5583,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6073,27 +5599,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6217,10 +5727,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6230,10 +5736,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6250,14 +5752,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6397,18 +5891,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6457,10 +5939,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6470,18 +5948,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6524,23 +5990,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6564,10 +6018,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6575,14 +6025,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6687,18 +6129,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6751,10 +6181,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6781,10 +6207,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -6965,7 +6387,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Controlla di nuovo domani per gli aggiornamenti sull'attività.",
-    "activityDropdownDesc": "Quando hai finito con questa attività, clicca qui sotto",
     "languageMismatchTitle": "Incompatibilità della lingua",
     "languageMismatchDesc": "La tua lingua di destinazione non corrisponde alla lingua di questa attività. Aggiornare la tua lingua di destinazione?",
     "reportWordIssueTooltip": "Segnala problema con le informazioni sulla parola",
@@ -6978,10 +6399,6 @@
     "selectAll": "Seleziona tutto",
     "deselectAll": "Deseleziona tutto",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7030,17 +6447,11 @@
         "placeholders": {}
     },
     "startOwn": "Avvia il mio",
-    "joinCourseDesc": "Ogni corso ha 8-10 argomenti sequenziali con una serie di attività di apprendimento linguistico basate su compiti.",
     "newMessageInPangeaChat": "🗨️ Nuovo messaggio in Pangea Chat",
     "shareCourse": "Condividi corso",
     "addCourse": "Aggiungi un corso",
-    "joinPublicCourse": "Unisciti al corso pubblico",
     "vocabLevelsDesc": "Qui andranno le parole di vocabolario una volta che le avrai potenziate!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7053,10 +6464,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7075,7 +6482,6 @@
     "emojiView": "Visualizzazione emoji",
     "feedbackDialogDesc": "Anch'io faccio errori! Qualcosa per aiutarmi a migliorare?",
     "contactHasBeenInvitedToTheCourse": "Il contatto è stato invitato al corso",
-    "activityStatsButtonTooltip": "Informazioni sull'attività",
     "allow": "Consenti",
     "deny": "Nega",
     "enabledRenewal": "Abilita il rinnovo dell'abbonamento",
@@ -7343,10 +6749,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8402,16 +7804,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Attività per sbloccare il prossimo argomento",
-    "activitiesToUnlockTopicDesc": "Imposta il numero di attività per sbloccare il prossimo argomento del corso",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Pratica corretta della definizione del vocabolario",
     "constructUseIncLMDesc": "Pratica scorretta della definizione del vocabolario",
     "constructUseCorLADesc": "Pratica corretta dell'audio del vocabolario",
@@ -8419,7 +7811,6 @@
     "constructUseBonus": "Bonus durante la pratica del vocabolario",
     "practiceVocab": "Pratica del vocabolario",
     "selectMeaning": "Seleziona il significato",
-    "selectAudio": "Seleziona l'audio corrispondente",
     "anotherRound": "Un altro turno",
     "activitySettingsOverrideWarning": "Lingua e livello di lingua determinati dal piano di attività",
     "voice": "Voce",
@@ -8451,10 +7842,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8472,12 +7859,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Download avviato",
     "webDownloadPermissionMessage": "Se il tuo browser blocca i download, abilita i download per questo sito.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8572,11 +7954,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Qualcosa è andato storto e stiamo lavorando duramente per risolverlo. Controlla di nuovo più tardi.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Abilita assistenza alla scrittura",
     "autoIGCToolDescription": "Esegui automaticamente gli strumenti di Pangea Chat per correggere i messaggi inviati nella lingua target.",
     "@autoIGCToolName": {
@@ -8632,24 +8009,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Grammatica",
-    "spanTypeWordChoice": "Scelta delle parole",
     "spanTypeSpelling": "Ortografia",
     "spanTypePunctuation": "Punteggiatura",
     "spanTypeStyle": "Stile",
     "spanTypeFluency": "Fluidità",
     "spanTypeAccents": "Accenti",
     "spanTypeCapitalization": "Capitalizzazione",
-    "spanTypeCorrection": "Correzione",
     "spanFeedbackTitle": "Segnala problema di correzione",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8674,21 +8040,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
     },
     "changedTheChatDescription": "{username} ha cambiato la descrizione della chat",
     "changedTheChatName": "{username} ha cambiato il nome della chat",
-    "removeFromSpaceDescription": "La chat verrà rimossa dallo spazio ma apparirà ancora nella tua lista chat.",
     "countChats": "{chats} chat",
-    "spaceMemberOf": "Membro dello spazio di {spaces}",
-    "spaceMemberOfCanKnock": "Membro dello spazio di {spaces} può bussare",
-    "donate": "Dona",
     "startedAPoll": "{username} ha avviato un sondaggio.",
     "poll": "Sondaggio",
     "startPoll": "Avvia sondaggio",
@@ -8712,10 +8070,6 @@
     "newStickerPack": "Nuovo pacchetto adesivi",
     "stickerPackName": "Nome del pacchetto adesivi",
     "attribution": "Attribuzione",
-    "skipChatBackup": "Salta il backup della chat",
-    "skipChatBackupWarning": "Sei sicuro? Senza abilitare il backup della chat potresti perdere l'accesso ai tuoi messaggi se cambi dispositivo.",
-    "loadingMessages": "Caricamento messaggi",
-    "setupChatBackup": "Imposta il backup della chat",
     "noMoreResultsFound": "Nessun altro risultato trovato",
     "chatSearchedUntil": "Chat cercata fino a {time}",
     "federationBaseUrl": "URL di base della federazione",
@@ -8733,10 +8087,6 @@
             "username": {}
         }
     },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -8744,26 +8094,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -8869,22 +8199,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8910,30 +8224,14 @@
         "placeholders": {}
     },
     "identityServer": "Server di Identità:",
-    "versionWithNumber": "Versione: {version}",
     "logs": "Registri",
-    "advancedConfigs": "Configurazioni Avanzate",
     "advancedConfigurations": "Configurazioni avanzate",
-    "signInWithLabel": "Accedi con:",
     "selectAllWords": "Seleziona tutte le parole che senti nell'audio",
-    "joinCourseForActivities": "Iscriviti a un corso per provare le attività.",
     "@identityServer": {
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8941,15 +8239,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9150,11 +8440,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "In una classe? Inserisci il tuo codice di accesso qui.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Evidenzia automaticamente i messaggi audio",
     "selectAudioMessagesOnPlayDescription": "Evidenzia automaticamente i messaggi audio quando vengono riprodotti",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9198,18 +8483,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Questo corso ha argomenti con meno di {input} attività. Si prega di inserire un numero minore o uguale a {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Clicca qui per accedere di nuovo.",
     "@clickToLogin": {
@@ -9626,17 +8899,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Un orso giallo in stile cartone animato con le braccia alzate in segno di eccitazione.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Seleziona le parole per saperne di più",
     "requireAnalyticsAccessTitle": "Richiedere l'accesso all'analisi per partecipare",
     "requireAnalyticsAccessDesc": "I partecipanti devono concedere l'accesso alle loro analisi di apprendimento per partecipare a questo corso",
     "analyticsAccessNoticeTitle": "Accesso all'analisi richiesto",
     "analyticsAccessNoticeDesc": "Partecipando a questo corso, accetti di concedere agli amministratori l'accesso alle tue analisi di apprendimento.",
-    "skipOnboardingClassCodeDesc": "Stai imparando in modo indipendente? Non preoccuparti, puoi:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9654,10 +8921,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9686,7 +8949,6 @@
     "pickCefrLevelTeacherStepTitle": "Quale livello insegni?",
     "pickCefrLevelStudentStepTitle": "Quale livello sei?",
     "customCourseStepTitle": "Compila questo modulo per ottenere un corso personalizzato",
-    "aboutYourClass": "Informazioni sul tuo corso",
     "courseCodeStepErrorMessage": "Controlla il tuo codice e riprova",
     "institution": "Istituzione",
     "courseGoals": "Obiettivi del corso",
@@ -9729,10 +8991,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9849,12 +9107,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logo di Pangea Chat",
     "introChatDetails": "Dì ciao! Presentati ai tuoi compagni di corso, trova amici e chatta al di fuori delle attività.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9898,11 +9151,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Azioni di attività",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Strumenti di pronuncia",
     "audioTranscription": "Trascrizione audio AI",
     "visualLearnerSupport": "Supporto per apprendenti visivi",
@@ -9943,7 +9191,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Unisciti a un corso che include questa attività per giocarla.",
     "resizeCoursePanel": "Ridimensiona il pannello del corso",
     "undo": "Annulla",
     "unlock": "Sblocca",
@@ -9957,7 +9204,6 @@
     "addCourseBrowsePublic": "Sfoglia i corsi pubblici",
     "browsePublicCourses": "Sfoglia i corsi pubblici",
     "editProfile": "Modifica profilo",
-    "numObjectives": "{count} obiettivi",
     "mapSearchHint": "Cerca attività",
     "mapSearchNoResults": "Nessuna corrispondenza in vista",
     "mapFilterAllLanguages": "Tutte le lingue",
@@ -9966,7 +9212,6 @@
     "mapFilterCompleted": "Completato",
     "mapFilterReset": "Ripristina",
     "activityTypeConversation": "Conversazione",
-    "lockedMissionRequirement": "Completa la missione precedente per sbloccare",
     "playAgain": "Gioca di nuovo",
     "reviewActivity": "Recensione",
     "mapEmptyInView": "Niente qui al tuo livello o lingua. Allarga i tuoi filtri o allontanati.",
@@ -9981,14 +9226,9 @@
     "scrollToBottom": "Scorri fino in fondo",
     "courseImage": "Immagine del corso",
     "avatarPreview": "Anteprima dell'avatar",
-    "activityPhoto": "Foto dell'attività",
     "emotePreview": "Anteprima dell'emote: {name}",
     "activityLabel": "Attività: {title}",
     "resetMapView": "Ripristina la vista della mappa",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10041,14 +9281,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10078,10 +9310,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10138,10 +9366,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -78,11 +78,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "ゲストユーザーの参加を許可する",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "これでよろしいですか？",
     "@areYouSure": {
         "type": "String",
@@ -340,11 +335,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "古いメッセージはリカバリーキーで保護されます。紛失しないようにご注意ください。",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "チャットの詳細",
     "@chatDetails": {
         "type": "String",
@@ -389,11 +379,6 @@
     },
     "connect": "接続",
     "@connect": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "連絡先に登録された人が招待されました",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -591,11 +576,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "一度暗号化を有効にするともとに戻せません。よろしいですか？",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "暗号化",
     "@encrypted": {
         "type": "String",
@@ -622,11 +602,6 @@
     },
     "enterAnEmailAddress": "メールアドレスを入力してください",
     "@enterAnEmailAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "すべての準備は完了しました！",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -667,11 +642,6 @@
     },
     "group": "グループ",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "グループは公開されています",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -765,15 +735,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "連絡先から{groupName}に招待する",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "招待されました",
     "@invited": {
@@ -886,15 +847,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "あと{count}名参加者を読み込む",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "読み込み中…お待ちください。",
     "@loadingPleaseWait": {
         "type": "String",
@@ -909,15 +861,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "{homeserver}にログインする",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "ログアウト",
     "@logout": {
@@ -981,16 +924,6 @@
     },
     "noEmotesFound": "Emoteは見つかりませんでした😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "ルームを非公開にした後暗号化を有効にできます。",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "あなたのスマホにはGoogleサービスがないようですね。プライバシーを保護するための良い選択です！プッシュ通知を受け取るには https://microg.org/ または https://unifiedpush.org/ を使うことをお勧めします。",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1090,11 +1023,6 @@
     },
     "passwordHasBeenChanged": "パスワードが変更されました",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "パスワードリカバリー",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1228,11 +1156,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "デバイスの削除",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "チャットからのブロックを解除する",
     "@unbanFromChat": {
@@ -1373,11 +1296,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "権限レベルをセット",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "ステータスの設定",
     "@setStatus": {
         "type": "String",
@@ -1467,11 +1385,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "違うデバイスから移行する",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "送信し直してみる",
     "@tryToSendAgain": {
         "type": "String",
@@ -1527,15 +1440,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1件の未読メッセージ} other{{unreadCount}件の未読メッセージ}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username}と他{count}名が入力しています…",
     "@userAndOthersAreTyping": {
@@ -1621,16 +1525,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "音声通話",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "チャット履歴の表示",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "すべての参加者が閲覧可能",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1676,23 +1570,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "誰がどの操作を実行できるか",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "誰がこのチャットに入れますか",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "これを通報する理由",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "チャットのバックアップを消去して、新しいリカバリーキーを作りますか？",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1754,8 +1633,6 @@
         "type": "String",
         "placeholder": {}
     },
-    "yourChatBackupHasBeenSetUp": "チャットバックアップを設定ました。",
-    "@yourChatBackupHasBeenSetUp": {},
     "sendOnEnter": "Enterで送信",
     "@sendOnEnter": {},
     "changeYourAvatar": "アバタるを変化しする",
@@ -1825,8 +1702,6 @@
     },
     "oneClientLoggedOut": "クライアントの 1つがログアウトしました",
     "@oneClientLoggedOut": {},
-    "addAccount": "アカウントを追加",
-    "@addAccount": {},
     "editBundlesForAccount": "このアカウントのバンドルを編集",
     "@editBundlesForAccount": {},
     "unverified": "未検証",
@@ -1835,8 +1710,6 @@
     "@sender": {},
     "placeCall": "電話をかける",
     "@placeCall": {},
-    "voiceCall": "音声通話",
-    "@voiceCall": {},
     "unsupportedAndroidVersionLong": "この機能を利用するには、より新しいAndroidのバージョンが必要です。アップデートまたはLineage OSのサポートをご確認ください。",
     "@unsupportedAndroidVersionLong": {},
     "widgetVideo": "動画",
@@ -1881,8 +1754,6 @@
     "@users": {},
     "youRejectedTheInvitation": "招待を拒否しました",
     "@youRejectedTheInvitation": {},
-    "screenSharingDetail": "FuffyChatで画面を共有しています",
-    "@screenSharingDetail": {},
     "homeserver": "ホームサーバー",
     "@homeserver": {},
     "scanQrCode": "QRコードをスキャン",
@@ -1937,32 +1808,14 @@
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKey": "リカバリーキー",
-    "@recoveryKey": {},
-    "spaceIsPublic": "スペースは公開されています",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "スペース名",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "messageInfo": "メッセージの情報",
     "@messageInfo": {},
     "openGallery": "ギャラリーを開く",
     "@openGallery": {},
-    "removeFromSpace": "スペースから削除",
-    "@removeFromSpace": {},
-    "pleaseEnterRecoveryKeyDescription": "古いメッセージを解除するには、以前のセッションで生成されたリカバリーキーを入力してください。リカバリーキーはパスワードではありません。",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "openChat": "チャットを開く",
     "@openChat": {},
     "experimentalVideoCalls": "実験的なビデオ通話",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "メールアドレスまたはユーザー名",
-    "@emailOrUsername": {},
     "youAcceptedTheInvitation": "👍 招待を承諾しました",
     "@youAcceptedTheInvitation": {},
     "errorAddingWidget": "ウィジェットの追加中にエラーが発生しました。",
@@ -2001,18 +1854,6 @@
             }
         }
     },
-    "storeInAppleKeyChain": "Apple KeyChainに保存",
-    "@storeInAppleKeyChain": {},
-    "storeInAndroidKeystore": "Android KeyStoreに保存する",
-    "@storeInAndroidKeystore": {},
-    "storeInSecureStorageDescription": "このデバイスの安全なストレージにリカバリーキーを保存。",
-    "@storeInSecureStorageDescription": {},
-    "unlockOldMessages": "古いメッセージのロックを解除する",
-    "@unlockOldMessages": {},
-    "screenSharingTitle": "画面共有",
-    "@screenSharingTitle": {},
-    "foregroundServiceRunning": "この通知は、フォアグラウンド サービスの実行中に表示されます。",
-    "@foregroundServiceRunning": {},
     "custom": "カスタム",
     "@custom": {},
     "countFiles": "{count}個のファイル",
@@ -2023,14 +1864,8 @@
             }
         }
     },
-    "storeSecurlyOnThisDevice": "このデバイスに安全に保管する",
-    "@storeSecurlyOnThisDevice": {},
     "whyIsThisMessageEncrypted": "このメッセージが読めない理由",
     "@whyIsThisMessageEncrypted": {},
-    "enableMultiAccounts": "(ベータ版) このデバイスで複数のアカウントを有効にする",
-    "@enableMultiAccounts": {},
-    "pleaseEnterRecoveryKey": "リカバリーキーを入力してください。",
-    "@pleaseEnterRecoveryKey": {},
     "serverRequiresEmail": "このサーバーは、登録のためにメールアドレスを検証する必要があります。",
     "@serverRequiresEmail": {},
     "synchronizingPleaseWait": "同期中...お待ちください。",
@@ -2042,8 +1877,6 @@
     "@emojis": {},
     "markAsRead": "既読にする",
     "@markAsRead": {},
-    "videoCallsBetaWarning": "ビデオ通話は、現在ベータ版であることにご注意ください。すべてのプラットフォームで期待通りに動作しない、あるいはまったく動作しない可能性があります。",
-    "@videoCallsBetaWarning": {},
     "confirmEventUnpin": "イベントの固定を完全に解除してもよろしいですか？",
     "@confirmEventUnpin": {},
     "unsupportedAndroidVersion": "サポートされていないAndroidのバージョン",
@@ -2054,8 +1887,6 @@
     "@newGroup": {},
     "noBackupWarning": "警告！チャットのバックアップを有効にしないと、暗号化されたメッセージにアクセスできなくなります。ログアウトする前に、まずチャットのバックアップを有効にすることを強くお勧めします。",
     "@noBackupWarning": {},
-    "disableEncryptionWarning": "セキュリティ上の理由から、以前は暗号化が有効だったチャットで暗号化を無効にすることはできません。",
-    "@disableEncryptionWarning": {},
     "youInvitedUser": "📩 {user} を招待しました",
     "@youInvitedUser": {
         "placeholders": {
@@ -2075,11 +1906,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "新しいスペース",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "widgetUrlError": "有効なURLではありません。",
     "@widgetUrlError": {},
@@ -2108,8 +1934,6 @@
     },
     "noOtherDevicesFound": "他のデバイスが見つかりません",
     "@noOtherDevicesFound": {},
-    "recoveryKeyLost": "リカバリーキーを紛失した場合",
-    "@recoveryKeyLost": {},
     "shareLocation": "位置情報の共有",
     "@shareLocation": {
         "type": "String",
@@ -2125,8 +1949,6 @@
     "@commandHint_googly": {},
     "commandHint_hug": "ハグを送る",
     "@commandHint_hug": {},
-    "encryptThisChat": "このチャットを暗号化する",
-    "@encryptThisChat": {},
     "commandHint_markasdm": "ダイレクトメッセージの部屋としてマークする",
     "@commandHint_markasdm": {},
     "commandHint_dm": "ダイレクトチャットを開始する\n暗号化を無効にするには、--no-encryptionを使用してください",
@@ -2171,8 +1993,6 @@
     },
     "deviceKeys": "デバイスキー:",
     "@deviceKeys": {},
-    "sorryThatsNotPossible": "申し訳ありません...それは不可能です",
-    "@sorryThatsNotPossible": {},
     "wasDirectChatDisplayName": "空のチャット (以前は {oldDisplayName})",
     "@wasDirectChatDisplayName": {
         "type": "String",
@@ -2186,8 +2006,6 @@
     "@doNotShowAgain": {},
     "allSpaces": "すべてのスペース",
     "@allSpaces": {},
-    "enterSpace": "スペースに入る",
-    "@enterSpace": {},
     "newSpace": "新しいスペース",
     "@newSpace": {},
     "reopenChat": "チャットを再開する",
@@ -2224,17 +2042,12 @@
     "commandHint_op": "指定されたユーザーの権限レベルを設定（デフォルト：50）",
     "commandHint_unban": "この部屋から指定されたユーザーの禁止を解除",
     "checkList": "チェックリスト",
-    "countInvited": "{count} 招待済み",
     "createGroup": "グループを作成",
     "chatPermissions": "チャット権限",
     "emoteKeyboardNoRecents": "最近使用した絵文字はここに表示されます...",
-    "globalChatId": "グローバルチャットID",
-    "accessAndVisibility": "アクセスと可視性",
-    "accessAndVisibilityDescription": "このチャットに参加できる人と、チャットがどのように見つけられるか。",
     "calls": "通話",
     "customEmojisAndStickers": "カスタム絵文字とステッカー",
     "customEmojisAndStickersBody": "カスタム絵文字やステッカーを追加または共有し、任意のチャットで使用できます。",
-    "chatDescription": "チャットの説明",
     "chatDescriptionHasBeenChanged": "チャットの説明が変更されました",
     "hideRedactedMessages": "編集済みメッセージを非表示",
     "hideRedactedMessagesBody": "誰かがメッセージを編集した場合、そのメッセージはチャットに表示されなくなります。",
@@ -2265,13 +2078,9 @@
     "widgetEtherpad": "テキストノート",
     "invitedBy": "📩 {user}によって招待されました",
     "hasKnocked": "🚪 {user}がノックしました",
-    "usersMustKnock": "ユーザーはノックする必要があります",
-    "noOneCanJoin": "誰も参加できません",
     "knock": "ノック",
-    "saveKeyManuallyDescription": "このキーを手動で保存するには、システムの共有ダイアログまたはクリップボードをトリガーしてください。",
     "noKeyForThisMessage": "このメッセージは、あなたがこのデバイスにサインインする前に送信された場合に発生することがあります。\n\nまたは、送信者があなたのデバイスをブロックしているか、インターネット接続に問題がある可能性もあります。\n\n別のセッションでメッセージを読むことができますか？ それから、そのセッションからメッセージを転送できます！ 設定 > デバイスに移動し、デバイスがお互いに検証されていることを確認してください。次に部屋を開くとき、両方のセッションが前面にある場合、キーは自動的に送信されます。\n\nログアウトやデバイスの切り替え時にキーを失いたくない場合は、設定でチャットバックアップを有効にしてください。",
     "hidePresences": "ステータスリストを非表示にしますか？",
-    "newSpaceDescription": "Spacesは、チャットを統合し、プライベートまたはパブリックなコミュニティを構築することを可能にします。",
     "fileIsTooBigForServer": "送信できません！サーバーは最大 {max} までの添付ファイルのみサポートしています。",
     "fileHasBeenSavedAt": "ファイルは {path} に保存されました",
     "jumpToLastReadMessage": "最後に読んだメッセージにジャンプ",
@@ -2280,7 +2089,6 @@
     "openLinkInBrowser": "リンクをブラウザで開く",
     "reportErrorDescription": "😞 おっと。何か問題が発生しました。必要であれば、このバグを開発者に報告できます。",
     "report": "報告",
-    "setTheme": "テーマを設定：",
     "setColorTheme": "カラーテーマを設定：",
     "invite": "招待",
     "inviteGroupChat": "📨 グループチャットを招待",
@@ -2299,12 +2107,8 @@
     "yourGlobalUserIdIs": "あなたのグローバルユーザーIDは：",
     "noUsersFoundWithQuery": "申し訳ありませんが、「{query}」でユーザーが見つかりませんでした。タイプミスがないかご確認ください。",
     "knocking": "ノック中",
-    "chatCanBeDiscoveredViaSearchOnServer": "チャットは {server} の検索を通じて見つけることができます",
-    "searchChatsRooms": "#チャット、@ユーザーを検索...",
     "nothingFound": "何も見つかりませんでした...",
     "groupName": "グループ名",
-    "createGroupAndInviteUsers": "グループを作成し、ユーザーを招待",
-    "groupCanBeFoundViaSearch": "グループは検索を通じて見つけることができます",
     "wrongRecoveryKey": "申し訳ありません...これは正しいリカバリーキーではないようです。",
     "startConversation": "会話を開始",
     "commandHint_sendraw": "生のJSONを送信",
@@ -2318,11 +2122,8 @@
     "pleaseChooseAStrongPassword": "強力なパスワードを選択してください",
     "passwordsDoNotMatch": "パスワードが一致しません",
     "passwordIsWrong": "入力されたパスワードが間違っています",
-    "publicChatAddresses": "公開チャットアドレス",
-    "createNewAddress": "新しいアドレスを作成",
     "joinSpace": "スペースに参加",
     "publicSpaces": "公開スペース",
-    "addChatOrSubSpace": "チャットまたはサブスペースを追加",
     "subspace": "サブスペース",
     "decline": "辞退",
     "thisDevice": "このデバイス：",
@@ -2331,15 +2132,11 @@
     "searchMore": "さらに検索...",
     "gallery": "ギャラリー",
     "files": "ファイル",
-    "sessionLostBody": "セッションが失われました。このエラーを開発者に報告してください：{url}。エラーメッセージは次のとおりです：{error}",
-    "restoreSessionBody": "アプリは現在、バックアップからセッションを復元しようとしています。このエラーを開発者に報告してください：{url}。エラーメッセージは次のとおりです：{error}",
     "sendReadReceipts": "既読通知を送信",
     "sendTypingNotificationsDescription": "チャットの他の参加者は、あなたが新しいメッセージを入力しているときにそれを見ることができます。",
     "sendReadReceiptsDescription": "チャットの他の参加者は、あなたがメッセージを読んだときにそれを見ることができます。",
     "formattedMessages": "フォーマットされたメッセージ",
     "formattedMessagesDescription": "マークダウンを使用して太字などのリッチなメッセージ内容を表示します。",
-    "verifyOtherUser": "🔐 他のユーザーを検証",
-    "verifyOtherUserDescription": "他のユーザーを検証すると、誰に対して書いているのか確信できます。💪\n\n検証を開始すると、あなたと相手のユーザーはアプリ内にポップアップを表示します。そこには比較すべき絵文字や数字のシリーズが表示されます。\n\nこれを最も良く行う方法は、会うかビデオ通話を始めることです。👭",
     "verifyOtherDevice": "🔐 他のデバイスを検証",
     "verifyOtherDeviceDescription": "他のデバイスを検証すると、それらのデバイス間で鍵を交換でき、セキュリティが向上します。💪 検証を開始すると、両方のデバイスにアプリ内でポップアップが表示されます。そこには比較すべき絵文字や数字のシリーズが表示されます。検証を始める前に両方のデバイスを手元に用意しておくのが最良です。🤳",
     "acceptedKeyVerification": "{sender} が鍵の検証を承認しました",
@@ -2375,10 +2172,6 @@
     "updateInstalled": "🎉 {version}のアップデートがインストールされました！",
     "changelog": "変更履歴",
     "sendCanceled": "送信がキャンセルされました",
-    "loginWithMatrixId": "Matrix-IDでログイン",
-    "discoverHomeservers": "ホームサーバーを探索",
-    "whatIsAHomeserver": "ホームサーバーとは何ですか？",
-    "homeserverDescription": "すべてのデータはホームサーバーに保存されます。メールプロバイダーのように、使用したいホームサーバーを選択できますが、誰とでも通信を続けることができます。詳細はhttps://matrix.orgをご覧ください。",
     "doesNotSeemToBeAValidHomeserver": "有効なホームサーバーのようではありません。URLが間違っていますか？",
     "calculatingFileSize": "ファイルサイズを計算中...",
     "prepareSendingAttachment": "添付ファイルの送信準備中...",
@@ -2390,11 +2183,9 @@
     "oneOfYourDevicesIsNotVerified": "あなたのデバイスの一つが未認証です",
     "noticeChatBackupDeviceVerification": "注意：すべてのデバイスをチャットバックアップに接続すると、自動的に認証されます。",
     "continueText": "続ける",
-    "welcomeText": "やあやあ 👋 これはFluffyChatです。https://matrix.orgに対応した任意のホームサーバーにサインインできます。そして誰とでもチャットできます。これは大規模な分散型メッセージングネットワークです！",
     "blur": "ぼかし:",
     "opacity": "不透明度:",
     "setWallpaper": "壁紙を設定",
-    "manageAccount": "アカウントを管理",
     "noContactInformationProvided": "サーバーは有効な連絡先情報を提供していません",
     "contactServerAdmin": "サーバー管理者に連絡",
     "contactServerSecurity": "サーバーのセキュリティに連絡",
@@ -2413,11 +2204,8 @@
     "unableToJoinChat": "チャットに参加できません。相手がすでに会話を終了している可能性があります。",
     "previous": "前へ",
     "otherPartyNotLoggedIn": "相手は現在ログインしておらず、メッセージを受信できません！",
-    "appWantsToUseForLogin": "'{server}'を使用してログイン",
-    "appWantsToUseForLoginDescription": "あなたは、アプリとウェブサイトがあなたに関する情報を共有することを許可します。",
     "open": "開く",
     "waitingForServer": "サーバーを待っています...",
-    "appIntroduction": "FluffyChatは、異なるメッセンジャーを越えて友達とチャットできるアプリです。詳細はhttps://matrix.orgをご覧ください。または、「続行」をタップしてください。",
     "newChatRequest": "📩 新しいチャットリクエスト",
     "contentNotificationSettings": "コンテンツ通知設定",
     "generalNotificationSettings": "一般通知設定",
@@ -2492,11 +2280,9 @@
     "taTooltip": "翻訳支援とともにL2を使用",
     "interactiveTranslatorSliderHeader": "インタラクティブ翻訳者",
     "interactiveGrammarSliderHeader": "インタラクティブ文法チェッカー",
-    "interactiveTranslatorRequired": "必須",
     "waTooltip": "支援なしでL2を使用",
     "interactiveTranslator": "翻訳支援",
     "noIdenticalLanguages": "異なる基礎言語とターゲット言語を選択してください",
-    "searchBy": "国と言語で検索",
     "joinWithClassCode": "コースに参加",
     "languageLevelPreA1": "初心者低 (プレA1)",
     "languageLevelA1": "初心者ミッド (A1)",
@@ -2517,19 +2303,14 @@
     "saveChanges": "変更を保存",
     "publicProfileTitle": "私のプロフィールを検索で見つけられるようにする",
     "publicProfileDesc": "オンにすると、他のユーザーがグローバル検索バーであなたのプロフィールを見つけてチャットリクエストを送ることができます。この時点で、リクエストを受け入れるか拒否するかを選択できます。",
-    "errorDisableIT": "翻訳支援がオフになっています。",
-    "errorDisableIGC": "文法支援がオフになっています。",
     "errorDisableITUserDesc": "こちらをクリックして翻訳支援の設定を更新してください",
     "errorDisableIGCUserDesc": "こちらをクリックして文法支援の設定を更新してください",
     "errorDisableITClassDesc": "このチャットが属するコースの翻訳支援がオフになっています。",
     "errorDisableIGCClassDesc": "このチャットが属するコースの文法支援がオフになっています。",
-    "error405Title": "言語が設定されていません",
     "error405Desc": "メインメニュー > 学習設定で言語を設定してください。",
     "termsAndConditions": "利用規約",
     "andCertifyIAmAtLeast13YearsOfAge": " および私は少なくとも16歳であることを証明します。",
-    "error502504Title": "わあ、多くの学生がオンラインです！",
     "error502504Desc": "Pangeaボットが追いつくまで、翻訳や文法ツールは遅くなるか利用できない場合があります。",
-    "error404Title": "翻訳エラー！",
     "error404Desc": "Pangea Botはそれをどう翻訳すればいいかわかりません...",
     "errorPleaseRefresh": "調査中です！ページをリロードしてもう一度お試しください。",
     "connectedToStaging": "ステージングに接続済み",
@@ -2567,13 +2348,9 @@
     "definitionsToolName": "単語の定義",
     "definitionsToolDescription": "有効にすると、青色の下線が引かれた単語をクリックして定義を確認できます。メッセージをクリックして定義にアクセスしてください。",
     "welcomeBack": "お帰りなさい！2023-2024年のパイロットに参加していた場合は、特別なパイロット購読のためにご連絡ください。あなたが教師で、あなたのクラスのためにライセンスを購入した（またはあなたの学校が購入した）場合は、教師購読のためにご連絡ください。",
-    "downloadTxtFile": "テキストファイルをダウンロード",
-    "downloadCSVFile": "CSVファイルをダウンロード",
     "promotionalSubscriptionDesc": "現在、あなたは生涯のプロモーション購読をしています。購読の変更についてはsupport@pangea.chatまでご連絡ください。",
     "originalSubscriptionPlatform": "{purchasePlatform}で購入した購読",
     "oneWeekTrial": "1週間のトライアル",
-    "downloadXLSXFile": "Excelファイルをダウンロード",
-    "unkDisplayName": "不明",
     "wwCountryDisplayName": "世界中",
     "afCountryDisplayName": "アフガニスタン",
     "axCountryDisplayName": "オーランド諸島",
@@ -2868,7 +2645,6 @@
     "chatCapacityHasBeenChanged": "チャット容量が変更されました",
     "chatCapacitySetTooLow": "チャット容量は少なくとも{count}でなければなりません。",
     "chatCapacityExplanation": "チャット容量は、チャットに許可されるメンバー数を制限します。",
-    "tooManyRequest": "リクエストが多すぎます。後でもう一度お試しください。",
     "enterNumber": "整数値を入力してください。",
     "practice": "練習",
     "versionNotFound": "バージョンが見つかりません",
@@ -2878,7 +2654,6 @@
     "deleteSubscriptionWarningTitle": "アクティブなサブスクリプションがあります",
     "deleteSubscriptionWarningBody": "アカウントを削除しても、自動的にサブスクリプションはキャンセルされません。",
     "manageSubscription": "サブスクリプションを管理",
-    "error520Title": "もう一度お試しください。",
     "error520Desc": "申し訳ありませんが、メッセージを理解できませんでした...",
     "wordsUsed": "使用した単語数",
     "level": "レベル",
@@ -2896,7 +2671,6 @@
     "other": "その他",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "容量制限なし",
-    "downloadGroupText": "グループテキストをダウンロード",
     "notificationsOn": "通知オン",
     "notificationsOff": "通知オフ",
     "joinWithCode": "コードで参加",
@@ -2960,24 +2734,12 @@
     "whatIsTheMorphTag": "'{wordForm}'の{morphologicalFeature}は何ですか？",
     "dataAvailable": "データの利用可能性",
     "available": "利用可能",
-    "pangeaBotIsFallible": "パンゲアボットも間違いを犯します！",
-    "whatIsMeaning": "'{lemma}'の意味は何ですか？",
     "chooseLemmaMeaningInstructionsBody": "メッセージ内の単語と意味を一致させてください！",
-    "doubleClickToEdit": "ダブルクリックして編集。",
-    "topicLabel": "トピック",
-    "topicPlaceholder": "トピックを選択...",
-    "modePlaceholder": "モードを選択...",
-    "learningObjectiveLabel": "学習目標",
-    "learningObjectivePlaceholder": "学習目標を選択...",
-    "targetLanguageLabel": "ターゲット言語",
     "cefrLevelLabel": "CEFRレベル",
     "image": "画像",
     "video": "ビデオ",
     "nan": "該当なし",
-    "addVocabulary": "語彙を追加",
     "instructions": "指示",
-    "numberOfLearners": "学習者数",
-    "mustBeInteger": "整数でなければなりません（例：1、2、3、...）",
     "constructUsePvmDesc": "音声メッセージで生成",
     "leaveSpaceDescription": "コースを離れると、そのコース内のすべてのチャットも離れます。 他のユーザーはあなたがコースを離れたことを確認します。",
     "constructUseCorMmDesc": "メッセージの意味を正しく",
@@ -2992,7 +2754,6 @@
     "ttsDisabledBody": "学習設定でテキスト読み上げを有効にできます",
     "noSpaceDescriptionYet": "コースの説明はまだ作成されていません。",
     "tooLargeToSend": "このメッセージは送信できるサイズを超えています",
-    "exitWithoutSaving": "保存せずに終了してもよろしいですか？",
     "enableAutocorrectPopupTitle": "ターゲット言語のキーボードを追加するには、次の場所に移動してください：",
     "enableAutocorrectPopupSteps": "  • 設定\n  • 一般\n  • キーボード\n  • キーボード\n  • 新しいキーボードを追加",
     "enableAutocorrectPopupDescription": "言語を選択したら、キーボードの左下にある小さな地球儀アイコンをクリックして、新しくインストールしたキーボードを有効にできます。",
@@ -3003,11 +2764,8 @@
     "displayName": "表示名",
     "leaveRoomDescription": "このチャットを退出しようとしています。 他のユーザーにはあなたが退出したことが表示されます。",
     "confirmUserId": "アカウントを削除するには、Pangea Chatのユーザー名を確認してください。",
-    "startingToday": "本日より",
-    "oneWeekFreeTrial": "1週間の無料トライアル",
     "paidSubscriptionStarts": "{startDate}から開始",
     "cancelInSubscriptionSettings": "• サブスクリプション設定でいつでもキャンセル可能",
-    "cancelToAvoidCharges": "• 請求を避けるために{trialEnds}前にキャンセルしてください",
     "downloadGboard": "Gboardをダウンロード",
     "autocorrectNotAvailable": "申し訳ありませんが、このプラットフォームではこの機能はサポートされていません。今後のアップデートにご期待ください！",
     "pleaseUpdateApp": "続行するにはアプリを更新してください。",
@@ -3017,17 +2775,12 @@
     "knockSpaceSuccess": "このコースに参加リクエストを送信しました！管理者が受信次第、返信します😊",
     "chooseWordAudioInstructionsBody": "完全なメッセージを聞いてください。その後、音声と単語を一致させてください。",
     "chooseMorphsInstructionsBody": "パズルのピースをクリックして文法の質問に答えましょう！",
-    "pleaseEnterInt": "数字を入力してください",
     "home": "ホーム",
     "join": "参加",
     "resetInstructionTooltipsTitle": "操作説明ツールチップをリセット",
     "resetInstructionTooltipsDesc": "クリックして、新規ユーザー向けの操作説明ツールチップを表示します。",
-    "randomize": "ランダム化",
     "clear": "クリア",
-    "featuredActivities": "注目のアクティビティ",
     "save": "保存",
-    "startChat": "チャットを開始",
-    "translationProblem": "翻訳の問題",
     "askToJoin": "参加をお願いする",
     "emptyChatWarningTitle": "チャットは空です",
     "emptyChatWarningDesc": "誰も招待していません。チャット設定に移動して連絡先やボットを招待してください。後でもできます。",
@@ -3057,17 +2810,13 @@
     "timesUsedIndependently": "独立して使用された回数",
     "timesUsedWithAssistance": "支援とともに使用された回数",
     "shareInviteCode": "招待コードを共有：{code}",
-    "leaderboard": "リーダーボード",
     "skipForNow": "今はスキップ",
     "permissions": "権限",
     "spaceChildPermission": "このコースに新しいチャットを追加できるのは誰ですか",
-    "addEnvironmentOverride": "環境の上書きを追加",
     "defaultOption": "デフォルト",
     "deleteChatDesc": "このチャットを削除してもよろしいですか？すべての参加者に対して削除され、チャット内のすべてのメッセージは練習や学習分析に利用できなくなります。",
     "deleteSpaceDesc": "コースと選択されたチャットはすべての参加者に対して削除され、チャット内のすべてのメッセージは練習や学習分析に利用できなくなります。この操作は元に戻せません。",
     "launch": "起動",
-    "searchChats": "チャットを検索",
-    "maxFifty": "最大50",
     "configureSpace": "コースを設定",
     "pinMessages": "メッセージを固定",
     "setJoinRules": "参加ルールを設定",
@@ -3101,9 +2850,6 @@
     "failedToFetchTranscription": "文字起こしの取得に失敗しました",
     "deleteEmptySpaceDesc": "コースはすべての参加者から削除されます。この操作は取り消せません。",
     "regenerate": "再生成",
-    "mySavedActivities": "私の保存済みアクティビティ",
-    "noSavedActivities": "保存済みのアクティビティはありません",
-    "saveActivity": "このアクティビティを保存",
     "failedToPlayVideo": "ビデオの再生に失敗しました",
     "done": "完了",
     "inThisSpace": "このコース内",
@@ -3114,13 +2860,9 @@
     "numInvited": "{count}人が招待されました",
     "saved": "保存済み",
     "reset": "リセット",
-    "errorFetchingActivitiesMessage": "アクティビティの取得に失敗しました",
     "errorFetchingDefinition": "定義の取得に失敗しました",
     "errorProcessAnalytics": "分析の処理に失敗しました",
     "errorDownloading": "ダウンロードに失敗しました",
-    "errorLoadingSpaceChildren": "このコース内のチャットの読み込みに失敗しました",
-    "unexpectedError": "予期しないエラーです。",
-    "pleaseReload": "再読み込みしてもう一度お試しください。",
     "translationError": "翻訳エラー",
     "check": "確認",
     "unableToFindRoom": "そのコードのチャットまたはコースが見つかりません。もう一度お試しください。",
@@ -3129,19 +2871,14 @@
     "request": "リクエスト",
     "requestAll": "すべてリクエスト",
     "confirmMessageUnpin": "このメッセージのピン留めを解除してもよろしいですか？",
-    "saveAndLaunch": "保存して開始",
-    "launchToSpace": "コースに開始",
     "pending": "保留中",
     "inactive": "非アクティブ",
-    "confirmRole": "役割を確認",
     "openRoleLabel": "開く",
     "finishedTheActivity": "🏆 {username} がこの活動を終了しました",
     "activitySummaryError": "活動の概要を利用できません",
     "requestSummaries": "概要をリクエスト",
-    "generatingNewActivities": "この言語ペアの最初のユーザーです！少々お待ちください。あなたのために活動を準備しています。",
     "requestAccessTitle": "分析アクセスをリクエストしますか？",
     "requestAccessDesc": "参加者の分析を見るためのアクセスをリクエストしますか？\n\n参加者が同意すれば、このコースの管理者は以下を閲覧できます：\n    • 単語総数\n    • 文法概念の合計\n    • 完了した活動セッションの合計\n    • 正しく使われた、誤って使われた特定の文法概念\n\n閲覧できない情報は以下です：\n    • コース外のチャットのメッセージ\n    • 単語リスト",
-    "requestAccess": "アクセスをリクエスト ({count})",
     "analyticsInactiveTitle": "非アクティブなユーザーへのリクエストは送信できませんでした",
     "analyticsInactiveDesc": "この機能が導入されて以来ログインしていない非アクティブなユーザーはリクエストを見ることができません。\n\nユーザーが戻ったときにリクエストボタンが表示されます。後で、利用可能になったときにその名前の下のリクエストボタンをクリックして再送信できます。",
     "accessRequestedTitle": "分析アクセスリクエスト",
@@ -3164,8 +2901,6 @@
     "accessDesc": "コースを公開して世界に向けることも、プライベートで安全に保つこともできます。",
     "createGroupChatDesc": "アクティビティセッションは開始と終了がありますが、グループチャットは日常的なコミュニケーションのために開いたままにします。",
     "deleteDesc": "コースを削除できるのは管理者のみです。これはすべてのユーザーを削除し、コース内のすべての選択されたチャットを削除する破壊的な操作です。注意して進めてください。",
-    "noCourseFound": "おっと、このコースにはプランが必要です！\n\nコースプランはトピックと会話活動のシーケンスです。",
-    "additionalParticipants": "+ {num} その他",
     "whatNow": "次はどうする？",
     "chooseNextActivity": "次の活動を選択してください！",
     "letsGo": "行きましょう",
@@ -3178,13 +2913,11 @@
     "waitNotDone": "待って、私はまだ終わっていません！",
     "waitingForOthersToFinish": "他の人が終わるのを待っています...",
     "generatingSummary": "チャットを分析して結果を生成しています",
-    "findCourse": "コースを見つける",
     "pingParticipantsNotification": "{user}が{room}のアクティビティセッションに参加するユーザーを探しています",
     "course": "コース",
     "courses": "コース",
     "goToCourse": "コースへ移動：{course}",
     "activityComplete": "このアクティビティは完了しました。アクティビティの概要は下に表示されるはずです。",
-    "startNewSession": "新しいセッションを開始",
     "joinOpenSession": "オープンセッションに参加",
     "activityNotFound": "アクティビティが見つかりません",
     "myActivities": "私のアクティビティ",
@@ -3375,14 +3108,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@createGroup": {
         "type": "String",
         "placeholders": {}
@@ -3395,18 +3120,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -3416,10 +3129,6 @@
         "placeholders": {}
     },
     "@customEmojisAndStickersBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3570,19 +3279,7 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3591,10 +3288,6 @@
         "placeholders": {}
     },
     "@hidePresences": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@newSpaceDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3635,10 +3328,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3722,31 +3411,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3802,23 +3471,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3858,28 +3515,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -3897,14 +3532,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4097,22 +3724,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4168,10 +3779,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4181,10 +3788,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4260,27 +3863,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4598,10 +4185,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4611,10 +4194,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4702,14 +4281,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4726,10 +4297,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4742,15 +4309,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4902,14 +4461,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4923,14 +4474,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6153,10 +5696,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6197,10 +5736,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6273,10 +5808,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6546,47 +6077,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6606,19 +6097,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6682,10 +6161,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6726,14 +6201,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6745,14 +6212,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6790,10 +6249,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6810,27 +6265,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6954,10 +6393,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6967,10 +6402,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6987,14 +6418,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7134,18 +6557,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7194,10 +6605,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7207,18 +6614,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7261,23 +6656,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7301,10 +6684,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7312,14 +6691,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7424,18 +6795,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7488,10 +6847,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7518,10 +6873,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7702,7 +7053,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "明日、アクティビティの更新情報を確認してください。",
-    "activityDropdownDesc": "これが終わったら、下のボタンをクリックしてください",
     "languageMismatchTitle": "言語の不一致",
     "languageMismatchDesc": "あなたのターゲット言語はこのアクティビティの言語と一致しません。ターゲット言語を更新しますか？",
     "reportWordIssueTooltip": "単語情報の問題を報告",
@@ -7715,10 +7065,6 @@
     "selectAll": "すべて選択",
     "deselectAll": "すべて解除",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7767,17 +7113,11 @@
         "placeholders": {}
     },
     "startOwn": "自分のものを始める",
-    "joinCourseDesc": "各コースには、8〜10のシーケンスされたトピックと、さまざまなタスクベースの言語学習活動があります。",
     "newMessageInPangeaChat": "📩 Pangeaチャットに新しいメッセージ",
     "shareCourse": "コースを共有",
     "addCourse": "コースを追加",
-    "joinPublicCourse": "公開コースに参加",
     "vocabLevelsDesc": "これが語彙をレベルアップしたら表示される場所です！",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7790,10 +7130,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7812,7 +7148,6 @@
     "emojiView": "絵文字ビュー",
     "feedbackDialogDesc": "私も間違いを犯します！私を改善するために何かありますか？",
     "contactHasBeenInvitedToTheCourse": "連絡先がコースに招待されました",
-    "activityStatsButtonTooltip": "アクティビティ情報",
     "allow": "許可",
     "deny": "拒否",
     "enabledRenewal": "サブスクリプション更新を有効にする",
@@ -8080,10 +7415,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9139,16 +8470,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "次のトピックをアンロックするためのアクティビティ",
-    "activitiesToUnlockTopicDesc": "次のコーストピックをアンロックするためのアクティビティの数を設定します",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "正しい語彙定義の練習",
     "constructUseIncLMDesc": "誤った語彙定義の練習",
     "constructUseCorLADesc": "正しい語彙音声の練習",
@@ -9156,7 +8477,6 @@
     "constructUseBonus": "語彙練習中のボーナス",
     "practiceVocab": "語彙を練習する",
     "selectMeaning": "意味を選択する",
-    "selectAudio": "一致する音声を選択する",
     "anotherRound": "もう一回",
     "activitySettingsOverrideWarning": "アクティビティプランによって決定された言語と言語レベル",
     "voice": "声",
@@ -9188,10 +8508,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9209,12 +8525,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "ダウンロードが開始されました",
     "webDownloadPermissionMessage": "ブラウザがダウンロードをブロックしている場合は、このサイトのダウンロードを有効にしてください。",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9309,11 +8620,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "何かがうまくいかなかったため、私たちは修正作業に取り組んでいます。後で再度確認してください。",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "ライティングアシスタントを有効にする",
     "autoIGCToolDescription": "送信されたメッセージをターゲット言語に修正するために、Pangea Chatツールを自動的に実行します。",
     "@autoIGCToolName": {
@@ -9369,24 +8675,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "文法",
-    "spanTypeWordChoice": "単語の選択",
     "spanTypeSpelling": "スペル",
     "spanTypePunctuation": "句読点",
     "spanTypeStyle": "スタイル",
     "spanTypeFluency": "流暢さ",
     "spanTypeAccents": "アクセント",
     "spanTypeCapitalization": "大文字化",
-    "spanTypeCorrection": "修正",
     "spanFeedbackTitle": "修正の問題を報告する",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9411,10 +8706,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9427,13 +8718,7 @@
     "longPressToRecordVoiceMessage": "長押しして音声メッセージを録音します。",
     "pause": "一時停止",
     "resume": "再開",
-    "newSubSpace": "新しいサブスペース",
-    "moveToDifferentSpace": "別のスペースに移動",
-    "removeFromSpaceDescription": "チャットはスペースから削除されますが、チャットリストには引き続き表示されます。",
     "countChats": "{chats} チャット",
-    "spaceMemberOf": "{spaces} のスペースメンバー",
-    "spaceMemberOfCanKnock": "{spaces} のスペースメンバーはノックできます",
-    "donate": "寄付する",
     "startedAPoll": "{username} が投票を開始しました。",
     "poll": "投票",
     "startPoll": "投票を開始",
@@ -9457,23 +8742,15 @@
     "newStickerPack": "新しいステッカーパック",
     "stickerPackName": "ステッカーパック名",
     "attribution": "帰属",
-    "skipChatBackup": "チャットバックアップをスキップ",
-    "skipChatBackupWarning": "本当によろしいですか？チャットバックアップを有効にしないと、デバイスを切り替えた際にメッセージにアクセスできなくなる可能性があります。",
-    "loadingMessages": "メッセージを読み込み中",
-    "setupChatBackup": "チャットバックアップを設定",
     "noMoreResultsFound": "これ以上の結果は見つかりません",
     "chatSearchedUntil": "{time}までチャットを検索",
     "federationBaseUrl": "連合ベースURL",
     "clientWellKnownInformation": "クライアントの一般情報:",
     "baseUrl": "ベースURL",
     "identityServer": "アイデンティティサーバー:",
-    "versionWithNumber": "バージョン: {version}",
     "logs": "ログ",
-    "advancedConfigs": "高度な設定",
     "advancedConfigurations": "高度な構成",
-    "signInWithLabel": "サインインするには:",
     "selectAllWords": "音声で聞こえるすべての単語を選択してください",
-    "joinCourseForActivities": "アクティビティを試すためにコースに参加してください。",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9510,18 +8787,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9529,26 +8794,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9654,22 +8899,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9698,19 +8927,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9718,15 +8935,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9927,11 +9136,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "クラスにいますか？ここに参加コードを入力してください。",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "オーディオメッセージを自動ハイライト",
     "selectAudioMessagesOnPlayDescription": "再生時にオーディオメッセージを自動的にハイライトします",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9975,18 +9179,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "このコースには、{input} アクティビティ未満のトピックがあります。{minValue} 以下の数を入力してください。",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "ここをクリックして再度サインインしてください。",
     "@clickToLogin": {
@@ -10403,17 +9595,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "興奮して腕を上げた漫画風の黄色いクマ。",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "学ぶための単語を選択してください",
     "requireAnalyticsAccessTitle": "参加するには分析アクセスが必要です",
     "requireAnalyticsAccessDesc": "参加者はこのコースに参加するために学習分析へのアクセスを許可する必要があります",
     "analyticsAccessNoticeTitle": "分析アクセスが必要です",
     "analyticsAccessNoticeDesc": "このコースに参加することで、管理者にあなたの学習分析へのアクセスを許可することに同意します。",
-    "skipOnboardingClassCodeDesc": "独自に学習していますか？心配しないでください、あなたは:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10431,10 +9617,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10463,7 +9645,6 @@
     "pickCefrLevelTeacherStepTitle": "どのレベルを教えていますか？",
     "pickCefrLevelStudentStepTitle": "あなたはどのレベルですか？",
     "customCourseStepTitle": "カスタムコースを取得するためにこのフォームに記入してください",
-    "aboutYourClass": "あなたのクラスについて",
     "courseCodeStepErrorMessage": "コードを確認して再試行してください",
     "institution": "機関",
     "courseGoals": "コースの目標",
@@ -10506,10 +9687,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10626,12 +9803,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "パングリアチャットロゴ",
     "introChatDetails": "こんにちは！コース参加者の皆さんに自己紹介をし、友達を見つけ、活動の外でチャットしましょう。",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10675,11 +9847,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "アクティビティアクション",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "発音ツール",
     "audioTranscription": "AI音声転写",
     "visualLearnerSupport": "視覚学習者サポート",
@@ -10720,7 +9887,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "このアクティビティをプレイするには、これを含むコースに参加してください。",
     "resizeCoursePanel": "コースパネルのサイズを変更",
     "undo": "元に戻す",
     "unlock": "ロック解除",
@@ -10734,7 +9900,6 @@
     "addCourseBrowsePublic": "公開コースをブラウズ",
     "browsePublicCourses": "公開コースをブラウズ",
     "editProfile": "プロフィールを編集",
-    "numObjectives": "{count} の目標",
     "mapSearchHint": "アクティビティを検索",
     "mapSearchNoResults": "表示中に一致するものはありません",
     "mapFilterAllLanguages": "すべての言語",
@@ -10743,7 +9908,6 @@
     "mapFilterCompleted": "完了",
     "mapFilterReset": "リセット",
     "activityTypeConversation": "会話",
-    "lockedMissionRequirement": "前のミッションを完了してロックを解除してください",
     "playAgain": "再度プレイ",
     "reviewActivity": "レビュー",
     "mapEmptyInView": "あなたのレベルまたは言語では何もありません。フィルターを広げるか、ズームアウトしてください。",
@@ -10758,14 +9922,9 @@
     "scrollToBottom": "下にスクロール",
     "courseImage": "コース画像",
     "avatarPreview": "アバタープレビュー",
-    "activityPhoto": "アクティビティ写真",
     "emotePreview": "エモートプレビュー: {name}",
     "activityLabel": "アクティビティ: {title}",
     "resetMapView": "マップビューをリセット",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10818,14 +9977,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10855,10 +10006,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10915,10 +10062,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_ka.arb
+++ b/lib/l10n/intl_ka.arb
@@ -128,15 +128,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "თქვენი ჩატის სარეზერვო საშუალება კონფიგურირებული იქნა.",
-    "@yourChatBackupHasBeenSetUp": {},
     "channelCorruptedDecryptError": "დაშიფვრა დაზიანდა",
     "@channelCorruptedDecryptError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "თქვენი შეტყობინებები დაცულია აღდგენის გასაღებით. არ დაკარგოთ ის.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -333,11 +326,6 @@
                 "type": "String"
             }
         }
-    },
-    "areGuestsAllowedToJoin": "შეუძლიათ თუ არა სტუმარ მომხმარებლებს გაწევრიანება",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
     },
     "askVerificationRequest": "მიიღებთ {username} დადასტურების მოთხოვნას?",
     "@askVerificationRequest": {
@@ -569,11 +557,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "კონტაქტი მოწვეული იქნა ჯგუფში",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "copiedToClipboard": "კოპირებულია ბუფერში",
     "@copiedToClipboard": {
         "type": "String",
@@ -611,11 +594,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "ახალი სივრცე",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "ახლა აქტიურია",
     "@currentlyActive": {
@@ -677,8 +655,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "globalChatId": "გლობალური ჩატის ID",
-    "@globalChatId": {},
     "repeatPassword": "გაიმეორეთ პაროლი",
     "@repeatPassword": {},
     "notAnImage": "ფაილი არაა სურათი.",
@@ -794,11 +770,8 @@
     "spaces": "სივრცეები",
     "commandHint_markasdm": "მარკირება როგორც პირდაპირი შეტყობინების ოთახი მითითებული მატრიქსის ID-სთვის",
     "checkList": "შეამოწმეთ სია",
-    "countInvited": "{count} მოწვეული",
     "emoteKeyboardNoRecents": "ბოლოს გამოყენებული ემოტები აქ გამოჩნდება...",
     "emotePacks": "ემოტების პაკეტები ოთახისთვის",
-    "accessAndVisibility": "წვდომა და ხილვადობა",
-    "accessAndVisibilityDescription": "ვინ არის დაშვებული ამ ჩატის შეუერთებლად და როგორ შეიძლება იპოვოს ეს ჩატი.",
     "calls": "ზარები",
     "customEmojisAndStickers": "მოწოდებული ემოტები და სტიკერები",
     "customEmojisAndStickersBody": "დაამატეთ ან გაუზიარეთ მოწოდებული ემოტები ან სტიკერები, რომლებიც შეიძლება გამოყენებულ იქნას ნებისმიერ ჩატში.",
@@ -806,7 +779,6 @@
     "emptyChat": "ცარიელი ჩატი",
     "enableEmotesGlobally": "ჩართეთ ემოტების პაკეტი გლობალურად",
     "enableEncryption": "ჩართეთ დაშიფვრა",
-    "enableEncryptionWarning": "თქვენ აღარ შეძლებთ დაშიფვრის გამორთვას. დარწმუნებული ხართ?",
     "encrypted": "დაშიფვრული",
     "encryption": "დაშიფვრა",
     "encryptionNotEnabled": "დაშიფვრა არ არის ჩართული",
@@ -814,7 +786,6 @@
     "enterAnEmailAddress": "შეიყვანეთ ელფოსტის მისამართი",
     "homeserver": "მთავარი სერვერი",
     "errorObtainingLocation": "შეცდომა მდებარეობის მიღებაში: {error}",
-    "everythingReady": "ყველაფერი მზადაა!",
     "extremeOffensive": "მძიმე შეურაცხყოფა",
     "fileName": "ფაილის სახელი",
     "fluffychat": "ფლუფი ჩატი",
@@ -823,9 +794,7 @@
     "fromJoining": "შესერთებისგან",
     "fromTheInvitation": "პატიჟიდან",
     "group": "ჯგუფი",
-    "chatDescription": "ჩატის აღწერა",
     "chatDescriptionHasBeenChanged": "ჩატის აღწერა შეიცვალა",
-    "groupIsPublic": "ჯგუფი საჯარია",
     "groups": "ჯგუფები",
     "groupWith": "ჯგუფი {displayname} -თან",
     "guestsAreForbidden": "მოწვევები აკრძალულია",
@@ -847,7 +816,6 @@
     "incorrectPassphraseOrKey": "არასწორი პაროლი ან აღდგენის გასაღები",
     "inoffensive": "არასაშიში",
     "inviteContact": "პიროვნების მოწვევა",
-    "inviteContactToGroup": "მოწვევა {groupName}-ში",
     "noChatDescriptionYet": "ჩატის აღწერა ჯერ არ შექმნილა.",
     "tryAgain": "მეორედ სცადეთ",
     "invalidServerName": "არასწორი სერვერის სახელი",
@@ -868,7 +836,6 @@
     "leave": "გადადი",
     "leftTheChat": "გადადგა საუბარი",
     "lightTheme": "მარტივი",
-    "loadCountMoreParticipants": "ატვირთეთ კიდევ {count} მონაწილე",
     "dehydrate": "ექსპორტი სესია და წაშალეთ მოწყობილობა",
     "dehydrateWarning": "ეს მოქმედება ვერ მოხერხდება უკან დაბრუნება. დარწმუნდით, რომ უსაფრთხოდ ინახავთ სარეზერვო ფაილს.",
     "hydrate": "აღადგინე სარეზერვო ფაილიდან",
@@ -877,7 +844,6 @@
     "locationDisabledNotice": "მდებარეობის სერვისები გამორთულია. გთხოვთ ჩართოთ მათ, რათა შეძლოთ თქვენი მდებარეობის გაზიარება.",
     "locationPermissionDeniedNotice": "მდებარეობის ნებართვა უარყოფილია. გთხოვთ მიაწოდოთ ნებართვა, რათა შეძლოთ თქვენი მდებარეობის გაზიარება.",
     "login": "შესვლა",
-    "logInTo": "შესვლა {homeserver}-ზე",
     "logout": "გამოსვლა",
     "mention": "შესანიშნავი მოხსენება",
     "messages": "შეტყობინებები",
@@ -892,8 +858,6 @@
     "no": "არა",
     "noConnectionToTheServer": "სერვერთან კავშირი არ არის",
     "noEmotesFound": "ემოტები არ მოიძებნა. 😕",
-    "noEncryptionForPublicRooms": "შეგიძლიათ გააქტიუროთ დაშიფვრა მხოლოდ მაშინ, როდესაც ოთახი აღარ არის საჯარო.",
-    "noGoogleServicesWarning": "Firebase Cloud Messaging-ი თქვენს მოწყობილობაზე არ ჩანს ხელმისაწვდომი. შეტყობინებების მიღებისათვის გირჩევთ დააინსტალიროთ ntfy. ntfy ან სხვა ერთიანი შეტყობინების მიმწოდებლის გამოყენებით შეგიძლიათ მიიღოთ შეტყობინებები მონაცემების უსაფრთხო გზით. შეგიძლიათ ჩამოტვირთოთ ntfy PlayStore-დან ან F-Droid-დან.",
     "noMatrixServer": "{server1} არ არის მეტრიქს სერვერი, გამოიყენეთ {server2} ნაცვლად?",
     "shareInviteLink": "გაუზიარე მოწვევის ბმული",
     "scanQrCode": "სკანერით QR კოდი",
@@ -915,12 +879,10 @@
     "openCamera": "კამერის გახსნა",
     "openVideoCamera": "ვიდეოსთვის კამერის გახსნა",
     "oneClientLoggedOut": "თქვენს ერთ-ერთ მომხმარებელს გამოუთვლია სისტემამ",
-    "addAccount": "ანგარიშის დამატება",
     "editBundlesForAccount": "ბანდლების რედაქტირება ამ ანგარიშისთვის",
     "addToBundle": "დამატება ბანდლში",
     "removeFromBundle": "ამ ბანდლიდან ამოღება",
     "bundleName": "ბანდლის სახელი",
-    "enableMultiAccounts": "(BETA) მრავალანგარიშის ჩართვა ამ მოწყობილობაზე",
     "openInMaps": "გახსნა რუკებში",
     "link": "ლინკი",
     "serverRequiresEmail": "ეს სერვერი საჭიროებს თქვენი ელფოსტის მისამართის დადასტურებას რეგისტრაციისთვის.",
@@ -932,7 +894,6 @@
     "passwordHasBeenChanged": "პაროლი შეიცვალა",
     "overview": "საგამოფენო",
     "passwordRecoverySettings": "პაროლის აღდგენის პარამეტრები",
-    "passwordRecovery": "პაროლის აღდგენა",
     "people": "ადამიანები",
     "pickImage": "აირჩიეთ სურათი",
     "pin": "პინ",
@@ -941,7 +902,6 @@
     "pleaseChooseAPasscode": "გთხოვთ, აირჩიეთ პაროლის კოდი",
     "pleaseClickOnLink": "გთხოვთ, დააჭირეთ ბმულს ელფოსტაში და შემდეგ განაგრძეთ.",
     "pleaseEnter4Digits": "გთხოვთ, შეიყვანეთ 4 ციფრი ან დატოვეთ ცარიელი აპლიკაციის გასაღების გამორთვისთვის.",
-    "pleaseEnterRecoveryKey": "გთხოვთ, შეიყვანეთ თქვენი აღდგენის გასაღები:",
     "pleaseEnterYourPassword": "გთხოვთ, შეიყვანოთ თქვენი პაროლი",
     "pleaseEnterYourPin": "გთხოვთ, შეიყვანოთ თქვენი პინკოდი",
     "pleaseEnterYourUsername": "გთხოვთ, შეიყვანოთ თქვენი მომხმარებლის სახელი",
@@ -961,7 +921,6 @@
     "rejectedTheInvitation": "{username} უარყო მოწვევა",
     "removeAllOtherDevices": "წაშალეთ ყველა სხვა მოწყობილობა",
     "removedBy": "წაშლილია {username} მიერ",
-    "removeDevice": "წაშალეთ მოწყობილობა",
     "unbanFromChat": "გამოდით ჩათიდან",
     "removeYourAvatar": "წაშალეთ თქვენი ავატარი",
     "replaceRoomWithNewerVersion": "გააახლეთ ოთახი ახალი ვერსიით",
@@ -973,8 +932,6 @@
     "saveFile": "ფაილის შენახვა",
     "search": "ძებნა",
     "security": "უსაფრთხოება",
-    "recoveryKey": "აღდგენის გასაღები",
-    "recoveryKeyLost": "აღდგენის გასაღები დაკარგულია?",
     "send": "გაგზავნა",
     "sendAMessage": "შეტყობინების გაგზავნა",
     "sendAsText": "გაგზავნეთ ტექსტის სახით",
@@ -993,7 +950,6 @@
     "separateChatTypes": "განსხვავებული პირდაპირი ჩატები და ჯგუფები",
     "setAsCanonicalAlias": "დააყენეთ როგორც მთავარი ალის",
     "setChatDescription": "დააყენეთ ჩატის აღწერა",
-    "setPermissionsLevel": "დააყენეთ დაშვების დონე",
     "setStatus": "დააყენეთ სტატუსი",
     "settings": "პარამეტრები",
     "share": "გააზიარე",
@@ -1003,8 +959,6 @@
     "presencesToggle": "აჩვენე სტატუსის შეტყობინებები სხვა მომხმარებლებისგან",
     "skip": "გადახვევა",
     "sourceCode": "კოდის წყარო",
-    "spaceIsPublic": "მდებარეობა საჯარია",
-    "spaceName": "მდებარეობის სახელი",
     "startedACall": "{senderName} დაიწყო ზარი",
     "status": "სტატუსი",
     "statusExampleMessage": "როგორ ხარ დღეს?",
@@ -1016,7 +970,6 @@
     "theyMatch": "მათ ემთხვევა",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "ძალიან ბევრი მოთხოვნა. გთხოვთ, სცადეთ მოგვიანებით!",
-    "transferFromAnotherDevice": "გადაცემა სხვა მოწყობილობიდან",
     "tryToSendAgain": "მეორედ სცადეთ გაგზავნა",
     "unavailable": "ხელმისაწვდომი არაა",
     "unbannedUser": "{username} გაათავისუფლა {targetName}",
@@ -1026,7 +979,6 @@
     "unknownEvent": "უცნობი მოვლენა '{type}'",
     "unmuteChat": "ჩუმის მოხსნა",
     "unpin": "გაუქმება",
-    "unreadChats": "{unreadCount, plural, =1{1 წაკითხული საუბარი} other{{unreadCount} წაკითხული საუბარი}}",
     "userAndOthersAreTyping": "{username} და {count} სხვა აკრეფენ…",
     "userAndUserAreTyping": "{username} და {username2} აკრეფენ…",
     "userIsTyping": "{username} აკრეფენ…",
@@ -1039,8 +991,6 @@
     "verifyStart": "დაწყება ვერიფიკაცია",
     "verifySuccess": "თქვენ წარმატებით დაადასტურეთ!",
     "verifyTitle": "სხვა ანგარიშის ვერიფიკაცია",
-    "videoCall": "ვიდეო ზარი",
-    "visibilityOfTheChatHistory": "ჩატის ისტორიის ხილვადობა",
     "visibleForAllParticipants": "ხილვადია ყველა მონაწილისთვის",
     "visibleForEveryone": "ხილვადია ყველასთვის",
     "voiceMessage": "ხმოვანი შეტყობინება",
@@ -1050,10 +1000,7 @@
     "wallpaper": "სათაური:",
     "warning": "გაფრთხილება!",
     "weSentYouAnEmail": "ჩვენ გაგზავნეთ ელფოსტა",
-    "whoCanPerformWhichAction": "ვინ შეუძლია განახორციელოს რომელიმე მოქმედება",
-    "whoIsAllowedToJoinThisGroup": "ვინ არის დაშვებული შეუერთდეს ამ ჯგუფს",
     "whyDoYouWantToReportThis": "რატომ გსურთ ამის შეტყობინება?",
-    "wipeChatBackup": "წაშალეთ თქვენი ჩატის სარეზერვო ასლი ახალი აღდგენის გასაღების შესაქმნელად?",
     "withTheseAddressesRecoveryDescription": "ამ მისამართებით შეგიძლიათ აღადგინოთ თქვენი პაროლი.",
     "writeAMessage": "დაწერეთ შეტყობინება…",
     "yes": "დიახ",
@@ -1066,9 +1013,7 @@
     "messageType": "შეტყობინების ტიპი",
     "sender": "გაგზავნი",
     "openGallery": "გაფართოვება გალერეა",
-    "removeFromSpace": "ამოიღეთ სივრციდან",
     "start": "დაწყება",
-    "pleaseEnterRecoveryKeyDescription": "შეიყვანეთ თქვენი აღდგენის გასაღები, რათა გახსნათ თქვენი ძველი შეტყობინებები, რომელიც გენერირებულია წინასწარ სესიაში. თქვენი აღდგენის გასაღები არ არის თქვენი პაროლი.",
     "publish": "გამოქვეყნება",
     "openChat": "ჩატი გახსნა",
     "markAsRead": "წაკითხულად მონიშვნა",
@@ -1079,12 +1024,9 @@
     "confirmEventUnpin": "დარწმუნებული ხართ, რომ გსურთ სამუდამოდ მოხსნათ ღონისძიების პინინგი?",
     "emojis": "ემოჯიები",
     "placeCall": "ზარის განხორციელება",
-    "voiceCall": "ხმოვანი ზარი",
     "unsupportedAndroidVersion": "მხარდაჭერა არ აქვს Android-ის ვერსიას",
     "unsupportedAndroidVersionLong": "ეს ფუნქცია საჭიროებს ახალი Android ვერსიას. გთხოვთ, შეამოწმოთ განახლებები ან Lineage OS-ის მხარდაჭერა.",
-    "videoCallsBetaWarning": "გთხოვთ, გაითვალისწინოთ, რომ ვიდეოზარები ამჟამად ბეტა ვერსიაშია. ისინი შესაძლოა არ მუშაობდეს როგორც უნდა ან საერთოდ არ იმუშაონ ყველა პლატფორმაზე.",
     "experimentalVideoCalls": "გამოყენებითი ვიდეოზარები",
-    "emailOrUsername": "ელფოსტა ან მომხმარებლის სახელი",
     "addWidget": "პლაგინის დამატება",
     "widgetVideo": "ვიდეო",
     "widgetEtherpad": "ტექსტური შენიშვნა",
@@ -1106,35 +1048,19 @@
     "youKickedAndBanned": "👥 თქვენ გამოგაგდეთ და ბლოკეთ {user}",
     "youUnbannedUser": "თქვენ გაუქმეთ ბლოკი {user}",
     "hasKnocked": "🚪 {user} დარეკა",
-    "usersMustKnock": "მომხმარებლებს უნდა დარეკონ",
-    "noOneCanJoin": "ვინც არ უნდა შემოუერთდეს",
     "knock": "დარეკვა",
     "users": "მომხმარებლები",
-    "unlockOldMessages": "გახსენი ძველი შეტყობინებები",
-    "storeInSecureStorageDescription": "შეინახეთ აღდგენის გასაღები ამ მოწყობილობის უსაფრთხო შენახვაში.",
-    "saveKeyManuallyDescription": "შეინახეთ ეს გასაღები ხელით სისტემის გაზიარების დიალოგის ან კლიპბორდის გამოყენებით.",
-    "storeInAndroidKeystore": "შეინახეთ Android KeyStore-ში",
-    "storeInAppleKeyChain": "შეინახეთ Apple KeyChain-ში",
-    "storeSecurlyOnThisDevice": "შეინახეთ უსაფრთხოდ ამ მოწყობილობაზე",
     "countFiles": "{count} ფაილი",
     "user": "მომხმარებელი",
     "custom": "შექმნილი",
-    "foregroundServiceRunning": "ეს შეტყობინება გამოჩნდება, როდესაც ფონი სერვისი მუშაობს.",
-    "screenSharingTitle": "ეკრანის გაზიარება",
-    "screenSharingDetail": "თქვენ გაზიარებთ თქვენს ეკრანს FuffyChat-ში",
     "whyIsThisMessageEncrypted": "რატომ არის ეს შეტყობინება გაუგებარი?",
     "noKeyForThisMessage": "ეს შეიძლება მოხდეს, თუ შეტყობინება გაგზავნილია თქვენი ანგარიშის შესვლის წინ ამ მოწყობილობაზე.\n\nასევე შესაძლებელია, რომ გამგზავნმა დაბლოკა თქვენი მოწყობილობა ან რამე მოხდა ინტერნეტ კავშირის დროს.\n\nშეგიძლიათ წაიკითხოთ შეტყობინება სხვა სესიაში? მაშინ შეგიძლიათ გადმოიტანოთ შეტყობინება მასიდან! წადით პარამეტრებზე > მოწყობილობები და დარწმუნდით, რომ თქვენი მოწყობილობები ერთმანეთს დაუდასტურეს. როდესაც გახსნით ოთახს შემდეგი ჯერზე და ორივე სესია იქნება წინაპირობაში, გასაღებები ავტომატურად გადმოიცემა.\n\nარ გსურთ დაკარგოთ გასაღებები გამოსვლის ან მოწყობილობების შეცვლის დროს? დარწმუნდით, რომ ჩართეთ ჩატის სარეზერვო ასლი პარამეტრებში.",
     "newGroup": "ახალი ჯგუფი",
     "newSpace": "ახალი სივრცე",
-    "enterSpace": "შეიყვანეთ სივრცე",
     "allSpaces": "ყველა სივრცე",
     "hidePresences": "დაფარეთ სტატუსის სია?",
     "doNotShowAgain": "მეორედ არ აჩვენოთ",
     "wasDirectChatDisplayName": "ცარიელი ჩატი (იყო {oldDisplayName})",
-    "newSpaceDescription": "Spaces გთავაზობთ თქვენს ჩეთებს ერთიანად დააშენოთ პირადი ან საჯარო საზოგადოებები.",
-    "encryptThisChat": "შეინახეთ ეს ჩათი კოდირებით",
-    "disableEncryptionWarning": "უსაფრთხოების მიზნით, ვერ შეძლებთ კოდირების გამორთვას ჩათში, სადაც ის ადრე ჩართული იყო.",
-    "sorryThatsNotPossible": "უკაცრავად... ეს შეუძლებელია",
     "deviceKeys": "მოწყობილობის გასაღებები:",
     "reopenChat": "ჩათის გადახსნა",
     "noBackupWarning": "გაფრთხილება! ჩათის სარეზერვო ასლების გამორთვის გარეშე, დაკარგავთ დაშიფრულ შეტყობინებებზე წვდომას. რეკომენდებულია სარეზერვო ასლის შექმნა პირველ რიგში, სანამ გამოვიდეთ სისტემიდან.",
@@ -1147,7 +1073,6 @@
     "openLinkInBrowser": "გახსენი ბმული ბრაუზერში",
     "reportErrorDescription": "😞 უაი, რაღაც შეცდა. თუ გსურთ, შეგიძლიათ ამ ბაგის შეტყობინება დეველოპერებს.",
     "report": "შეტყობინება",
-    "setTheme": "პარამეტრის დაყენება:",
     "setColorTheme": "ფერის თემის დაყენება:",
     "invite": "პატიჟება",
     "inviteGroupChat": "📨 ჯგუფის ჩატი მოწვევა",
@@ -1166,12 +1091,8 @@
     "yourGlobalUserIdIs": "თქვენი გლობალური მომხმარებლის ID არის: ",
     "noUsersFoundWithQuery": "სამწუხაროდ, ვერ მოიძებნა მომხმარებელი \"{query}\"-ით. გთხოვთ, გადაამოწმოთ შეცდომა.",
     "knocking": "საკაკუნო",
-    "chatCanBeDiscoveredViaSearchOnServer": "ჩათი შეიძლება იპოვოთ სერვერზე ძიებით {server}",
-    "searchChatsRooms": "ძებნა #ჩატებს, @მომხმარებლებს...",
     "nothingFound": "არაფერი მოიძებნა...",
     "groupName": "ჯგუფის სახელი",
-    "createGroupAndInviteUsers": "შექმენით ჯგუფი და მიიწვიეთ მომხმარებლები",
-    "groupCanBeFoundViaSearch": "ჯგუფი შეიძლება იპოვოთ ძიებით",
     "wrongRecoveryKey": "უკაცრავად... ეს არ ჩანს სწორი აღდგენის გასაღები.",
     "startConversation": "დაუწყეთ საუბარი",
     "commandHint_sendraw": "გაგზავნეთ ნედლი json",
@@ -1185,11 +1106,8 @@
     "pleaseChooseAStrongPassword": "გთხოვთ, აირჩიეთ ძლიერი პაროლი",
     "passwordsDoNotMatch": "პაროლები არ ემთხვევა",
     "passwordIsWrong": "თქვენი შეყვანილი პაროლი არასწორია",
-    "publicChatAddresses": "საზოგადოების ჩატის მისამართები",
-    "createNewAddress": "ახალი მისამართის შექმნა",
     "joinSpace": "შეერთება სივრცეში",
     "publicSpaces": "საზოგადოების სივრცეები",
-    "addChatOrSubSpace": "ჩატის ან ქვესივრცის დამატება",
     "subspace": "ქვესივრცე",
     "decline": "უარყოფა",
     "thisDevice": "ეს მოწყობილობა:",
@@ -1198,15 +1116,11 @@
     "searchMore": "მეტი ძებნა...",
     "gallery": "გალერეა",
     "files": "ფაილები",
-    "sessionLostBody": "თქვენი სესია დაკარგულია. გთხოვთ, აცნობოთ ამ შეცდომის შესახებ დეველოპერებს {url}-ზე. შეცდომის შეტყობინება არის: {error}",
-    "restoreSessionBody": "აპლიკაცია ახლა ცდილობს აღადგინოს თქვენი სესია სარეზერვო კოპიიდან. გთხოვთ, აცნობოთ ამ შეცდომის შესახებ დეველოპერებს {url}-ზე. შეცდომის შეტყობინება არის: {error}",
     "sendReadReceipts": "გაგზავნეთ წაკითხვის დადასტურებები",
     "sendTypingNotificationsDescription": "სხვა მონაწილეები ჩატში ხედავენ, როდესაც თქვენ აკრავთ ახალ შეტყობინებას.",
     "sendReadReceiptsDescription": "სხვა მონაწილეები ჩატში ხედავენ, როდესაც თქვენ წაიკითხეთ შეტყობინება.",
     "formattedMessages": "ფორმატირებული შეტყობინებები",
     "formattedMessagesDescription": "აჩვენეთ მდიდარი შეტყობინების შინაარსი, როგორიცაა გამკაცრებული ტექსტი, მარკდაუნის გამოყენებით.",
-    "verifyOtherUser": "🔐 სხვა მომხმარებლის გადამოწმება",
-    "verifyOtherUserDescription": "თუ გადამოწმებთ სხვა მომხმარებელს, შეგიძლიათ დარწმუნდეთ, რომ ნამდვილად იცით, ვისთან გწერთ. 💪\n\nგადამოწმების დაწყებისას, თქვენ და სხვა მომხმარებელი იხილავთ აპლიკაციაში პოპაპს. იქ თქვენ იხილავთ ემოჯებს ან ნომრებს, რომლებსაც უნდა შეადაროთ ერთმანეთს.\n\nსაუკეთესო გზაა შეხვედრა ან ვიდეო ზარის დაწყება. 👩‍💻",
     "verifyOtherDevice": "🔐 სხვა მოწყობილობის გადამოწმება",
     "verifyOtherDeviceDescription": "როდესაც გადამოწმებთ სხვა მოწყობილობას, ეს მოწყობილობები შეძლებენ გასაღებების გაცვლას, რაც ზრდის თქვენი მთლიან უსაფრთხოებას. 💪 როდესაც დაიწყებთ გადამოწმებას, პოპაპი გამოჩნდება ორივე მოწყობილობაზე. იქ თქვენ იხილავთ ემოჯებს ან ნომრებს, რომლებსაც უნდა შეადაროთ ერთმანეთს. საუკეთესოა ორივე მოწყობილობა ხელთ გქონდეთ გადამოწმების დაწყებამდე. 🤳",
     "acceptedKeyVerification": "{sender} მიიღო გასაღების გადამოწმება",
@@ -1242,10 +1156,6 @@
     "updateInstalled": "🎉 განახლება {version} დამონტაჟებულია!",
     "changelog": "ცვლილებები",
     "sendCanceled": "გაგზავნა გაუქმდა",
-    "loginWithMatrixId": "შესვლა Matrix-ID-ით",
-    "discoverHomeservers": "მოძებნეთ სახლის სერვერები",
-    "whatIsAHomeserver": "რა არის სახლის სერვერი?",
-    "homeserverDescription": "თქვენი ყველა მონაცემი ინახება სახლის სერვერზე, როგორც ელფოსტის მიმწოდებელი. შეგიძლიათ აირჩიოთ რომელ სახლის სერვერს გამოიყენებთ, ხოლო თქვენ შეგიძლიათ კომუნიკაცია გქონდეთ ყველასთან. მეტი ინფორმაციისთვის იხილეთ https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "საიმედო სახლის სერვერი არ ჩანს. არასწორი URL?",
     "calculatingFileSize": "ფაილის ზომის გამოთვლა...",
     "prepareSendingAttachment": "მზადება მიმაგრებული ფაილის გაგზავნისთვის...",
@@ -1257,11 +1167,9 @@
     "oneOfYourDevicesIsNotVerified": "თქვენს ერთ-ერთ მოწყობილობას ვერ დაუდასტურეს",
     "noticeChatBackupDeviceVerification": "შენიშვნა: როდესაც ყველა თქვენი მოწყობილობა ჩართეთ ჩატის სარეზერვო ასლში, ისინი ავტომატურად დადასტურებული იქნება.",
     "continueText": "გაგრძელება",
-    "welcomeText": "გამარჯობა, ეს არის FluffyChat. შეგიძლიათ შეხვიდეთ ნებისმიერ სახლის სერვერზე, რომელიც თავსებადია https://matrix.org-თან. და შემდეგ ისაუბროთ ნებისმიერ ადამიანთან. ეს არის დიდი დეცენტრალიზებული შეტყობინებების ქსელი!",
     "blur": "დაფარვა:",
     "opacity": "მოჩინვარება:",
     "setWallpaper": "საფონი დაყენება",
-    "manageAccount": "ანგარიშის მართვა",
     "noContactInformationProvided": "სერვერმა არ უზრუნველყო ვალიდური კონტაქტის ინფორმაცია",
     "contactServerAdmin": "სერვერის ადმინისტრატორთან დაკავშირება",
     "contactServerSecurity": "სერვერის უსაფრთხოებასთან დაკავშირება",
@@ -1280,11 +1188,8 @@
     "unableToJoinChat": "ჩართვა ვერ მოხერხდა. შესაძლოა მეორე მხარემ უკვე დახურა საუბარი.",
     "previous": "წინა",
     "otherPartyNotLoggedIn": "მეორე მხარე ამჟამად არ არის შესული და შესაბამისად ვერ მიიღებს შეტყობინებებს!",
-    "appWantsToUseForLogin": "გამოიყენეთ '{server}' შესასვლელად",
-    "appWantsToUseForLoginDescription": "თქვენ აქვე აძლევთ საშუალებას აპლიკაციას და ვებგვერდს გააზიარონ თქვენი ინფორმაცია.",
     "open": "გახსნა",
     "waitingForServer": "მოსალოდნელია სერვერის პასუხი...",
-    "appIntroduction": "FluffyChat-ის საშუალებით შეგიძლიათ ისაუბროთ მეგობრებთან სხვადასხვა მესენჯერებზე. მეტი ინფორმაციისთვის ეწვიეთ https://matrix.org ან უბრალოდ დააჭირეთ *გაგრძელება*.",
     "newChatRequest": "📩 ახალი საუბრის მოთხოვნა",
     "contentNotificationSettings": "შინაარსის შეტყობინებების პარამეტრები",
     "generalNotificationSettings": "საერთო შეტყობინებების პარამეტრები",
@@ -1361,11 +1266,9 @@
     "taTooltip": "L2 გამოყენება თარგმნის დახმარებით",
     "interactiveTranslatorSliderHeader": "ინტერაქტიული თარგმნელი",
     "interactiveGrammarSliderHeader": "ინტერაქტიული გრამატიკის შემოწმება",
-    "interactiveTranslatorRequired": "მოსახერხია",
     "waTooltip": "L2 გამოყენება დახმარების გარეშე",
     "interactiveTranslator": "თარგმნის დახმარება",
     "noIdenticalLanguages": "გთხოვთ, აირჩიოთ განსხვავებული საწყისი და სამიზნე ენები",
-    "searchBy": "ძებნა ქვეყნით და ენებით",
     "joinWithClassCode": "შეერთება კურსში",
     "languageLevelPreA1": "ახალი დაბალი (წინა A1)",
     "languageLevelA1": "ახალი შუა (A1)",
@@ -1386,19 +1289,14 @@
     "saveChanges": "შენახვა ცვლილებები",
     "publicProfileTitle": "მომეცი ნება ჩემი პროფილი იპოვოს ძიებაში",
     "publicProfileDesc": "ჩართვისას, თქვენ აძლევთ სხვა მომხმარებლებს საშუალებას იპოვონ თქვენი პროფილი გლობალურ ძიებაში და გამოგზავნონ შეტყობინებები ჩატისთვის. ამ ეტაპზე, შეგიძლიათ აირჩიოთ მიიღოთ თუ უარყოთ მოთხოვნა.",
-    "errorDisableIT": "თარგმნის დახმარება გამორთულია.",
-    "errorDisableIGC": "გრამატიკის დახმარება გამორთულია.",
     "errorDisableITUserDesc": "დააჭირეთ აქ, რათა განაახლოთ თარგმნის დახმარების პარამეტრები",
     "errorDisableIGCUserDesc": "დააჭირეთ აქ, რათა განაახლოთ გრამატიკის დახმარების პარამეტრები",
     "errorDisableITClassDesc": "თარგმნის დახმარება გამორთულია ამ კურსისთვის, სადაც ეს ჩატი მდებარეობს.",
     "errorDisableIGCClassDesc": "გრამატიკის დახმარება გამორთულია ამ კურსისთვის, სადაც ეს ჩატი მდებარეობს.",
-    "error405Title": "ენა არ არის მითითებული",
     "error405Desc": "გთხოვთ, დააყენოთ თქვენი ენები მთავარი მენიუდან > სწავლების პარამეტრებიდან.",
     "termsAndConditions": "წესებს და პირობებს",
     "andCertifyIAmAtLeast13YearsOfAge": "და ვადასტურებ, რომ მე მინიმუმ 16 წლის ვარ.",
-    "error502504Title": "ვაი, ბევრი სტუდენტი ონლაინშია!",
     "error502504Desc": "თარგმნის და გრამატიკის ხელსაწყოები შეიძლება იყოს ნელი ან მიუწვდომელი, სანამ პანგეა ბოტები არ დაეწევიან.",
-    "error404Title": "თარგმნის შეცდომა!",
     "error404Desc": "Pangea Bot-ი ვერ გარჩევს, როგორ უნდა თარგმნოს ეს...",
     "errorPleaseRefresh": "ჩვენ ამას ვისწრაფვით! გთხოვთ, განაახლოთ გვერდი და სცადოთ თავიდან.",
     "connectedToStaging": "დაკავშირებულია სტეიჯთან",
@@ -1436,13 +1334,9 @@
     "definitionsToolName": "სიტყვის განმარტებები",
     "definitionsToolDescription": "როდესაც ჩართულია, ლურჯი ხაზით აღნიშნული სიტყვები შეიძლება დაწკაპუნებით იხილოთ განმარტებისთვის. დაწკაპუნეთ შეტყობინებებზე განმარტებების მისაღებად.",
     "welcomeBack": "კეთილი იყოს თქვენი დაბრუნება! თუ თქვენ მონაწილეობდით 2023-2024 წლის პილოტში, გთხოვთ დაგვიკავშირდეთ თქვენი სპეციალური პილოტის გამოწერისთვის. თუ თქვენ მასწავლებელი ხართ და გაქვთ (ან თქვენი დაწესებულება აქვს) ლიცენზიები თქვენი კლასი, გთხოვთ დაგვიკავშირდეთ თქვენი მასწავლებლის გამოწერისთვის.",
-    "downloadTxtFile": "ტექსტის ფაილის ჩამოტვირთვა",
-    "downloadCSVFile": "CSV ფაილის ჩამოტვირთვა",
     "promotionalSubscriptionDesc": "ამჟამად გაქვთ სიცოცხლის ხანგრძლივობის პრომო გამოწერა. დახმარებისთვის დაუკავშირდით support@pangea.chat-ს, თქვენი გამოწერის შეცვლის მიზნით.",
     "originalSubscriptionPlatform": "გამოწერა შეძენილი {purchasePlatform}-დან",
     "oneWeekTrial": "ერთი კვირის საცდელი პერიოდი",
-    "downloadXLSXFile": "Excel ფაილის ჩამოტვირთვა",
-    "unkDisplayName": "უცნობი",
     "wwCountryDisplayName": "მსოფლიოს მასშტაბით",
     "afCountryDisplayName": "აფგანისტანი",
     "axCountryDisplayName": "ალანდის კუნძულები",
@@ -1737,7 +1631,6 @@
     "chatCapacityHasBeenChanged": "ჩატის შესაძლებლობა შეიცვალა",
     "chatCapacitySetTooLow": "ჩატის შესაძლებლობა უნდა იყოს მინიმუმ {count}.",
     "chatCapacityExplanation": "ჩატის შესაძლებლობა განსაზღვრავს წევრთა რაოდენობას, რომელიც შეიძლება იყოს ჩატში.",
-    "tooManyRequest": "ძალიან ბევრი მოთხოვნა, გთხოვთ სცადოთ მოგვიანებით.",
     "enterNumber": "გთხოვთ შეიყვანოთ მთელი რიცხვი.",
     "practice": "ვარჯიში",
     "versionNotFound": "ვერსია ვერ მოიძებნა",
@@ -1747,7 +1640,6 @@
     "deleteSubscriptionWarningTitle": "თქვენ გაქვთ აქტიური გამოწერა",
     "deleteSubscriptionWarningBody": "თქვენის ანგარიშის წაშლა ავტომატურად არ გააუქმებს თქვენს გამოწერას.",
     "manageSubscription": "მოწერის მართვა",
-    "error520Title": "გთხოვთ, სცადეთ თავიდან.",
     "error520Desc": "უკაცრავად, ვერ გავიგეთ თქვენი შეტყობინება...",
     "wordsUsed": "გამოყენებული სიტყვები",
     "level": "საფეხური",
@@ -1765,7 +1657,6 @@
     "other": "სხვა",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "შესაძლებლობის შეზღუდვა არ არის",
-    "downloadGroupText": "გთხოვთ, ჩამოტვირთოთ ჯგუფის ტექსტი",
     "notificationsOn": "შეტყობინებები ჩართულია",
     "notificationsOff": "შეტყობინებები გამორთულია",
     "joinWithCode": "შეერთდით კოდის საშუალებით",
@@ -1829,24 +1720,12 @@
     "whatIsTheMorphTag": "რა არის {morphologicalFeature} '{wordForm}'-ის?",
     "dataAvailable": "მონაცემების ხელმისაწვდომობა",
     "available": "ხელმისაწვდომია",
-    "pangeaBotIsFallible": "Pangea Bot-იც შეცდომებს უშვებს!",
-    "whatIsMeaning": "რა ნიშნავს '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "შეადარეთ მნიშვნელობები სიტყვებთან შეტყობინებაში!",
-    "doubleClickToEdit": "ჩამკეცეთ ორჯერ რედაქტირებისთვის.",
-    "topicLabel": "თემა",
-    "topicPlaceholder": "აირჩიეთ თემა...",
-    "modePlaceholder": "აირჩიეთ რეჟიმი...",
-    "learningObjectiveLabel": "სწავლების მიზანი",
-    "learningObjectivePlaceholder": "აირჩიეთ სასწავლო მიზანი...",
-    "targetLanguageLabel": "მიზნობრივი ენა",
     "cefrLevelLabel": "CEFR დონე",
     "image": "სურათი",
     "video": "ვიდეო",
     "nan": "არ არის გამოყენებადი",
-    "addVocabulary": "დაამატეთ ლექსიკა",
     "instructions": "ინსტრუქციები",
-    "numberOfLearners": "სწავლողների რაოდენობა",
-    "mustBeInteger": "უნდა იყოს მთელი რიცხვი, მაგ. 1, 2, 3, ...",
     "constructUsePvmDesc": "წარმოქმნილი ხმის შეტყობინებაში",
     "leaveSpaceDescription": "კურსის დატოვებით, დატოვებთ ყველა ჩათს მასში. სხვა მომხმარებლები იხილავენ, რომ დატოვეთ კურსი.",
     "constructUseCorMmDesc": "სწორი შეტყობინების მნიშვნელობა",
@@ -1861,7 +1740,6 @@
     "ttsDisabledBody": "თქვენ შეგიძლიათ ჩართოთ ტექსტიდან ხმაში გამოთქმა თქვენი სწავლების პარამეტრებში",
     "noSpaceDescriptionYet": "ჯერ არ შექმნილა კურსის აღწერა.",
     "tooLargeToSend": "ეს შეტყობინება ძალიან დიდია გამოგზავნისთვის",
-    "exitWithoutSaving": "დარწმუნებული ხართ, რომ გსურთ დატოვოთ შენახვის გარეშე?",
     "enableAutocorrectPopupTitle": "დაამატეთ თქვენი მიზნობრივი ენის კლავიატურა შემდეგ მისამართზე გადასვლით:",
     "enableAutocorrectPopupSteps": "  • პარამეტრები\n  • ზოგადი\n  • კლავიატურა\n  • კლავიატურები\n  • ახალი კლავიატურის დამატება",
     "enableAutocorrectPopupDescription": "როდესაც ენა აირჩევა, შეგიძლიათ დააჭიროთ პატარა გლობუსის ხატულას კლავიატურის ქვედა მარცხენა მხარეს, რათა გააქტიუროთ ახალი ინსტალირებული კლავიატურა.",
@@ -1872,11 +1750,8 @@
     "displayName": "სახელის ჩვენება",
     "leaveRoomDescription": "თქვენ აპირებთ ამ ჩატის დატოვებას. სხვა მომხმარებლები იხილავენ, რომ თქვენ დატოვეთ ჩატი.",
     "confirmUserId": "გთხოვთ დაადასტუროთ თქვენი Pangea Chat-ის მომხმარებლის სახელი თქვენი ანგარიშის წაშლის მიზნით.",
-    "startingToday": "დაწყება დღეს",
-    "oneWeekFreeTrial": "ერთი კვირის უფასო საცდელი პერიოდი",
     "paidSubscriptionStarts": "დაწყება {startDate}",
     "cancelInSubscriptionSettings": "• გაუქმება ნებისმიერ დროს გამოწერის პარამეტრებში",
-    "cancelToAvoidCharges": "• გაუქმება წინასწარ {trialEnds} რათა თავიდან აიცილოთ გადასახადები",
     "downloadGboard": "ჩამოტვირთეთ Gboard",
     "autocorrectNotAvailable": "სამწუხაროდ, თქვენი პლატფორმა ამ ფუნქციისთვის ამჟამად არ არის მხარდაჭერილი. დარჩით განახლებებისთვის!",
     "pleaseUpdateApp": "გთხოვთ განაახლოთ აპლიკაცია გაგრძელებისთვის.",
@@ -1886,17 +1761,12 @@
     "knockSpaceSuccess": "თქვენ მოითხოვეთ ამ კურსში ჩართვა! ადმინისტრატორი უპასუხებს თქვენს მოთხოვნას, როდესაც მიიღებს მას 😊",
     "chooseWordAudioInstructionsBody": "მოსმინეთ სრულ შეტყობინებას. შემდეგ შეადარეთ აუდიოები მათ სიტყვებთან.",
     "chooseMorphsInstructionsBody": "დაწკაპეთ პაზლის ნაწილებს გრამატიკული კითხვებისთვის!",
-    "pleaseEnterInt": "გთხოვთ, შეიყვანეთ რიცხვი",
     "home": "მთავარი",
     "join": "შეერთება",
     "resetInstructionTooltipsTitle": "გადატვირთეთ ინსტრუქციის ხატულები",
     "resetInstructionTooltipsDesc": "დააჭირეთ, რათა აჩვენოთ ინსტრუქციის ხატულები, როგორც ახალი მომხმარებლისთვის.",
-    "randomize": "შემთხვევითი",
     "clear": "წაშლა",
-    "featuredActivities": "გამორჩეული",
     "save": "შენახვა",
-    "startChat": "დაიწყეთ ჩათი",
-    "translationProblem": "თარგმნის პრობლემა",
     "askToJoin": "მოითხოვეთ შეუერთება",
     "emptyChatWarningTitle": "ჩათი ცარიელია",
     "emptyChatWarningDesc": "თქვენ არ მოგიწვიათ ვინმე თქვენს ჩათში. გადადით ჩატის პარამეტრებში და მოიწვიეთ თქვენი კონტაქტები ან ბოტი. ასევე შეგიძლიათ ამის გაკეთება მოგვიანებით.",
@@ -1926,17 +1796,13 @@
     "timesUsedIndependently": "გამოყენებულია დამოუკიდებლად",
     "timesUsedWithAssistance": "გამოყენებულია დახმარებით",
     "shareInviteCode": "გაზიარეთ მოწვევის კოდი: {code}",
-    "leaderboard": "წინსვლის სია",
     "skipForNow": "ამ დროისთვის გამოტოვება",
     "permissions": "უფლებები",
     "spaceChildPermission": "ვინ შეუძლია დაამატოს ახალი ჩატები ამ კურსში",
-    "addEnvironmentOverride": "დამატეთ გარემოს გადახედვა",
     "defaultOption": "ნაგულისხმევი",
     "deleteChatDesc": "დარწმუნებული ხართ, რომ გსურთ ამ ჩატის წაშლა? ის წაიშლება ყველა მონაწილისთვის და ყველა შეტყობინება, რომელიც ჩატშია, აღარ იქნება ხელმისაწვდომი პრაქტიკის ან სწავლების ანალიტიკისთვის.",
     "deleteSpaceDesc": "კურსი და ნებისმიერი არჩეული ჩატები წაიშლება ყველა მონაწილისთვის და ყველა შეტყობინება, რომელიც ჩატშია, აღარ იქნება ხელმისაწვდომი პრაქტიკის ან სწავლების ანალიტიკისთვის. ეს მოქმედება ვერ იქნება გაუქმებული.",
     "launch": "შესრულება",
-    "searchChats": "ძებნა საუბრები",
-    "maxFifty": "მაქსიმუმ 50",
     "configureSpace": "კურსის კონფიგურაცია",
     "pinMessages": "მესიჯების პინვა",
     "setJoinRules": "შეადგინეთ შეუერთების წესები",
@@ -1970,9 +1836,6 @@
     "failedToFetchTranscription": "ტრანსკრიპტის მიღება ვერ მოხერხდა",
     "deleteEmptySpaceDesc": "კურსი წაიშლება ყველა მონაწილისთვის. ეს მოქმედება ვერ იქნება გაუქმებული.",
     "regenerate": "განახლება",
-    "mySavedActivities": "ჩემი შენახული აქტივობები",
-    "noSavedActivities": "შენახული აქტივობები არ არის",
-    "saveActivity": "შენახე ეს აქტივობა",
     "failedToPlayVideo": "ვიდეოს გაშვება ვერ მოხერხდა",
     "done": "შესრულებულია",
     "inThisSpace": "ამ კურსში",
@@ -1983,13 +1846,9 @@
     "numInvited": "{count} მოწვეული",
     "saved": "შენახულია",
     "reset": "გადატვირთვა",
-    "errorFetchingActivitiesMessage": "აქტივობების მიღება ვერ მოხერხდა",
     "errorFetchingDefinition": "განმარტების მიღება ვერ მოხერხდა",
     "errorProcessAnalytics": "ანალიტიკის დამუშავება ვერ მოხერხდა",
     "errorDownloading": "ჩამოტვირთვა ვერ მოხერხდა",
-    "errorLoadingSpaceChildren": "ჩათის ჩატვირთვა ვერ მოხერხდა ამ კურსში",
-    "unexpectedError": "უცნობი შეცდომა.",
-    "pleaseReload": "გთხოვთ, გადატვირთეთ და სცადეთ თავიდან.",
     "translationError": "თარგმნის შეცდომა",
     "check": "შემოწმება",
     "unableToFindRoom": "ამ კოდით ვერ მოიძებნა ჩატი ან კურსი. სცადეთ თავიდან.",
@@ -1998,19 +1857,14 @@
     "request": "მოთხოვნა",
     "requestAll": "მოთხოვნა ყველა",
     "confirmMessageUnpin": "დარწმუნებული ხართ, რომ გსურთ ამ შეტყობინების განთავსების გაუქმება?",
-    "saveAndLaunch": "შენახვა და დაწყება",
-    "launchToSpace": "გახსნა კურსზე",
     "pending": "მოლოდინში",
     "inactive": "არაქტიული",
-    "confirmRole": "დადასტურება როლი",
     "openRoleLabel": "ღია",
     "finishedTheActivity": "🎯 {username} დასრულდა ეს აქტივობა",
     "activitySummaryError": "აქტივობის მიმოხილვები ხელმისაწვდომი არაა",
     "requestSummaries": "მოთხოვნა მიმოხილვებისთვის",
-    "generatingNewActivities": "თქვენ ხართ ამ ენის წყვილის პირველი მომხმარებელი! გთხოვთ, ერთი წუთი გქონდეთ, ჩვენ ვამზადებთ აქტივობებს თქვენთვის.",
     "requestAccessTitle": "ანალიტიკის წვდომის მოთხოვნა?",
     "requestAccessDesc": "გსურთ მიიღოთ დაშვება მონაწილეთა ანალიტიკის სანახავად?\n\nთუ მონაწილეები თანხმდებიან, ამ კურსის ადმინისტრატორები შეძლებენ ნახონ მათ:\n    • საერთო ლექსიკონი\n    • საერთო გრამატიკის კონცეპტები\n    • დასრულებული აქტივობის სესიონები\n    • გამოყენებული, სწორად და არასწორად გრამატიკის კონცეპტები\n\nისინი ვერ შეძლებენ ნახონ:\n    • შეტყობინებები ჩატებში კურსის გარეთ\n    • ლექსიკონის სია",
-    "requestAccess": "მოთხოვნა დაშვებაზე ({count})",
     "analyticsInactiveTitle": "მოთხოვნები არაქტიურ მომხმარებლებს ვერ გაიგზავნება",
     "analyticsInactiveDesc": "არაქტიური მომხმარებლები, რომლებიც ამ ფუნქციის გამოჩენის შემდეგ არ შესულან, თქვენი მოთხოვნა ვერ იხილავენ.\n\nმოთხოვნის ღილაკი გამოჩნდება, როდესაც ისინი დაბრუნდებიან. შეგიძლიათ მოგვიანებით ისევ გამოაგზავნოთ მოთხოვნა მათი სახელის ქვეშ არსებული ღილაკის დაჭერით, როდესაც ის ხელმისაწვდომია.",
     "accessRequestedTitle": "ანალიტიკის დაშვების მოთხოვნა",
@@ -2033,8 +1887,6 @@
     "accessDesc": "თქვენ შეგიძლიათ გახსნათ თქვენი კურსი მსოფლიოისთვის! ან, გახადოთ თქვენი კურსი პირადი და უსაფრთხო.",
     "createGroupChatDesc": "სადაც იწყება და მთავრდება აქტივობის სესია, ჯგუფური ჩატები დარჩება ღია რეგულარული კომუნიკაციისთვის.",
     "deleteDesc": "მხოლოდ ადმინისტრატორებს შეუძლიათ კურსის წაშლა. ეს არის განადგურების მოქმედება, რომელიც წაშლის ყველა მომხმარებელს და ყველა არჩეულ ჩატს კურსის ფარგლებში. გთხოვთ, გამოიჩინოთ სიფრთხილე.",
-    "noCourseFound": "ოჰ, ამ კურსისთვის სჭირდება გეგმა!\n\nკურსის გეგმა არის თემების და საუბრის აქტივობების სერია.",
-    "additionalParticipants": "+ {num} სხვა",
     "whatNow": "ახლა რა?",
     "chooseNextActivity": "აირჩიეთ თქვენი შემდეგი აქტივობა!",
     "letsGo": "მოდით დავიწყოთ",
@@ -2047,13 +1899,11 @@
     "waitNotDone": "მოლოდინი, ჯერ არ დამისრულებია!",
     "waitingForOthersToFinish": "მოსალოდნელია დანარჩენების დასრულება...",
     "generatingSummary": "საუბრის ანალიზი და შედეგების გენერირება",
-    "findCourse": "კურსის მოძებნა",
     "pingParticipantsNotification": "{user} ეძებს მომხმარებლებს, რომ შეუერთდნენ აქტივობის სესიას {room}-ში",
     "course": "კურსი",
     "courses": "კურსები",
     "goToCourse": "გადადი კურსზე: {course}",
     "activityComplete": "ეს აქტივობა დასრულებულია. აქტივობის მიმოხილვა უნდა იყოს ხელმისაწვდომი ქვემოთ.",
-    "startNewSession": "ახალი სესიის დაწყება",
     "joinOpenSession": "შეერთება ღია სესიაში",
     "activityNotFound": "აქტივობა ვერ მოიძებნა",
     "myActivities": "ჩემი აქტივობები",
@@ -2166,27 +2016,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@emoteKeyboardNoRecents": {
         "type": "String",
         "placeholders": {}
     },
     "@emotePacks": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -2215,10 +2049,6 @@
         "placeholders": {}
     },
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2258,10 +2088,6 @@
             }
         }
     },
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@extremeOffensive": {
         "type": "String",
         "placeholders": {}
@@ -2294,15 +2120,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@chatDescriptionHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -2400,14 +2218,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "@noChatDescriptionYet": {
         "type": "String",
@@ -2525,14 +2335,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@dehydrate": {
         "type": "String",
         "placeholders": {}
@@ -2564,14 +2366,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@logout": {
         "type": "String",
@@ -2626,14 +2420,6 @@
         "placeholders": {}
     },
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2732,10 +2518,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addAccount": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@editBundlesForAccount": {
         "type": "String",
         "placeholders": {}
@@ -2749,10 +2531,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableMultiAccounts": {
         "type": "String",
         "placeholders": {}
     },
@@ -2800,10 +2578,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@people": {
         "type": "String",
         "placeholders": {}
@@ -2837,10 +2611,6 @@
         "placeholders": {}
     },
     "@pleaseEnter4Digits": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKey": {
         "type": "String",
         "placeholders": {}
     },
@@ -2943,10 +2713,6 @@
             }
         }
     },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unbanFromChat": {
         "type": "String",
         "placeholders": {}
@@ -2988,14 +2754,6 @@
         "placeholders": {}
     },
     "@security": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
         "type": "String",
         "placeholders": {}
     },
@@ -3099,10 +2857,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@setStatus": {
         "type": "String",
         "placeholders": {}
@@ -3140,14 +2894,6 @@
         "placeholders": {}
     },
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -3203,10 +2949,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@tryToSendAgain": {
         "type": "String",
         "placeholders": {}
@@ -3253,14 +2995,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -3339,14 +3073,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@visibleForAllParticipants": {
         "type": "String",
         "placeholders": {}
@@ -3383,19 +3109,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -3447,15 +3161,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3506,10 +3212,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3518,15 +3220,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3650,43 +3344,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3706,18 +3368,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
@@ -3731,10 +3381,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3757,22 +3403,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3827,10 +3457,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3914,31 +3540,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3994,23 +3600,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4050,28 +3644,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4089,14 +3661,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4289,22 +3853,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4360,10 +3908,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4373,10 +3917,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4452,27 +3992,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4798,10 +4322,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4811,10 +4331,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4902,14 +4418,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4926,10 +4434,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4942,15 +4446,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5102,14 +4598,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5123,14 +4611,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6353,10 +5833,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6397,10 +5873,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6473,10 +5945,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6746,47 +6214,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6806,19 +6234,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6882,10 +6298,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6926,14 +6338,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6945,14 +6349,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6990,10 +6386,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7010,27 +6402,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7154,10 +6530,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7167,10 +6539,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7187,14 +6555,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7334,18 +6694,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7394,10 +6742,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7407,18 +6751,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7461,23 +6793,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7501,10 +6821,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7512,14 +6828,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7624,18 +6932,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7688,10 +6984,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7718,10 +7010,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7902,7 +7190,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "ხვედრეთ ხვალისთვის აქტივობის განახლებებისთვის.",
-    "activityDropdownDesc": "როდესაც ამ აქტივობას დაასრულებთ, დაწკაპეთ ქვემოთ",
     "languageMismatchTitle": "ენის შეუთავსებლობა",
     "languageMismatchDesc": "თქვენი სამიზნე ენა არ ემთხვევა ამ აქტივობის ენას. განაახლეთ თქვენი სამიზნე ენა?",
     "reportWordIssueTooltip": "გთხოვთ, გამოეხმაუროთ სიტყვების ინფორმაციის პრობლემას",
@@ -7915,10 +7202,6 @@
     "selectAll": "მთლიანი არჩევა",
     "deselectAll": "ყველას მოხსნა",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7967,17 +7250,11 @@
         "placeholders": {}
     },
     "startOwn": "დაიწყე შენი საკუთარი",
-    "joinCourseDesc": "ყოველ კურსზე აქვს 8-10 სერიული თემა და სხვადასხვა დავალებებზე დაფუძნებული ენის სწავლების აქტივობები.",
     "newMessageInPangeaChat": "💬 ახალი შეტყობინება Pangea ჩატში",
     "shareCourse": "გააზიარე კურსი",
     "addCourse": "დაამატე კურსი",
-    "joinPublicCourse": "შეერთდი საჯარო კურსთან",
     "vocabLevelsDesc": "ეს არის ადგილი, სადაც სიტყვები განთავსდება, როგორც კი მათ დონე გაუმჯობესდება!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7990,10 +7267,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8012,7 +7285,6 @@
     "emojiView": "ემოჯი ხედვა",
     "feedbackDialogDesc": "მეაც ვაკეთებ შეცდომებს! რაიმე, რაც დამეხმარება გაუმჯობესებაში?",
     "contactHasBeenInvitedToTheCourse": "კონტაქტი მოწვეულ იქნა კურსზე",
-    "activityStatsButtonTooltip": "აქტივობის ინფორმაცია",
     "allow": "დაშვება",
     "deny": "უარყოფა",
     "enabledRenewal": "გამოწერის განახლების გაწვდვა",
@@ -8280,10 +7552,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9339,16 +8607,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "აქტივობები შემდეგ თემაზე გადასასვლელად",
-    "activitiesToUnlockTopicDesc": "განსაზღვრეთ აქტივობების რაოდენობა, რათა გახსნათ შემდეგი კურსის თემა",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "სწორი სიტყვების განმარტების პრაქტიკა",
     "constructUseIncLMDesc": "არასწორი სიტყვების განმარტების პრაქტიკა",
     "constructUseCorLADesc": "სწორი სიტყვების აუდიო პრაქტიკა",
@@ -9356,7 +8614,6 @@
     "constructUseBonus": "ბონუსი სიტყვების პრაქტიკის დროს",
     "practiceVocab": "სიტყვების პრაქტიკა",
     "selectMeaning": "მნიშვნელობის არჩევა",
-    "selectAudio": "შესაბამის აუდიოს არჩევა",
     "anotherRound": "მეორე რაუნდი",
     "activitySettingsOverrideWarning": "ენასა და ენების დონეს განსაზღვრავს აქტივობის გეგმა",
     "voice": "ხმა",
@@ -9388,10 +8645,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9409,12 +8662,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "ჩამოტვირთვა დაწყებულია",
     "webDownloadPermissionMessage": "თუ თქვენი ბრაუზერი ბლოკავს ჩამოტვირთვებს, გთხოვთ გააქტიუროთ ჩამოტვირთვები ამ ვებსაიტისთვის.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9509,11 +8757,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "რამე არასწორად მოხდა, და ჩვენ აქტიურად ვმუშაობთ ამის გამოსასწორებლად. შეამოწმეთ მოგვიანებით.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "წერის დახმარების ჩართვა",
     "autoIGCToolDescription": "ავტომატურად გაწვდეთ Pangea Chat ინსტრუმენტები გაგზავნილი შეტყობინებების მიზნობრივი ენაზე გასასწორებლად.",
     "@autoIGCToolName": {
@@ -9569,24 +8812,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "გრამატიკა",
-    "spanTypeWordChoice": "სიტყვების არჩევანი",
     "spanTypeSpelling": "წერა",
     "spanTypePunctuation": "ნიშნის გამოყენება",
     "spanTypeStyle": "სტილი",
     "spanTypeFluency": "მიმდინარე",
     "spanTypeAccents": "აქცენტები",
     "spanTypeCapitalization": "დიდი ასოები",
-    "spanTypeCorrection": "კორექტირება",
     "spanFeedbackTitle": "შეტყობინება კორექტირების პრობლემაზე",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9611,10 +8843,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9627,13 +8855,7 @@
     "longPressToRecordVoiceMessage": "ხანგრძლივი დაჭერა ხმის შეტყობინების ჩასაწერად.",
     "pause": "შეჩერება",
     "resume": "გაგრძელება",
-    "newSubSpace": "ახალი ქვესივრცე",
-    "moveToDifferentSpace": "გადაიყვანეთ სხვა სივრცეში",
-    "removeFromSpaceDescription": "ჩატი მოიხსნება სივრციდან, მაგრამ მაინც გამოჩნდება თქვენს ჩატების სიაში.",
     "countChats": "{chats} ჩატი",
-    "spaceMemberOf": "სივრცის წევრი {spaces}-ის",
-    "spaceMemberOfCanKnock": "სივრცის წევრი {spaces} შეუძლია დააკაკუნოს",
-    "donate": "გადარიცხვა",
     "startedAPoll": "{username} დაიწყო გამოკითხვა.",
     "poll": "გამოკითხვა",
     "startPoll": "დაიწყეთ გამოკითხვა",
@@ -9657,23 +8879,15 @@
     "newStickerPack": "ახალი სტიკერის პაკეტი",
     "stickerPackName": "სტიკერის პაკეტის სახელი",
     "attribution": "ატრიბუცია",
-    "skipChatBackup": "ჩეთის სარეზერვო ასლის გამოტოვება",
-    "skipChatBackupWarning": "დარწმუნებული ხართ? თუ ჩეთის სარეზერვო ასლი არ გააქტიურებთ, შესაძლოა დაკარგოთ წვდომა თქვენს შეტყობინებებზე, თუ მოწყობილობას შეცვლით.",
-    "loadingMessages": "შეტყობინებების დატვირთვა",
-    "setupChatBackup": "ჩეთის სარეზერვო ასლის დაყენება",
     "noMoreResultsFound": "მეტი შედეგი ვერ მოიძებნა",
     "chatSearchedUntil": "ჩეთი მოძიებულია {time}-მდე",
     "federationBaseUrl": "ფედერაციის ძირითადი URL",
     "clientWellKnownInformation": "კლაიენტის კარგად ცნობილი ინფორმაცია:",
     "baseUrl": "ძირითადი URL",
     "identityServer": "იდენტობის სერვერი:",
-    "versionWithNumber": "ვერსია: {version}",
     "logs": "ლოგები",
-    "advancedConfigs": "განვითარებული კონფიგურაციები",
     "advancedConfigurations": "განვითარებული კონფიგურაციები",
-    "signInWithLabel": "შეიყვანეთ:",
     "selectAllWords": "აირჩიეთ ყველა სიტყვა, რომელიც მოისმენთ აუდიოში",
-    "joinCourseForActivities": "შეერთდით კურსს, რათა სცადოთ აქტივობები.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9710,18 +8924,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9729,26 +8931,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9854,22 +9036,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9898,19 +9064,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9918,15 +9072,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10127,11 +9273,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "კლასში ხართ? მოათავსეთ თქვენი გაწვდილი კოდი აქ.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "აუდიო შეტყობინებების ავტომატური ხაზგასმა",
     "selectAudioMessagesOnPlayDescription": "აუდიო შეტყობინებების ავტომატურად ხაზგასმა მათი დაკვრის დროს",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10175,18 +9316,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "ამ კურსში თემებია, რომელთა აქტივობების რაოდენობა {input}-ზე ნაკლებია. გთხოვთ, შეიყვანოთ რიცხვი, რომელიც ნაკლებია ან თანაბარია {minValue}-ს.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "დააჭირეთ აქ, რომ კვლავ შეხვიდეთ.",
     "@clickToLogin": {
@@ -10603,17 +9732,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "კარტონული ყვითელი დათვი, რომლის ხელები აღიმართა აღფრთოვანებით.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "აირჩიეთ სიტყვები, რომ მეტი გაიგოთ მათზე",
     "requireAnalyticsAccessTitle": "ანალიტიკის წვდომა საჭიროა გაწვდისთვის",
     "requireAnalyticsAccessDesc": "მონაწილეებს უნდა მიაწვდონ წვდომა თავიანთი სასწავლო ანალიტიკაზე, რომ ამ კურსში გაწვდონ",
     "analyticsAccessNoticeTitle": "ანალიტიკის წვდომა საჭიროა",
     "analyticsAccessNoticeDesc": "ამ კურსში გაწვდით, თქვენ თანხმდებით, რომ ადმინისტრატორებს მიაწვდონ წვდომა თქვენს სასწავლო ანალიტიკაზე.",
-    "skipOnboardingClassCodeDesc": "მარტო სწავლობთ? ნუ ინერვიულებთ, შეგიძლიათ:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10631,10 +9754,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10663,7 +9782,6 @@
     "pickCefrLevelTeacherStepTitle": "რომელი დონე ასწავლით?",
     "pickCefrLevelStudentStepTitle": "რომელი დონეზე ხართ?",
     "customCourseStepTitle": "შეავსეთ ეს ფორმა რომ მიიღოთ პერსონალური კურსი",
-    "aboutYourClass": "შენი კლასის შესახებ",
     "courseCodeStepErrorMessage": "გთხოვთ გადაამოწმოთ თქვენი კოდი და სცადოთ კიდევ ერთხელ",
     "institution": "ინსტიტუტი",
     "courseGoals": "კურსის მიზნები",
@@ -10706,10 +9824,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10826,12 +9940,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "პანჯეა ჩატის ლოგო",
     "introChatDetails": "თქვენი გამარჯობა! წარუდგინეთ თავი თქვენს თანაკურსელებს, მოიძიეთ მეგობრები და ისაუბრეთ აქტივობების გარეთ.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10875,11 +9984,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "აქტივობის მოქმედებები",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "გამოთქმის ინსტრუმენტები",
     "audioTranscription": "AI აუდიო ტრანსკრიფცია",
     "visualLearnerSupport": "ვიზუალური სწავლების მხარდაჭერა",
@@ -10920,7 +10024,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "შეერთდით კურსს, რომელიც მოიცავს ამ აქტივობას, რომ ითამაშოთ იგი.",
     "resizeCoursePanel": "კურსის პანელის ზომის შეცვლა",
     "undo": "გაუქმება",
     "unlock": "გახსნა",
@@ -10934,7 +10037,6 @@
     "addCourseBrowsePublic": "გადახედეთ საჯარო კურსებს",
     "browsePublicCourses": "გადახედეთ საჯარო კურსებს",
     "editProfile": "რედაქტირება პროფილში",
-    "numObjectives": "{count} მიზანი",
     "mapSearchHint": "ძებნა აქტივობებში",
     "mapSearchNoResults": "არ არის შესაბამისი შედეგები",
     "mapFilterAllLanguages": "ყველა ენა",
@@ -10943,7 +10045,6 @@
     "mapFilterCompleted": "დასრულებულია",
     "mapFilterReset": "გაასუფთავე",
     "activityTypeConversation": "საუბარი",
-    "lockedMissionRequirement": "გთხოვთ, დაასრულოთ წინა მისია, რომ გაახსნათ",
     "playAgain": "მორიგე თამაში",
     "reviewActivity": "მიმოხილვა",
     "mapEmptyInView": "აქ არაფერია თქვენს დონეზე ან ენაზე. გააფართოვეთ თქვენი ფილტრები ან დააკლებეთ ზუმი.",
@@ -10958,14 +10059,9 @@
     "scrollToBottom": "ქვედა მხარეზე გადახვევა",
     "courseImage": "კურსის სურათი",
     "avatarPreview": "ავატარის წინასწარი ნახვა",
-    "activityPhoto": "აქტივობის ფოტო",
     "emotePreview": "ემოჯის წინასწარი ნახვა: {name}",
     "activityLabel": "აქტივობა: {title}",
     "resetMapView": "მონიტორის ხედვის აღდგენა",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11018,14 +10114,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11055,10 +10143,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11115,10 +10199,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_ko.arb
+++ b/lib/l10n/intl_ko.arb
@@ -74,15 +74,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "{count}명의 참가자 더 표시",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "lightTheme": "라이트",
     "@lightTheme": {
         "type": "String",
@@ -100,11 +91,6 @@
     },
     "groups": "그룹 채팅",
     "@groups": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "그룹 채팅 공개",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -148,11 +134,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "everythingReady": "모든 것이 준비됐어요!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "homeserver": "홈서버",
     "@homeserver": {},
     "enterAnEmailAddress": "이메일 주소 입력",
@@ -181,11 +162,6 @@
     },
     "encrypted": "암호화됨",
     "@encrypted": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "enableEncryptionWarning": "당신은 다시 암호화를 비활성화할 수 없습니다. 확실한가요?",
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -304,11 +280,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "createNewSpace": "새로운 스페이스",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "createdTheChat": "💬 {username}님이 채팅을 생성함",
     "@createdTheChat": {
         "type": "String",
@@ -358,11 +329,6 @@
     },
     "contentHasBeenReported": "콘텐츠가 서버 운영자에게 신고되었습니다",
     "@contentHasBeenReported": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "연락처가 채팅에 초대되었습니다",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -449,11 +415,6 @@
     },
     "chatDetails": "채팅 정보",
     "@chatDetails": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "당신의 오래된 메시지는 보안 키로 보호됩니다. 이 키를 잃어버리지 마세요.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -726,11 +687,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "게스트 유저의 참가 여부",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "archive": "저장",
     "@archive": {
         "type": "String",
@@ -897,23 +853,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "wipeChatBackup": "새로운 복구키를 생성하기 위해 채팅 백업을 초기화할까요?",
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "왜 이것을 신고하려고 하나요?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "참가 제한 설정",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoCanPerformWhichAction": "누가 어떤 행동을 할 수 있는지",
-    "@whoCanPerformWhichAction": {
         "type": "String",
         "placeholders": {}
     },
@@ -959,11 +900,6 @@
     },
     "visibleForAllParticipants": "모든 참가자에게 보임",
     "@visibleForAllParticipants": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "videoCall": "영상 통화",
-    "@videoCall": {
         "type": "String",
         "placeholders": {}
     },
@@ -1064,11 +1000,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "passwordRecovery": "비밀번호 복구",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "passwordForgotten": "비밀번호 까먹음",
     "@passwordForgotten": {
         "type": "String",
@@ -1089,8 +1020,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "addAccount": "계정 추가",
-    "@addAccount": {},
     "openCamera": "카메라 열기",
     "@openCamera": {
         "type": "String",
@@ -1174,15 +1103,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "logInTo": "{homeserver} 에 로그인",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
-    },
     "login": "로그인",
     "@login": {
         "type": "String",
@@ -1238,15 +1158,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unreadChats": "{unreadCount, plural, =1{읽지 않은 채팅 1} other{{unreadCount} 개}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "unavailable": "사용할 수 없음",
     "@unavailable": {
         "type": "String",
@@ -1274,11 +1185,6 @@
     },
     "you": "당신",
     "@you": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "대화 기록 설정",
-    "@visibilityOfTheChatHistory": {
         "type": "String",
         "placeholders": {}
     },
@@ -1327,11 +1233,6 @@
     },
     "tryToSendAgain": "다시 보내도록 시도",
     "@tryToSendAgain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "transferFromAnotherDevice": "다른 기기에서 가져오기",
-    "@transferFromAnotherDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -1389,16 +1290,6 @@
                 "type": "String"
             }
         }
-    },
-    "spaceName": "스페이스 이름",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "스페이스 공개",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
     },
     "pushRules": "푸시 규칙",
     "@pushRules": {
@@ -1465,8 +1356,6 @@
     },
     "serverRequiresEmail": "이 서버는 가입을 위해 당신의 이메일을 확인해야 합니다.",
     "@serverRequiresEmail": {},
-    "enableMultiAccounts": "(베타) 이 기기에서 다중 계정 활성화",
-    "@enableMultiAccounts": {},
     "bundleName": "번들 이름",
     "@bundleName": {},
     "removeFromBundle": "이 번들에서 삭제",
@@ -1494,16 +1383,6 @@
     },
     "none": "없음",
     "@none": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "이 휴대폰에 Firebase Cloud Messaging 서비스가 없는 것 같습니다. FluffyChat에서 푸시 알림을 받으려면 ntfy 사용을 추천합니다. ntfy 혹은 다른 푸시 알림 제공자를 사용하면 알림을 보안적인 방법으로 받을 수 있습니다. ntfy는 PlayStore와 F-Droid에서 설치 가능합니다.",
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "당신은 방이 공개적으로 접근 가능하지 않을 때만 암호화를 켤 수 있습니다.",
-    "@noEncryptionForPublicRooms": {
         "type": "String",
         "placeholders": {}
     },
@@ -1583,11 +1462,6 @@
     },
     "setStatus": "상태 설정",
     "@setStatus": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "setPermissionsLevel": "권한 레벨 설정",
-    "@setPermissionsLevel": {
         "type": "String",
         "placeholders": {}
     },
@@ -1771,15 +1645,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "inviteContactToGroup": "연락처를 {groupName}에 초대",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
     "inviteContact": "연락처 초대",
     "@inviteContact": {
         "type": "String",
@@ -1863,11 +1728,6 @@
     },
     "unbanFromChat": "채팅에서 영구추방 해제됨",
     "@unbanFromChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "removeDevice": "기기 삭제",
-    "@removeDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -1966,8 +1826,6 @@
     "@link": {},
     "unverified": "확인되지 않음",
     "@unverified": {},
-    "yourChatBackupHasBeenSetUp": "당신의 채팅 백업이 설정되었습니다.",
-    "@yourChatBackupHasBeenSetUp": {},
     "time": "시간",
     "@time": {},
     "messageType": "메시지 유형",
@@ -1982,8 +1840,6 @@
     "@repeatPassword": {},
     "start": "시작",
     "@start": {},
-    "removeFromSpace": "스페이스에서 삭제",
-    "@removeFromSpace": {},
     "commandHint_discardsession": "세션 삭제",
     "@commandHint_discardsession": {
         "type": "String",
@@ -2037,8 +1893,6 @@
     "@pinMessage": {},
     "emojis": "이모지",
     "@emojis": {},
-    "voiceCall": "음성 통화",
-    "@voiceCall": {},
     "placeCall": "전화 걸기",
     "@placeCall": {},
     "experimentalVideoCalls": "실험적인 영상 통화",
@@ -2047,10 +1901,6 @@
     "@unsupportedAndroidVersion": {},
     "unsupportedAndroidVersionLong": "이 기능은 새로운 안드로이드 버전을 요구합니다. Lineage OS 지원이나 업데이트를 확인해주세요.",
     "@unsupportedAndroidVersionLong": {},
-    "videoCallsBetaWarning": "영상 통화는 베타임을 확인해주세요. 의도한 대로 작동하지 않거나 모든 플랫폼에서 작동하지 않을 수 있습니다.",
-    "@videoCallsBetaWarning": {},
-    "emailOrUsername": "이메일이나 유저 이름",
-    "@emailOrUsername": {},
     "confirmMatrixId": "계정을 삭제하려면 Matrix ID를 입력해 주세요.",
     "@confirmMatrixId": {},
     "commandHint_googly": "왕눈이 눈알 보내기",
@@ -2143,18 +1993,8 @@
     "@messagesStyle": {},
     "widgetUrlError": "유효한 URL이 아닙니다.",
     "@widgetUrlError": {},
-    "newSpaceDescription": "스페이스를 사용하면 채팅을 통합하고 비공개 또는 공개 커뮤니티를 구축할 수 있습니다.",
-    "@newSpaceDescription": {},
-    "chatDescription": "채팅 설명",
-    "@chatDescription": {},
-    "enterSpace": "스페이스에 입장",
-    "@enterSpace": {},
-    "encryptThisChat": "이 채팅을 암호화",
-    "@encryptThisChat": {},
     "reopenChat": "채팅 다시 열기",
     "@reopenChat": {},
-    "pleaseEnterRecoveryKey": "당신의 복구키를 입력하세요:",
-    "@pleaseEnterRecoveryKey": {},
     "widgetNameError": "표시 이름을 입력하세요.",
     "@widgetNameError": {},
     "addWidget": "위젯 추가",
@@ -2171,20 +2011,14 @@
     "@noKeyForThisMessage": {},
     "pushNotificationsNotAvailable": "푸시 알림 사용 불가",
     "@pushNotificationsNotAvailable": {},
-    "storeInAppleKeyChain": "Apple KeyChain에 저장하기",
-    "@storeInAppleKeyChain": {},
     "hydrate": "백업 파일로부터 가져오기",
     "@hydrate": {},
     "invalidServerName": "잘못된 서버 이름",
     "@invalidServerName": {},
     "chatPermissions": "채팅 권한",
     "@chatPermissions": {},
-    "storeInAndroidKeystore": "Android KeyStore에 저장하기",
-    "@storeInAndroidKeystore": {},
     "makeAdminDescription": "유저를 한 번 관리자로 만들면, 당신과 같은 권한을 가지기때문에 권한 회수가 불가능합니다.",
     "@makeAdminDescription": {},
-    "saveKeyManuallyDescription": "공유나 클립보드를 이용해 수동으로 키를 저장합니다.",
-    "@saveKeyManuallyDescription": {},
     "whyIsThisMessageEncrypted": "왜 이 메시지를 읽을 수 없나요?",
     "@whyIsThisMessageEncrypted": {},
     "setChatDescription": "채팅 설명 설정",
@@ -2206,16 +2040,12 @@
     "@fileIsTooBigForServer": {},
     "readUpToHere": "여기까지 읽음",
     "@readUpToHere": {},
-    "unlockOldMessages": "오래된 메시지 잠금 해제하기",
-    "@unlockOldMessages": {},
     "optionalRedactReason": "(선택) 이 메시지를 편집하는 이유...",
     "@optionalRedactReason": {},
     "archiveRoomDescription": "채팅이 보관함으로 이동합니다. 다른 유저들은 당신이 떠난다는것을 볼 수 있습니다.",
     "@archiveRoomDescription": {},
     "exportEmotePack": ".zip 파일로 이모트 내보내기",
     "@exportEmotePack": {},
-    "pleaseEnterRecoveryKeyDescription": "오래된 메시지를 잠금 해제하려면, 이전 세션에서 생성된 복호화 키를 입력하세요. 복호화 키는 비밀번호가 아닙니다.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "redactedByBecause": "{username}님이 삭제함. 사유: \"{reason}\"",
     "@redactedByBecause": {
         "type": "String",
@@ -2255,16 +2085,12 @@
     },
     "redactMessageDescription": "메시지는 이 대화의 모든 참여자에게 삭제될 것 입니다. 되돌릴 수 없습니다.",
     "@redactMessageDescription": {},
-    "recoveryKey": "복구키",
-    "@recoveryKey": {},
     "invalidInput": "잘못된 입력!",
     "@invalidInput": {},
     "doNotShowAgain": "다시 보지 않기",
     "@doNotShowAgain": {},
     "report": "신고",
     "@report": {},
-    "screenSharingTitle": "화면 공유",
-    "@screenSharingTitle": {},
     "widgetCustom": "사용자 정의",
     "@widgetCustom": {},
     "youBannedUser": "{user}님을 영구 추방함",
@@ -2285,8 +2111,6 @@
     },
     "openLinkInBrowser": "브라우저에서 링크 열기",
     "@openLinkInBrowser": {},
-    "disableEncryptionWarning": "보안상의 이유로 암호화가 활성화된 채팅에서 암호화를 비활성화 할 수 없습니다.",
-    "@disableEncryptionWarning": {},
     "directChat": "다이렉트 채팅",
     "@directChat": {},
     "wrongPinEntered": "잘못된 pin입니다! {seconds}초 후에 다시 시도하세요...",
@@ -2302,8 +2126,6 @@
     "@sendTypingNotifications": {},
     "inviteGroupChat": "📨 그룹 채팅에 초대",
     "@inviteGroupChat": {},
-    "foregroundServiceRunning": "이 알림은 백그라운드 서비스가 실행중일때 표시됩니다.",
-    "@foregroundServiceRunning": {},
     "importEmojis": "이모지 불러오기",
     "@importEmojis": {},
     "wasDirectChatDisplayName": "빈 채팅 (전 {oldDisplayName})",
@@ -2341,14 +2163,10 @@
     },
     "jump": "점프",
     "@jump": {},
-    "sorryThatsNotPossible": "죄송합니다...그것은 불가능합니다",
-    "@sorryThatsNotPossible": {},
     "shareInviteLink": "초대 링크 공유",
     "@shareInviteLink": {},
     "commandHint_markasdm": "Matrix ID를 위한 다이렉트 메시지 방으로 표시",
     "@commandHint_markasdm": {},
-    "recoveryKeyLost": "복구키를 분실하셨나요?",
-    "@recoveryKeyLost": {},
     "cuddleContent": "{senderName} 님이 당신에게 미소짓습니다",
     "@cuddleContent": {
         "type": "String",
@@ -2365,8 +2183,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "테마 설정:",
-    "@setTheme": {},
     "youJoinedTheChat": "채팅에 참가하였습니다",
     "@youJoinedTheChat": {},
     "widgetName": "이름",
@@ -2393,18 +2209,12 @@
     "@custom": {},
     "noBackupWarning": "경고! 채팅 백업을 켜지 않을경우, 당신은 암호화된 메시지에 대한 접근권한을 잃을것 입니다. 로그아웃 하기 전에 채팅을 백업하는것이 강력히 권장됩니다.",
     "@noBackupWarning": {},
-    "storeInSecureStorageDescription": "이 기기의 보안 스토리지에 복구키를 저장합니다.",
-    "@storeInSecureStorageDescription": {},
     "kickUserDescription": "유저는 채팅에서 추방되지만 영구 추방되지 않습니다. 공개 채팅의 경우, 언제든 유저가 다시 참가할 수 있습니다.",
     "@kickUserDescription": {},
     "importNow": "지금 불러오기",
     "@importNow": {},
     "invite": "초대",
     "@invite": {},
-    "storeSecurlyOnThisDevice": "이 기기에 안전하게 저장",
-    "@storeSecurlyOnThisDevice": {},
-    "screenSharingDetail": "FluffyChat에 당신의 화면을 공유하는중",
-    "@screenSharingDetail": {},
     "blockUsername": "유저 이름 무시",
     "@blockUsername": {},
     "block": "차단",
@@ -2417,8 +2227,6 @@
     "@commandHint_sendraw": {},
     "pleaseChooseAStrongPassword": "강력한 비밀번호를 사용하세요",
     "@pleaseChooseAStrongPassword": {},
-    "addChatOrSubSpace": "채팅 또는 하위 스페이스 추가",
-    "@addChatOrSubSpace": {},
     "subspace": "하위 스페이스",
     "@subspace": {},
     "databaseMigrationBody": "잠시만 기다리세요. 시간이 걸릴 수 있습니다.",
@@ -2449,8 +2257,6 @@
             }
         }
     },
-    "createGroupAndInviteUsers": "그룹 채팅을 생성하고 유저를 초대",
-    "@createGroupAndInviteUsers": {},
     "passwordsDoNotMatch": "비밀번호가 일치하지 않습니다",
     "@passwordsDoNotMatch": {},
     "passwordIsWrong": "비밀번호가 틀립니다",
@@ -2461,26 +2267,8 @@
     "@sendReadReceipts": {},
     "sendReadReceiptsDescription": "채팅의 다른 참가자들이 당신이 메시지를 읽었는지 볼 수 있습니다.",
     "@sendReadReceiptsDescription": {},
-    "verifyOtherUser": "🔐 다른 유저 확인",
-    "@verifyOtherUser": {},
     "hidePresences": "상태 목록을 숨길까요?",
     "@hidePresences": {},
-    "searchChatsRooms": "#chats, @users 검색...",
-    "@searchChatsRooms": {},
-    "groupCanBeFoundViaSearch": "검색으로 그룹 채팅을 찾을 수 있음",
-    "@groupCanBeFoundViaSearch": {},
-    "restoreSessionBody": "앱이 백업에서 세션을 복원하려 시도중입니다. {url} 에서 개발자에게 오류를 신고하세요. 오류 메시지는 다음과 같습니다: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "acceptedKeyVerification": "{sender}가 키 검증을 수락함",
     "@acceptedKeyVerification": {
         "type": "String",
@@ -2509,18 +2297,6 @@
     "@commandHint_unignore": {},
     "blockListDescription": "당신은 당신을 방해하는 유저들을 차단할 수 있습니다. 당신은 당신의 개인 차단 목록에 있는 어떠한 유저의 메시지와 방 초대도 받지 않을것 입니다.",
     "@blockListDescription": {},
-    "sessionLostBody": "세션을 잃었습니다. {url} 에서 개발자에게 오류를 신고하세요. 오류 메시지는 다음과 같습니다: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "yourGlobalUserIdIs": "글로벌 유저 ID: ",
     "@yourGlobalUserIdIs": {},
     "noUsersFoundWithQuery": "안타깝게도 \"{query}\"로 유저를 찾을 수 없습니다. 오타가 없는지 확인하십시오.",
@@ -2550,8 +2326,6 @@
     "@formattedMessages": {},
     "verifyOtherDevice": "🔐 다른 기기를 확인",
     "@verifyOtherDevice": {},
-    "verifyOtherUserDescription": "다른 유저를 확인하면, 당신은 당신이 누구에게 말하고있는지 알 수 있습니다. 💪\n\n확인을 시작할 때, 다른 유저는 앱에서 팝업을 볼 수 있습니다. 당신은 그런 다음 서로 비교해야 이모지 또는 숫자의 목록을 볼 수 있습니다.\n\n이 작업을 수행하는 가장 좋은 방법은 직접 만나거나 영상통화를 하는것입니다. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDeviceDescription": "다른 장치를 확인하면, 장치와 키를 교환하고, 전반적인 보안을 증가시킵니다. 💪 확인을 시작하면 팝업은 두 장치에 나타납니다. 그런 다음 서로 비교해야 이모지 또는 숫자의 목록를 볼 수 있습니다. 확인을 시작하기 전에 모든 장치를 준비하세요. 🤳",
     "@verifyOtherDeviceDescription": {},
     "isReadyForKeyVerification": "{sender}가 키 검증 준비를 완료함",
@@ -2605,14 +2379,8 @@
     "@appLockDescription": {},
     "calls": "전화",
     "@calls": {},
-    "globalChatId": "글로벌 채팅 ID",
-    "@globalChatId": {},
     "customEmojisAndStickers": "커스텀 이모지와 스티커",
     "@customEmojisAndStickers": {},
-    "accessAndVisibilityDescription": "채팅에 참가 할 수 있는 사람과 채팅을 볼 수 있는 범위",
-    "@accessAndVisibilityDescription": {},
-    "accessAndVisibility": "채팅 가입과 대화 기록",
-    "@accessAndVisibility": {},
     "customEmojisAndStickersBody": "모든 채팅에서 사용할 수있는 커스텀 이모지와 스티커를 추가하거나 공유합니다.",
     "@customEmojisAndStickersBody": {},
     "hideRedactedMessages": "삭제된 메시지 숨기기",
@@ -2627,21 +2395,8 @@
     "@passwordRecoverySettings": {},
     "knock": "참가 요청",
     "@knock": {},
-    "usersMustKnock": "유저들이 참가를 허가받아야함",
-    "@usersMustKnock": {},
     "knocking": "참가 요청중",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "채팅은 {server} 에서 검색하여 찾을 수 있습니다.",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "noOneCanJoin": "아무도 참가할 수 없음",
-    "@noOneCanJoin": {},
     "thereAreCountUsersBlocked": "{count}명의 차단된 유저가 있습니다.",
     "@thereAreCountUsersBlocked": {
         "type": "String",
@@ -2649,10 +2404,6 @@
     },
     "noDatabaseEncryption": "데이터베이스 암호화는 이 플랫폼에서 지원되지 않음",
     "@noDatabaseEncryption": {},
-    "publicChatAddresses": "공개 채팅 주소",
-    "@publicChatAddresses": {},
-    "createNewAddress": "새 주소 만들기",
-    "@createNewAddress": {},
     "searchMore": "더 검색...",
     "@searchMore": {},
     "files": "파일",
@@ -2738,8 +2489,6 @@
     "@changeTheCanonicalRoomAlias": {},
     "sendCanceled": "전송 최소됨",
     "@sendCanceled": {},
-    "homeserverDescription": "당신의 모든 데이터는 이메일과 흡사하게 당신의 홈서버에 저장됩니다. 당신이 소통하고 싶은 사람들과 다른 서버를 사용해도 무관하니 당신이 원하는 홈서버를 선택해도 됩니다. https://matrix.org에서 자세히 알아보세요.",
-    "@homeserverDescription": {},
     "sendingAttachmentCountOfCount": "첨부파일 {length}개중 {index}번째 전송 중...",
     "@sendingAttachmentCountOfCount": {
         "type": "integer",
@@ -2763,8 +2512,6 @@
     },
     "noContactInformationProvided": "서버가 유효한 연락처 정보를 제공하지 않음",
     "@noContactInformationProvided": {},
-    "welcomeText": "안녕하세요 👋 FluffyChat이에요. 당신은 htpps://matrix.org와 호환되는 모든 홈서버를 사용할 수 있어요. 그리고 모두와 대화해보세요. 거대한 분산 대화망이니까요!",
-    "@welcomeText": {},
     "changeGeneralChatSettings": "일반 채팅 설정 번경하기",
     "@changeGeneralChatSettings": {},
     "inviteOtherUsers": "다른 사용자를 이 채팅에 초대하기",
@@ -2783,8 +2530,6 @@
     "@opacity": {},
     "setWallpaper": "배경화면 설정하기",
     "@setWallpaper": {},
-    "manageAccount": "계정 관리하기",
-    "@manageAccount": {},
     "aboutHomeserver": "{homeserver}의 대해서",
     "@aboutHomeserver": {
         "type": "String",
@@ -2814,12 +2559,6 @@
     "@sendRoomNotifications": {},
     "chatPermissionsDescription": "이 채팅에서 특정 작업에 요구할 권한 레벨을 정의합니다. 권한 레벨 0, 50, 100은 일반적으로 유저, 관리자, 운영자를 나타내지만, 모든 숫자가 가능합니다.",
     "@chatPermissionsDescription": {},
-    "loginWithMatrixId": "Matrix-ID로 로그인",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "홈서버 찾아보기",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "홈서버가 무엇인가요?",
-    "@whatIsAHomeserver": {},
     "doesNotSeemToBeAValidHomeserver": "호환되는 홈서버가 아닌 것 같습니다. URL을 올바르게 입력됐나요?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "continueText": "계속하기",
@@ -2856,17 +2595,6 @@
     "@italicText": {},
     "boldText": "두꺼운 글꼴",
     "@boldText": {},
-    "appWantsToUseForLoginDescription": "웹사이트와 당신에 대한 정보를 공유하게됩니다.",
-    "@appWantsToUseForLoginDescription": {},
-    "appWantsToUseForLogin": "'{server}'로 로그인",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "otherPartyNotLoggedIn": "다른 구성원이 현재 로그인하지 않아 메시지를 수신하지 못합니다!",
     "@otherPartyNotLoggedIn": {},
     "open": "열기",
@@ -2887,8 +2615,6 @@
     "@previous": {},
     "newChatRequest": "📩 새 채팅 요청",
     "@newChatRequest": {},
-    "appIntroduction": "FluffyChat는 다른 메신저들을 사용하는 친구들과도 채팅할 수 있습니다. https://matrix.org에 방문하거나 *계속*을 눌러 자세한 정보를 확인하세요.",
-    "@appIntroduction": {},
     "synchronizingPleaseWaitCounter": " 동기화중… ({percentage}%)",
     "@synchronizingPleaseWaitCounter": {
         "type": "String",
@@ -2974,15 +2700,6 @@
     "@commandHint_roomupgrade": {},
     "checkList": "체크리스트",
     "@checkList": {},
-    "countInvited": "{count}초대받은",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "userSpecificNotificationSettings": "사용자별 알림 설정",
     "notificationRuleCallDescription": "통화에 대해 사용자에게 알림을 보냅니다.",
     "notificationRuleEncryptedRoomOneToOne": "암호화된 1:1 방",
@@ -3025,11 +2742,9 @@
     "taTooltip": "번역 도움말과 함께 L2 사용",
     "interactiveTranslatorSliderHeader": "인터랙티브 번역기",
     "interactiveGrammarSliderHeader": "인터랙티브 문법 검사기",
-    "interactiveTranslatorRequired": "필수",
     "waTooltip": "도움말 없이 L2 사용",
     "interactiveTranslator": "번역 지원",
     "noIdenticalLanguages": "기본 언어와 대상 언어를 다르게 선택하세요",
-    "searchBy": "국가 및 언어별 검색",
     "joinWithClassCode": "수업 참여",
     "languageLevelPreA1": "초급 낮음 (Pre A1)",
     "languageLevelA1": "초급 중급 (A1)",
@@ -3050,19 +2765,14 @@
     "saveChanges": "변경 사항 저장",
     "publicProfileTitle": "내 프로필을 검색에서 찾을 수 있도록 허용",
     "publicProfileDesc": "켜면, 다른 사용자가 글로벌 검색창에서 당신의 프로필을 찾고 채팅 요청을 보낼 수 있습니다. 이때 요청을 수락하거나 거부할 수 있습니다.",
-    "errorDisableIT": "번역 지원이 꺼져 있습니다.",
-    "errorDisableIGC": "문법 지원이 꺼져 있습니다.",
     "errorDisableITUserDesc": "여기를 클릭하여 번역 지원 설정을 업데이트하세요",
     "errorDisableIGCUserDesc": "여기를 클릭하여 문법 지원 설정을 업데이트하세요",
     "errorDisableITClassDesc": "이 채팅이 속한 강좌에 대한 번역 지원이 꺼져 있습니다.",
     "errorDisableIGCClassDesc": "이 채팅이 속한 강좌에 대한 문법 지원이 꺼져 있습니다.",
-    "error405Title": "언어가 설정되지 않음",
     "error405Desc": "메인 메뉴 > 학습 설정에서 언어를 설정하세요.",
     "termsAndConditions": "이용 약관",
     "andCertifyIAmAtLeast13YearsOfAge": " 및 만 16세 이상임을 인증합니다.",
-    "error502504Title": "와, 온라인에 학생이 정말 많네요!",
     "error502504Desc": "파니아 봇이 따라잡는 동안 번역 및 문법 도구가 느리거나 사용할 수 없을 수 있습니다.",
-    "error404Title": "번역 오류!",
     "error404Desc": "파니아 봇이 어떻게 번역해야 할지 확실하지 않아요...",
     "errorPleaseRefresh": "문제를 해결 중입니다! 새로고침 후 다시 시도하세요.",
     "connectedToStaging": "스테이징에 연결됨",
@@ -3100,13 +2810,9 @@
     "definitionsToolName": "단어 정의",
     "definitionsToolDescription": "활성화하면 파란색 밑줄이 그어진 단어를 클릭하여 정의를 볼 수 있습니다. 메시지를 클릭하여 정의에 접근하세요.",
     "welcomeBack": "다시 오신 것을 환영합니다! 2023-2024 파일럿에 참여하셨다면, 특별 파일럿 구독을 위해 저희에게 연락하세요. 교사이거나 귀하의 기관이 수업용 라이선스를 구매한 경우, 교사 구독을 위해 저희에게 연락하세요.",
-    "downloadTxtFile": "텍스트 파일 다운로드",
-    "downloadCSVFile": "CSV 파일 다운로드",
     "promotionalSubscriptionDesc": "현재 평생 프로모션 구독을 보유하고 있습니다. 구독 변경에 대한 도움을 원하시면 support@pangea.chat으로 메시지를 보내세요.",
     "originalSubscriptionPlatform": "구매 플랫폼: {purchasePlatform}",
     "oneWeekTrial": "일주일 무료 체험",
-    "downloadXLSXFile": "엑셀 파일 다운로드",
-    "unkDisplayName": "알 수 없음",
     "wwCountryDisplayName": "전 세계",
     "afCountryDisplayName": "아프가니스탄",
     "axCountryDisplayName": "올란드 제도",
@@ -3401,7 +3107,6 @@
     "chatCapacityHasBeenChanged": "채팅 용량이 변경되었습니다.",
     "chatCapacitySetTooLow": "채팅 용량은 최소 {count} 이상이어야 합니다.",
     "chatCapacityExplanation": "채팅 용량은 채팅에 허용되는 멤버 수를 제한합니다.",
-    "tooManyRequest": "요청이 너무 많습니다. 잠시 후 다시 시도하세요.",
     "enterNumber": "정수 값을 입력하세요.",
     "practice": "연습",
     "versionNotFound": "버전을 찾을 수 없습니다",
@@ -3411,7 +3116,6 @@
     "deleteSubscriptionWarningTitle": "활성 구독이 있습니다",
     "deleteSubscriptionWarningBody": "계정을 삭제하더라도 구독이 자동으로 취소되지 않습니다.",
     "manageSubscription": "구독 관리",
-    "error520Title": "다시 시도해 주세요.",
     "error520Desc": "죄송합니다, 메시지를 이해하지 못했습니다...",
     "wordsUsed": "사용된 단어",
     "level": "레벨",
@@ -3429,7 +3133,6 @@
     "other": "기타",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "용량 제한 없음",
-    "downloadGroupText": "그룹 텍스트 다운로드",
     "notificationsOn": "알림 켜기",
     "notificationsOff": "알림 끄기",
     "joinWithCode": "코드로 참여",
@@ -3493,24 +3196,12 @@
     "whatIsTheMorphTag": "'{wordForm}'의 {morphologicalFeature}는 무엇입니까?",
     "dataAvailable": "데이터 가용성",
     "available": "이용 가능",
-    "pangeaBotIsFallible": "판게아 봇도 실수를 합니다!",
-    "whatIsMeaning": "'{lemma}'의 의미는 무엇입니까?",
     "chooseLemmaMeaningInstructionsBody": "메시지의 단어와 의미를 일치시키세요!",
-    "doubleClickToEdit": "더블 클릭하여 편집하세요.",
-    "topicLabel": "주제",
-    "topicPlaceholder": "주제 선택...",
-    "modePlaceholder": "모드 선택...",
-    "learningObjectiveLabel": "학습 목표",
-    "learningObjectivePlaceholder": "학습 목표 선택...",
-    "targetLanguageLabel": "목표 언어",
     "cefrLevelLabel": "CEFR 수준",
     "image": "이미지",
     "video": "비디오",
     "nan": "해당 없음",
-    "addVocabulary": "어휘 추가",
     "instructions": "지침",
-    "numberOfLearners": "학습자 수",
-    "mustBeInteger": "정수여야 합니다. 예: 1, 2, 3, ...",
     "constructUsePvmDesc": "음성 메시지로 제작됨",
     "leaveSpaceDescription": "코스를 떠나면 그 안의 모든 채팅이 종료됩니다. 다른 사용자는 당신이 코스를 떠났다는 것을 볼 수 있습니다.",
     "constructUseCorMmDesc": "메시지 의미가 정확함",
@@ -3525,7 +3216,6 @@
     "ttsDisabledBody": "학습 설정에서 텍스트 음성 변환을 활성화할 수 있습니다",
     "noSpaceDescriptionYet": "아직 생성된 강좌 설명이 없습니다.",
     "tooLargeToSend": "이 메시지는 너무 커서 보낼 수 없습니다",
-    "exitWithoutSaving": "저장하지 않고 종료하시겠습니까?",
     "enableAutocorrectPopupTitle": "목표 언어 키보드를 추가하려면 다음으로 이동하세요:",
     "enableAutocorrectPopupSteps": "  • 설정\n  • 일반\n  • 키보드\n  • 키보드\n  • 새 키보드 추가",
     "enableAutocorrectPopupDescription": "언어를 선택하면, 키보드 왼쪽 하단의 작은 지구본 아이콘을 클릭하여 새로 설치한 키보드를 활성화할 수 있습니다.",
@@ -3536,11 +3226,8 @@
     "displayName": "표시 이름",
     "leaveRoomDescription": "이 채팅을 떠날 예정입니다. 다른 사용자는 당신이 채팅을 떠났음을 볼 수 있습니다.",
     "confirmUserId": "계정을 삭제하려면 Pangea 채팅 사용자 이름을 확인하세요.",
-    "startingToday": "오늘부터 시작",
-    "oneWeekFreeTrial": "일주일 무료 체험",
     "paidSubscriptionStarts": "{startDate}부터 시작",
     "cancelInSubscriptionSettings": "• 구독 설정에서 언제든 취소 가능",
-    "cancelToAvoidCharges": "• {trialEnds} 전에 취소하여 요금을 피하세요",
     "downloadGboard": "Gboard 다운로드",
     "autocorrectNotAvailable": "안타깝게도 현재 이 플랫폼은 이 기능을 지원하지 않습니다. 향후 개발을 기대하세요!",
     "pleaseUpdateApp": "앱을 계속 사용하려면 업데이트하세요.",
@@ -3550,17 +3237,12 @@
     "knockSpaceSuccess": "이 강좌에 참여 요청을 보냈습니다! 관리자가 요청을 받으면 응답할 것입니다 😄",
     "chooseWordAudioInstructionsBody": "전체 메시지를 듣고, 그 다음에 오디오와 단어를 일치시키세요.",
     "chooseMorphsInstructionsBody": "문법 질문을 위해 퍼즐 조각을 클릭하세요!",
-    "pleaseEnterInt": "숫자를 입력하세요",
     "home": "홈",
     "join": "참여하기",
     "resetInstructionTooltipsTitle": "설명 툴팁 재설정",
     "resetInstructionTooltipsDesc": "클릭하여 새 사용자처럼 설명 툴팁을 표시하세요.",
-    "randomize": "무작위로 선택",
     "clear": "지우기",
-    "featuredActivities": "추천 활동",
     "save": "저장",
-    "startChat": "채팅 시작",
-    "translationProblem": "번역 문제",
     "askToJoin": "참여 요청",
     "emptyChatWarningTitle": "채팅이 비어 있습니다",
     "emptyChatWarningDesc": "아무도 채팅에 초대하지 않으셨습니다. 채팅 설정으로 이동하여 연락처 또는 봇을 초대하세요. 나중에 하셔도 됩니다.",
@@ -3590,17 +3272,13 @@
     "timesUsedIndependently": "독립적으로 사용된 횟수",
     "timesUsedWithAssistance": "도움과 함께 사용된 횟수",
     "shareInviteCode": "초대 코드 공유: {code}",
-    "leaderboard": "리더보드",
     "skipForNow": "지금은 건너뛰기",
     "permissions": "권한",
     "spaceChildPermission": "이 강좌에 새 채팅을 추가할 수 있는 사람",
-    "addEnvironmentOverride": "환경 재정의 추가",
     "defaultOption": "기본값",
     "deleteChatDesc": "이 채팅을 삭제하시겠습니까? 모든 참가자에게 삭제되며, 채팅 내 모든 메시지는 더 이상 연습이나 학습 분석에 사용할 수 없습니다.",
     "deleteSpaceDesc": "이 강좌와 선택된 채팅은 모든 참가자에게 삭제되며, 채팅 내 모든 메시지는 더 이상 연습이나 학습 분석에 사용할 수 없습니다. 이 작업은 되돌릴 수 없습니다.",
     "launch": "시작",
-    "searchChats": "채팅 검색",
-    "maxFifty": "최대 50개",
     "configureSpace": "강좌 구성",
     "pinMessages": "메시지 고정",
     "setJoinRules": "참여 규칙 설정",
@@ -3634,9 +3312,6 @@
     "failedToFetchTranscription": "전사 정보를 가져오지 못했어요",
     "deleteEmptySpaceDesc": "이 과정은 모든 참가자에게 삭제됩니다. 이 작업은 취소할 수 없습니다.",
     "regenerate": "다시 생성",
-    "mySavedActivities": "내 저장된 활동",
-    "noSavedActivities": "저장된 활동이 없습니다",
-    "saveActivity": "이 활동 저장",
     "failedToPlayVideo": "비디오 재생 실패",
     "done": "완료",
     "inThisSpace": "이 과정에서",
@@ -3647,13 +3322,9 @@
     "numInvited": "{count} 명이 초대됨",
     "saved": "저장됨",
     "reset": "초기화",
-    "errorFetchingActivitiesMessage": "활동 가져오기 실패",
     "errorFetchingDefinition": "정의를 가져오지 못했습니다",
     "errorProcessAnalytics": "분석 처리 실패",
     "errorDownloading": "다운로드 실패",
-    "errorLoadingSpaceChildren": "이 과정 내 채팅을 불러오지 못했습니다",
-    "unexpectedError": "예기치 않은 오류가 발생했습니다.",
-    "pleaseReload": "다시 로드하고 다시 시도하세요.",
     "translationError": "번역 오류",
     "check": "확인",
     "unableToFindRoom": "해당 코드로 채팅 또는 과정을 찾을 수 없습니다. 다시 시도하세요.",
@@ -3662,19 +3333,14 @@
     "request": "요청",
     "requestAll": "모든 요청",
     "confirmMessageUnpin": "이 메시지의 고정을 해제하시겠습니까?",
-    "saveAndLaunch": "저장하고 시작",
-    "launchToSpace": "과정에 시작",
     "pending": "보류 중",
     "inactive": "비활성",
-    "confirmRole": "역할 확인",
     "openRoleLabel": "오픈",
     "finishedTheActivity": "🎯 {username}님이 이 활동을 마무리하셨습니다",
     "activitySummaryError": "활동 요약을 사용할 수 없습니다",
     "requestSummaries": "요약 요청",
-    "generatingNewActivities": "이 언어 쌍의 첫 사용자입니다! 잠시만 기다려 주세요, 여러분만을 위한 활동을 준비 중입니다.",
     "requestAccessTitle": "분석 접근 요청?",
     "requestAccessDesc": "참가자 분석 보기 권한을 요청하시겠습니까?\n\n참가자가 동의하면, 이 강좌의 관리자는 다음을 볼 수 있습니다:\n    • 총 어휘 수\n    • 총 문법 개념\n    • 완료된 활동 세션 수\n    • 사용된 문법 개념, 맞게 또는 틀리게\n\n그들은 다음을 볼 수 없습니다:\n    • 강좌 외 채팅 메시지\n    • 어휘 목록",
-    "requestAccess": "접근 요청 ({count})",
     "analyticsInactiveTitle": "비활성 사용자에게 요청을 보낼 수 없습니다",
     "analyticsInactiveDesc": "이 기능이 도입된 이후로 로그인하지 않은 비활성 사용자는 요청을 볼 수 없습니다.\n\n사용자가 돌아오면 요청 버튼이 표시됩니다. 요청 버튼을 클릭하여 나중에 다시 요청할 수 있습니다.",
     "accessRequestedTitle": "분석 액세스 요청",
@@ -3697,8 +3363,6 @@
     "accessDesc": "코스를 공개하거나 비공개로 안전하게 설정할 수 있습니다!",
     "createGroupChatDesc": "활동 세션이 시작되고 종료되는 동안, 그룹 채팅은 일상적인 소통을 위해 열려 있습니다.",
     "deleteDesc": "코스는 관리자만 삭제할 수 있습니다. 이는 모든 사용자와 선택된 채팅을 삭제하는 파괴적인 작업입니다. 신중히 진행하세요.",
-    "noCourseFound": "이 코스에는 계획이 필요합니다!\n\n코스 계획은 주제와 대화 활동의 연속입니다.",
-    "additionalParticipants": "+ {num}명 더",
     "whatNow": "이제 무엇을 할까요?",
     "chooseNextActivity": "다음 활동을 선택하세요!",
     "letsGo": "시작합시다",
@@ -3711,13 +3375,11 @@
     "waitNotDone": "기다려, 아직 끝나지 않았어!",
     "waitingForOthersToFinish": "나머지 사람들이 끝내기를 기다리는 중...",
     "generatingSummary": "채팅 분석 및 결과 생성 중",
-    "findCourse": "코스 찾기",
     "pingParticipantsNotification": "{user}님이 {room}에서 활동 세션에 참여할 사용자를 찾고 있습니다",
     "course": "코스",
     "courses": "코스들",
     "goToCourse": "코스로 이동: {course}",
     "activityComplete": "이 활동이 완료되었습니다. 활동 요약은 아래에서 확인하실 수 있습니다.",
-    "startNewSession": "새 세션 시작",
     "joinOpenSession": "열린 세션에 참여하기",
     "activityNotFound": "활동을 찾을 수 없습니다",
     "myActivities": "내 활동",
@@ -3947,10 +3609,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3960,10 +3618,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4051,14 +3705,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4075,10 +3721,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4091,15 +3733,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4251,14 +3885,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4272,14 +3898,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5502,10 +5120,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5546,10 +5160,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5622,10 +5232,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5895,47 +5501,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5955,19 +5521,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6031,10 +5585,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6075,14 +5625,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6094,14 +5636,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6139,10 +5673,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6159,27 +5689,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6303,10 +5817,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6316,10 +5826,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6336,14 +5842,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6483,18 +5981,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6543,10 +6029,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6556,18 +6038,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6610,23 +6080,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6650,10 +6108,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6661,14 +6115,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6773,18 +6219,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6837,10 +6271,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6867,10 +6297,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7051,7 +6477,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "내일 다시 확인하여 활동 업데이트를 확인하세요.",
-    "activityDropdownDesc": "이 활동이 끝나면 아래를 클릭하세요",
     "languageMismatchTitle": "언어 불일치",
     "languageMismatchDesc": "목표 언어가 이 활동의 언어와 일치하지 않습니다. 목표 언어를 업데이트하시겠습니까?",
     "reportWordIssueTooltip": "단어 정보 문제 신고",
@@ -7064,10 +6489,6 @@
     "selectAll": "모두 선택",
     "deselectAll": "모두 선택 해제",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7116,17 +6537,11 @@
         "placeholders": {}
     },
     "startOwn": "나만의 시작",
-    "joinCourseDesc": "각 강좌에는 8-10개의 순차적인 주제와 다양한 과제 기반 언어 학습 활동이 포함되어 있습니다.",
     "newMessageInPangeaChat": "💬 Pangea 채팅에 새 메시지",
     "shareCourse": "강좌 공유",
     "addCourse": "강좌 추가",
-    "joinPublicCourse": "공개 강좌 참여",
     "vocabLevelsDesc": "단어를 레벨업하면 여기에 단어가 표시됩니다!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7139,10 +6554,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7161,7 +6572,6 @@
     "emojiView": "이모지 보기",
     "feedbackDialogDesc": "저도 실수를 해요! 제가 개선할 수 있도록 도와줄 수 있는 것이 있나요?",
     "contactHasBeenInvitedToTheCourse": "연락처가 과정에 초대되었습니다",
-    "activityStatsButtonTooltip": "활동 정보",
     "allow": "허용",
     "deny": "거부",
     "enabledRenewal": "구독 갱신 활성화",
@@ -7429,10 +6839,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8488,16 +7894,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "다음 주제를 잠금 해제할 활동",
-    "activitiesToUnlockTopicDesc": "다음 과정 주제를 잠금 해제할 활동 수를 설정하세요",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "정확한 어휘 정의 연습",
     "constructUseIncLMDesc": "부정확한 어휘 정의 연습",
     "constructUseCorLADesc": "정확한 어휘 오디오 연습",
@@ -8505,7 +7901,6 @@
     "constructUseBonus": "어휘 연습 중 보너스",
     "practiceVocab": "어휘 연습",
     "selectMeaning": "의미 선택",
-    "selectAudio": "일치하는 오디오 선택",
     "anotherRound": "또 다른 라운드",
     "activitySettingsOverrideWarning": "활동 계획에 의해 결정된 언어 및 언어 수준",
     "voice": "음성",
@@ -8537,10 +7932,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8558,12 +7949,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "다운로드가 시작되었습니다",
     "webDownloadPermissionMessage": "브라우저가 다운로드를 차단하는 경우, 이 사이트에 대한 다운로드를 활성화해 주세요.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8658,11 +8044,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "문제가 발생했으며, 우리는 이를 해결하기 위해 열심히 작업하고 있습니다. 나중에 다시 확인해 주세요.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "쓰기 지원 활성화",
     "autoIGCToolDescription": "전송된 메시지를 목표 언어로 수정하기 위해 Pangea Chat 도구를 자동으로 실행합니다.",
     "@autoIGCToolName": {
@@ -8718,24 +8099,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "문법",
-    "spanTypeWordChoice": "단어 선택",
     "spanTypeSpelling": "철자",
     "spanTypePunctuation": "구두점",
     "spanTypeStyle": "스타일",
     "spanTypeFluency": "유창성",
     "spanTypeAccents": "억양",
     "spanTypeCapitalization": "대문자 사용",
-    "spanTypeCorrection": "수정",
     "spanFeedbackTitle": "수정 문제 보고",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8760,10 +8130,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8776,13 +8142,7 @@
     "longPressToRecordVoiceMessage": "길게 눌러 음성 메시지를 녹음하세요.",
     "pause": "일시 정지",
     "resume": "재개",
-    "newSubSpace": "새 하위 공간",
-    "moveToDifferentSpace": "다른 공간으로 이동",
-    "removeFromSpaceDescription": "채팅은 공간에서 제거되지만 여전히 채팅 목록에 나타납니다.",
     "countChats": "{chats} 개의 채팅",
-    "spaceMemberOf": "{spaces}의 공간 구성원",
-    "spaceMemberOfCanKnock": "{spaces}의 공간 구성원이 노크할 수 있습니다.",
-    "donate": "기부하기",
     "startedAPoll": "{username}이(가) 설문조사를 시작했습니다.",
     "poll": "설문조사",
     "startPoll": "설문조사 시작",
@@ -8806,23 +8166,15 @@
     "newStickerPack": "새 스티커 팩",
     "stickerPackName": "스티커 팩 이름",
     "attribution": "출처",
-    "skipChatBackup": "채팅 백업 건너뛰기",
-    "skipChatBackupWarning": "확실합니까? 채팅 백업을 활성화하지 않으면 기기를 전환할 때 메시지에 대한 접근을 잃을 수 있습니다.",
-    "loadingMessages": "메시지 로딩 중",
-    "setupChatBackup": "채팅 백업 설정",
     "noMoreResultsFound": "더 이상 결과가 없습니다",
     "chatSearchedUntil": "{time}까지 채팅 검색됨",
     "federationBaseUrl": "연합 기본 URL",
     "clientWellKnownInformation": "클라이언트-잘 알려진 정보:",
     "baseUrl": "기본 URL",
     "identityServer": "아이덴티티 서버:",
-    "versionWithNumber": "버전: {version}",
     "logs": "로그",
-    "advancedConfigs": "고급 구성",
     "advancedConfigurations": "고급 구성",
-    "signInWithLabel": "다음으로 로그인:",
     "selectAllWords": "오디오에서 들리는 모든 단어를 선택하세요",
-    "joinCourseForActivities": "활동을 시도하려면 코스에 참여하세요.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -8859,18 +8211,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -8878,26 +8218,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9003,22 +8323,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9047,19 +8351,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9067,15 +8359,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9276,11 +8560,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "수업 중인가요? 여기에 참여 코드를 입력하세요.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "오디오 메시지 자동 강조",
     "selectAudioMessagesOnPlayDescription": "재생할 때 오디오 메시지를 자동으로 강조 표시합니다",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9324,18 +8603,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "이 과정에는 {input} 활동보다 적은 주제가 있습니다. {minValue} 이하의 숫자를 입력해 주세요.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "여기에 클릭하여 다시 로그인하세요.",
     "@clickToLogin": {
@@ -9752,17 +9019,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "흥분한 듯 팔을 들고 있는 만화 같은 노란 곰.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "배우고 싶은 단어를 선택하세요",
     "requireAnalyticsAccessTitle": "참여를 위해 분석 접근 권한 필요",
     "requireAnalyticsAccessDesc": "참여자는 이 과정에 참여하기 위해 학습 분석에 대한 접근 권한을 부여해야 합니다.",
     "analyticsAccessNoticeTitle": "분석 접근 권한 필요",
     "analyticsAccessNoticeDesc": "이 과정에 참여함으로써, 귀하는 관리자에게 귀하의 학습 분석에 대한 접근 권한을 부여하는 것에 동의합니다.",
-    "skipOnboardingClassCodeDesc": "독립적으로 학습하고 있나요? 걱정하지 마세요, 당신은:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9780,10 +9041,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9812,7 +9069,6 @@
     "pickCefrLevelTeacherStepTitle": "어떤 수준을 가르치고 있습니까?",
     "pickCefrLevelStudentStepTitle": "당신은 어떤 수준입니까?",
     "customCourseStepTitle": "맞춤 코스를 받으려면 이 양식을 작성하세요",
-    "aboutYourClass": "수업에 대하여",
     "courseCodeStepErrorMessage": "코드를 확인하고 다시 시도해 주세요",
     "institution": "기관",
     "courseGoals": "강좌 목표",
@@ -9855,10 +9111,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9975,12 +9227,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "판게아 채팅 로고",
     "introChatDetails": "안녕하세요! 동료 코스 참가자에게 자신을 소개하고, 친구를 찾고, 활동 외부에서 채팅하세요.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10024,11 +9271,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "활동 작업",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "발음 도구",
     "audioTranscription": "AI 오디오 전사",
     "visualLearnerSupport": "시각 학습자 지원",
@@ -10069,7 +9311,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "이 활동을 플레이하려면 이 활동이 포함된 코스를 가입하세요.",
     "resizeCoursePanel": "코스 패널 크기 조정",
     "undo": "실행 취소",
     "unlock": "잠금 해제",
@@ -10083,7 +9324,6 @@
     "addCourseBrowsePublic": "공개 과정 탐색",
     "browsePublicCourses": "공개 과정 탐색",
     "editProfile": "프로필 수정",
-    "numObjectives": "{count} 개의 목표",
     "mapSearchHint": "활동 검색",
     "mapSearchNoResults": "일치하는 항목이 없습니다",
     "mapFilterAllLanguages": "모든 언어",
@@ -10092,7 +9332,6 @@
     "mapFilterCompleted": "완료됨",
     "mapFilterReset": "재설정",
     "activityTypeConversation": "대화",
-    "lockedMissionRequirement": "이전 미션을 완료하여 잠금을 해제하세요",
     "playAgain": "다시 플레이",
     "reviewActivity": "검토",
     "mapEmptyInView": "귀하의 수준이나 언어에 해당하는 내용이 없습니다. 필터를 넓히거나 축소하세요.",
@@ -10107,14 +9346,9 @@
     "scrollToBottom": "맨 아래로 스크롤",
     "courseImage": "강의 이미지",
     "avatarPreview": "아바타 미리보기",
-    "activityPhoto": "활동 사진",
     "emotePreview": "이모티콘 미리보기: {name}",
     "activityLabel": "활동: {title}",
     "resetMapView": "지도 보기 초기화",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10167,14 +9401,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10204,10 +9430,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10264,10 +9486,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_lt.arb
+++ b/lib/l10n/intl_lt.arb
@@ -110,8 +110,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "addAccount": "Pridėti paskyrą",
-    "@addAccount": {},
     "or": "Arba",
     "@or": {
         "type": "String",
@@ -179,11 +177,6 @@
     },
     "homeserver": "Namų serveris",
     "@homeserver": {},
-    "everythingReady": "Viskas paruošta!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "fontSize": "Šrifto dydis",
     "@fontSize": {
         "type": "String",
@@ -293,11 +286,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "passwordRecovery": "Slaptažodžio atkūrimas",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pickImage": "Pasirinkite paveiksliuką",
     "@pickImage": {
         "type": "String",
@@ -380,11 +368,6 @@
     },
     "removeAllOtherDevices": "Pašalinti visus kitus įrenginius",
     "@removeAllOtherDevices": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "removeDevice": "Pašalinti įrenginį",
-    "@removeDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -639,11 +622,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "groupIsPublic": "Grupė yra vieša",
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "groups": "Grupės",
     "@groups": {
         "type": "String",
@@ -731,8 +709,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "Jūsų pokalbio atsarginė kopija buvo nustatyta.",
-    "@yourChatBackupHasBeenSetUp": {},
     "chatBackup": "Pokalbio atsargine kopija",
     "@chatBackup": {
         "type": "String",
@@ -868,16 +844,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceIsPublic": "Erdvė yra vieša",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Erdvės pavadinimas",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "status": "Būsena",
     "@status": {
         "type": "String",
@@ -898,11 +864,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Perkėlimas iš kito įrenginio",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "verify": "Patvirtinti",
     "@verify": {
         "type": "String",
@@ -920,11 +881,6 @@
     },
     "verifyTitle": "Patvirtinama kita paskyra",
     "@verifyTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Pokalbių istorijos matomumas",
-    "@visibilityOfTheChatHistory": {
         "type": "String",
         "placeholders": {}
     },
@@ -955,8 +911,6 @@
     },
     "messageInfo": "Žinutės informacija",
     "@messageInfo": {},
-    "removeFromSpace": "Pašalinti iš erdvės",
-    "@removeFromSpace": {},
     "security": "Apsauga",
     "@security": {
         "type": "String",
@@ -998,11 +952,6 @@
     },
     "setAsCanonicalAlias": "Nustatyti kaip pagrindinį slapyvardį",
     "@setAsCanonicalAlias": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "setPermissionsLevel": "Nustatyti leidimų lygį",
-    "@setPermissionsLevel": {
         "type": "String",
         "placeholders": {}
     },
@@ -1058,11 +1007,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Vaizdo skambutis",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "yourPublicKey": "Jūsų viešasis raktas",
     "@yourPublicKey": {
         "type": "String",
@@ -1082,11 +1026,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Ar svečiams leidžiama prisijungti",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "channelCorruptedDecryptError": "Šifravimas buvo sugadintas",
     "@channelCorruptedDecryptError": {
         "type": "String",
@@ -1102,18 +1041,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Kontaktas buvo pakviestas į grupę",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Apie turinį pranešta serverio administratoriams",
     "@contentHasBeenReported": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "createNewSpace": "Nauja erdvė",
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1124,11 +1053,6 @@
     },
     "defaultPermissionLevel": "Numatytasis teisių lygis",
     "@defaultPermissionLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "enableEncryptionWarning": "Šifravimo nebegalėsite išjungti. Ar jūs tuo tikri?",
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1172,23 +1096,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Kas gali atlikti kokį veiksmą",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Kam leidžiama prisijungti prie šios grupės",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Kodėl norite apie tai pranešti?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Ištrinti atsarginę pokalbių kopiją, kad sukurti naują atkūrimo raktą?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1237,18 +1146,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "noEncryptionForPublicRooms": "Šifravimą galite suaktyvinti tik tada, kai kambarys nebebus viešai pasiekiamas.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "noEmotesFound": "Nerasta jaustukų. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Atrodo, kad jūsų telefone nėra Google Services. Tai geras sprendimas jūsų privatumui! Norėdami gauti tiesioginius pranešimus FluffyChat, rekomenduojame naudoti https://microg.org/ arba https://unifiedpush.org/.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1478,8 +1377,6 @@
     },
     "unsupportedAndroidVersion": "Nepalaikoma Android versija",
     "@unsupportedAndroidVersion": {},
-    "emailOrUsername": "El. paštas arba vartotojo vardas",
-    "@emailOrUsername": {},
     "widgetVideo": "Video",
     "@widgetVideo": {},
     "widgetNameError": "Pateikite rodomą vardą.",
@@ -1564,11 +1461,6 @@
                 "type": "String"
             }
         }
-    },
-    "chatBackupDescription": "Jūsų senos žinutės yra apsaugotos atkūrimo raktu. Pasirūpinkite, kad jo neprarastumėte.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
     },
     "commandHint_create": "Sukurti tuščią grupinį pokalbį\nNaudokite --no-encryption kad išjungti šifravimą",
     "@commandHint_create": {
@@ -1711,15 +1603,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "inviteContactToGroup": "Pakviesti kontaktą į {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
     "invitedUser": "📩 {username} pakvietė {targetName}",
     "@invitedUser": {
         "type": "String",
@@ -1782,24 +1665,6 @@
         "type": "String",
         "placeholders": {
             "localizedTimeShort": {
-                "type": "String"
-            }
-        }
-    },
-    "loadCountMoreParticipants": "Įkelti dar {count} dalyvius",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "logInTo": "Prisijungti prie {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
                 "type": "String"
             }
         }
@@ -1944,12 +1809,8 @@
     "@emojis": {},
     "placeCall": "Skambinti",
     "@placeCall": {},
-    "voiceCall": "Balso skambutis",
-    "@voiceCall": {},
     "unsupportedAndroidVersionLong": "Šiai funkcijai reikalinga naujesnė Android versija. Patikrinkite, ar nėra naujinimų arba Lineage OS palaikymo.",
     "@unsupportedAndroidVersionLong": {},
-    "videoCallsBetaWarning": "Atminkite, kad vaizdo skambučiai šiuo metu yra beta versijos. Jie gali neveikti taip kaip tikėtasi, arba iš viso neveikti visose platformose.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "Eksperimentiniai vaizdo skambučiai",
     "@experimentalVideoCalls": {},
     "widgetEtherpad": "Teksto pastaba",
@@ -2060,8 +1921,6 @@
             }
         }
     },
-    "enableMultiAccounts": "(BETA) Įgalinkite kelias paskyras šiame įrenginyje",
-    "@enableMultiAccounts": {},
     "openInMaps": "Atidaryti žemėlapiuose",
     "@openInMaps": {
         "type": "String",
@@ -2110,15 +1969,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unreadChats": "{unreadCount, plural, =1{1 unread chat} other{{unreadCount} neperskaityti pokalbiai}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "addWidget": "Pridėti programėlę",
     "@addWidget": {},
     "widgetCustom": "Pasirinktinis",
@@ -2141,14 +1991,8 @@
     "@dehydrateWarning": {},
     "commandHint_markasgroup": "Pažymėti kaip grupę",
     "@commandHint_markasgroup": {},
-    "pleaseEnterRecoveryKeyDescription": "Norėdami atrakinti senas žinutes, įveskite atkūrimo raktą, kuris buvo sukurtas ankstesnės sesijos metu. Atkūrimo raktas NĖRA jūsų slaptažodis.",
-    "@pleaseEnterRecoveryKeyDescription": {},
-    "storeInAppleKeyChain": "Saugoti Apple raktų grandinėje",
-    "@storeInAppleKeyChain": {},
     "newSpace": "Nauja erdvė",
     "@newSpace": {},
-    "enterSpace": "Įeiti į erdvę",
-    "@enterSpace": {},
     "allSpaces": "Visos erdvės",
     "@allSpaces": {},
     "user": "Vartotojas",
@@ -2170,12 +2014,6 @@
     "@dehydrate": {},
     "hydrate": "Atkurti iš atsarginės kopijos failo",
     "@hydrate": {},
-    "pleaseEnterRecoveryKey": "Įveskite savo atkūrimo raktą:",
-    "@pleaseEnterRecoveryKey": {},
-    "recoveryKey": "Atkūrimo raktas",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Pamestas atkūrimo raktas?",
-    "@recoveryKeyLost": {},
     "countFiles": "{count} failai",
     "@countFiles": {
         "placeholders": {
@@ -2184,30 +2022,14 @@
             }
         }
     },
-    "storeInSecureStorageDescription": "Atkūrimo raktą laikyti saugioje šio prietaiso saugykloje.",
-    "@storeInSecureStorageDescription": {},
-    "saveKeyManuallyDescription": "Įrašykite šį raktą rankiniu būdu, įjungę sistemos bendrinimo dialogo langą arba iškarpinę.",
-    "@saveKeyManuallyDescription": {},
     "users": "Vartotojai",
     "@users": {},
-    "storeSecurlyOnThisDevice": "Saugiai laikyti šiame prietaise",
-    "@storeSecurlyOnThisDevice": {},
-    "unlockOldMessages": "Atrakinti senas žinutes",
-    "@unlockOldMessages": {},
-    "storeInAndroidKeystore": "Saugoti Android raktų saugykloje",
-    "@storeInAndroidKeystore": {},
     "noKeyForThisMessage": "Taip gali atsitikti, jei žinutė buvo išsiųsta prieš prisijungiant prie paskyros šiame prietaise.\n\nTaip pat gali būti, kad siuntėjas užblokavo jūsų prietaisą arba kažkas sutriko su interneto ryšiu.\n\nAr galite perskaityti žinutę kitoje sesijoje? Tada galite perkelti žinutę iš jos! Eikite į Nustatymai > Prietaisai ir įsitikinkite, kad jūsų prietaisai patvirtino vienas kitą. Kai kitą kartą atidarysite kambarį ir abi sesijos bus pirmame plane, raktai bus perduoti automatiškai.\n\nNenorite prarasti raktų atsijungdami arba keisdami įrenginius? Įsitikinkite, kad nustatymuose įjungėte pokalbių atsarginę kopiją.",
     "@noKeyForThisMessage": {},
-    "foregroundServiceRunning": "Šis pranešimas rodomas, kai veikia pirmojo plano paslauga.",
-    "@foregroundServiceRunning": {},
-    "screenSharingTitle": "ekrano bendrinimas",
-    "@screenSharingTitle": {},
     "whyIsThisMessageEncrypted": "Kodėl ši žinutė neperskaitoma?",
     "@whyIsThisMessageEncrypted": {},
     "newGroup": "Nauja grupė",
     "@newGroup": {},
-    "screenSharingDetail": "Bendrinate savo ekraną per FuffyChat",
-    "@screenSharingDetail": {},
     "alwaysUse24HourFormat": "ne",
     "notAnImage": "Nėra vaizdo įrašas.",
     "setCustomPermissionLevel": "Nustatyti pasirinktinį leidimo lygį",
@@ -2237,17 +2059,12 @@
     "space": "Vieta",
     "spaces": "Vietos",
     "checkList": "Patikros sąrašas",
-    "countInvited": "Kviestųjų: {count}",
     "createGroup": "Sukurti grupę",
     "chatPermissions": "Pokalbių leidimai",
     "emoteKeyboardNoRecents": "Neseniai naudoti emocai čia pasirodys...",
-    "globalChatId": "Pasaulinio pokalbio ID",
-    "accessAndVisibility": "Prieiga ir matomumas",
-    "accessAndVisibilityDescription": "Kas gali prisijungti prie šio pokalbio ir kaip jis gali būti atrastas.",
     "calls": "Skambučiai",
     "customEmojisAndStickers": "Individualūs jaustukai ir lipdukai",
     "customEmojisAndStickersBody": "Pridėkite arba bendrinkite individualius jaustukus ar lipdukus, kurie gali būti naudojami bet kuriame pokalbyje.",
-    "chatDescription": "Pokalbio aprašymas",
     "chatDescriptionHasBeenChanged": "Pokalbio aprašymas pakeistas",
     "hideRedactedMessages": "Slėpti redaguotas žinutes",
     "hideRedactedMessagesBody": "Jei kas nors redaguoja žinutę, ši žinutė nebus matoma pokalbyje.",
@@ -2274,16 +2091,10 @@
     "synchronizingPleaseWaitCounter": "Sinchronizuojama… ({percentage}%)",
     "invitedBy": "📩 Pakvietė {user}",
     "hasKnocked": "🚪 {user} pasibeldė",
-    "usersMustKnock": "Vartotojai turi pasibeldži",
-    "noOneCanJoin": "Niekas negali prisijungti",
     "knock": "Klausyti",
     "hidePresences": "Slėpti būsenų sąrašą?",
     "doNotShowAgain": "Nekartoti rodyti",
     "wasDirectChatDisplayName": "Tuščias pokalbis (buvo {oldDisplayName})",
-    "newSpaceDescription": "Erdvės leidžia sujungti jūsų pokalbius ir kurti privačias arba viešas bendruomenes.",
-    "encryptThisChat": "Užšifruoti šį pokalbį",
-    "disableEncryptionWarning": "Dėl saugumo priežasčių jūs negalite išjungti šifravimo pokalbyje, kuriame jis buvo įjungtas anksčiau.",
-    "sorryThatsNotPossible": "Atsiprašome... tai neįmanoma",
     "deviceKeys": "Įrenginio raktai:",
     "reopenChat": "Vėl atidaryti pokalbį",
     "noBackupWarning": "Įspėjimas! Be pokalbio atsarginės kopijos įjungimo prarasite prieigą prie savo šifruotų žinučių. Labai rekomenduojama pirmiausia įjungti pokalbio atsarginę kopiją prieš atsijungiant.",
@@ -2296,7 +2107,6 @@
     "openLinkInBrowser": "Atidaryti nuorodą naršyklėje",
     "reportErrorDescription": "😞 Oi. Įvyko klaida. Jei norite, galite pranešti apie šią klaidą kūrėjams.",
     "report": "Pranešti",
-    "setTheme": "Nustatyti temą:",
     "setColorTheme": "Nustatyti spalvų temą:",
     "invite": "Pakviesti",
     "inviteGroupChat": "📨 Pakviesti grupės pokalbiui",
@@ -2315,12 +2125,8 @@
     "yourGlobalUserIdIs": "Jūsų pasaulinis vartotojo ID yra: ",
     "noUsersFoundWithQuery": "Deja, su užklausa \"{query}\" nerasta vartotojo. Prašome patikrinti, ar nepadarėte rašybos klaidos.",
     "knocking": "Skambinama",
-    "chatCanBeDiscoveredViaSearchOnServer": "Pokalbį galima rasti per paiešką {server}",
-    "searchChatsRooms": "Ieškoti #pokalbių, @vartotojų...",
     "nothingFound": "Nieko nerasta...",
     "groupName": "Grupės pavadinimas",
-    "createGroupAndInviteUsers": "Sukurti grupę ir pakviesti vartotojus",
-    "groupCanBeFoundViaSearch": "Grupę galima rasti per paiešką",
     "wrongRecoveryKey": "Atsiprašome... atrodo, kad tai nėra teisingas atkūrimo raktas.",
     "startConversation": "Pradėti pokalbį",
     "commandHint_sendraw": "Siųsti neapdorotą JSON",
@@ -2334,11 +2140,8 @@
     "pleaseChooseAStrongPassword": "Prašome pasirinkti stiprią slaptažodį",
     "passwordsDoNotMatch": "Slaptažodžiai nesutampa",
     "passwordIsWrong": "Jūsų įvestas slaptažodis yra neteisingas",
-    "publicChatAddresses": "Viešojo pokalbio adresai",
-    "createNewAddress": "Sukurti naują adresą",
     "joinSpace": "Prisijungti prie erdvės",
     "publicSpaces": "Viešosios erdvės",
-    "addChatOrSubSpace": "Pridėti pokalbį arba pogrupį",
     "subspace": "Pogruppis",
     "decline": "Atmesti",
     "thisDevice": "Šis įrenginys:",
@@ -2347,15 +2150,11 @@
     "searchMore": "Ieškoti daugiau...",
     "gallery": "Galerija",
     "files": "Failai",
-    "sessionLostBody": "Jūsų sesija prarasta. Prašome pranešti apie šią klaidą kūrėjams adresu {url}. Klaidos pranešimas yra: {error}",
-    "restoreSessionBody": "Programėlė dabar bando atkurti jūsų sesiją iš atsarginės kopijos. Prašome pranešti apie šią klaidą kūrėjams adresu {url}. Klaidos pranešimas yra: {error}",
     "sendReadReceipts": "Siųsti skaitymo patvirtinimus",
     "sendTypingNotificationsDescription": "Kiti pokalbio dalyviai gali matyti, kada rašote naują žinutę.",
     "sendReadReceiptsDescription": "Kiti pokalbio dalyviai gali matyti, kada perskaitėte žinutę.",
     "formattedMessages": "Formatuotos žinutės",
     "formattedMessagesDescription": "Rodyti turtingą žinučių turinį, pvz., paryškintą tekstą, naudojant markdown.",
-    "verifyOtherUser": "🔐 Patvirtinti kitą vartotoją",
-    "verifyOtherUserDescription": "Jei patvirtinate kitą vartotoją, galite būti tikri, kad tikrai rašote tam tikram asmeniui. 💪\n\nPradėjus patvirtinimą, jūs ir kitas vartotojas matys iššokantį langą programėlėje. Ten pamatysite seriją emocijų ar skaičių, kuriuos turite palyginti tarpusavyje.\n\nGeriausias būdas tai padaryti – susitikti arba pradėti vaizdo skambutį. 👭",
     "verifyOtherDevice": "🔐 Patvirtinti kitą įrenginį",
     "verifyOtherDeviceDescription": "Patvirtinus kitą įrenginį, šie įrenginiai gali keistis raktus, taip padidindami jūsų bendrą saugumą. 💪 Pradėjus patvirtinimą, abiejų įrenginių programėlėse pasirodys iššokantis langas. Ten pamatysite seriją emocijų ar skaičių, kuriuos turite palyginti tarpusavyje. Geriausia turėti abu įrenginius po ranka prieš pradedant patvirtinimą. 🤳",
     "acceptedKeyVerification": "{sender} priėmė raktų patvirtinimą",
@@ -2391,10 +2190,6 @@
     "updateInstalled": "🎉 Įdiegta {version}!",
     "changelog": "Pakeitimų žurnalas",
     "sendCanceled": "Siuntimas atšauktas",
-    "loginWithMatrixId": "Prisijungti naudodami Matrix-ID",
-    "discoverHomeservers": "Atrasti namų serverius",
-    "whatIsAHomeserver": "Kas yra namų serveris?",
-    "homeserverDescription": "Visi jūsų duomenys saugomi namų serveryje, kaip ir el. pašto paslaugos teikėjas. Galite pasirinkti, kurį namų serverį naudoti, tačiau vis tiek galite bendrauti su visais. Sužinokite daugiau adresu https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Atrodo, kad tai nėra suderinamas namų serveris. Neteisingas URL?",
     "calculatingFileSize": "Skaičiuojama failo dydis...",
     "prepareSendingAttachment": "Ruošiama siųsti priedą...",
@@ -2406,11 +2201,9 @@
     "oneOfYourDevicesIsNotVerified": "Vienas iš jūsų įrenginių nėra patvirtintas",
     "noticeChatBackupDeviceVerification": "Pastaba: Kai prijungiate visus savo įrenginius prie pokalbių atsarginės kopijos, jie automatiškai patvirtinami.",
     "continueText": "Tęsti",
-    "welcomeText": "Sveiki Sveiki 👋 Tai yra FluffyChat. Jūs galite prisijungti prie bet kurio namų serverio, kuris yra suderinamas su https://matrix.org. Ir tada kalbėtis su bet kuo. Tai didelė decentralizuota žinučių tinklas!",
     "blur": "Išsklaidymas:",
     "opacity": " Skaidrumas:",
     "setWallpaper": "Nustatyti foną",
-    "manageAccount": "Tvarkyti paskyrą",
     "noContactInformationProvided": "Serveris nepateikia jokių galiojančių kontaktinės informacijos",
     "contactServerAdmin": "Susisiekti su serverio administratoriumi",
     "contactServerSecurity": "Susisiekti su serverio saugumu",
@@ -2429,11 +2222,8 @@
     "unableToJoinChat": "Negalima prisijungti prie pokalbio. Galbūt kita šalis jau uždarė pokalbį.",
     "previous": "Ankstesnis",
     "otherPartyNotLoggedIn": "Kita šalis šiuo metu neprisijungusi ir todėl negali gauti žinučių!",
-    "appWantsToUseForLogin": "Naudoti '{server}' prisijungimui",
-    "appWantsToUseForLoginDescription": "Jūs šiuo metu leidžiate programai ir svetainei dalintis informacija apie jus.",
     "open": "Atidaryti",
     "waitingForServer": "Laukiama serverio...",
-    "appIntroduction": "FluffyChat leidžia jums kalbėtis su draugais per skirtingus pranešėjų programas. Sužinokite daugiau adresu https://matrix.org arba tiesiog spustelėkite *Tęsti*.",
     "newChatRequest": "📩 Naujas pokalbio užklausimas",
     "contentNotificationSettings": "Turinio pranešimų nustatymai",
     "generalNotificationSettings": "Bendrieji pranešimų nustatymai",
@@ -2508,11 +2298,9 @@
     "taTooltip": "L2 naudojimas su vertimo pagalba",
     "interactiveTranslatorSliderHeader": "Interaktyvus vertėjas",
     "interactiveGrammarSliderHeader": "Interaktyvus gramatikos tikrintuvas",
-    "interactiveTranslatorRequired": "Būtina",
     "waTooltip": "L2 naudojimas be pagalbos",
     "interactiveTranslator": "Vertimo pagalba",
     "noIdenticalLanguages": "Prašome pasirinkti skirtingas pagrindines ir tikslines kalbas",
-    "searchBy": "Ieškoti pagal šalį ir kalbas",
     "joinWithClassCode": "Prisijungti prie kurso",
     "languageLevelPreA1": "Pradedantysis Žemas (Pre A1)",
     "languageLevelA1": "Pradedančiojo vidurinis (A1)",
@@ -2533,19 +2321,14 @@
     "saveChanges": "Išsaugoti pakeitimus",
     "publicProfileTitle": "Leisti mano profilį būti randamam paieškoje",
     "publicProfileDesc": "Įjungus, kiti vartotojai galės rasti jūsų profilį globalioje paieškos juostoje ir siųsti užklausas pokalbiui. Šiuo metu galite pasirinkti priimti arba atmesti užklausą.",
-    "errorDisableIT": "Vertimo pagalba išjungta.",
-    "errorDisableIGC": "Gramatikos pagalba išjungta.",
     "errorDisableITUserDesc": "Spustelėkite čia, norėdami atnaujinti vertimo pagalbos nustatymus",
     "errorDisableIGCUserDesc": "Spustelėkite čia, norėdami atnaujinti gramatikos pagalbos nustatymus",
     "errorDisableITClassDesc": "Vertimo pagalba išjungta kursui, kuriame yra šis pokalbis.",
     "errorDisableIGCClassDesc": "Gramatikos pagalba išjungta kursui, kuriame yra šis pokalbis.",
-    "error405Title": "Kalbos nėra nustatytos",
     "error405Desc": "Prašome nustatyti savo kalbas pagrindiniame meniu > Mokymosi nustatymai.",
     "termsAndConditions": " Paslaugų teikimo sąlygomis",
     "andCertifyIAmAtLeast13YearsOfAge": " ir patvirtinu, kad man yra bent 16 metų.",
-    "error502504Title": "Oho, internete yra daug mokinių!",
     "error502504Desc": "Vertimo ir gramatikos įrankiai gali būti lėti arba neprieinami, kol Pangea robotai pasivys.",
-    "error404Title": "Vertimo klaida!",
     "error404Desc": "Pangea robotas nėra tikras, kaip tai išversti...",
     "errorPleaseRefresh": "Mes tai tikriname! Prašome įkelti dar kartą ir bandyti iš naujo.",
     "connectedToStaging": "Prisijungta prie Staging",
@@ -2583,13 +2366,9 @@
     "definitionsToolName": "Žodžių apibrėžimai",
     "definitionsToolDescription": "Įjungus, žodžiai pažymėti mėlyna spalva gali būti spustelėti norint gauti apibrėžimus. Spustelėkite žinutes, kad pasiektumėte apibrėžimus.",
     "welcomeBack": "Sveiki sugrįžę! Jei buvote 2023-2024 m. bandomojo projekto dalyvis, susisiekite su mumis dėl specialios bandomojo projekto prenumeratos. Jei esate mokytojas, kuris (arba jūsų įstaiga) įsigijo licencijas savo klasei, susisiekite su mumis dėl mokytojo prenumeratos.",
-    "downloadTxtFile": "Parsisiųsti teksto failą",
-    "downloadCSVFile": "Parsisiųsti CSV failą",
     "promotionalSubscriptionDesc": "Šiuo metu turite visam laikui galiojančią reklaminę prenumeratą. Susisiekite su support@pangea.chat dėl pagalbos keičiant prenumeratą.",
     "originalSubscriptionPlatform": "Prenumerata įsigyta per {purchasePlatform}",
     "oneWeekTrial": "Vienos savaitės bandomoji versija",
-    "downloadXLSXFile": "Parsisiųsti Excel failą",
-    "unkDisplayName": "Nežinoma",
     "wwCountryDisplayName": "Pasaulinis",
     "afCountryDisplayName": "Afganistanas",
     "axCountryDisplayName": "Alandų Salos",
@@ -2884,7 +2663,6 @@
     "chatCapacityHasBeenChanged": "Pokalbių talpa pasikeitė",
     "chatCapacitySetTooLow": "Pokalbių talpa turi būti ne mažesnė kaip {count}.",
     "chatCapacityExplanation": "Pokalbių talpa riboja leidžiamų narių skaičių pokalbyje.",
-    "tooManyRequest": "Per daug užklausų, bandykite vėliau.",
     "enterNumber": "Įveskite sveiko skaičiaus reikšmę.",
     "practice": "Praktika",
     "versionNotFound": "Versija nerasta",
@@ -2894,7 +2672,6 @@
     "deleteSubscriptionWarningTitle": "Jūs turite aktyvią prenumeratą",
     "deleteSubscriptionWarningBody": "Ištrynus savo paskyrą, jūsų prenumerata nebus automatiškai atšaukta.",
     "manageSubscription": "Valdyti prenumeratą",
-    "error520Title": "Prašome bandyti dar kartą.",
     "error520Desc": "Atsiprašome, mes nesupratome jūsų žinutės...",
     "wordsUsed": "Naudoti žodžiai",
     "level": "Lygis",
@@ -2912,7 +2689,6 @@
     "other": "Kita",
     "levelShort": "LYGIS {level}",
     "noCapacityLimit": "Nėra talpos limito",
-    "downloadGroupText": "Parsisiųsti grupės tekstą",
     "notificationsOn": "Pranešimai įjungti",
     "notificationsOff": "Pranešimai išjungti",
     "joinWithCode": "Prisijungti su kodu",
@@ -2976,24 +2752,12 @@
     "whatIsTheMorphTag": "Kokia yra '{wordForm}' {morphologicalFeature}?",
     "dataAvailable": "Duomenų prieinamumas",
     "available": "Prieinama",
-    "pangeaBotIsFallible": "Pangea botas taip pat daro klaidų!",
-    "whatIsMeaning": "Ką reiškia '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Suderink reikšmes su žodžiais žinutėje!",
-    "doubleClickToEdit": "Dukart spustelėkite norėdami redaguoti.",
-    "topicLabel": "Tema",
-    "topicPlaceholder": "Pasirinkite temą...",
-    "modePlaceholder": "Pasirinkite režimą...",
-    "learningObjectiveLabel": "Mokymosi tikslas",
-    "learningObjectivePlaceholder": "Pasirinkite mokymosi tikslą...",
-    "targetLanguageLabel": "Tikslo kalba",
     "cefrLevelLabel": "CEFR lygis",
     "image": "Paveikslėlis",
     "video": "Vaizdo įrašas",
     "nan": "Netaikoma",
-    "addVocabulary": "Pridėti žodyną",
     "instructions": "Instrukcijos",
-    "numberOfLearners": "Mokinių skaičius",
-    "mustBeInteger": "Turi būti sveikas skaičius, pvz., 1, 2, 3, ...",
     "constructUsePvmDesc": "Sukurtas balso žinutėje",
     "leaveSpaceDescription": "Palikus kursą, paliksite visus jame esančius pokalbius. Kiti naudotojai matys, kad palikote kursą.",
     "constructUseCorMmDesc": "Teisingas žinutės reikšmė",
@@ -3008,7 +2772,6 @@
     "ttsDisabledBody": "Galite įjungti teksto į kalbą funkciją savo mokymosi nustatymuose",
     "noSpaceDescriptionYet": "Dar nėra sukurta kurso aprašymo.",
     "tooLargeToSend": "Ši žinutė yra per didelė siųsti",
-    "exitWithoutSaving": "Ar tikrai norite išeiti neišsaugojus?",
     "enableAutocorrectPopupTitle": "Pridėkite savo tikslios kalbos klaviatūrą, eikite į:",
     "enableAutocorrectPopupSteps": "  • Nustatymai\n  • Bendra\n  • Klaviatūra\n  • Klaviatūros\n  • Pridėti naują klaviatūrą",
     "enableAutocorrectPopupDescription": "Pasirinkus kalbą, galite spustelėti mažą pasaulio ženklo piktogramą apatinėje kairėje klaviatūros dalyje, kad aktyvuotumėte naujai įdiegtą klaviatūrą.",
@@ -3019,11 +2782,8 @@
     "displayName": "Rodomas vardas",
     "leaveRoomDescription": "Jūs ketinate išeiti iš šio pokalbio. Kiti vartotojai matys, kad išėjote iš pokalbio.",
     "confirmUserId": "Patvirtinkite savo Pangea pokalbio vartotojo vardą, kad galėtumėte ištrinti savo paskyrą.",
-    "startingToday": "Nuo šiandien",
-    "oneWeekFreeTrial": "Vienos savaitės nemokama bandomoji versija",
     "paidSubscriptionStarts": "Pradedama {startDate}",
     "cancelInSubscriptionSettings": "• Atšaukite bet kuriuo metu prenumeratos nustatymuose",
-    "cancelToAvoidCharges": "• Atšaukite prieš {trialEnds}, kad išvengtumėte mokesčių",
     "downloadGboard": "Atsisiųsti Gboard",
     "autocorrectNotAvailable": "Deja, jūsų platforma šiuo metu nepalaikoma šiai funkcijai. Sekite naujienas dėl tolimesnio vystymo!",
     "pleaseUpdateApp": "Prašome atnaujinti programėlę, kad galėtumėte tęsti.",
@@ -3033,17 +2793,12 @@
     "knockSpaceSuccess": "Jūs pateikėte užklausą prisijungti prie šio kurso! Administratorius atsakys į jūsų užklausą, kai gaus ją 😊",
     "chooseWordAudioInstructionsBody": "Klausykite viso pranešimo. Tada suderinkite garso įrašus su žodžiais.",
     "chooseMorphsInstructionsBody": "Spustelėkite dėlionės dalis gramatikos klausimams!",
-    "pleaseEnterInt": "Įveskite skaičių",
     "home": "Pradžia",
     "join": "Prisijungti",
     "resetInstructionTooltipsTitle": "Atstatyti instrukcijų patarimus",
     "resetInstructionTooltipsDesc": "Spustelėkite, kad parodytumėte instrukcijų patarimus kaip naujam vartotojui.",
-    "randomize": "Atsitiktinai parinkti",
     "clear": "Išvalyti",
-    "featuredActivities": "Pasiūlytos veiklos",
     "save": "Išsaugoti",
-    "startChat": "Pradėti pokalbį",
-    "translationProblem": "Vertimo problema",
     "askToJoin": "Paprašyti prisijungti",
     "emptyChatWarningTitle": "Pokalbis tuščias",
     "emptyChatWarningDesc": "Niekas nebuvo pakviestas į jūsų pokalbį. Eikite į Pokalbio nustatymus, kad pakviestumėte kontaktus arba Botą. Taip pat galite tai padaryti vėliau.",
@@ -3073,17 +2828,13 @@
     "timesUsedIndependently": "Naudota nepriklausomai kartų",
     "timesUsedWithAssistance": "Naudota su pagalba kartų",
     "shareInviteCode": "Pasidalink kvietimo kodu: {code}",
-    "leaderboard": "Rezultatų lentelė",
     "skipForNow": "Nuošalyje dabar",
     "permissions": "Leidimai",
     "spaceChildPermission": "Kas gali pridėti naujus pokalbius šiam kursui",
-    "addEnvironmentOverride": "Pridėti aplinkos perrašymą",
     "defaultOption": "Numatytasis",
     "deleteChatDesc": "Ar tikrai norite ištrinti šį pokalbį? Jis bus ištrintas visiems dalyviams, o visi pranešimai pokalbyje nebeprieinami praktikai ar mokymosi analitikai.",
     "deleteSpaceDesc": "Kursas ir bet kurie pasirinktini pokalbiai bus ištrinti visiems dalyviams, o visi pranešimai pokalbyje nebeprieinami praktikai ar mokymosi analitikai. Šis veiksmas nėra atšaukiamas.",
     "launch": "Pradėti",
-    "searchChats": "Ieškoti pokalbių",
-    "maxFifty": "Maks. 50",
     "configureSpace": "Konfigūruoti kursą",
     "pinMessages": "Prisegti žinutes",
     "setJoinRules": "Nustatyti prisijungimo taisykles",
@@ -3117,9 +2868,6 @@
     "failedToFetchTranscription": "Nepavyko gauti transkripcijos",
     "deleteEmptySpaceDesc": "Kursas bus ištrintas visiems dalyviams. Šio veiksmo atšaukti neįmanoma.",
     "regenerate": "Atnaujinti",
-    "mySavedActivities": "Mano išsaugotos veiklos",
-    "noSavedActivities": "Nėra išsaugotų veiklų",
-    "saveActivity": "Išsaugoti šią veiklą",
     "failedToPlayVideo": "Nepavyko paleisti vaizdo įrašo",
     "done": "Atlikta",
     "inThisSpace": "Šio kurso metu",
@@ -3130,13 +2878,9 @@
     "numInvited": "{count} pakviesti",
     "saved": "Išsaugota",
     "reset": "Atstatyti",
-    "errorFetchingActivitiesMessage": "Nepavyko gauti veiklų",
     "errorFetchingDefinition": "Nepavyko gauti apibrėžimo",
     "errorProcessAnalytics": "Nepavyko apdoroti analizės",
     "errorDownloading": "Atsisiuntimas nepavyko",
-    "errorLoadingSpaceChildren": "Nepavyko įkelti pokalbių šiame kurse",
-    "unexpectedError": "Nenumatyta klaida.",
-    "pleaseReload": "Prašome perkrauti ir bandyti dar kartą.",
     "translationError": "Vertimo klaida",
     "check": "Patikrinti",
     "unableToFindRoom": "Su šiuo kodu nerasta pokalbio ar kurso. Bandykite dar kartą.",
@@ -3145,19 +2889,14 @@
     "request": "Prašymas",
     "requestAll": "Prašyti viską",
     "confirmMessageUnpin": "Ar tikrai norite atjungti šią žinutę?",
-    "saveAndLaunch": "Išsaugoti ir paleisti",
-    "launchToSpace": "Paleisti į kursą",
     "pending": "Laukiama",
     "inactive": "Nekeičiama",
-    "confirmRole": "Patvirtinti vaidmenį",
     "openRoleLabel": "ATVIRAS",
     "finishedTheActivity": "🎯 {username} užbaigė šią veiklą",
     "activitySummaryError": "Veiklos santraukų nėra",
     "requestSummaries": "Prašyti santraukų",
-    "generatingNewActivities": "Jūs esate pirmasis šios kalbos poros naudotojas! Prašome palaukti minutėlę, ruošiame veiklas būtent jums.",
     "requestAccessTitle": "Prašyti analizės prieigos?",
     "requestAccessDesc": "Ar norėtumėte prašyti prieigos peržiūrėti dalyvių analitiką?\n\nJei dalyviai sutiks, šios kurso administratoriai galės matyti:\n    • bendrą žodyną\n    • bendrus gramatikos konceptus\n    • atliktų veiklos sesijų skaičių\n    • naudotus, teisingus ir neteisingus gramatikos konceptus\n\nJie negalės matyti:\n    • žinučių pokalbiuose už kurso ribų\n    • žodyno sąrašo",
-    "requestAccess": "Prašyti prieigos ({count})",
     "analyticsInactiveTitle": "Užklausų nebuvo galima siųsti neaktyviems vartotojams",
     "analyticsInactiveDesc": "Neaktyvūs vartotojai, kurie nesiregistravo nuo šios funkcijos įdiegimo, nematys jūsų užklausos.\n\nUžklausos mygtukas pasirodys, kai jie sugrįš. Galite iš naujo siųsti užklausą vėliau paspausdami Užklausos mygtuką po jų vardu, kai jis bus prieinamas.",
     "accessRequestedTitle": "Prieigos prie analitikos užklausa",
@@ -3180,8 +2919,6 @@
     "accessDesc": "Galite padaryti savo kursą atvirą visiems! Arba, padaryti jį privačiu ir saugiu.",
     "createGroupChatDesc": "Nors veiklos sesijos prasideda ir baigiasi, grupiniai pokalbiai liks atviri kasdieniam bendravimui.",
     "deleteDesc": "Tik tik administratori gali ištrinti kursą. Tai yra destruktyvus veiksmas, kuris pašalina visus naudotojus ir ištrina visus pasirinktus pokalbius kurse. Būkite atsargūs.",
-    "noCourseFound": "O, šis kursas turi būti suplanuotas!\n\nKurso planai yra temų ir pokalbių veiklų seka.",
-    "additionalParticipants": "+ {num} kiti",
     "whatNow": "Kas dabar?",
     "chooseNextActivity": "Pasirinkite savo kitą veiklą!",
     "letsGo": "Pradėkime",
@@ -3194,13 +2931,11 @@
     "waitNotDone": "Palauk, aš dar nesu baigęs!",
     "waitingForOthersToFinish": "Laukiama kitų pabaigos...",
     "generatingSummary": "Analizuojama pokalbis ir generuojami rezultatai",
-    "findCourse": "Rasti kursą",
     "pingParticipantsNotification": "{user} ieško naudotojų prisijungti prie veiklos sesijos {room}",
     "course": "Kursas",
     "courses": "Kursai",
     "goToCourse": "Eiti į kursą: {course}",
     "activityComplete": "Ši veikla buvo užbaigta. Apžvalga turėtų būti prieinama žemiau.",
-    "startNewSession": "Pradėti naują sesiją",
     "joinOpenSession": "Prisijungti prie atviros sesijos",
     "activityNotFound": "Veikla nerasta",
     "myActivities": "Mano veiklos",
@@ -3377,14 +3112,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@createGroup": {
         "type": "String",
         "placeholders": {}
@@ -3397,18 +3124,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -3418,10 +3133,6 @@
         "placeholders": {}
     },
     "@customEmojisAndStickersBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3556,14 +3267,6 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
@@ -3583,22 +3286,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3653,10 +3340,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3740,31 +3423,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3820,23 +3483,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3876,28 +3527,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -3915,14 +3544,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4115,22 +3736,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4186,10 +3791,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4199,10 +3800,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4278,27 +3875,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4616,10 +4197,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4629,10 +4206,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4720,14 +4293,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4744,10 +4309,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4760,15 +4321,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4920,14 +4473,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4941,14 +4486,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6171,10 +5708,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6215,10 +5748,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6291,10 +5820,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6564,47 +6089,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6624,19 +6109,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6700,10 +6173,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6744,14 +6213,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6763,14 +6224,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6808,10 +6261,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6828,27 +6277,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6972,10 +6405,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6985,10 +6414,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7005,14 +6430,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7152,18 +6569,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7212,10 +6617,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7225,18 +6626,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7279,23 +6668,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7319,10 +6696,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7330,14 +6703,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7442,18 +6807,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7506,10 +6859,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7536,10 +6885,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7720,7 +7065,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Kitą dieną patikrinkite atnaujinimus apie veiklą.",
-    "activityDropdownDesc": "Kai baigsite šią veiklą, spustelėkite žemiau",
     "languageMismatchTitle": "Kalbos neatitikimas",
     "languageMismatchDesc": "Jūsų tikslinė kalba nesutampa su šios veiklos kalba. Ar norite atnaujinti savo tikslinę kalbą?",
     "reportWordIssueTooltip": "Pranešti apie žodžio informacijos problemą",
@@ -7733,10 +7077,6 @@
     "selectAll": "Pasirinkti viską",
     "deselectAll": "Atšaukti viską",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7785,17 +7125,11 @@
         "placeholders": {}
     },
     "startOwn": "Pradėkite savo",
-    "joinCourseDesc": "Kiekvienas kursas turi 8-10 temų sekų su įvairiomis užduotimis pagrįstomis kalbos mokymosi veiklomis.",
     "newMessageInPangeaChat": "📩 Naujiena žinutė Pangea pokalbyje",
     "shareCourse": "Pasidalinti kursu",
     "addCourse": "Pridėti kursą",
-    "joinPublicCourse": "Prisijungti prie viešo kurso",
     "vocabLevelsDesc": "Čia pateks žodžiai, kai juos pakelsite į aukštesnį lygį!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7808,10 +7142,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7830,7 +7160,6 @@
     "emojiView": "Emodžių peržiūra",
     "feedbackDialogDesc": "Aš taip pat darau klaidų! Ar yra kas nors, kas galėtų man padėti tobulėti?",
     "contactHasBeenInvitedToTheCourse": "Kontaktas buvo pakviestas į kursą",
-    "activityStatsButtonTooltip": "Veiklos informacija",
     "allow": "Leisti",
     "deny": "Atmesti",
     "enabledRenewal": "Įjungti prenumeratos atnaujinimą",
@@ -8098,10 +7427,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9157,16 +8482,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Veiklos, kad atrakintumėte kitą temą",
-    "activitiesToUnlockTopicDesc": "Nustatykite veiklų skaičių, kad atrakintumėte kitą kurso temą",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Teisinga žodyno apibrėžimo praktika",
     "constructUseIncLMDesc": "Neteisinga žodyno apibrėžimo praktika",
     "constructUseCorLADesc": "Teisinga žodyno garso praktika",
@@ -9174,7 +8489,6 @@
     "constructUseBonus": "Premija žodyno praktikos metu",
     "practiceVocab": "Praktikuoti žodyną",
     "selectMeaning": "Pasirinkite reikšmę",
-    "selectAudio": "Pasirinkite atitinkamą garsą",
     "anotherRound": "Dar viena raundas",
     "activitySettingsOverrideWarning": "Kalba ir kalbos lygis nustatomi pagal veiklos planą",
     "voice": "Balsas",
@@ -9206,10 +8520,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9227,12 +8537,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Atsisiuntimas pradėtas",
     "webDownloadPermissionMessage": "Jei jūsų naršyklė blokuoja atsisiuntimus, prašome įgalinti atsisiuntimus šiam tinklalapiui.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9327,11 +8632,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Kažkas nepavyko, ir mes sunkiai dirbame, kad tai išspręstume. Patikrinkite vėliau.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Įgalinti rašymo pagalbą",
     "autoIGCToolDescription": "Automatiškai paleisti Pangea Chat įrankius, kad ištaisytumėte išsiųstas žinutes į tikslinę kalbą.",
     "@autoIGCToolName": {
@@ -9387,24 +8687,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatika",
-    "spanTypeWordChoice": "Žodžių pasirinkimas",
     "spanTypeSpelling": "Rašyba",
     "spanTypePunctuation": "Skyryba",
     "spanTypeStyle": "Stilius",
     "spanTypeFluency": "Sklandumas",
     "spanTypeAccents": "Akcentai",
     "spanTypeCapitalization": "Didžiųjų raidžių naudojimas",
-    "spanTypeCorrection": "Korekcija",
     "spanFeedbackTitle": "Pranešti apie korekcijos problemą",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9429,10 +8718,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9445,13 +8730,7 @@
     "longPressToRecordVoiceMessage": "Ilgai paspauskite, kad įrašytumėte balso žinutę.",
     "pause": "Sustabdyti",
     "resume": "Tęsti",
-    "newSubSpace": "Naujas sub erdvė",
-    "moveToDifferentSpace": "Perkelti į kitą erdvę",
-    "removeFromSpaceDescription": "Pokalbiai bus pašalinti iš erdvės, bet vis tiek pasirodys jūsų pokalbių sąraše.",
     "countChats": "{chats} pokalbiai",
-    "spaceMemberOf": "Erdvės narys {spaces}",
-    "spaceMemberOfCanKnock": "Erdvės narys {spaces} gali pasibeldti",
-    "donate": "Aukoti",
     "startedAPoll": "{username} pradėjo apklausą.",
     "poll": "Apklausa",
     "startPoll": "Pradėti apklausą",
@@ -9475,23 +8754,15 @@
     "newStickerPack": "Naujas lipdukų paketas",
     "stickerPackName": "Lipdukų paketo pavadinimas",
     "attribution": "Priskyrimas",
-    "skipChatBackup": "Praleisti pokalbio atsarginę kopiją",
-    "skipChatBackupWarning": "Ar tikrai norite? Neįjungus pokalbio atsarginės kopijos, galite prarasti prieigą prie savo žinučių, jei pakeisite įrenginį.",
-    "loadingMessages": "Kraunamos žinutės",
-    "setupChatBackup": "Nustatyti pokalbio atsarginę kopiją",
     "noMoreResultsFound": "Daugiau rezultatų nerasta",
     "chatSearchedUntil": "Pokalbis ieškotas iki {time}",
     "federationBaseUrl": "Federacijos pagrindinis URL",
     "clientWellKnownInformation": "Kliento gerai žinoma informacija:",
     "baseUrl": "Pagrindinis URL",
     "identityServer": "Identiteto serveris:",
-    "versionWithNumber": "Versija: {version}",
     "logs": "Žurnalai",
-    "advancedConfigs": "Išplėstinės konfigūracijos",
     "advancedConfigurations": "Išplėstinės konfigūracijos",
-    "signInWithLabel": "Prisijungti su:",
     "selectAllWords": "Pasirinkite visus žodžius, kuriuos girdite garse",
-    "joinCourseForActivities": "Prisijunkite prie kurso, kad išbandytumėte veiklas.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9528,18 +8799,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9547,26 +8806,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9672,22 +8911,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9716,19 +8939,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9736,15 +8947,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9945,11 +9148,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Klasėje? Įrašykite savo prisijungimo kodą čia.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automatiškai paryškinti garso pranešimus",
     "selectAudioMessagesOnPlayDescription": "Automatiškai paryškinti garso pranešimus, kai jie atkuriami",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9993,18 +9191,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Šiame kurse yra temų, turinčių mažiau nei {input} veiklų. Prašome įvesti skaičių, kuris yra mažesnis arba lygus {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Paspauskite čia, kad vėl prisijungtumėte.",
     "@clickToLogin": {
@@ -10421,17 +9607,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Kartoninis geltonas lokys su pakeltomis rankomis džiaugsmu.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Pasirinkite žodžius, kad sužinotumėte daugiau apie juos",
     "requireAnalyticsAccessTitle": "Reikia analitikos prieigos, kad prisijungtumėte",
     "requireAnalyticsAccessDesc": "Dalyviai turi suteikti prieigą prie savo mokymosi analitikos, kad galėtų prisijungti prie šio kurso",
     "analyticsAccessNoticeTitle": "Reikalinga analitikos prieiga",
     "analyticsAccessNoticeDesc": "Prisijungdami prie šio kurso, sutinkate suteikti administratoriams prieigą prie savo mokymosi analitikos.",
-    "skipOnboardingClassCodeDesc": "Mokotės savarankiškai? Nesijaudinkite, galite:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10449,10 +9629,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10481,7 +9657,6 @@
     "pickCefrLevelTeacherStepTitle": "Kokį lygį mokote?",
     "pickCefrLevelStudentStepTitle": "Kokio lygio esate?",
     "customCourseStepTitle": "Užpildykite šią formą, kad gautumėte individualų kursą",
-    "aboutYourClass": "Apie jūsų klasę",
     "courseCodeStepErrorMessage": "Prašome patikrinti savo kodą ir bandyti dar kartą",
     "institution": "Institucija",
     "courseGoals": "Kurso tikslai",
@@ -10524,10 +9699,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10644,12 +9815,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logotipas",
     "introChatDetails": "Pasakykite labas! Pristatykite save savo kursų dalyviams, raskite draugų ir bendraukite už veiklų ribų.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10693,11 +9859,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Veiklos veiksmai",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Tariamojo įrankiai",
     "audioTranscription": "AI garso transkripcija",
     "visualLearnerSupport": "Vizualių mokinių palaikymas",
@@ -10738,7 +9899,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Prisijunkite prie kurso, kuris apima šią veiklą, kad galėtumėte ją žaisti.",
     "resizeCoursePanel": "Pakeisti kurso skydelio dydį",
     "undo": "Atšaukti",
     "unlock": "Atrakinti",
@@ -10752,7 +9912,6 @@
     "addCourseBrowsePublic": "Naršyti viešus kursus",
     "browsePublicCourses": "Naršyti viešus kursus",
     "editProfile": "Redaguoti profilį",
-    "numObjectives": "{count} tikslai",
     "mapSearchHint": "Ieškoti veiklų",
     "mapSearchNoResults": "Nėra atitikmenų",
     "mapFilterAllLanguages": "Visos kalbos",
@@ -10761,7 +9920,6 @@
     "mapFilterCompleted": "Užbaigta",
     "mapFilterReset": "Atstatyti",
     "activityTypeConversation": "Pokalbis",
-    "lockedMissionRequirement": "Baigkite ankstesnę misiją, kad atrakintumėte",
     "playAgain": "Žaisti vėl",
     "reviewActivity": "Peržiūrėti",
     "mapEmptyInView": "Čia nieko nėra jūsų lygyje ar kalba. Išplėskite filtrus arba priartinkite.",
@@ -10776,14 +9934,9 @@
     "scrollToBottom": "Slinkti žemyn",
     "courseImage": "Kurso nuotrauka",
     "avatarPreview": "Avataro peržiūra",
-    "activityPhoto": "Veiklos nuotrauka",
     "emotePreview": "Emocijos peržiūra: {name}",
     "activityLabel": "Veikla: {title}",
     "resetMapView": "Atstatyti žemėlapio vaizdą",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10836,14 +9989,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10873,10 +10018,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10933,10 +10074,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_lv.arb
+++ b/lib/l10n/intl_lv.arb
@@ -66,11 +66,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "noEncryptionForPublicRooms": "Šifrēšanu var iespējot tikai tad, kad istaba vairs nav publiski pieejama.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "admin": "Pārvaldītājs",
     "@admin": {
         "type": "String",
@@ -83,22 +78,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Iestatīt atļauju līmeni",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "inviteContactToGroup": "Uzaicināt kontaktpersonu {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
-    "addAccount": "Pievienot kontu",
-    "@addAccount": {},
     "close": "Aizvērt",
     "@close": {
         "type": "String",
@@ -286,11 +265,6 @@
             }
         }
     },
-    "videoCall": "Videozvans",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "youAcceptedTheInvitation": "👍 Tu pieņēmi uzaicinājumu",
     "@youAcceptedTheInvitation": {},
     "banFromChat": "Izslēgt no tērzēšanas",
@@ -422,11 +396,6 @@
     },
     "tryAgain": "Jāmēģina vēlreiz",
     "@tryAgain": {},
-    "areGuestsAllowedToJoin": "Vai vieslietotājiem ir ļauts pievienoties",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "blocked": "Liegta",
     "@blocked": {
         "type": "String",
@@ -439,11 +408,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Noņemt ierīci",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanUserDescription": "Lietotājs varēs atkal pievienoties tērzēšanai, ja mēģinās.",
     "@unbanUserDescription": {},
@@ -507,12 +471,6 @@
     "@link": {},
     "widgetUrlError": "Tas nav derīgs URL.",
     "@widgetUrlError": {},
-    "emailOrUsername": "E-pasta adrese vai lietotājvārds",
-    "@emailOrUsername": {},
-    "newSpaceDescription": "Vietas ļauj apvienot tērzēšanas un būvēt privātas vai publiskas kopienas.",
-    "@newSpaceDescription": {},
-    "chatDescription": "Tērzēšanas apraksts",
-    "@chatDescription": {},
     "next": "Nākamais",
     "@next": {
         "type": "String",
@@ -537,10 +495,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enterSpace": "Ieiet vietā",
-    "@enterSpace": {},
-    "encryptThisChat": "Šifrēt šo tērzēšanu",
-    "@encryptThisChat": {},
     "fileName": "Datnes nosaukums",
     "@fileName": {
         "type": "String",
@@ -573,8 +527,6 @@
     },
     "reopenChat": "Atkārtoti atvērt tērzēšanu",
     "@reopenChat": {},
-    "pleaseEnterRecoveryKey": "Lūgums ievadīt savu atkopes atslēgu:",
-    "@pleaseEnterRecoveryKey": {},
     "create": "Izveidot",
     "@create": {
         "type": "String",
@@ -609,11 +561,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceIsPublic": "Vieta ir publiska",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "addWidget": "Pievienot logrīku",
     "@addWidget": {},
     "all": "Viss",
@@ -641,11 +588,6 @@
     },
     "noKeyForThisMessage": "Tā var notikt, ja ziņa tika nosūtīta, pirms pieteicies savā kontā šajā ierīcē.\n\nIr arī iespējams, ka sūtītājs noliedza Tavu ierīci vai kaut kas nogāja greizi ar interneta savienojumu.\n\nVai ziņas ir lasāmas citā sesijā? Tad Tu vari pārsūtīt ziņu no tās. Jādodas uz Iestatījumi > Ierīces un jāpārliecinās, ka ierīces viena otru ir apliecinājušas. Kad nākamreiz atvērsi istabu un abas sesijas būs priekšplānā, atslēgas tiks automātiski pārsūtītas.\n\nVai nevēlies zaudēt atslēgas, kad atsakies vai maini ierīces? Jāpārliecinās, ka iestatījumos ir iespējota tērzēšanu rezerves kopija.",
     "@noKeyForThisMessage": {},
-    "enableEncryptionWarning": "Vairs nebūs iespējams atspējot šifrēšanu. Vai tiešām to darīt?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "inviteText": "{username} uzaicināja pievienoties FluffyChat.\n1. Jāapmeklē fluffychat.im un jāuzstāda lietotne \n2. Jāizveido konts vai jāpiesakās \n3. Jāatver uzaicinājuma saite: \n {link}",
     "@inviteText": {
         "type": "String",
@@ -681,13 +623,6 @@
     },
     "pushNotificationsNotAvailable": "Pašpiegādes paziņojumi nav pieejami",
     "@pushNotificationsNotAvailable": {},
-    "passwordRecovery": "Paroles atkope",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "storeInAppleKeyChain": "Glabāt Apple KeyChain",
-    "@storeInAppleKeyChain": {},
     "replaceRoomWithNewerVersion": "Aizvietot istabu ar jaunāku versiju",
     "@replaceRoomWithNewerVersion": {
         "type": "String",
@@ -716,11 +651,6 @@
             }
         }
     },
-    "wipeChatBackup": "Notīrīt tērzēšanu rezerves kopiju, lai izveidotu jaunu atkopes atslēgu?",
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "cantOpenUri": "Nevar atvērt adresi {uri}",
     "@cantOpenUri": {
         "type": "String",
@@ -732,8 +662,6 @@
     },
     "sender": "Sūtītājs",
     "@sender": {},
-    "storeInAndroidKeystore": "Glabāt Android KeyStore",
-    "@storeInAndroidKeystore": {},
     "hideRedactedEvents": "Paslēpt labošanas notikumus",
     "@hideRedactedEvents": {
         "type": "String",
@@ -802,11 +730,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Pārnest no citas ierīces",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "passwordHasBeenChanged": "Parole tikai nomainīta",
     "@passwordHasBeenChanged": {
         "type": "String",
@@ -832,8 +755,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "saveKeyManuallyDescription": "Šo atslēgu var pašrocīgi saglabāt ar sistēmas kopīgošanas dialogloga vai starpliktuves izsaukšanu.",
-    "@saveKeyManuallyDescription": {},
     "none": "Neviens",
     "@none": {
         "type": "String",
@@ -848,15 +769,6 @@
     },
     "whyIsThisMessageEncrypted": "Kādēļ šī ziņa ir nelasāma?",
     "@whyIsThisMessageEncrypted": {},
-    "unreadChats": "{unreadCount, plural, zero{{unreadCount} nelasītu tērzēšanu} =1{{unreadCount} nelasīta tērzēšana} other{{unreadCount} nelasītas tērzēšanas}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "rejectedTheInvitation": "{username} noraidīja uzaicinājumu",
     "@rejectedTheInvitation": {
         "type": "String",
@@ -877,11 +789,6 @@
             }
         }
     },
-    "spaceName": "Vietas nosaukums",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "importFromZipFile": "Ievietot no .zip datnes",
     "@importFromZipFile": {},
     "or": "Vai",
@@ -893,20 +800,11 @@
     "@dehydrateWarning": {},
     "noOtherDevicesFound": "Netika atrastas citas ierīces",
     "@noOtherDevicesFound": {},
-    "whoIsAllowedToJoinThisGroup": "Kuram ir ļauts pievienoties šai kopai",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "emptyChat": "Tukša tērzēšana",
     "@emptyChat": {
         "type": "String",
         "placeholders": {}
     },
-    "storeSecurlyOnThisDevice": "Droši uzglabāt šajā ierīcē",
-    "@storeSecurlyOnThisDevice": {},
-    "yourChatBackupHasBeenSetUp": "Tērzēšanu rezerves kopēšana iestatīta.",
-    "@yourChatBackupHasBeenSetUp": {},
     "chatBackup": "Tērzēšanu rezerves kopēšana",
     "@chatBackup": {
         "type": "String",
@@ -926,8 +824,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCallsBetaWarning": "Lūgums ņemt vērā, ka video zvani pašreiz ir beta stāvoklī. Tie visās platformās var nedarboties kā paredzēs vai pat nedarboties vispār.",
-    "@videoCallsBetaWarning": {},
     "unmuteChat": "Atcelt tērzēšanas apklusināšanu",
     "@unmuteChat": {
         "type": "String",
@@ -965,15 +861,6 @@
     "@participant": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "PIeteikties {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "yes": "Jā",
     "@yes": {
@@ -1080,8 +967,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unlockOldMessages": "Atslēgt vecās ziņas",
-    "@unlockOldMessages": {},
     "identity": "Identitāte",
     "@identity": {
         "type": "String",
@@ -1294,8 +1179,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "pleaseEnterRecoveryKeyDescription": "Lai atslēgtu savas vecās ziņas, lūgums ievadīt savu atkopes atslēgu, kas tika izveidota iepriekšējā sesijā. Atkopes atslēga NAV parole.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "guestsAreForbidden": "Viesi nav ļauti",
     "@guestsAreForbidden": {
         "type": "String",
@@ -1493,8 +1376,6 @@
     },
     "redactMessageDescription": "Ziņa tiks labota visiem šīs sarunas dalībniekiem. To nevar atdarīt.",
     "@redactMessageDescription": {},
-    "recoveryKey": "Atkopes atslēga",
-    "@recoveryKey": {},
     "redactMessage": "Labot ziņu",
     "@redactMessage": {
         "type": "String",
@@ -1587,11 +1468,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "groupIsPublic": "Kopa ir publiska",
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "verifyStart": "Uzsākt apliecināšanu",
     "@verifyStart": {
         "type": "String",
@@ -1616,8 +1492,6 @@
     },
     "serverRequiresEmail": "Šim serverim ir nepieciešams pārbaudīt Tavu e-pasta adresi reģistrācijai.",
     "@serverRequiresEmail": {},
-    "screenSharingTitle": "ekrāna kopīgošana",
-    "@screenSharingTitle": {},
     "widgetCustom": "Pielāgots",
     "@widgetCustom": {},
     "sentCallInformations": "{senderName} nosūtīja informāciju par zvanu",
@@ -1740,8 +1614,6 @@
     },
     "messageInfo": "Informācija par ziņu",
     "@messageInfo": {},
-    "disableEncryptionWarning": "Drošības iemeslu dēļ tērzēšanā nevar atspējot šifrēšanu, ja tā ir pirms tam ir bijusi iespējota.",
-    "@disableEncryptionWarning": {},
     "directChat": "Tiešā tērzēšana",
     "@directChat": {},
     "encryptionNotEnabled": "Šifrēšana nav iespējota",
@@ -1772,15 +1644,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "foregroundServiceRunning": "Šis paziņojums parādās, kad darbojas priekšplāna pakalpojums.",
-    "@foregroundServiceRunning": {},
     "enterAnEmailAddress": "Jāievada e-pasta adrese",
     "@enterAnEmailAddress": {
         "type": "String",
         "placeholders": {}
     },
-    "voiceCall": "Balss zvans",
-    "@voiceCall": {},
     "commandHint_kick": "Noņemt norādīto lietotāju no šīs istabas",
     "@commandHint_kick": {
         "type": "String",
@@ -1788,11 +1656,6 @@
     },
     "copiedToClipboard": "Ievietots starpliktuvē",
     "@copiedToClipboard": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "createNewSpace": "Jauna vieta",
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1850,11 +1713,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Kurš var veikt kādas darbības",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "confirmMatrixId": "Lūgums apliecināt savu Matrix Id, lai varētu izdzēst savu kontu.",
     "@confirmMatrixId": {},
     "learnMore": "Uzzināt vairāk",
@@ -1886,8 +1744,6 @@
     "@newGroup": {},
     "bundleName": "Komplekta nosaukums",
     "@bundleName": {},
-    "removeFromSpace": "Noņemt no vietas",
-    "@removeFromSpace": {},
     "dateAndTimeOfDay": "{date}, {timeOfDay}",
     "@dateAndTimeOfDay": {
         "type": "String",
@@ -1943,11 +1799,6 @@
     },
     "pleaseEnterANumber": "Lūgums ievadīt skaitli lielāku par 0",
     "@pleaseEnterANumber": {},
-    "contactHasBeenInvitedToTheGroup": "Kontaktpersona tika uzaicināta kopā",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "youKicked": "👞 Tu izraidīji {user}",
     "@youKicked": {
         "placeholders": {
@@ -2001,28 +1852,15 @@
             }
         }
     },
-    "sorryThatsNotPossible": "Atvaino! Tas nav iespējams",
-    "@sorryThatsNotPossible": {},
     "oopsSomethingWentWrong": "Ups! Kaut kas nogāja greizi…",
     "@oopsSomethingWentWrong": {
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Ielādēt vēl {count} dalībniekus",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "shareInviteLink": "Kopīgot uzaicinājuma saiti",
     "@shareInviteLink": {},
     "commandHint_markasdm": "Atzīmēt kā tiešo ziņu istabu norādītajam Matrix Id",
     "@commandHint_markasdm": {},
-    "recoveryKeyLost": "Pazaudēta atkopes atslēga?",
-    "@recoveryKeyLost": {},
     "cuddleContent": "{senderName} samīļo Tevi",
     "@cuddleContent": {
         "type": "String",
@@ -2055,16 +1893,6 @@
     "@deviceKeys": {},
     "waitingPartnerNumbers": "Gaida, līdz biedrs apstiprinās skaitļus…",
     "@waitingPartnerNumbers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Izskatās, ka Firebase mākoņziņojumapmaiņa nav pieejama šajā ierīcē. Lai joprojām saņemtu pašpiegādes paziņojumus, mēs iesakām uzstādīt ntfy. Ar ntfy vai citu UnifiedPush nodrošinātāju ir iespējams saņemt pašpiegādes paziņojumus drošā veidā. ntfy var lejupielādēt no Play Store vai F-Droid.",
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "Viss ir gatavs!",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -2102,18 +1930,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "visibilityOfTheChatHistory": "Tērzēšanas vēstures redzamība",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "settings": "Iestatījumi",
     "@settings": {
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "Iestatīt izskatu:",
-    "@setTheme": {},
     "changeTheHomeserver": "Mainīt mājasserveri",
     "@changeTheHomeserver": {
         "type": "String",
@@ -2139,11 +1960,6 @@
                 "type": "String"
             }
         }
-    },
-    "chatBackupDescription": "Ziņas ir aizsargātas ar atkopes atslēgu. Lūgums nodrošināt, ka tā netiek pazaudēta.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
     },
     "changeDeviceName": "Mainīt ierīces nosaukumu",
     "@changeDeviceName": {
@@ -2339,8 +2155,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "storeInSecureStorageDescription": "Glabāt atkopes atslēgu šīs ierīces drošajā krātuvē.",
-    "@storeInSecureStorageDescription": {},
     "openChat": "Atvērt tērzēšanu",
     "@openChat": {},
     "kickUserDescription": "Lietotājs ir izmests no tērzēšanas, bet piekļuve nav liegta. Publiskās tērzēšanās lietotājs var atkārtoti pievienoties jebkurā laikā.",
@@ -2364,8 +2178,6 @@
     },
     "pinMessage": "Piespraust istabai",
     "@pinMessage": {},
-    "screenSharingDetail": "Tu kopīgo savu ekrānu FluffyChat",
-    "@screenSharingDetail": {},
     "muteChat": "Apklusināt tērzēšanu",
     "@muteChat": {
         "type": "String",
@@ -2373,8 +2185,6 @@
     },
     "invite": "Uzaicināt",
     "@invite": {},
-    "enableMultiAccounts": "(BETA) Iespējot vairākus kontus šajā ierīcē",
-    "@enableMultiAccounts": {},
     "anyoneCanJoin": "Ikviens var pievienoties",
     "@anyoneCanJoin": {
         "type": "String",
@@ -2396,10 +2206,6 @@
     },
     "appLockDescription": "Aizslēgt lietotni, kad tā netiek izmantota, ar PIN kodu",
     "@appLockDescription": {},
-    "globalChatId": "Vispārējais tērzēšanas Id",
-    "@globalChatId": {},
-    "accessAndVisibilityDescription": "Kam ir ļauts pievienoties šai tērzēšanai un kā tērzēšana var tikt atklāta.",
-    "@accessAndVisibilityDescription": {},
     "customEmojisAndStickers": "Pielāgotas emocijzīmes un uzlīmes",
     "@customEmojisAndStickers": {},
     "customEmojisAndStickersBody": "Pievienot vai kopīgot pielāgotas emocijzīmes vai uzlīmes, kas var tikt izmantotas jebkurā tērzēšanā.",
@@ -2408,8 +2214,6 @@
     "@hideInvalidOrUnknownMessageFormats": {},
     "blockUsername": "Neņemt vērā lietotājvārdu",
     "@blockUsername": {},
-    "accessAndVisibility": "Piekļuve un redzamība",
-    "@accessAndVisibility": {},
     "calls": "Zvani",
     "@calls": {},
     "hideRedactedMessages": "Paslēpt labošanas ziņas",
@@ -2440,18 +2244,12 @@
     "@decline": {},
     "joinSpace": "Pievienoties vietai",
     "@joinSpace": {},
-    "createGroupAndInviteUsers": "Izveidot kopu un uzaicināt lietotājus",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "Kopu var atrast meklēšanā",
-    "@groupCanBeFoundViaSearch": {},
     "commandHint_sendraw": "Nosūtīt neapstrādātu JSON",
     "@commandHint_sendraw": {},
     "newPassword": "Jauna parole",
     "@newPassword": {},
     "sendReadReceipts": "Nosūtīt lasīšanas atskaites",
     "@sendReadReceipts": {},
-    "verifyOtherUser": "🔐 Apliecināt otru lietotāju",
-    "@verifyOtherUser": {},
     "verifyOtherDevice": "🔐 Apliecināt otru ierīci",
     "@verifyOtherDevice": {},
     "yourGlobalUserIdIs": "Vispārējais lietotāja Id ir: ",
@@ -2513,31 +2311,16 @@
     "@commandHint_unignore": {},
     "commandHint_ignore": "Neņemt vērā norādīto Matrix Id",
     "@commandHint_ignore": {},
-    "searchChatsRooms": "Meklēt #tērzēšanas, @lietotājus...",
-    "@searchChatsRooms": {},
     "groupName": "Kopas nosaukums",
     "@groupName": {},
     "knock": "Pieklauvēt",
     "@knock": {},
     "stickers": "Uzlīmes",
     "@stickers": {},
-    "usersMustKnock": "Lietotājiem jāpieklauvē",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Neviens nevar pievienoties",
-    "@noOneCanJoin": {},
     "hidePresences": "Paslēpt stāvokļu sarakstu?",
     "@hidePresences": {},
     "knocking": "Klauvē",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Tērzēšana var tikt atklāta ar meklēšanu {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "nothingFound": "Nekas netika atrasts...",
     "@nothingFound": {},
     "startConversation": "Uzsākt sarunu",
@@ -2572,10 +2355,6 @@
     "@databaseMigrationBody": {},
     "passwordsDoNotMatch": "Paroles nesakrīt",
     "@passwordsDoNotMatch": {},
-    "publicChatAddresses": "Publiskas tērzēšanas adreses",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Izveidot jaunu adresi",
-    "@createNewAddress": {},
     "discover": "Atklāt",
     "@discover": {},
     "unreadChatsInApp": "{appname}: {unread} nelasītas tērzēšanas",
@@ -2592,24 +2371,8 @@
     },
     "subspace": "Apakšvieta",
     "@subspace": {},
-    "addChatOrSubSpace": "Pievienot tērzēšanu vai apakšvietu",
-    "@addChatOrSubSpace": {},
     "formattedMessagesDescription": "Attēlot bagātinātu ziņu saturu, piemēram, ar Markdown iezīmētu treknrakstu.",
     "@formattedMessagesDescription": {},
-    "sessionLostBody": "Sesija ir zaudēta. Lūgums ziņot par šo kļūdu izstrādātājiem {url}. Kļūdas ziņojums ir: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "verifyOtherUserDescription": "Ar cita lietotāja apliecināšanu vari pārliecināties, ka zini, kam Tu tiešām raksti. 💪\n\nKad uzsāc apliecināšanu, Tu un otrs lietotājs lietotnē redzēs uznirstošo logu. Tajā jūs redzēsiet dažādas emocijzīmes vai skaitļus, kas ir jāsalīdzina savā starpā.\n\nLabākais veids, kā to izdarīt, ir satikties vai uzsākt videozvanu. 👭",
-    "@verifyOtherUserDescription": {},
     "sendTypingNotificationsDescription": "Citi tērzēšanas dalībnieki var redzēt, kad raksti jaunu ziņu.",
     "@sendTypingNotificationsDescription": {},
     "noUsersFoundWithQuery": "Diemžēl ar \"{query}\" netika atrasts neviens lietotājs. Lūgums pārbaudīt, vai ir pieļauta drukas kļūda.",
@@ -2617,18 +2380,6 @@
         "type": "String",
         "placeholders": {
             "query": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Lietotne tagad mēģina atjaunot sesiju no rezerves kopijas. Lūgums ziņot par šo kļūdu izstrādātājiem {url}. Kļūdas ziņojums ir: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
                 "type": "String"
             }
         }
@@ -2729,14 +2480,6 @@
     "@chatPermissionsDescription": {},
     "doesNotSeemToBeAValidHomeserver": "Neizskatās pēc saderīga mājasservera. Nepareizs URL?",
     "@doesNotSeemToBeAValidHomeserver": {},
-    "loginWithMatrixId": "Pieteikties ar Matrix-Id",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Atklāt mājasserverus",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Kas ir mājasserveris?",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "Visi lietotāja dati tiek glabāti mājasserverī, gluži kā ar e-pasta nodrošinātāju. Ir iespējams izvēlēties, kuru mājasserveri izmantot, saglabājot iespēju sazināties ar ikvienu. Vairāk var uzzināt https://matrix.org.",
-    "@homeserverDescription": {},
     "updateInstalled": "🎉 Atjauninājums {version} uzstādīts.",
     "@updateInstalled": {
         "type": "String",
@@ -2797,16 +2540,12 @@
     "@noticeChatBackupDeviceVerification": {},
     "continueText": "Turpināt",
     "@continueText": {},
-    "welcomeText": "Sveicieni! 👋 Šis ir FluffyChat. Tu vari pieteikties jebkurā mājasserverī, kas ir saderīgs ar https://matrix.org. Tad vari tērzēt ar ikvienu. Tas ir milzīgs decentralizētās saziņas tīkls.",
-    "@welcomeText": {},
     "blur": "Aizmiglojums:",
     "@blur": {},
     "setWallpaper": "Iestatīt ekrāntapeti",
     "@setWallpaper": {},
     "opacity": "Necaurredzamība:",
     "@opacity": {},
-    "manageAccount": "Pārvaldīt kontu",
-    "@manageAccount": {},
     "noContactInformationProvided": "Serveris nesniedz nekādu derīgu saziņas informāciju",
     "@noContactInformationProvided": {},
     "serverInformation": "Informācija par serveri:",
@@ -2857,10 +2596,6 @@
     "@compress": {},
     "unableToJoinChat": "Nevarēja pievienoties tērzēšanai. Varbūt otra puse jau ir aizvērusi sarunu.",
     "@unableToJoinChat": {},
-    "appWantsToUseForLoginDescription": "Ar šo tiek ļauts lietotnei un tīmekļvietnei kopīgot informāciju par Tevi.",
-    "@appWantsToUseForLoginDescription": {},
-    "appIntroduction": "FluffyChat ļauj tērzēt ar draugiem, kuri izmanto dažādas ziņojumapmaiņas lietotnes. Vairāk var uzzināt https://matrix.org vai vienkārši piesitot *Turpināt*.",
-    "@appIntroduction": {},
     "synchronizingPleaseWaitCounter": " Sinhronizē... ({percentage}%)",
     "@synchronizingPleaseWaitCounter": {
         "type": "String",
@@ -2874,15 +2609,6 @@
     "@previous": {},
     "otherPartyNotLoggedIn": "Otra puse pašlaik nav pieteikusies un tādēļ nevar saņemt ziņas.",
     "@otherPartyNotLoggedIn": {},
-    "appWantsToUseForLogin": "Izmantot '{server}', lai pieteiktos",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "open": "Atvērt",
     "@open": {},
     "waitingForServer": "Gaida serveri...",
@@ -3032,15 +2758,6 @@
     "@approve": {},
     "checkList": "Pārbaužu saraksts",
     "@checkList": {},
-    "countInvited": "{count} uzaicināti",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "sentVoiceMessage": "🎙️ {duration} - Balss ziņa no {sender}",
     "@sentVoiceMessage": {
         "type": "String",
@@ -3073,12 +2790,6 @@
     "@pause": {},
     "resume": "Atsākt",
     "@resume": {},
-    "newSubSpace": "Jauna apakšvieta",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Pārvietot uz citu vietu",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "Tērzēšana tiks noņemta no vietas, bet tā joprojām būs redzama tērzēšanu sarakstā.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} tērzēšanas",
     "@countChats": {
         "type": "String",
@@ -3088,26 +2799,6 @@
             }
         }
     },
-    "spaceMemberOf": "{spaces} dalībnieks",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "{spaces} dalībnieks var pieklauvēt",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "Ziedot",
-    "@donate": {},
     "startedAPoll": "{username} uzsāka aptauju.",
     "@startedAPoll": {
         "type": "String",
@@ -3177,14 +2868,6 @@
     "@stickerPackName": {},
     "attribution": "Piedēvējums",
     "@attribution": {},
-    "skipChatBackup": "Izlaist tērzēšanu rezerves kopēšanu",
-    "@skipChatBackup": {},
-    "skipChatBackupWarning": "Vai tiešām? Bez tērzēšanu rezerves kopēšanas var tikt zaudēta piekļuve savām ziņām, kad tiks mainīta ierīce.",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "Ielādē ziņas",
-    "@loadingMessages": {},
-    "setupChatBackup": "Iestatīt tērzēšanu rezerves kopēšanu",
-    "@setupChatBackup": {},
     "changedTheChatDescription": "{username} nomainīja tērzēšanas aprakstu",
     "@changedTheChatDescription": {},
     "changedTheChatName": "{username} nomainīja tērzēšanas nosaukumu",
@@ -3197,11 +2880,9 @@
     "taTooltip": "L2 lietošana ar tulkošanas palīdzību",
     "interactiveTranslatorSliderHeader": "Interaktīvais tulkotājs",
     "interactiveGrammarSliderHeader": "Interaktīvais gramatikas pārbaudītājs",
-    "interactiveTranslatorRequired": "Nepieciešams",
     "waTooltip": "L2 lietošana bez palīdzības",
     "interactiveTranslator": "Tulkotāja palīdzība",
     "noIdenticalLanguages": "Lūdzu, izvēlieties atšķirīgas pamata un mērķa valodas",
-    "searchBy": "Meklēt pēc valsts un valodām",
     "joinWithClassCode": "Pievienoties kursam",
     "languageLevelPreA1": "Sākuma līmenis Zems (Pre A1)",
     "languageLevelA1": "Jaunais Vidējais (A1)",
@@ -3221,19 +2902,14 @@
     "whatIsYourBaseLanguage": "Kāda ir jūsu pamata valoda?",
     "publicProfileTitle": "Atļaut, lai manu profilu var atrast meklēšanā",
     "publicProfileDesc": "Ieslēdzot, jūs ļaujat citiem lietotājiem atrast jūsu profilu globālajā meklēšanas joslā un sūtīt pieprasījumus tērzēšanai. Šajā brīdī jūs varat izvēlēties pieņemt vai noraidīt pieprasījumu.",
-    "errorDisableIT": "Tulkošanas palīdzība ir izslēgta.",
-    "errorDisableIGC": "Gramatikas palīdzība ir izslēgta.",
     "errorDisableITUserDesc": "Noklikšķiniet šeit, lai atjauninātu tulkošanas palīdzības iestatījumus",
     "errorDisableIGCUserDesc": "Noklikšķiniet šeit, lai atjauninātu gramatikas palīdzības iestatījumus",
     "errorDisableITClassDesc": "Tulkošanas palīdzība ir izslēgta kursam, kurā atrodas šī tērzēšana.",
     "errorDisableIGCClassDesc": "Gramatikas palīdzība ir izslēgta kursam, kurā atrodas šī tērzēšana.",
-    "error405Title": "Valodas nav iestatītas",
     "error405Desc": "Lūdzu, iestatiet savas valodas galvenajā izvēlnē > Mācību iestatījumi.",
     "termsAndConditions": "Noteikumiem un nosacījumiem",
     "andCertifyIAmAtLeast13YearsOfAge": " un apliecinu, ka man ir vismaz 16 gadu.",
-    "error502504Title": "Vau, ir daudz studentu tiešsaistē!",
     "error502504Desc": "Tulkotāja un gramatikas rīki var būt lēni vai nepieejami, kamēr Pangea roboti seko līdzi.",
-    "error404Title": "Tulkotāja kļūda!",
     "error404Desc": "Pangea bots nav pārliecināts, kā to tulkot...",
     "errorPleaseRefresh": "Mēs to izpētām! Lūdzu, ielādējiet lapu vēlreiz un mēģiniet vēlreiz.",
     "connectedToStaging": "Savienots ar testēšanas vidi",
@@ -3271,13 +2947,9 @@
     "definitionsToolName": "Vārdu definīcijas",
     "definitionsToolDescription": "Kad ir ieslēgts, zili pasvītroti vārdi ir klikšķināmi, lai skatītu definīcijas. Klikšķiniet uz ziņojumiem, lai piekļūtu definīcijām.",
     "welcomeBack": "Laipni atpakaļ! Ja jūs bijāt 2023-2024. gada pilotprojektā, lūdzu, sazinieties ar mums par jūsu īpašo pilotabonementu. Ja jūs esat skolotājs, kurš ir (vai jūsu iestāde ir) iegādājies licenci jūsu klasei, sazinieties ar mums par jūsu skolotāja abonementu.",
-    "downloadTxtFile": "Lejupielādēt teksta failu",
-    "downloadCSVFile": "Lejupielādēt CSV failu",
     "promotionalSubscriptionDesc": "Jums pašlaik ir uz mūžu spēkā esoša reklāmas abonēšana. Sazinieties ar support@pangea.chat, lai saņemtu palīdzību ar abonēšanas maiņu.",
     "originalSubscriptionPlatform": "Abonēšana iegādāta caur {purchasePlatform}",
     "oneWeekTrial": "Vienas nedēļas izmēģinājuma periods",
-    "downloadXLSXFile": "Lejupielādēt Excel failu",
-    "unkDisplayName": "Nezināms",
     "wwCountryDisplayName": "Visā pasaulē",
     "afCountryDisplayName": "Afganistāna",
     "axCountryDisplayName": "Alandu salas",
@@ -3572,7 +3244,6 @@
     "chatCapacityHasBeenChanged": "Čata jauda ir mainīta",
     "chatCapacitySetTooLow": "Čata jaudai jābūt vismaz {count}.",
     "chatCapacityExplanation": "Čata jauda ierobežo dalībnieku skaitu, kas var piedalīties čatā.",
-    "tooManyRequest": "Pārāk daudz pieprasījumu, lūdzu, mēģiniet vēlreiz vēlāk.",
     "enterNumber": "Lūdzu, ievadiet veselu skaitli.",
     "practice": "Prakse",
     "versionNotFound": "Versija nav atrasta",
@@ -3582,7 +3253,6 @@
     "deleteSubscriptionWarningTitle": "Jums ir aktīva abonēšana",
     "deleteSubscriptionWarningBody": "Dzēšot savu kontu, jūsu abonēšana netiks automātiski atcelta.",
     "manageSubscription": "Pārvaldīt abonēšanu",
-    "error520Title": "Lūdzu, mēģiniet vēlreiz.",
     "error520Desc": "Atvainojiet, mēs nesapratām jūsu ziņojumu...",
     "wordsUsed": "Izmantotās vārdi",
     "level": "Līmenis",
@@ -3600,7 +3270,6 @@
     "other": "Cits",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "Nav kapacitātes ierobežojuma",
-    "downloadGroupText": "Lejupielādēt grupas tekstu",
     "notificationsOn": "Paziņojumi ieslēgti",
     "notificationsOff": "Paziņojumi izslēgti",
     "joinWithCode": "Pievienoties ar kodu",
@@ -3664,24 +3333,12 @@
     "whatIsTheMorphTag": "Kas ir {morphologicalFeature} '{wordForm}'?",
     "dataAvailable": "Datu pieejamība",
     "available": "Pieejams",
-    "pangeaBotIsFallible": "Pangea bots arī kļūdās!",
-    "whatIsMeaning": "Ko nozīmē '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Saskaņo nozīmes ar vārdiem ziņojumā!",
-    "doubleClickToEdit": "Divreiz klikšķini, lai rediģētu.",
-    "topicLabel": "Tēma",
-    "topicPlaceholder": "Izvēlieties tēmu...",
-    "modePlaceholder": "Izvēlieties režīmu...",
-    "learningObjectiveLabel": "Mācību mērķis",
-    "learningObjectivePlaceholder": "Izvēlieties mācību mērķi...",
-    "targetLanguageLabel": "Mērķvaloda",
     "cefrLevelLabel": "CEFR līmenis",
     "image": "Attēls",
     "video": "Video",
     "nan": "Nav piemērojams",
-    "addVocabulary": "Pievienot vārdu krājumu",
     "instructions": "Instrukcijas",
-    "numberOfLearners": "Mācību dalībnieku skaits",
-    "mustBeInteger": "Jābūt veselam skaitlim, piemēram, 1, 2, 3, ...",
     "constructUsePvmDesc": "Ražots balss ziņojumā",
     "leaveSpaceDescription": "Atstājot kursu, jūs atstājat visus tajā esošos čatus. Citi lietotāji redzēs, ka esat atstājis kursu.",
     "constructUseCorMmDesc": "Pareiza ziņojuma nozīme",
@@ -3696,7 +3353,6 @@
     "ttsDisabledBody": "Jūs varat iespējojiet teksta runas funkciju savās mācību iestatījumos",
     "noSpaceDescriptionYet": "Vēl nav izveidots kursa apraksts.",
     "tooLargeToSend": "Šī ziņa ir pārāk liela, lai to nosūtītu",
-    "exitWithoutSaving": "Vai tiešām vēlaties aiziet bez saglabāšanas?",
     "enableAutocorrectPopupTitle": "Pievienojiet savu mērķvalodas tastatūru, dodoties uz:",
     "enableAutocorrectPopupSteps": "  • Iestatījumi\n  • Vispārīgi\n  • Tastatūra\n  • Tastatūras\n  • Pievienot jaunu tastatūru",
     "enableAutocorrectPopupDescription": "Kad valoda ir izvēlēta, jūs varat noklikšķināt uz mazās globusa ikonas apakšējā kreisajā stūrī, lai aktivizētu jauno instalēto tastatūru.",
@@ -3707,11 +3363,8 @@
     "displayName": "Parādāmais vārds",
     "leaveRoomDescription": "Jūs parādīsiet, ka pametat šo čatu. Citi lietotāji redzēs, ka esat aizgājis no čata.",
     "confirmUserId": "Lūdzu, apstipriniet savu Pangea Chat lietotājvārdu, lai dzēstu savu kontu.",
-    "startingToday": "Sākot no šodienas",
-    "oneWeekFreeTrial": "Viena nedēļa bezmaksas izmēģinājuma",
     "paidSubscriptionStarts": "Sākas {startDate}",
     "cancelInSubscriptionSettings": "• Atcelt jebkurā laikā abonementa iestatījumos",
-    "cancelToAvoidCharges": "• Atcelt pirms {trialEnds}, lai izvairītos no maksājumiem",
     "downloadGboard": "Lejupielādēt Gboard",
     "autocorrectNotAvailable": "Diemžēl jūsu platforma šobrīd nav atbalstīta šai funkcijai. Sekojiet līdzi turpmākajiem attīstības posmiem!",
     "pleaseUpdateApp": "Lūdzu, atjauniniet lietotni, lai turpinātu.",
@@ -3721,17 +3374,12 @@
     "knockSpaceSuccess": "Jūs esat pieprasījis pievienoties šai kursam! Administrators atbildēs uz jūsu pieprasījumu, kad tas tiks saņemts 😀",
     "chooseWordAudioInstructionsBody": "Klausieties pilnu ziņojumu. Tad saskaņojiet audio ar vārdiem.",
     "chooseMorphsInstructionsBody": "Noklikšķiniet uz puzles gabaliņiem, lai atbildētu uz gramatikas jautājumiem!",
-    "pleaseEnterInt": "Lūdzu, ievadiet skaitli",
     "home": "Sākumlapa",
     "join": "Pievienoties",
     "resetInstructionTooltipsTitle": "Atiestatīt instrukciju rīkjoslas",
     "resetInstructionTooltipsDesc": "Klikšķiniet, lai parādītu instrukciju rīkjoslas, kā jauns lietotājs.",
-    "randomize": " nejauši izvēlēties",
     "clear": "Notīrīt",
-    "featuredActivities": "Ieteiktās",
     "save": "Saglabāt",
-    "startChat": "Sākt sarunu",
-    "translationProblem": "Tulkošanas problēma",
     "askToJoin": "Lūgt pievienoties",
     "emptyChatWarningTitle": "Čats ir tukšs",
     "emptyChatWarningDesc": "Tu neesi uzaicinājis nevienu uz savu čatu. Dodies uz Čata iestatījumiem, lai uzaicinātu kontaktus vai Botu. To vari izdarīt arī vēlāk.",
@@ -3761,17 +3409,13 @@
     "timesUsedIndependently": "Reizes, kad izmantots neatkarīgi",
     "timesUsedWithAssistance": "Reizes, kad izmantots ar palīdzību",
     "shareInviteCode": "Dalīties ar ielūguma kodu: {code}",
-    "leaderboard": "Rezultātu tabula",
     "skipForNow": "Pagaidām izlaist",
     "permissions": "Atļaujas",
     "spaceChildPermission": "Kas var pievienot jaunas tērzēšanas šim kursam",
-    "addEnvironmentOverride": "Pievienot vides pārrakstīšanu",
     "defaultOption": "Noklusējuma",
     "deleteChatDesc": "Vai tiešām vēlaties dzēst šo tērzēšanu? Tā tiks dzēsta visiem dalībniekiem, un visas tērzēšanas ziņas vairs nebūs pieejamas praksei vai mācību analītikai.",
     "deleteSpaceDesc": "Kursa un jebkuru izvēlēto tērzēšanu tiks dzēsts visiem dalībniekiem, un visas tērzēšanas ziņas vairs nebūs pieejamas praksei vai mācību analītikai. Šo darbību nevar atsaukt.",
     "launch": "Sākt",
-    "searchChats": "Meklēt tērzēšanas",
-    "maxFifty": "Maks. 50",
     "configureSpace": "Konfigurēt kursu",
     "pinMessages": "Pin ziņas",
     "setJoinRules": "Iestatīt pievienošanās noteikumus",
@@ -3805,9 +3449,6 @@
     "failedToFetchTranscription": "Neizdevās iegūt pārveidojumu",
     "deleteEmptySpaceDesc": "Kurss tiks dzēsts visiem dalībniekiem. Šo darbību nevar atsaukt.",
     "regenerate": "Atkārtoti ģenerēt",
-    "mySavedActivities": "Mani saglabātie pasākumi",
-    "noSavedActivities": "Nav saglabātu pasākumu",
-    "saveActivity": "Saglabāt šo pasākumu",
     "failedToPlayVideo": "Neizdevās atskaņot video",
     "done": "Gatavs",
     "inThisSpace": "Šajā kursā",
@@ -3818,13 +3459,9 @@
     "numInvited": "{count} ielūgts",
     "saved": "Saglabāts",
     "reset": "Atiestatīt",
-    "errorFetchingActivitiesMessage": "Neizdevās iegūt pasākumus",
     "errorFetchingDefinition": "Neizdevās iegūt definīciju",
     "errorProcessAnalytics": "Neizdevās apstrādāt analītiku",
     "errorDownloading": "Lejupielāde neizdevās",
-    "errorLoadingSpaceChildren": "Neizdevās ielādēt sarakstes šajā kursā",
-    "unexpectedError": "Neparedzēta kļūda.",
-    "pleaseReload": "Lūdzu, ielādējiet vēlreiz un mēģiniet vēlreiz.",
     "translationError": "Tulkošanas kļūda",
     "check": "Pārbaudīt",
     "unableToFindRoom": "Nav atrasta sarakste vai kurss ar šo kodu. Lūdzu, mēģiniet vēlreiz.",
@@ -3833,19 +3470,14 @@
     "request": "Pieprasīt",
     "requestAll": "Pieprasīt visu",
     "confirmMessageUnpin": "Vai tiešām vēlaties noņemt šo ziņojumu no piestiprinājuma?",
-    "saveAndLaunch": "Saglabāt un palaist",
-    "launchToSpace": "Palaist kursā",
     "pending": "Gaidāms",
     "inactive": "Neaktīvs",
-    "confirmRole": "Apstiprināt lomu",
     "openRoleLabel": "ATVĒRTS",
     "finishedTheActivity": "🎯 {username} pabeidza šo aktivitāti",
     "activitySummaryError": "Aktivitātes kopsavilkumi nav pieejami",
     "requestSummaries": "Pieprasīt kopsavilkumus",
-    "generatingNewActivities": "Jūs esat šīs valodu pāra pirmais lietotājs! Lūdzu, dodiet mums minūti, mēs sagatavojam aktivitātes tieši jums.",
     "requestAccessTitle": "Pieprasīt analītikas piekļuvi?",
     "requestAccessDesc": "Vai vēlaties pieprasīt piekļuvi, lai skatītu dalībnieku analītiku?\n\nJa dalībnieki piekrīt, šīs kursa administratori varēs skatīt viņu:\n    • kopējo vārdu krājumu\n    • kopējo gramatikas jēdzienu skaitu\n    • kopējo aktivitāšu sesiju skaitu\n    • konkrētus izmantotos, pareizi un nepareizi, gramatikas jēdzienus\n\nViņi nevarēs skatīt viņu:\n    • ziņojumus ārpus kursa čatos\n    • vārdu krājuma sarakstu",
-    "requestAccess": "Pieprasīt piekļuvi ({count})",
     "createGroupChat": "Izveidot grupu čatu",
     "editCourse": "Rediģēt kursu",
     "inviteDesc": "Ar lietotājvārdu, ar kodu vai saiti",
@@ -3854,8 +3486,6 @@
     "accessDesc": "Jūs varat padarīt savu kursu atvērtu pasaulei! Vai arī padarīt kursu privātu un drošu.",
     "createGroupChatDesc": "Kamēr aktivitāšu sesijas sākas un beidzas, grupu čati paliks atvērti ikdienas saziņai.",
     "deleteDesc": "Tikai administratori var dzēst kursu. Šī ir postoša darbība, kas izdzēš visus lietotājus un dzēš visus atlasītos čatus kursā. Esiet uzmanīgs.",
-    "noCourseFound": "Ak, šim kursam ir nepieciešams plāns!\n\nKursa plāni ir tematu un sarunu aktivitāšu secība.",
-    "additionalParticipants": "+ {num} citi",
     "whatNow": "Kas tagad?",
     "chooseNextActivity": "Izvēlies nākamo aktivitāti!",
     "letsGo": "Ejam",
@@ -3868,13 +3498,11 @@
     "waitNotDone": "Gaidiet, es neesmu pabeidzis!",
     "waitingForOthersToFinish": "Gaidām, lai pārējie pabeigtu...",
     "generatingSummary": "Analizē čatu un ģenerē rezultātus",
-    "findCourse": "Atrodi kursu",
     "pingParticipantsNotification": "{user} meklē lietotājus, lai pievienotos aktivitātes sesijai {room}",
     "course": "Kursa",
     "courses": "Kursi",
     "goToCourse": "Dodieties uz kursu: {course}",
     "activityComplete": "Šī aktivitāte ir pabeigta. Apakšā ir pieejams aktivitātes kopsavilkums.",
-    "startNewSession": "Sākt jaunu sesiju",
     "joinOpenSession": "Pievienoties atvērtai sesijai",
     "activityNotFound": "Aktivitate nav atrasta",
     "myActivities": "Manas aktivitātes",
@@ -3972,10 +3600,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3985,10 +3609,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4072,14 +3692,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4096,10 +3708,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4112,15 +3720,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4272,14 +3872,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4293,14 +3885,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5523,10 +5107,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5567,10 +5147,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5643,10 +5219,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5916,47 +5488,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5976,19 +5508,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6052,10 +5572,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6096,14 +5612,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6115,14 +5623,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6160,10 +5660,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6180,27 +5676,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6324,10 +5804,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6337,10 +5813,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6357,14 +5829,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6504,18 +5968,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6564,10 +6016,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6577,18 +6025,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6631,23 +6067,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6671,10 +6095,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6682,14 +6102,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6794,18 +6206,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6858,10 +6258,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6888,10 +6284,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7072,7 +6464,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Pārbaudiet rīt, lai saņemtu aktivitātes atjauninājumus.",
-    "activityDropdownDesc": "Kad esat pabeidzis šo aktivitāti, noklikšķiniet zemāk",
     "languageMismatchTitle": "Valodu neatbilstība",
     "languageMismatchDesc": "Jūsu mērķa valoda neatbilst šīs aktivitātes valodai. Vai vēlaties atjaunināt savu mērķa valodu?",
     "reportWordIssueTooltip": "Ziņot par vārda informācijas problēmu",
@@ -7085,10 +6476,6 @@
     "selectAll": "Izvēlēties visu",
     "deselectAll": "Izņemt izvēli no visa",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7137,17 +6524,11 @@
         "placeholders": {}
     },
     "startOwn": "Sākt savu",
-    "joinCourseDesc": "Katram kursam ir 8-10 secīgu tematu ar dažādām uzdevumu balstītām valodas mācību aktivitātēm.",
     "newMessageInPangeaChat": "💬 Jauna ziņa Pangea Čatā",
     "shareCourse": "Dalīties ar kursu",
     "addCourse": "Pievienot kursu",
-    "joinPublicCourse": "Pievienoties publiskajam kursam",
     "vocabLevelsDesc": "Šeit ietilps vārdu krājuma vārdi, kad jūs tos uzlabosiet līmenī!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7160,10 +6541,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7182,7 +6559,6 @@
     "emojiView": "Emodžiju skats",
     "feedbackDialogDesc": "Es arī pieļauju kļūdas! Vai ir kaut kas, kas varētu man palīdzēt uzlaboties?",
     "contactHasBeenInvitedToTheCourse": "Kontakts ir uzaicināts uz kursu",
-    "activityStatsButtonTooltip": "Aktivitātes informācija",
     "allow": "Atļaut",
     "deny": "Noraidīt",
     "enabledRenewal": "Iespējot abonēšanas atjaunošanu",
@@ -7450,10 +6826,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8509,16 +7881,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktivitātes, lai atbloķētu nākamo tēmu",
-    "activitiesToUnlockTopicDesc": "Iestatiet aktivitāšu skaitu, lai atbloķētu nākamo kursa tēmu",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Pareiza vārdu definīciju prakse",
     "constructUseIncLMDesc": "Nepareiza vārdu definīciju prakse",
     "constructUseCorLADesc": "Pareiza vārdu audio prakse",
@@ -8526,7 +7888,6 @@
     "constructUseBonus": "Bonuss vārdu praksē",
     "practiceVocab": "Praktizēt vārdu krājumu",
     "selectMeaning": "Izvēlieties nozīmi",
-    "selectAudio": "Izvēlieties atbilstošo audio",
     "anotherRound": "Vēl viena kārta",
     "activitySettingsOverrideWarning": "Valoda un valodas līmenis, ko nosaka aktivitāšu plāns",
     "voice": "Balss",
@@ -8558,10 +7919,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8579,12 +7936,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Lejupielāde uzsākta",
     "webDownloadPermissionMessage": "Ja jūsu pārlūkprogramma bloķē lejupielādes, lūdzu, iespējot lejupielādes šai vietnei.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8679,11 +8031,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Kaut kas nogāja greizi, un mēs smagi strādājam, lai to labotu. Pārbaudiet vēlāk.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Iespējot rakstīšanas palīdzību",
     "autoIGCToolDescription": "Automātiski palaist Pangea Chat rīkus, lai labotu nosūtītās ziņas mērķa valodā.",
     "@autoIGCToolName": {
@@ -8739,24 +8086,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatika",
-    "spanTypeWordChoice": "Vārdu izvēle",
     "spanTypeSpelling": "Ortogrāfija",
     "spanTypePunctuation": "Interpunkcija",
     "spanTypeStyle": "Stils",
     "spanTypeFluency": "Plūdums",
     "spanTypeAccents": "Akcenti",
     "spanTypeCapitalization": "Lielie burti",
-    "spanTypeCorrection": "Korekcija",
     "spanFeedbackTitle": "Ziņot par korekcijas problēmu",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8781,10 +8117,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8795,13 +8127,9 @@
     "clientWellKnownInformation": "Klienta zināmā informācija:",
     "baseUrl": "Bāzes URL",
     "identityServer": "Identitātes serveris:",
-    "versionWithNumber": "Versija: {version}",
     "logs": "Žurnāli",
-    "advancedConfigs": "Papildu konfigurācijas",
     "advancedConfigurations": "Papildu konfigurācijas",
-    "signInWithLabel": "Pierakstīties ar:",
     "selectAllWords": "Atlasiet visas dzirdētās vārdus audio ierakstā",
-    "joinCourseForActivities": "Pievienojieties kursam, lai izmēģinātu aktivitātes.",
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8830,19 +8158,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8850,15 +8166,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9059,11 +8367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Klases? Ievietojiet savu pievienošanās kodu šeit.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automātiski izcelt audio ziņojumus",
     "selectAudioMessagesOnPlayDescription": "Automātiski izcelt audio ziņojumus, kad tie tiek atskaņoti",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9107,18 +8410,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Šim kursam ir tēmas ar mazāk nekā {input} aktivitātēm. Lūdzu, ievadiet skaitli, kas ir mazāks par vai vienāds ar {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Noklikšķiniet šeit, lai atkal pierakstītos.",
     "@clickToLogin": {
@@ -9535,17 +8826,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Karikatūrisks dzeltenais lācis ar paceltām rokām sajūsmā.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Izvēlieties vārdus, lai uzzinātu vairāk par tiem",
     "requireAnalyticsAccessTitle": "Nepieciešama analītikas piekļuve, lai pievienotos",
     "requireAnalyticsAccessDesc": "Dalībniekiem jāpiešķir piekļuve viņu mācību analītikai, lai pievienotos šim kursam",
     "analyticsAccessNoticeTitle": "Nepieciešama analītikas piekļuve",
     "analyticsAccessNoticeDesc": "Pievienojoties šim kursam, jūs piekrītat piešķirt administratoriem piekļuvi jūsu mācību analītikai.",
-    "skipOnboardingClassCodeDesc": "Mācāties patstāvīgi? Neuztraucieties, jūs varat:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9563,10 +8848,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9595,7 +8876,6 @@
     "pickCefrLevelTeacherStepTitle": "Kādu līmeni jūs mācat?",
     "pickCefrLevelStudentStepTitle": "Kāds līmenis jums ir?",
     "customCourseStepTitle": "Aizpildiet šo veidlapu, lai iegūtu pielāgotu kursu",
-    "aboutYourClass": "Par jūsu klasi",
     "courseCodeStepErrorMessage": "Lūdzu, pārbaudiet savu kodu un mēģiniet vēlreiz",
     "institution": "Iestāde",
     "courseGoals": "Kursa mērķi",
@@ -9638,10 +8918,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9758,12 +9034,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logo",
     "introChatDetails": "Saki sveiki! Iepazīstini sevi ar citiem kursa dalībniekiem, atrodi draugus un sarunājies ārpus aktivitātēm.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9807,11 +9078,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Darbību darbības",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Izruna rīki",
     "audioTranscription": "AI audio transkripcija",
     "visualLearnerSupport": "Vizuālo mācīšanās atbalsts",
@@ -9852,7 +9118,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Pievienojieties kursam, kas ietver šo aktivitāti, lai to spēlētu.",
     "resizeCoursePanel": "Mainīt kursa paneļa izmēru",
     "undo": "Atcelt",
     "unlock": "Atbloķēt",
@@ -9866,7 +9131,6 @@
     "addCourseBrowsePublic": "Pārlūkot publiskos kursus",
     "browsePublicCourses": "Pārlūkot publiskos kursus",
     "editProfile": "Rediģēt profilu",
-    "numObjectives": "{count} mērķi",
     "mapSearchHint": "Meklēt aktivitātes",
     "mapSearchNoResults": "Nav atbilžu skatā",
     "mapFilterAllLanguages": "Visas valodas",
@@ -9875,7 +9139,6 @@
     "mapFilterCompleted": "Pabeigts",
     "mapFilterReset": "Atjaunot",
     "activityTypeConversation": "Saruna",
-    "lockedMissionRequirement": "Pabeidziet iepriekšējo misiju, lai atbloķētu",
     "playAgain": "Spēlēt vēlreiz",
     "reviewActivity": "Pārskatīt",
     "mapEmptyInView": "Šeit nav nekas jūsu līmenī vai valodā. Paplašiniet savus filtrus vai tālummaiņu.",
@@ -9890,14 +9153,9 @@
     "scrollToBottom": "Ritināt uz leju",
     "courseImage": "Kursa attēls",
     "avatarPreview": "Apskata attēls",
-    "activityPhoto": "Aktivitātes foto",
     "emotePreview": "Emocijas priekšskatījums: {name}",
     "activityLabel": "Aktivitāte: {title}",
     "resetMapView": "Atjaunot kartes skatu",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9950,14 +9208,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9987,10 +9237,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10047,10 +9293,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_nb.arb
+++ b/lib/l10n/intl_nb.arb
@@ -72,11 +72,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Skal gjester tillates å ta del",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Er du sikker?",
     "@areYouSure": {
         "type": "String",
@@ -317,11 +312,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Din sludringssikkerhetskopi er sikret med en sikkerhetsnøkkel. Ikke mist den.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Sludringsdetaljer",
     "@chatDetails": {
         "type": "String",
@@ -359,11 +349,6 @@
     },
     "connect": "Koble til",
     "@connect": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "Kontakt invitert til gruppen",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -556,11 +541,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Du vil ikke kunne skru av kryptering lenger. Er du sikker?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Kryptert",
     "@encrypted": {
         "type": "String",
@@ -587,11 +567,6 @@
     },
     "enterAnEmailAddress": "Skriv inn en e-postadresse",
     "@enterAnEmailAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "Alt er klart!",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -632,11 +607,6 @@
     },
     "group": "Gruppe",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Gruppen er offentlig",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -730,15 +700,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Inviter kontakt til {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Invitert",
     "@invited": {
@@ -851,15 +812,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Last inn {count} deltagere til",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Laster inn… Vent.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -874,15 +826,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Logg inn på {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Logg ut",
     "@logout": {
@@ -941,11 +884,6 @@
     },
     "noEmotesFound": "Fant ingen smilefjes. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Bruk https://microg.org/ for å få Google-tjenester (uten at det går ut over personvernet) for å få push-merknader i FluffyChat:",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1045,11 +983,6 @@
     },
     "passwordHasBeenChanged": "Passord endret",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Passordgjenoppretting",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1158,11 +1091,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Fjern enhet",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Opphev bannlysning",
     "@unbanFromChat": {
@@ -1293,11 +1221,6 @@
             }
         }
     },
-    "setPermissionsLevel": "Sett tilgangsnivå",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Angi status",
     "@setStatus": {
         "type": "String",
@@ -1382,11 +1305,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Overfør fra en annen enhet",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Prøv å sende igjen",
     "@tryToSendAgain": {
         "type": "String",
@@ -1442,15 +1360,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, other{{unreadCount} uleste sludringer}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} og {count} andre skriver…",
     "@userAndOthersAreTyping": {
@@ -1531,16 +1440,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Videosamtale",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Sludrehistorikkens synlighet",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Synlig for alle deltagere",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1573,16 +1472,6 @@
     },
     "weSentYouAnEmail": "Du har fått en e-post",
     "@weSentYouAnEmail": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoCanPerformWhichAction": "Hvem kan utføre hvilken handling",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Hvem tillates å ta del i denne gruppen",
-    "@whoIsAllowedToJoinThisGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1746,10 +1635,6 @@
     "@passwordsDoNotMatch": {},
     "decline": "Avslå",
     "@decline": {},
-    "emailOrUsername": "E-post eller brukernavn",
-    "@emailOrUsername": {},
-    "encryptThisChat": "Krypter denne chatten",
-    "@encryptThisChat": {},
     "doNotShowAgain": "Ikke vis igjen",
     "@doNotShowAgain": {},
     "notificationRuleContainsUserName": "Inneholder brukernavn",
@@ -1766,8 +1651,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKey": "Gjenopprettingsnøkkel",
-    "@recoveryKey": {},
     "shareLocation": "Del lokasjon",
     "@shareLocation": {
         "type": "String",
@@ -1870,8 +1753,6 @@
     "@passwordIsWrong": {},
     "startConversation": "Start samtale",
     "@startConversation": {},
-    "manageAccount": "Administrer konto",
-    "@manageAccount": {},
     "nothingFound": "Ingenting funnet...",
     "@nothingFound": {},
     "incomingMessages": "Innkommende meldinger",
@@ -1900,8 +1781,6 @@
     "@allDevices": {},
     "learnMore": "Lær mer",
     "@learnMore": {},
-    "sorryThatsNotPossible": "Beklager... det er ikke mulig",
-    "@sorryThatsNotPossible": {},
     "markAsUnread": "Marker som ulest",
     "@markAsUnread": {},
     "newGroup": "Ny gruppe",
@@ -2008,15 +1887,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "pleaseEnterRecoveryKey": "Vennligst skriv inn gjenopprettingsnøkkelen din:",
-    "@pleaseEnterRecoveryKey": {},
     "pleaseEnterYourPin": "Vennligst skriv inn PIN-koden din",
     "@pleaseEnterYourPin": {
         "type": "String",
         "placeholders": {}
     },
-    "globalChatId": "Global chat-ID",
-    "@globalChatId": {},
     "chatPermissions": "Chat tillatelser",
     "@chatPermissions": {},
     "setPermissionsLevelDescription": "Vennligst velg en forhåndsdefinert rolle nedenfor eller skriv inn et tilpasset tillatelsesnivå mellom 0 og 100.",
@@ -2036,8 +1911,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "Sikkerhetskopien av chatten din er konfigurert.",
-    "@yourChatBackupHasBeenSetUp": {},
     "discover": "Oppdag",
     "@discover": {},
     "thereAreCountUsersBlocked": "Akkurat nå er det {count} blokkerte brukere.",
@@ -2047,10 +1920,6 @@
     },
     "sendCanceled": "Sending avbrutt",
     "@sendCanceled": {},
-    "loginWithMatrixId": "Logg på med Matrix ID",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Oppdag hjemmeservere",
-    "@discoverHomeservers": {},
     "shareInviteLink": "Del invitasjonslenke",
     "@shareInviteLink": {},
     "scanQrCode": "Skann QR-kode",
@@ -2061,10 +1930,6 @@
     "@hydrate": {},
     "oneClientLoggedOut": "En av klientene dine har blitt logget ut",
     "@oneClientLoggedOut": {},
-    "addAccount": "Legg til konto",
-    "@addAccount": {},
-    "enableMultiAccounts": "(BETA) Aktiver flere kontoer på denne enheten",
-    "@enableMultiAccounts": {},
     "openInMaps": "Åpne i kart",
     "@openInMaps": {
         "type": "String",
@@ -2087,15 +1952,6 @@
     "@user": {},
     "users": "Brukere",
     "@users": {},
-    "countInvited": "{count} inviterte",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "createGroup": "Opprett gruppe",
     "@createGroup": {},
     "editRoomAliases": "Rediger rom aliaser",
@@ -2103,8 +1959,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "accessAndVisibility": "Tilgang og synlighet",
-    "@accessAndVisibility": {},
     "hideInvalidOrUnknownMessageFormats": "Skjul ugyldige eller ukjente meldingsformater",
     "@hideInvalidOrUnknownMessageFormats": {},
     "block": "Blokkér",
@@ -2147,20 +2001,12 @@
     },
     "chatDescriptionHasBeenChanged": "Chatbeskrivelsen er endret",
     "@chatDescriptionHasBeenChanged": {},
-    "screenSharingTitle": "skjermdeling",
-    "@screenSharingTitle": {},
-    "screenSharingDetail": "Du deler skjermen din i FuffyChat",
-    "@screenSharingDetail": {},
     "whyIsThisMessageEncrypted": "Hvorfor er denne meldingen uleselig?",
     "@whyIsThisMessageEncrypted": {},
     "yourGlobalUserIdIs": "Din globale bruker-ID er: ",
     "@yourGlobalUserIdIs": {},
-    "searchChatsRooms": "Søk etter #chatter, @brukere...",
-    "@searchChatsRooms": {},
     "groupName": "Gruppenavn",
     "@groupName": {},
-    "createGroupAndInviteUsers": "Opprett en gruppe og inviter brukere",
-    "@createGroupAndInviteUsers": {},
     "invite": "Inviter",
     "@invite": {},
     "wrongPinEntered": "Feil PIN-kode tastet inn! Prøv igjen om {seconds} sekunder...",
@@ -2190,10 +2036,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "voiceCall": "Taleanrop",
-    "@voiceCall": {},
-    "accessAndVisibilityDescription": "Hvem som har lov til å bli med i denne chatten og hvordan chatten kan oppdages.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Anrop",
     "@calls": {},
     "customEmojisAndStickers": "Egendefinerte emojier og klistremerker",
@@ -2320,8 +2162,6 @@
             }
         }
     },
-    "disableEncryptionWarning": "Av sikkerhetshensyn kan du ikke deaktivere kryptering i en chat der det har vært aktivert tidligere.",
-    "@disableEncryptionWarning": {},
     "deviceKeys": "Enhetsnøkler:",
     "@deviceKeys": {},
     "readUpToHere": "Lest frem til her",
@@ -2338,18 +2178,12 @@
     "@archiveRoomDescription": {},
     "removeDevicesDescription": "Du vil bli logget ut av denne enheten og vil ikke lenger kunne motta meldinger.",
     "@removeDevicesDescription": {},
-    "setTheme": "Angi tema:",
-    "@setTheme": {},
     "setColorTheme": "Angi fargetema:",
     "@setColorTheme": {},
     "inviteGroupChat": "📨 Invitasjon til gruppechat",
     "@inviteGroupChat": {},
     "pleaseChooseAStrongPassword": "Vennligst velg et sterkt passord",
     "@pleaseChooseAStrongPassword": {},
-    "publicChatAddresses": "Offentlige chatadresser",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Opprett ny adresse",
-    "@createNewAddress": {},
     "initAppError": "Det oppsto en feil under oppstart av appen",
     "@initAppError": {},
     "sendReadReceipts": "Send lesebekreftelser",
@@ -2382,17 +2216,6 @@
     "@notificationRuleInviteForMeDescription": {},
     "newChatRequest": "📩 Ny chatforespørsel",
     "@newChatRequest": {},
-    "appWantsToUseForLogin": "Bruk '{server}' for å logge inn",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Du gir herved tillatelse til at appen og nettstedet deler informasjon om deg.",
-    "@appWantsToUseForLoginDescription": {},
     "exportEmotePack": "Eksporter smilefjes som .zip-fil",
     "@exportEmotePack": {},
     "noUsersFoundWithQuery": "Dessverre ble ingen bruker funnet med \"{query}\". Sjekk om du har skrevet feil.",
@@ -2400,15 +2223,6 @@
         "type": "String",
         "placeholders": {
             "query": {
-                "type": "String"
-            }
-        }
-    },
-    "chatCanBeDiscoveredViaSearchOnServer": "Chatten kan oppdages via søket på {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
                 "type": "String"
             }
         }
@@ -2425,18 +2239,6 @@
     "@wrongRecoveryKey": {},
     "declineInvitation": "Avslå invitasjon",
     "@declineInvitation": {},
-    "restoreSessionBody": "Appen prøver nå å gjenopprette økten din fra sikkerhetskopien. Rapporter denne feilen til utviklerne på {url}. Feilmeldingen er: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "hidePresences": "Skjul statuslisten?",
     "@hidePresences": {},
     "noMessagesYet": "Ingen meldinger enda",
@@ -2482,8 +2284,6 @@
     "@sendRoomNotifications": {},
     "formattedMessagesDescription": "Vis rikt meldingsinnhold som fet skrift ved hjelp av markdown.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Verifiser annen bruker",
-    "@verifyOtherUser": {},
     "verifyOtherDevice": "🔐 Verifiser annen enhet",
     "@verifyOtherDevice": {},
     "sendTypingNotificationsDescription": "Andre deltakere i en chat kan se når du skriver en ny melding.",
@@ -2576,8 +2376,6 @@
             }
         }
     },
-    "chatDescription": "Chat beskrivelse",
-    "@chatDescription": {},
     "hideRedactedMessages": "Skjul redigerte meldinger",
     "@hideRedactedMessages": {},
     "hideRedactedMessagesBody": "Hvis noen redigerer en melding, vil ikke denne meldingen lenger være synlig i chatten.",
@@ -2606,11 +2404,6 @@
     "@dehydrate": {},
     "dehydrateWarning": "Denne handlingen kan ikke angres. Sørg for at du lagrer sikkerhetskopifilen på en trygg måte.",
     "@dehydrateWarning": {},
-    "noEncryptionForPublicRooms": "Du kan bare aktivere kryptering på rom som ikke er offentlig tilgjengelig.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "noMatrixServer": "{server1} er ingen matrix-server, bruk {server2} i stedet?",
     "@noMatrixServer": {
         "type": "String",
@@ -2633,14 +2426,8 @@
     "@contentNotificationSettings": {},
     "generalNotificationSettings": "Generelle varslingsinnstillinger",
     "@generalNotificationSettings": {},
-    "appIntroduction": "Med FluffyChat kan du chatte med vennene dine på tvers av forskjellige meldingstjenester. Finn ut mer på https://matrix.org eller trykk bare på *Fortsett*.",
-    "@appIntroduction": {},
     "notificationRuleContainsUserNameDescription": "Varsler bruker når en melding inneholder ens brukernavn.",
     "@notificationRuleContainsUserNameDescription": {},
-    "removeFromSpace": "Fjern fra området",
-    "@removeFromSpace": {},
-    "pleaseEnterRecoveryKeyDescription": "For å låse opp gamle meldinger, vennligst skriv inn gjenopprettingsnøkkelen som ble generert i en tidligere økt. Gjenopprettingsnøkkelen er IKKE passordet ditt.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "reactedWith": "{sender} reagerte med {reaction}",
     "@reactedWith": {
         "type": "String",
@@ -2661,8 +2448,6 @@
     "@placeCall": {},
     "unsupportedAndroidVersionLong": "Denne funksjonen krever en nyere Android-versjon. Se etter oppdateringer eller støtte for Lineage OS.",
     "@unsupportedAndroidVersionLong": {},
-    "videoCallsBetaWarning": "Vær oppmerksom på at videosamtaler for øyeblikket er i betaversjon. Det fungerer kanskje ikke som forventet eller i det hele tatt.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "Eksperimentelle videoanrop",
     "@experimentalVideoCalls": {},
     "notificationRuleRoomnotifDescription": "Varsler brukeren når en melding inneholder ‘@room’.",
@@ -2687,8 +2472,6 @@
         "type": "String",
         "description": "Usage hint for the command /clearcache"
     },
-    "homeserverDescription": "Alle dataene dine lagres på hjemmeserveren, akkurat som hos en e-postleverandør. Du kan velge hvilken hjemmeserver du vil bruke, samtidig som du fortsatt kan kommunisere med alle. Lær mer på https://matrix.org.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "Ser ikke ut til å være en kompatibel hjemmeserver. Feil URL?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "prepareSendingAttachment": "Forbered sending av vedlegg...",
@@ -2697,8 +2480,6 @@
     "@generatingVideoThumbnail": {},
     "compressVideo": "Komprimerer video...",
     "@compressVideo": {},
-    "welcomeText": "Hei, hei! 👋 Dette er FluffyChat. Du kan logge på hvilken som helst hjemmeserver som er kompatibel med https://matrix.org. Og deretter chatte med hvem som helst. Det er et stort desentralisert meldingsnettverk!",
-    "@welcomeText": {},
     "notificationRuleIsUserMentionDescription": "Varsler brukeren når de er direkte nevnt i en melding.",
     "@notificationRuleIsUserMentionDescription": {},
     "notificationRuleContainsDisplayName": "Inneholder visningsnavn",
@@ -2709,8 +2490,6 @@
     "@notificationRuleIsUserMention": {},
     "notificationRuleIsRoomMention": "Romomtale",
     "@notificationRuleIsRoomMention": {},
-    "whatIsAHomeserver": "Hva er en hjemmeserver?",
-    "@whatIsAHomeserver": {},
     "commandHint_me": "Beskriv deg selv",
     "@commandHint_me": {
         "type": "String",
@@ -2762,11 +2541,6 @@
     },
     "checkList": "Sjekkliste",
     "@checkList": {},
-    "createNewSpace": "Nytt område",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "emoteKeyboardNoRecents": "Nylig brukte emotes vil vises her ...",
     "@emoteKeyboardNoRecents": {
         "type": "String",
@@ -2794,15 +2568,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "wipeChatBackup": "Vil du slette sikkerhetskopien av chatten din for å opprette en ny gjenopprettingsnøkkel?",
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "widgetEtherpad": "Tekstnotat",
     "@widgetEtherpad": {},
-    "noOneCanJoin": "Ingen kan bli med",
-    "@noOneCanJoin": {},
     "commandHint_html": "Send HTML-formatert tekst",
     "@commandHint_html": {
         "type": "String",
@@ -2879,8 +2646,6 @@
             }
         }
     },
-    "removeFromSpaceDescription": "Chatten blir fjernet fra området, men vises fortsatt i chatlisten din.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} chats",
     "@countChats": {
         "type": "String",
@@ -2890,8 +2655,6 @@
             }
         }
     },
-    "donate": "Doner",
-    "@donate": {},
     "banUserDescription": "Brukeren vil bli utestengt fra chatten og vil ikke kunne delta i chatten igjen før utestengelsen er opphevet.",
     "@banUserDescription": {},
     "unbanUserDescription": "Brukeren vil kunne gå inn i chatten igjen hvis vedkommende prøver.",
@@ -2902,14 +2665,6 @@
     "@sendTypingNotifications": {},
     "swipeRightToLeftToReply": "Sveip fra høyre mot venstre for å svare",
     "@swipeRightToLeftToReply": {},
-    "unlockOldMessages": "Lås opp gamle meldinger",
-    "@unlockOldMessages": {},
-    "storeInAndroidKeystore": "Lagre i Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Lagre i Apple nøkkelring",
-    "@storeInAppleKeyChain": {},
-    "storeSecurlyOnThisDevice": "Lagre sikkert på denne enheten",
-    "@storeSecurlyOnThisDevice": {},
     "acceptedKeyVerification": "{sender} godtok nøkkelverifisering",
     "@acceptedKeyVerification": {
         "type": "String",
@@ -2935,12 +2690,6 @@
     "@customReaction": {},
     "pause": "Pause",
     "@pause": {},
-    "moveToDifferentSpace": "Flytt til et annet område",
-    "@moveToDifferentSpace": {},
-    "storeInSecureStorageDescription": "Oppbevar gjenopprettingsnøkkelen på en sikker lagringsplass på denne enheten.",
-    "@storeInSecureStorageDescription": {},
-    "foregroundServiceRunning": "Denne varslingen vises når forgrunnstjenesten kjører.",
-    "@foregroundServiceRunning": {},
     "longPressToRecordVoiceMessage": "Langt trykk for å spille inn talemelding.",
     "@longPressToRecordVoiceMessage": {},
     "startedAPoll": "{username} startet en avstemning.",
@@ -2970,24 +2719,10 @@
     "@pollHasBeenEnded": {},
     "roomUpgradeDescription": "Chatten vil deretter bli gjenskapt med den nye romversjonen. Alle deltakere vil bli varslet om at de må bytte til den nye chatten. Du kan finne ut mer om romversjoner på https://spec.matrix.org/latest/rooms/",
     "@roomUpgradeDescription": {},
-    "groupCanBeFoundViaSearch": "Gruppen kan finnes via søk",
-    "@groupCanBeFoundViaSearch": {},
     "commandHint_sendraw": "Send raw json",
     "@commandHint_sendraw": {},
     "replyInThread": "Svar i tråden",
     "@replyInThread": {},
-    "sessionLostBody": "Sesjonen din er tapt. Vennligst rapporter denne feilen til utviklerne på {url}. Feilmeldingen er: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "noticeChatBackupDeviceVerification": "Merk: Når du kobler alle enhetene dine til chat-sikkerhetskopien, blir de automatisk bekreftet.",
     "@noticeChatBackupDeviceVerification": {},
     "notificationRuleTombstone": "Gravstein",
@@ -3000,12 +2735,6 @@
     "@backToMainChat": {},
     "saveChanges": "Lagre endringer",
     "@saveChanges": {},
-    "skipChatBackup": "Hopp over sikkerhetskopiering av chat",
-    "@skipChatBackup": {},
-    "loadingMessages": "Laster inn meldinger",
-    "@loadingMessages": {},
-    "setupChatBackup": "Konfigurer sikkerhetskopi av chat",
-    "@setupChatBackup": {},
     "commandHint_googly": "Send noen stirreøyne",
     "@commandHint_googly": {},
     "commandHint_cuddle": "Send en kos",
@@ -3029,29 +2758,20 @@
     "removeFromBundle": "Fjern fra denne pakken",
     "bundleName": "Pakke navn",
     "register": "Registrer",
-    "recoveryKeyLost": "Gjenopprettingsnøkkel tapt?",
     "separateChatTypes": "Separat direktemeldinger og grupper",
     "setAsCanonicalAlias": "Sett som hovedalias",
-    "spaceIsPublic": "Rom er offentlig",
-    "spaceName": "Romnavn",
     "confirmEventUnpin": "Er du sikker på at du vil fjerne festingen av arrangementet permanent?",
     "errorAddingWidget": "Feil ved tillegg av widgeten.",
     "hasKnocked": "🚪 {user} har banket på",
-    "usersMustKnock": "Brukere må banke på",
     "knock": "Bank på",
-    "saveKeyManuallyDescription": "Lagre denne nøkkelen manuelt ved å utløse systemets delingsdialog eller utklippstavle.",
     "noKeyForThisMessage": "Dette kan skje hvis meldingen ble sendt før du logget inn på kontoen din på denne enheten.\n\nDet er også mulig at avsenderen har blokkert enheten din eller at noe gikk galt med internettforbindelsen.\n\nEr du i stand til å lese meldingen på en annen økt? Da kan du overføre meldingen derfra! Gå til Innstillinger > Enheter og sørg for at enhetene dine har verifisert hverandre. Når du åpner rommet neste gang og begge øktene er i forgrunnen, vil nøklene bli overført automatisk.\n\nVil du ikke miste nøklene når du logger ut eller bytter enhet? Sørg for at du har aktivert chat-sikkerhetskopiering i innstillingene.",
-    "enterSpace": "Gå inn i rommet",
-    "newSpaceDescription": "Rom lar deg konsolidere dine chatter og bygge private eller offentlige fellesskap.",
     "noBackupWarning": "Advarsel! Uten å aktivere chat-sikkerhetskopi vil du miste tilgangen til dine krypterte meldinger. Det anbefales sterkt å aktivere chat-sikkerhetskopi før du logger ut.",
     "report": "rapporter",
     "makeAdminDescription": "Når du gjør denne brukeren til administrator, kan det hende du ikke kan angre dette, da de da vil ha de samme tillatelsene som deg.",
     "knocking": "Banker på",
     "joinSpace": "Bli med i rom",
     "publicSpaces": "Offentlige rom",
-    "addChatOrSubSpace": "Legg til chat eller underrom",
     "subspace": "Underrom",
-    "verifyOtherUserDescription": "Hvis du verifiserer en annen bruker, kan du være sikker på at du vet hvem du faktisk skriver til. 💪\n\nNår du starter en verifisering, vil du og den andre brukeren se en popup i appen. Der vil dere se en serie av emojis eller tall som dere må sammenligne.\n\nDen beste måten å gjøre dette på er å møtes eller starte en videosamtale. 👩‍💻",
     "verifyOtherDeviceDescription": "Når du verifiserer en annen enhet, kan disse enhetene utveksle nøkler, noe som øker din totale sikkerhet. 💪 Når du starter en verifisering, vil en popup vises i appen på begge enhetene. Der vil dere se en serie av emojis eller tall som dere må sammenligne.\nDet er best å ha begge enhetene tilgjengelig før du starter verifiseringen. 🤳",
     "knockRestricted": "Knock-begrenset",
     "chatPermissionsDescription": "Definer hvilket maktnivå som er nødvendig for visse handlinger i denne chatten. Maktnivåene 0, 50 og 100 representerer vanligvis brukere, moderatorer og administratorer, men alle grader er mulige.",
@@ -3070,11 +2790,9 @@
     "taTooltip": "L2 bruk med oversettelseshjelp",
     "interactiveTranslatorSliderHeader": "Interaktiv oversetter",
     "interactiveGrammarSliderHeader": "Interaktiv grammatikkontroll",
-    "interactiveTranslatorRequired": "Påkrevd",
     "waTooltip": "L2 bruk uten hjelp",
     "interactiveTranslator": "Oversettelseshjelp",
     "noIdenticalLanguages": "Vennligst velg ulike grunn- og målspråk",
-    "searchBy": "Søk etter land og språk",
     "joinWithClassCode": "Bli med i kurs",
     "languageLevelPreA1": "Novice Low (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -3094,19 +2812,14 @@
     "whatIsYourBaseLanguage": "Hva er ditt hovedspråk?",
     "publicProfileTitle": "La profilen min bli funnet i søk",
     "publicProfileDesc": "Ved å slå på dette, gjør du det mulig for andre brukere å finne profilen din i den globale søkefeltet og sende forespørsler om chat. På dette tidspunktet kan du velge å godta eller avvise forespørselen.",
-    "errorDisableIT": "Oversettelsesassistanse er slått av.",
-    "errorDisableIGC": "Grammatikkhjelp er slått av.",
     "errorDisableITUserDesc": "Klikk her for å oppdatere innstillingene for oversettelseshjelp",
     "errorDisableIGCUserDesc": "Klikk her for å oppdatere innstillingene for grammatikkhjelp",
     "errorDisableITClassDesc": "Oversettelseshjelp er slått av for kurset som denne chatten er i.",
     "errorDisableIGCClassDesc": "Grammatikkhjelp er slått av for kurset som denne chatten er i.",
-    "error405Title": "Språk ikke satt",
     "error405Desc": "Vennligst sett språkene dine i Hovedmeny > Læringsinnstillinger.",
     "termsAndConditions": "Vilkår og betingelser",
     "andCertifyIAmAtLeast13YearsOfAge": " og bekrefter at jeg er minst 16 år gammel.",
-    "error502504Title": "Wow, det er mange elever pålogget!",
     "error502504Desc": "Oversettelses- og grammatikkverktøy kan være trege eller utilgjengelige mens Pangea-botene tar igjen.",
-    "error404Title": "Oversettelsesfeil!",
     "error404Desc": "Pangea Bot er ikke sikker på hvordan den skal oversette det...",
     "errorPleaseRefresh": "Vi undersøker det! Vennligst last inn siden på nytt og prøv igjen.",
     "connectedToStaging": "Tilkoblet til staging",
@@ -3144,13 +2857,9 @@
     "definitionsToolName": "Orddefinisjoner",
     "definitionsToolDescription": "Når det er aktivert, kan ord understreket i blått klikkes for definisjoner. Klikk på meldinger for å få tilgang til definisjoner.",
     "welcomeBack": "Velkommen tilbake! Hvis du var en del av pilotprosjektet 2023-2024, kontakt oss for din spesielle pilotabonnement. Hvis du er lærer som har (eller institusjonen din har) kjøpt lisenser for klassen din, kontakt oss for ditt lærerabonnement.",
-    "downloadTxtFile": "Last ned tekstfil",
-    "downloadCSVFile": "Last ned CSV-fil",
     "promotionalSubscriptionDesc": "Du har for øyeblikket et livstids kampanjeabonnement. Send en melding til support@pangea.chat for hjelp med å endre abonnementet ditt.",
     "originalSubscriptionPlatform": "Abonnement kjøpt via {purchasePlatform}",
     "oneWeekTrial": "Én ukes prøveperiode",
-    "downloadXLSXFile": "Last ned Excel-fil",
-    "unkDisplayName": "Ukjent",
     "wwCountryDisplayName": "Verden",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Ålandøyene",
@@ -3445,7 +3154,6 @@
     "chatCapacityHasBeenChanged": "Chattkapasiteten er endret",
     "chatCapacitySetTooLow": "Chattkapasiteten må være minst {count}.",
     "chatCapacityExplanation": "Chattkapasitet begrenser antall medlemmer som kan delta i en chat.",
-    "tooManyRequest": "For mange forespørsler, vennligst prøv igjen senere.",
     "enterNumber": "Vennligst skriv inn en heltallsverdi.",
     "practice": "Øv",
     "versionNotFound": "Versjon ikke funnet",
@@ -3455,7 +3163,6 @@
     "deleteSubscriptionWarningTitle": "Du har et aktivt abonnement",
     "deleteSubscriptionWarningBody": "Sletting av kontoen din vil ikke automatisk kansellere abonnementet ditt.",
     "manageSubscription": "Administrer abonnement",
-    "error520Title": "Vennligst prøv igjen.",
     "error520Desc": "Beklager, vi kunne ikke forstå meldingen din...",
     "wordsUsed": "Ord brukt",
     "level": "Nivå",
@@ -3473,7 +3180,6 @@
     "other": "Annet",
     "levelShort": "NIVÅ {level}",
     "noCapacityLimit": "Ingen kapasitetbegrensning",
-    "downloadGroupText": "Last ned gruppe tekst",
     "notificationsOn": "Varslinger på",
     "notificationsOff": "Varslinger av",
     "joinWithCode": "Bli med med kode",
@@ -3537,24 +3243,12 @@
     "whatIsTheMorphTag": "Hva er {morphologicalFeature} av '{wordForm}'?",
     "dataAvailable": "Data tilgjengelighet",
     "available": "Tilgjengelig",
-    "pangeaBotIsFallible": "Pangea Bot gjør også feil!",
-    "whatIsMeaning": "Hva betyr '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Match betydninger med ordene i meldingen!",
-    "doubleClickToEdit": "Dobbeltklikk for å redigere.",
-    "topicLabel": "Tema",
-    "topicPlaceholder": "Velg et tema...",
-    "modePlaceholder": "Velg en modus...",
-    "learningObjectiveLabel": "Læringsmål",
-    "learningObjectivePlaceholder": "Velg et læringsmål...",
-    "targetLanguageLabel": "Mål språk",
     "cefrLevelLabel": "CEFR-nivå",
     "image": "Bilde",
     "video": "Video",
     "nan": "Ikke aktuelt",
-    "addVocabulary": "Legg til vokabular",
     "instructions": "Instruksjoner",
-    "numberOfLearners": "Antall elever",
-    "mustBeInteger": "Må være et heltall, f.eks. 1, 2, 3, ...",
     "constructUsePvmDesc": "Produsert i talemeldingsmodus",
     "leaveSpaceDescription": "Ved å forlate kurset vil du forlate alle chattene innenfor det. Andre brukere vil se at du har forlatt kurset.",
     "constructUseCorMmDesc": "Korrekt meldingsbetydning",
@@ -3569,7 +3263,6 @@
     "ttsDisabledBody": "Du kan aktivere tekst-til-tale i læringsinnstillingene dine",
     "noSpaceDescriptionYet": "Ingen kursbeskrivelse opprettet ennå.",
     "tooLargeToSend": "Denne meldingen er for stor til å sende",
-    "exitWithoutSaving": "Er du sikker på at du vil forlate uten å lagre?",
     "enableAutocorrectPopupTitle": "Legg til tastaturet for målspråket ditt ved å gå til:",
     "enableAutocorrectPopupSteps": "  • Innstillinger\n  • Generelt\n  • Tastatur\n  • Tastaturer\n  • Legg til nytt tastatur",
     "enableAutocorrectPopupDescription": "Når språket er valgt, kan du klikke på det lille globus-ikonet nederst til venstre på tastaturet for å aktivere det nylig installerte tastaturet.",
@@ -3580,11 +3273,8 @@
     "displayName": "Visningsnavn",
     "leaveRoomDescription": "Du er i ferd med å forlate denne chatten. Andre brukere vil se at du har forlatt chatten.",
     "confirmUserId": "Vennligst bekreft brukernavnet ditt i Pangea Chat for å slette kontoen din.",
-    "startingToday": "Fra og med i dag",
-    "oneWeekFreeTrial": "En ukes gratis prøveperiode",
     "paidSubscriptionStarts": "Starter {startDate}",
     "cancelInSubscriptionSettings": "• Avbryt når som helst i abonnementinnstillingene",
-    "cancelToAvoidCharges": "• Avbryt før {trialEnds} for å unngå gebyrer",
     "downloadGboard": "Last ned Gboard",
     "autocorrectNotAvailable": "Dessverre er ikke plattformen din for tiden støttet for denne funksjonen. Følg med for videre utvikling!",
     "pleaseUpdateApp": "Vennligst oppdater appen for å fortsette.",
@@ -3594,17 +3284,12 @@
     "knockSpaceSuccess": "Du har bedt om å bli med i dette kurset! En administrator vil svare på forespørselen din når de mottar den 😀",
     "chooseWordAudioInstructionsBody": "Lytt til hele meldingen. Deretter matcher du lydene med ordene.",
     "chooseMorphsInstructionsBody": "Klikk på puslespillbitene for grammatikkspørsmål!",
-    "pleaseEnterInt": "Vennligst skriv inn et tall",
     "home": "Hjem",
     "join": "Bli med",
     "resetInstructionTooltipsTitle": "Tilbakestill instruksjonstips",
     "resetInstructionTooltipsDesc": "Klikk for å vise instruksjonstips som for en helt ny bruker.",
-    "randomize": "Tilfeldiggjør",
     "clear": "Tøm",
-    "featuredActivities": "Utvalgte",
     "save": "Lagre",
-    "startChat": "Start en chat",
-    "translationProblem": "Oversettelsesproblem",
     "askToJoin": "Spør om å bli med",
     "emptyChatWarningTitle": "Chatten er tom",
     "emptyChatWarningDesc": "Du har ikke invitert noen til chatten din. Gå til Chat-innstillinger for å invitere kontaktene dine eller Bot. Du kan også gjøre dette senere.",
@@ -3634,17 +3319,13 @@
     "timesUsedIndependently": "Antall ganger brukt uavhengig",
     "timesUsedWithAssistance": "Antall ganger brukt med hjelp",
     "shareInviteCode": "Del invitasjonskode: {code}",
-    "leaderboard": "Toppliste",
     "skipForNow": "Hopp over for nå",
     "permissions": "Tillatelser",
     "spaceChildPermission": "Hvem kan legge til nye chatter i dette kurset",
-    "addEnvironmentOverride": "Legg til miljøoverstyring",
     "defaultOption": "Standard",
     "deleteChatDesc": "Er du sikker på at du vil slette denne samtalen? Den vil bli slettet for alle deltakere, og alle meldinger i samtalen vil ikke lenger være tilgjengelige for praksis eller læringsanalyse.",
     "deleteSpaceDesc": "Kurset og eventuelle valgte samtaler vil bli slettet for alle deltakere, og alle meldinger i samtalen vil ikke lenger være tilgjengelige for praksis eller læringsanalyse. Denne handlingen kan ikke angres.",
     "launch": "Start",
-    "searchChats": "Søk i samtaler",
-    "maxFifty": "Maks 50",
     "configureSpace": "Konfigurer kurs",
     "pinMessages": "Fest meldinger",
     "setJoinRules": "Sett innmeldingsregler",
@@ -3678,9 +3359,6 @@
     "failedToFetchTranscription": "Kunne ikke hente transkripsjon",
     "deleteEmptySpaceDesc": "Kurset vil bli slettet for alle deltakere. Denne handlingen kan ikke angres.",
     "regenerate": "Regenerer",
-    "mySavedActivities": "Mine lagrede aktiviteter",
-    "noSavedActivities": "Ingen lagrede aktiviteter",
-    "saveActivity": "Lagre denne aktiviteten",
     "failedToPlayVideo": "Mislyktes i å spille av video",
     "done": "Ferdig",
     "inThisSpace": "I dette kurset",
@@ -3691,13 +3369,9 @@
     "numInvited": "{count} invitert",
     "saved": "Lagret",
     "reset": "Tilbakestill",
-    "errorFetchingActivitiesMessage": "Mislyktes i å hente aktiviteter",
     "errorFetchingDefinition": "Mislyktes i å hente definisjon",
     "errorProcessAnalytics": "Mislyktes i å behandle analyse",
     "errorDownloading": "Nedlasting mislyktes",
-    "errorLoadingSpaceChildren": "Mislyktes i å laste inn chatter innenfor dette kurset",
-    "unexpectedError": "Uventet feil.",
-    "pleaseReload": "Vennligst last inn på nytt og prøv igjen.",
     "translationError": "Oversettelsesfeil",
     "check": "Sjekk",
     "unableToFindRoom": "Ingen chat eller kurs funnet med den koden. Vennligst prøv igjen.",
@@ -3706,19 +3380,14 @@
     "request": "Forespørsel",
     "requestAll": "Forespør alle",
     "confirmMessageUnpin": "Er du sikker på at du vil fjerne festingen av denne meldingen?",
-    "saveAndLaunch": "Lagre og start",
-    "launchToSpace": "Start i kurs",
     "pending": "Venter",
     "inactive": "Inaktiv",
-    "confirmRole": "Bekreft rolle",
     "openRoleLabel": "ÅPEN",
     "finishedTheActivity": "🎯 {username} avsluttet denne aktiviteten",
     "activitySummaryError": "Aktivitetsoppsummeringer er utilgjengelige",
     "requestSummaries": "Be om oppsummeringer",
-    "generatingNewActivities": "Du er den første brukeren av dette språkparet! Vennligst gi oss et minutt, vi forbereder aktiviteter spesielt for deg.",
     "requestAccessTitle": "Be om tilgang til analyser?",
     "requestAccessDesc": "Vil du be om tilgang til å se deltakeranalyser?\n\nHvis deltakerne godtar, vil administratorer av kurset kunne se deres:\n    • total vokabular\n    • totale grammatikkonsepter\n    • fullførte aktivitetsøkter\n    • de spesifikke grammatikkonseptene som er brukt, riktig og feil\n\nDe vil ikke kunne se deres:\n    • meldinger i chatter utenfor kurset\n    • vokabularlisten",
-    "requestAccess": "Be om tilgang ({count})",
     "analyticsInactiveTitle": "Forespørsler til inaktive brukere kunne ikke sendes",
     "analyticsInactiveDesc": "Inaktive brukere som ikke har logget inn siden denne funksjonen ble introdusert, vil ikke se forespørselen din.\n\nForespørselsknappen vil vises når de kommer tilbake. Du kan sende forespørselen på nytt senere ved å klikke på Forespørselsknappen under navnet deres når den er tilgjengelig.",
     "accessRequestedTitle": "Forespørsel om tilgang til analyse",
@@ -3741,8 +3410,6 @@
     "accessDesc": "Du kan gjøre kurset ditt åpent for alle! Eller, gjør kurset ditt privat og sikkert.",
     "createGroupChatDesc": "Mens aktivitetsøkter starter og slutter, vil gruppechatter forbli åpne for rutinemessig kommunikasjon.",
     "deleteDesc": "Bare administratorer kan slette et kurs. Dette er en ødeleggende handling som fjerner alle brukere og sletter alle valgte chatter innen kurset. Vær forsiktig.",
-    "noCourseFound": "Åh, dette kurset trenger en plan!\n\nKursplaner er en sekvens av emner og samtaleaktiviteter.",
-    "additionalParticipants": "+ {num} andre",
     "whatNow": "Hva nå?",
     "chooseNextActivity": "Velg din neste aktivitet!",
     "letsGo": "La oss dra",
@@ -3755,13 +3422,11 @@
     "waitNotDone": "Vent, jeg er ikke ferdig!",
     "waitingForOthersToFinish": "Venter på at de andre skal bli ferdige...",
     "generatingSummary": "Analyserer chat og genererer resultater",
-    "findCourse": "Finn et kurs",
     "pingParticipantsNotification": "{user} ser etter brukere for å delta i aktivitetsøkten i {room}",
     "course": "Kurs",
     "courses": "Kurs",
     "goToCourse": "Gå til kurset: {course}",
     "activityComplete": "Denne aktiviteten er fullført. Oppsummeringen av aktiviteten skal være tilgjengelig nedenfor.",
-    "startNewSession": "Start ny økt",
     "joinOpenSession": "Bli med i åpen økt",
     "activityNotFound": "Aktivitet ikke funnet",
     "myActivities": "Mine aktiviteter",
@@ -3845,23 +3510,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@recoveryKeyLost": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@separateChatTypes": {
         "type": "String",
         "placeholders": {}
     },
     "@setAsCanonicalAlias": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -3881,27 +3534,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noKeyForThisMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@newSpaceDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3929,15 +3566,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addChatOrSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@subspace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4027,10 +3656,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4040,10 +3665,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4127,14 +3748,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4151,10 +3764,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4167,15 +3776,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4327,14 +3928,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4348,14 +3941,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5578,10 +5163,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5622,10 +5203,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5698,10 +5275,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5971,47 +5544,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6031,19 +5564,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6107,10 +5628,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6151,14 +5668,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6170,14 +5679,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6215,10 +5716,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6235,27 +5732,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6379,10 +5860,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6392,10 +5869,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6412,14 +5885,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6559,18 +6024,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6619,10 +6072,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6632,18 +6081,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6686,23 +6123,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6726,10 +6151,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6737,14 +6158,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6849,18 +6262,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6913,10 +6314,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6943,10 +6340,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7127,7 +6520,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Sjekk igjen i morgen for oppdateringer om aktiviteten.",
-    "activityDropdownDesc": "Når du er ferdig med denne aktiviteten, klikk nedenfor",
     "languageMismatchTitle": "Språkavvik",
     "languageMismatchDesc": "Mål språket ditt stemmer ikke overens med språket for denne aktiviteten. Vil du oppdatere målspråket?",
     "reportWordIssueTooltip": "Rapporter problem med ordinformasjon",
@@ -7140,10 +6532,6 @@
     "selectAll": "Velg alle",
     "deselectAll": "Fjern valg av alle",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7192,17 +6580,11 @@
         "placeholders": {}
     },
     "startOwn": "Start min egen",
-    "joinCourseDesc": "Hvert kurs har 8-10 sekvenserte emner med en rekke oppgavebaserte språklæringsaktiviteter.",
     "newMessageInPangeaChat": "🗨️ Ny melding i Pangea Chat",
     "shareCourse": "Del kurs",
     "addCourse": "Legg til et kurs",
-    "joinPublicCourse": "Bli med på offentlig kurs",
     "vocabLevelsDesc": "Dette er hvor vokabularord vil komme når du har nivåert dem opp!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7215,10 +6597,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7237,7 +6615,6 @@
     "emojiView": "Emoji-visning",
     "feedbackDialogDesc": "Jeg gjør også feil! Noe for å hjelpe meg å bli bedre?",
     "contactHasBeenInvitedToTheCourse": "Kontakt har blitt invitert til kurset",
-    "activityStatsButtonTooltip": "Aktivitetsinfo",
     "allow": "Tillat",
     "deny": "Avvis",
     "enabledRenewal": "Aktiver abonnementfornyelse",
@@ -7505,10 +6882,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8564,16 +7937,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktiviteter for å låse opp neste emne",
-    "activitiesToUnlockTopicDesc": "Sett antall aktiviteter for å låse opp neste kurs emne",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Korrekt orddefinisjonspraksis",
     "constructUseIncLMDesc": "Feil orddefinisjonspraksis",
     "constructUseCorLADesc": "Korrekt ordlyttpraksis",
@@ -8581,7 +7944,6 @@
     "constructUseBonus": "Bonus under ordpraksis",
     "practiceVocab": "Øv på ordforråd",
     "selectMeaning": "Velg betydningen",
-    "selectAudio": "Velg den matchende lyden",
     "anotherRound": "En runde til",
     "activitySettingsOverrideWarning": "Språk og språknivå bestemt av aktivitetsplan",
     "voice": "Stemme",
@@ -8613,10 +7975,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8634,12 +7992,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Nedlasting initiert",
     "webDownloadPermissionMessage": "Hvis nettleseren din blokkerer nedlastinger, vennligst aktiver nedlastinger for dette nettstedet.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8734,11 +8087,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Noe gikk galt, og vi jobber hardt med å fikse det. Sjekk igjen senere.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Aktiver skriveassistent",
     "autoIGCToolDescription": "Kjør Pangea Chat-verktøy automatisk for å korrigere sendte meldinger til målspråket.",
     "@autoIGCToolName": {
@@ -8794,24 +8142,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Grammatikk",
-    "spanTypeWordChoice": "Ordvalg",
     "spanTypeSpelling": "Staving",
     "spanTypePunctuation": "Tegnsetting",
     "spanTypeStyle": "Stil",
     "spanTypeFluency": "Flyt",
     "spanTypeAccents": "Aksenter",
     "spanTypeCapitalization": "Store bokstaver",
-    "spanTypeCorrection": "Korrigering",
     "spanFeedbackTitle": "Rapporter korrigeringsproblem",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8836,10 +8173,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8847,9 +8180,6 @@
     "changedTheChatDescription": "{username} endret chatbeskrivelsen",
     "changedTheChatName": "{username} endret chatnavnet",
     "moreEvents": "Flere hendelser",
-    "newSubSpace": "Nytt underområde",
-    "spaceMemberOf": "Rommedlem av {spaces}",
-    "spaceMemberOfCanKnock": "Rommedlem av {spaces} kan banke",
     "pollQuestion": "Avstemningsspørsmål",
     "countVotes": "{count, plural, =1{Én stemme} other{{count} stemmer}}",
     "@changedTheChatDescription": {
@@ -8867,26 +8197,6 @@
     "@moreEvents": {
         "type": "String",
         "placeholders": {}
-    },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
     },
     "@pollQuestion": {
         "type": "String",
@@ -8908,20 +8218,15 @@
     "newStickerPack": "Ny klistremerke-pakke",
     "stickerPackName": "Klistremerke-pakkens navn",
     "attribution": "Attribusjon",
-    "skipChatBackupWarning": "Er du sikker? Uten å aktivere chat-sikkerhetskopi kan du miste tilgangen til meldingene dine hvis du bytter enhet.",
     "noMoreResultsFound": "Ingen flere resultater funnet",
     "chatSearchedUntil": "Chat søkt til {time}",
     "federationBaseUrl": "Føderasjonsbasis-URL",
     "clientWellKnownInformation": "Klient-Vel-Kjent Informasjon:",
     "baseUrl": "Basis-URL",
     "identityServer": "Identitetsserver:",
-    "versionWithNumber": "Versjon: {version}",
     "logs": "Logger",
-    "advancedConfigs": "Avanserte konfigurasjoner",
     "advancedConfigurations": "Avanserte konfigurasjoner",
-    "signInWithLabel": "Logg inn med:",
     "selectAllWords": "Velg alle ordene du hører i lyden",
-    "joinCourseForActivities": "Bli med i et kurs for å prøve aktiviteter.",
     "courseDescription": "Kurs består av 3-8 moduler, hver med aktiviteter for å oppmuntre til å øve på ord i forskjellige sammenhenger",
     "@courseDescription": {
         "type": "String",
@@ -9119,11 +8424,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "I en klasse? Skriv inn koden din her.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automatisk utheving av lydmeldinger",
     "selectAudioMessagesOnPlayDescription": "Automatisk utheve lydmeldinger når de spilles av",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9167,18 +8467,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Dette kurset har emner med færre enn {input} aktiviteter. Vennligst skriv inn et tall som er mindre enn eller lik {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Klikk her for å logge inn igjen.",
     "@clickToLogin": {
@@ -9595,17 +8883,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "En tegneserieaktig gul bjørn med armene hevet i begeistring.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Velg ord for å lære mer om dem",
     "requireAnalyticsAccessTitle": "Krever tilgang til analyser for å bli med",
     "requireAnalyticsAccessDesc": "Deltakere må gi tilgang til sine læringsanalyser for å bli med i dette kurset",
     "analyticsAccessNoticeTitle": "Tilgang til analyser kreves",
     "analyticsAccessNoticeDesc": "Ved å bli med i dette kurset, godtar du å gi administratorer tilgang til dine læringsanalyser.",
-    "skipOnboardingClassCodeDesc": "Lærer du uavhengig? Ikke bekymre deg, du kan:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9623,10 +8905,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9655,7 +8933,6 @@
     "pickCefrLevelTeacherStepTitle": "Hvilket nivå underviser du?",
     "pickCefrLevelStudentStepTitle": "Hvilket nivå er du?",
     "customCourseStepTitle": "Fyll ut dette skjemaet for å få et tilpasset kurs",
-    "aboutYourClass": "Om klassen din",
     "courseCodeStepErrorMessage": "Vennligst sjekk koden din og prøv igjen",
     "institution": "Institusjon",
     "courseGoals": "Kursmål",
@@ -9698,10 +8975,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9818,12 +9091,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat-logo",
     "introChatDetails": "Si hei! Introduser deg selv for dine medkursdeltakere, finn venner, og chat utenfor aktiviteter.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9867,11 +9135,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Aktivitetshandlinger",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Uttaleverktøy",
     "audioTranscription": "AI lydtranskripsjon",
     "visualLearnerSupport": "Støtte for visuelle lærere",
@@ -9912,7 +9175,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Bli med i et kurs som inkluderer denne aktiviteten for å spille den.",
     "resizeCoursePanel": "Endre størrelse på kurspanel",
     "undo": "Angre",
     "unlock": "Lås opp",
@@ -9926,7 +9188,6 @@
     "addCourseBrowsePublic": "Bla gjennom offentlige kurs",
     "browsePublicCourses": "Bla gjennom offentlige kurs",
     "editProfile": "Rediger profil",
-    "numObjectives": "{count} mål",
     "mapSearchHint": "Søk aktiviteter",
     "mapSearchNoResults": "Ingen treff i visningen",
     "mapFilterAllLanguages": "Alle språk",
@@ -9935,7 +9196,6 @@
     "mapFilterCompleted": "Fullført",
     "mapFilterReset": "Tilbakestill",
     "activityTypeConversation": "Samtale",
-    "lockedMissionRequirement": "Fullfør den forrige oppgaven for å låse opp",
     "playAgain": "Spill igjen",
     "reviewActivity": "Vurder",
     "mapEmptyInView": "Ingenting her på ditt nivå eller språk. Utvid filtrene dine eller zoom ut.",
@@ -9950,14 +9210,9 @@
     "scrollToBottom": "Rull til bunnen",
     "courseImage": "Kursbilde",
     "avatarPreview": "Avatar forhåndsvisning",
-    "activityPhoto": "Aktivitetsbilde",
     "emotePreview": "Emote forhåndsvisning: {name}",
     "activityLabel": "Aktivitet: {title}",
     "resetMapView": "Tilbakestill kartvisning",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10010,14 +9265,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10047,10 +9294,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10107,10 +9350,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -84,11 +84,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Mogen gasten deelnemen",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Weet je het zeker?",
     "@areYouSure": {
         "type": "String",
@@ -365,11 +360,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Je berichten zijn beveiligd met een herstelsleutel. Zorg ervoor dat je deze niet verliest.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Chatdetails",
     "@chatDetails": {
         "type": "String",
@@ -501,11 +491,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Contact is voor de groep uitgenodigd",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "De inhoud is gerapporteerd aan de serverbeheerders",
     "@contentHasBeenReported": {
         "type": "String",
@@ -557,11 +542,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Maak nieuwe space aan",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Momenteel actief",
     "@currentlyActive": {
@@ -705,11 +685,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Je kunt de versleuteling hierna niet meer uitschakelen. Weet je het zeker?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Versleuteld",
     "@encrypted": {
         "type": "String",
@@ -748,11 +723,6 @@
             }
         }
     },
-    "everythingReady": "Alles klaar!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Extreem beledigend",
     "@extremeOffensive": {
         "type": "String",
@@ -790,11 +760,6 @@
     },
     "group": "Groep",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Groep is openbaar",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -888,15 +853,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Contact voor {groupName} uitnodigen",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Uitgenodigd",
     "@invited": {
@@ -1009,15 +965,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Laad nog {count} personen",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Bezig met laden… Even geduld.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -1042,15 +989,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Inloggen bij {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Uitloggen",
     "@logout": {
@@ -1114,16 +1052,6 @@
     },
     "noEmotesFound": "Geen emoticons gevonden. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Je kunt de versleuteling pas activeren zodra de chat niet meer openbaar toegankelijk is.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Firebase Cloud Messaging lijkt niet beschikbaar op je apparaat. Om pushmeldingen te krijgen, adviseren we om ntfy te installeren. Met ntfy of een andere Unified Push-provider kun je pushmeldingen ontvangen op een veilige manier. Je kunt ntfy downloaden in de PlayStore of F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1255,11 +1183,6 @@
     },
     "passwordHasBeenChanged": "Wachtwoord gewijzigd",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Wachtwoordherstel",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1403,11 +1326,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Verwijder apparaat",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Verbanning opheffen",
     "@unbanFromChat": {
@@ -1562,11 +1480,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Rechten-niveau instellen",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Status instellen",
     "@setStatus": {
         "type": "String",
@@ -1608,16 +1521,6 @@
     },
     "sourceCode": "Broncode",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Space is openbaar",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Spacenaam",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1676,11 +1579,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Overzetten vanaf een ander apparaat",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Probeer nogmaals te verzenden",
     "@tryToSendAgain": {
         "type": "String",
@@ -1736,15 +1634,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 ongelezen chat} other{{unreadCount} ongelezen chats}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} en {count} anderen zijn aan het typen …",
     "@userAndOthersAreTyping": {
@@ -1830,16 +1719,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Videogesprek",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Chatgeschiedenis zichtbaarheid",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Zichtbaar voor alle personen",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1885,23 +1764,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Wie kan welke actie uitvoeren",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Wie mag deelnemen aan deze groep",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Waarom wil je dit rapporteren?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Wil je de chatback-up wissen om een nieuwe herstelsleutel te kunnen maken?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1950,8 +1814,6 @@
     "@serverRequiresEmail": {},
     "oneClientLoggedOut": "Één van jouw apparaten is uitgelogd",
     "@oneClientLoggedOut": {},
-    "enableMultiAccounts": "(BETA) Meerdere accounts op dit apparaat inschakelen",
-    "@enableMultiAccounts": {},
     "bundleName": "Bundelnaam",
     "@bundleName": {},
     "removeFromBundle": "Van bundel verwijderen",
@@ -1960,12 +1822,8 @@
     "@addToBundle": {},
     "editBundlesForAccount": "Bundels voor dit account wijzigen",
     "@editBundlesForAccount": {},
-    "addAccount": "Account toevoegen",
-    "@addAccount": {},
     "link": "Link",
     "@link": {},
-    "yourChatBackupHasBeenSetUp": "Jouw chatback-up is ingesteld.",
-    "@yourChatBackupHasBeenSetUp": {},
     "unverified": "Niet geverifieerd",
     "@unverified": {},
     "repeatPassword": "Wachtwoord herhalen",
@@ -1980,8 +1838,6 @@
     "@sender": {},
     "openGallery": "Galerij openen",
     "@openGallery": {},
-    "removeFromSpace": "Uit de space verwijderen",
-    "@removeFromSpace": {},
     "start": "Start",
     "@start": {},
     "commandHint_clearcache": "Cache wissen",
@@ -2041,16 +1897,10 @@
     "@unsupportedAndroidVersion": {},
     "unsupportedAndroidVersionLong": "Voor deze functie is een nieuwe Android-versie verplicht. Controleer je updates of Lineage OS-ondersteuning.",
     "@unsupportedAndroidVersionLong": {},
-    "videoCallsBetaWarning": "Houd er rekening mee dat videogesprekken momenteel in bèta zijn. Ze werken misschien niet zoals je verwacht of werken niet op alle platformen.",
-    "@videoCallsBetaWarning": {},
-    "voiceCall": "Spraakoproep",
-    "@voiceCall": {},
     "confirmEventUnpin": "Weet je zeker dat je de gebeurtenis definitief wilt losmaken?",
     "@confirmEventUnpin": {},
     "experimentalVideoCalls": "Videogesprekken (experimenteel)",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "Email of inlognaam",
-    "@emailOrUsername": {},
     "widgetCustom": "Aangepast",
     "@widgetCustom": {},
     "widgetName": "Naam",
@@ -2136,28 +1986,8 @@
             }
         }
     },
-    "recoveryKey": "Herstelsleutel",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Herstelsleutel verloren?",
-    "@recoveryKeyLost": {},
-    "pleaseEnterRecoveryKey": "Voer jouw herstelsleutel in:",
-    "@pleaseEnterRecoveryKey": {},
     "users": "Personen",
     "@users": {},
-    "unlockOldMessages": "Oude berichten ontgrendelen",
-    "@unlockOldMessages": {},
-    "storeInAndroidKeystore": "In Android KeyStore opslaan",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "In Apple KeyChain opslaan",
-    "@storeInAppleKeyChain": {},
-    "saveKeyManuallyDescription": "Sla deze sleutel handmatig op via delen of het klembord.",
-    "@saveKeyManuallyDescription": {},
-    "pleaseEnterRecoveryKeyDescription": "Om je oude berichten te ontgrendelen voer je jouw herstelsleutel in die gemaakt is in je vorige sessie. Je sleutel is niet je wachtwoord.",
-    "@pleaseEnterRecoveryKeyDescription": {},
-    "storeInSecureStorageDescription": "Sla de herstelsleutel op in de beveiligde opslag van dit apparaat.",
-    "@storeInSecureStorageDescription": {},
-    "storeSecurlyOnThisDevice": "Veilig opslaan op dit apparaat",
-    "@storeSecurlyOnThisDevice": {},
     "dehydrate": "Sessie exporteren en apparaat wissen",
     "@dehydrate": {},
     "dehydrateWarning": "Deze actie kan niet ongedaan worden gemaakt. Zorg ervoor dat je het back-upbestand veilig opslaat.",
@@ -2195,16 +2025,8 @@
     "@whyIsThisMessageEncrypted": {},
     "noKeyForThisMessage": "Dit kan gebeuren als het bericht is verzonden voordat je bij je account op dit apparaat hebt aangemeld.\n\nHet is ook mogelijk dat de afzender je apparaat heeft geblokkeerd of dat er iets mis is gegaan met de internetverbinding.\n\nKan je het bericht wel lezen in een andere sessie? Dan kan je het bericht daarvandaan overzetten! Ga naar Instellingen > Apparaten en zorg ervoor dat je apparaten elkaar hebben geverifieerd. Wanneer je de chat de volgende keer opent en beide sessies op de voorgrond staan, zullen de sleutels automatisch worden verzonden.\n\nWil je de sleutels niet verliezen als je uitlogt of van apparaat wisselt? Zorg er dan voor dat je de chatback-up hebt aangezet in de instellingen.",
     "@noKeyForThisMessage": {},
-    "enterSpace": "Space betreden",
-    "@enterSpace": {},
     "allSpaces": "Alle spaces",
     "@allSpaces": {},
-    "foregroundServiceRunning": "Deze melding verschijnt wanneer de voorgronddienst draait.",
-    "@foregroundServiceRunning": {},
-    "screenSharingTitle": "scherm delen",
-    "@screenSharingTitle": {},
-    "screenSharingDetail": "Je deelt je scherm in FuffyChat",
-    "@screenSharingDetail": {},
     "newGroup": "Nieuwe groep",
     "@newGroup": {},
     "newSpace": "Space aanmaken",
@@ -2253,18 +2075,10 @@
             }
         }
     },
-    "disableEncryptionWarning": "Om veiligheidsredenen kun je versleuteling niet uitschakelen in een chat, waar deze eerder is ingeschakeld.",
-    "@disableEncryptionWarning": {},
-    "sorryThatsNotPossible": "Sorry, dat is niet mogelijk",
-    "@sorryThatsNotPossible": {},
     "reopenChat": "Chat heropenen",
     "@reopenChat": {},
-    "encryptThisChat": "Versleutel deze chat",
-    "@encryptThisChat": {},
     "deviceKeys": "Apparaatsleutels:",
     "@deviceKeys": {},
-    "newSpaceDescription": "Met spaces kun je je chats samenvoegen en privé- of openbare community's bouwen.",
-    "@newSpaceDescription": {},
     "noOtherDevicesFound": "Geen andere apparaten gevonden",
     "@noOtherDevicesFound": {},
     "noBackupWarning": "Waarschuwing! Zonder de chatback-up in te schakelen, verlies je de toegang tot je versleutelde berichten. Het is sterk aanbevolen om eerst de chatback-up in te schakelen voordat je uitlogt.",
@@ -2308,8 +2122,6 @@
     "@sendTypingNotifications": {},
     "chatPermissions": "Chat rechten",
     "@chatPermissions": {},
-    "chatDescription": "Chatomschrijving",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "Chatomschrijving gewijzigd",
     "@chatDescriptionHasBeenChanged": {},
     "noChatDescriptionYet": "Nog geen chatomschrijving gemaakt.",
@@ -2353,8 +2165,6 @@
     "@directChat": {},
     "setChatDescription": "Chatomschrijving instellen",
     "@setChatDescription": {},
-    "setTheme": "Thema instellen:",
-    "@setTheme": {},
     "setColorTheme": "Kleurthema instellen:",
     "@setColorTheme": {},
     "invite": "Uitnodigen",
@@ -2415,16 +2225,12 @@
     "@block": {},
     "blockedUsers": "Geblokkeerde personen",
     "@blockedUsers": {},
-    "searchChatsRooms": "Zoek #chats, @personen...",
-    "@searchChatsRooms": {},
     "swipeRightToLeftToReply": "Veeg van rechts naar links om te reageren",
     "@swipeRightToLeftToReply": {},
     "calls": "Gesprekken",
     "@calls": {},
     "customEmojisAndStickers": "Aangepaste emoji's en stickers",
     "@customEmojisAndStickers": {},
-    "accessAndVisibilityDescription": "Wie mag toetreden tot deze chat en hoe de chat ontdekt kan worden.",
-    "@accessAndVisibilityDescription": {},
     "customEmojisAndStickersBody": "Voeg toe of deel aangepaste emoji's en stickers die in elke chat gebruikt kunnen worden.",
     "@customEmojisAndStickersBody": {},
     "hideRedactedMessages": "Verwijderde berichten verbergen",
@@ -2441,16 +2247,10 @@
     "@overview": {},
     "hidePresences": "Verberg statuslijst?",
     "@hidePresences": {},
-    "noOneCanJoin": "Niemand kan deelnemen",
-    "@noOneCanJoin": {},
     "yourGlobalUserIdIs": "Je Matrix-ID is: ",
     "@yourGlobalUserIdIs": {},
     "appLockDescription": "Vergendel de app wanneer het niet gebruikt wordt met een pincode",
     "@appLockDescription": {},
-    "globalChatId": "Globale chat ID",
-    "@globalChatId": {},
-    "accessAndVisibility": "Toegang en zichtbaarheid",
-    "@accessAndVisibility": {},
     "invitedBy": "📩 Uitgenodigd door: {user}",
     "@invitedBy": {
         "placeholders": {
@@ -2463,10 +2263,6 @@
     "@publicSpaces": {},
     "blockUsername": "Negeer inlognaam",
     "@blockUsername": {},
-    "publicChatAddresses": "Openbare chat adressen",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Creëer nieuw adres",
-    "@createNewAddress": {},
     "noMoreChatsFound": "Geen chats gevonden...",
     "@noMoreChatsFound": {},
     "joinedChats": "Chats waaraan je deelneemt",
@@ -2489,8 +2285,6 @@
     "@searchForUsers": {},
     "searchMore": "Zoek meer...",
     "@searchMore": {},
-    "groupCanBeFoundViaSearch": "Groep kan gevonden worden via zoeken",
-    "@groupCanBeFoundViaSearch": {},
     "searchIn": "Zoek in chat \"{chat}\"...",
     "@searchIn": {
         "type": "String",
@@ -2615,24 +2409,11 @@
     "@website": {},
     "startConversation": "Start gesprek",
     "@startConversation": {},
-    "usersMustKnock": "Personen moeten kloppen",
-    "@usersMustKnock": {},
     "noUsersFoundWithQuery": "Helaas kan er geen persoon gevonden worden met \"{query}\". Controleer of je een typfout hebt gemaakt.",
     "@noUsersFoundWithQuery": {
         "type": "String",
         "placeholders": {
             "query": {
-                "type": "String"
-            }
-        }
-    },
-    "createGroupAndInviteUsers": "Maak groep en nodig personen uit",
-    "@createGroupAndInviteUsers": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Chat kan worden gevonden via een zoekopdracht op {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
                 "type": "String"
             }
         }
@@ -2664,8 +2445,6 @@
     "@select": {},
     "leaveEmptyToClearStatus": "Laat leeg om je status te resetten.",
     "@leaveEmptyToClearStatus": {},
-    "addChatOrSubSpace": "Voeg chat of subspace toe",
-    "@addChatOrSubSpace": {},
     "subspace": "Subspace",
     "@subspace": {},
     "pleaseEnterYourCurrentPassword": "Vul je huidige wachtwoord in",
@@ -2707,30 +2486,14 @@
             }
         }
     },
-    "sessionLostBody": "Je sessie is verlopen. Meldt alsjeblieft deze fout aan de ontwikkelaars via deze link {url}. De foutmelding is: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendTypingNotificationsDescription": "Andere deelnemers in de chat kunnen zien wanneer je een bericht aan het typen bent.",
     "@sendTypingNotificationsDescription": {},
     "sendCanceled": "Versturen geannuleerd",
     "@sendCanceled": {},
     "opacity": "Doorzichtigheid:",
     "@opacity": {},
-    "verifyOtherUserDescription": "Als je een persoon verifieert ben je er zeker van dat je echt met haar contact hebt. 💪\n\nWanneer je een verificatie start ziet de persoon een popup in de app. Hier staat een serie van emoji's of getallen die je met elkaar moet vergelijken.\n\nDe beste manier om dit te doen is in persoon of met een videogesprek. 👭",
-    "@verifyOtherUserDescription": {},
     "changeTheVisibilityOfChatHistory": "Zichtbaarheid van de chat-geschiedenis wijzigen",
     "@changeTheVisibilityOfChatHistory": {},
-    "whatIsAHomeserver": "Wat is een server?",
-    "@whatIsAHomeserver": {},
     "sendRoomNotifications": "@room-meldingen versturen",
     "@sendRoomNotifications": {},
     "noticeChatBackupDeviceVerification": "Opmerking: Als al je apparaten zijn verbonden met de chat back-up worden ze automatisch geverifieerd.",
@@ -2745,8 +2508,6 @@
     "@oneOfYourDevicesIsNotVerified": {},
     "contactServerAdmin": "Contact opnemen met serverbeheerder",
     "@contactServerAdmin": {},
-    "manageAccount": "Account beheren",
-    "@manageAccount": {},
     "noContactInformationProvided": "Server geeft geen geldige contactinformatie",
     "@noContactInformationProvided": {},
     "waitingForServer": "Wachten op server...",
@@ -2823,12 +2584,8 @@
             }
         }
     },
-    "discoverHomeservers": "Ontdek servers",
-    "@discoverHomeservers": {},
     "changelog": "Wijzigingengeschiedenis",
     "@changelog": {},
-    "loginWithMatrixId": "Inloggen met Matrix-ID",
-    "@loginWithMatrixId": {},
     "calculatingFileSize": "Bestandsgrootte berekenen...",
     "@calculatingFileSize": {},
     "sendingAttachment": "Bijlage versturen...",
@@ -2860,18 +2617,6 @@
     "@verifyOtherDeviceDescription": {},
     "commandHint_unignore": "Herstel de negeerde Matrix-ID",
     "@commandHint_unignore": {},
-    "restoreSessionBody": "De app probeert nu je sessie te herstellen van een back-up. Meldt alsjeblieft deze fout aan de ontwikkelaars via deze link {url}. De foutmelding is: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendReadReceipts": "Leesbevestigingen versturen",
     "@sendReadReceipts": {},
     "formattedMessages": "Opgemaakte berichten",
@@ -2884,8 +2629,6 @@
     "@sendReadReceiptsDescription": {},
     "formattedMessagesDescription": "Geef rijke berichtinhoud weer zoals vetgedrukte tekst met markdown.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Persoon verifiëren",
-    "@verifyOtherUser": {},
     "verifyOtherDevice": "🔐 Ander apparaat verifiëren",
     "@verifyOtherDevice": {},
     "doesNotSeemToBeAValidHomeserver": "Dit lijkt geen ondersteunde server. Verkeerde URL?",
@@ -2904,23 +2647,8 @@
     },
     "continueText": "Doorgaan",
     "@continueText": {},
-    "welcomeText": "Hallo hallo 👋 Dit is FluffyChat. Je kan inloggen op elke server die werkt met https://matrix.org. En dan chat je met iedereen. Het is een groot decentraal chat-netwerk!",
-    "@welcomeText": {},
-    "appWantsToUseForLogin": "Inloggen met '{server}'",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Hierbij sta je toe dat de app en website informatie over je delen.",
-    "@appWantsToUseForLoginDescription": {},
     "open": "Open",
     "@open": {},
-    "appIntroduction": "FluffyChat laat je chatten met je vrienden tussen verschillende chat-netwerken. Lees meer op https://matrix.org of tik *Continue*.",
-    "@appIntroduction": {},
     "completedKeyVerification": "{sender} ronde de sleutelverificatie af",
     "@completedKeyVerification": {
         "type": "String",
@@ -2930,8 +2658,6 @@
             }
         }
     },
-    "homeserverDescription": "Al je data is opgeslagen op de server, net als bij een email-leverancier. Je kan kiezen welke server je gebruikt en toch communiceren met iedereen. Lees meer op https://matrix.org.",
-    "@homeserverDescription": {},
     "notificationRuleContainsDisplayName": "Bevat de naam",
     "@notificationRuleContainsDisplayName": {},
     "notificationRuleIsUserMentionDescription": "Stuur een melding als je direct genoemd wordt in een bericht.",
@@ -3053,15 +2779,6 @@
             }
         }
     },
-    "countInvited": "{count} uitgenodigd",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "checkList": "Checklist",
     "@checkList": {},
     "commandHint_logout": "Uw huidige apparaat uitloggen",
@@ -3084,38 +2801,12 @@
     "@pause": {},
     "resume": "Hervat",
     "@resume": {},
-    "donate": "Doneer",
-    "@donate": {},
-    "newSubSpace": "Nieuwe sub-space",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Naar andere space verplaatsen",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "De chat zal worden verwijderd uit de space, maar blijft in je chats.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} chats",
     "@countChats": {
         "type": "String",
         "placeholders": {
             "chats": {
                 "type": "int"
-            }
-        }
-    },
-    "spaceMemberOf": "{spaces} personen in space",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "{spaces} personen in space kunnen kloppen",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
             }
         }
     },
@@ -3188,14 +2879,6 @@
     "@stickerPackName": {},
     "attribution": "Toeschrijving",
     "@attribution": {},
-    "skipChatBackup": "Chatback-up overslaan",
-    "@skipChatBackup": {},
-    "skipChatBackupWarning": "Weet je het zeker? Zonder chat back-up verlies je toegang tot je berichten als je van apparaat wisselt.",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "Berichten laden",
-    "@loadingMessages": {},
-    "setupChatBackup": "Chatback-up instellen",
-    "@setupChatBackup": {},
     "changedTheChatDescription": "{username} heeft de chatomschrijving gewijzigd",
     "@changedTheChatDescription": {},
     "changedTheChatName": "{username} heeft de chatnaam gewijzigd",
@@ -3206,11 +2889,9 @@
     "taTooltip": "L2 gebruik met vertaalhulp",
     "interactiveTranslatorSliderHeader": "Interactieve Vertaler",
     "interactiveGrammarSliderHeader": "Interactieve Grammatica Controle",
-    "interactiveTranslatorRequired": "Vereist",
     "waTooltip": "L2 gebruik zonder hulp",
     "interactiveTranslator": "Vertaalhulp",
     "noIdenticalLanguages": "Kies alstublieft verschillende basis- en doeltalen",
-    "searchBy": "Zoeken op land en talen",
     "joinWithClassCode": "Deelname via cursuscode",
     "languageLevelPreA1": "Novice Laag (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -3230,19 +2911,14 @@
     "whatIsYourBaseLanguage": "Wat is jouw brontaal?",
     "publicProfileTitle": "Sta toe dat mijn profiel gevonden kan worden in zoekopdrachten",
     "publicProfileDesc": "Door deze optie in te schakelen, kunnen andere gebruikers jouw profiel vinden in de wereldwijde zoekbalk en verzoeken sturen om te chatten. Op dat moment kun je kiezen om het verzoek te accepteren of te weigeren.",
-    "errorDisableIT": "Vertaalhulp is uitgeschakeld.",
-    "errorDisableIGC": "Grammatica hulp is uitgeschakeld.",
     "errorDisableITUserDesc": "Klik hier om vertaalhulp-instellingen bij te werken",
     "errorDisableIGCUserDesc": "Klik hier om grammatica hulp-instellingen bij te werken",
     "errorDisableITClassDesc": "Vertaalhulp is uitgeschakeld voor de cursus waarin deze chat zich bevindt.",
     "errorDisableIGCClassDesc": "Grammatica hulp is uitgeschakeld voor de cursus waarin deze chat zich bevindt.",
-    "error405Title": "Talen niet ingesteld",
     "error405Desc": "Stel uw talen in in Hoofdmenu > Leerinstellingen.",
     "termsAndConditions": "Algemene voorwaarden",
     "andCertifyIAmAtLeast13YearsOfAge": " en verklaar dat ik minstens 16 jaar oud ben.",
-    "error502504Title": "Wow, er zijn veel studenten online!",
     "error502504Desc": "Vertaal- en grammaticagereedschappen kunnen traag zijn of niet beschikbaar terwijl de Pangea-bots bijwerken.",
-    "error404Title": "Vertaalfout!",
     "error404Desc": "Pangea Bot weet niet zeker hoe dit te vertalen...",
     "errorPleaseRefresh": "We zijn het aan het onderzoeken! Verversen en probeer het opnieuw.",
     "connectedToStaging": "Verbonden met Staging",
@@ -3280,13 +2956,9 @@
     "definitionsToolName": "Woordendefinities",
     "definitionsToolDescription": "Wanneer ingeschakeld, kunnen woorden onderstreept in blauw worden aangeklikt voor definities. Klik op berichten om definities te openen.",
     "welcomeBack": "Welkom terug! Als je deel uitmaakte van de pilot 2023-2024, neem dan contact met ons op voor je speciale pilotabonnement. Als je een leraar bent die (of wiens instelling) licenties voor je klas heeft gekocht, neem dan contact met ons op voor je lerarenabonnement.",
-    "downloadTxtFile": "Download tekstbestand",
-    "downloadCSVFile": "Download CSV-bestand",
     "promotionalSubscriptionDesc": "U hebt momenteel een levenslange promotie-abonnement. Stuur een bericht naar support@pangea.chat voor hulp bij het wijzigen van uw abonnement.",
     "originalSubscriptionPlatform": "Abonnement gekocht via {purchasePlatform}",
     "oneWeekTrial": "Proefweek",
-    "downloadXLSXFile": "Download Excel-bestand",
-    "unkDisplayName": "Onbekend",
     "wwCountryDisplayName": "Wereldwijd",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Ålandeilanden",
@@ -3581,7 +3253,6 @@
     "chatCapacityHasBeenChanged": "Chatcapaciteit gewijzigd",
     "chatCapacitySetTooLow": "De chatcapaciteit moet minimaal {count} zijn.",
     "chatCapacityExplanation": "Chatcapaciteit beperkt het aantal leden dat in een chat mag.",
-    "tooManyRequest": "Te veel verzoeken, probeer het later opnieuw.",
     "enterNumber": "Voer een geheel getal in.",
     "practice": "Oefenen",
     "versionNotFound": "Versie niet gevonden",
@@ -3591,7 +3262,6 @@
     "deleteSubscriptionWarningTitle": "Je hebt een actief abonnement",
     "deleteSubscriptionWarningBody": "Het verwijderen van je account annuleert je abonnement niet automatisch.",
     "manageSubscription": "Abonnement beheren",
-    "error520Title": "Probeer het opnieuw.",
     "error520Desc": "Sorry, we konden je bericht niet begrijpen...",
     "wordsUsed": "Gekende woorden",
     "level": "Niveau",
@@ -3609,7 +3279,6 @@
     "other": "Andere",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "Geen capaciteitslimiet",
-    "downloadGroupText": "Download groepsbericht",
     "notificationsOn": "Meldingen aan",
     "notificationsOff": "Meldingen uit",
     "joinWithCode": "Deelname met code",
@@ -3673,24 +3342,12 @@
     "whatIsTheMorphTag": "Wat is de {morphologicalFeature} van '{wordForm}'?",
     "dataAvailable": "Beschikbare gegevens",
     "available": "Beschikbaar",
-    "pangeaBotIsFallible": "Pangea Bot maakt ook fouten!",
-    "whatIsMeaning": "Wat betekent '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Koppel betekenissen aan de woorden in het bericht!",
-    "doubleClickToEdit": "Dubbelklik om te bewerken.",
-    "topicLabel": "Onderwerp",
-    "topicPlaceholder": "Kies een onderwerp...",
-    "modePlaceholder": "Kies een modus...",
-    "learningObjectiveLabel": "Leerdoel",
-    "learningObjectivePlaceholder": "Kies een leerdoel...",
-    "targetLanguageLabel": "Doeltaal",
     "cefrLevelLabel": "CEFR-niveau",
     "image": "Afbeelding",
     "video": "Video",
     "nan": "Niet van toepassing",
-    "addVocabulary": "Voeg vocabulaire toe",
     "instructions": "Instructies",
-    "numberOfLearners": "Aantal leerlingen",
-    "mustBeInteger": "Moet een geheel getal zijn, bijv. 1, 2, 3, ...",
     "constructUsePvmDesc": "Gemaakt in spraakbericht",
     "leaveSpaceDescription": "Door de cursus te verlaten, verlaat je alle chats binnen die cursus. Andere gebruikers zien dat je de cursus hebt verlaten.",
     "constructUseCorMmDesc": "Correct berichtbetekenis",
@@ -3705,7 +3362,6 @@
     "ttsDisabledBody": "Je kunt tekst-naar-spraak inschakelen in je leerinstellingen",
     "noSpaceDescriptionYet": "Nog geen cursusbeschrijving gemaakt.",
     "tooLargeToSend": "Dit bericht is te groot om te verzenden",
-    "exitWithoutSaving": "Weet je zeker dat je wilt vertrekken zonder op te slaan?",
     "enableAutocorrectPopupTitle": "Voeg je doeltaal-toetsenbord toe door naar te gaan:",
     "enableAutocorrectPopupSteps": "  • Instellingen\n  • Algemeen\n  • Toetsenbord\n  • Toetsenborden\n  • Nieuw toetsenbord toevoegen",
     "enableAutocorrectPopupDescription": "Zodra de taal is geselecteerd, kun je op het kleine wereldbol-icoon linksonder op je toetsenbord klikken om het nieuw geïnstalleerde toetsenbord te activeren.",
@@ -3716,11 +3372,8 @@
     "displayName": "Weergavenaam",
     "leaveRoomDescription": "Je staat op het punt deze chat te verlaten. Andere gebruikers zien dat je de chat hebt verlaten.",
     "confirmUserId": "Bevestig je Pangea Chat-gebruikersnaam om je account te verwijderen.",
-    "startingToday": "Vanaf vandaag",
-    "oneWeekFreeTrial": "Eén week gratis proefperiode",
     "paidSubscriptionStarts": "Begint op {startDate}",
     "cancelInSubscriptionSettings": "• Annuleer op elk moment in abonnementinstellingen",
-    "cancelToAvoidCharges": "• Annuleer voor {trialEnds} om kosten te voorkomen",
     "downloadGboard": "Download Gboard",
     "autocorrectNotAvailable": "Helaas wordt uw platform momenteel niet ondersteund voor deze functie. Blijf op de hoogte voor verdere ontwikkeling!",
     "pleaseUpdateApp": "Update de app om door te gaan.",
@@ -3730,17 +3383,12 @@
     "knockSpaceSuccess": "Je hebt verzocht om lid te worden van deze cursus! Een beheerder zal op je verzoek reageren zodra hij het ontvangt 😄",
     "chooseWordAudioInstructionsBody": "Luister naar het volledige bericht. Match daarna de audio's met de woorden.",
     "chooseMorphsInstructionsBody": "Klik op de puzzelstukjes voor grammaticavragen!",
-    "pleaseEnterInt": "Voer een nummer in",
     "home": "Startpagina",
     "join": "Deelnemen",
     "resetInstructionTooltipsTitle": "Reset instructiehulpmiddelen",
     "resetInstructionTooltipsDesc": "Klik om instructiehulpmiddelen te tonen, zoals voor een gloednieuwe gebruiker.",
-    "randomize": "Willekeurig maken",
     "clear": "Wissen",
-    "featuredActivities": "Uitgelicht",
     "save": "Opslaan",
-    "startChat": "Begin een chat",
-    "translationProblem": "Vertaalprobleem",
     "askToJoin": "Vraag om lid te worden",
     "emptyChatWarningTitle": "Chat is leeg",
     "emptyChatWarningDesc": "Je hebt niemand uitgenodigd voor je chat. Ga naar Chat-instellingen om je contacten of de Bot uit te nodigen. Je kunt dit later ook doen.",
@@ -3770,17 +3418,13 @@
     "timesUsedIndependently": "Aantal keer zelfstandig gebruikt",
     "timesUsedWithAssistance": "Aantal keer met hulp gebruikt",
     "shareInviteCode": "Deel uitnodigingscode: {code}",
-    "leaderboard": "Highscorelijst",
     "skipForNow": "Sla over",
     "permissions": "Toestemmingen",
     "spaceChildPermission": "Wie kan nieuwe chats toevoegen aan deze cursus",
-    "addEnvironmentOverride": "Voeg omgevingsoverride toe",
     "defaultOption": "Standaard",
     "deleteChatDesc": "Weet je zeker dat je deze chat wilt verwijderen? Deze wordt verwijderd voor alle deelnemers en alle berichten binnen de chat zijn niet meer beschikbaar voor oefening of leeranalyses.",
     "deleteSpaceDesc": "De cursus en alle geselecteerde chats worden verwijderd voor alle deelnemers en alle berichten binnen de chat zijn niet meer beschikbaar voor oefening of leeranalyses. Deze actie kan niet ongedaan worden gemaakt.",
     "launch": "Start",
-    "searchChats": "Zoek chats",
-    "maxFifty": "Maximaal 50",
     "configureSpace": "Configureer cursus",
     "pinMessages": "Pin berichten",
     "setJoinRules": "Stel toetredingsregels in",
@@ -3814,9 +3458,6 @@
     "failedToFetchTranscription": "Het ophalen van transcriptie is mislukt",
     "deleteEmptySpaceDesc": "De cursus wordt verwijderd voor alle deelnemers. Deze actie kan niet ongedaan worden gemaakt.",
     "regenerate": "Opnieuw genereren",
-    "mySavedActivities": "Mijn opgeslagen activiteiten",
-    "noSavedActivities": "Geen opgeslagen activiteiten",
-    "saveActivity": "Deze activiteit opslaan",
     "failedToPlayVideo": "Video afspelen is mislukt",
     "done": "Klaar",
     "inThisSpace": "In deze cursus",
@@ -3827,13 +3468,9 @@
     "numInvited": "{count} uitgenodigd",
     "saved": "Opgeslagen",
     "reset": "Reset",
-    "errorFetchingActivitiesMessage": "Fout bij het ophalen van activiteiten",
     "errorFetchingDefinition": "Fout bij het ophalen van definitie",
     "errorProcessAnalytics": "Fout bij het verwerken van analytics",
     "errorDownloading": "Downloaden mislukt",
-    "errorLoadingSpaceChildren": "Fout bij het laden van chats binnen deze cursus",
-    "unexpectedError": "Onverwachte fout.",
-    "pleaseReload": "Herkader en probeer het opnieuw.",
     "translationError": "Vertaalfout",
     "check": "Controleren",
     "unableToFindRoom": "Geen chat of cursus gevonden met die code. Probeer het opnieuw.",
@@ -3842,19 +3479,14 @@
     "request": "Verzoek",
     "requestAll": "Alles aanvragen",
     "confirmMessageUnpin": "Weet u zeker dat u dit bericht wilt losmaken?",
-    "saveAndLaunch": "Opslaan en starten",
-    "launchToSpace": "Lanceren naar cursus",
     "pending": "In afwachting",
     "inactive": "Inactief",
-    "confirmRole": "Bevestig rol",
     "openRoleLabel": "OPEN",
     "finishedTheActivity": "🎯 {username} heeft deze activiteit afgerond",
     "activitySummaryError": "Samenvattingen van activiteiten niet beschikbaar",
     "requestSummaries": "Vraag samenvattingen aan",
-    "generatingNewActivities": "Je bent de eerste gebruiker van dit taalpaar! Geef ons een minuutje, we bereiden activiteiten voor je voor.",
     "requestAccessTitle": "Toegang tot analyses aanvragen?",
     "requestAccessDesc": "Wil je toegang aanvragen om deelnemeranalyses te bekijken?\n\nAls deelnemers akkoord gaan, kunnen beheerders van deze cursus hun bekijken:\n    • totaal vocabulaire\n    • totaal grammaticaconcepten\n    • totaal voltooide activiteitensessies\n    • de specifieke grammaticaconcepten die correct en incorrect worden gebruikt\n\nZe kunnen niet bekijken:\n    • berichten in chats buiten de cursus\n    • vocabulairelijst",
-    "requestAccess": "Verzoek toegang ({count})",
     "analyticsInactiveTitle": "Verzoeken aan inactieve gebruikers konden niet worden verzonden",
     "analyticsInactiveDesc": "Inactieve gebruikers die zich sinds de introductie van deze functie niet hebben aangemeld, zien uw verzoek niet.\n\nDe knop Verzoek verschijnt zodra ze terugkeren. U kunt het verzoek later opnieuw verzenden door op de knop Verzoek onder hun naam te klikken wanneer deze beschikbaar is.",
     "accessRequestedTitle": "Verzoek om toegang tot analytics",
@@ -3877,8 +3509,6 @@
     "accessDesc": "U kunt uw cursus openstellen voor de wereld! Of, maak uw cursus privé en veilig.",
     "createGroupChatDesc": "Aangezien activiteitensessies starten en eindigen, blijven groepschats open voor routinematige communicatie.",
     "deleteDesc": "Alleen beheerders kunnen een cursus verwijderen. Dit is een destructieve actie die alle gebruikers verwijdert en alle geselecteerde chats binnen de cursus verwijdert. Ga voorzichtig te werk.",
-    "noCourseFound": "Oh, deze cursus heeft een plan nodig!\n\nCursusplannen zijn een reeks onderwerpen en gespreksactiviteiten.",
-    "additionalParticipants": "+ {num} anderen",
     "whatNow": "Wat nu?",
     "chooseNextActivity": "Kies je volgende activiteit!",
     "letsGo": "Laten we gaan",
@@ -3891,13 +3521,11 @@
     "waitNotDone": "Wacht, ik ben nog niet klaar!",
     "waitingForOthersToFinish": "Wachten tot de rest klaar is...",
     "generatingSummary": "Chat analyseren en resultaten genereren",
-    "findCourse": "Vind een cursus",
     "pingParticipantsNotification": "{user} zoekt gebruikers om deel te nemen aan de activiteitensessie in {room}",
     "course": "Cursus",
     "courses": "Cursussen",
     "goToCourse": "Ga naar cursus: {course}",
     "activityComplete": "Deze activiteit is voltooid. Het overzicht van de activiteit zou hieronder beschikbaar moeten zijn.",
-    "startNewSession": "Nieuwe sessie starten",
     "joinOpenSession": "Deelname aan open sessie",
     "activityNotFound": "Activiteit niet gevonden",
     "myActivities": "Mijn activiteiten",
@@ -3972,10 +3600,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3985,10 +3609,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4072,14 +3692,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4096,10 +3708,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4112,15 +3720,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4272,14 +3872,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4293,14 +3885,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5523,10 +5107,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5567,10 +5147,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5643,10 +5219,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5916,47 +5488,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5976,19 +5508,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6052,10 +5572,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6096,14 +5612,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6115,14 +5623,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6160,10 +5660,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6180,27 +5676,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6324,10 +5804,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6337,10 +5813,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6357,14 +5829,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6504,18 +5968,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6564,10 +6016,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6577,18 +6025,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6631,23 +6067,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6671,10 +6095,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6682,14 +6102,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6794,18 +6206,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6858,10 +6258,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6888,10 +6284,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7072,7 +6464,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Kom morgen terug voor updates over de activiteit.",
-    "activityDropdownDesc": "Wanneer je klaar bent met deze activiteit, klik hieronder",
     "languageMismatchTitle": "Taal mismatch",
     "languageMismatchDesc": "Je doeltaal komt niet overeen met de taal van deze activiteit. Wil je je doeltaal bijwerken?",
     "reportWordIssueTooltip": "Meld probleem met woordinformatie",
@@ -7085,10 +6476,6 @@
     "selectAll": "Alles selecteren",
     "deselectAll": "Alles deselecteren",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7137,17 +6524,11 @@
         "placeholders": {}
     },
     "startOwn": "Begin mijn eigen",
-    "joinCourseDesc": "Elk cursus heeft 8-10 opeenvolgende onderwerpen met een reeks taalleeractiviteiten op basis van taken.",
     "newMessageInPangeaChat": "📩 Nieuw bericht in Pangea Chat",
     "shareCourse": "Deel cursus",
     "addCourse": "Voeg een cursus toe",
-    "joinPublicCourse": "Deelname openbare cursus",
     "vocabLevelsDesc": "Hier komen de vocabulaire woorden zodra je ze hebt opgewaardeerd!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7160,10 +6541,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7182,7 +6559,6 @@
     "emojiView": "Emoji-weergave",
     "feedbackDialogDesc": "Ik maak ook fouten! Iets om me te helpen verbeteren?",
     "contactHasBeenInvitedToTheCourse": "Contact is uitgenodigd voor de cursus",
-    "activityStatsButtonTooltip": "Activiteitsinformatie",
     "allow": "Toestaan",
     "deny": "Weigeren",
     "enabledRenewal": "Abonnementsvernieuwing inschakelen",
@@ -7450,10 +6826,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8509,16 +7881,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Activiteiten om het Volgende Onderwerp te Ontgrendelen",
-    "activitiesToUnlockTopicDesc": "Stel het aantal activiteiten in om het volgende cursusonderwerp te ontgrendelen",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Correcte vocabulaire definitie oefening",
     "constructUseIncLMDesc": "Onjuiste vocabulaire definitie oefening",
     "constructUseCorLADesc": "Correcte vocabulaire audio oefening",
@@ -8526,7 +7888,6 @@
     "constructUseBonus": "Bonus tijdens vocabulaire oefening",
     "practiceVocab": "Oefen vocabulaire",
     "selectMeaning": "Selecteer de betekenis",
-    "selectAudio": "Selecteer de bijpassende audio",
     "anotherRound": "Nog een ronde",
     "activitySettingsOverrideWarning": "Taal en taalniveau bepaald door het activiteitenplan",
     "voice": "Stem",
@@ -8558,10 +7919,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8579,12 +7936,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Download gestart",
     "webDownloadPermissionMessage": "Als uw browser downloads blokkeert, schakel dan downloads voor deze site in.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8679,11 +8031,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Er is iets misgegaan en we zijn hard aan het werk om het op te lossen. Kijk later nog eens.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Schrijfassistentie inschakelen",
     "autoIGCToolDescription": "Voer automatisch Pangea Chat-tools uit om verzonden berichten naar de doeltaal te corrigeren.",
     "@autoIGCToolName": {
@@ -8739,24 +8086,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Grammatica",
-    "spanTypeWordChoice": "Woordkeuze",
     "spanTypeSpelling": "Spelling",
     "spanTypePunctuation": "Interpunctie",
     "spanTypeStyle": "Stijl",
     "spanTypeFluency": "Vloeiendheid",
     "spanTypeAccents": "Accenten",
     "spanTypeCapitalization": "Hoofdletters",
-    "spanTypeCorrection": "Correctie",
     "spanFeedbackTitle": "Rapporteer correctiefout",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8781,16 +8117,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "joinCourseForActivities": "Doe mee aan een cursus om activiteiten uit te proberen.",
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -8799,18 +8126,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "signInWithLabel": "Inloggen met:",
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "advancedConfigurations": "Geavanceerde configuraties",
     "@advancedConfigurations": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "advancedConfigs": "Geavanceerde configuraties",
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8818,15 +8135,6 @@
     "@logs": {
         "type": "String",
         "placeholders": {}
-    },
-    "versionWithNumber": "Versie: {version}",
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
     },
     "identityServer": "Identiteitsserver:",
     "@identityServer": {
@@ -9059,11 +8367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "In een klas? Plaats hier je join-code.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automatisch audio berichten markeren",
     "selectAudioMessagesOnPlayDescription": "Audio berichten automatisch markeren wanneer ze worden afgespeeld",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9107,18 +8410,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Deze cursus heeft onderwerpen met minder dan {input} activiteiten. Voer alstublieft een getal in dat kleiner is dan of gelijk aan {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Klik hier om opnieuw in te loggen.",
     "@clickToLogin": {
@@ -9535,17 +8826,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Een cartoonachtige gele beer met zijn armen omhoog in opwinding.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Selecteer woorden om er meer over te leren",
     "requireAnalyticsAccessTitle": "Analytics-toegang vereist om deel te nemen",
     "requireAnalyticsAccessDesc": "Deelnemers moeten toegang tot hun leeranalyses verlenen om aan deze cursus deel te nemen",
     "analyticsAccessNoticeTitle": "Analytics-toegang vereist",
     "analyticsAccessNoticeDesc": "Door deel te nemen aan deze cursus stem je ermee in dat beheerders toegang krijgen tot je leeranalyses.",
-    "skipOnboardingClassCodeDesc": "Leer je zelfstandig? Maak je geen zorgen, je kunt:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9563,10 +8848,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9595,7 +8876,6 @@
     "pickCefrLevelTeacherStepTitle": "Welk niveau geef je les?",
     "pickCefrLevelStudentStepTitle": "Welk niveau ben je?",
     "customCourseStepTitle": "Vul dit formulier in om een aangepaste cursus te krijgen",
-    "aboutYourClass": "Over je klas",
     "courseCodeStepErrorMessage": "Controleer je code en probeer het opnieuw",
     "institution": "Instelling",
     "courseGoals": "Cursusdoelen",
@@ -9638,10 +8918,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9758,12 +9034,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat-logo",
     "introChatDetails": "Zeg hallo! Stel jezelf voor aan je medecursisten, vind vrienden en chat buiten de activiteiten.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9807,11 +9078,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Activiteitenacties",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Uitspraaktools",
     "audioTranscription": "AI-audiotranscriptie",
     "visualLearnerSupport": "Ondersteuning voor visuele leerlingen",
@@ -9852,7 +9118,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Sluit je aan bij een cursus die deze activiteit bevat om deze te spelen.",
     "resizeCoursePanel": "Wijzig de grootte van het cursuspaneel",
     "undo": "Ongedaan maken",
     "unlock": "Ontgrendelen",
@@ -9866,7 +9131,6 @@
     "addCourseBrowsePublic": "Blader door openbare cursussen",
     "browsePublicCourses": "Blader door openbare cursussen",
     "editProfile": "Bewerk profiel",
-    "numObjectives": "{count} doelstellingen",
     "mapSearchHint": "Zoek activiteiten",
     "mapSearchNoResults": "Geen overeenkomsten in weergave",
     "mapFilterAllLanguages": "Alle talen",
@@ -9875,7 +9139,6 @@
     "mapFilterCompleted": "Voltooid",
     "mapFilterReset": "Resetten",
     "activityTypeConversation": "Gesprek",
-    "lockedMissionRequirement": "Voltooi de vorige missie om te ontgrendelen",
     "playAgain": "Speel opnieuw",
     "reviewActivity": "Beoordelen",
     "mapEmptyInView": "Niets hier op jouw niveau of taal. Verbreed je filters of zoom uit.",
@@ -9890,14 +9153,9 @@
     "scrollToBottom": "Scroll naar beneden",
     "courseImage": "Cursusafbeelding",
     "avatarPreview": "Avatarvoorbeeld",
-    "activityPhoto": "Activiteitsfoto",
     "emotePreview": "Emotevoorbeeld: {name}",
     "activityLabel": "Activiteit: {title}",
     "resetMapView": "Reset kaartweergave",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9950,14 +9208,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9987,10 +9237,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10047,10 +9293,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -68,11 +68,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Czy użytkownicy-goście mogą dołączyć",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Czy na pewno?",
     "@areYouSure": {
         "type": "String",
@@ -330,11 +325,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Twoje stare wiadomości są zabezpieczone kluczem odzyskiwania. Uważaj żeby go nie zgubić.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Szczegóły czatu",
     "@chatDetails": {
         "type": "String",
@@ -458,11 +448,6 @@
     },
     "connect": "Połącz",
     "@connect": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "Kontakt został zaproszony do grupy",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -635,11 +620,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Nie będziesz już mógł wyłączyć szyfrowania. Jesteś pewny?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Szyfrowane",
     "@encrypted": {
         "type": "String",
@@ -666,11 +646,6 @@
     },
     "enterAnEmailAddress": "Wpisz adres e-mail",
     "@enterAnEmailAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "Wszystko gotowe!",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -701,11 +676,6 @@
     },
     "group": "Grupa",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Grupa jest publiczna",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -779,15 +749,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Zaproś kontakty do {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Zaproszono",
     "@invited": {
@@ -900,15 +861,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Załaduj jeszcze {count} uczestników",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Ładowanie… Proszę czekać.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -923,15 +875,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Zaloguj się do {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Wyloguj się",
     "@logout": {
@@ -980,16 +923,6 @@
     },
     "no": "Nie",
     "@no": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Możesz aktywować szyfrowanie dopiero kiedy pokój nie będzie publicznie dostępny.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Wygląda na to, że Twoje urządzenie nie obsługuje Firebase Cloud Messaging. Aby wciąż otrzymywać powiadomienia push, zalecamy istalację ntfy. Używając ntfy lub inengo zunifikowanego dostawcy powiadomień push, możesz bezpiecznie otrzymywać takowe powiadomienia. Ntfy można pobrać ze sklepu Google Play Store lub z F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1133,11 +1066,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Usuń urządzenie",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Odbanuj w czacie",
     "@unbanFromChat": {
@@ -1284,11 +1212,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Przenieś z innego urządzenia",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Spróbuj wysłać ponownie",
     "@tryToSendAgain": {
         "type": "String",
@@ -1334,15 +1257,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 unread chat} other{{unreadCount} unread chats}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} oraz {count} pozostałych pisze…",
     "@userAndOthersAreTyping": {
@@ -1413,16 +1327,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Rozmowa wideo",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Widoczność historii czatu",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Widoczny dla wszystkich użytkowników",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1440,11 +1344,6 @@
     },
     "wallpaper": "Tapeta:",
     "@wallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Kto może dołączyć do tej grupy",
-    "@whoIsAllowedToJoinThisGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1493,8 +1392,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "addAccount": "Dodaj konto",
-    "@addAccount": {},
     "serverRequiresEmail": "Ten serwer wymaga potwierdzenia Twojego adresu email w celu rejestracji.",
     "@serverRequiresEmail": {},
     "or": "Lub",
@@ -1590,15 +1487,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableMultiAccounts": "(BETA) Włącza obsługę wielu kont na tym urządzeniu",
-    "@enableMultiAccounts": {},
     "pickImage": "Wybierz obraz",
     "@pickImage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Odzyskiwanie hasła",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1671,8 +1561,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "Kopia zapasowa Twojego czatu została ustawiona.",
-    "@yourChatBackupHasBeenSetUp": {},
     "contentHasBeenReported": "Treść została zgłoszona administratorom serwera",
     "@contentHasBeenReported": {
         "type": "String",
@@ -1733,28 +1621,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceIsPublic": "Ustaw jako publiczną",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "shareLocation": "Udostępnij lokalizację",
     "@shareLocation": {
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Ustaw poziom uprawnień",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "skip": "Pomiń",
     "@skip": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Nazwa przestrzeni",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1767,11 +1640,6 @@
     "@publish": {},
     "scanQrCode": "Skanuj kod QR",
     "@scanQrCode": {},
-    "createNewSpace": "Nowa przestrzeń",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "offline": "Offline",
     "@offline": {
         "type": "String",
@@ -1890,8 +1758,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "removeFromSpace": "Usuń z przestrzeni",
-    "@removeFromSpace": {},
     "extremeOffensive": "Bardzo obraźliwe",
     "@extremeOffensive": {
         "type": "String",
@@ -1916,10 +1782,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKey": "Klucz odzyskiwania",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Utracono klucz odzyskiwania?",
-    "@recoveryKeyLost": {},
     "sentCallInformations": "{senderName} wysłał/-a informacje o połączeniu",
     "@sentCallInformations": {
         "type": "String",
@@ -1955,8 +1817,6 @@
     "@openGallery": {},
     "start": "Start",
     "@start": {},
-    "pleaseEnterRecoveryKeyDescription": "Aby odblokować wcześniejsze wiadomości, wprowadź swój klucz odzyskiwania, który został wygenerowany w poprzedniej sesji. Twój klucz odzyskiwania NIE jest Twoim hasłem.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "hydrate": "Przywracanie z pliku kopii zapasowej",
     "@hydrate": {},
     "noMatrixServer": "{server1} nie jest serwerem Matriksa, czy chcesz zamiast niego użyć {server2}?",
@@ -1985,8 +1845,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "pleaseEnterRecoveryKey": "Wprowadź swój klucz odzyskiwania:",
-    "@pleaseEnterRecoveryKey": {},
     "submit": "Odeślij",
     "@submit": {
         "type": "String",
@@ -1999,16 +1857,6 @@
     },
     "unverified": "Niezweryfikowane",
     "@unverified": {},
-    "wipeChatBackup": "Wymazać kopię zapasową czatu, aby utworzyć nowy klucz odzyskiwania?",
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoCanPerformWhichAction": "Kto może wykonywać jakie czynności",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "reportUser": "Zgłoś użytkownika",
     "@reportUser": {},
     "dismiss": "Odrzuć",
@@ -2094,28 +1942,14 @@
     "@widgetUrlError": {},
     "widgetNameError": "Podaj nazwę wyświetlaną.",
     "@widgetNameError": {},
-    "encryptThisChat": "Zaszyfruj ten czat",
-    "@encryptThisChat": {},
-    "disableEncryptionWarning": "Ze względów bezpieczeństwa nie można wyłączyć szyfrowania w czacie, w którym zostało ono wcześniej włączone.",
-    "@disableEncryptionWarning": {},
     "deviceKeys": "Klucze urządzenia:",
     "@deviceKeys": {},
-    "emailOrUsername": "Adres e-mail lub nazwa użytkownika",
-    "@emailOrUsername": {},
-    "saveKeyManuallyDescription": "Zapisz ten klucz ręcznie, uruchamiając systemowe okno dialogowe udostępniania lub schowek.",
-    "@saveKeyManuallyDescription": {},
-    "screenSharingTitle": "udostępnianie ekranu",
-    "@screenSharingTitle": {},
     "noKeyForThisMessage": "Może się to zdarzyć, jeśli wiadomość została wysłana przed zalogowaniem się na to konto na tym urządzeniu.\n\nMożliwe jest również, że nadawca zablokował Twoje urządzenie lub coś poszło nie tak z połączeniem internetowym.\n\nJesteś w stanie odczytać wiadomość na innej sesji? W takim razie możesz przenieść z niej wiadomość! Wejdź w Ustawienia > Urządzenia i upewnij się, że Twoje urządzenia zweryfikowały się wzajemnie. Gdy następnym razem otworzysz pokój i obie sesje będą włączone, klucze zostaną przekazane automatycznie.\n\nNie chcesz stracić kluczy podczas wylogowania lub przełączania urządzeń? Upewnij się, że w ustawieniach masz włączoną kopię zapasową czatu.",
     "@noKeyForThisMessage": {},
-    "sorryThatsNotPossible": "Przepraszamy... to nie jest możliwe",
-    "@sorryThatsNotPossible": {},
     "noBackupWarning": "Uwaga! Bez włączenia kopii zapasowej czatu, stracisz dostęp do swoich zaszyfrowanych wiadomości. Zaleca się włączenie kopii zapasowej czatu przed wylogowaniem.",
     "@noBackupWarning": {},
     "commandHint_googly": "Wyślij kręcące się oczka",
     "@commandHint_googly": {},
-    "storeInAndroidKeystore": "Przechowaj w Android KeyStore",
-    "@storeInAndroidKeystore": {},
     "commandHint_cuddle": "Wyślij przytulenie",
     "@commandHint_cuddle": {},
     "googlyEyesContent": "{senderName} wysyła ci kręcące się oczka",
@@ -2163,12 +1997,8 @@
     "@emojis": {},
     "placeCall": "Zadzwoń",
     "@placeCall": {},
-    "voiceCall": "Połączenie głosowe",
-    "@voiceCall": {},
     "unsupportedAndroidVersionLong": "Ta funkcja wymaga nowszej wersji systemu Android. Sprawdź aktualizacje lub wsparcie Lineage OS.",
     "@unsupportedAndroidVersionLong": {},
-    "videoCallsBetaWarning": "Należy pamiętać, że połączenia wideo są obecnie w fazie beta. Mogą nie działać zgodnie z oczekiwaniami lub nie działać w ogóle na wszystkich platformach.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "Eksperymentalne połączenia wideo",
     "@experimentalVideoCalls": {},
     "addWidget": "Dodaj widżet",
@@ -2231,22 +2061,8 @@
             }
         }
     },
-    "unlockOldMessages": "Odblokuj stare wiadomości",
-    "@unlockOldMessages": {},
-    "storeInSecureStorageDescription": "Przechowaj klucz odzyskiwania w bezpiecznym magazynie tego urządzenia.",
-    "@storeInSecureStorageDescription": {},
-    "storeInAppleKeyChain": "Przechowaj w pęku kluczy Apple",
-    "@storeInAppleKeyChain": {},
-    "storeSecurlyOnThisDevice": "Przechowaj bezpiecznie na tym urządzeniu",
-    "@storeSecurlyOnThisDevice": {},
-    "foregroundServiceRunning": "To powiadomienie pojawia się, gdy usługa w tle jest uruchomiona.",
-    "@foregroundServiceRunning": {},
-    "screenSharingDetail": "Udostępniasz swój ekran w FluffyChat",
-    "@screenSharingDetail": {},
     "whyIsThisMessageEncrypted": "Dlaczego nie można odczytać tej wiadomości?",
     "@whyIsThisMessageEncrypted": {},
-    "enterSpace": "Wejdź do przestrzeni",
-    "@enterSpace": {},
     "allSpaces": "Wszystkie przestrzenie",
     "@allSpaces": {},
     "doNotShowAgain": "Nie pokazuj ponownie",
@@ -2260,8 +2076,6 @@
             }
         }
     },
-    "newSpaceDescription": "Przestrzenie pozwalają na konsolidację czatów i budowanie prywatnych lub publicznych społeczności.",
-    "@newSpaceDescription": {},
     "reopenChat": "Otwórz ponownie czat",
     "@reopenChat": {},
     "fileHasBeenSavedAt": "Plik został zapisany w ścieżce {path}",
@@ -2297,8 +2111,6 @@
     "@tryAgain": {},
     "messagesStyle": "Wiadomości:",
     "@messagesStyle": {},
-    "chatDescription": "Opis czatu",
-    "@chatDescription": {},
     "invalidServerName": "Nieprawidłowa nazwa serwera",
     "@invalidServerName": {},
     "chatPermissions": "Uprawnienia w czacie",
@@ -2368,8 +2180,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "Ustaw wygląd:",
-    "@setTheme": {},
     "replace": "Zastąp",
     "@replace": {},
     "createGroup": "Utwórz grupę",
@@ -2517,18 +2327,6 @@
     },
     "knock": "Zapukaj",
     "@knock": {},
-    "restoreSessionBody": "Aplikacja spróbuje teraz odzyskać Twoją sesję z kopii zapasowej. Prosimy zgłosić ten błąd autorom aplikacji na {url}. Treść błędu to: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "startedKeyVerification": "{sender} rozpoczął/-ęła weryfikację kluczy",
     "@startedKeyVerification": {
         "type": "String",
@@ -2584,8 +2382,6 @@
     "@changeTheDescriptionOfTheGroup": {},
     "sendCanceled": "Anulowano wysyłanie",
     "@sendCanceled": {},
-    "homeserverDescription": "Wszystkie Twoje dane trzymane są na serwerze domowym, jak u dostawców usług e-mail. Możesz wybrać swój serwer domowy i nadal rozmawiać ze wszystkimi. Dowiedz się więcej na https://matrix.org.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "Wydaje się nie być kompatybilnym serwerem domowym. Niepoprawny adres URL?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "calculatingFileSize": "Obliczanie rozmiaru pliku...",
@@ -2608,16 +2404,12 @@
             }
         }
     },
-    "welcomeText": "No cześć! 👋 Tutaj FluffyChat. Możesz zapisać się do dowolnego serwera domowego, kompatybilnego z https://matrix.org i rozmawiać ze wszystkimi. To duża zdecentralizowana sieć czatów!",
-    "@welcomeText": {},
     "blur": "Rozmazanie:",
     "@blur": {},
     "opacity": "Przezroczystość:",
     "@opacity": {},
     "setWallpaper": "Ustaw tapetę",
     "@setWallpaper": {},
-    "manageAccount": "Zarządzaj kontem",
-    "@manageAccount": {},
     "noContactInformationProvided": "Serwer nie dostarcza żadnych poprawnych danych kontaktowych",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "Skontaktuj się z administratorem serwera",
@@ -2675,14 +2467,8 @@
     "@contactServerSecurity": {},
     "version": "Wersja",
     "@version": {},
-    "accessAndVisibility": "Dostęp i widoczność",
-    "@accessAndVisibility": {},
     "customEmojisAndStickers": "Własne emotikony i naklejki",
     "@customEmojisAndStickers": {},
-    "globalChatId": "Globalny identyfikator czatu",
-    "@globalChatId": {},
-    "accessAndVisibilityDescription": "Kto może dołączyć do tego czatu i w jaki sposób można ten czat znaleźć.",
-    "@accessAndVisibilityDescription": {},
     "customEmojisAndStickersBody": "Dodaj lub podziel się własnymi emotikonami i naklejkami, które będą mogły być użyte w dowolnym czacie.",
     "@customEmojisAndStickersBody": {},
     "hideRedactedMessages": "Nie pokazuj usuniętych wiadomości",
@@ -2700,23 +2486,12 @@
             }
         }
     },
-    "chatCanBeDiscoveredViaSearchOnServer": "Czat będzie można znaleźć, szukając na {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "publicSpaces": "Przestrzenie publiczne",
     "@publicSpaces": {},
     "searchMore": "Szukaj dalej...",
     "@searchMore": {},
     "formattedMessagesDescription": "Używaj Markdown do wyświetlania dodatkowego formatowania w wiadomościach, jak np. pogrubienie tekstu.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Zweryfikuj innego użytkownika",
-    "@verifyOtherUser": {},
     "knockRestricted": "Pukanie jest ograniczone",
     "@knockRestricted": {},
     "appLockDescription": "Zablokuj aplikację pinem kiedy nie jest używana",
@@ -2725,10 +2500,6 @@
     "@knocking": {},
     "pleaseChooseAStrongPassword": "Proszę wybrać silne hasło",
     "@pleaseChooseAStrongPassword": {},
-    "usersMustKnock": "Użytkownicy muszą zapukać",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Nikt nie może dołączyć",
-    "@noOneCanJoin": {},
     "alwaysUse24HourFormat": "false",
     "@alwaysUse24HourFormat": {
         "description": "Set to true to always display time of day in 24 hour format."
@@ -2750,22 +2521,6 @@
     "@databaseMigrationBody": {},
     "leaveEmptyToClearStatus": "Pozostaw puste, aby wyczyścić swój status.",
     "@leaveEmptyToClearStatus": {},
-    "sessionLostBody": "Twoja sesja została utracona. Prosimy zgłosić ten błąd autorom aplikacji na {url}. Treść błędu to: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "publicChatAddresses": "Adresy publicznych czatów",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Utwórz nowy adres",
-    "@createNewAddress": {},
     "completedKeyVerification": "{sender} zakończył/-a weryfikację kluczy",
     "@completedKeyVerification": {
         "type": "String",
@@ -2783,12 +2538,6 @@
     "@strikeThrough": {},
     "incomingMessages": "Wiadomości przychodzące",
     "@incomingMessages": {},
-    "discoverHomeservers": "Odkrywaj serwery domowe",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Czym jest serwer domowy?",
-    "@whatIsAHomeserver": {},
-    "loginWithMatrixId": "Zaloguj się identyfikatorem Matrix",
-    "@loginWithMatrixId": {},
     "passwordsDoNotMatch": "Hasła się nie zgadzają",
     "@passwordsDoNotMatch": {},
     "unbanUserDescription": "Użytkownik będzie w stanie dołączyć do czatu ponownie.",
@@ -2806,8 +2555,6 @@
     },
     "changeGeneralChatSettings": "Zmień ogólne ustawienia czatu",
     "@changeGeneralChatSettings": {},
-    "verifyOtherUserDescription": "Jeśli zweryfikujesz innego użytkownika, możesz być pewien/-na z kim naprawdę piszesz. 💪\n\nKiedy rozpoczniesz weryfikację, Ty i ta druga osoba zobaczycie okienko dialogowe. Zobaczycie w nim serię emotikonów lub numery do porównania.\n\nNajlepiej potwierdzić ich zgodność osobiście lub przez wideorozmowę. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDeviceDescription": "Jeśli zweryfikujesz inne urządzenie, będzie mogło ono wymienić klucze z dotychczasowym, zwiększając ogólne bezpieczeństwo. 💪 Kiedy rozpoczniesz weryfikację, na obu urządzeniach wyświetli się okno dialogowe. Zobaczysz w nim serię emotikonów lub numery do porównania. Najlepiej mieć oba urządzenia pod ręką przed rozpoczęciem weryfikacji. 🤳",
     "@verifyOtherDeviceDescription": {},
     "unreadChatsInApp": "{appname}: {unread} nieprzeczytanych czatów",
@@ -2838,12 +2585,6 @@
     "@removeDevicesDescription": {},
     "makeAdminDescription": "Kiedy użytkownik zostanie adminem, nie będziesz móc tego cofnąć, bo nabierze takich samych uprawnień, jak Ty.",
     "@makeAdminDescription": {},
-    "searchChatsRooms": "Szukaj #czatów, @użytkowników...",
-    "@searchChatsRooms": {},
-    "createGroupAndInviteUsers": "Utwórz grupę i zaproś użytkowników",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "Grupa może być znaleziona poprzez wyszukiwanie",
-    "@groupCanBeFoundViaSearch": {},
     "wrongRecoveryKey": "Niestety to nie wygląda na poprawny klucz odzyskiwania.",
     "@wrongRecoveryKey": {},
     "searchForUsers": "Szukaj @użytkowników...",
@@ -2854,8 +2595,6 @@
     "@passwordIsWrong": {},
     "joinSpace": "Dołącz do przestrzeni",
     "@joinSpace": {},
-    "addChatOrSubSpace": "Dodaj czat lub podprzestrzeń",
-    "@addChatOrSubSpace": {},
     "initAppError": "Wystąpił błąd podczas inicjalizacji aplikacji",
     "@initAppError": {},
     "searchIn": "Szukaj w czacie \"{chat}\"...",
@@ -2869,17 +2608,6 @@
     },
     "kickUserDescription": "Użytkownik jest wyrzucony z czatu, ale nie zbanowany. Do czatu publicznego może dołączyć ponownie.",
     "@kickUserDescription": {},
-    "appWantsToUseForLogin": "Użyj serwera '{server}' do zalogowania się",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Niniejszym zezwalasz aplikacji i witrynie na udostępnianie informacji o sobie.",
-    "@appWantsToUseForLoginDescription": {},
     "open": "Otwórz",
     "@open": {},
     "contentNotificationSettings": "Ustawienia powiadomień o treści",
@@ -2994,8 +2722,6 @@
     },
     "waitingForServer": "Oczekiwanie na serwer...",
     "@waitingForServer": {},
-    "appIntroduction": "FluffyChat umożliwia czatowanie ze znajomymi za pośrednictwem różnych komunikatorów. Dowiedz się więcej na stronie https://matrix.org lub kliknij na *Kontynuuj*.",
-    "@appIntroduction": {},
     "previous": "Poprzedni",
     "@previous": {},
     "otherPartyNotLoggedIn": "Druga strona nie jest obecnie zalogowana i dlatego nie może odbierać wiadomości!",
@@ -3028,15 +2754,6 @@
     "@commandHint_roomupgrade": {},
     "enterNewChat": "Dołącz do nowego czatu",
     "@enterNewChat": {},
-    "countInvited": "{count} zaproszonych",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "sentVoiceMessage": "🎙️ {duration} - Wiadomość głosowa od: {sender}",
     "@sentVoiceMessage": {
         "type": "String",
@@ -3083,11 +2800,9 @@
     "taTooltip": "L2 użycie z pomocą tłumaczeniową",
     "interactiveTranslatorSliderHeader": "Interaktywny Tłumacz",
     "interactiveGrammarSliderHeader": "Interaktywny Sprawdzacz Gramatyczny",
-    "interactiveTranslatorRequired": "Wymagane",
     "waTooltip": "L2 użycie bez pomocy",
     "interactiveTranslator": "Wspomaganie tłumaczenia",
     "noIdenticalLanguages": "Proszę wybrać różne języki bazowe i docelowe",
-    "searchBy": "Szukaj według kraju i języków",
     "joinWithClassCode": "Dołącz do kursu",
     "languageLevelPreA1": "Nowicjusz Niski (Pre A1)",
     "languageLevelA1": "Nowicjusz Środkowy (A1)",
@@ -3108,19 +2823,14 @@
     "saveChanges": "Zapisz zmiany",
     "publicProfileTitle": "Pozwól, aby mój profil był znajdowany w wyszukiwarce",
     "publicProfileDesc": "Włączając tę opcję, umożliwiasz innym użytkownikom znalezienie Twojego profilu w globalnej wyszukiwarce i wysyłanie zapytań do czatu. W tym momencie możesz zaakceptować lub odrzucić zapytanie.",
-    "errorDisableIT": "Pomoc w tłumaczeniu jest wyłączona.",
-    "errorDisableIGC": "Pomoc gramatyczna jest wyłączona.",
     "errorDisableITUserDesc": "Kliknij tutaj, aby zaktualizować ustawienia pomocy w tłumaczeniu",
     "errorDisableIGCUserDesc": "Kliknij tutaj, aby zaktualizować ustawienia pomocy gramatycznej",
     "errorDisableITClassDesc": "Pomoc w tłumaczeniu jest wyłączona dla kursu, w którym znajduje się ten czat.",
     "errorDisableIGCClassDesc": "Pomoc gramatyczna jest wyłączona dla kursu, w którym znajduje się ten czat.",
-    "error405Title": "Języki nie ustawione",
     "error405Desc": "Ustaw swoje języki w menu głównym > Ustawienia nauki.",
     "termsAndConditions": "Warunki i zasady",
     "andCertifyIAmAtLeast13YearsOfAge": " oraz potwierdzam, że mam co najmniej 16 lat.",
-    "error502504Title": "Wow, jest wielu uczniów online!",
     "error502504Desc": "Narzędzia do tłumaczeń i sprawdzania gramatyki mogą działać wolno lub być niedostępne, podczas gdy boty Pangea nadążają za ruchem.",
-    "error404Title": "Błąd tłumaczenia!",
     "error404Desc": "Bot Pangea nie jest pewien, jak to przetłumaczyć...",
     "errorPleaseRefresh": "Pracujemy nad tym! Odśwież stronę i spróbuj ponownie.",
     "connectedToStaging": "Połączono z wersją testową",
@@ -3158,13 +2868,9 @@
     "definitionsToolName": "Definicje słów",
     "definitionsToolDescription": "Po włączeniu słowa podkreślone na niebiesko można kliknąć, aby zobaczyć definicje. Kliknij wiadomości, aby uzyskać dostęp do definicji.",
     "welcomeBack": "Witamy ponownie! Jeśli brałeś udział w pilotażu 2023-2024, skontaktuj się z nami, aby uzyskać specjalną subskrypcję pilotażową. Jeśli jesteś nauczycielem, który (lub Twoja instytucja) zakupił licencje dla Twojej klasy, skontaktuj się z nami w sprawie subskrypcji nauczyciela.",
-    "downloadTxtFile": "Pobierz plik tekstowy",
-    "downloadCSVFile": "Pobierz plik CSV",
     "promotionalSubscriptionDesc": "Obecnie masz dożywotnią subskrypcję promocyjną. Skontaktuj się z support@pangea.chat, aby uzyskać pomoc w zmianie subskrypcji.",
     "originalSubscriptionPlatform": "Subskrypcja zakupiona przez {purchasePlatform}",
     "oneWeekTrial": "Tydzień próbny",
-    "downloadXLSXFile": "Pobierz plik Excel",
-    "unkDisplayName": "Nieznany",
     "wwCountryDisplayName": "Na całym świecie",
     "afCountryDisplayName": "Afganistan",
     "axCountryDisplayName": "Wyspy Alandzkie",
@@ -3459,7 +3165,6 @@
     "chatCapacityHasBeenChanged": "Pojemność czatu została zmieniona",
     "chatCapacitySetTooLow": "Pojemność czatu musi wynosić co najmniej {count}.",
     "chatCapacityExplanation": "Pojemność czatu ogranicza liczbę członków dozwolonych w czacie.",
-    "tooManyRequest": "Zbyt wiele żądań, spróbuj ponownie później.",
     "enterNumber": "Wprowadź wartość liczby całkowitej.",
     "practice": "Ćwiczenia",
     "versionNotFound": "Nie znaleziono wersji",
@@ -3469,7 +3174,6 @@
     "deleteSubscriptionWarningTitle": "Masz aktywną subskrypcję",
     "deleteSubscriptionWarningBody": "Usunięcie konta nie spowoduje automatycznego anulowania subskrypcji.",
     "manageSubscription": "Zarządzaj subskrypcją",
-    "error520Title": "Spróbuj ponownie.",
     "error520Desc": "Przepraszamy, nie mogliśmy zrozumieć Twojej wiadomości...",
     "wordsUsed": "Użyte słowa",
     "level": "Poziom",
@@ -3487,7 +3191,6 @@
     "other": "Inne",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "Brak limitu pojemności",
-    "downloadGroupText": "Pobierz tekst grupy",
     "notificationsOn": "Powiadomienia włączone",
     "notificationsOff": "Powiadomienia wyłączone",
     "joinWithCode": "Dołącz z kodem",
@@ -3551,24 +3254,12 @@
     "whatIsTheMorphTag": "Czym jest {morphologicalFeature} w '{wordForm}'?",
     "dataAvailable": "Dostępność danych",
     "available": "Dostępne",
-    "pangeaBotIsFallible": "Pangea Bot popełnia błędy też!",
-    "whatIsMeaning": "Co oznacza '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Dopasuj znaczenia do słów w wiadomości!",
-    "doubleClickToEdit": "Kliknij dwukrotnie, aby edytować.",
-    "topicLabel": "Temat",
-    "topicPlaceholder": "Wybierz temat...",
-    "modePlaceholder": "Wybierz tryb...",
-    "learningObjectiveLabel": "Cel nauki",
-    "learningObjectivePlaceholder": "Wybierz cel nauki...",
-    "targetLanguageLabel": "Język docelowy",
     "cefrLevelLabel": "Poziom CEFR",
     "image": "Obraz",
     "video": "Wideo",
     "nan": "Nie dotyczy",
-    "addVocabulary": "Dodaj słownictwo",
     "instructions": "Instrukcje",
-    "numberOfLearners": "Liczba uczniów",
-    "mustBeInteger": "Musi być liczbą całkowitą np. 1, 2, 3, ...",
     "constructUsePvmDesc": "Wygenerowane w wiadomości głosowej",
     "leaveSpaceDescription": "Opuszczając kurs, opuścisz wszystkie czaty w nim zawarte. Inni użytkownicy zobaczą, że opuściłeś kurs.",
     "constructUseCorMmDesc": "Poprawne znaczenie wiadomości",
@@ -3583,7 +3274,6 @@
     "ttsDisabledBody": "Możesz włączyć syntezę tekstu na mowie w ustawieniach nauki",
     "noSpaceDescriptionYet": "Nie utworzono jeszcze opisu kursu.",
     "tooLargeToSend": "Ta wiadomość jest za duża, aby ją wysłać",
-    "exitWithoutSaving": "Czy na pewno chcesz opuścić bez zapisywania?",
     "enableAutocorrectPopupTitle": "Dodaj klawiaturę języka docelowego, przechodząc do:",
     "enableAutocorrectPopupSteps": "  • Ustawienia\n  • Ogólne\n  • Klawiatura\n  • Klawiatury\n  • Dodaj nową klawiaturę",
     "enableAutocorrectPopupDescription": "Po wybraniu języka możesz kliknąć małą ikonę globu w lewym dolnym rogu klawiatury, aby aktywować nowo zainstalowaną klawiaturę.",
@@ -3594,11 +3284,8 @@
     "displayName": "Nazwa wyświetlana",
     "leaveRoomDescription": "Zamierzasz opuścić ten czat. Inni użytkownicy zobaczą, że opuściłeś czat.",
     "confirmUserId": "Proszę potwierdź swoją nazwę użytkownika Pangea Chat, aby usunąć swoje konto.",
-    "startingToday": "Od dziś",
-    "oneWeekFreeTrial": "Tydzień bezpłatnego okresu próbnego",
     "paidSubscriptionStarts": "Rozpoczyna się {startDate}",
     "cancelInSubscriptionSettings": "• Anuluj w dowolnym momencie w ustawieniach subskrypcji",
-    "cancelToAvoidCharges": "• Anuluj przed {trialEnds}, aby uniknąć opłat",
     "downloadGboard": "Pobierz Gboard",
     "autocorrectNotAvailable": "Niestety, Twoja platforma nie jest obecnie obsługiwana dla tej funkcji. Bądź na bieżąco z dalszym rozwojem!",
     "pleaseUpdateApp": "Zaktualizuj aplikację, aby kontynuować.",
@@ -3608,17 +3295,12 @@
     "knockSpaceSuccess": "Poprosiłeś o dołączenie do tego kursu! Administrator odpowie na Twoją prośbę, gdy ją otrzyma 😊",
     "chooseWordAudioInstructionsBody": "Posłuchaj pełnej wiadomości. Następnie dopasuj dźwięki do słów.",
     "chooseMorphsInstructionsBody": "Kliknij kawałki układanki, aby odpowiedzieć na pytania gramatyczne!",
-    "pleaseEnterInt": "Proszę wprowadzić liczbę",
     "home": "Strona główna",
     "join": "Dołącz",
     "resetInstructionTooltipsTitle": "Zresetuj podpowiedzi instrukcji",
     "resetInstructionTooltipsDesc": "Kliknij, aby wyświetlić podpowiedzi instrukcji, jak dla nowego użytkownika.",
-    "randomize": "Losuj",
     "clear": "Wyczyść",
-    "featuredActivities": "Polecane",
     "save": "Zapisz",
-    "startChat": "Rozpocznij rozmowę",
-    "translationProblem": "Problem z tłumaczeniem",
     "askToJoin": "Poproś o dołączenie",
     "emptyChatWarningTitle": "Czat jest pusty",
     "emptyChatWarningDesc": "Nie zaprosiłeś nikogo do swojego czatu. Przejdź do ustawień czatu, aby zaprosić kontakty lub bota. Możesz to zrobić również później.",
@@ -3648,17 +3330,13 @@
     "timesUsedIndependently": "Liczba użyć samodzielnie",
     "timesUsedWithAssistance": "Liczba użyć z pomocą",
     "shareInviteCode": "Udostępnij kod zaproszenia: {code}",
-    "leaderboard": "Tablica wyników",
     "skipForNow": "Pomiń na razie",
     "permissions": "Uprawnienia",
     "spaceChildPermission": "Kto może dodawać nowe czaty do tego kursu",
-    "addEnvironmentOverride": "Dodaj nadpisanie środowiska",
     "defaultOption": "Domyślnie",
     "deleteChatDesc": "Czy na pewno chcesz usunąć ten czat? Zostanie on usunięty dla wszystkich uczestników, a wszystkie wiadomości w czacie nie będą już dostępne do ćwiczeń lub analityki nauki.",
     "deleteSpaceDesc": "Kurs i wybrane czaty zostaną usunięte dla wszystkich uczestników, a wszystkie wiadomości w czacie nie będą już dostępne do ćwiczeń lub analityki nauki. Ta operacja jest nieodwracalna.",
     "launch": "Uruchom",
-    "searchChats": "Wyszukaj czaty",
-    "maxFifty": "Max 50",
     "configureSpace": "Konfiguruj kurs",
     "pinMessages": "Przypnij wiadomości",
     "setJoinRules": "Ustaw zasady dołączenia",
@@ -3692,9 +3370,6 @@
     "failedToFetchTranscription": "Nie udało się pobrać transkrypcji",
     "deleteEmptySpaceDesc": "Kurs zostanie usunięty dla wszystkich uczestników. Ta akcja jest nieodwracalna.",
     "regenerate": "Regeneruj",
-    "mySavedActivities": "Moje zapisane aktywności",
-    "noSavedActivities": "Brak zapisanych aktywności",
-    "saveActivity": "Zapisz tę aktywność",
     "failedToPlayVideo": "Nie udało się odtworzyć filmu",
     "done": "Gotowe",
     "inThisSpace": "W tym kursie",
@@ -3705,13 +3380,9 @@
     "numInvited": "{count} zaproszonych",
     "saved": "Zapisane",
     "reset": "Resetuj",
-    "errorFetchingActivitiesMessage": "Nie udało się pobrać aktywności",
     "errorFetchingDefinition": "Nie udało się pobrać definicji",
     "errorProcessAnalytics": "Nie udało się przetworzyć analityki",
     "errorDownloading": "Pobieranie nie powiodło się",
-    "errorLoadingSpaceChildren": "Nie udało się załadować czatów w ramach tego kursu",
-    "unexpectedError": "Nieoczekiwany błąd.",
-    "pleaseReload": "Proszę odświeżyć i spróbować ponownie.",
     "translationError": "Błąd tłumaczenia",
     "check": "Sprawdź",
     "unableToFindRoom": "Nie znaleziono czatu ani kursu z tym kodem. Spróbuj ponownie.",
@@ -3720,19 +3391,14 @@
     "request": "Żądanie",
     "requestAll": "Zażądaj wszystkiego",
     "confirmMessageUnpin": "Czy na pewno chcesz odpiąć tę wiadomość?",
-    "saveAndLaunch": "Zapisz i uruchom",
-    "launchToSpace": "Uruchom do kursu",
     "pending": "Oczekujące",
     "inactive": "Nieaktywne",
-    "confirmRole": "Potwierdź rolę",
     "openRoleLabel": "OTWARTA",
     "finishedTheActivity": "🎯 {username} zakończył tę aktywność",
     "activitySummaryError": "Podsumowania aktywności niedostępne",
     "requestSummaries": "Żądaj podsumowań",
-    "generatingNewActivities": "Jesteś pierwszym użytkownikiem tego zestawu językowego! Prosimy o chwilę, przygotowujemy dla Ciebie aktywności.",
     "requestAccessTitle": "Czy chcesz poprosić o dostęp do analityki?",
     "requestAccessDesc": "Czy chcesz poprosić o dostęp do analityki uczestników?\n\nJeśli uczestnicy się zgodzą, administratorzy tego kursu będą mogli zobaczyć ich:\n    • łączny słownik\n    • łączną gramatykę\n    • łączną liczbę ukończonych sesji aktywności\n    • konkretne użyte, poprawne i niepoprawne koncepty gramatyczne\n\nNie będą mogli zobaczyć ich:\n    • wiadomości w czatach spoza kursu\n    • listy słówek",
-    "requestAccess": "Poproś o dostęp ({count})",
     "analyticsInactiveTitle": "Wnioski do nieaktywnych użytkowników nie mogły zostać wysłane",
     "analyticsInactiveDesc": "Nieaktywni użytkownicy, którzy nie zalogowali się od momentu wprowadzenia tej funkcji, nie zobaczą Twojego wniosku.\n\nPrzycisk „Poproś” pojawi się, gdy wrócą. Możesz ponownie wysłać wniosek, klikając przycisk „Poproś” pod ich nazwiskiem, gdy będzie dostępny.",
     "accessRequestedTitle": "Wniosek o dostęp do analityki",
@@ -3755,8 +3421,6 @@
     "accessDesc": "Możesz uczynić swój kurs otwartym dla świata! Lub, uczynić go prywatnym i bezpiecznym.",
     "createGroupChatDesc": "Podczas gdy sesje aktywności zaczynają się i kończą, czaty grupowe pozostaną otwarte do rutynowej komunikacji.",
     "deleteDesc": "Tylko administratorzy mogą usunąć kurs. To działanie destrukcyjne, które usuwa wszystkich użytkowników i kasuje wszystkie wybrane czaty w kursie. Postępuj ostrożnie.",
-    "noCourseFound": "O, ten kurs potrzebuje planu!\n\nPlany kursów to sekwencje tematów i aktywności konwersacyjnych.",
-    "additionalParticipants": "+ {num} innych",
     "whatNow": "Co teraz?",
     "chooseNextActivity": "Wybierz swoją następną aktywność!",
     "letsGo": "Chodźmy",
@@ -3769,13 +3433,11 @@
     "waitNotDone": "Czekaj, nie skończyłem!",
     "waitingForOthersToFinish": "Czekanie na resztę do ukończenia...",
     "generatingSummary": "Analiza czatu i generowanie wyników",
-    "findCourse": "Znajdź kurs",
     "pingParticipantsNotification": "{user} szuka użytkowników do dołączenia do sesji aktywności w {room}",
     "course": "Kurs",
     "courses": "Kursy",
     "goToCourse": "Przejdź do kursu: {course}",
     "activityComplete": "Ta aktywność została ukończona. Podsumowanie aktywności powinno być dostępne poniżej.",
-    "startNewSession": "Rozpocznij nową sesję",
     "joinOpenSession": "Dołącz do otwartej sesji",
     "activityNotFound": "Nie znaleziono aktywności",
     "myActivities": "Moje aktywności",
@@ -3849,10 +3511,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3862,10 +3520,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -3953,14 +3607,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -3977,10 +3623,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -3993,15 +3635,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4153,14 +3787,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4174,14 +3800,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5404,10 +5022,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5448,10 +5062,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5524,10 +5134,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5797,47 +5403,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5857,19 +5423,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -5933,10 +5487,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -5977,14 +5527,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -5996,14 +5538,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6041,10 +5575,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6061,27 +5591,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6205,10 +5719,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6218,10 +5728,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6238,14 +5744,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6385,18 +5883,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6445,10 +5931,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6458,18 +5940,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6512,23 +5982,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6552,10 +6010,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6563,14 +6017,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6675,18 +6121,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6739,10 +6173,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6769,10 +6199,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -6953,7 +6379,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Sprawdź jutro aktualizacje aktywności.",
-    "activityDropdownDesc": "Gdy skończysz z tą aktywnością, kliknij poniżej",
     "languageMismatchTitle": "Niezgodność języków",
     "languageMismatchDesc": "Twój język docelowy nie zgadza się z językiem tej aktywności. Chcesz zaktualizować swój język docelowy?",
     "reportWordIssueTooltip": "Zgłoś problem z informacją o słowie",
@@ -6966,10 +6391,6 @@
     "selectAll": "Zaznacz wszystko",
     "deselectAll": "Odznacz wszystko",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7018,17 +6439,11 @@
         "placeholders": {}
     },
     "startOwn": "Rozpocznij własny",
-    "joinCourseDesc": "Każdy kurs składa się z 8-10 sekwencyjnych tematów z różnorodnymi zadaniami do nauki języka.",
     "newMessageInPangeaChat": "📝 Nowa wiadomość w Pangea Chat",
     "shareCourse": "Udostępnij kurs",
     "addCourse": "Dodaj kurs",
-    "joinPublicCourse": "Dołącz do kursu publicznego",
     "vocabLevelsDesc": "To tutaj pojawią się słowa słownictwa, gdy je podniesiesz na wyższy poziom!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7041,10 +6456,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7063,7 +6474,6 @@
     "emojiView": "Widok emoji",
     "feedbackDialogDesc": "Też popełniam błędy! Czy jest coś, co mogłoby mi pomóc się poprawić?",
     "contactHasBeenInvitedToTheCourse": "Kontakt został zaproszony do kursu",
-    "activityStatsButtonTooltip": "Informacje o aktywności",
     "allow": "Zezwól",
     "deny": "Odmów",
     "enabledRenewal": "Włącz odnowienie subskrypcji",
@@ -7331,10 +6741,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8389,16 +7795,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktywności do odblokowania następnego tematu",
-    "activitiesToUnlockTopicDesc": "Ustaw liczbę aktywności do odblokowania następnego tematu kursu",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Poprawna praktyka definicji słownictwa",
     "constructUseIncLMDesc": "Niepoprawna praktyka definicji słownictwa",
     "constructUseCorLADesc": "Poprawna praktyka audio słownictwa",
@@ -8406,7 +7802,6 @@
     "constructUseBonus": "Bonus podczas praktyki słownictwa",
     "practiceVocab": "Ćwicz słownictwo",
     "selectMeaning": "Wybierz znaczenie",
-    "selectAudio": "Wybierz pasujące audio",
     "anotherRound": "Kolejna runda",
     "activitySettingsOverrideWarning": "Język i poziom językowy określone przez plan aktywności",
     "voice": "Głos",
@@ -8438,10 +7833,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8459,12 +7850,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Pobieranie zainicjowane",
     "webDownloadPermissionMessage": "Jeśli Twoja przeglądarka blokuje pobieranie, włącz pobieranie dla tej strony.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8559,11 +7945,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Coś poszło nie tak, a my ciężko pracujemy nad naprawą. Sprawdź ponownie później.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Włącz pomoc w pisaniu",
     "autoIGCToolDescription": "Automatycznie uruchom narzędzia Pangea Chat, aby poprawić wysłane wiadomości na docelowy język.",
     "@autoIGCToolName": {
@@ -8619,24 +8000,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatyka",
-    "spanTypeWordChoice": "Wybór słów",
     "spanTypeSpelling": "Ortografia",
     "spanTypePunctuation": "Interpunkcja",
     "spanTypeStyle": "Styl",
     "spanTypeFluency": "Płynność",
     "spanTypeAccents": "Akcenty",
     "spanTypeCapitalization": "Kapitalizacja",
-    "spanTypeCorrection": "Korekta",
     "spanFeedbackTitle": "Zgłoś problem z korektą",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8661,10 +8031,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8675,13 +8041,7 @@
     "longPressToRecordVoiceMessage": "Długie naciśnięcie, aby nagrać wiadomość głosową.",
     "pause": "Pauza",
     "resume": "Wznów",
-    "newSubSpace": "Nowa podprzestrzeń",
-    "moveToDifferentSpace": "Przenieś do innej przestrzeni",
-    "removeFromSpaceDescription": "Czat zostanie usunięty z przestrzeni, ale nadal będzie widoczny na liście czatów.",
     "countChats": "{chats} czatów",
-    "spaceMemberOf": "Członek przestrzeni {spaces}",
-    "spaceMemberOfCanKnock": "Członek przestrzeni {spaces} może zapukać",
-    "donate": "Darowizna",
     "startedAPoll": "{username} rozpoczął ankietę.",
     "poll": "Ankieta",
     "startPoll": "Rozpocznij ankietę",
@@ -8705,23 +8065,15 @@
     "newStickerPack": "Nowy pakiet naklejek",
     "stickerPackName": "Nazwa pakietu naklejek",
     "attribution": "Atrybut",
-    "skipChatBackup": "Pomiń kopię zapasową czatu",
-    "skipChatBackupWarning": "Czy jesteś pewny? Bez włączenia kopii zapasowej czatu możesz stracić dostęp do swoich wiadomości, jeśli zmienisz urządzenie.",
-    "loadingMessages": "Ładowanie wiadomości",
-    "setupChatBackup": "Skonfiguruj kopię zapasową czatu",
     "noMoreResultsFound": "Nie znaleziono więcej wyników",
     "chatSearchedUntil": "Czat przeszukany do {time}",
     "federationBaseUrl": "Podstawowy URL federacji",
     "clientWellKnownInformation": "Informacje o kliencie - znane:",
     "baseUrl": "Podstawowy URL",
     "identityServer": "Serwer tożsamości:",
-    "versionWithNumber": "Wersja: {version}",
     "logs": "Dzienniki",
-    "advancedConfigs": "Zaawansowane konfiguracje",
     "advancedConfigurations": "Zaawansowane konfiguracje",
-    "signInWithLabel": "Zaloguj się za pomocą:",
     "selectAllWords": "Wybierz wszystkie słowa, które słyszysz w audio",
-    "joinCourseForActivities": "Dołącz do kursu, aby spróbować aktywności.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -8750,18 +8102,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -8769,26 +8109,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -8894,22 +8214,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8938,19 +8242,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8958,15 +8250,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9168,11 +8452,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "W klasie? Wpisz tutaj swój kod dołączenia.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automatyczne podświetlanie wiadomości audio",
     "selectAudioMessagesOnPlayDescription": "Automatycznie podświetlaj wiadomości audio podczas odtwarzania",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9216,18 +8495,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Ten kurs ma tematy z mniej niż {input} aktywności. Proszę wprowadzić liczbę mniejszą lub równą {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Kliknij tutaj, aby ponownie się zalogować.",
     "@clickToLogin": {
@@ -9644,17 +8911,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Karykaturalny żółty niedźwiedź z uniesionymi w górę rękami w ekscytacji.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Wybierz słowa, aby dowiedzieć się o nich więcej",
     "requireAnalyticsAccessTitle": "Wymagaj dostępu do analityki, aby dołączyć",
     "requireAnalyticsAccessDesc": "Uczestnicy muszą przyznać dostęp do swoich analiz uczenia się, aby dołączyć do tego kursu",
     "analyticsAccessNoticeTitle": "Wymagany dostęp do analityki",
     "analyticsAccessNoticeDesc": "Dołączając do tego kursu, zgadzasz się na udzielenie administratorom dostępu do swoich analiz uczenia się.",
-    "skipOnboardingClassCodeDesc": "Uczysz się samodzielnie? Nie martw się, możesz:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9672,10 +8933,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9704,7 +8961,6 @@
     "pickCefrLevelTeacherStepTitle": "Jaki poziom uczysz?",
     "pickCefrLevelStudentStepTitle": "Jaki jesteś na poziomie?",
     "customCourseStepTitle": "Wypełnij ten formularz, aby uzyskać spersonalizowany kurs",
-    "aboutYourClass": "O twojej klasie",
     "courseCodeStepErrorMessage": "Sprawdź swój kod i spróbuj ponownie",
     "institution": "Instytucja",
     "courseGoals": "Cele kursu",
@@ -9747,10 +9003,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9867,12 +9119,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logo Pangea Chat",
     "introChatDetails": "Przywitaj się! Przedstaw się swoim kolegom z kursu, znajdź przyjaciół i rozmawiaj poza zajęciami.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9916,11 +9163,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Akcje aktywności",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Narzędzia do wymowy",
     "audioTranscription": "Transkrypcja audio AI",
     "visualLearnerSupport": "Wsparcie dla uczniów wzrokowych",
@@ -9961,7 +9203,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Dołącz do kursu, który zawiera tę aktywność, aby w nią zagrać.",
     "resizeCoursePanel": "Zmień rozmiar panelu kursu",
     "undo": "Cofnij",
     "unlock": "Odblokuj",
@@ -9975,7 +9216,6 @@
     "addCourseBrowsePublic": "Przeglądaj publiczne kursy",
     "browsePublicCourses": "Przeglądaj publiczne kursy",
     "editProfile": "Edytuj profil",
-    "numObjectives": "{count} celów",
     "mapSearchHint": "Szukaj aktywności",
     "mapSearchNoResults": "Brak dopasowań w widoku",
     "mapFilterAllLanguages": "Wszystkie języki",
@@ -9984,7 +9224,6 @@
     "mapFilterCompleted": "Zakończone",
     "mapFilterReset": "Resetuj",
     "activityTypeConversation": "Rozmowa",
-    "lockedMissionRequirement": "Zakończ poprzednią misję, aby odblokować",
     "playAgain": "Graj ponownie",
     "reviewActivity": "Przegląd",
     "mapEmptyInView": "Nic tutaj na twoim poziomie lub języku. Poszerz swoje filtry lub oddal widok.",
@@ -9999,14 +9238,9 @@
     "scrollToBottom": "Przewiń na dół",
     "courseImage": "Obraz kursu",
     "avatarPreview": "Podgląd awatara",
-    "activityPhoto": "Zdjęcie aktywności",
     "emotePreview": "Podgląd emotki: {name}",
     "activityLabel": "Aktywność: {title}",
     "resetMapView": "Zresetuj widok mapy",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10059,14 +9293,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10096,10 +9322,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10156,10 +9378,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -178,31 +178,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@reportErrorDescription": {
         "type": "String",
         "placeholders": {}
     },
     "@directChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
-    "@addAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -362,10 +342,6 @@
             }
         }
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youAcceptedTheInvitation": {
         "type": "String",
         "placeholders": {}
@@ -491,10 +467,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blocked": {
         "type": "String",
         "placeholders": {}
@@ -506,10 +478,6 @@
             }
         },
         "type": "String"
-    },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "@unbanUserDescription": {
         "type": "String",
@@ -574,18 +542,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@emailOrUsername": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@next": {
         "type": "String",
         "placeholders": {}
@@ -603,14 +559,6 @@
         }
     },
     "@editRoomAliases": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
         "type": "String",
         "placeholders": {}
     },
@@ -639,10 +587,6 @@
         "placeholders": {}
     },
     "@reopenChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKey": {
         "type": "String",
         "placeholders": {}
     },
@@ -678,10 +622,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@addWidget": {
         "type": "String",
         "placeholders": {}
@@ -707,10 +647,6 @@
         "type": "String"
     },
     "@noKeyForThisMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -745,14 +681,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@replaceRoomWithNewerVersion": {
         "type": "String",
         "placeholders": {}
@@ -784,10 +712,6 @@
             }
         }
     },
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@cantOpenUri": {
         "type": "String",
         "placeholders": {
@@ -797,10 +721,6 @@
         }
     },
     "@sender": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
         "type": "String",
         "placeholders": {}
     },
@@ -867,10 +787,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@passwordHasBeenChanged": {
         "type": "String",
         "placeholders": {}
@@ -888,10 +804,6 @@
         "placeholders": {}
     },
     "@copy": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -931,10 +843,6 @@
             }
         }
     },
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@importFromZipFile": {
         "type": "String",
         "placeholders": {}
@@ -951,15 +859,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@emptyChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@yourChatBackupHasBeenSetUp": {
         "type": "String",
         "placeholders": {}
     },
@@ -976,10 +876,6 @@
         }
     },
     "@submit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@videoCallsBetaWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1014,14 +910,6 @@
     "@participant": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@yes": {
         "type": "String",
@@ -1111,10 +999,6 @@
         "placeholders": {}
     },
     "@register": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
         "type": "String",
         "placeholders": {}
     },
@@ -1293,10 +1177,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterRecoveryKeyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@guestsAreForbidden": {
         "type": "String",
         "placeholders": {}
@@ -1455,10 +1335,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@redactMessage": {
         "type": "String",
         "placeholders": {}
@@ -1538,10 +1414,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@verifyStart": {
         "type": "String",
         "placeholders": {}
@@ -1563,10 +1435,6 @@
         "placeholders": {}
     },
     "@serverRequiresEmail": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
         "type": "String",
         "placeholders": {}
     },
@@ -1682,10 +1550,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@directChat": {
         "type": "String",
         "placeholders": {}
@@ -1718,25 +1582,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterAnEmailAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@voiceCall": {
         "type": "String",
         "placeholders": {}
     },
     "@commandHint_kick": {
         "type": "String",
         "description": "Usage hint for the command /kick"
-    },
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "@commandHint_unban": {
         "type": "String",
@@ -1790,10 +1642,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@confirmMatrixId": {
         "type": "String",
         "placeholders": {}
@@ -1823,10 +1671,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1866,10 +1710,6 @@
         "placeholders": {}
     },
     "@pleaseEnterANumber": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1923,31 +1763,15 @@
             }
         }
     },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@oopsSomethingWentWrong": {
         "type": "String",
         "placeholders": {}
-    },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@shareInviteLink": {
         "type": "String",
         "placeholders": {}
     },
     "@commandHint_markasdm": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
         "type": "String",
         "placeholders": {}
     },
@@ -1972,10 +1796,6 @@
         "placeholders": {}
     },
     "@waitingPartnerNumbers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -2007,14 +1827,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@changeTheHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -2038,10 +1850,6 @@
                 "type": "String"
             }
         }
-    },
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
     },
     "@changeDeviceName": {
         "type": "String",
@@ -2223,10 +2031,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@openChat": {
         "type": "String",
         "placeholders": {}
@@ -2263,10 +2067,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@enableMultiAccounts": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anyoneCanJoin": {
         "type": "String",
         "placeholders": {}
@@ -2287,10 +2087,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@storeSecurlyOnThisDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@ok": {
         "type": "String",
         "placeholders": {}
@@ -2307,10 +2103,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@changedTheDisplaynameTo": {
         "type": "String",
         "placeholders": {
@@ -2319,14 +2111,6 @@
             },
             "displayname": {
                 "type": "String"
-            }
-        }
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
             }
         }
     },
@@ -2339,10 +2123,6 @@
         "placeholders": {}
     },
     "@placeCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2382,7 +2162,6 @@
     "appLock": "Bloqueio do aplicativo",
     "appLockDescription": "Bloqueie o aplicativo quando não estiver usando com um código PIN",
     "archive": "Arquivar",
-    "areGuestsAllowedToJoin": "Convidados podem participar?",
     "areYouSureYouWantToLogout": "Tem certeza de que deseja sair?",
     "askSSSSSign": "Para poder assinar a outra pessoa, por favor, insira sua frase secreta de armazenamento seguro ou chave de recuperação.",
     "askVerificationRequest": "Aceitar esta solicitação de verificação de {username}?",
@@ -2425,9 +2204,7 @@
     "changeYourAvatar": "Alterar seu avatar",
     "channelCorruptedDecryptError": "A criptografia foi corrompida",
     "chat": "Bate-papo",
-    "yourChatBackupHasBeenSetUp": "Seu backup de bate-papo foi configurado.",
     "chatBackup": "Backup de bate-papo",
-    "chatBackupDescription": "Suas mensagens antigas estão protegidas com uma chave de recuperação. Por favor, certifique-se de não perdê-la.",
     "chatDetails": "Detalhes do bate-papo",
     "chats": "Bate-papos",
     "chooseAStrongPassword": "Escolha uma senha forte",
@@ -2459,18 +2236,15 @@
     "configureChat": "Configurar chat",
     "confirm": "Confirmar",
     "connect": "Conectar",
-    "contactHasBeenInvitedToTheGroup": "Contato foi convidado para o grupo",
     "contentHasBeenReported": "O conteúdo foi reportado aos administradores do servidor",
     "copy": "Copiar",
     "copyToClipboard": "Copiar para a área de transferência",
     "couldNotDecryptMessage": "Não foi possível descriptografar a mensagem: {error}",
     "checkList": "Lista de verificação",
     "countParticipants": "{count} participantes",
-    "countInvited": "{count} convidados",
     "create": "Criar",
     "createdTheChat": "💬 {username} criou o chat",
     "createGroup": "Criar grupo",
-    "createNewSpace": "Novo espaço",
     "currentlyActive": "Atualmente ativo",
     "darkTheme": "Escuro",
     "deactivateAccountWarning": "Isso desativará sua conta de usuário. Isso não pode ser desfeito! Você tem certeza?",
@@ -2494,9 +2268,6 @@
     "emoteKeyboardNoRecents": "Emotes usados recentemente aparecerão aqui...",
     "emotePacks": "Pacotes de emotes para o grupo",
     "emoteSettings": "Configurações de Emote",
-    "globalChatId": "ID do bate-papo global",
-    "accessAndVisibility": "Acesso e visibilidade",
-    "accessAndVisibilityDescription": "Quem pode entrar neste bate-papo e como ele pode ser descoberto.",
     "calls": "Chamadas",
     "customEmojisAndStickers": "Emojis e stickers personalizados",
     "customEmojisAndStickersBody": "Adicione ou compartilhe emojis ou stickers personalizados que podem ser usados em qualquer chat.",
@@ -2504,7 +2275,6 @@
     "emptyChat": "Chat vazio",
     "enableEmotesGlobally": "Ativar pacote de emojis globalmente",
     "enableEncryption": "Ativar criptografia",
-    "enableEncryptionWarning": "Você não poderá mais desativar a criptografia. Tem certeza?",
     "encrypted": "Criptografado",
     "encryption": "Criptografia",
     "encryptionNotEnabled": "Criptografia não está ativada",
@@ -2512,7 +2282,6 @@
     "enterAnEmailAddress": "Digite um endereço de email",
     "homeserver": "Servidor principal",
     "errorObtainingLocation": "Erro ao obter localização: {error}",
-    "everythingReady": "Tudo pronto!",
     "extremeOffensive": "Extremamente ofensivo",
     "fileName": "Nome do arquivo",
     "fluffychat": "FluffyChat",
@@ -2521,9 +2290,7 @@
     "fromJoining": "Ao ingressar",
     "fromTheInvitation": "A partir do convite",
     "group": "Grupo",
-    "chatDescription": "Descrição do chat",
     "chatDescriptionHasBeenChanged": "Descrição do chat alterada",
-    "groupIsPublic": "O grupo é público",
     "groups": "Grupos",
     "groupWith": "Grupo com {displayname}",
     "guestsAreForbidden": "Convidados são proibidos",
@@ -2544,7 +2311,6 @@
     "incorrectPassphraseOrKey": "Frase de senha ou chave de recuperação incorreta",
     "inoffensive": "Inofensivo",
     "inviteContact": "Convidar contato",
-    "inviteContactToGroup": "Convidar contato para {groupName}",
     "noChatDescriptionYet": "Ainda não foi criada uma descrição para o chat.",
     "tryAgain": "Tentar novamente",
     "invalidServerName": "Nome de servidor inválido",
@@ -2565,7 +2331,6 @@
     "leave": "Sair",
     "leftTheChat": "Saiu do chat",
     "lightTheme": "Claro",
-    "loadCountMoreParticipants": "Carregar {count} participantes adicionais",
     "dehydrate": "Exportar sessão e limpar o dispositivo",
     "dehydrateWarning": "Esta ação não pode ser desfeita. Certifique-se de armazenar o arquivo de backup com segurança.",
     "hydrate": "Restaurar a partir do arquivo de backup",
@@ -2573,7 +2338,6 @@
     "loadMore": "Carregar mais…",
     "locationDisabledNotice": "Os serviços de localização estão desativados. Por favor, ative-os para poder compartilhar sua localização.",
     "locationPermissionDeniedNotice": "Permissão de localização negada. Por favor, conceda-as para poder compartilhar sua localização.",
-    "logInTo": "Faça login em {homeserver}",
     "mention": "Menção",
     "messagesStyle": "Mensagens:",
     "moderator": "Moderador",
@@ -2586,8 +2350,6 @@
     "no": "Não",
     "noConnectionToTheServer": "Sem conexão com o servidor",
     "noEmotesFound": "Nenhum emote encontrado. 😕",
-    "noEncryptionForPublicRooms": "Você só pode ativar a criptografia assim que a sala não estiver mais acessível ao público.",
-    "noGoogleServicesWarning": "Firebase Cloud Messaging não parece estar disponível no seu dispositivo. Para ainda receber notificações push, recomendamos instalar o ntfy. Com o ntfy ou outro provedor de Push Unificado, você pode receber notificações push de forma segura. Você pode baixar o ntfy na PlayStore ou no F-Droid.",
     "noMatrixServer": "{server1} não é um servidor Matrix, usar {server2} em vez disso?",
     "shareInviteLink": "Compartilhar link de convite",
     "scanQrCode": "Escanear código QR",
@@ -2607,12 +2369,10 @@
     "openAppToReadMessages": "Abra o aplicativo para ler mensagens",
     "openVideoCamera": "Abrir câmera para um vídeo",
     "oneClientLoggedOut": "Um de seus clientes foi desconectado",
-    "addAccount": "Adicionar conta",
     "editBundlesForAccount": "Editar pacotes para esta conta",
     "addToBundle": "Adicionar ao pacote",
     "removeFromBundle": "Remover deste pacote",
     "bundleName": "Nome do pacote",
-    "enableMultiAccounts": "(BETA) Ativar múltiplas contas neste dispositivo",
     "openInMaps": "Abrir no Maps",
     "link": "Link",
     "serverRequiresEmail": "Este servidor precisa validar seu endereço de email para registro.",
@@ -2624,7 +2384,6 @@
     "passwordHasBeenChanged": "Senha foi alterada",
     "overview": "Visão geral",
     "passwordRecoverySettings": "Configurações de recuperação de senha",
-    "passwordRecovery": "Recuperação de senha",
     "people": "Pessoas",
     "pickImage": "Escolha uma imagem",
     "pin": "Fixar",
@@ -2633,7 +2392,6 @@
     "pleaseChooseAPasscode": "Por favor, escolha um código de acesso",
     "pleaseClickOnLink": "Por favor, clique no link no e-mail e prossiga.",
     "pleaseEnter4Digits": "Por favor, insira 4 dígitos ou deixe vazio para desativar o bloqueio do aplicativo.",
-    "pleaseEnterRecoveryKey": "Por favor, insira sua chave de recuperação:",
     "pleaseEnterYourPassword": "Por favor, insira sua senha",
     "pleaseEnterYourPin": "Por favor, insira seu PIN",
     "pleaseEnterYourUsername": "Por favor, insira seu nome de usuário",
@@ -2651,7 +2409,6 @@
     "rejectedTheInvitation": "{username} rejeitou o convite",
     "removeAllOtherDevices": "Remover todos os outros dispositivos",
     "removedBy": "Removido por {username}",
-    "removeDevice": "Remover dispositivo",
     "unbanFromChat": "Desbanir do chat",
     "removeYourAvatar": "Remover seu avatar",
     "replaceRoomWithNewerVersion": "Substituir sala por uma versão mais recente",
@@ -2662,8 +2419,6 @@
     "roomVersion": "Versão da sala",
     "saveFile": "Salvar arquivo",
     "security": "Segurança",
-    "recoveryKey": "Chave de recuperação",
-    "recoveryKeyLost": "Chave de recuperação perdida?",
     "send": "Enviar",
     "sendAMessage": "Enviar uma mensagem",
     "sendAsText": "Enviar como texto",
@@ -2682,7 +2437,6 @@
     "separateChatTypes": "Separar Chats Diretos e Grupos",
     "setAsCanonicalAlias": "Definir como alias principal",
     "setChatDescription": "Definir descrição do chat",
-    "setPermissionsLevel": "Definir nível de permissões",
     "setStatus": "Definir status",
     "share": "Compartilhar",
     "sharedTheLocation": "{username} compartilhou sua localização",
@@ -2691,8 +2445,6 @@
     "presencesToggle": "Mostrar mensagens de status de outros usuários",
     "skip": "Pular",
     "sourceCode": "Código-fonte",
-    "spaceIsPublic": "Espaço é público",
-    "spaceName": "Nome do espaço",
     "startedACall": "{senderName} iniciou uma chamada",
     "status": "Status",
     "statusExampleMessage": "Como você está hoje?",
@@ -2704,7 +2456,6 @@
     "theyMatch": "Eles correspondem",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "Muitas solicitações. Por favor, tente novamente mais tarde!",
-    "transferFromAnotherDevice": "Transferir de outro dispositivo",
     "tryToSendAgain": "Tente enviar novamente",
     "unavailable": "Indisponível",
     "unbannedUser": "{username} desbanido {targetName}",
@@ -2714,7 +2465,6 @@
     "unknownEvent": "Evento desconhecido '{type}'",
     "unmuteChat": "Desativar o modo silencioso do chat",
     "unpin": "Desafixar",
-    "unreadChats": "{unreadCount, plural, =1{1 conversa não lida} other{{unreadCount} conversas não lidas}}",
     "userAndOthersAreTyping": "{username} e {count} outros estão digitando…",
     "userAndUserAreTyping": "{username} e {username2} estão digitando…",
     "userIsTyping": "{username} está digitando…",
@@ -2727,8 +2477,6 @@
     "verifyStart": "Iniciar verificação",
     "verifySuccess": "Você verificou com sucesso!",
     "verifyTitle": "Verificando outra conta",
-    "videoCall": "Chamada de vídeo",
-    "visibilityOfTheChatHistory": "Visibilidade do histórico do chat",
     "visibleForAllParticipants": "Visível para todos os participantes",
     "visibleForEveryone": "Visível para todos",
     "voiceMessage": "Mensagem de voz",
@@ -2738,10 +2486,7 @@
     "wallpaper": "Papel de parede:",
     "warning": "Atenção!",
     "weSentYouAnEmail": "Enviamos um e-mail para você",
-    "whoCanPerformWhichAction": "Quem pode realizar qual ação",
-    "whoIsAllowedToJoinThisGroup": "Quem tem permissão para entrar neste grupo",
     "whyDoYouWantToReportThis": "Por que você quer denunciar isto?",
-    "wipeChatBackup": "Deseja apagar o backup do chat para criar uma nova chave de recuperação?",
     "withTheseAddressesRecoveryDescription": "Com esses endereços você pode recuperar sua senha.",
     "writeAMessage": "Escreva uma mensagem…",
     "yes": "Sim",
@@ -2754,9 +2499,7 @@
     "messageType": "Tipo de mensagem",
     "sender": "Remetente",
     "openGallery": "Abrir galeria",
-    "removeFromSpace": "Remover do espaço",
     "start": "Iniciar",
-    "pleaseEnterRecoveryKeyDescription": "Para desbloquear suas mensagens antigas, insira sua chave de recuperação que foi gerada em uma sessão anterior. Sua chave de recuperação NÃO é sua senha.",
     "publish": "Publicar",
     "openChat": "Abrir conversa",
     "markAsRead": "Marcar como lida",
@@ -2767,12 +2510,9 @@
     "confirmEventUnpin": "Tem certeza de que deseja desfixar permanentemente o evento?",
     "emojis": "Emojis",
     "placeCall": "Realizar chamada",
-    "voiceCall": "Chamada de voz",
     "unsupportedAndroidVersion": "Versão do Android não suportada",
     "unsupportedAndroidVersionLong": "Este recurso requer uma versão mais recente do Android. Por favor, verifique atualizações ou suporte do Lineage OS.",
-    "videoCallsBetaWarning": "Por favor, note que as chamadas de vídeo estão atualmente em versão beta. Elas podem não funcionar como esperado ou não funcionar em todas as plataformas.",
     "experimentalVideoCalls": "Chamadas de vídeo experimentais",
-    "emailOrUsername": "Email ou nome de usuário",
     "addWidget": "Adicionar widget",
     "widgetVideo": "Vídeo",
     "widgetEtherpad": "Nota de texto",
@@ -2794,34 +2534,18 @@
     "youKickedAndBanned": "🙅 Você expulsou e baniu {user}",
     "youUnbannedUser": "Você desbaniu {user}",
     "hasKnocked": "🚪 {user} bateu na porta",
-    "usersMustKnock": "Os usuários devem bater na porta",
-    "noOneCanJoin": "Ninguém pode entrar",
     "knock": "Bater na porta",
-    "unlockOldMessages": "Desbloquear mensagens antigas",
-    "storeInSecureStorageDescription": "Armazene a chave de recuperação no armazenamento seguro deste dispositivo.",
-    "saveKeyManuallyDescription": "Salve esta chave manualmente acionando o diálogo de compartilhamento do sistema ou a área de transferência.",
-    "storeInAndroidKeystore": "Armazenar no Android KeyStore",
-    "storeInAppleKeyChain": "Armazenar no Apple KeyChain",
-    "storeSecurlyOnThisDevice": "Armazene com segurança neste dispositivo",
     "countFiles": "{count} arquivos",
     "user": "Usuário",
     "custom": "Personalizado",
-    "foregroundServiceRunning": "Esta notificação aparece quando o serviço em primeiro plano está em execução.",
-    "screenSharingTitle": "compartilhamento de tela",
-    "screenSharingDetail": "Você está compartilhando sua tela no FuffyChat",
     "whyIsThisMessageEncrypted": "Por que esta mensagem está ilegível?",
     "noKeyForThisMessage": "Isso pode acontecer se a mensagem foi enviada antes de você fazer login na sua conta neste dispositivo.\n\nTambém é possível que o remetente tenha bloqueado seu dispositivo ou algo deu errado com a conexão de internet.\n\nVocê consegue ler a mensagem em outra sessão? Então você pode transferi-la para lá! Vá para Configurações > Dispositivos e certifique-se de que seus dispositivos verificaram um ao outro. Quando você abrir a sala na próxima vez e ambas as sessões estiverem em primeiro plano, as chaves serão transmitidas automaticamente.\n\nNão quer perder as chaves ao fazer logout ou trocar de dispositivo? Certifique-se de que ativou o backup de chat nas configurações.",
     "newGroup": "Novo grupo",
     "newSpace": "Novo espaço",
-    "enterSpace": "Entrar no espaço",
     "allSpaces": "Todos os espaços",
     "hidePresences": "Ocultar Lista de Status?",
     "doNotShowAgain": "Não mostrar novamente",
     "wasDirectChatDisplayName": "Chat vazio (era {oldDisplayName})",
-    "newSpaceDescription": "Espaços permitem consolidar suas conversas e construir comunidades privadas ou públicas.",
-    "encryptThisChat": "Criptografar esta conversa",
-    "disableEncryptionWarning": "Por razões de segurança, você não pode desativar a criptografia em uma conversa onde ela foi ativada anteriormente.",
-    "sorryThatsNotPossible": "Desculpe... isso não é possível",
     "deviceKeys": "Chaves do dispositivo:",
     "reopenChat": "Reabrir conversa",
     "noBackupWarning": "Aviso! Sem ativar o backup da conversa, você perderá o acesso às suas mensagens criptografadas. Recomenda-se fortemente ativar o backup da conversa antes de sair.",
@@ -2834,7 +2558,6 @@
     "openLinkInBrowser": "Abrir link no navegador",
     "reportErrorDescription": "😞 Oh não. Algo deu errado. Se desejar, você pode relatar esse erro aos desenvolvedores.",
     "report": "denunciar",
-    "setTheme": "Definir tema:",
     "setColorTheme": "Definir tema de cores:",
     "invite": "Convidar",
     "inviteGroupChat": "📨 Convidar grupo de chat",
@@ -2853,12 +2576,8 @@
     "yourGlobalUserIdIs": "Seu ID de usuário global é: ",
     "noUsersFoundWithQuery": "Infelizmente, nenhum usuário foi encontrado com \"{query}\". Por favor, verifique se você digitou corretamente.",
     "knocking": "Batendo",
-    "chatCanBeDiscoveredViaSearchOnServer": "O chat pode ser descoberto via busca no {server}",
-    "searchChatsRooms": "Pesquisar por #conversas, @usuários...",
     "nothingFound": "Nada encontrado...",
     "groupName": "Nome do grupo",
-    "createGroupAndInviteUsers": "Criar um grupo e convidar usuários",
-    "groupCanBeFoundViaSearch": "O grupo pode ser encontrado via busca",
     "wrongRecoveryKey": "Desculpe... isso não parece ser a chave de recuperação correta.",
     "startConversation": "Iniciar conversa",
     "commandHint_sendraw": "Enviar JSON bruto",
@@ -2872,11 +2591,8 @@
     "pleaseChooseAStrongPassword": "Por favor, escolha uma senha forte",
     "passwordsDoNotMatch": "As senhas não coincidem",
     "passwordIsWrong": "A senha digitada está incorreta",
-    "publicChatAddresses": "Endereços de chat público",
-    "createNewAddress": "Criar novo endereço",
     "joinSpace": "Entrar no espaço",
     "publicSpaces": "Espaços públicos",
-    "addChatOrSubSpace": "Adicionar chat ou subespaço",
     "subspace": "Subespaço",
     "decline": "Recusar",
     "thisDevice": "Este dispositivo:",
@@ -2885,15 +2601,11 @@
     "searchMore": "Pesquisar mais...",
     "gallery": "Galeria",
     "files": "Arquivos",
-    "sessionLostBody": "Sua sessão foi perdida. Por favor, reporte esse erro aos desenvolvedores em {url}. A mensagem de erro é: {error}",
-    "restoreSessionBody": "O aplicativo agora tenta restaurar sua sessão a partir do backup. Por favor, reporte esse erro aos desenvolvedores em {url}. A mensagem de erro é: {error}",
     "sendReadReceipts": "Enviar confirmações de leitura",
     "sendTypingNotificationsDescription": "Outros participantes de uma conversa podem ver quando você está digitando uma nova mensagem.",
     "sendReadReceiptsDescription": "Outros participantes de uma conversa podem ver quando você leu uma mensagem.",
     "formattedMessages": "Mensagens formatadas",
     "formattedMessagesDescription": "Exibir conteúdo de mensagens ricas, como texto em negrito, usando markdown.",
-    "verifyOtherUser": "🔐 Verificar outro usuário",
-    "verifyOtherUserDescription": "Se você verificar outro usuário, pode ter certeza de que sabe com quem realmente está escrevendo. 💪\n\nQuando você inicia uma verificação, você e o outro usuário verão uma janela pop-up no aplicativo. Lá, vocês verão uma série de emojis ou números que devem comparar entre si.\n\nA melhor maneira de fazer isso é se encontrar pessoalmente ou iniciar uma chamada de vídeo. 👭",
     "verifyOtherDevice": "🔐 Verificar outro dispositivo",
     "verifyOtherDeviceDescription": "Quando você verifica outro dispositivo, esses dispositivos podem trocar chaves, aumentando sua segurança geral. 💪 Quando você inicia uma verificação, aparecerá uma janela pop-up no aplicativo em ambos os dispositivos. Lá, vocês verão uma série de emojis ou números que devem comparar entre si. É melhor ter ambos os dispositivos à mão antes de iniciar a verificação. 🤳",
     "acceptedKeyVerification": "{sender} aceitou a verificação de chave",
@@ -2929,10 +2641,6 @@
     "updateInstalled": "🎉 Atualização {version} instalada!",
     "changelog": "Registro de alterações",
     "sendCanceled": "Envio cancelado",
-    "loginWithMatrixId": "Entrar com Matrix-ID",
-    "discoverHomeservers": "Descobrir servidores principais",
-    "whatIsAHomeserver": "O que é um servidor principal?",
-    "homeserverDescription": "Todos os seus dados são armazenados no servidor principal, assim como um provedor de email. Você pode escolher qual servidor principal deseja usar, enquanto ainda pode se comunicar com todos. Saiba mais em https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Parece que não é um servidor principal compatível. URL incorreta?",
     "calculatingFileSize": "Calculando o tamanho do arquivo...",
     "prepareSendingAttachment": "Preparando envio de anexo...",
@@ -2944,11 +2652,9 @@
     "oneOfYourDevicesIsNotVerified": "Um dos seus dispositivos não está verificado",
     "noticeChatBackupDeviceVerification": "Nota: Quando você conecta todos os seus dispositivos ao backup de chat, eles são automaticamente verificados.",
     "continueText": "Continuar",
-    "welcomeText": "Ei Ei 👋 Esta é a FluffyChat. Você pode fazer login em qualquer servidor doméstico, que seja compatível com https://matrix.org. E então conversar com qualquer pessoa. É uma grande rede de mensagens descentralizada!",
     "blur": "Desfocar:",
     "opacity": "Opacidade:",
     "setWallpaper": "Definir papel de parede",
-    "manageAccount": "Gerenciar conta",
     "noContactInformationProvided": "O servidor não fornece nenhuma informação de contato válida",
     "contactServerAdmin": "Contatar o administrador do servidor",
     "contactServerSecurity": "Contatar a segurança do servidor",
@@ -2967,11 +2673,8 @@
     "unableToJoinChat": "Não foi possível entrar no chat. Talvez a outra parte já tenha encerrado a conversa.",
     "previous": "Anterior",
     "otherPartyNotLoggedIn": "A outra parte atualmente não está conectada e, portanto, não pode receber mensagens!",
-    "appWantsToUseForLogin": "Usar '{server}' para fazer login",
-    "appWantsToUseForLoginDescription": "Você permite que o aplicativo e o site compartilhem informações sobre você.",
     "open": "Abrir",
     "waitingForServer": "Aguardando o servidor...",
-    "appIntroduction": "FluffyChat permite que você converse com seus amigos em diferentes mensageiros. Saiba mais em https://matrix.org ou apenas toque em *Continuar*.",
     "newChatRequest": "📩 Novo pedido de chat",
     "contentNotificationSettings": "Configurações de notificação de conteúdo",
     "generalNotificationSettings": "Configurações gerais de notificação",
@@ -3048,11 +2751,9 @@
     "taTooltip": "L2 com assistência de tradução",
     "interactiveTranslatorSliderHeader": "Tradutor Interativo",
     "interactiveGrammarSliderHeader": "Verificador de Gramática Interativo",
-    "interactiveTranslatorRequired": "Obrigatório",
     "waTooltip": "L2 sem assistência",
     "interactiveTranslator": "Assistência de tradução",
     "noIdenticalLanguages": "Por favor, escolha idiomas base e alvo diferentes",
-    "searchBy": "Pesquisar por país e idiomas",
     "joinWithClassCode": "Participar do curso",
     "languageLevelPreA1": "Iniciante Baixo (Pré A1)",
     "languageLevelA1": "Novato Mid (A1)",
@@ -3073,19 +2774,14 @@
     "saveChanges": "Salvar alterações",
     "publicProfileTitle": "Permitir que meu perfil seja encontrado na busca",
     "publicProfileDesc": "Ao ativar, você permite que outros usuários encontrem seu perfil na barra de busca global e enviem solicitações para conversar. Neste momento, você pode escolher aceitar ou negar a solicitação.",
-    "errorDisableIT": "Assistência de tradução está desativada.",
-    "errorDisableIGC": "Assistência de gramática está desativada.",
     "errorDisableITUserDesc": "Clique aqui para atualizar as configurações de assistência de tradução",
     "errorDisableIGCUserDesc": "Clique aqui para atualizar as configurações de assistência de gramática",
     "errorDisableITClassDesc": "Assistência de tradução está desativada para o curso em que esta conversa está.",
     "errorDisableIGCClassDesc": "Assistência de gramática está desativada para o curso em que esta conversa está.",
-    "error405Title": "Idiomas não configurados",
     "error405Desc": "Por favor, configure seus idiomas em Menu Principal > Configurações de Aprendizado.",
     "termsAndConditions": "Termos e Condições",
     "andCertifyIAmAtLeast13YearsOfAge": " e certifico que tenho pelo menos 16 anos de idade.",
-    "error502504Title": "Uau, há muitos estudantes online!",
     "error502504Desc": "Ferramentas de tradução e gramática podem estar lentas ou indisponíveis enquanto os bots Pangea se atualizam.",
-    "error404Title": "Erro de tradução!",
     "error404Desc": "O Pangea Bot não tem certeza de como traduzir isso...",
     "errorPleaseRefresh": "Estamos investigando! Por favor, recarregue e tente novamente.",
     "connectedToStaging": "Conectado ao Staging",
@@ -3123,13 +2819,9 @@
     "definitionsToolName": "Definições de Palavras",
     "definitionsToolDescription": "Quando ativado, palavras sublinhadas em azul podem ser clicadas para obter definições. Clique nas mensagens para acessar definições.",
     "welcomeBack": "Bem-vindo de volta! Se você fez parte do piloto de 2023-2024, entre em contato conosco para sua assinatura piloto especial. Se você é um professor que possui (ou cuja instituição possui) licenças para sua turma, entre em contato conosco para sua assinatura de professor.",
-    "downloadTxtFile": "Baixar Arquivo de Texto",
-    "downloadCSVFile": "Baixar Arquivo CSV",
     "promotionalSubscriptionDesc": "Você atualmente possui uma assinatura promocional vitalícia. Envie uma mensagem para support@pangea.chat para ajuda na alteração da sua assinatura.",
     "originalSubscriptionPlatform": "Assinatura adquirida através de {purchasePlatform}",
     "oneWeekTrial": "Teste de Uma Semana",
-    "downloadXLSXFile": "Baixar Arquivo Excel",
-    "unkDisplayName": "Desconhecido",
     "wwCountryDisplayName": "Mundo",
     "afCountryDisplayName": "Afeganistão",
     "axCountryDisplayName": "Ilhas Aland",
@@ -3424,7 +3116,6 @@
     "chatCapacityHasBeenChanged": "Capacidade do chat alterada",
     "chatCapacitySetTooLow": "A capacidade do chat deve ser pelo menos {count}.",
     "chatCapacityExplanation": "A capacidade do chat limita o número de membros permitidos em um chat.",
-    "tooManyRequest": "Muitas solicitações, por favor tente novamente mais tarde.",
     "enterNumber": "Por favor, insira um valor numérico inteiro.",
     "practice": "Praticar",
     "versionNotFound": "Versão não encontrada",
@@ -3434,7 +3125,6 @@
     "deleteSubscriptionWarningTitle": "Você tem uma assinatura ativa",
     "deleteSubscriptionWarningBody": "Excluir sua conta não cancelará automaticamente sua assinatura.",
     "manageSubscription": "Gerenciar assinatura",
-    "error520Title": "Por favor, tente novamente.",
     "error520Desc": "Desculpe, não conseguimos entender sua mensagem...",
     "wordsUsed": "Palavras usadas",
     "level": "Nível",
@@ -3452,7 +3142,6 @@
     "other": "Outro",
     "levelShort": "NÍVEL {level}",
     "noCapacityLimit": "Sem limite de capacidade",
-    "downloadGroupText": "Baixar texto do grupo",
     "notificationsOn": "Notificações ativadas",
     "notificationsOff": "Notificações desativadas",
     "joinWithCode": "Entrar com código",
@@ -3516,24 +3205,12 @@
     "whatIsTheMorphTag": "O que é {morphologicalFeature} de '{wordForm}'?",
     "dataAvailable": "Disponibilidade de dados",
     "available": "Disponível",
-    "pangeaBotIsFallible": "O Pangea Bot também comete erros!",
-    "whatIsMeaning": "O que significa '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Combine os significados com as palavras na mensagem!",
-    "doubleClickToEdit": "Clique duas vezes para editar.",
-    "topicLabel": "Tópico",
-    "topicPlaceholder": "Escolha um tópico...",
-    "modePlaceholder": "Escolha um modo...",
-    "learningObjectiveLabel": "Objetivo de aprendizagem",
-    "learningObjectivePlaceholder": "Escolha um objetivo de aprendizagem...",
-    "targetLanguageLabel": "Idioma alvo",
     "cefrLevelLabel": "Nível CEFR",
     "image": "Imagem",
     "video": "Vídeo",
     "nan": "Não aplicável",
-    "addVocabulary": "Adicionar vocabulário",
     "instructions": "Instruções",
-    "numberOfLearners": "Número de aprendizes",
-    "mustBeInteger": "Deve ser um número inteiro, por exemplo, 1, 2, 3, ...",
     "constructUsePvmDesc": "Produzido em mensagem de voz",
     "leaveSpaceDescription": "Ao sair do curso, você deixará todos os chats dentro dele. Outros usuários verão que você saiu do curso.",
     "constructUseCorMmDesc": "Significado da mensagem correta",
@@ -3548,7 +3225,6 @@
     "ttsDisabledBody": "Você pode ativar o texto para fala nas configurações de aprendizado",
     "noSpaceDescriptionYet": "Ainda não foi criada uma descrição do curso.",
     "tooLargeToSend": "Esta mensagem é grande demais para enviar",
-    "exitWithoutSaving": "Tem certeza de que deseja sair sem salvar?",
     "enableAutocorrectPopupTitle": "Adicione o teclado do seu idioma alvo indo para:",
     "enableAutocorrectPopupSteps": "  • Configurações\n  • Geral\n  • Teclado\n  • Teclados\n  • Adicionar Novo Teclado",
     "enableAutocorrectPopupDescription": "Depois de selecionar o idioma, você pode clicar no pequeno ícone do globo na parte inferior esquerda do seu teclado para ativar o teclado recentemente instalado.",
@@ -3559,11 +3235,8 @@
     "displayName": "Nome de exibição",
     "leaveRoomDescription": "Você está prestes a sair deste chat. Outros usuários verão que você saiu do chat.",
     "confirmUserId": "Por favor, confirme seu nome de usuário no Pangea Chat para excluir sua conta.",
-    "startingToday": "A partir de hoje",
-    "oneWeekFreeTrial": "Período de teste gratuito de uma semana",
     "paidSubscriptionStarts": "Começa em {startDate}",
     "cancelInSubscriptionSettings": "• Cancelar a qualquer momento nas configurações de assinatura",
-    "cancelToAvoidCharges": "• Cancelar antes de {trialEnds} para evitar cobranças",
     "downloadGboard": "Baixar Gboard",
     "autocorrectNotAvailable": "Infelizmente, sua plataforma não é suportada atualmente para esse recurso. Fique atento para mais desenvolvimentos!",
     "pleaseUpdateApp": "Por favor, atualize o aplicativo para continuar.",
@@ -3573,17 +3246,12 @@
     "knockSpaceSuccess": "Você solicitou ingressar neste curso! Um administrador responderá à sua solicitação quando a receber 😊",
     "chooseWordAudioInstructionsBody": "Ouça a mensagem completa. Depois, associe os áudios às palavras.",
     "chooseMorphsInstructionsBody": "Clique nas peças do quebra-cabeça para perguntas de gramática!",
-    "pleaseEnterInt": "Por favor, insira um número",
     "home": "Início",
     "join": "Entrar",
     "resetInstructionTooltipsTitle": "Redefinir dicas de instruções",
     "resetInstructionTooltipsDesc": "Clique para mostrar dicas de instruções como para um usuário totalmente novo.",
-    "randomize": "Embaralhar",
     "clear": "Limpar",
-    "featuredActivities": "Destaques",
     "save": "Salvar",
-    "startChat": "Iniciar um chat",
-    "translationProblem": "Problema de tradução",
     "askToJoin": "Solicitar para participar",
     "emptyChatWarningTitle": "Chat vazio",
     "emptyChatWarningDesc": "Você não convidou ninguém para o seu chat. Vá para Configurações de Chat para convidar seus contatos ou o Bot. Você também pode fazer isso mais tarde.",
@@ -3613,17 +3281,13 @@
     "timesUsedIndependently": "Vezes usadas independentemente",
     "timesUsedWithAssistance": "Vezes usadas com assistência",
     "shareInviteCode": "Compartilhar código de convite: {code}",
-    "leaderboard": "Classificação",
     "skipForNow": "Pular por enquanto",
     "permissions": "Permissões",
     "spaceChildPermission": "Quem pode adicionar novas conversas a este curso",
-    "addEnvironmentOverride": "Adicionar substituição de ambiente",
     "defaultOption": "Padrão",
     "deleteChatDesc": "Tem certeza de que deseja excluir esta conversa? Ela será excluída para todos os participantes e todas as mensagens dentro da conversa não estarão mais disponíveis para prática ou análises de aprendizagem.",
     "deleteSpaceDesc": "O curso e quaisquer conversas selecionadas serão excluídos para todos os participantes e todas as mensagens dentro da conversa não estarão mais disponíveis para prática ou análises de aprendizagem. Esta ação não pode ser desfeita.",
     "launch": "Iniciar",
-    "searchChats": "Pesquisar conversas",
-    "maxFifty": "Máximo 50",
     "configureSpace": "Configurar curso",
     "pinMessages": "Fixar mensagens",
     "setJoinRules": "Definir regras de entrada",
@@ -3657,9 +3321,6 @@
     "failedToFetchTranscription": "Falha ao buscar a transcrição",
     "deleteEmptySpaceDesc": "O curso será excluído para todos os participantes. Esta ação não pode ser desfeita.",
     "regenerate": "Regenerar",
-    "mySavedActivities": "Minhas Atividades Salvas",
-    "noSavedActivities": "Nenhuma atividade salva",
-    "saveActivity": "Salvar esta atividade",
     "failedToPlayVideo": "Falha ao reproduzir o vídeo",
     "done": "Concluído",
     "inThisSpace": "Neste espaço",
@@ -3670,13 +3331,9 @@
     "numInvited": "{count} convidado(s)",
     "saved": "Salvo",
     "reset": "Redefinir",
-    "errorFetchingActivitiesMessage": "Falha ao buscar atividades",
     "errorFetchingDefinition": "Falha ao buscar definição",
     "errorProcessAnalytics": "Falha ao processar análises",
     "errorDownloading": "Falha ao baixar",
-    "errorLoadingSpaceChildren": "Falha ao carregar chats dentro deste curso",
-    "unexpectedError": "Erro inesperado.",
-    "pleaseReload": "Por favor, recarregue e tente novamente.",
     "translationError": "Erro de tradução",
     "check": "Verificar",
     "unableToFindRoom": "Nenhum chat ou curso encontrado com esse código. Por favor, tente novamente.",
@@ -3685,19 +3342,14 @@
     "request": "Solicitar",
     "requestAll": "Solicitar Tudo",
     "confirmMessageUnpin": "Tem certeza de que deseja desfixar esta mensagem?",
-    "saveAndLaunch": "Salvar e Iniciar",
-    "launchToSpace": "Iniciar no curso",
     "pending": "Pendente",
     "inactive": "Inativo",
-    "confirmRole": "Confirmar papel",
     "openRoleLabel": "ABERTO",
     "finishedTheActivity": "🎯 {username} concluiu esta atividade",
     "activitySummaryError": "Resumos de atividades indisponíveis",
     "requestSummaries": "Solicitar resumos",
-    "generatingNewActivities": "Você é o primeiro usuário deste par de idiomas! Por favor, aguarde um minuto, estamos preparando atividades especialmente para você.",
     "requestAccessTitle": "Solicitar acesso à análise?",
     "requestAccessDesc": "Gostaria de solicitar acesso para visualizar as análises dos participantes?\n\nSe os participantes concordarem, os administradores deste curso poderão ver:\n    • vocabulário total\n    • conceitos gramaticais totais\n    • sessões de atividade concluídas\n    • os conceitos gramaticais específicos usados, corretamente e incorretamente\n\nEles não poderão ver:\n    • mensagens em chats fora do curso\n    • lista de vocabulário",
-    "requestAccess": "Solicitar acesso ({count})",
     "analyticsInactiveTitle": "Solicitações para usuários inativos não puderam ser enviadas",
     "analyticsInactiveDesc": "Usuários inativos que não fizeram login desde a introdução deste recurso não verão sua solicitação.\n\nO botão Solicitar aparecerá assim que eles retornarem. Você pode reenviar a solicitação mais tarde clicando no botão Solicitar sob o nome deles quando estiver disponível.",
     "accessRequestedTitle": "Solicitação de acesso às análises",
@@ -3720,8 +3372,6 @@
     "accessDesc": "Você pode tornar seu curso aberto ao mundo! Ou, tornar seu curso privado e seguro.",
     "createGroupChatDesc": "Enquanto sessões de atividade começam e terminam, os chats em grupo permanecerão abertos para comunicação rotineira.",
     "deleteDesc": "Somente administradores podem excluir um curso. Esta é uma ação destrutiva que remove todos os usuários e exclui todos os chats selecionados dentro do curso. Proceda com cautela.",
-    "noCourseFound": "Oh, este curso precisa de um plano!\n\nPlanos de curso são uma sequência de tópicos e atividades de conversa.",
-    "additionalParticipants": "+ {num} outros",
     "whatNow": "E agora?",
     "chooseNextActivity": "Escolha sua próxima atividade!",
     "letsGo": "Vamos lá",
@@ -3734,13 +3384,11 @@
     "waitNotDone": "Espere, eu não terminei!",
     "waitingForOthersToFinish": "Aguardando os demais terminarem...",
     "generatingSummary": "Analisando o chat e gerando resultados",
-    "findCourse": "Encontrar um curso",
     "pingParticipantsNotification": "{user} está procurando usuários para participar da sessão de atividade em {room}",
     "course": "Curso",
     "courses": "Cursos",
     "goToCourse": "Ir para o curso: {course}",
     "activityComplete": "Esta atividade foi concluída. O resumo da atividade deve estar disponível abaixo.",
-    "startNewSession": "Iniciar nova sessão",
     "joinOpenSession": "Participar de sessão aberta",
     "activityNotFound": "Atividade não encontrada",
     "myActivities": "Minhas atividades",
@@ -3844,26 +3492,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -3940,14 +3568,6 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
@@ -3972,31 +3592,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -4052,23 +3652,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4108,28 +3696,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4147,14 +3713,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4347,22 +3905,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4418,10 +3960,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4431,10 +3969,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4510,27 +4044,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4848,10 +4366,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4861,10 +4375,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4952,14 +4462,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4976,10 +4478,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4992,15 +4490,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5152,14 +4642,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5173,14 +4655,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6403,10 +5877,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6447,10 +5917,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6523,10 +5989,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6796,47 +6258,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6856,19 +6278,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6932,10 +6342,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6976,14 +6382,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6995,14 +6393,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -7040,10 +6430,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7060,27 +6446,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7204,10 +6574,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7217,10 +6583,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7237,14 +6599,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7384,18 +6738,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7444,10 +6786,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7457,18 +6795,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7511,23 +6837,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7551,10 +6865,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7562,14 +6872,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7674,18 +6976,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7738,10 +7028,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7768,10 +7054,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7952,7 +7234,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Verifique novamente amanhã para atualizações da atividade.",
-    "activityDropdownDesc": "Quando terminar esta atividade, clique abaixo",
     "languageMismatchTitle": "Incompatibilidade de idioma",
     "languageMismatchDesc": "O idioma de destino não corresponde ao idioma desta atividade. Deseja atualizar seu idioma de destino?",
     "reportWordIssueTooltip": "Relatar problema na informação da palavra",
@@ -7965,10 +7246,6 @@
     "selectAll": "Selecionar tudo",
     "deselectAll": "Desmarcar tudo",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8017,17 +7294,11 @@
         "placeholders": {}
     },
     "startOwn": "Comece o seu próprio",
-    "joinCourseDesc": "Cada curso tem de 8 a 10 tópicos sequenciais com uma variedade de atividades de aprendizagem de idiomas baseadas em tarefas.",
     "newMessageInPangeaChat": "📩 Nova mensagem no Pangea Chat",
     "shareCourse": "Compartilhar curso",
     "addCourse": "Adicionar um curso",
-    "joinPublicCourse": "Entrar no curso público",
     "vocabLevelsDesc": "É aqui que as palavras de vocabulário irão aparecer assim que você as evoluir!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8040,10 +7311,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8062,7 +7329,6 @@
     "emojiView": "Visualização de emoji",
     "feedbackDialogDesc": "Eu também cometo erros! Algo para me ajudar a melhorar?",
     "contactHasBeenInvitedToTheCourse": "O contato foi convidado para o curso",
-    "activityStatsButtonTooltip": "Informações da atividade",
     "allow": "Permitir",
     "deny": "Negar",
     "enabledRenewal": "Ativar Renovação de Assinatura",
@@ -8330,10 +7596,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9389,16 +8651,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Atividades para Desbloquear o Próximo Tópico",
-    "activitiesToUnlockTopicDesc": "Defina o número de atividades para desbloquear o próximo tópico do curso",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Prática correta de definição de vocabulário",
     "constructUseIncLMDesc": "Prática incorreta de definição de vocabulário",
     "constructUseCorLADesc": "Prática correta de áudio de vocabulário",
@@ -9406,7 +8658,6 @@
     "constructUseBonus": "Bônus durante a prática de vocabulário",
     "practiceVocab": "Praticar vocabulário",
     "selectMeaning": "Selecione o significado",
-    "selectAudio": "Selecione o áudio correspondente",
     "anotherRound": "Outra rodada",
     "activitySettingsOverrideWarning": "Idioma e nível de idioma determinados pelo plano de atividade",
     "voice": "Voz",
@@ -9438,10 +8689,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9459,12 +8706,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Download iniciado",
     "webDownloadPermissionMessage": "Se o seu navegador bloquear downloads, por favor, habilite downloads para este site.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9559,11 +8801,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Algo deu errado, e estamos trabalhando arduamente para corrigir isso. Verifique novamente mais tarde.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Ativar assistência de escrita",
     "autoIGCToolDescription": "Executar automaticamente as ferramentas do Pangea Chat para corrigir mensagens enviadas para o idioma de destino.",
     "@autoIGCToolName": {
@@ -9619,24 +8856,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramática",
-    "spanTypeWordChoice": "Escolha de Palavras",
     "spanTypeSpelling": "Ortografia",
     "spanTypePunctuation": "Pontuação",
     "spanTypeStyle": "Estilo",
     "spanTypeFluency": "Fluência",
     "spanTypeAccents": "Acentos",
     "spanTypeCapitalization": "Capitalização",
-    "spanTypeCorrection": "Correção",
     "spanFeedbackTitle": "Relatar problema de correção",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9661,10 +8887,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9677,13 +8899,7 @@
     "longPressToRecordVoiceMessage": "Pressione longamente para gravar mensagem de voz.",
     "pause": "Pausar",
     "resume": "Retomar",
-    "newSubSpace": "Novo subespaço",
-    "moveToDifferentSpace": "Mover para um espaço diferente",
-    "removeFromSpaceDescription": "O chat será removido do espaço, mas ainda aparecerá na sua lista de chats.",
     "countChats": "{chats} chats",
-    "spaceMemberOf": "Membro do espaço {spaces}",
-    "spaceMemberOfCanKnock": "Membro do espaço {spaces} pode bater",
-    "donate": "Doar",
     "startedAPoll": "{username} iniciou uma enquete.",
     "poll": "Enquete",
     "startPoll": "Iniciar enquete",
@@ -9707,23 +8923,15 @@
     "newStickerPack": "Novo pacote de adesivos",
     "stickerPackName": "Nome do pacote de adesivos",
     "attribution": "Atribuição",
-    "skipChatBackup": "Pular backup de chat",
-    "skipChatBackupWarning": "Você tem certeza? Sem ativar o backup de chat, você pode perder o acesso às suas mensagens se trocar de dispositivo.",
-    "loadingMessages": "Carregando mensagens",
-    "setupChatBackup": "Configurar backup de chat",
     "noMoreResultsFound": "Nenhum resultado encontrado",
     "chatSearchedUntil": "Chat pesquisado até {time}",
     "federationBaseUrl": "URL Base da Federação",
     "clientWellKnownInformation": "Informações do Cliente-Bem-Conhecidas:",
     "baseUrl": "URL Base",
     "identityServer": "Servidor de Identidade:",
-    "versionWithNumber": "Versão: {version}",
     "logs": "Registros",
-    "advancedConfigs": "Configurações Avançadas",
     "advancedConfigurations": "Configurações avançadas",
-    "signInWithLabel": "Entrar com:",
     "selectAllWords": "Selecione todas as palavras que você ouve no áudio",
-    "joinCourseForActivities": "Junte-se a um curso para experimentar atividades.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9760,18 +8968,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9779,26 +8975,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9904,22 +9080,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9948,19 +9108,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9968,15 +9116,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10177,11 +9317,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Em uma aula? Coloque seu código de entrada aqui.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Realçar automaticamente mensagens de áudio",
     "selectAudioMessagesOnPlayDescription": "Realçar automaticamente mensagens de áudio quando reproduzidas",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10225,18 +9360,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Este curso tem tópicos com menos de {input} atividades. Por favor, insira um número menor ou igual a {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Clique aqui para fazer login novamente.",
     "@clickToLogin": {
@@ -10653,17 +9776,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Um urso amarelo em estilo de desenho animado com os braços levantados em empolgação.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Selecione palavras para saber mais sobre elas",
     "requireAnalyticsAccessTitle": "Requerer acesso à análise para participar",
     "requireAnalyticsAccessDesc": "Os participantes devem conceder acesso às suas análises de aprendizado para participar deste curso",
     "analyticsAccessNoticeTitle": "Acesso à Análise Necessário",
     "analyticsAccessNoticeDesc": "Ao participar deste curso, você concorda em conceder acesso aos administradores às suas análises de aprendizado.",
-    "skipOnboardingClassCodeDesc": "Aprendendo de forma independente? Não se preocupe, você pode:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10681,10 +9798,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10713,7 +9826,6 @@
     "pickCefrLevelTeacherStepTitle": "Qual nível você ensina?",
     "pickCefrLevelStudentStepTitle": "Qual nível você está?",
     "customCourseStepTitle": "Preencha este formulário para obter um curso personalizado",
-    "aboutYourClass": "Sobre sua turma",
     "courseCodeStepErrorMessage": "Por favor, verifique seu código e tente novamente",
     "institution": "Instituição",
     "courseGoals": "Objetivos do Curso",
@@ -10756,10 +9868,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10876,12 +9984,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logotipo do Pangea Chat",
     "introChatDetails": "Diga olá! Apresente-se aos seus colegas participantes do curso, encontre amigos e converse fora das atividades.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10925,11 +10028,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Ações de atividade",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Ferramentas de pronúncia",
     "audioTranscription": "Transcrição de áudio com IA",
     "visualLearnerSupport": "Apoio a aprendizes visuais",
@@ -10970,7 +10068,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Junte-se a um curso que inclua esta atividade para jogá-la.",
     "resizeCoursePanel": "Redimensionar painel do curso",
     "undo": "Desfazer",
     "unlock": "Desbloquear",
@@ -10984,7 +10081,6 @@
     "addCourseBrowsePublic": "Navegar por cursos públicos",
     "browsePublicCourses": "Navegar por cursos públicos",
     "editProfile": "Editar perfil",
-    "numObjectives": "{count} objetivos",
     "mapSearchHint": "Pesquisar atividades",
     "mapSearchNoResults": "Nenhuma correspondência na visualização",
     "mapFilterAllLanguages": "Todos os idiomas",
@@ -10993,7 +10089,6 @@
     "mapFilterCompleted": "Concluído",
     "mapFilterReset": "Redefinir",
     "activityTypeConversation": "Conversa",
-    "lockedMissionRequirement": "Termine a missão anterior para desbloquear",
     "playAgain": "Jogar novamente",
     "reviewActivity": "Revisar",
     "mapEmptyInView": "Nada aqui no seu nível ou idioma. Amplie seus filtros ou afaste-se.",
@@ -11008,14 +10103,9 @@
     "scrollToBottom": "Role para baixo",
     "courseImage": "Imagem do curso",
     "avatarPreview": "Pré-visualização do avatar",
-    "activityPhoto": "Foto da atividade",
     "emotePreview": "Pré-visualização do emote: {name}",
     "activityLabel": "Atividade: {title}",
     "resetMapView": "Redefinir visualização do mapa",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11068,14 +10158,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11105,10 +10187,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11165,10 +10243,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_pt_BR.arb
+++ b/lib/l10n/intl_pt_BR.arb
@@ -82,11 +82,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Visitantes podem entrar",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Tem certeza?",
     "@areYouSure": {
         "type": "String",
@@ -363,11 +358,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Suas mensagens são protegidas com sua chave de recuperação. Evite perdê-la.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Detalhes da conversa",
     "@chatDetails": {
         "type": "String",
@@ -499,11 +489,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "O contato foi convidado ao grupo",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "O conteúdo foi denunciado para os administradores do servidor",
     "@contentHasBeenReported": {
         "type": "String",
@@ -555,11 +540,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Novo espaço",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Ativo",
     "@currentlyActive": {
@@ -703,11 +683,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Você não poderá desativar a criptografia posteriormente. Tem certeza?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Criptografado",
     "@encrypted": {
         "type": "String",
@@ -746,11 +721,6 @@
             }
         }
     },
-    "everythingReady": "Tudo pronto!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Extremamente ofensivo",
     "@extremeOffensive": {
         "type": "String",
@@ -788,11 +758,6 @@
     },
     "group": "Grupo",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "O grupo é público",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -886,15 +851,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Convidar contato para {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Convidado",
     "@invited": {
@@ -1007,15 +963,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Carregar mais {count} participantes",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Carregando... Aguarde.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -1040,15 +987,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Conectar com {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Desconectar-se",
     "@logout": {
@@ -1112,16 +1050,6 @@
     },
     "noEmotesFound": "Nenhum emoji encontrado. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Você só poderá ativar a criptografia quando a sala não for mais publicamente acessível.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "O Firebase Cloud Messaging não parece estar disponível no seu dispositivo. Para receber notificações push, recomendados que você instwl3 o ntfy. Com o ntfy outro provedor do UnifiedPush, você pode receber notificações push de um modo seguro em relação aos dados. Você pode baixar o ntfy da Play Store ou do F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1253,11 +1181,6 @@
     },
     "passwordHasBeenChanged": "Senha foi alterada",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Recuperação de senha",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1401,11 +1324,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Remover dispositivo",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Desbanir da conversa",
     "@unbanFromChat": {
@@ -1560,11 +1478,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Configurar níveis de permissão",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Alterar estado",
     "@setStatus": {
         "type": "String",
@@ -1606,16 +1519,6 @@
     },
     "sourceCode": "Código-fonte",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "O espaço é público",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Nome do espaço",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1674,11 +1577,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Transferir de outro dispositivo",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Tentar enviar novamente",
     "@tryToSendAgain": {
         "type": "String",
@@ -1734,15 +1632,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 conversa não lida} other{{unreadCount} conversas não lidas}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} e mais {count} pessoas estão digitando…",
     "@userAndOthersAreTyping": {
@@ -1828,16 +1717,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Chamada de vídeo",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Visibilidade do histórico da conversa",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Visível para todos os participantes",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1883,23 +1762,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Quem pode desempenhar quais ações",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Quem pode entrar no grupo",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Por que quer denunciar isto?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Apagar o backup de conversas para criar uma nova chave de recuperação?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1940,12 +1804,8 @@
     },
     "oneClientLoggedOut": "Um dos seus clientes foi desconectado",
     "@oneClientLoggedOut": {},
-    "addAccount": "Adicionar conta",
-    "@addAccount": {},
     "unverified": "Não verificado",
     "@unverified": {},
-    "yourChatBackupHasBeenSetUp": "Seu backup de conversas foi configurado.",
-    "@yourChatBackupHasBeenSetUp": {},
     "editBundlesForAccount": "Editar coleções para esta conta",
     "@editBundlesForAccount": {},
     "serverRequiresEmail": "Este servidor precisa validar seu e-mail para efetuar o cadastro.",
@@ -1956,8 +1816,6 @@
     "@sender": {},
     "publish": "Publicar",
     "@publish": {},
-    "removeFromSpace": "Remover do espaço",
-    "@removeFromSpace": {},
     "link": "Link",
     "@link": {},
     "start": "Iniciar",
@@ -2003,8 +1861,6 @@
     "@removeFromBundle": {},
     "bundleName": "Nome da coleção",
     "@bundleName": {},
-    "enableMultiAccounts": "(BETA) Ativar múltiplas contas neste dispositivo",
-    "@enableMultiAccounts": {},
     "time": "Horário",
     "@time": {},
     "messageType": "Tipo da mensagem",
@@ -2044,18 +1900,12 @@
     "@confirmEventUnpin": {},
     "pinMessage": "Fixar na sala",
     "@pinMessage": {},
-    "voiceCall": "Chamada de voz",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "Versão Android sem suporte",
     "@unsupportedAndroidVersion": {},
     "widgetNameError": "Forneça um nome de exibição.",
     "@widgetNameError": {},
     "unsupportedAndroidVersionLong": "Esta funcionalidade requer uma versão mais nova do Android. Verifique se há atualizações ou suporte ao LineageOS.",
     "@unsupportedAndroidVersionLong": {},
-    "emailOrUsername": "E-mail ou nome de usuário",
-    "@emailOrUsername": {},
-    "videoCallsBetaWarning": "Observe que chamadas de vídeo estão atualmente em teste. Podem não funcionar como esperado ou sequer funcionar em algumas plataformas.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "Vídeo chamadas experimentais",
     "@experimentalVideoCalls": {},
     "widgetVideo": "Vídeo",
@@ -2145,8 +1995,6 @@
             }
         }
     },
-    "pleaseEnterRecoveryKeyDescription": "Para desbloquear as suas mensagens antigas, digite a sua chave de recuperação gerada numa sessão prévia. Sua chave de recuperação NÃO é sua senha.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "users": "Usuários",
     "@users": {},
     "confirmMatrixId": "Confirme seu ID Matrix para apagar sua conta.",
@@ -2160,10 +2008,6 @@
             }
         }
     },
-    "recoveryKey": "Chave de recuperação",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Perdeu a chave de recuperação?",
-    "@recoveryKeyLost": {},
     "commandHint_cuddle": "Enviar um afago",
     "@commandHint_cuddle": {},
     "commandHint_hug": "Enviar um abraço",
@@ -2194,30 +2038,14 @@
     "@commandHint_markasgroup": {},
     "hydrate": "Restaurar a partir de um arquivo de backup",
     "@hydrate": {},
-    "pleaseEnterRecoveryKey": "Digite sua chave de recuperação:",
-    "@pleaseEnterRecoveryKey": {},
-    "storeInSecureStorageDescription": "Guardar a chave de recuperação no armazenamento seguro deste dispositivo.",
-    "@storeInSecureStorageDescription": {},
-    "saveKeyManuallyDescription": "Salvar esta chave manualmente via compartilhamento do sistema ou área de transferência.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "Guardar no cofre do Android (KeyStore)",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Guardar no chaveiro da Apple",
-    "@storeInAppleKeyChain": {},
-    "storeSecurlyOnThisDevice": "Guardar de modo seguro neste dispositivo",
-    "@storeSecurlyOnThisDevice": {},
     "user": "Usuário",
     "@user": {},
     "custom": "Personalizado",
     "@custom": {},
-    "foregroundServiceRunning": "Esta notificação aparece quando o serviço de primeiro plano está sendo executado.",
-    "@foregroundServiceRunning": {},
     "newGroup": "Novo grupo",
     "@newGroup": {},
     "newSpace": "Novo espaço",
     "@newSpace": {},
-    "enterSpace": "Abrir espaço",
-    "@enterSpace": {},
     "allSpaces": "Todos os espaços",
     "@allSpaces": {},
     "countFiles": "{count} arquivos",
@@ -2230,18 +2058,12 @@
     },
     "doNotShowAgain": "Não mostrar novamente",
     "@doNotShowAgain": {},
-    "unlockOldMessages": "Desbloquear mensagens antigas",
-    "@unlockOldMessages": {},
     "dehydrate": "Exportar sessão e apagar dispositivo",
     "@dehydrate": {},
     "dehydrateWarning": "Esta ação não pode ser desfeita. Certifique-se de que o arquivo de backup está guardado e seguro.",
     "@dehydrateWarning": {},
     "whyIsThisMessageEncrypted": "Por que não consigo ler esta mensagem?",
     "@whyIsThisMessageEncrypted": {},
-    "screenSharingTitle": "compartilhamento de tela",
-    "@screenSharingTitle": {},
-    "screenSharingDetail": "Você está compartilhando sua tela no FluffyChat",
-    "@screenSharingDetail": {},
     "noKeyForThisMessage": "Isto pode ocorrer caso a mensagem tenha sido enviada antes de você ter se conectado à sua conta com este dispositivo.\n\nTambém é possível que o remetente tenha bloqueado o seu dispositivo ou ocorreu algum problema com a conexão.\n\nVocê consegue ler as mensagens em outra sessão? Então, pode transferir as mensagens de lá! Vá em Configurações > Dispositivos e confira se os dispositivos verificaram um ao outro. Quando abrir a sala da próxima vez e ambas as sessões estiverem abertas, as chaves serão transmitidas automaticamente.\n\nNão gostaria de perder suas chaves ao desconectar ou trocar de dispositivos? Certifique-se que o backup de conversas esteja ativado nas configurações.",
     "@noKeyForThisMessage": {},
     "notAnImage": "Não é um arquivo de imagem.",
@@ -2274,12 +2096,6 @@
     "@unbanUserDescription": {},
     "messagesStyle": "Mensagens:",
     "@messagesStyle": {},
-    "newSpaceDescription": "Os espaços permitem que você consolide suas conversas e construa comunidades públicas ou privadas.",
-    "@newSpaceDescription": {},
-    "chatDescription": "Descrição da conversa",
-    "@chatDescription": {},
-    "encryptThisChat": "Criptografar esta conversa",
-    "@encryptThisChat": {},
     "reopenChat": "Reabrir conversa",
     "@reopenChat": {},
     "pushNotificationsNotAvailable": "Notificações push não estão disponíveis",
@@ -2348,8 +2164,6 @@
     },
     "openLinkInBrowser": "Abrir link no navegador",
     "@openLinkInBrowser": {},
-    "disableEncryptionWarning": "Por razões de segurança, não é possível desativar a criptografada uma vez ativada.",
-    "@disableEncryptionWarning": {},
     "directChat": "Conversa direta",
     "@directChat": {},
     "wrongPinEntered": "PIN incorreto! Tente novamente em {seconds} segundos...",
@@ -2384,8 +2198,6 @@
     "@pleaseEnterANumber": {},
     "jump": "Pular",
     "@jump": {},
-    "sorryThatsNotPossible": "Desculpe... isto não é possível",
-    "@sorryThatsNotPossible": {},
     "shareInviteLink": "Compartilhar link de convite",
     "@shareInviteLink": {},
     "deviceKeys": "Chaves de dispositivo:",
@@ -2395,8 +2207,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "Aplicar tema:",
-    "@setTheme": {},
     "createGroup": "Criar grupo",
     "@createGroup": {},
     "noBackupWarning": "Atenção! Se não ativar o backup de conversas, você perderá acesso a suas mensagens criptografadas. É altamente recomendável ativar o backup antes de sair.",
@@ -2407,8 +2217,6 @@
     "@invite": {},
     "blockListDescription": "Você pode bloquear usuários que estejam te perturbando. Você não receberá mensagens ou convites de usuários na sua lista pessoal de bloqueios.",
     "@blockListDescription": {},
-    "createGroupAndInviteUsers": "Criar um grupo e convidar pessoas",
-    "@createGroupAndInviteUsers": {},
     "thisDevice": "Este dispositivo:",
     "@thisDevice": {},
     "startConversation": "Iniciar uma conversa",
@@ -2421,8 +2229,6 @@
     "@passwordIsWrong": {},
     "pleaseEnterYourCurrentPassword": "Digite sua senha atual",
     "@pleaseEnterYourCurrentPassword": {},
-    "groupCanBeFoundViaSearch": "Grupos podem ser encontrados por pesquisa",
-    "@groupCanBeFoundViaSearch": {},
     "noUsersFoundWithQuery": "Infelizmente, não foi encontrado usuário com \"{query}\". Verifique se digitou corretamente.",
     "@noUsersFoundWithQuery": {
         "type": "String",
@@ -2456,8 +2262,6 @@
     "@pleaseChooseAStrongPassword": {},
     "blockUsername": "Ignorar nome de usuário",
     "@blockUsername": {},
-    "addChatOrSubSpace": "Adicionar conversa ou subespaço",
-    "@addChatOrSubSpace": {},
     "groupName": "Nome do grupo",
     "@groupName": {},
     "leaveEmptyToClearStatus": "Deixe em branco para limpar seu estado.",
@@ -2468,14 +2272,10 @@
     "@searchForUsers": {},
     "databaseMigrationTitle": "O banco de dados está otimizado",
     "@databaseMigrationTitle": {},
-    "searchChatsRooms": "Pesquisar por #conversas, @usuários...",
-    "@searchChatsRooms": {},
     "databaseMigrationBody": "Aguarde. Isto pode demorar um pouco.",
     "@databaseMigrationBody": {},
     "formattedMessagesDescription": "Exibir conteúdo de mensagem rico, como texto em negrito usando markdown.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Verificar outro usuário",
-    "@verifyOtherUser": {},
     "verifyOtherDevice": "🔐 Verificar outro dispositivo",
     "@verifyOtherDevice": {},
     "acceptedKeyVerification": "{sender} aceitou a verificação de chaves",
@@ -2500,18 +2300,6 @@
     "@transparent": {},
     "initAppError": "Ocorreu um erro enquanto o app era iniciado",
     "@initAppError": {},
-    "restoreSessionBody": "O app tentará agora restaurar sua sessão a partir do backup. Relate isto ao desenvolvedor em {url}. A mensagem de erro é: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendReadReceipts": "Enviar recibos de leitura",
     "@sendReadReceipts": {},
     "sendTypingNotificationsDescription": "Outros participantes nesta conversa podem ver quando você está digitando uma nova mensagem.",
@@ -2529,22 +2317,8 @@
     "@commandHint_unignore": {},
     "hidePresences": "Ocultar lista de estado?",
     "@hidePresences": {},
-    "sessionLostBody": "Sua sessão foi desconectada. Relate este ao desenvolvedor em {url}. A mensagem de erro é: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendReadReceiptsDescription": "Outros participantes nesta conversa podem ver quando você tiver lido uma mensagem.",
     "@sendReadReceiptsDescription": {},
-    "verifyOtherUserDescription": "Se você verificar outro usuário, você terá certeza que você conhece com quem está conversando. 💪\n\nAo iniciar uma verificação, você e o outro usuário receberão um pop-up no app. Então vocês receberão uma série de emojis ou números para comparar um com o outro.\n\nA melhor maneira de fazer este procedimento é se encontrar pessoalmente ou através de uma chamada de vídeo. 👭",
-    "@verifyOtherUserDescription": {},
     "requestedKeyVerification": "{sender} solicitou uma verificação de chaves",
     "@requestedKeyVerification": {
         "type": "String",
@@ -2603,8 +2377,6 @@
     },
     "appLockDescription": "Bloquear o app com um código PIN quando não estiver usando",
     "@appLockDescription": {},
-    "accessAndVisibilityDescription": "Quem pode entrar nesta conversa e como a conversa pode ser descoberta.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Chamadas",
     "@calls": {},
     "customEmojisAndStickers": "Emojis e stickers customizados",
@@ -2619,38 +2391,17 @@
     "@hideInvalidOrUnknownMessageFormats": {},
     "overview": "Visão geral",
     "@overview": {},
-    "usersMustKnock": "Usuários devem bater na porta",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Ninguém pode entrar",
-    "@noOneCanJoin": {},
     "knocking": "Batendo na porta",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "A conversa pode ser descoberta por pesquisa em {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "publicChatAddresses": "Endereços de conversas públicas",
-    "@publicChatAddresses": {},
     "thereAreCountUsersBlocked": "Nesse momento, há {count} usuários bloqueados.",
     "@thereAreCountUsersBlocked": {
         "type": "String",
         "count": {}
     },
-    "globalChatId": "ID global de conversa",
-    "@globalChatId": {},
-    "accessAndVisibility": "Acesso e visibilidade",
-    "@accessAndVisibility": {},
     "passwordRecoverySettings": "Configurações de recuperação de senha",
     "@passwordRecoverySettings": {},
     "noDatabaseEncryption": "A criptografia do banco de dados não é suportada nesta plataforma",
     "@noDatabaseEncryption": {},
-    "createNewAddress": "Criar um novo endereço",
-    "@createNewAddress": {},
     "knock": "Bater na porta",
     "@knock": {},
     "searchIn": "Procurar na conversa {chat}...",
@@ -2743,21 +2494,10 @@
     "@compress": {},
     "invalidUrl": "URL inválida",
     "@invalidUrl": {},
-    "appWantsToUseForLoginDescription": "Aqui, você permite que o app e o site compartilhem informações sobre você.",
-    "@appWantsToUseForLoginDescription": {},
     "notificationRuleMemberEvent": "Evento de membro",
     "@notificationRuleMemberEvent": {},
     "crossVerifiedDevicesIfEnabled": "Dispositivos verificados por ambos se ativado",
     "@crossVerifiedDevicesIfEnabled": {},
-    "countInvited": "{count} convidados",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "checkList": "Lista de tarefas",
     "@checkList": {},
     "synchronizingPleaseWaitCounter": " Sincronizando… ({percentage}%)",
@@ -2794,8 +2534,6 @@
     "@sendCanceled": {},
     "unableToJoinChat": "Não foi possível entrar na conversa. Talvez a outra pessoa já fechou a conversa.",
     "@unableToJoinChat": {},
-    "whatIsAHomeserver": "O que é um servidor?",
-    "@whatIsAHomeserver": {},
     "prepareSendingAttachment": "Preparando o envio do anexo...",
     "@prepareSendingAttachment": {},
     "sendingAttachment": "Enviando o anexo...",
@@ -2822,15 +2560,6 @@
     "@italicText": {},
     "strikeThrough": "Risco",
     "@strikeThrough": {},
-    "appWantsToUseForLogin": "Usar '{server}' para conectar",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "open": "Abrir",
     "@open": {},
     "roomNotificationSettings": "Configurações de notificações de sala",
@@ -2902,10 +2631,6 @@
         "type": "String",
         "space": {}
     },
-    "discoverHomeservers": "Explorar servidores",
-    "@discoverHomeservers": {},
-    "loginWithMatrixId": "Conectar com ID Matrix",
-    "@loginWithMatrixId": {},
     "calculatingFileSize": "Calculando o tamanho do arquivo...",
     "@calculatingFileSize": {},
     "compressVideo": "Comprimindo o vídeo...",
@@ -2923,8 +2648,6 @@
             }
         }
     },
-    "manageAccount": "Gerenciar conta",
-    "@manageAccount": {},
     "newChatRequest": "📩 Nova solicitação de conversa",
     "@newChatRequest": {},
     "userLevel": "{level} - Usuário",
@@ -2944,8 +2667,6 @@
     "@notificationRuleInviteForMeDescription": {},
     "approve": "Aprovar",
     "@approve": {},
-    "homeserverDescription": "Todos os seus dados são armazenados no servidor, parecido como um provedor de e-mail. Pode escolher qual servidor quer usar, enquanto ainda conversa com todo mundo. Aprenda mais em https://matrix.org.",
-    "@homeserverDescription": {},
     "notificationRuleEncryptedRoomOneToOne": "Sala criptografada de 2 pessoas",
     "@notificationRuleEncryptedRoomOneToOne": {},
     "pleaseWaitUntilInvited": "Aguarde até que alguém da sala te convide.",
@@ -2968,12 +2689,8 @@
             }
         }
     },
-    "welcomeText": "Olá! 👋 Este é o FluffyChat. Você pode se conectar com qualquer servidor que é compatível com o https://matrix.org. E então conversar com qualquer um. É uma rede gigante e descentralizada de conversa!",
-    "@welcomeText": {},
     "notificationRuleRoomServerAclDescription": "Omite notificações de listas de controle de acesso de servidor de uma sala (ACL).",
     "@notificationRuleRoomServerAclDescription": {},
-    "appIntroduction": "O FluffyChat permite que você converse com os seus amigos entre mensageiros diferentes. Aprenda mais em https://matrix.org ou toque em *Continuar*.",
-    "@appIntroduction": {},
     "notificationRuleIsUserMentionDescription": "Notifica o usuário quando é mencionado diretamente em uma mensagem.",
     "@notificationRuleIsUserMentionDescription": {},
     "notificationRuleSuppressEdits": "Omitir edições",
@@ -3084,12 +2801,6 @@
     "@pause": {},
     "resume": "Retomar",
     "@resume": {},
-    "newSubSpace": "Novo sub espaço",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Mover para espaço diferente",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "A conversa será removida do espaço mas ainda aparecerá na sua lista de conversas.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} conversas",
     "@countChats": {
         "type": "String",
@@ -3099,26 +2810,6 @@
             }
         }
     },
-    "spaceMemberOf": "Membro do espaço de {spaces}",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "Membro do espaço de {spaces} pode bater na porta",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "Doar",
-    "@donate": {},
     "startedAPoll": "{username} iniciou uma enquete.",
     "@startedAPoll": {
         "type": "String",
@@ -3188,14 +2879,6 @@
     "@stickerPackName": {},
     "attribution": "Créditos",
     "@attribution": {},
-    "skipChatBackup": "Pular backup de conversas",
-    "@skipChatBackup": {},
-    "skipChatBackupWarning": "Tem certeza? Se não ativar o backup de conversas, você pode perder o acesso às suas mensagens se trocar de dispositivo.",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "Carregando mensagens",
-    "@loadingMessages": {},
-    "setupChatBackup": "Configurar backup de conversas",
-    "@setupChatBackup": {},
     "changedTheChatDescription": "{username} alterou a descrição da conversa",
     "@changedTheChatDescription": {},
     "changedTheChatName": "{username} alterou o nome da conversa",
@@ -3206,11 +2889,9 @@
     "taTooltip": "L2 usar com assistência de tradução",
     "interactiveTranslatorSliderHeader": "Tradutor Interativo",
     "interactiveGrammarSliderHeader": "Verificador de Gramática Interativo",
-    "interactiveTranslatorRequired": "Obrigatório",
     "waTooltip": "L2 usar sem assistência",
     "interactiveTranslator": "Assistência de tradução",
     "noIdenticalLanguages": "Por favor, escolha idiomas base e alvo diferentes",
-    "searchBy": "Pesquisar por país e idiomas",
     "joinWithClassCode": "Participar do curso",
     "languageLevelPreA1": "Novato Baixo (Pré A1)",
     "languageLevelA1": "Novato Médio (A1)",
@@ -3230,19 +2911,14 @@
     "whatIsYourBaseLanguage": "Qual é o seu idioma base?",
     "publicProfileTitle": "Permitir que meu perfil seja encontrado na busca",
     "publicProfileDesc": "Ao ativar, você permite que outros usuários encontrem seu perfil na barra de busca global e enviem solicitações para conversar. Neste momento, você pode escolher aceitar ou negar a solicitação.",
-    "errorDisableIT": "Assistência de tradução está desativada.",
-    "errorDisableIGC": "Assistência de gramática está desativada.",
     "errorDisableITUserDesc": "Clique aqui para atualizar as configurações de assistência de tradução",
     "errorDisableIGCUserDesc": "Clique aqui para atualizar as configurações de assistência de gramática",
     "errorDisableITClassDesc": "Assistência de tradução está desativada para o curso em que esta conversa está.",
     "errorDisableIGCClassDesc": "Assistência de gramática está desativada para o curso em que esta conversa está.",
-    "error405Title": "Idiomas não configurados",
     "error405Desc": "Por favor, configure seus idiomas no Menu Principal > Configurações de Aprendizado.",
     "termsAndConditions": "Termos e Condições",
     "andCertifyIAmAtLeast13YearsOfAge": " e certifico que tenho pelo menos 16 anos de idade.",
-    "error502504Title": "Uau, há muitos estudantes online!",
     "error502504Desc": "Ferramentas de tradução e gramática podem estar lentas ou indisponíveis enquanto os bots do Pangea se atualizam.",
-    "error404Title": "Erro de tradução!",
     "error404Desc": "O Pangea Bot não tem certeza de como traduzir isso...",
     "errorPleaseRefresh": "Estamos investigando! Por favor, recarregue e tente novamente.",
     "connectedToStaging": "Conectado ao Ambiente de Teste",
@@ -3280,13 +2956,9 @@
     "definitionsToolName": "Definições de Palavras",
     "definitionsToolDescription": "Quando ativado, palavras sublinhadas em azul podem ser clicadas para obter definições. Clique nas mensagens para acessar definições.",
     "welcomeBack": "Bem-vindo de volta! Se você fez parte do piloto de 2023-2024, entre em contato conosco para sua assinatura piloto especial. Se você é um professor que comprou licenças para sua turma, entre em contato conosco para sua assinatura de professor.",
-    "downloadTxtFile": "Baixar Arquivo de Texto",
-    "downloadCSVFile": "Baixar Arquivo CSV",
     "promotionalSubscriptionDesc": "Você atualmente possui uma assinatura promocional vitalícia. Envie uma mensagem para support@pangea.chat para ajuda na alteração da sua assinatura.",
     "originalSubscriptionPlatform": "Assinatura adquirida através de {purchasePlatform}",
     "oneWeekTrial": "Teste de Uma Semana",
-    "downloadXLSXFile": "Baixar arquivo Excel",
-    "unkDisplayName": "Desconhecido",
     "wwCountryDisplayName": "Mundo",
     "afCountryDisplayName": "Afeganistão",
     "axCountryDisplayName": "Ilhas Aland",
@@ -3581,7 +3253,6 @@
     "chatCapacityHasBeenChanged": "Capacidade do chat alterada",
     "chatCapacitySetTooLow": "A capacidade do chat deve ser pelo menos {count}.",
     "chatCapacityExplanation": "A capacidade do chat limita o número de membros permitidos em um chat.",
-    "tooManyRequest": "Muitas solicitações, por favor tente novamente mais tarde.",
     "enterNumber": "Por favor, insira um valor numérico inteiro.",
     "practice": "Praticar",
     "versionNotFound": "Versão não encontrada",
@@ -3591,7 +3262,6 @@
     "deleteSubscriptionWarningTitle": "Você tem uma assinatura ativa",
     "deleteSubscriptionWarningBody": "Excluir sua conta não cancelará automaticamente sua assinatura.",
     "manageSubscription": "Gerenciar assinatura",
-    "error520Title": "Por favor, tente novamente.",
     "error520Desc": "Desculpe, não conseguimos entender sua mensagem...",
     "wordsUsed": "Palavras usadas",
     "level": "Nível",
@@ -3609,7 +3279,6 @@
     "other": "Outro",
     "levelShort": "NÍVEL {level}",
     "noCapacityLimit": "Sem limite de capacidade",
-    "downloadGroupText": "Baixar texto do grupo",
     "notificationsOn": "Notificações ativadas",
     "notificationsOff": "Notificações desativadas",
     "joinWithCode": "Entrar com código",
@@ -3673,24 +3342,12 @@
     "whatIsTheMorphTag": "O que é {morphologicalFeature} de '{wordForm}'?",
     "dataAvailable": "Disponibilidade de dados",
     "available": "Disponível",
-    "pangeaBotIsFallible": "O Pangea Bot também comete erros!",
-    "whatIsMeaning": "O que significa '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Combine os significados com as palavras na mensagem!",
-    "doubleClickToEdit": "Clique duas vezes para editar.",
-    "topicLabel": "Tópico",
-    "topicPlaceholder": "Escolha um tópico...",
-    "modePlaceholder": "Escolha um modo...",
-    "learningObjectiveLabel": "Objetivo de aprendizagem",
-    "learningObjectivePlaceholder": "Escolha um objetivo de aprendizagem...",
-    "targetLanguageLabel": "Idioma alvo",
     "cefrLevelLabel": "Nível CEFR",
     "image": "Imagem",
     "video": "Vídeo",
     "nan": "Não aplicável",
-    "addVocabulary": "Adicionar vocabulário",
     "instructions": "Instruções",
-    "numberOfLearners": "Número de aprendizes",
-    "mustBeInteger": "Deve ser um número inteiro, ex: 1, 2, 3, ...",
     "constructUsePvmDesc": "Produzido em mensagem de voz",
     "leaveSpaceDescription": "Ao sair do curso, você deixará todos os chats dentro dele. Outros usuários verão que você saiu do curso.",
     "constructUseCorMmDesc": "Significado correto da mensagem",
@@ -3705,7 +3362,6 @@
     "ttsDisabledBody": "Você pode ativar a leitura de texto para fala nas configurações de aprendizado",
     "noSpaceDescriptionYet": "Ainda não foi criado uma descrição do curso.",
     "tooLargeToSend": "Esta mensagem é grande demais para enviar",
-    "exitWithoutSaving": "Tem certeza de que deseja sair sem salvar?",
     "enableAutocorrectPopupTitle": "Adicione seu teclado de idioma alvo indo em:",
     "enableAutocorrectPopupSteps": "  • Configurações\n  • Geral\n  • Teclado\n  • Teclados\n  • Adicionar Novo Teclado",
     "enableAutocorrectPopupDescription": "Depois que o idioma for selecionado, você pode clicar no pequeno ícone do globo na parte inferior esquerda do seu teclado para ativar o teclado recém-instalado.",
@@ -3716,11 +3372,8 @@
     "displayName": "Nome de exibição",
     "leaveRoomDescription": "Você está prestes a sair deste chat. Outros usuários verão que você saiu do chat.",
     "confirmUserId": "Por favor, confirme seu nome de usuário no Pangea Chat para excluir sua conta.",
-    "startingToday": "A partir de hoje",
-    "oneWeekFreeTrial": "Período de teste gratuito de uma semana",
     "paidSubscriptionStarts": "Começa em {startDate}",
     "cancelInSubscriptionSettings": "• Cancelar a qualquer momento nas configurações de assinatura",
-    "cancelToAvoidCharges": "• Cancelar antes de {trialEnds} para evitar cobranças",
     "downloadGboard": "Baixar Gboard",
     "autocorrectNotAvailable": "Infelizmente, sua plataforma não é suportada atualmente para esse recurso. Fique atento para novos desenvolvimentos!",
     "pleaseUpdateApp": "Por favor, atualize o aplicativo para continuar.",
@@ -3730,17 +3383,12 @@
     "knockSpaceSuccess": "Você solicitou ingressar neste curso! Um administrador responderá à sua solicitação quando a receber 😀",
     "chooseWordAudioInstructionsBody": "Ouça a mensagem completa. Depois, combine os áudios com as palavras.",
     "chooseMorphsInstructionsBody": "Clique nas peças do quebra-cabeça para perguntas de gramática!",
-    "pleaseEnterInt": "Por favor, insira um número",
     "home": "Início",
     "join": "Entrar",
     "resetInstructionTooltipsTitle": "Redefinir dicas de instruções",
     "resetInstructionTooltipsDesc": "Clique para mostrar dicas de instruções, como para um usuário novo.",
-    "randomize": "Embaralhar",
     "clear": "Limpar",
-    "featuredActivities": "Destaques",
     "save": "Salvar",
-    "startChat": "Iniciar um chat",
-    "translationProblem": "Problema de tradução",
     "askToJoin": "Solicitar entrada",
     "emptyChatWarningTitle": "Chat vazio",
     "emptyChatWarningDesc": "Você não convidou ninguém para o seu chat. Vá para Configurações de Chat para convidar seus contatos ou o Bot. Você também pode fazer isso mais tarde.",
@@ -3770,17 +3418,13 @@
     "timesUsedIndependently": "Vezes usadas independentemente",
     "timesUsedWithAssistance": "Vezes usadas com assistência",
     "shareInviteCode": "Compartilhar código de convite: {code}",
-    "leaderboard": "Classificação",
     "skipForNow": "Pular por enquanto",
     "permissions": "Permissões",
     "spaceChildPermission": "Quem pode adicionar novas conversas a este curso",
-    "addEnvironmentOverride": "Adicionar substituição de ambiente",
     "defaultOption": "Padrão",
     "deleteChatDesc": "Tem certeza de que deseja excluir esta conversa? Ela será excluída para todos os participantes e todas as mensagens dentro da conversa não estarão mais disponíveis para prática ou análises de aprendizado.",
     "deleteSpaceDesc": "O curso e quaisquer conversas selecionadas serão excluídos para todos os participantes e todas as mensagens dentro da conversa não estarão mais disponíveis para prática ou análises de aprendizado. Esta ação não pode ser desfeita.",
     "launch": "Iniciar",
-    "searchChats": "Pesquisar conversas",
-    "maxFifty": "Máximo 50",
     "configureSpace": "Configurar curso",
     "pinMessages": "Fixar mensagens",
     "setJoinRules": "Definir regras de entrada",
@@ -3814,9 +3458,6 @@
     "failedToFetchTranscription": "Falha ao buscar a transcrição",
     "deleteEmptySpaceDesc": "O curso será excluído para todos os participantes. Esta ação não pode ser desfeita.",
     "regenerate": "Regenerar",
-    "mySavedActivities": "Minhas atividades salvas",
-    "noSavedActivities": "Nenhuma atividade salva",
-    "saveActivity": "Salvar esta atividade",
     "failedToPlayVideo": "Falha ao reproduzir o vídeo",
     "done": "Concluído",
     "inThisSpace": "Neste espaço",
@@ -3827,13 +3468,9 @@
     "numInvited": "{count} convidado(s)",
     "saved": "Salvo",
     "reset": "Redefinir",
-    "errorFetchingActivitiesMessage": "Falha ao buscar atividades",
     "errorFetchingDefinition": "Falha ao buscar definição",
     "errorProcessAnalytics": "Falha ao processar análises",
     "errorDownloading": "Falha ao baixar",
-    "errorLoadingSpaceChildren": "Falha ao carregar conversas dentro deste curso",
-    "unexpectedError": "Erro inesperado.",
-    "pleaseReload": "Por favor, recarregue e tente novamente.",
     "translationError": "Erro de tradução",
     "check": "Verificar",
     "unableToFindRoom": "Nenhum chat ou curso encontrado com esse código. Por favor, tente novamente.",
@@ -3842,19 +3479,14 @@
     "request": "Solicitar",
     "requestAll": "Solicitar Tudo",
     "confirmMessageUnpin": "Tem certeza de que deseja desfixar esta mensagem?",
-    "saveAndLaunch": "Salvar e Iniciar",
-    "launchToSpace": "Iniciar no curso",
     "pending": "Pendente",
     "inactive": "Inativo",
-    "confirmRole": "Confirmar papel",
     "openRoleLabel": "ABERTO",
     "finishedTheActivity": "🎯 {username} encerrou esta atividade",
     "activitySummaryError": "Resumos de atividades indisponíveis",
     "requestSummaries": "Solicitar resumos",
-    "generatingNewActivities": "Você é o primeiro usuário deste par de idiomas! Por favor, aguarde um momento, estamos preparando atividades especialmente para você.",
     "requestAccessTitle": "Solicitar acesso à análise?",
     "requestAccessDesc": "Gostaria de solicitar acesso para visualizar as análises dos participantes?\n\nSe os participantes concordarem, os administradores deste curso poderão ver:\n    • vocabulário total\n    • conceitos gramaticais totais\n    • sessões de atividade concluídas\n    • os conceitos gramaticais específicos usados, corretamente e incorretamente\n\nEles não poderão ver:\n    • mensagens em chats fora do curso\n    • lista de vocabulário",
-    "requestAccess": "Solicitar acesso ({count})",
     "analyticsInactiveTitle": "Solicitações para usuários inativos não puderam ser enviadas",
     "analyticsInactiveDesc": "Usuários inativos que não fizeram login desde a introdução desta funcionalidade não verão sua solicitação.\n\nO botão Solicitar aparecerá assim que eles retornarem. Você pode reenviar a solicitação mais tarde clicando no botão Solicitar sob o nome deles quando estiver disponível.",
     "accessRequestedTitle": "Solicitação de acesso às análises",
@@ -3877,8 +3509,6 @@
     "accessDesc": "Você pode tornar seu curso aberto ao mundo! Ou, tornar seu curso privado e seguro.",
     "createGroupChatDesc": "Enquanto as sessões de atividade começam e terminam, os chats em grupo permanecerão abertos para comunicação rotineira.",
     "deleteDesc": "Somente administradores podem excluir um curso. Esta é uma ação destrutiva que remove todos os usuários e exclui todos os chats selecionados dentro do curso. Proceda com cautela.",
-    "noCourseFound": "Oh, este curso precisa de um plano!\n\nPlanos de curso são uma sequência de tópicos e atividades de conversa.",
-    "additionalParticipants": "+ {num} outros",
     "whatNow": "E agora?",
     "chooseNextActivity": "Escolha sua próxima atividade!",
     "letsGo": "Vamos lá",
@@ -3890,13 +3520,11 @@
     "waitNotDone": "Espere, eu não terminei!",
     "waitingForOthersToFinish": "Aguardando os demais terminarem...",
     "generatingSummary": "Analisando o chat e gerando resultados",
-    "findCourse": "Encontrar um curso",
     "pingParticipantsNotification": "{user} está procurando usuários para participar da sessão de atividade em {room}",
     "course": "Curso",
     "courses": "Cursos",
     "goToCourse": "Ir para o curso: {course}",
     "activityComplete": "Esta atividade foi concluída. O resumo da atividade deve estar disponível abaixo.",
-    "startNewSession": "Iniciar nova sessão",
     "joinOpenSession": "Participar de sessão aberta",
     "activityNotFound": "Atividade não encontrada",
     "myActivities": "Minhas atividades",
@@ -3940,7 +3568,6 @@
     "inviteYourFriends": "Convide seus amigos",
     "playWithAI": "Jogue com IA por enquanto",
     "courseStartDesc": "O Pangea Bot está pronto para começar a qualquer momento!\n\n...mas aprender é melhor com amigos!",
-    "activityDropdownDesc": "Quando terminar esta atividade, clique abaixo",
     "languageMismatchTitle": "Incompatibilidade de idioma",
     "languageMismatchDesc": "O idioma de destino não corresponde ao idioma desta atividade. Deseja atualizar seu idioma de destino?",
     "reportWordIssueTooltip": "Reportar problema na informação da palavra",
@@ -3984,10 +3611,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3997,10 +3620,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4084,14 +3703,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4108,10 +3719,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4124,15 +3731,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4284,14 +3883,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4305,14 +3896,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5535,10 +5118,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5579,10 +5158,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5655,10 +5230,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5928,47 +5499,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5988,19 +5519,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6064,10 +5583,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6108,14 +5623,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6127,14 +5634,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6172,10 +5671,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6192,27 +5687,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6336,10 +5815,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6349,10 +5824,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6369,14 +5840,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6516,18 +5979,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6576,10 +6027,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6589,18 +6036,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6643,23 +6078,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6683,10 +6106,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6694,14 +6113,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6806,18 +6217,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6866,10 +6265,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6896,10 +6291,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7083,10 +6474,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@activityDropdownDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@languageMismatchTitle": {
         "type": "String",
         "placeholders": {}
@@ -7132,17 +6519,11 @@
         "placeholders": {}
     },
     "startOwn": "Comece o seu próprio",
-    "joinCourseDesc": "Cada curso possui de 8 a 10 tópicos sequenciais com uma variedade de atividades de aprendizagem de idiomas baseadas em tarefas.",
     "newMessageInPangeaChat": "💬 Nova mensagem no Pangea Chat",
     "shareCourse": "Compartilhar curso",
     "addCourse": "Adicionar um curso",
-    "joinPublicCourse": "Entrar em curso público",
     "vocabLevelsDesc": "É aqui que as palavras de vocabulário irão aparecer assim que você as evoluir!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7155,10 +6536,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7177,7 +6554,6 @@
     "emojiView": "Visualização de emoji",
     "feedbackDialogDesc": "Eu também cometo erros! Algo para me ajudar a melhorar?",
     "contactHasBeenInvitedToTheCourse": "O contato foi convidado para o curso",
-    "activityStatsButtonTooltip": "Informações da atividade",
     "allow": "Permitir",
     "deny": "Negar",
     "enabledRenewal": "Ativar Renovação de Assinatura",
@@ -7445,10 +6821,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8504,16 +7876,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Atividades para Desbloquear o Próximo Tópico",
-    "activitiesToUnlockTopicDesc": "Defina o número de atividades para desbloquear o próximo tópico do curso",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Prática de definição de vocabulário correta",
     "constructUseIncLMDesc": "Prática de definição de vocabulário incorreta",
     "constructUseCorLADesc": "Prática de áudio de vocabulário correta",
@@ -8521,7 +7883,6 @@
     "constructUseBonus": "Bônus durante a prática de vocabulário",
     "practiceVocab": "Praticar vocabulário",
     "selectMeaning": "Selecione o significado",
-    "selectAudio": "Selecione o áudio correspondente",
     "anotherRound": "Outra rodada",
     "activitySettingsOverrideWarning": "Idioma e nível de idioma determinados pelo plano de atividade",
     "voice": "Voz",
@@ -8553,10 +7914,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8574,12 +7931,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Download iniciado",
     "webDownloadPermissionMessage": "Se o seu navegador bloquear downloads, por favor, habilite downloads para este site.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8674,11 +8026,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Algo deu errado, e estamos trabalhando duro para consertar. Verifique novamente mais tarde.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Ativar assistência de escrita",
     "autoIGCToolDescription": "Executar automaticamente as ferramentas do Pangea Chat para corrigir mensagens enviadas para o idioma de destino.",
     "@autoIGCToolName": {
@@ -8734,24 +8081,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramática",
-    "spanTypeWordChoice": "Escolha de Palavras",
     "spanTypeSpelling": "Ortografia",
     "spanTypePunctuation": "Pontuação",
     "spanTypeStyle": "Estilo",
     "spanTypeFluency": "Fluência",
     "spanTypeAccents": "Acentos",
     "spanTypeCapitalization": "Capitalização",
-    "spanTypeCorrection": "Correção",
     "spanFeedbackTitle": "Relatar problema de correção",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8776,10 +8112,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8790,14 +8122,10 @@
     "clientWellKnownInformation": "Informações Conhecidas do Cliente:",
     "baseUrl": "URL Base",
     "identityServer": "Servidor de Identidade:",
-    "versionWithNumber": "Versão: {version}",
     "logs": "Registros",
-    "advancedConfigs": "Configurações Avançadas",
     "advancedConfigurations": "Configurações avançadas",
-    "signInWithLabel": "Entrar com:",
     "inviteFriends": "Convidar amigos",
     "selectAllWords": "Selecione todas as palavras que você ouve no áudio",
-    "joinCourseForActivities": "Participe de um curso para experimentar atividades.",
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8826,27 +8154,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
         "type": "String",
         "placeholders": {}
     },
-    "@advancedConfigs": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@advancedConfigurations": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@signInWithLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -8855,10 +8167,6 @@
         "placeholders": {}
     },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9059,11 +8367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Em uma aula? Coloque seu código de entrada aqui.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Realçar automaticamente mensagens de áudio",
     "selectAudioMessagesOnPlayDescription": "Realçar automaticamente mensagens de áudio quando reproduzidas",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9107,18 +8410,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Este curso tem tópicos com menos de {input} atividades. Por favor, insira um número menor ou igual a {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Clique aqui para fazer login novamente.",
     "@clickToLogin": {
@@ -9535,17 +8826,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Um urso amarelo em estilo de desenho animado com os braços levantados em empolgação.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Selecione palavras para aprender mais sobre elas",
     "requireAnalyticsAccessTitle": "Requer acesso à análise para participar",
     "requireAnalyticsAccessDesc": "Os participantes devem conceder acesso às suas análises de aprendizado para participar deste curso",
     "analyticsAccessNoticeTitle": "Acesso à Análise Necessário",
     "analyticsAccessNoticeDesc": "Ao participar deste curso, você concorda em conceder acesso aos administradores às suas análises de aprendizado.",
-    "skipOnboardingClassCodeDesc": "Aprendendo de forma independente? Não se preocupe, você pode:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9563,10 +8848,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9595,7 +8876,6 @@
     "pickCefrLevelTeacherStepTitle": "Qual nível você ensina?",
     "pickCefrLevelStudentStepTitle": "Qual nível você está?",
     "customCourseStepTitle": "Preencha este formulário para obter um curso personalizado",
-    "aboutYourClass": "Sobre sua turma",
     "courseCodeStepErrorMessage": "Por favor, verifique seu código e tente novamente",
     "institution": "Instituição",
     "courseGoals": "Objetivos do Curso",
@@ -9638,10 +8918,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9758,12 +9034,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logotipo do Pangea Chat",
     "introChatDetails": "Diga olá! Apresente-se aos seus colegas participantes do curso, encontre amigos e converse fora das atividades.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9807,11 +9078,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Ações de atividade",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Ferramentas de pronúncia",
     "audioTranscription": "Transcrição de áudio com IA",
     "visualLearnerSupport": "Apoio para aprendizes visuais",
@@ -9852,7 +9118,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Junte-se a um curso que inclua esta atividade para jogá-la.",
     "resizeCoursePanel": "Redimensionar painel do curso",
     "undo": "Desfazer",
     "unlock": "Desbloquear",
@@ -9866,7 +9131,6 @@
     "addCourseBrowsePublic": "Navegar por cursos públicos",
     "browsePublicCourses": "Navegar por cursos públicos",
     "editProfile": "Editar perfil",
-    "numObjectives": "{count} objetivos",
     "mapSearchHint": "Pesquisar atividades",
     "mapSearchNoResults": "Nenhuma correspondência na visualização",
     "mapFilterAllLanguages": "Todos os idiomas",
@@ -9875,7 +9139,6 @@
     "mapFilterCompleted": "Concluído",
     "mapFilterReset": "Redefinir",
     "activityTypeConversation": "Conversa",
-    "lockedMissionRequirement": "Termine a missão anterior para desbloquear",
     "playAgain": "Jogar novamente",
     "reviewActivity": "Revisar",
     "mapEmptyInView": "Nada aqui no seu nível ou idioma. Amplie seus filtros ou afaste-se.",
@@ -9890,14 +9153,9 @@
     "scrollToBottom": "Role para baixo",
     "courseImage": "Imagem do curso",
     "avatarPreview": "Pré-visualização do avatar",
-    "activityPhoto": "Foto da atividade",
     "emotePreview": "Pré-visualização do emote: {name}",
     "activityLabel": "Atividade: {title}",
     "resetMapView": "Redefinir visualização do mapa",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9950,14 +9208,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9987,10 +9237,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10047,10 +9293,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_pt_PT.arb
+++ b/lib/l10n/intl_pt_PT.arb
@@ -80,11 +80,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Todos os visitantes podem entrar",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Tens a certeza?",
     "@areYouSure": {
         "type": "String",
@@ -295,15 +290,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "A cópia de segurança foi configurada.",
-    "@yourChatBackupHasBeenSetUp": {},
     "chatBackup": "Cópia de segurança de conversas",
     "@chatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "A tuas mensagens antigas estão protegidas com uma chave de recuperação. Por favor, certifica-te que não a perdes.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -438,11 +426,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "O contacto foi convidado para o grupo",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "O conteúdo foi denunciado aos admins do servidor",
     "@contentHasBeenReported": {
         "type": "String",
@@ -494,11 +477,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Novo espaço",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Ativo(a) agora",
     "@currentlyActive": {
@@ -642,11 +620,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Nunca mais poderás desativar a encriptação. Tens a certeza?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Encriptada",
     "@encrypted": {
         "type": "String",
@@ -687,11 +660,6 @@
             }
         }
     },
-    "everythingReady": "Tudo a postos!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Extremamente ofensivo",
     "@extremeOffensive": {
         "type": "String",
@@ -719,11 +687,6 @@
     },
     "group": "Grupo",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "O grupo é público",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -817,15 +780,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Convidar contacto para {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Convidado(a)",
     "@invited": {
@@ -938,15 +892,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Carregar mais {count} participantes",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "A carregar... Por favor aguarde.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -971,15 +916,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Entrar em {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Sair",
     "@logout": {
@@ -1043,16 +979,6 @@
     },
     "noEmotesFound": "Nenhuns emotes encontrados. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Só podes ativar a encriptação quando a sala não for publicamente acessível.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Parece que não tens nenhuns serviços da Google no seu telemóvel. É uma boa decisão para a sua privacidade! Para receber notificações instantâneas no FluffyChat, recomendamos que uses https://microg.org/ ou https://unifiedpush.org/.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1241,8 +1167,6 @@
     },
     "oneClientLoggedOut": "Um dos teus clientes terminou sessão",
     "@oneClientLoggedOut": {},
-    "addAccount": "Adicionar conta",
-    "@addAccount": {},
     "editBundlesForAccount": "Editar pacotes para esta conta",
     "@editBundlesForAccount": {},
     "addToBundle": "Adicionar ao pacote",
@@ -1251,8 +1175,6 @@
     "@removeFromBundle": {},
     "bundleName": "Nome do pacote",
     "@bundleName": {},
-    "enableMultiAccounts": "(BETA) Ativar múltiplas contas neste dispositivo",
-    "@enableMultiAccounts": {},
     "openInMaps": "Abrir nos mapas",
     "@openInMaps": {
         "type": "String",
@@ -1289,11 +1211,6 @@
     },
     "passwordHasBeenChanged": "A palavra-passe foi alterada",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Recuperação de palavra-passe",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1432,11 +1349,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Remover dispositivo",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Perdoar nesta conversa",
     "@unbanFromChat": {
@@ -1617,19 +1529,14 @@
     "commandHint_markasdm": "Marcar como sala de mensagem direta para o ID Matrix fornecido",
     "commandHint_markasgroup": "Marcar como grupo",
     "checkList": "Lista de verificação",
-    "countInvited": "{count} convidado(s)",
     "createGroup": "Criar grupo",
     "chatPermissions": "Permissões de conversa",
     "emoteKeyboardNoRecents": "Emotes usados recentemente aparecerão aqui...",
-    "globalChatId": "ID do chat global",
-    "accessAndVisibility": "Acesso e visibilidade",
-    "accessAndVisibilityDescription": "Quem pode participar neste chat e como o chat pode ser descoberto.",
     "calls": "Chamadas",
     "customEmojisAndStickers": "Emojis e stickers personalizados",
     "customEmojisAndStickersBody": "Adicione ou partilhe emojis ou stickers personalizados que podem ser usados em qualquer chat.",
     "fromJoining": "Ao juntar-se",
     "fromTheInvitation": "A partir do convite",
-    "chatDescription": "Descrição do chat",
     "chatDescriptionHasBeenChanged": "Descrição do chat alterada",
     "hideRedactedMessages": "Ocultar mensagens redigidas",
     "hideRedactedMessagesBody": "Se alguém redigir uma mensagem, essa mensagem não será mais visível no chat.",
@@ -1649,19 +1556,15 @@
     "openVideoCamera": "Abrir câmara para vídeo",
     "overview": "Visão geral",
     "passwordRecoverySettings": "Configurações de recuperação de palavra-passe",
-    "pleaseEnterRecoveryKey": "Por favor, insira a sua chave de recuperação:",
     "pushRules": "Regras de notificação",
     "redactedBy": "Redigido por {username}",
     "directChat": "Chat direto",
     "redactedByBecause": "Redigido por {username} porque: \"{reason}\"",
-    "recoveryKey": "Chave de recuperação",
-    "recoveryKeyLost": "Chave de recuperação perdida?",
     "sendImages": "Enviar {count} imagem",
     "sentCallInformations": "{senderName} enviou informações da chamada",
     "separateChatTypes": "Separar conversas diretas e grupos",
     "setAsCanonicalAlias": "Definir como alias principal",
     "setChatDescription": "Definir descrição do chat",
-    "setPermissionsLevel": "Definir nível de permissões",
     "setStatus": "Definir estado",
     "settings": "Configurações",
     "share": "Partilhar",
@@ -1671,8 +1574,6 @@
     "presencesToggle": "Mostrar mensagens de estado de outros utilizadores",
     "skip": "Pular",
     "sourceCode": "Código fonte",
-    "spaceIsPublic": "O espaço é público",
-    "spaceName": "Nome do espaço",
     "startedACall": "{senderName} iniciou uma chamada",
     "status": "Estado",
     "statusExampleMessage": "Como estás hoje?",
@@ -1684,7 +1585,6 @@
     "theyMatch": "Correspondem",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "Muitas solicitações. Por favor, tente novamente mais tarde!",
-    "transferFromAnotherDevice": "Transferir de outro dispositivo",
     "tryToSendAgain": "Tente enviar novamente",
     "unavailable": "Indisponível",
     "unbannedUser": "{username} desbanido {targetName}",
@@ -1694,7 +1594,6 @@
     "unknownEvent": "Evento desconhecido '{type}'",
     "unmuteChat": "Ativar som do chat",
     "unpin": "Desafixar",
-    "unreadChats": "{unreadCount, plural, =1{1 chat não lido} other{{unreadCount} chats não lidos}}",
     "userAndOthersAreTyping": "{username} e {count} outros estão a digitar…",
     "userAndUserAreTyping": "{username} e {username2} estão a digitar…",
     "userIsTyping": "{username} está a digitar…",
@@ -1707,8 +1606,6 @@
     "verifyStart": "Iniciar verificação",
     "verifySuccess": "Verificação bem-sucedida!",
     "verifyTitle": "A verificar outra conta",
-    "videoCall": "Chamada de vídeo",
-    "visibilityOfTheChatHistory": "Visibilidade do histórico do chat",
     "visibleForAllParticipants": "Visível para todos os participantes",
     "visibleForEveryone": "Visível para todos",
     "voiceMessage": "Mensagem de voz",
@@ -1718,10 +1615,7 @@
     "wallpaper": "Papel de parede:",
     "warning": "Aviso!",
     "weSentYouAnEmail": "Enviámos-lhe um email",
-    "whoCanPerformWhichAction": "Quem pode realizar qual ação",
-    "whoIsAllowedToJoinThisGroup": "Quem tem permissão para entrar neste grupo",
     "whyDoYouWantToReportThis": "Por que deseja denunciar isto?",
-    "wipeChatBackup": "Apagar o backup do chat para criar uma nova chave de recuperação?",
     "withTheseAddressesRecoveryDescription": "Com estes endereços pode recuperar a sua palavra-passe.",
     "writeAMessage": "Escreva uma mensagem…",
     "yes": "Sim",
@@ -1734,9 +1628,7 @@
     "messageType": "Tipo de mensagem",
     "sender": "Remetente",
     "openGallery": "Abrir galeria",
-    "removeFromSpace": "Remover do espaço",
     "start": "Iniciar",
-    "pleaseEnterRecoveryKeyDescription": "Para desbloquear as suas mensagens antigas, insira a sua chave de recuperação que foi gerada numa sessão anterior. A sua chave de recuperação NÃO é a sua palavra-passe.",
     "publish": "Publicar",
     "openChat": "Abrir conversa",
     "markAsRead": "Marcar como lida",
@@ -1747,12 +1639,9 @@
     "confirmEventUnpin": "Tem certeza de que deseja desfixar permanentemente o evento?",
     "emojis": "Emojis",
     "placeCall": "Realizar chamada",
-    "voiceCall": "Chamada de voz",
     "unsupportedAndroidVersion": "Versão do Android não suportada",
     "unsupportedAndroidVersionLong": "Este recurso requer uma versão mais recente do Android. Por favor, verifique atualizações ou suporte do Lineage OS.",
-    "videoCallsBetaWarning": "Por favor, note que as chamadas de vídeo estão atualmente em beta. Elas podem não funcionar como esperado ou podem não funcionar em todas as plataformas.",
     "experimentalVideoCalls": "Chamadas de vídeo experimentais",
-    "emailOrUsername": "Email ou nome de utilizador",
     "addWidget": "Adicionar widget",
     "widgetVideo": "Vídeo",
     "widgetEtherpad": "Nota de texto",
@@ -1774,35 +1663,19 @@
     "youKickedAndBanned": "🙅‍♀️ Você expulsou e baniu {user}",
     "youUnbannedUser": "Você desbaniu {user}",
     "hasKnocked": "🚪 {user} bateu na porta",
-    "usersMustKnock": "Os usuários devem bater na porta",
-    "noOneCanJoin": "Ninguém pode entrar",
     "knock": "Bater na porta",
     "users": "Usuários",
-    "unlockOldMessages": "Desbloquear mensagens antigas",
-    "storeInSecureStorageDescription": "Armazene a chave de recuperação no armazenamento seguro deste dispositivo.",
-    "saveKeyManuallyDescription": "Salve esta chave manualmente acionando o diálogo de compartilhamento do sistema ou a área de transferência.",
-    "storeInAndroidKeystore": "Armazenar no Android KeyStore",
-    "storeInAppleKeyChain": "Armazenar no Apple KeyChain",
-    "storeSecurlyOnThisDevice": "Armazenar com segurança neste dispositivo",
     "countFiles": "{count} ficheiros",
     "user": "Utilizador",
     "custom": "Personalizado",
-    "foregroundServiceRunning": "Esta notificação aparece quando o serviço em primeiro plano está em execução.",
-    "screenSharingTitle": "partilha de ecrã",
-    "screenSharingDetail": "Está a partilhar o seu ecrã no FuffyChat",
     "whyIsThisMessageEncrypted": "Por que esta mensagem é ilegível?",
     "noKeyForThisMessage": "Isto pode acontecer se a mensagem foi enviada antes de iniciar sessão na sua conta neste dispositivo.\n\nTambém é possível que o remetente tenha bloqueado o seu dispositivo ou que algo tenha corrido mal com a conexão à internet.\n\nConsegue ler a mensagem numa outra sessão? Então pode transferi-la para ela! Vá a Configurações > Dispositivos e certifique-se de que os seus dispositivos verificaram-se mutuamente. Quando abrir a sala na próxima vez e ambas as sessões estiverem em primeiro plano, as chaves serão transmitidas automaticamente.\n\nNão quer perder as chaves ao sair ou trocar de dispositivo? Certifique-se de que ativou o backup do chat nas configurações.",
     "newGroup": "Novo grupo",
     "newSpace": "Novo espaço",
-    "enterSpace": "Entrar no espaço",
     "allSpaces": "Todos os espaços",
     "hidePresences": "Ocultar lista de status?",
     "doNotShowAgain": "Não mostrar novamente",
     "wasDirectChatDisplayName": "Chat vazio (era {oldDisplayName})",
-    "newSpaceDescription": "Espaços permitem consolidar suas conversas e construir comunidades privadas ou públicas.",
-    "encryptThisChat": "Criptografar esta conversa",
-    "disableEncryptionWarning": "Por razões de segurança, não pode desativar a criptografia numa conversa onde ela foi ativada anteriormente.",
-    "sorryThatsNotPossible": "Desculpe... isso não é possível",
     "deviceKeys": "Chaves do dispositivo:",
     "reopenChat": "Reabrir conversa",
     "noBackupWarning": "Aviso! Sem ativar o backup da conversa, perderá o acesso às suas mensagens criptografadas. Recomenda-se fortemente ativar o backup da conversa antes de sair.",
@@ -1815,7 +1688,6 @@
     "openLinkInBrowser": "Abrir link no navegador",
     "reportErrorDescription": "😞 Oh não. Algo deu errado. Se desejar, pode relatar este erro aos desenvolvedores.",
     "report": "relatar",
-    "setTheme": "Definir tema:",
     "setColorTheme": "Definir tema de cor:",
     "invite": "Convidar",
     "inviteGroupChat": "📨 Convidar grupo de chat",
@@ -1834,12 +1706,8 @@
     "yourGlobalUserIdIs": "O seu ID de utilizador global é: ",
     "noUsersFoundWithQuery": "Infelizmente, não foi possível encontrar nenhum utilizador com \"{query}\". Por favor, verifique se cometeu algum erro de digitação.",
     "knocking": "A tocar",
-    "chatCanBeDiscoveredViaSearchOnServer": "O chat pode ser descoberto através da pesquisa no {server}",
-    "searchChatsRooms": "Pesquisar #chats, @utilizadores...",
     "nothingFound": "Nada encontrado...",
     "groupName": "Nome do grupo",
-    "createGroupAndInviteUsers": "Criar um grupo e convidar utilizadores",
-    "groupCanBeFoundViaSearch": "O grupo pode ser encontrado através da pesquisa",
     "wrongRecoveryKey": "Desculpe... parece que esta não é a chave de recuperação correta.",
     "startConversation": "Iniciar conversa",
     "commandHint_sendraw": "Enviar JSON bruto",
@@ -1853,11 +1721,8 @@
     "pleaseChooseAStrongPassword": "Por favor, escolha uma palavra-passe forte",
     "passwordsDoNotMatch": "As palavras-passe não coincidem",
     "passwordIsWrong": "A palavra-passe inserida está incorreta",
-    "publicChatAddresses": "Endereços de chat públicos",
-    "createNewAddress": "Criar novo endereço",
     "joinSpace": "Juntar-se ao espaço",
     "publicSpaces": "Espaços públicos",
-    "addChatOrSubSpace": "Adicionar chat ou subespaço",
     "subspace": "Subespaço",
     "decline": "Recusar",
     "thisDevice": "Este dispositivo:",
@@ -1866,15 +1731,11 @@
     "searchMore": "Pesquisar mais...",
     "gallery": "Galeria",
     "files": "Ficheiros",
-    "sessionLostBody": "A sua sessão foi perdida. Por favor, reporte este erro aos desenvolvedores em {url}. A mensagem de erro é: {error}",
-    "restoreSessionBody": "A aplicação tenta agora restaurar a sua sessão a partir do backup. Por favor, reporte este erro aos desenvolvedores em {url}. A mensagem de erro é: {error}",
     "sendReadReceipts": "Enviar confirmações de leitura",
     "sendTypingNotificationsDescription": "Outros participantes num chat podem ver quando está a escrever uma nova mensagem.",
     "sendReadReceiptsDescription": "Outros participantes num chat podem ver quando leu uma mensagem.",
     "formattedMessages": "Mensagens formatadas",
     "formattedMessagesDescription": "Exibir conteúdo de mensagens enriquecido, como texto em negrito, usando markdown.",
-    "verifyOtherUser": "🔐 Verificar outro utilizador",
-    "verifyOtherUserDescription": "Se verificar outro utilizador, pode ter a certeza de que sabe realmente com quem está a falar. 💪\n\nQuando inicia uma verificação, você e o outro utilizador verão uma janela pop-up na aplicação. Lá, vocês verão uma série de emojis ou números que devem comparar entre si.\n\nA melhor forma de fazer isto é encontrarem-se pessoalmente ou iniciarem uma chamada de vídeo. 👭",
     "verifyOtherDevice": "🔐 Verificar outro dispositivo",
     "verifyOtherDeviceDescription": "Quando verifica outro dispositivo, esses dispositivos podem trocar chaves, aumentando a sua segurança geral. 💪 Quando inicia uma verificação, aparecerá uma janela pop-up na aplicação em ambos os dispositivos. Lá, vocês verão uma série de emojis ou números que devem comparar entre si. É melhor ter ambos os dispositivos à mão antes de iniciar a verificação. 🤳",
     "acceptedKeyVerification": "{sender} aceitou a verificação de chaves",
@@ -1910,10 +1771,6 @@
     "updateInstalled": "🎉 Atualização {version} instalada!",
     "changelog": "Registo de alterações",
     "sendCanceled": "Envio cancelado",
-    "loginWithMatrixId": "Entrar com Matrix-ID",
-    "discoverHomeservers": "Descobrir servidores principais",
-    "whatIsAHomeserver": "O que é um servidor principal?",
-    "homeserverDescription": "Todos os seus dados são armazenados no servidor principal, tal como um provedor de email. Pode escolher qual servidor principal quer usar, enquanto ainda pode comunicar com todos. Saiba mais em https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Parece que não é um servidor principal compatível. URL incorreta?",
     "calculatingFileSize": "A calcular o tamanho do ficheiro...",
     "prepareSendingAttachment": "Preparar envio de anexo...",
@@ -1925,11 +1782,9 @@
     "oneOfYourDevicesIsNotVerified": "Um dos seus dispositivos não está verificado",
     "noticeChatBackupDeviceVerification": "Nota: Quando conecta todos os seus dispositivos ao backup de chat, eles são automaticamente verificados.",
     "continueText": "Continuar",
-    "welcomeText": "Ei Ei 👋 Isto é o FluffyChat. Pode iniciar sessão em qualquer servidor doméstico, que seja compatível com https://matrix.org. E então conversar com qualquer pessoa. É uma enorme rede de mensagens descentralizada!",
     "blur": "Desfocar:",
     "opacity": "Opacidade:",
     "setWallpaper": "Definir papel de parede",
-    "manageAccount": "Gerir conta",
     "noContactInformationProvided": "O servidor não fornece nenhuma informação de contacto válida",
     "contactServerAdmin": "Contactar o administrador do servidor",
     "contactServerSecurity": "Contactar a segurança do servidor",
@@ -1948,11 +1803,8 @@
     "unableToJoinChat": "Impossível juntar-se ao chat. Talvez a outra parte já tenha encerrado a conversa.",
     "previous": "Anterior",
     "otherPartyNotLoggedIn": "A outra parte atualmente não está conectada e, portanto, não pode receber mensagens!",
-    "appWantsToUseForLogin": "Usar '{server}' para fazer login",
-    "appWantsToUseForLoginDescription": "Permite que a aplicação e o site partilhem informações sobre si.",
     "open": "Abrir",
     "waitingForServer": "A aguardar o servidor...",
-    "appIntroduction": "O FluffyChat permite que converse com os seus amigos através de diferentes mensageiros. Saiba mais em https://matrix.org ou simplesmente toque em *Continuar*.",
     "newChatRequest": "📩 Novo pedido de chat",
     "contentNotificationSettings": "Configurações de notificação de conteúdo",
     "generalNotificationSettings": "Configurações gerais de notificação",
@@ -2027,11 +1879,9 @@
     "taTooltip": "L2 usar com assistência de tradução",
     "interactiveTranslatorSliderHeader": "Tradutor Interativo",
     "interactiveGrammarSliderHeader": "Verificador de Gramática Interativo",
-    "interactiveTranslatorRequired": "Necessário",
     "waTooltip": "L2 usar sem assistência",
     "interactiveTranslator": "Assistência de tradução",
     "noIdenticalLanguages": "Por favor, escolha línguas base e alvo diferentes",
-    "searchBy": "Pesquisar por país e línguas",
     "joinWithClassCode": "Juntar-se ao curso",
     "languageLevelPreA1": "Iniciante Baixo (Pré A1)",
     "languageLevelA1": "Novato Mid (A1)",
@@ -2052,19 +1902,14 @@
     "saveChanges": "Guardar alterações",
     "publicProfileTitle": "Permitir que o meu perfil seja encontrado na pesquisa",
     "publicProfileDesc": "Ao ativar, permite que outros utilizadores encontrem o seu perfil na barra de pesquisa global e enviem pedidos para conversar. Neste momento, pode optar por aceitar ou recusar o pedido.",
-    "errorDisableIT": "Assistência de tradução está desativada.",
-    "errorDisableIGC": "Assistência de gramática está desativada.",
     "errorDisableITUserDesc": "Clique aqui para atualizar as definições de assistência de tradução",
     "errorDisableIGCUserDesc": "Clique aqui para atualizar as definições de assistência de gramática",
     "errorDisableITClassDesc": "Assistência de tradução está desativada para o curso em que esta conversa está.",
     "errorDisableIGCClassDesc": "Assistência de gramática está desativada para o curso em que esta conversa está.",
-    "error405Title": "Línguas não configuradas",
     "error405Desc": "Por favor, configure os seus idiomas no Menu Principal > Configurações de Aprendizagem.",
     "termsAndConditions": "Termos e Condições",
     "andCertifyIAmAtLeast13YearsOfAge": " e certifico que tenho pelo menos 16 anos de idade.",
-    "error502504Title": "Uau, há muitos estudantes online!",
     "error502504Desc": "Ferramentas de tradução e gramática podem estar lentas ou indisponíveis enquanto os bots Pangea se atualizam.",
-    "error404Title": "Erro de tradução!",
     "error404Desc": "O Bot Pangea não tem certeza de como traduzir isso...",
     "errorPleaseRefresh": "Estamos a resolver o problema! Por favor, recarregue e tente novamente.",
     "connectedToStaging": "Conectado ao Ambiente de Teste",
@@ -2102,13 +1947,9 @@
     "definitionsToolName": "Definições de Palavras",
     "definitionsToolDescription": "Quando ativado, palavras sublinhadas em azul podem ser clicadas para obter definições. Clique nas mensagens para aceder às definições.",
     "welcomeBack": "Bem-vindo de volta! Se fez parte do piloto de 2023-2024, entre em contacto connosco para a sua assinatura piloto especial. Se é professor e adquiriu (ou a sua instituição adquiriu) licenças para a sua turma, entre em contacto connosco para a sua assinatura de professor.",
-    "downloadTxtFile": "Descarregar Ficheiro de Texto",
-    "downloadCSVFile": "Descarregar Ficheiro CSV",
     "promotionalSubscriptionDesc": "Atualmente possui uma assinatura promocional vitalícia. Envie uma mensagem para support@pangea.chat para obter ajuda na alteração da sua assinatura.",
     "originalSubscriptionPlatform": "Assinatura adquirida através de {purchasePlatform}",
     "oneWeekTrial": "Período de teste de uma semana",
-    "downloadXLSXFile": "Descarregar ficheiro Excel",
-    "unkDisplayName": "Desconhecido",
     "wwCountryDisplayName": "Mundo",
     "afCountryDisplayName": "Afeganistão",
     "axCountryDisplayName": "Ilhas Aland",
@@ -2403,7 +2244,6 @@
     "chatCapacityHasBeenChanged": "Capacidade de chat alterada",
     "chatCapacitySetTooLow": "A capacidade de chat deve ser pelo menos {count}.",
     "chatCapacityExplanation": "A capacidade de chat limita o número de membros permitidos em um chat.",
-    "tooManyRequest": "Muitas solicitações, por favor tente novamente mais tarde.",
     "enterNumber": "Por favor, insira um valor numérico inteiro.",
     "practice": "Praticar",
     "versionNotFound": "Versão não encontrada",
@@ -2413,7 +2253,6 @@
     "deleteSubscriptionWarningTitle": "Você tem uma assinatura ativa",
     "deleteSubscriptionWarningBody": "Excluir sua conta não cancelará automaticamente sua assinatura.",
     "manageSubscription": "Gerenciar Assinatura",
-    "error520Title": "Por favor, tente novamente.",
     "error520Desc": "Desculpe, não conseguimos entender sua mensagem...",
     "wordsUsed": "Palavras Usadas",
     "level": "Nível",
@@ -2431,7 +2270,6 @@
     "other": "Outro",
     "levelShort": "NÍVEL {level}",
     "noCapacityLimit": "Sem limite de capacidade",
-    "downloadGroupText": "Descarregar texto do grupo",
     "notificationsOn": "Notificações ativadas",
     "notificationsOff": "Notificações desativadas",
     "joinWithCode": "Entrar com código",
@@ -2495,24 +2333,12 @@
     "whatIsTheMorphTag": "O que é o {morphologicalFeature} de '{wordForm}'?",
     "dataAvailable": "Disponibilidade de dados",
     "available": "Disponível",
-    "pangeaBotIsFallible": "O Pangea Bot também comete erros!",
-    "whatIsMeaning": "O que significa '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Combine os significados com as palavras na mensagem!",
-    "doubleClickToEdit": "Duplo clique para editar.",
-    "topicLabel": "Tópico",
-    "topicPlaceholder": "Escolha um tópico...",
-    "modePlaceholder": "Escolha um modo...",
-    "learningObjectiveLabel": "Objetivo de aprendizagem",
-    "learningObjectivePlaceholder": "Escolha um objetivo de aprendizagem...",
-    "targetLanguageLabel": "Idioma alvo",
     "cefrLevelLabel": "Nível CEFR",
     "image": "Imagem",
     "video": "Vídeo",
     "nan": "Não aplicável",
-    "addVocabulary": "Adicionar vocabulário",
     "instructions": "Instruções",
-    "numberOfLearners": "Número de aprendizes",
-    "mustBeInteger": "Deve ser um número inteiro, por exemplo, 1, 2, 3, ...",
     "constructUsePvmDesc": "Produzido em mensagem de voz",
     "leaveSpaceDescription": "Ao sair do curso, deixará todas as conversas dentro dele. Outros utilizadores verão que saiu do curso.",
     "constructUseCorMmDesc": "Significado correto da mensagem",
@@ -2527,7 +2353,6 @@
     "ttsDisabledBody": "Pode ativar o texto-para-fala nas suas definições de aprendizagem",
     "noSpaceDescriptionYet": "Ainda não foi criada uma descrição do curso.",
     "tooLargeToSend": "Esta mensagem é demasiado grande para enviar",
-    "exitWithoutSaving": "Tem a certeza de que deseja sair sem guardar?",
     "enableAutocorrectPopupTitle": "Adicione o teclado do seu idioma de destino indo para:",
     "enableAutocorrectPopupSteps": "  • Definições\n  • Geral\n  • Teclado\n  • Teclados\n  • Adicionar novo teclado",
     "enableAutocorrectPopupDescription": "Depois de selecionar o idioma, pode clicar no pequeno ícone do globo na parte inferior esquerda do seu teclado para ativar o teclado recentemente instalado.",
@@ -2538,11 +2363,8 @@
     "displayName": "Nome de exibição",
     "leaveRoomDescription": "Está prestes a sair deste chat. Outros utilizadores verão que saiu do chat.",
     "confirmUserId": "Por favor, confirme o seu nome de utilizador no Pangea Chat para excluir a sua conta.",
-    "startingToday": "A partir de hoje",
-    "oneWeekFreeTrial": "Período de teste gratuito de uma semana",
     "paidSubscriptionStarts": "Começa em {startDate}",
     "cancelInSubscriptionSettings": "• Cancelar a qualquer momento nas definições de assinatura",
-    "cancelToAvoidCharges": "• Cancelar antes de {trialEnds} para evitar cobranças",
     "downloadGboard": "Baixar Gboard",
     "autocorrectNotAvailable": "Infelizmente, a sua plataforma não é atualmente suportada para este recurso. Fique atento a novos desenvolvimentos!",
     "pleaseUpdateApp": "Por favor, atualize o aplicativo para continuar.",
@@ -2552,17 +2374,12 @@
     "knockSpaceSuccess": "Solicitou juntar-se a este curso! Um administrador responderá ao seu pedido quando o receber 😀",
     "chooseWordAudioInstructionsBody": "Ouça a mensagem completa. Depois, associe os áudios às palavras.",
     "chooseMorphsInstructionsBody": "Clique nas peças do puzzle para perguntas de gramática!",
-    "pleaseEnterInt": "Por favor, insira um número",
     "home": "Início",
     "join": "Juntar",
     "resetInstructionTooltipsTitle": "Redefinir dicas de instruções",
     "resetInstructionTooltipsDesc": "Clique para mostrar dicas de instruções como para um utilizador novo.",
-    "randomize": "Aleatorizar",
     "clear": "Limpar",
-    "featuredActivities": "Destaques",
     "save": "Guardar",
-    "startChat": "Iniciar um chat",
-    "translationProblem": "Problema de tradução",
     "askToJoin": "Pedir para participar",
     "emptyChatWarningTitle": "Chat vazio",
     "emptyChatWarningDesc": "Não convidaste ninguém para o teu chat. Vai às definições do chat para convidar os teus contactos ou o Bot. Também podes fazer isto mais tarde.",
@@ -2592,17 +2409,13 @@
     "timesUsedIndependently": "Vezes usadas de forma independente",
     "timesUsedWithAssistance": "Vezes usadas com assistência",
     "shareInviteCode": "Compartilhar código de convite: {code}",
-    "leaderboard": "Classificação",
     "skipForNow": "Pular por agora",
     "permissions": "Permissões",
     "spaceChildPermission": "Quem pode adicionar novos chats a este curso",
-    "addEnvironmentOverride": "Adicionar substituição de ambiente",
     "defaultOption": "Padrão",
     "deleteChatDesc": "Tem certeza de que deseja excluir esta conversa? Ela será excluída para todos os participantes e todas as mensagens dentro da conversa não estarão mais disponíveis para prática ou análises de aprendizagem.",
     "deleteSpaceDesc": "O curso e quaisquer conversas selecionadas serão excluídos para todos os participantes e todas as mensagens dentro da conversa não estarão mais disponíveis para prática ou análises de aprendizagem. Esta ação não pode ser desfeita.",
     "launch": "Lançar",
-    "searchChats": "Pesquisar conversas",
-    "maxFifty": "Máximo 50",
     "configureSpace": "Configurar curso",
     "pinMessages": "Fixar mensagens",
     "setJoinRules": "Definir regras de entrada",
@@ -2636,9 +2449,6 @@
     "failedToFetchTranscription": "Falha ao obter a transcrição",
     "deleteEmptySpaceDesc": "O curso será apagado para todos os participantes. Esta ação não pode ser desfeita.",
     "regenerate": "Regenerar",
-    "mySavedActivities": "As minhas atividades guardadas",
-    "noSavedActivities": "Sem atividades guardadas",
-    "saveActivity": "Guardar esta atividade",
     "failedToPlayVideo": "Falha ao reproduzir o vídeo",
     "done": "Concluído",
     "inThisSpace": "Neste espaço",
@@ -2649,13 +2459,9 @@
     "numInvited": "{count} convidado(s)",
     "saved": "Guardado",
     "reset": "Reiniciar",
-    "errorFetchingActivitiesMessage": "Falha ao obter atividades",
     "errorFetchingDefinition": "Falha ao obter definição",
     "errorProcessAnalytics": "Falha ao processar análises",
     "errorDownloading": "Falha ao descarregar",
-    "errorLoadingSpaceChildren": "Falha ao carregar os chats dentro deste curso",
-    "unexpectedError": "Erro inesperado.",
-    "pleaseReload": "Por favor, recarregue e tente novamente.",
     "translationError": "Erro de tradução",
     "check": "Verificar",
     "unableToFindRoom": "Nenhum chat ou curso encontrado com esse código. Por favor, tente novamente.",
@@ -2664,19 +2470,14 @@
     "request": "Solicitar",
     "requestAll": "Solicitar Tudo",
     "confirmMessageUnpin": "Tem certeza de que deseja desfixar esta mensagem?",
-    "saveAndLaunch": "Salvar e Iniciar",
-    "launchToSpace": "Iniciar no curso",
     "pending": "Pendente",
     "inactive": "Inativo",
-    "confirmRole": "Confirmar papel",
     "openRoleLabel": "ABERTO",
     "finishedTheActivity": "🎯 {username} concluiu esta atividade",
     "activitySummaryError": "Resumos de atividades indisponíveis",
     "requestSummaries": "Solicitar resumos",
-    "generatingNewActivities": "Você é o primeiro usuário deste par de idiomas! Por favor, aguarde um momento, estamos preparando atividades especialmente para você.",
     "requestAccessTitle": "Solicitar acesso à análise?",
     "requestAccessDesc": "Gostaria de solicitar acesso para visualizar análises dos participantes?\n\nSe os participantes concordarem, os administradores deste curso poderão visualizar:\n    • vocabulário total\n    • conceitos gramaticais totais\n    • sessões de atividade concluídas\n    • os conceitos gramaticais específicos utilizados, corretamente e incorretamente\n\nEles não poderão visualizar:\n    • mensagens em chats fora do curso\n    • lista de vocabulário",
-    "requestAccess": "Solicitar acesso ({count})",
     "analyticsInactiveTitle": "Solicitações a usuários inativos não puderam ser enviadas",
     "analyticsInactiveDesc": "Usuários inativos que não fizeram login desde a introdução deste recurso não verão sua solicitação.\n\nO botão Solicitar aparecerá assim que eles retornarem. Você pode reenviar a solicitação mais tarde clicando no botão Solicitar sob o nome deles quando estiver disponível.",
     "accessRequestedTitle": "Pedido de Acesso à Análise",
@@ -2699,8 +2500,6 @@
     "accessDesc": "Pode tornar o seu curso aberto ao mundo! Ou, tornar o seu curso privado e seguro.",
     "createGroupChatDesc": "Enquanto as sessões de atividade começam e terminam, os chats de grupo permanecerão abertos para comunicação de rotina.",
     "deleteDesc": "Apenas administradores podem eliminar um curso. Esta é uma ação destrutiva que remove todos os utilizadores e elimina todos os chats selecionados dentro do curso. Proceda com cautela.",
-    "noCourseFound": "Oh, este curso precisa de um plano!\n\nOs planos de curso são uma sequência de tópicos e atividades de conversa.",
-    "additionalParticipants": "+ {num} outros",
     "whatNow": "E agora?",
     "chooseNextActivity": "Escolha a sua próxima atividade!",
     "letsGo": "Vamos lá",
@@ -2712,13 +2511,11 @@
     "waitNotDone": "Espere, eu não terminei!",
     "waitingForOthersToFinish": "Aguardando os restantes terminarem...",
     "generatingSummary": "Analisando o chat e gerando resultados",
-    "findCourse": "Encontrar um curso",
     "pingParticipantsNotification": "{user} está a procurar utilizadores para participar na sessão de atividade em {room}",
     "course": "Curso",
     "courses": "Cursos",
     "goToCourse": "Ir para o curso: {course}",
     "activityComplete": "Esta atividade foi concluída. O resumo da atividade deve estar disponível abaixo.",
-    "startNewSession": "Iniciar nova sessão",
     "joinOpenSession": "Juntar-se à sessão aberta",
     "activityNotFound": "Atividade não encontrada",
     "myActivities": "As minhas atividades",
@@ -2762,7 +2559,6 @@
     "inviteYourFriends": "Convide os seus amigos",
     "playWithAI": "Jogue com IA por agora",
     "courseStartDesc": "O Pangea Bot está pronto para começar a qualquer momento!\n\n...mas aprender é melhor com amigos!",
-    "activityDropdownDesc": "Quando terminar esta atividade, clique abaixo",
     "languageMismatchTitle": "Incompatibilidade de idioma",
     "languageMismatchDesc": "O seu idioma alvo não corresponde ao idioma desta atividade. Deseja atualizar o seu idioma alvo?",
     "reportWordIssueTooltip": "Reportar problema na informação da palavra",
@@ -2928,14 +2724,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@createGroup": {
         "type": "String",
         "placeholders": {}
@@ -2945,18 +2733,6 @@
         "placeholders": {}
     },
     "@emoteKeyboardNoRecents": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -2977,10 +2753,6 @@
         "placeholders": {}
     },
     "@fromTheInvitation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3060,10 +2832,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterRecoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pushRules": {
         "type": "String",
         "placeholders": {}
@@ -3091,14 +2859,6 @@
             }
         }
     },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@sendImages": {
         "type": "String",
         "placeholders": {
@@ -3124,10 +2884,6 @@
         "placeholders": {}
     },
     "@setChatDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setPermissionsLevel": {
         "type": "String",
         "placeholders": {}
     },
@@ -3168,14 +2924,6 @@
         "placeholders": {}
     },
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -3231,10 +2979,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@tryToSendAgain": {
         "type": "String",
         "placeholders": {}
@@ -3281,14 +3025,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -3367,14 +3103,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@visibleForAllParticipants": {
         "type": "String",
         "placeholders": {}
@@ -3411,19 +3139,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -3475,15 +3191,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3534,10 +3242,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3546,15 +3250,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3678,43 +3374,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3734,18 +3398,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
@@ -3759,10 +3411,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3785,22 +3433,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3855,10 +3487,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3942,31 +3570,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -4022,23 +3630,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4078,28 +3674,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4117,14 +3691,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4317,22 +3883,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4388,10 +3938,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4401,10 +3947,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4480,27 +4022,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4818,10 +4344,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4831,10 +4353,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4922,14 +4440,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4946,10 +4456,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4962,15 +4468,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5122,14 +4620,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5143,14 +4633,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6373,10 +5855,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6417,10 +5895,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6493,10 +5967,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6766,47 +6236,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6826,19 +6256,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6902,10 +6320,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6946,14 +6360,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6965,14 +6371,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -7010,10 +6408,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7030,27 +6424,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7174,10 +6552,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7187,10 +6561,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7207,14 +6577,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7354,18 +6716,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7414,10 +6764,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7427,18 +6773,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7481,23 +6815,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7521,10 +6843,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7532,14 +6850,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7644,18 +6954,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7704,10 +7002,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7734,10 +7028,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7921,10 +7211,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@activityDropdownDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@languageMismatchTitle": {
         "type": "String",
         "placeholders": {}
@@ -7970,17 +7256,11 @@
         "placeholders": {}
     },
     "startOwn": "Começar o meu próprio",
-    "joinCourseDesc": "Cada curso tem entre 8 e 10 tópicos sequenciais com uma variedade de atividades de aprendizagem de línguas baseadas em tarefas.",
     "newMessageInPangeaChat": "📩 Nova mensagem no Pangea Chat",
     "shareCourse": "Partilhar curso",
     "addCourse": "Adicionar um curso",
-    "joinPublicCourse": "Entrar no curso público",
     "vocabLevelsDesc": "É aqui que as palavras de vocabulário irão aparecer assim que as tiveres evoluído!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7993,10 +7273,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8015,7 +7291,6 @@
     "emojiView": "Visualização de emoji",
     "feedbackDialogDesc": "Eu também cometo erros! Algo para me ajudar a melhorar?",
     "contactHasBeenInvitedToTheCourse": "O contato foi convidado para o curso",
-    "activityStatsButtonTooltip": "Informações da atividade",
     "allow": "Permitir",
     "deny": "Negar",
     "enabledRenewal": "Ativar Renovação de Assinatura",
@@ -8283,10 +7558,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9342,16 +8613,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Atividades para Desbloquear o Próximo Tópico",
-    "activitiesToUnlockTopicDesc": "Defina o número de atividades para desbloquear o próximo tópico do curso",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Prática correta de definição de vocabulário",
     "constructUseIncLMDesc": "Prática incorreta de definição de vocabulário",
     "constructUseCorLADesc": "Prática correta de áudio de vocabulário",
@@ -9359,7 +8620,6 @@
     "constructUseBonus": "Bônus durante a prática de vocabulário",
     "practiceVocab": "Praticar vocabulário",
     "selectMeaning": "Selecione o significado",
-    "selectAudio": "Selecione o áudio correspondente",
     "anotherRound": "Outra rodada",
     "activitySettingsOverrideWarning": "Idioma e nível de idioma determinados pelo plano de atividade",
     "voice": "Voz",
@@ -9391,10 +8651,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9412,12 +8668,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Download iniciado",
     "webDownloadPermissionMessage": "Se o seu navegador bloquear downloads, por favor, habilite downloads para este site.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9512,11 +8763,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Algo deu errado, e estamos trabalhando arduamente para corrigir isso. Verifique novamente mais tarde.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Ativar assistência de escrita",
     "autoIGCToolDescription": "Executar automaticamente as ferramentas do Pangea Chat para corrigir mensagens enviadas para o idioma de destino.",
     "@autoIGCToolName": {
@@ -9572,24 +8818,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramática",
-    "spanTypeWordChoice": "Escolha de Palavras",
     "spanTypeSpelling": "Ortografia",
     "spanTypePunctuation": "Pontuação",
     "spanTypeStyle": "Estilo",
     "spanTypeFluency": "Fluência",
     "spanTypeAccents": "Acentos",
     "spanTypeCapitalization": "Capitalização",
-    "spanTypeCorrection": "Correção",
     "spanFeedbackTitle": "Relatar problema de correção",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9614,10 +8849,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9630,13 +8861,7 @@
     "longPressToRecordVoiceMessage": "Pressione longamente para gravar mensagem de voz.",
     "pause": "Pausar",
     "resume": "Retomar",
-    "newSubSpace": "Novo subespaço",
-    "moveToDifferentSpace": "Mover para um espaço diferente",
-    "removeFromSpaceDescription": "O chat será removido do espaço, mas ainda aparecerá na sua lista de chats.",
     "countChats": "{chats} chats",
-    "spaceMemberOf": "Membro do espaço {spaces}",
-    "spaceMemberOfCanKnock": "Membro do espaço {spaces} pode bater",
-    "donate": "Doar",
     "startedAPoll": "{username} iniciou uma enquete.",
     "poll": "Enquete",
     "startPoll": "Iniciar enquete",
@@ -9660,23 +8885,15 @@
     "newStickerPack": "Novo pacote de adesivos",
     "stickerPackName": "Nome do pacote de adesivos",
     "attribution": "Atribuição",
-    "skipChatBackup": "Pular backup de chat",
-    "skipChatBackupWarning": "Você tem certeza? Sem ativar o backup de chat, você pode perder o acesso às suas mensagens se trocar de dispositivo.",
-    "loadingMessages": "Carregando mensagens",
-    "setupChatBackup": "Configurar backup de chat",
     "noMoreResultsFound": "Nenhum resultado encontrado",
     "chatSearchedUntil": "Chat pesquisado até {time}",
     "federationBaseUrl": "URL Base da Federação",
     "clientWellKnownInformation": "Informações do Cliente-Bem-Conhecidas:",
     "baseUrl": "URL Base",
     "identityServer": "Servidor de Identidade:",
-    "versionWithNumber": "Versão: {version}",
     "logs": "Registros",
-    "advancedConfigs": "Configurações Avançadas",
     "advancedConfigurations": "Configurações avançadas",
-    "signInWithLabel": "Entrar com:",
     "selectAllWords": "Selecione todas as palavras que você ouve no áudio",
-    "joinCourseForActivities": "Junte-se a um curso para tentar atividades.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9713,18 +8930,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9732,26 +8937,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9857,22 +9042,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9901,19 +9070,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9921,15 +9078,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10135,11 +9284,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Em uma aula? Coloque seu código de entrada aqui.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Realçar automaticamente mensagens de áudio",
     "selectAudioMessagesOnPlayDescription": "Realçar automaticamente mensagens de áudio quando reproduzidas",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10183,18 +9327,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Este curso tem tópicos com menos de {input} atividades. Por favor, insira um número menor ou igual a {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Clique aqui para fazer o login novamente.",
     "@clickToLogin": {
@@ -10611,17 +9743,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Um urso amarelo em estilo de desenho animado com os braços levantados em empolgação.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Selecione palavras para saber mais sobre elas",
     "requireAnalyticsAccessTitle": "Requerer acesso à análise para participar",
     "requireAnalyticsAccessDesc": "Os participantes devem conceder acesso às suas análises de aprendizado para participar deste curso",
     "analyticsAccessNoticeTitle": "Acesso à Análise Necessário",
     "analyticsAccessNoticeDesc": "Ao participar deste curso, você concorda em conceder acesso aos administradores às suas análises de aprendizado.",
-    "skipOnboardingClassCodeDesc": "Aprendendo de forma independente? Não se preocupe, você pode:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10639,10 +9765,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10671,7 +9793,6 @@
     "pickCefrLevelTeacherStepTitle": "Qual nível você ensina?",
     "pickCefrLevelStudentStepTitle": "Qual nível você está?",
     "customCourseStepTitle": "Preencha este formulário para obter um curso personalizado",
-    "aboutYourClass": "Sobre sua turma",
     "courseCodeStepErrorMessage": "Por favor, verifique seu código e tente novamente",
     "institution": "Instituição",
     "courseGoals": "Objetivos do Curso",
@@ -10714,10 +9835,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10834,12 +9951,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logotipo do Pangea Chat",
     "introChatDetails": "Diga olá! Apresente-se aos seus colegas participantes do curso, encontre amigos e converse fora das atividades.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10883,11 +9995,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Ações de atividade",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Ferramentas de pronúncia",
     "audioTranscription": "Transcrição de áudio com IA",
     "visualLearnerSupport": "Apoio a aprendizes visuais",
@@ -10928,7 +10035,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Junte-se a um curso que inclua esta atividade para jogá-la.",
     "resizeCoursePanel": "Redimensionar painel do curso",
     "undo": "Desfazer",
     "unlock": "Desbloquear",
@@ -10942,7 +10048,6 @@
     "addCourseBrowsePublic": "Navegar por cursos públicos",
     "browsePublicCourses": "Navegar por cursos públicos",
     "editProfile": "Editar perfil",
-    "numObjectives": "{count} objetivos",
     "mapSearchHint": "Pesquisar atividades",
     "mapSearchNoResults": "Nenhuma correspondência na visualização",
     "mapFilterAllLanguages": "Todos os idiomas",
@@ -10951,7 +10056,6 @@
     "mapFilterCompleted": "Concluído",
     "mapFilterReset": "Redefinir",
     "activityTypeConversation": "Conversa",
-    "lockedMissionRequirement": "Termine a missão anterior para desbloquear",
     "playAgain": "Jogar novamente",
     "reviewActivity": "Revisar",
     "mapEmptyInView": "Nada aqui no seu nível ou idioma. Amplie seus filtros ou afaste-se.",
@@ -10966,14 +10070,9 @@
     "scrollToBottom": "Role para baixo",
     "courseImage": "Imagem do curso",
     "avatarPreview": "Pré-visualização do avatar",
-    "activityPhoto": "Foto da atividade",
     "emotePreview": "Pré-visualização do emote: {name}",
     "activityLabel": "Atividade: {title}",
     "resetMapView": "Redefinir visualização do mapa",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11026,14 +10125,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11063,10 +10154,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11123,10 +10210,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_ro.arb
+++ b/lib/l10n/intl_ro.arb
@@ -62,11 +62,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Vizitatorii \"guest\" se pot alătura",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Ești sigur?",
     "@areYouSure": {
         "type": "String",
@@ -245,15 +240,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unreadChats": "{unreadCount, plural, =1{Un chat necitit} other{{unreadCount} chaturi necitite}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "verifySuccess": "A reușit verificarea!",
     "@verifySuccess": {
         "type": "String",
@@ -330,11 +316,6 @@
             }
         }
     },
-    "removeDevice": "Eliminați dispozitivul",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "share": "Partajați",
     "@share": {
         "type": "String",
@@ -352,16 +333,6 @@
     },
     "sourceCode": "Codul surs",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Spațiul este public",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Numele spațiului",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -397,8 +368,6 @@
     },
     "placeCall": "Faceți apel",
     "@placeCall": {},
-    "voiceCall": "Apel vocal",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "Versiune de Android nesuportat",
     "@unsupportedAndroidVersion": {},
     "userIsTyping": "{username} tastează…",
@@ -412,8 +381,6 @@
     },
     "widgetCustom": "Personalizat",
     "@widgetCustom": {},
-    "screenSharingTitle": "partajarea de ecran",
-    "@screenSharingTitle": {},
     "newGroup": "Grup nou",
     "@newGroup": {},
     "changedTheRoomInvitationLink": "{username} a schimbat linkul de invitație",
@@ -457,8 +424,6 @@
     },
     "removeFromBundle": "Stergeți din acest pachet",
     "@removeFromBundle": {},
-    "enableMultiAccounts": "(BETA) Activați multiple conturi pe acest dispozitiv",
-    "@enableMultiAccounts": {},
     "participant": "Participant",
     "@participant": {
         "type": "String",
@@ -580,8 +545,6 @@
     },
     "openChat": "Deschideți Chat",
     "@openChat": {},
-    "emailOrUsername": "Email sau nume de utilizator",
-    "@emailOrUsername": {},
     "youBannedUser": "Ați interzis pe {user}",
     "@youBannedUser": {
         "placeholders": {
@@ -594,13 +557,6 @@
     "@fileIsTooBigForServer": {},
     "widgetName": "Nume",
     "@widgetName": {},
-    "sorryThatsNotPossible": "Scuze... acest nu este posibil",
-    "@sorryThatsNotPossible": {},
-    "enableEncryptionWarning": "Activând criptare, nu mai puteți să o dezactivați în viitor. Sunteți sigur?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "commandMissing": "{command} nu este o comandă.",
     "@commandMissing": {
         "type": "String",
@@ -628,8 +584,6 @@
     },
     "start": "Începeți",
     "@start": {},
-    "videoCallsBetaWarning": "Vă rugăm să luați notă că apeluri video sunt în beta. Se poate că nu funcționează normal sau de loc pe fie care platformă.",
-    "@videoCallsBetaWarning": {},
     "pinMessage": "Fixați în cameră",
     "@pinMessage": {},
     "wasDirectChatDisplayName": "Chat gol (a fost {oldDisplayName})",
@@ -683,8 +637,6 @@
     },
     "scanQrCode": "Scanați cod QR",
     "@scanQrCode": {},
-    "addAccount": "Adăugați cont",
-    "@addAccount": {},
     "experimentalVideoCalls": "Apeluri video experimentale",
     "@experimentalVideoCalls": {},
     "confirmEventUnpin": "Sunteți sigur că doriți să anulați permanent fixarea evenimentului?",
@@ -693,8 +645,6 @@
     "@emojis": {},
     "users": "Utilizatori",
     "@users": {},
-    "foregroundServiceRunning": "Această notificare apare când serviciul de foreground rulează.",
-    "@foregroundServiceRunning": {},
     "currentlyActive": "Activ acum",
     "@currentlyActive": {
         "type": "String",
@@ -820,11 +770,6 @@
             }
         }
     },
-    "createNewSpace": "Spațiu nou",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "forward": "Înainte",
     "@forward": {
         "type": "String",
@@ -874,15 +819,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Invitați contact la {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "inviteText": "{username} v-a invitat la FluffyChat.\n1. Instalați FluffyChat: https://fluffychat.im\n2. Înregistrați-vă sau conectați-vă\n3. Deschideți invitația: {link}",
     "@inviteText": {
@@ -941,15 +877,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Încărcați încă mai {count} participanți",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "dehydrate": "Exportați sesiunea și ștergeți dispozitivul",
     "@dehydrate": {},
     "hydrate": "Restaurați din fișier backup",
@@ -981,11 +908,6 @@
     },
     "noEmotesFound": "Nu s-a găsit nici un emote. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Criptare nu poate fi activată până când camera este accesibilă public.",
-    "@noEncryptionForPublicRooms": {
         "type": "String",
         "placeholders": {}
     },
@@ -1034,11 +956,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Stabiliți nivelul de permisii",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "startedACall": "{senderName} a început un apel",
     "@startedACall": {
         "type": "String",
@@ -1077,16 +994,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Apel video",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Vizibilitatea istoria chatului",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Vizibil pentru toți participanți",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1107,23 +1014,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Cine poate face care acțiune",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Cine se poate alătura la acest grup",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "De ce doriți să reportați acest conținut?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Ștergeți backup-ul vostru de chat să creați o nouă cheie de recuperare?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1147,8 +1039,6 @@
     "@sender": {},
     "openGallery": "Deschideți galeria",
     "@openGallery": {},
-    "removeFromSpace": "Eliminați din spațiu",
-    "@removeFromSpace": {},
     "publish": "Publicați",
     "@publish": {},
     "unsupportedAndroidVersionLong": "Această funcție are nevoie de o versiune de Android mai nouă. Vă rugăm să verificați dacă sunt actualizări sau suport de la Lineage OS.",
@@ -1189,8 +1079,6 @@
             }
         }
     },
-    "unlockOldMessages": "Deblocați mesajele vechi",
-    "@unlockOldMessages": {},
     "youInvitedUser": "📩Ați invitat pe {user}",
     "@youInvitedUser": {
         "placeholders": {
@@ -1215,32 +1103,18 @@
             }
         }
     },
-    "storeInAndroidKeystore": "Stoca în Android KeyStore",
-    "@storeInAndroidKeystore": {},
     "user": "Utilizator",
     "@user": {},
     "custom": "Personalizat",
     "@custom": {},
-    "screenSharingDetail": "Partajați ecranul în FluffyChat",
-    "@screenSharingDetail": {},
-    "storeSecurlyOnThisDevice": "Stoca sigur pe acest dispozitiv",
-    "@storeSecurlyOnThisDevice": {},
     "whyIsThisMessageEncrypted": "De ce este acest mesaj ilizibil?",
     "@whyIsThisMessageEncrypted": {},
     "newSpace": "Spațiu nou",
     "@newSpace": {},
-    "enterSpace": "Intrați în spațiu",
-    "@enterSpace": {},
     "allSpaces": "Toate spațiile",
     "@allSpaces": {},
     "doNotShowAgain": "Nu se mai apară din nou",
     "@doNotShowAgain": {},
-    "newSpaceDescription": "Spațiile vă permit să vă consolidați chaturile și să stabiliți comunități private sau publice.",
-    "@newSpaceDescription": {},
-    "encryptThisChat": "Criptați acest chat",
-    "@encryptThisChat": {},
-    "disableEncryptionWarning": "Pentru motive de securitate, nu este posibil să dezactivați criptarea unui chat în care criptare este activată.",
-    "@disableEncryptionWarning": {},
     "noBackupWarning": "Avertisment! Fără să activați backup de chat, veți pierde accesul la mesajele voastre criptate. E foarte recomandat să activați backup de chat înainte să vă deconectați.",
     "@noBackupWarning": {},
     "noOtherDevicesFound": "Nu s-a găsit alte dispozitive",
@@ -1290,11 +1164,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "groupIsPublic": "Grupul este public",
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "guestsAreForbidden": "Musafiri sunt interziși",
     "@guestsAreForbidden": {
         "type": "String",
@@ -1319,22 +1188,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "logInTo": "Conectați-vă la {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
-    },
     "locationDisabledNotice": "Servicile de locație sunt dezactivate. Vă rugăm să le activați să împărțiți locația voastră.",
     "@locationDisabledNotice": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Se pare că nu aveți serviciile google pe dispozitivul vostru. Această decizie este bună pentru confidențialitatea voastră! Să primiți notificari push în FluffyChat vă recomandăm https://microg.org/ sau https://unifiedpush.org/.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1394,11 +1249,6 @@
                 "type": "String"
             }
         }
-    },
-    "transferFromAnotherDevice": "Transfera de la alt dispozitiv",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "synchronizingPleaseWait": "Sincronizează... Vă rugăm să așteptați.",
     "@synchronizingPleaseWait": {
@@ -1585,10 +1435,6 @@
             }
         }
     },
-    "storeInSecureStorageDescription": "Păstrați cheia de recuperare în stocarea sigură a acestui dispozitiv.",
-    "@storeInSecureStorageDescription": {},
-    "saveKeyManuallyDescription": "Activați dialogul de partajare sistemului sau folosiți clipboard-ul să salvați manual această cheie.",
-    "@saveKeyManuallyDescription": {},
     "countFiles": "{count} fișiere",
     "@countFiles": {
         "placeholders": {
@@ -1606,8 +1452,6 @@
             }
         }
     },
-    "storeInAppleKeyChain": "Stoca în Apple KeyChain",
-    "@storeInAppleKeyChain": {},
     "addEmail": "Adăugați email",
     "@addEmail": {
         "type": "String",
@@ -1678,8 +1522,6 @@
             }
         }
     },
-    "yourChatBackupHasBeenSetUp": "Backup-ul vostru de chat a fost configurat.",
-    "@yourChatBackupHasBeenSetUp": {},
     "cantOpenUri": "Nu se poate deschide URI-ul {uri}",
     "@cantOpenUri": {
         "type": "String",
@@ -1715,11 +1557,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Mesajele voastre vechi sunt sigurate cu o cheie de recuperare. Vă rugăm să nu o pierdeți.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Conținutul a fost reportat la administratori serverului",
     "@contentHasBeenReported": {
         "type": "String",
@@ -1739,11 +1576,6 @@
     "@commandHint_me": {
         "type": "String",
         "description": "Usage hint for the command /me"
-    },
-    "contactHasBeenInvitedToTheGroup": "Contactul a fost invitat la grup",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
     },
     "copyToClipboard": "Copiați în clipboard",
     "@copyToClipboard": {
@@ -1791,11 +1623,6 @@
     },
     "enableEmotesGlobally": "Activați pachet de emote global",
     "@enableEmotesGlobally": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "Totul e gata!",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -1933,8 +1760,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "pleaseEnterRecoveryKeyDescription": "Să vă deblocați mesajele vechi, vă rugăm să introduceți cheia de recuperare creată de o seșiune anterioră. Cheia de recuperare NU este parola voastră.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "separateChatTypes": "Afișați chaturi directe și grupuri separat",
     "@separateChatTypes": {
         "type": "String",
@@ -1987,11 +1812,6 @@
     },
     "passwordHasBeenChanged": "Parola a fost schimbată",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Recuperare parolei",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -2103,10 +1923,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKey": "Cheie de recuperare",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Cheia de recuperare pierdută?",
-    "@recoveryKeyLost": {},
     "muteChat": "Amuțați chatul",
     "@muteChat": {
         "type": "String",
@@ -2157,8 +1973,6 @@
     },
     "deviceKeys": "Cheile dispozitivului:",
     "@deviceKeys": {},
-    "pleaseEnterRecoveryKey": "Vă rugăm să introduceți cheia voastră de recuperare:",
-    "@pleaseEnterRecoveryKey": {},
     "newVerificationRequest": "Cerere de verificare nouă!",
     "@newVerificationRequest": {
         "type": "String",
@@ -2315,17 +2129,12 @@
     "space": "Spațiu",
     "spaces": "Spații",
     "checkList": "Listă de verificare",
-    "countInvited": "{count} invitat",
     "createGroup": "Creează grup",
     "chatPermissions": "Permisiuni de chat",
     "emoteKeyboardNoRecents": "Emoticoane folosite recent vor apărea aici...",
-    "globalChatId": "ID chat global",
-    "accessAndVisibility": "Acces și vizibilitate",
-    "accessAndVisibilityDescription": "Cine are voie să se alăture acestui chat și cum poate fi descoperit chat-ul.",
     "calls": "Apeluri",
     "customEmojisAndStickers": "Emoticoane și stickere personalizate",
     "customEmojisAndStickersBody": "Adaugă sau partajează emoticoane sau stickere personalizate care pot fi folosite în orice chat.",
-    "chatDescription": "Descrierea chat-ului",
     "chatDescriptionHasBeenChanged": "Descrierea chat-ului a fost schimbată",
     "hideRedactedMessages": "Ascunde mesajele cenzurate",
     "hideRedactedMessagesBody": "Dacă cineva cenzurează un mesaj, acesta nu va mai fi vizibil în chat.",
@@ -2352,11 +2161,8 @@
     "synchronizingPleaseWaitCounter": "Se sincronizează… ({percentage}%)",
     "invitedBy": "📩 Invitat de {user}",
     "hasKnocked": "🚪 {user} a bătut la ușă",
-    "usersMustKnock": "Utilizatorii trebuie să bată la ușă",
-    "noOneCanJoin": "Nimeni nu poate intra",
     "knock": "Bate la ușă",
     "hidePresences": "Ascunde lista de stare?",
-    "setTheme": "Setează tema:",
     "setColorTheme": "Setează tema de culoare:",
     "invite": "Invită",
     "inviteGroupChat": "📨 Invită chat de grup",
@@ -2375,12 +2181,8 @@
     "yourGlobalUserIdIs": "ID-ul global al utilizatorului dvs. este: ",
     "noUsersFoundWithQuery": "Din păcate, nu a fost găsit niciun utilizator cu \"{query}\". Vă rugăm să verificați dacă ați făcut o greșeală de tastare.",
     "knocking": "Bătaie",
-    "chatCanBeDiscoveredViaSearchOnServer": "Chat-ul poate fi descoperit prin căutare pe {server}",
-    "searchChatsRooms": "Caută #chat-uri, @utilizatori...",
     "nothingFound": "Nimic găsit...",
     "groupName": "Numele grupului",
-    "createGroupAndInviteUsers": "Creează un grup și invită utilizatori",
-    "groupCanBeFoundViaSearch": "Grupul poate fi găsit prin căutare",
     "wrongRecoveryKey": "Îmi pare rău... acesta nu pare a fi cheia de recuperare corectă.",
     "startConversation": "Începe o conversație",
     "commandHint_sendraw": "Trimite json brut",
@@ -2394,11 +2196,8 @@
     "pleaseChooseAStrongPassword": "Vă rugăm să alegeți o parolă puternică",
     "passwordsDoNotMatch": "Parolele nu se potrivesc",
     "passwordIsWrong": "Parola introdusă este greșită",
-    "publicChatAddresses": "Adrese de chat public",
-    "createNewAddress": "Creează adresă nouă",
     "joinSpace": "Alătură-te spațiului",
     "publicSpaces": "Spații publice",
-    "addChatOrSubSpace": "Adaugă chat sau subspațiu",
     "subspace": "Subspațiu",
     "decline": "Refuză",
     "thisDevice": "Acest dispozitiv:",
@@ -2407,15 +2206,11 @@
     "searchMore": "Caută mai mult...",
     "gallery": "Galerie",
     "files": "Fișiere",
-    "sessionLostBody": "Sesiunea dvs. s-a pierdut. Vă rugăm să raportați această eroare dezvoltatorilor la {url}. Mesajul de eroare este: {error}",
-    "restoreSessionBody": "Aplicația încearcă acum să restaureze sesiunea din backup. Vă rugăm să raportați această eroare dezvoltatorilor la {url}. Mesajul de eroare este: {error}",
     "sendReadReceipts": "Trimite confirmări de citire",
     "sendTypingNotificationsDescription": "Alți participanți la chat pot vedea când tastați un mesaj nou.",
     "sendReadReceiptsDescription": "Alți participanți la chat pot vedea când ați citit un mesaj.",
     "formattedMessages": "Mesaje formatate",
     "formattedMessagesDescription": "Afișează conținut bogat al mesajelor, cum ar fi textul îngroșat, folosind markdown.",
-    "verifyOtherUser": "🔐 Verifică celălalt utilizator",
-    "verifyOtherUserDescription": "Dacă verifici un alt utilizator, te poți asigura că știi cu cine vorbești cu adevărat. 💪\n\nCând începi o verificare, tu și celălalt utilizator veți vedea o fereastră pop-up în aplicație. Acolo veți vedea apoi o serie de emoji sau numere pe care trebuie să le comparați între voi.\n\nCel mai bun mod de a face acest lucru este să vă întâlniți sau să începeți un apel video. 👭",
     "verifyOtherDevice": "🔐 Verifică celălalt dispozitiv",
     "verifyOtherDeviceDescription": "Când verifici un alt dispozitiv, acele dispozitive pot schimba chei, sporind securitatea generală. 💪 Când începi o verificare, va apărea o fereastră pop-up în aplicație pe ambele dispozitive. Acolo vei vedea apoi o serie de emoji sau numere pe care trebuie să le compari cu celălalt. Este recomandat să ai ambele dispozitive la îndemână înainte de a începe verificarea. 🤳",
     "acceptedKeyVerification": "{sender} a acceptat verificarea cheii",
@@ -2451,10 +2246,6 @@
     "updateInstalled": "🎉 Actualizare {version} instalată!",
     "changelog": "Jurnal de modificări",
     "sendCanceled": "Trimiterea a fost anulată",
-    "loginWithMatrixId": "Autentificare cu Matrix-ID",
-    "discoverHomeservers": "Descoperă serverele principale",
-    "whatIsAHomeserver": "Ce este un server principal?",
-    "homeserverDescription": "Toate datele dvs. sunt stocate pe serverul de acasă, la fel ca un furnizor de email. Puteți alege serverul de acasă pe care doriți să îl utilizați, în timp ce puteți comunica în continuare cu toți. Aflați mai multe la https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Se pare că nu este un server de acasă compatibil. URL greșit?",
     "calculatingFileSize": "Calcularea dimensiunii fișierului...",
     "prepareSendingAttachment": "Pregătirea trimiterii atașamentului...",
@@ -2466,11 +2257,9 @@
     "oneOfYourDevicesIsNotVerified": "Unul dintre dispozitivele dvs. nu este verificat",
     "noticeChatBackupDeviceVerification": "Notă: Când conectați toate dispozitivele dvs. la backup-ul de chat, acestea sunt verificate automat.",
     "continueText": "Continuă",
-    "welcomeText": "Salut Salut 👋 Acesta este FluffyChat. Puteți să vă conectați la orice server de acasă, care este compatibil cu https://matrix.org. Și apoi să conversați cu oricine. Este o rețea mare de mesagerie descentralizată!",
     "blur": "Estompare:",
     "opacity": "Opacitate:",
     "setWallpaper": "Setează fundalul de ecran",
-    "manageAccount": "Gestionați contul",
     "noContactInformationProvided": "Serverul nu furnizează nicio informație de contact validă",
     "contactServerAdmin": "Contactați administratorul serverului",
     "contactServerSecurity": "Contactați securitatea serverului",
@@ -2489,11 +2278,8 @@
     "unableToJoinChat": "Imposibil de alăturat chat-ului. Poate cealaltă parte a închis deja conversația.",
     "previous": "Anterior",
     "otherPartyNotLoggedIn": "Cealaltă parte nu este conectată în prezent și, prin urmare, nu poate primi mesaje!",
-    "appWantsToUseForLogin": "Utilizați '{server}' pentru autentificare",
-    "appWantsToUseForLoginDescription": "Permiteți aplicației și site-ului web să partajeze informații despre dvs.",
     "open": "Deschide",
     "waitingForServer": "Se așteaptă serverul...",
-    "appIntroduction": "FluffyChat vă permite să discutați cu prietenii dvs. prin diferite mesagerie. Aflați mai multe la https://matrix.org sau apăsați doar *Continuă*.",
     "newChatRequest": "📩 Cerere de chat nou",
     "contentNotificationSettings": "Setări notificări conținut",
     "generalNotificationSettings": "Setări generale de notificare",
@@ -2568,11 +2354,9 @@
     "taTooltip": "L2 utilizare cu asistență de traducere",
     "interactiveTranslatorSliderHeader": "Traducător Interactiv",
     "interactiveGrammarSliderHeader": "Verificator Gramatică Interactiv",
-    "interactiveTranslatorRequired": "Obligatoriu",
     "waTooltip": "L2 utilizare fără asistență",
     "interactiveTranslator": "Asistență pentru traducere",
     "noIdenticalLanguages": "Te rog să alegi limbi de bază și țintă diferite",
-    "searchBy": "Caută după țară și limbi",
     "joinWithClassCode": "Participă la curs",
     "languageLevelPreA1": "Novice Low (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -2593,19 +2377,14 @@
     "saveChanges": "Salvează modificările",
     "publicProfileTitle": "Permite ca profilul meu să fie găsit în căutare",
     "publicProfileDesc": "Activând această opțiune, permiți altor utilizatori să găsească profilul tău în bara de căutare globală și să trimită cereri de chat. În acest moment, poți alege să accepți sau să refuzi cererea.",
-    "errorDisableIT": "Asistența de traducere este dezactivată.",
-    "errorDisableIGC": "Asistența gramaticală este dezactivată.",
     "errorDisableITUserDesc": "Clic aici pentru a actualiza setările de asistență pentru traducere",
     "errorDisableIGCUserDesc": "Clic aici pentru a actualiza setările de asistență gramaticală",
     "errorDisableITClassDesc": "Asistența de traducere este dezactivată pentru cursul în care se află această conversație.",
     "errorDisableIGCClassDesc": "Asistența de gramatică este dezactivată pentru cursul în care se află această conversație.",
-    "error405Title": "Limbi neconfigurate",
     "error405Desc": "Vă rugăm să setați limbile în Meniu Principal > Setări de Învățare.",
     "termsAndConditions": "Termenii și Condițiile",
     "andCertifyIAmAtLeast13YearsOfAge": " și certific că am cel puțin 16 ani.",
-    "error502504Title": "Wow, sunt mulți elevi online!",
     "error502504Desc": "Instrumentele de traducere și gramatică pot fi lente sau indisponibile în timp ce roboții Pangea se actualizează.",
-    "error404Title": "Eroare de traducere!",
     "error404Desc": "Botul Pangea nu este sigur cum să traducă asta...",
     "errorPleaseRefresh": "Ne uităm la problemă! Vă rugăm să reîncărcați și să încercați din nou.",
     "connectedToStaging": "Conectat la Staging",
@@ -2643,13 +2422,9 @@
     "definitionsToolName": "Definiții Cuvinte",
     "definitionsToolDescription": "Când este activat, cuvintele subliniate în albastru pot fi făcute clic pentru definiții. Faceți clic pe mesaje pentru a accesa definițiile.",
     "welcomeBack": "Bine ai revenit! Dacă ai fost parte din pilotul 2023-2024, te rugăm să ne contactezi pentru abonamentul tău special de pilot. Dacă ești profesor care a achiziționat (sau instituția ta a achiziționat) licențe pentru clasa ta, contactează-ne pentru abonamentul tău de profesor.",
-    "downloadTxtFile": "Descarcă Fișier Text",
-    "downloadCSVFile": "Descarcă Fișier CSV",
     "promotionalSubscriptionDesc": "În prezent ai un abonament promoțional pe viață. Trimite un mesaj la support@pangea.chat pentru ajutor în schimbarea abonamentului tău.",
     "originalSubscriptionPlatform": "Abonament achiziționat prin {purchasePlatform}",
     "oneWeekTrial": "Perioadă de încercare de o săptămână",
-    "downloadXLSXFile": "Descarcă Fișier Excel",
-    "unkDisplayName": "Necunoscut",
     "wwCountryDisplayName": "Lumea întreagă",
     "afCountryDisplayName": "Afganistan",
     "axCountryDisplayName": "Insulele Aland",
@@ -2944,7 +2719,6 @@
     "chatCapacityHasBeenChanged": "Capacitatea chat-ului a fost schimbată",
     "chatCapacitySetTooLow": "Capacitatea chat-ului trebuie să fie cel puțin {count}.",
     "chatCapacityExplanation": "Capacitatea chat-ului limitează numărul de membri permis într-un chat.",
-    "tooManyRequest": "Prea multe solicitări, vă rugăm să încercați din nou mai târziu.",
     "enterNumber": "Vă rugăm să introduceți o valoare întreagă.",
     "practice": "Exersează",
     "versionNotFound": "Versiune Negăsită",
@@ -2954,7 +2728,6 @@
     "deleteSubscriptionWarningTitle": "Ai o abonare activă",
     "deleteSubscriptionWarningBody": "Ștergerea contului tău nu va anula automat abonamentul.",
     "manageSubscription": "Gestionează Abonamentul",
-    "error520Title": "Te rugăm să încerci din nou.",
     "error520Desc": "Ne pare rău, nu am putut înțelege mesajul tău...",
     "wordsUsed": "Cuvinte Folosite",
     "level": "Nivel",
@@ -2972,7 +2745,6 @@
     "other": "Altele",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "Fără limită de capacitate",
-    "downloadGroupText": "Descarcă textul grupului",
     "notificationsOn": "Notificări activate",
     "notificationsOff": "Notificări dezactivate",
     "joinWithCode": "Alătură-te cu cod",
@@ -3036,24 +2808,12 @@
     "whatIsTheMorphTag": "Ce este {morphologicalFeature} din '{wordForm}'?",
     "dataAvailable": "Disponibilitatea datelor",
     "available": "Disponibil",
-    "pangeaBotIsFallible": "Pangea Bot face greșeli și el!",
-    "whatIsMeaning": "Ce înseamnă '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Potrivește sensurile cu cuvintele din mesaj!",
-    "doubleClickToEdit": "Dublu clic pentru editare.",
-    "topicLabel": "Subiect",
-    "topicPlaceholder": "Alegeți un subiect...",
-    "modePlaceholder": "Alegeți un mod...",
-    "learningObjectiveLabel": "Obiectiv de învățare",
-    "learningObjectivePlaceholder": "Alegeți un obiectiv de învățare...",
-    "targetLanguageLabel": "Limba țintă",
     "cefrLevelLabel": "Nivel CEFR",
     "image": "Imagine",
     "video": "Video",
     "nan": "Nu se aplică",
-    "addVocabulary": "Adaugă vocabular",
     "instructions": "Instrucțiuni",
-    "numberOfLearners": "Numărul de cursanți",
-    "mustBeInteger": "Trebuie să fie un număr întreg, de exemplu 1, 2, 3, ...",
     "constructUsePvmDesc": "Produs în mesaj vocal",
     "leaveSpaceDescription": "Părăsind cursul, vei părăsi toate chat-urile din cadrul acestuia. Alți utilizatori vor vedea că ai părăsit cursul.",
     "constructUseCorMmDesc": "Semnificația mesajului corect",
@@ -3068,7 +2828,6 @@
     "ttsDisabledBody": "Poți activa funcția text-to-speech în setările de învățare",
     "noSpaceDescriptionYet": "Încă nu a fost creată nicio descriere a cursului.",
     "tooLargeToSend": "Mesajul este prea mare pentru a fi trimis",
-    "exitWithoutSaving": "Ești sigur că vrei să ieși fără a salva?",
     "enableAutocorrectPopupTitle": "Adaugă tastatura limbii tale țintă accesând:",
     "enableAutocorrectPopupSteps": "  • Setări\n  • General\n  • Tastatură\n  • Tastaturi\n  • Adaugă tastatură nouă",
     "enableAutocorrectPopupDescription": "Odată ce limba este selectată, poți face clic pe micuța pictogramă glob pe partea stângă jos a tastaturii pentru a activa tastatura recent instalată.",
@@ -3079,11 +2838,8 @@
     "displayName": "Nume afișat",
     "leaveRoomDescription": "Ești pe cale să părăsești acest chat. Alți utilizatori vor vedea că ai părăsit chat-ul.",
     "confirmUserId": "Te rugăm să confirmi numele de utilizator Pangea Chat pentru a-ți șterge contul.",
-    "startingToday": "Începând de astăzi",
-    "oneWeekFreeTrial": "O săptămână de încercare gratuită",
     "paidSubscriptionStarts": "Începând cu {startDate}",
     "cancelInSubscriptionSettings": "• Anulează oricând din setările de abonament",
-    "cancelToAvoidCharges": "• Anulează înainte de {trialEnds} pentru a evita taxele",
     "downloadGboard": "Descarcă Gboard",
     "autocorrectNotAvailable": "Din păcate, platforma dvs. nu este în prezent compatibilă pentru această funcție. Rămâneți aproape pentru dezvoltări viitoare!",
     "pleaseUpdateApp": "Vă rugăm să actualizați aplicația pentru a continua.",
@@ -3093,17 +2849,12 @@
     "knockSpaceSuccess": "Ai solicitat să te alături acestui curs! Un administrator va răspunde cererii tale când o va primi 😊",
     "chooseWordAudioInstructionsBody": "Ascultă mesajul complet. Apoi potrivește audio-urile cu cuvintele.",
     "chooseMorphsInstructionsBody": "Fă clic pe piesele de puzzle pentru întrebări gramaticale!",
-    "pleaseEnterInt": "Te rugăm să introduci un număr",
     "home": "Acasă",
     "join": "Alătură-te",
     "resetInstructionTooltipsTitle": "Resetează sfaturile de instrucțiuni",
     "resetInstructionTooltipsDesc": "Fă clic pentru a afișa sfaturi de instrucțiuni precum pentru un utilizator nou.",
-    "randomize": "Aleatorizează",
     "clear": "Șterge",
-    "featuredActivities": "Recomandate",
     "save": "Salvează",
-    "startChat": "Începe o conversație",
-    "translationProblem": "Problemă de traducere",
     "askToJoin": "Cere să te alături",
     "emptyChatWarningTitle": "Conversația este goală",
     "emptyChatWarningDesc": "Nu ai invitat pe nimeni în conversația ta. Mergi la setările de chat pentru a invita contactele sau Botul. Poți face acest lucru și mai târziu.",
@@ -3133,17 +2884,13 @@
     "timesUsedIndependently": "Timpuri folosite independent",
     "timesUsedWithAssistance": "Timpuri folosite cu asistență",
     "shareInviteCode": "Partaja codul de invitație: {code}",
-    "leaderboard": "Clasament",
     "skipForNow": "Sari peste pentru moment",
     "permissions": "Permisiuni",
     "spaceChildPermission": "Cine poate adăuga noi conversații la acest curs",
-    "addEnvironmentOverride": "Adaugă suprascriere de mediu",
     "defaultOption": "Implicit",
     "deleteChatDesc": "Ești sigur că vrei să ștergi această conversație? Va fi ștearsă pentru toți participanții și toate mesajele din conversație nu vor mai fi disponibile pentru practică sau analize de învățare.",
     "deleteSpaceDesc": "Cursul și orice conversație selectată vor fi șterse pentru toți participanții și toate mesajele din conversație nu vor mai fi disponibile pentru practică sau analize de învățare. Această acțiune nu poate fi anulată.",
     "launch": "Lansează",
-    "searchChats": "Caută conversații",
-    "maxFifty": "Maxim 50",
     "configureSpace": "Configurează cursul",
     "pinMessages": "Fixează mesaje",
     "setJoinRules": "Setează regulile de aderare",
@@ -3177,9 +2924,6 @@
     "failedToFetchTranscription": "Nu s-a reușit preluarea transcrierii",
     "deleteEmptySpaceDesc": "Cursul va fi șters pentru toți participanții. Această acțiune nu poate fi anulată.",
     "regenerate": "Regenerare",
-    "mySavedActivities": "Activitățile mele salvate",
-    "noSavedActivities": "Nu există activități salvate",
-    "saveActivity": "Salvează această activitate",
     "failedToPlayVideo": "Nu s-a reușit redarea videoclipului",
     "done": "Gata",
     "inThisSpace": "În acest curs",
@@ -3190,13 +2934,9 @@
     "numInvited": "{count} invitați",
     "saved": "Salvat",
     "reset": "Resetare",
-    "errorFetchingActivitiesMessage": "Eșec la preluarea activităților",
     "errorFetchingDefinition": "Eșec la preluarea definiției",
     "errorProcessAnalytics": "Eșec la procesarea analizelor",
     "errorDownloading": "Eșec la descărcare",
-    "errorLoadingSpaceChildren": "Eșec la încărcarea conversațiilor din acest curs",
-    "unexpectedError": "Eroare neașteptată.",
-    "pleaseReload": "Vă rugăm să reîncărcați și să încercați din nou.",
     "translationError": "Eroare de traducere",
     "check": "Verifică",
     "unableToFindRoom": "Niciun chat sau curs cu acest cod nu a fost găsit. Vă rugăm să încercați din nou.",
@@ -3205,19 +2945,14 @@
     "request": "Cerere",
     "requestAll": "Solicită tot",
     "confirmMessageUnpin": "Ești sigur că vrei să dezlipești acest mesaj?",
-    "saveAndLaunch": "Salvează și pornește",
-    "launchToSpace": "Lansează în spațiu",
     "pending": "În așteptare",
     "inactive": "Inactiv",
-    "confirmRole": "Confirmă rolul",
     "openRoleLabel": "DESCHIS",
     "finishedTheActivity": "🎯 {username} a încheiat această activitate",
     "activitySummaryError": "Rezumatul activităților indisponibil",
     "requestSummaries": "Solicită rezumate",
-    "generatingNewActivities": "Sunteți primul utilizator al acestei perechi de limbi! Vă rugăm să ne acordați un minut, pregătim activități speciale pentru dvs.",
     "requestAccessTitle": "Solicitați acces la analize?",
     "requestAccessDesc": "Doriți să solicitați acces pentru a vizualiza analizele participanților?\n\nDacă participanții sunt de acord, administratorii acestui curs vor putea vizualiza:\n    • vocabularul total\n    • conceptele gramaticale totale\n    • sesiuni de activitate finalizate\n    • conceptele gramaticale specifice utilizate, corect și incorect\n\nEi nu vor putea vizualiza:\n    • mesajele din chat-urile din afara cursului\n    • lista de vocabular",
-    "requestAccess": "Solicită acces ({count})",
     "analyticsInactiveTitle": "Solicitările către utilizatorii inactivi nu au putut fi trimise",
     "analyticsInactiveDesc": "Utilizatorii inactivi care nu s-au autentificat de când a fost introdusă această funcție nu vor vedea solicitarea dvs.\n\nButonul de solicitare va apărea odată ce se vor întoarce. Puteți retrimite solicitarea mai târziu făcând clic pe butonul Solicitare sub numele lor când este disponibil.",
     "accessRequestedTitle": "Solicitare de acces la analize",
@@ -3240,8 +2975,6 @@
     "accessDesc": "Poți face cursul tău deschis lumii! Sau, îl poți face privat și sigur.",
     "createGroupChatDesc": "În timp ce sesiunile de activitate încep și se termină, chat-urile de grup vor rămâne deschise pentru comunicare de rutină.",
     "deleteDesc": "Doar administratorii pot șterge un curs. Aceasta este o acțiune distructivă care elimină toți utilizatorii și șterge toate chat-urile selectate din curs. Procedează cu precauție.",
-    "noCourseFound": "Oh, acest curs are nevoie de un plan!\n\nPlanurile de curs sunt o succesiune de subiecte și activități de conversație.",
-    "additionalParticipants": "+ {num} alții",
     "whatNow": "Ce urmează?",
     "chooseNextActivity": "Alege următoarea activitate!",
     "letsGo": "Hai să începem",
@@ -3254,13 +2987,11 @@
     "waitNotDone": "Așteaptă, nu am terminat!",
     "waitingForOthersToFinish": "Aștept ca ceilalți să termine...",
     "generatingSummary": "Analizăm chat-ul și generăm rezultate",
-    "findCourse": "Găsește un curs",
     "pingParticipantsNotification": "{user} caută utilizatori pentru a se alătura sesiunii de activitate în {room}",
     "course": "Curs",
     "courses": "Cursuri",
     "goToCourse": "Mergi la curs: {course}",
     "activityComplete": "Această activitate a fost finalizată. Rezumatul activității ar trebui să fie disponibil mai jos.",
-    "startNewSession": "Începe o sesiune nouă",
     "joinOpenSession": "Participă la sesiune deschisă",
     "activityNotFound": "Activitate negăsită",
     "myActivities": "Activitățile mele",
@@ -3400,14 +3131,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@createGroup": {
         "type": "String",
         "placeholders": {}
@@ -3420,18 +3143,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -3441,10 +3152,6 @@
         "placeholders": {}
     },
     "@customEmojisAndStickersBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3579,23 +3286,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@hidePresences": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3679,31 +3374,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3759,23 +3434,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3815,28 +3478,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -3854,14 +3495,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4054,22 +3687,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4125,10 +3742,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4138,10 +3751,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4217,27 +3826,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4555,10 +4148,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4568,10 +4157,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4659,14 +4244,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4683,10 +4260,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4699,15 +4272,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4859,14 +4424,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4880,14 +4437,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6110,10 +5659,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6154,10 +5699,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6230,10 +5771,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6503,47 +6040,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6563,19 +6060,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6639,10 +6124,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6683,14 +6164,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6702,14 +6175,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6747,10 +6212,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6767,27 +6228,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6911,10 +6356,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6924,10 +6365,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6944,14 +6381,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7091,18 +6520,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7151,10 +6568,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7164,18 +6577,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7218,23 +6619,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7258,10 +6647,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7269,14 +6654,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7381,18 +6758,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7445,10 +6810,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7475,10 +6836,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7659,7 +7016,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Verifică mâine pentru actualizări ale activității.",
-    "activityDropdownDesc": "Când termini această activitate, fă clic mai jos",
     "languageMismatchTitle": "Incompatibilitate de limbaj",
     "languageMismatchDesc": "Limba țintă nu se potrivește cu limba acestei activități. Vrei să actualizezi limba țintă?",
     "reportWordIssueTooltip": "Raportează problemă cu informația cuvântului",
@@ -7672,10 +7028,6 @@
     "selectAll": "Selectează tot",
     "deselectAll": "Deselectează tot",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7724,17 +7076,11 @@
         "placeholders": {}
     },
     "startOwn": "Începe propriul meu",
-    "joinCourseDesc": "Fiecare curs are 8-10 subiecte secvențiale cu o gamă de activități de învățare a limbajului bazate pe sarcini.",
     "newMessageInPangeaChat": "📝 Mesaj nou în Pangea Chat",
     "shareCourse": "Partajează cursul",
     "addCourse": "Adaugă un curs",
-    "joinPublicCourse": "Alătură-te cursului public",
     "vocabLevelsDesc": "Aici vor fi plasate cuvintele de vocabular odată ce le-ai nivelat!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7747,10 +7093,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7769,7 +7111,6 @@
     "emojiView": "Vizualizare emoji",
     "feedbackDialogDesc": "Fac și eu greșeli! Ai ceva care să mă ajute să mă îmbunătățesc?",
     "contactHasBeenInvitedToTheCourse": "Contactul a fost invitat la curs",
-    "activityStatsButtonTooltip": "Informații despre activitate",
     "allow": "Permite",
     "deny": "Refuză",
     "enabledRenewal": "Activează reînnoirea abonamentului",
@@ -8037,10 +7378,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9096,16 +8433,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Activități pentru deblocarea următorului subiect",
-    "activitiesToUnlockTopicDesc": "Stabilește numărul de activități pentru a debloca următorul subiect al cursului",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Practică corectă a definițiilor vocabularului",
     "constructUseIncLMDesc": "Practică incorectă a definițiilor vocabularului",
     "constructUseCorLADesc": "Practică corectă a audio-ului vocabularului",
@@ -9113,7 +8440,6 @@
     "constructUseBonus": "Bonus în timpul practicii vocabularului",
     "practiceVocab": "Practică vocabularul",
     "selectMeaning": "Selectați semnificația",
-    "selectAudio": "Selectați audio-ul corespunzător",
     "anotherRound": "Încă o rundă",
     "activitySettingsOverrideWarning": "Limba și nivelul de limbă sunt determinate de planul de activitate",
     "voice": "Voce",
@@ -9145,10 +8471,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9166,12 +8488,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Descărcare inițiată",
     "webDownloadPermissionMessage": "Dacă browserul dvs. blochează descărcările, vă rugăm să activați descărcările pentru acest site.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9266,11 +8583,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Ceva a mers prost și lucrăm din greu pentru a remedia problema. Verifică din nou mai târziu.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Activare asistență la scriere",
     "autoIGCToolDescription": "Rulați automat instrumentele Pangea Chat pentru a corecta mesajele trimise în limba țintă.",
     "@autoIGCToolName": {
@@ -9326,24 +8638,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatica",
-    "spanTypeWordChoice": "Alegerea cuvintelor",
     "spanTypeSpelling": "Ortografie",
     "spanTypePunctuation": "Punctuație",
     "spanTypeStyle": "Stil",
     "spanTypeFluency": "Fluență",
     "spanTypeAccents": "Accente",
     "spanTypeCapitalization": "Capitalizare",
-    "spanTypeCorrection": "Corectare",
     "spanFeedbackTitle": "Raportează problema de corectare",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9368,10 +8669,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9384,13 +8681,7 @@
     "longPressToRecordVoiceMessage": "Apasă lung pentru a înregistra un mesaj vocal.",
     "pause": "Pauză",
     "resume": "Continuă",
-    "newSubSpace": "Nou sub spațiu",
-    "moveToDifferentSpace": "Mută în alt spațiu",
-    "removeFromSpaceDescription": "Chatul va fi eliminat din spațiu, dar va apărea în continuare în lista ta de chat-uri.",
     "countChats": "{chats} chat-uri",
-    "spaceMemberOf": "Membru al spațiului {spaces}",
-    "spaceMemberOfCanKnock": "Membru al spațiului {spaces} poate bate",
-    "donate": "Donează",
     "startedAPoll": "{username} a început un sondaj.",
     "poll": "Sondaj",
     "startPoll": "Începe sondaj",
@@ -9414,23 +8705,15 @@
     "newStickerPack": "Pachet nou de autocolante",
     "stickerPackName": "Numele pachetului de autocolante",
     "attribution": "Atribuire",
-    "skipChatBackup": "Sari peste backup-ul chat-ului",
-    "skipChatBackupWarning": "Ești sigur? Fără activarea backup-ului chat-ului, s-ar putea să pierzi accesul la mesajele tale dacă îți schimbi dispozitivul.",
-    "loadingMessages": "Se încarcă mesajele",
-    "setupChatBackup": "Configurează backup-ul chat-ului",
     "noMoreResultsFound": "Nu s-au găsit alte rezultate",
     "chatSearchedUntil": "Chat-ul a fost căutat până la {time}",
     "federationBaseUrl": "URL de bază al federației",
     "clientWellKnownInformation": "Informații Client-Bine-Cunoscute:",
     "baseUrl": "URL de bază",
     "identityServer": "Server de identitate:",
-    "versionWithNumber": "Versiune: {version}",
     "logs": "Jurnale",
-    "advancedConfigs": "Configurații avansate",
     "advancedConfigurations": "Configurații avansate",
-    "signInWithLabel": "Conectează-te cu:",
     "selectAllWords": "Selectează toate cuvintele pe care le auzi în audio",
-    "joinCourseForActivities": "Alătură-te unui curs pentru a încerca activități.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9467,18 +8750,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9486,26 +8757,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9611,22 +8862,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9655,19 +8890,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9675,15 +8898,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9884,11 +9099,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Într-o clasă? Pune codul tău de alăturare aici.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Subliniază automat mesajele audio",
     "selectAudioMessagesOnPlayDescription": "Subliniază automat mesajele audio atunci când sunt redată",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9932,18 +9142,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Acest curs are subiecte cu mai puțin de {input} activități. Vă rugăm să introduceți un număr mai mic sau egal cu {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Faceți clic aici pentru a vă reconecta.",
     "@clickToLogin": {
@@ -10360,17 +9558,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Un urs galben în stil desenat, cu brațele ridicate de entuziasm.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Selectați cuvintele pentru a învăța mai multe despre ele",
     "requireAnalyticsAccessTitle": "Necesită acces la analize pentru a se alătura",
     "requireAnalyticsAccessDesc": "Participanții trebuie să acorde acces la analizele lor de învățare pentru a se alătura acestui curs",
     "analyticsAccessNoticeTitle": "Acces la analize necesar",
     "analyticsAccessNoticeDesc": "Prin alăturarea acestui curs, sunteți de acord să acordați administratorilor acces la analizele dumneavoastră de învățare.",
-    "skipOnboardingClassCodeDesc": "Învățați independent? Nu vă faceți griji, puteți:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10388,10 +9580,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10420,7 +9608,6 @@
     "pickCefrLevelTeacherStepTitle": "Ce nivel predai?",
     "pickCefrLevelStudentStepTitle": "Ce nivel ești?",
     "customCourseStepTitle": "Completează acest formular pentru a obține un curs personalizat",
-    "aboutYourClass": "Despre clasa ta",
     "courseCodeStepErrorMessage": "Te rugăm să verifici codul tău și să încerci din nou",
     "institution": "Instituție",
     "courseGoals": "Obiectivele cursului",
@@ -10463,10 +9650,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10583,12 +9766,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logo Pangea Chat",
     "introChatDetails": "Spune salut! Prezintă-te colegilor tăi participanți la curs, găsește prieteni și discută în afara activităților.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10632,11 +9810,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Acțiuni de activitate",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Instrumente de pronunție",
     "audioTranscription": "Transcriere audio AI",
     "visualLearnerSupport": "Suport pentru învățarea vizuală",
@@ -10677,7 +9850,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Alătură-te unui curs care include această activitate pentru a o juca.",
     "resizeCoursePanel": "Redimensionează panoul cursului",
     "undo": "Anulează",
     "unlock": "Dezactivează",
@@ -10691,7 +9863,6 @@
     "addCourseBrowsePublic": "Răsfoiți cursurile publice",
     "browsePublicCourses": "Răsfoiți cursurile publice",
     "editProfile": "Editează profilul",
-    "numObjectives": "{count} obiective",
     "mapSearchHint": "Căutați activități",
     "mapSearchNoResults": "Niciun rezultat în vizualizare",
     "mapFilterAllLanguages": "Toate limbile",
@@ -10700,7 +9871,6 @@
     "mapFilterCompleted": "Finalizat",
     "mapFilterReset": "Resetare",
     "activityTypeConversation": "Conversație",
-    "lockedMissionRequirement": "Finalizați misiunea anterioară pentru a debloca",
     "playAgain": "Joacă din nou",
     "reviewActivity": "Recenzie",
     "mapEmptyInView": "Nimic aici la nivelul sau limba ta. Lărgiți filtrele sau faceți zoom out.",
@@ -10715,14 +9885,9 @@
     "scrollToBottom": "Derulează la fund",
     "courseImage": "Imagine curs",
     "avatarPreview": "Previzualizare avatar",
-    "activityPhoto": "Fotografie activitate",
     "emotePreview": "Previzualizare emote: {name}",
     "activityLabel": "Activitate: {title}",
     "resetMapView": "Resetează vederea hărții",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10775,14 +9940,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10812,10 +9969,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10872,10 +10025,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -84,11 +84,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Разрешено ли гостям присоединяться",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Вы уверены?",
     "@areYouSure": {
         "type": "String",
@@ -391,12 +386,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Резервная копия старых сообщений защищена ключом восстановления. Пожалуйста, не потеряйте его.",
-    "@chatBackupDescription": {
-        "pangea_override": true,
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Детали чата",
     "@chatDetails": {
         "type": "String",
@@ -531,12 +520,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Контакт был приглашён в группу",
-    "@contactHasBeenInvitedToTheGroup": {
-        "pangea_override": true,
-        "type": "String",
-        "placeholders": {}
-    },
     "containsDisplayName": "Содержит отображаемое имя",
     "@containsDisplayName": {
         "type": "String",
@@ -599,11 +582,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Новое пространство",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "В настоящее время активен",
     "@currentlyActive": {
@@ -781,11 +759,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Вы больше не сможете отключить шифрование. Вы уверены?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Зашифровано",
     "@encrypted": {
         "type": "String",
@@ -829,11 +802,6 @@
             }
         }
     },
-    "everythingReady": "Всё готово!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Крайне оскорбительный",
     "@extremeOffensive": {
         "type": "String",
@@ -876,11 +844,6 @@
     },
     "group": "Группа",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Публичная группа",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -980,15 +943,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Пригласить контакт в {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Приглашён",
     "@invited": {
@@ -1136,15 +1090,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "logInTo": "Войти в {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
-    },
     "logout": "Выйти",
     "@logout": {
         "type": "String",
@@ -1213,18 +1158,6 @@
     },
     "noEmotesFound": "Эмодзи не найдены 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Вы сможете включить шифрование только после того, как комната перестанет быть публично доступной.",
-    "@noEncryptionForPublicRooms": {
-        "pangea_override": true,
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Похоже, Firebase Cloud Messaging недоступен на вашем устройстве. Чтобы продолжать получать push-уведомления, мы рекомендуем установить ntfy. С помощью ntfy или другого провайдера Unified Push вы сможете получать push-уведомления безопасным для данных способом. Вы можете скачать ntfy из PlayStore или F-Droid.",
-    "@noGoogleServicesWarning": {
-        "pangea_override": true,
         "type": "String",
         "placeholders": {}
     },
@@ -1362,11 +1295,6 @@
     },
     "passwordHasBeenChanged": "Пароль был изменён",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Восстановление пароля",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1517,11 +1445,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Удалить устройство",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Разблокировать в чате",
     "@unbanFromChat": {
@@ -1706,11 +1629,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Установить уровень разрешений",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Задать статус",
     "@setStatus": {
         "type": "String",
@@ -1759,16 +1677,6 @@
     },
     "sourceCode": "Исходный код",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Публичное пространство",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Название пространства",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1842,11 +1750,6 @@
     },
     "tooManyRequestsWarning": "Слишком много запросов. Пожалуйста, повторите попытку позже!",
     "@tooManyRequestsWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "transferFromAnotherDevice": "Перенос с другого устройства",
-    "@transferFromAnotherDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -1991,16 +1894,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Видеозвонок",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Видимость истории чата",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Видима для всех участников",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -2050,25 +1943,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Кто и какие действия может выполнять",
-    "@whoCanPerformWhichAction": {
-        "pangea_override": true,
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Кому разрешено присоединяться к этой группе",
-    "@whoIsAllowedToJoinThisGroup": {
-        "pangea_override": true,
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Почему вы хотите сообщить об этом?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Удалить резервную копию чата, чтобы создать новый ключ восстановления?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -2124,10 +2000,6 @@
     "@serverRequiresEmail": {
         "pangea_override": true
     },
-    "enableMultiAccounts": "(БЕТА) Включить несколько учётных записей на этом устройстве",
-    "@enableMultiAccounts": {
-        "pangea_override": true
-    },
     "bundleName": "Название пакета",
     "@bundleName": {},
     "removeFromBundle": "Удалить из этого пакета",
@@ -2138,16 +2010,10 @@
     "@editBundlesForAccount": {
         "pangea_override": true
     },
-    "addAccount": "Добавить учётную запись",
-    "@addAccount": {
-        "pangea_override": true
-    },
     "link": "Ссылка",
     "@link": {},
     "oneClientLoggedOut": "Один из ваших клиентов вышел",
     "@oneClientLoggedOut": {},
-    "yourChatBackupHasBeenSetUp": "Резервное копирование чата настроено.",
-    "@yourChatBackupHasBeenSetUp": {},
     "unverified": "Не проверено",
     "@unverified": {},
     "commandHint_clearcache": "Очистить кэш",
@@ -2169,8 +2035,6 @@
     "@messageInfo": {},
     "openGallery": "Открыть галерею",
     "@openGallery": {},
-    "removeFromSpace": "Удалить из пространства",
-    "@removeFromSpace": {},
     "commandHint_create": "Создайте пустой групповой чат\nИспользуйте --no-encryption, чтобы отключить шифрование",
     "@commandHint_create": {
         "type": "String",
@@ -2229,22 +2093,14 @@
     },
     "emojis": "Эмодзи",
     "@emojis": {},
-    "voiceCall": "Голосовой звонок",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "Неподдерживаемая версия Android",
     "@unsupportedAndroidVersion": {},
     "unsupportedAndroidVersionLong": "Для этой функции требуется более новая версия Android. Проверьте наличие обновлений или поддержку Lineage OS.",
     "@unsupportedAndroidVersionLong": {},
     "placeCall": "Совершить звонок",
     "@placeCall": {},
-    "videoCallsBetaWarning": "Обратите внимание, что видеозвонки в настоящее время находятся в стадии бета-тестирования. Они могут работать нестабильно или не работать на всех платформах вовсе.",
-    "@videoCallsBetaWarning": {
-        "pangea_override": true
-    },
     "experimentalVideoCalls": "Экспериментальные видеозвонки",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "Адрес электронной почты или имя пользователя",
-    "@emailOrUsername": {},
     "pinMessage": "Прикрепить к комнате",
     "@pinMessage": {},
     "confirmEventUnpin": "Вы уверены, что хотите навсегда открепить событие?",
@@ -2353,32 +2209,8 @@
             }
         }
     },
-    "recoveryKeyLost": "Ключ восстановления утерян?",
-    "@recoveryKeyLost": {},
     "users": "Пользователи",
     "@users": {},
-    "unlockOldMessages": "Разблокировать старые сообщения",
-    "@unlockOldMessages": {},
-    "storeInSecureStorageDescription": "Сохраните ключ восстановления в безопасном хранилище этого устройства.",
-    "@storeInSecureStorageDescription": {},
-    "storeSecurlyOnThisDevice": "Сохранить на этом устройстве",
-    "@storeSecurlyOnThisDevice": {},
-    "saveKeyManuallyDescription": "Сохраните этот ключ вручную, используя системный диалог или буфер обмена.",
-    "@saveKeyManuallyDescription": {
-        "pangea_override": true
-    },
-    "recoveryKey": "Ключ восстановления",
-    "@recoveryKey": {},
-    "pleaseEnterRecoveryKey": "Введите ключ восстановления:",
-    "@pleaseEnterRecoveryKey": {},
-    "pleaseEnterRecoveryKeyDescription": "Чтобы получить доступ к вашим старым сообщениям, введите ключ восстановления, созданный в предыдущей сессии. Ключ восстановления — это НЕ ваш пароль.",
-    "@pleaseEnterRecoveryKeyDescription": {
-        "pangea_override": true
-    },
-    "storeInAndroidKeystore": "Сохранить в Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Сохранить в Apple KeyChain",
-    "@storeInAppleKeyChain": {},
     "user": "Пользователь",
     "@user": {},
     "confirmMatrixId": "Пожалуйста, подтвердите свой Matrix ID, чтобы удалить свою учётную запись.",
@@ -2424,10 +2256,6 @@
     "@otherCallingPermissions": {
         "pangea_override": true
     },
-    "enterSpace": "Войти в пространство",
-    "@enterSpace": {},
-    "screenSharingDetail": "Вы делитесь своим экраном в FuffyChat",
-    "@screenSharingDetail": {},
     "callingAccountDetails": "Позволяет FluffyChat использовать встроенное приложение для звонков Android.",
     "@callingAccountDetails": {
         "pangea_override": true
@@ -2442,10 +2270,6 @@
     "@commandHint_markasdm": {},
     "appearOnTopDetails": "Разрешает приложению отображаться поверх других приложений (не требуется, если FluffyChat уже настроен как приложение для звонков)",
     "@appearOnTopDetails": {
-        "pangea_override": true
-    },
-    "foregroundServiceRunning": "Это уведомление отображается при работе фонового сервиса.",
-    "@foregroundServiceRunning": {
         "pangea_override": true
     },
     "newGroup": "Новая группа",
@@ -2466,10 +2290,6 @@
     "@noKeyForThisMessage": {
         "pangea_override": true
     },
-    "screenSharingTitle": "Демонстрация экрана",
-    "@screenSharingTitle": {
-        "pangea_override": true
-    },
     "numChats": "{number} чатов",
     "@numChats": {
         "type": "number",
@@ -2487,8 +2307,6 @@
     "@hideUnimportantStateEvents": {
         "pangea_override": true
     },
-    "sorryThatsNotPossible": "Извините... это невозможно",
-    "@sorryThatsNotPossible": {},
     "openLinkInBrowser": "Открыть ссылку в браузере",
     "@openLinkInBrowser": {},
     "fileHasBeenSavedAt": "Файл сохранён в {path}",
@@ -2535,14 +2353,6 @@
     },
     "doNotShowAgain": "Не показывать снова",
     "@doNotShowAgain": {},
-    "newSpaceDescription": "Пространства позволяют объединять ваши чаты и создавать частные или публичные сообщества.",
-    "@newSpaceDescription": {
-        "pangea_override": true
-    },
-    "disableEncryptionWarning": "В целях безопасности вы не можете отключить шифрование в чате, где оно было включено.",
-    "@disableEncryptionWarning": {
-        "pangea_override": true
-    },
     "deviceKeys": "Ключи устройств:",
     "@deviceKeys": {},
     "noBackupWarning": "Внимание! Без включённого резервного копирования чатов вы потеряете доступ к зашифрованным сообщениям. Настоятельно рекомендуется включить резервное копирование перед выходом из аккаунта.",
@@ -2573,8 +2383,6 @@
             }
         }
     },
-    "encryptThisChat": "Зашифровать этот чат",
-    "@encryptThisChat": {},
     "reopenChat": "Открыть чат заново",
     "@reopenChat": {},
     "commandHint_googly": "Отправить глазки",
@@ -2625,8 +2433,6 @@
     "@chatPermissions": {
         "pangea_override": true
     },
-    "chatDescription": "Описание чата",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "Описание чата изменено",
     "@chatDescriptionHasBeenChanged": {},
     "noChatDescriptionYet": "Описание чата не создано.",
@@ -2661,8 +2467,6 @@
     "@profileNotFound": {
         "pangea_override": true
     },
-    "setTheme": "Тема:",
-    "@setTheme": {},
     "redactedByBecause": "{username} отредактировал это событие. Причина: \"{reason}\"",
     "@redactedByBecause": {
         "type": "String",
@@ -2752,12 +2556,8 @@
     "@block": {},
     "blockUsername": "Игнорировать имя пользователя",
     "@blockUsername": {},
-    "createGroupAndInviteUsers": "Создать и начать приглашать",
-    "@createGroupAndInviteUsers": {},
     "startConversation": "Начать общение",
     "@startConversation": {},
-    "groupCanBeFoundViaSearch": "Группа может быть найдена поиском",
-    "@groupCanBeFoundViaSearch": {},
     "noUsersFoundWithQuery": "К сожалению пользователей с именем \"{query}\" не найдено. Пожалуйста, проверьте, нет ли опечатки.",
     "@noUsersFoundWithQuery": {
         "pangea_override": true,
@@ -2782,8 +2582,6 @@
     "@groupName": {},
     "databaseMigrationTitle": "База данных оптимизированна",
     "@databaseMigrationTitle": {},
-    "searchChatsRooms": "Поиск #чатов, @людей...",
-    "@searchChatsRooms": {},
     "databaseMigrationBody": "Пожалуйста, подождите. Это может занять некоторое время.",
     "@databaseMigrationBody": {},
     "publicSpaces": "Публичные пространства",
@@ -2831,36 +2629,8 @@
     },
     "initAppError": "Произошла ошибка при запуске приложения",
     "@initAppError": {},
-    "sessionLostBody": "Ваш сеанс утерян. Пожалуйста, сообщите об этой ошибке разработчикам по адресу {url}. Сообщение об ошибке: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Приложение пытается восстановить сеанс из резервной копии. Пожалуйста, сообщите об этой ошибке разработчикам по адресу {url}. Сообщение об ошибке: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "subspace": "Подпространство",
     "@subspace": {
-        "pangea_override": true
-    },
-    "addChatOrSubSpace": "Добавить чат или подпространство",
-    "@addChatOrSubSpace": {
         "pangea_override": true
     },
     "youInvitedToBy": "📩 Вы были приглашены по ссылке в:\n{alias}",
@@ -2876,8 +2646,6 @@
     "@sendReadReceipts": {
         "pangea_override": true
     },
-    "verifyOtherUser": "🔐 Подтвердить другого пользователя",
-    "@verifyOtherUser": {},
     "verifyOtherDevice": "🔐 Подтвердить другое устройство",
     "@verifyOtherDevice": {},
     "forwardMessageTo": "Переслать сообщение в {roomName}?",
@@ -2893,10 +2661,6 @@
     "@sendReadReceiptsDescription": {},
     "transparent": "Прозрачный",
     "@transparent": {},
-    "verifyOtherUserDescription": "Подтвердив другого пользователя, вы можете быть уверены, что точно знаете, с кем общаетесь. 💪\n\nКогда вы начнёте проверку, у вас и у другого пользователя в приложении появится всплывающее окно. В нём вы увидите набор эмодзи или чисел, которые нужно сравнить друг с другом.\n\nЛучший способ сделать это — встретиться лично или начать видеозвонок. 👭",
-    "@verifyOtherUserDescription": {
-        "pangea_override": true
-    },
     "verifyOtherDeviceDescription": "Когда вы подтверждаете другое устройство, эти устройства могут обмениваться ключами, повышая общий уровень безопасности. 💪 Когда вы начнёте проверку, на обоих устройствах в приложении появится всплывающее окно. В нём вы увидите набор эмодзи или чисел, которые нужно сравнить между собой. Перед началом проверки лучше держать оба устройства под рукой. 🤳",
     "@verifyOtherDeviceDescription": {
         "pangea_override": true
@@ -2981,8 +2745,6 @@
     "@stickers": {},
     "discover": "Исследовать",
     "@discover": {},
-    "globalChatId": "ID глобального чата",
-    "@globalChatId": {},
     "customEmojisAndStickersBody": "Добавлять или делиться пользовательскими эмодзи и стикерами, которые можно использовать в любом чате.",
     "@customEmojisAndStickersBody": {
         "pangea_override": true
@@ -2993,12 +2755,6 @@
     },
     "knocking": "Стучаться",
     "@knocking": {},
-    "accessAndVisibility": "Доступность и видимость",
-    "@accessAndVisibility": {},
-    "publicChatAddresses": "Адресы публичного чата",
-    "@publicChatAddresses": {},
-    "accessAndVisibilityDescription": "Кому разрешено войти в этот чат и как этот чат может быть обнаружен.",
-    "@accessAndVisibilityDescription": {},
     "userRole": "Роль пользователя",
     "@userRole": {},
     "noDatabaseEncryption": "Шифрование базы данных не поддерживается на этой платформе",
@@ -3038,27 +2794,10 @@
     },
     "knock": "Постучаться",
     "@knock": {},
-    "usersMustKnock": "Требуется запрос на вступление",
-    "@usersMustKnock": {
-        "pangea_override": true
-    },
-    "noOneCanJoin": "Никто не может присоединиться",
-    "@noOneCanJoin": {},
     "noPublicLinkHasBeenCreatedYet": "Публичная ссылка ещё не была создана",
     "@noPublicLinkHasBeenCreatedYet": {
         "pangea_override": true
     },
-    "chatCanBeDiscoveredViaSearchOnServer": "Чат может быть обнаружен через поиск в {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "createNewAddress": "Создать новый адрес",
-    "@createNewAddress": {},
     "minimumPowerLevel": "{level} является минимальным уровнем.",
     "@minimumPowerLevel": {
         "type": "String",
@@ -3209,16 +2948,6 @@
     "@noticeChatBackupDeviceVerification": {},
     "changeTheCanonicalRoomAlias": "Изменить основной общедоступный адрес чата",
     "@changeTheCanonicalRoomAlias": {},
-    "loginWithMatrixId": "Войти через Matrix ID",
-    "@loginWithMatrixId": {},
-    "whatIsAHomeserver": "Для чего нужен домашний сервер?",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "Все ваши данные хранятся на домашнем сервере — так же, как у провайдера электронной почты. Вы можете выбрать, какой сервер использовать, и при этом продолжать общаться со всеми. Узнайте больше на https://matrix.org.",
-    "@homeserverDescription": {
-        "pangea_override": true
-    },
-    "discoverHomeservers": "Список домашних серверов",
-    "@discoverHomeservers": {},
     "joinedChats": "Чаты, в которых вы состоите",
     "@joinedChats": {
         "pangea_override": true
@@ -3237,10 +2966,6 @@
                 "type": "int"
             }
         }
-    },
-    "welcomeText": "Привет-привет 👋 Это FluffyChat. Вы можете войти на любой homeserver, совместимый с https://matrix.org, и общаться с кем угодно. Это огромная децентрализованная сеть для обмена сообщениями!",
-    "@welcomeText": {
-        "pangea_override": true
     },
     "noContactInformationProvided": "Сервер не предоставляет корректной контактной информации",
     "@noContactInformationProvided": {
@@ -3281,8 +3006,6 @@
     "@opacity": {},
     "setWallpaper": "Установить обои",
     "@setWallpaper": {},
-    "manageAccount": "Управление аккаунтом",
-    "@manageAccount": {},
     "contactServerAdmin": "Связаться с администратором сервера",
     "@contactServerAdmin": {
         "pangea_override": true
@@ -3313,10 +3036,6 @@
     "@compress": {},
     "notificationRuleMessage": "Сообщение",
     "@notificationRuleMessage": {},
-    "appWantsToUseForLoginDescription": "Вы разрешаете приложению и сайту обмениваться информацией о вас.",
-    "@appWantsToUseForLoginDescription": {
-        "pangea_override": true
-    },
     "newChatRequest": "📩 Запрос нового чата",
     "@newChatRequest": {},
     "allDevices": "Все устройства",
@@ -3352,15 +3071,6 @@
         "type": "String",
         "placeholders": {
             "percentage": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLogin": "Использовать '{server}' для входа",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
                 "type": "String"
             }
         }
@@ -3407,10 +3117,6 @@
     "@open": {},
     "waitingForServer": "Ожидание сервера...",
     "@waitingForServer": {},
-    "appIntroduction": "FluffyChat позволяет общаться с друзьями через разные мессенджеры. Узнайте больше на https://matrix.org или просто нажмите *Продолжить*.",
-    "@appIntroduction": {
-        "pangea_override": true
-    },
     "previous": "Предыдущий",
     "@previous": {},
     "notificationRuleCallDescription": "Уведомляет пользователя о звонках.",
@@ -3604,16 +3310,10 @@
     "@resume": {
         "pangea_override": true
     },
-    "newSubSpace": "Новое подпространство",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Переместить в другое пространство",
-    "@moveToDifferentSpace": {},
     "moveUp": "Переместить вверх",
     "@moveUp": {},
     "moveDown": "Переместить вниз",
     "@moveDown": {},
-    "removeFromSpaceDescription": "Чат будет удален из пространства, но все равно появится в вашем списке чатов.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} чатов",
     "@countChats": {
         "type": "String",
@@ -3623,26 +3323,6 @@
             }
         }
     },
-    "spaceMemberOf": "Участник пространства из {spaces}",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "Участник пространства из {spaces} может постучать",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "Пожертвовать",
-    "@donate": {},
     "startedAPoll": "{username} начал опрос.",
     "@startedAPoll": {
         "type": "String",
@@ -3700,33 +3380,6 @@
     "@stickerPackName": {},
     "attribution": "Атрибуция",
     "@attribution": {},
-    "skipChatBackup": "Пропустить резервную копию чата",
-    "@skipChatBackup": {},
-    "skipChatBackupWarning": "Вы уверены? Без включения резервного копирования чата вы можете потерять доступ к своим сообщениям, если переключите устройство.",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "Загрузка сообщений",
-    "@loadingMessages": {},
-    "setupChatBackup": "Настроить резервную копию чата",
-    "@setupChatBackup": {},
-    "loadCountMoreParticipants": "{count, plural, one{Загрузить ещё # участника} few{Загрузить ещё # участников} other{Загрузить ещё # участников}}",
-    "@loadCountMoreParticipants": {
-        "pangea_override": true,
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "unreadChats": "{unreadCount, plural, one{# непрочитанный чат} few{# непрочитанных чата} other{# непрочитанных чатов}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "countFiles": "{count, plural, one{# файл} few{# файла} other{# файлов}}",
     "@countFiles": {
         "placeholders": {
@@ -3773,16 +3426,6 @@
             }
         }
     },
-    "countInvited": "{count, plural, one{Приглашён # участник} few{Приглашены # участника} other{Приглашены # участников}}",
-    "@countInvited": {
-        "pangea_override": true,
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "countVotes": "{count, plural, =1{Один голос} other{{count} голосов}}",
     "@countVotes": {
         "type": "int",
@@ -3815,13 +3458,11 @@
     "interactiveGrammarSliderHeader": "Интерактивная проверка грамматики",
     "interactiveTranslatorNotAllowed": "Отключено",
     "interactiveTranslatorAllowed": "Выбор студента",
-    "interactiveTranslatorRequired": "Обязательно",
     "notYetSet": "Ещё не установлено",
     "waTooltip": "Использование L2 без помощи",
     "languageSettings": "Настройки языка",
     "interactiveTranslator": "Помощь с переводом",
     "noIdenticalLanguages": "Пожалуйста, выберите разные исходный и целевой языки",
-    "searchBy": "Поиск по стране и языкам",
     "joinWithClassCode": "Присоединиться к курсу",
     "languageLevelPreA1": "Преддверие A1 (Pre A1)",
     "languageLevelA1": "Начальный (A1)",
@@ -3843,21 +3484,16 @@
     "whatIsYourBaseLanguage": "Какой у вас основной язык?",
     "publicProfileTitle": "Разрешить находить мой профиль в поиске",
     "publicProfileDesc": "Включив это, вы позволяете другим пользователям находить ваш профиль в глобальной строке поиска и отправлять запросы на чат. После этого вы можете принять или отклонить запрос.",
-    "errorDisableIT": "Помощь с переводом отключена.",
-    "errorDisableIGC": "Помощь с грамматикой отключена.",
     "errorDisableLanguageAssistance": "Помощь с переводом и грамматикой отключены.",
     "errorDisableITUserDesc": "Нажмите здесь, чтобы обновить настройки помощи с переводом",
     "errorDisableIGCUserDesc": "Нажмите здесь, чтобы обновить настройки помощи с грамматикой",
     "errorDisableLanguageAssistanceUserDesc": "Нажмите здесь, чтобы обновить настройки помощи с переводом и грамматикой",
     "errorDisableITClassDesc": "Помощь с переводом отключена для курса, в котором находится этот чат.",
     "errorDisableIGCClassDesc": "Помощь с грамматикой отключена для курса, в котором находится этот чат.",
-    "error405Title": "Языки не установлены",
     "error405Desc": "Пожалуйста, установите ваши языки в Главное меню > Настройки обучения.",
     "termsAndConditions": "Условиями использования",
     "andCertifyIAmAtLeast13YearsOfAge": " и подтверждаю, что мне не менее 16 лет.",
-    "error502504Title": "Вау, много студентов онлайн!",
     "error502504Desc": "Инструменты перевода и грамматики могут работать медленно или быть недоступны, пока боты Pangea обрабатывают запросы.",
-    "error404Title": "Ошибка перевода!",
     "error404Desc": "Бот Pangea не уверен, как это перевести...",
     "errorPleaseRefresh": "Мы этим занимаемся! Пожалуйста, обновите страницу и попробуйте снова.",
     "connectedToStaging": "Подключено к тестовой среде",
@@ -3897,13 +3533,9 @@
     "definitionsToolDescription": "При включении слова, подчеркнутые синим, можно щелкнуть для получения определений. Щелкните сообщение для доступа к определениям.",
     "translationsToolDescrption": "При включении щелкните сообщение и значок перевода, чтобы увидеть сообщение на вашем основном языке.",
     "welcomeBack": "С возвращением! Если вы участвовали в пилоте 2023-2024 годов, свяжитесь с нами для получения вашей специальной подписки пилота. Если вы учитель, у которого (или у вашей организации) есть лицензии для вашего класса, свяжитесь с нами для получения учительской подписки.",
-    "downloadTxtFile": "Скачать текстовый файл",
-    "downloadCSVFile": "Скачать CSV-файл",
     "promotionalSubscriptionDesc": "У вас в настоящее время пожизненная промо-подписка. Обратитесь в поддержку@pangea.chat для помощи в изменении вашей подписки.",
     "originalSubscriptionPlatform": "Подписка приобретена через {purchasePlatform}",
     "oneWeekTrial": "Недельный пробный период",
-    "downloadXLSXFile": "Скачать файл Excel",
-    "unkDisplayName": "Неизвестно",
     "wwCountryDisplayName": "Всемирная сеть",
     "afCountryDisplayName": "Афганистан",
     "axCountryDisplayName": "Аландские острова",
@@ -4203,7 +3835,6 @@
     "chatCapacityHasBeenChanged": "Вместимость чата изменена",
     "chatCapacitySetTooLow": "Вместимость чата должна быть не менее {count}.",
     "chatCapacityExplanation": "Ограничение вместимости чата ограничивает количество участников, допускаемых в чат.",
-    "tooManyRequest": "Слишком много запросов, пожалуйста, попробуйте позже.",
     "enterNumber": "Пожалуйста, введите целое число.",
     "buildTranslation": "Создайте перевод из приведённых выше вариантов",
     "practice": "Практика",
@@ -4215,7 +3846,6 @@
     "deleteSubscriptionWarningTitle": "У вас есть активная подписка",
     "deleteSubscriptionWarningBody": "Удаление аккаунта не приводит к автоматической отмене подписки.",
     "manageSubscription": "Управление подпиской",
-    "error520Title": "Пожалуйста, попробуйте снова.",
     "error520Desc": "Извините, мы не смогли понять ваше сообщение...",
     "wordsUsed": "Использованные слова",
     "level": "Уровень",
@@ -4240,7 +3870,6 @@
     "other": "Другое",
     "levelShort": "УРОВЕНЬ {level}",
     "noCapacityLimit": "Нет ограничения по вместимости",
-    "downloadGroupText": "Скачать текст группы",
     "notificationsOn": "Уведомления включены",
     "notificationsOff": "Уведомления выключены",
     "createChatAndInviteUsers": "Создать чат и пригласить пользователей",
@@ -4307,25 +3936,13 @@
     "whatIsTheMorphTag": "Что такое {morphologicalFeature} для '{wordForm}'?",
     "dataAvailable": "Доступность данных",
     "available": "Доступно",
-    "pangeaBotIsFallible": "Pangea Bot тоже ошибается!",
-    "whatIsMeaning": "Что означает '{lemma}'?",
     "pickAnEmoji": "Какое ваше любимое эмодзи для '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Соответствуйте значениям слова в сообщении!",
-    "doubleClickToEdit": "Дважды нажмите, чтобы редактировать.",
-    "topicLabel": "Тема",
-    "topicPlaceholder": "Выберите тему...",
-    "modePlaceholder": "Выберите режим...",
-    "learningObjectiveLabel": "Цель обучения",
-    "learningObjectivePlaceholder": "Выберите цель обучения...",
-    "targetLanguageLabel": "Целевой язык",
     "cefrLevelLabel": "Уровень CEFR",
     "image": "Изображение",
     "video": "Видео",
     "nan": "Не применимо",
-    "addVocabulary": "Добавить словарь",
     "instructions": "Инструкции",
-    "numberOfLearners": "Количество учащихся",
-    "mustBeInteger": "Должно быть целым числом, например 1, 2, 3, ...",
     "constructUsePvmDesc": "Произведено в голосовом сообщении",
     "leaveSpaceDescription": "Покидая курс, вы покидаете все чаты внутри него. Другие пользователи увидят, что вы покинули курс.",
     "constructUseCorMmDesc": "Правильное значение сообщения",
@@ -4341,7 +3958,6 @@
     "ttsDisabledBody": "Вы можете включить преобразование текста в речь в настройках обучения",
     "noSpaceDescriptionYet": "Описание курса еще не создано.",
     "tooLargeToSend": "Это сообщение слишком большое для отправки",
-    "exitWithoutSaving": "Вы уверены, что хотите выйти без сохранения?",
     "enableAutocorrectPopupTitle": "Добавьте клавиатуру целевого языка, перейдя в:",
     "enableAutocorrectPopupSteps": "  • Настройки\n  • Общие\n  • Клавиатура\n  • Клавиатуры\n  • Добавить новую клавиатуру",
     "enableAutocorrectPopupDescription": "После выбора языка вы можете нажать на маленькую иконку глобуса в левом нижнем углу клавиатуры, чтобы активировать недавно установленную клавиатуру.",
@@ -4352,11 +3968,8 @@
     "displayName": "Отображаемое имя",
     "leaveRoomDescription": "Вы собираетесь покинуть этот чат. Другие пользователи увидят, что вы покинули чат.",
     "confirmUserId": "Пожалуйста, подтвердите ваше имя пользователя в Pangea Chat, чтобы удалить ваш аккаунт.",
-    "startingToday": "Начиная с сегодня",
-    "oneWeekFreeTrial": "Бесплатная пробная неделя",
     "paidSubscriptionStarts": "Начинается {startDate}",
     "cancelInSubscriptionSettings": "• Отменить в любой момент в настройках подписки",
-    "cancelToAvoidCharges": "• Отмените до {trialEnds}, чтобы избежать списаний",
     "downloadGboard": "Скачать Gboard",
     "autocorrectNotAvailable": "К сожалению, эта функция пока не поддерживается на вашей платформе. Следите за обновлениями!",
     "pleaseUpdateApp": "Пожалуйста, обновите приложение, чтобы продолжить.",
@@ -4366,19 +3979,14 @@
     "knockSpaceSuccess": "Вы отправили запрос на присоединение к этому курсу! Администратор ответит на ваш запрос, как только получит его 😀",
     "chooseWordAudioInstructionsBody": "Прослушайте полное сообщение. Затем сопоставьте аудио с словами.",
     "chooseMorphsInstructionsBody": "Нажмите на элементы пазла, чтобы открыть вопросы по грамматике!",
-    "pleaseEnterInt": "Пожалуйста, введите число",
     "home": "Главная",
     "join": "Присоединиться",
     "levelSummaryPopupTitle": "Сводка уровня {level}",
     "resetInstructionTooltipsTitle": "Сбросить подсказки инструкций",
     "resetInstructionTooltipsDesc": "Нажмите, чтобы показать подсказки с инструкциями, как для нового пользователя.",
     "selectForGrammar": "Выберите значок грамматики для заданий и деталей.",
-    "randomize": "Перемешать",
     "clear": "Очистить",
-    "featuredActivities": "Рекомендуемые",
     "save": "Сохранить",
-    "startChat": "Начать чат",
-    "translationProblem": "Проблема с переводом",
     "askToJoin": "Попросить присоединиться",
     "emptyChatWarningTitle": "Чат пуст",
     "emptyChatWarningDesc": "Вы ещё никого не пригласили в этот чат. Перейдите в настройки чата, чтобы пригласить свои контакты или бота. Вы также можете сделать это позже.",
@@ -4409,17 +4017,13 @@
     "timesUsedIndependently": "Использовано независимо",
     "timesUsedWithAssistance": "Использовано с помощью",
     "shareInviteCode": "Поделиться кодом приглашения: {code}",
-    "leaderboard": "Таблица лидеров",
     "skipForNow": "Пропустить пока",
     "permissions": "Разрешения",
     "spaceChildPermission": "Кто может добавлять новые чаты в этот курс",
-    "addEnvironmentOverride": "Добавить переопределение окружения",
     "defaultOption": "По умолчанию",
     "deleteChatDesc": "Вы уверены, что хотите удалить этот чат? Он будет удален для всех участников, и все сообщения в чате больше не будут доступны для практики или аналитики обучения.",
     "deleteSpaceDesc": "Курс и все выбранные чаты будут удалены для всех участников, и все сообщения в чате больше не будут доступны для практики или аналитики обучения. Это действие нельзя отменить.",
     "launch": "Запустить",
-    "searchChats": "Поиск чатов",
-    "maxFifty": "Макс. 50",
     "configureSpace": "Настроить курс",
     "pinMessages": "Закрепить сообщения",
     "setJoinRules": "Установить правила присоединения",
@@ -4456,9 +4060,6 @@
     "failedToFetchTranscription": "Не удалось получить транскрипцию",
     "deleteEmptySpaceDesc": "Курс будет удален для всех участников. Это действие нельзя отменить.",
     "regenerate": "Восстановить",
-    "mySavedActivities": "Мои сохранённые активности",
-    "noSavedActivities": "Нет сохранённых активностей",
-    "saveActivity": "Сохранить эту активность",
     "failedToPlayVideo": "Не удалось воспроизвести видео",
     "done": "Готово",
     "inThisSpace": "На этом курсе",
@@ -4469,14 +4070,10 @@
     "numInvited": "{count} приглашено",
     "saved": "Сохранено",
     "reset": "Сбросить",
-    "errorFetchingActivitiesMessage": "Не удалось получить активности",
     "errorFetchingDefinition": "Не удалось получить определение",
     "errorProcessAnalytics": "Не удалось обработать аналитику",
     "errorDownloading": "Не удалось скачать",
     "errorFetchingLevelSummary": "Не удалось получить сводку уровня",
-    "errorLoadingSpaceChildren": "Не удалось загрузить чаты в этом курсе",
-    "unexpectedError": "Неожиданная ошибка.",
-    "pleaseReload": "Пожалуйста, перезагрузите и попробуйте снова.",
     "translationError": "Ошибка перевода",
     "errorFetchingTranslation": "Не удалось получить перевод",
     "check": "Проверить",
@@ -4486,20 +4083,15 @@
     "request": "Запрос",
     "requestAll": "Запросить всё",
     "confirmMessageUnpin": "Вы уверены, что хотите открепить это сообщение?",
-    "saveAndLaunch": "Сохранить и запустить",
-    "launchToSpace": "Запустить в курс",
     "pending": "В ожидании",
     "inactive": "Неактивно",
-    "confirmRole": "Подтвердить роль",
     "openRoleLabel": "ОТКРЫТАЯ",
     "finishedTheActivity": "🎯 {username} завершил эту активность",
     "archiveToAnalytics": "Добавить в мои завершённые активности",
     "activitySummaryError": "Сводки по активности недоступны",
     "requestSummaries": "Запросить сводки",
-    "generatingNewActivities": "Вы первый пользователь этой языковой пары! Пожалуйста, подождите минуту, мы готовим для вас активности.",
     "requestAccessTitle": "Запросить доступ к аналитике?",
     "requestAccessDesc": "Хотите запросить доступ к просмотру аналитики участников?\n\nЕсли участники согласятся, администраторы этого курса смогут видеть:\n    • общий словарный запас\n    • общие грамматические концепции\n    • общее количество завершённых сессий\n    • конкретные грамматические концепции, использованные правильно и неправильно\n\nОни не смогут видеть:\n    • сообщения в чатах вне курса\n    • список словарных запасов",
-    "requestAccess": "Запросить доступ ({count})",
     "analyticsInactiveTitle": "Запросы не могут быть отправлены неактивным пользователям",
     "analyticsInactiveDesc": "Неактивные пользователи, которые не входили в систему с момента внедрения этой функции, не увидят вашу заявку.\n\nКнопка «Запрос» появится, когда они вернутся. Вы можете повторно отправить запрос позже, нажав кнопку «Запрос» под их именем, когда она станет доступна.",
     "accessRequestedTitle": "Запрос доступа к аналитике",
@@ -4522,8 +4114,6 @@
     "accessDesc": "Вы можете сделать ваш курс открытым для всех! Или сделать его приватным и безопасным.",
     "createGroupChatDesc": "В отличие от заданий, которые имеют начало и конец, групповые чаты остаются открытыми для повседневного общения.",
     "deleteDesc": "Только администраторы могут удалить курс. Это разрушительное действие, которое удаляет всех пользователей и удаляет все выбранные чаты внутри курса. Будьте осторожны.",
-    "noCourseFound": "О, этот курс нуждается в плане!\n\nПланы курса — это последовательность тем и разговорных активностей.",
-    "additionalParticipants": "+ {num} других",
     "directMessages": "Личные сообщения",
     "whatNow": "Что дальше?",
     "chooseNextActivity": "Выберите следующую активность!",
@@ -4537,7 +4127,6 @@
     "waitNotDone": "Подожди, я еще не закончил!",
     "waitingForOthersToFinish": "Ждём, пока остальные закончат...",
     "generatingSummary": "Анализ чата и генерация результатов",
-    "findCourse": "Найти курс",
     "pingParticipantsNotification": "{user} ищет участников для присоединения к сессии в {room}",
     "course": "Курс",
     "courses": "Курсы",
@@ -4545,7 +4134,6 @@
     "createNewCourse": "Новый курс",
     "goToCourse": "Перейти к курсу: {course}",
     "activityComplete": "Эта активность завершена. Обзор активности должен быть доступен ниже.",
-    "startNewSession": "Начать новую сессию",
     "joinOpenSession": "Присоединиться к открытому сеансу",
     "less": "меньше",
     "activityNotFound": "Активность не найдена",
@@ -4664,10 +4252,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@notYetSet": {
         "type": "String",
         "placeholders": {}
@@ -4685,10 +4269,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4780,14 +4360,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableLanguageAssistance": {
         "type": "String",
         "placeholders": {}
@@ -4812,10 +4384,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4828,15 +4396,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4996,14 +4556,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5017,14 +4569,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6295,10 +5839,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6347,10 +5887,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6451,10 +5987,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6744,18 +6276,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@pickAnEmoji": {
         "type": "String",
         "placeholders": {
@@ -6765,34 +6285,6 @@
         }
     },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6812,19 +6304,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6892,10 +6372,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6936,14 +6412,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6955,14 +6423,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -7000,10 +6460,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7032,27 +6488,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7180,10 +6620,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7193,10 +6629,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7213,14 +6645,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7372,18 +6796,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7432,10 +6844,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7449,18 +6857,6 @@
         "placeholders": {}
     },
     "@errorFetchingLevelSummary": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7507,23 +6903,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7551,10 +6935,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7562,14 +6942,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7674,18 +7046,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@directMessages": {
         "type": "String",
         "placeholders": {}
@@ -7742,10 +7102,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7780,10 +7136,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -8016,7 +7368,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Загляните завтра за обновлениями заданий.",
-    "activityDropdownDesc": "Когда вы закончите это задание, нажмите ниже",
     "languageMismatchTitle": "Несовпадение языка",
     "languageMismatchDesc": "Ваш целевой язык не совпадает с языком этого мероприятия. Обновить ваш целевой язык?",
     "reportWordIssueTooltip": "Сообщить о проблеме с информацией о слове",
@@ -8029,10 +7380,6 @@
     "selectAll": "Выбрать все",
     "deselectAll": "Снять выделение со всего",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8081,18 +7428,12 @@
         "placeholders": {}
     },
     "startOwn": "Начать свой собственный",
-    "joinCourseDesc": "Каждый курс состоит из 8-10 последовательных тем с разнообразными заданиями для изучения языка.",
     "newMessageInPangeaChat": "🗨️ Новое сообщение в чате Pangea",
     "shareCourse": "Поделиться курсом",
     "addCourse": "Добавить курс",
-    "joinPublicCourse": "Присоединиться к публичному курсу",
     "vocabLevelsDesc": "Здесь появятся слова словаря, как только вы их повысите!",
     "highlightVocabTooltip": "Выделяйте целевые слова ниже, отправляя их или практикуясь с ними в чате.",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8105,10 +7446,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8127,7 +7464,6 @@
     "emojiView": "Просмотр эмодзи",
     "feedbackDialogDesc": "Я тоже совершаю ошибки! Есть что-то, что поможет мне улучшиться?",
     "contactHasBeenInvitedToTheCourse": "Контакт был приглашен на курс",
-    "activityStatsButtonTooltip": "Информация о деятельности",
     "allow": "Разрешить",
     "deny": "Запретить",
     "enabledRenewal": "Включить автоматическое продление подписки",
@@ -8395,10 +7731,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9484,16 +8816,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Деятельности для разблокировки следующей темы",
-    "activitiesToUnlockTopicDesc": "Установите количество действий для разблокировки следующей темы курса",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Правильная практика определения слов",
     "constructUseIncLMDesc": "Неправильная практика определения слов",
     "constructUseCorLADesc": "Правильная практика аудио слов",
@@ -9501,7 +8823,6 @@
     "constructUseBonus": "Бонус во время практики слов",
     "practiceVocab": "Практика словарного запаса",
     "selectMeaning": "Выберите значение",
-    "selectAudio": "Выберите соответствующее аудио",
     "congratulations": "Поздравляем!",
     "anotherRound": "Еще один раунд",
     "noActivityRequest": "Нет текущего запроса на активность.",
@@ -9534,10 +8855,6 @@
         "placeholders": {}
     },
     "@selectMeaning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@selectAudio": {
         "type": "String",
         "placeholders": {}
     },
@@ -9574,12 +8891,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Загрузка начата",
     "webDownloadPermissionMessage": "Если ваш браузер блокирует загрузки, пожалуйста, разрешите загрузки для этого сайта.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9702,11 +9014,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Что-то пошло не так, и мы усердно работаем над исправлением. Проверьте позже.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Автоматически запускать помощь в написании Pangea",
     "autoIGCToolDescription": "Автоматически запускать помощь в грамматике и переводе Pangea Chat перед отправкой моего сообщения.",
     "@autoIGCToolName": {
@@ -9762,24 +9069,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Грамматика",
-    "spanTypeWordChoice": "Выбор слов",
     "spanTypeSpelling": "Орфография",
     "spanTypePunctuation": "Пунктуация",
     "spanTypeStyle": "Стиль",
     "spanTypeFluency": "Связность",
     "spanTypeAccents": "Акценты",
     "spanTypeCapitalization": "Капитализация",
-    "spanTypeCorrection": "Коррекция",
     "spanFeedbackTitle": "Сообщить о проблеме с коррекцией",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9804,10 +9100,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9818,13 +9110,9 @@
     "clientWellKnownInformation": "Известная информация клиента:",
     "baseUrl": "Базовый URL",
     "identityServer": "Сервер идентификации:",
-    "versionWithNumber": "Версия: {version}",
     "logs": "Журналы",
-    "advancedConfigs": "Расширенные настройки",
     "advancedConfigurations": "Расширенные конфигурации",
-    "signInWithLabel": "Войти с помощью:",
     "selectAllWords": "Выберите все слова, которые вы слышите в аудио",
-    "joinCourseForActivities": "Присоединяйтесь к курсу, чтобы попробовать активности.",
     "@noMoreResultsFound": {
         "pangea_override": true,
         "type": "String",
@@ -9854,19 +9142,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9874,15 +9150,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10083,11 +9351,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "В классе? Введите свой код присоединения здесь.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Автовыделение аудиосообщений",
     "selectAudioMessagesOnPlayDescription": "Автоматически выделять аудиосообщения при воспроизведении",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10121,18 +9384,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "В этом курсе есть темы с менее чем {input} активностями. Пожалуйста, введите число, меньшее или равное {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Нажмите здесь, чтобы войти снова.",
     "@clickToLogin": {
@@ -10549,17 +9800,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Мультяшный жёлтый медведь с поднятыми в восторге руками.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Выберите слова, чтобы узнать о них больше",
     "requireAnalyticsAccessTitle": "Требуется доступ к аналитике для участия",
     "requireAnalyticsAccessDesc": "Участники должны предоставить доступ к своей учебной аналитике, чтобы присоединиться к этому курсу",
     "analyticsAccessNoticeTitle": "Требуется доступ к аналитике",
     "analyticsAccessNoticeDesc": "Присоединяясь к этому курсу, вы соглашаетесь предоставить администраторам доступ к вашей учебной аналитике.",
-    "skipOnboardingClassCodeDesc": "Учитесь самостоятельно? Не волнуйтесь, вы можете:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10577,10 +9822,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10609,7 +9850,6 @@
     "pickCefrLevelTeacherStepTitle": "Какой уровень вы преподаете?",
     "pickCefrLevelStudentStepTitle": "Какой у вас уровень?",
     "customCourseStepTitle": "Заполните эту форму, чтобы получить индивидуальный курс",
-    "aboutYourClass": "О вашем классе",
     "courseCodeStepErrorMessage": "Пожалуйста, проверьте ваш код и попробуйте снова",
     "institution": "Учебное заведение",
     "courseGoals": "Цели курса",
@@ -10652,10 +9892,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10772,12 +10008,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Логотип Pangea Chat",
     "introChatDetails": "Скажи привет! Представься своим товарищам по курсу, найди друзей и общайся вне занятий.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10821,11 +10052,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Действия активности",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Инструменты произношения",
     "audioTranscription": "AI транскрипция аудио",
     "visualLearnerSupport": "Поддержка визуальных учащихся",
@@ -10866,7 +10092,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Присоединитесь к курсу, который включает в себя это занятие, чтобы сыграть в него.",
     "resizeCoursePanel": "Изменить размер панели курса",
     "undo": "Отменить",
     "unlock": "Разблокировать",
@@ -10880,7 +10105,6 @@
     "addCourseBrowsePublic": "Просмотреть публичные курсы",
     "browsePublicCourses": "Просмотреть публичные курсы",
     "editProfile": "Редактировать профиль",
-    "numObjectives": "{count} целей",
     "mapSearchHint": "Поиск мероприятий",
     "mapSearchNoResults": "Нет совпадений в области видимости",
     "mapFilterAllLanguages": "Все языки",
@@ -10889,7 +10113,6 @@
     "mapFilterCompleted": "Завершено",
     "mapFilterReset": "Сбросить",
     "activityTypeConversation": "Разговор",
-    "lockedMissionRequirement": "Завершите предыдущую миссию, чтобы разблокировать",
     "playAgain": "Играть снова",
     "reviewActivity": "Обзор",
     "mapEmptyInView": "Здесь ничего нет на вашем уровне или языке. Расширьте свои фильтры или уменьшите масштаб.",
@@ -10904,14 +10127,9 @@
     "scrollToBottom": "Прокрутить вниз",
     "courseImage": "Изображение курса",
     "avatarPreview": "Предварительный просмотр аватара",
-    "activityPhoto": "Фото активности",
     "emotePreview": "Предварительный просмотр эмоции: {name}",
     "activityLabel": "Активность: {title}",
     "resetMapView": "Сбросить вид карты",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10964,14 +10182,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11001,10 +10211,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11061,10 +10267,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_sk.arb
+++ b/lib/l10n/intl_sk.arb
@@ -54,11 +54,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Môžu sa pripojiť hostia",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Ste si istí?",
     "@areYouSure": {
         "type": "String",
@@ -314,11 +309,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Kontakt bol pozvaný do skupiny",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "copiedToClipboard": "Skopírované do schránky",
     "@copiedToClipboard": {
         "type": "String",
@@ -443,11 +433,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Šifrovanie už nebude možné vypnúť. Ste si tým istí?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encryption": "Šifrovanie",
     "@encryption": {
         "type": "String",
@@ -485,11 +470,6 @@
     },
     "group": "Skupina",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Skupina je verejná",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -548,15 +528,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Pozvať kontakt do {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Pozvanie",
     "@invited": {
@@ -659,15 +630,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Načítať ďalších {count} účastníkov",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Načítava sa… Čakajte prosím.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -682,15 +644,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Prihlásenie k {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Odhlásiť sa",
     "@logout": {
@@ -724,11 +677,6 @@
     },
     "noEmotesFound": "Nenašli sa žiadne emotikony. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Zdá sa, že nemáte žiadne služby Googlu v telefóne. To je dobré rozhodnutie pre vaše súkromie! Ak chcete dostávať push notifikácie vo FluffyChat, odporúčame používať microG: https://microg.org/.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -857,11 +805,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Odstráňiť zariadenie",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Odblokovať",
     "@unbanFromChat": {
@@ -1059,15 +1002,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unreadChats": "{unreadCount, plural, other{{unreadCount} neprečítaných chatov}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "userAndOthersAreTyping": "{username} a {count} dalších píšu…",
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -1147,16 +1081,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Videohovor",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Viditeľnosť histórie chatu",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Viditeľné pre všetkých účastníkov",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1189,11 +1113,6 @@
     },
     "wallpaper": "Pozadie",
     "@wallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Kto môže vstúpiť do tejto skupiny",
-    "@whoIsAllowedToJoinThisGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1291,11 +1210,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Nastaviť úroveň oprávnení",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "badServerLoginTypesException": "Server podporuje tieto typy prihlásenia:\n{serverVersions}\nAle táto aplikácia podporuje iba:\n{supportedVersions}",
     "@badServerLoginTypesException": {
         "type": "String",
@@ -1324,8 +1238,6 @@
             }
         }
     },
-    "yourChatBackupHasBeenSetUp": "Záloha vašich chatov bola nastavená.",
-    "@yourChatBackupHasBeenSetUp": {},
     "repeatPassword": "Zopakujte heslo",
     "@repeatPassword": {},
     "all": "Všetky",
@@ -1403,7 +1315,6 @@
     "spaces": "Priestory",
     "blocked": "Blokované",
     "changeYourAvatar": "Zmeniť svoj avatar",
-    "chatBackupDescription": "Vaše staré správy sú zabezpečené kľúčom na obnovenie. Uistite sa, že ho neztratíte.",
     "clearArchive": "Vymazať archív",
     "commandHint_markasdm": "Označiť ako priame správy pre dané ID Matrix",
     "commandHint_markasgroup": "Označiť ako skupinu",
@@ -1431,9 +1342,7 @@
     "contentHasBeenReported": "Obsah bol nahlásený správcom servera",
     "copyToClipboard": "Skopírovať do schránky",
     "checkList": "Zoznam kontrol",
-    "countInvited": "Pozvaných {count}",
     "createGroup": "Vytvoriť skupinu",
-    "createNewSpace": "Nový priestor",
     "deactivateAccountWarning": "Toto deaktivuje váš používateľský účet. Toto nemôže byť vrátené! Ste si istí?",
     "defaultPermissionLevel": "Predvolená úroveň oprávnení pre nových používateľov",
     "deleteAccount": "Vymazať účet",
@@ -1446,9 +1355,6 @@
     "editRoomAvatar": "Upraviť avatar miestnosti",
     "emoteKeyboardNoRecents": "Nedávno použité emotikony sa tu zobrazia...",
     "emotePacks": "Balíky emotikonov pre miestnosť",
-    "globalChatId": "Globálne ID chatu",
-    "accessAndVisibility": "Prístup a viditeľnosť",
-    "accessAndVisibilityDescription": "Kto má povolenie pripojiť sa k tomuto chatu a ako môže byť chat objavený.",
     "calls": "Hovory",
     "customEmojisAndStickers": "Vlastné emotikony a nálepky",
     "customEmojisAndStickersBody": "Pridajte alebo zdieľajte vlastné emotikony alebo nálepky, ktoré môžu byť použité v akomkoľvek chate.",
@@ -1459,10 +1365,8 @@
     "enterAnEmailAddress": "Zadajte e-mailovú adresu",
     "homeserver": "Domáci server",
     "errorObtainingLocation": "Chyba pri získavaní polohy: {error}",
-    "everythingReady": "Všetko pripravené!",
     "extremeOffensive": "Extrémne urážlivé",
     "fontSize": "Veľkosť písma",
-    "chatDescription": "Popis chatu",
     "chatDescriptionHasBeenChanged": "Popis chatu bol zmenený",
     "groups": "Skupiny",
     "hideRedactedEvents": "Skryť redigované udalosti",
@@ -1494,7 +1398,6 @@
     "next": "Ďalej",
     "no": "Nie",
     "noConnectionToTheServer": "Žiadne spojenie so serverom",
-    "noEncryptionForPublicRooms": "Šifrovanie môžete aktivovať iba vtedy, keď miestnosť už nie je verejne prístupná.",
     "noMatrixServer": "{server1} nie je matrix server, namiesto toho použite {server2}?",
     "shareInviteLink": "Zdieľať odkaz na pozvanie",
     "scanQrCode": "Naskenujte QR kód",
@@ -1508,12 +1411,10 @@
     "oopsPushError": "Ups! Pri nastavovaní upozornení na odosielanie sa vyskytla chyba.",
     "openVideoCamera": "Otvorte kameru na video",
     "oneClientLoggedOut": "Jeden z vašich klientov bol odhlásený",
-    "addAccount": "Pridať účet",
     "editBundlesForAccount": "Upraviť balíky pre tento účet",
     "addToBundle": "Pridať do balíka",
     "removeFromBundle": "Odstrániť z tohto balíka",
     "bundleName": "Názov balíka",
-    "enableMultiAccounts": "(BETA) Povoliť viacero účtov na tomto zariadení",
     "openInMaps": "Otvoriť v mapách",
     "link": "Odkaz",
     "serverRequiresEmail": "Tento server potrebuje overiť vašu e-mailovú adresu na registráciu.",
@@ -1523,13 +1424,11 @@
     "passwordHasBeenChanged": "Heslo bolo zmenené",
     "overview": "Prehľad",
     "passwordRecoverySettings": "Nastavenia obnovenia hesla",
-    "passwordRecovery": "Obnovenie hesla",
     "pin": "Pin",
     "pleaseChoose": "Prosím, vyberte",
     "pleaseChooseAPasscode": "Prosím, vyberte kód",
     "pleaseClickOnLink": "Kliknite na odkaz v e-maile a pokračujte.",
     "pleaseEnter4Digits": "Zadajte 4 číslice alebo nechajte prázdne na vypnutie zámku aplikácie.",
-    "pleaseEnterRecoveryKey": "Zadajte svoj kľúč na obnovenie:",
     "pleaseEnterYourPin": "Zadajte svoj pin",
     "pleaseFollowInstructionsOnWeb": "Postupujte podľa pokynov na webovej stránke a klepnite na ďalšie.",
     "privacy": "Súkromie",
@@ -1543,8 +1442,6 @@
     "removeYourAvatar": "Odstrániť svoj avatar",
     "replaceRoomWithNewerVersion": "Nahradiť miestnosť novšou verziou",
     "saveFile": "Uložiť súbor",
-    "recoveryKey": "Kľúč na obnovenie",
-    "recoveryKeyLost": "Stratil sa kľúč na obnovenie?",
     "sendImages": "Odoslať {count} obrázok",
     "sentCallInformations": "{senderName} odoslal informácie o hovore",
     "separateChatTypes": "Oddeliť Priame konverzácie a Skupiny",
@@ -1553,23 +1450,18 @@
     "shareLocation": "Zdieľať polohu",
     "showPassword": "Zobraziť heslo",
     "presencesToggle": "Zobraziť stavové správy od iných používateľov",
-    "spaceIsPublic": "Priestor je verejný",
-    "spaceName": "Názov priestoru",
     "startedACall": "{senderName} začal hovor",
     "status": "Stav",
     "synchronizingPleaseWait": "Synchronizácia... Prosím čakajte.",
     "synchronizingPleaseWaitCounter": " Synchronizácia... ({percentage}%)",
     "tooManyRequestsWarning": "Príliš veľa požiadaviek. Skúste to prosím neskôr!",
-    "transferFromAnotherDevice": "Preniesť z iného zariadenia",
     "unavailable": "Nedostupné",
     "unpin": "Odinštalovať",
     "unverified": "Neoverené",
     "verified": "Overené",
     "warning": "Varovanie!",
     "weSentYouAnEmail": "Poslali sme vám e-mail",
-    "whoCanPerformWhichAction": "Kto môže vykonať ktorú akciu",
     "whyDoYouWantToReportThis": "Prečo to chcete nahlásiť?",
-    "wipeChatBackup": "Vymazať zálohu chatu na vytvorenie nového kľúča na obnovenie?",
     "withTheseAddressesRecoveryDescription": "S týmito adresami môžete obnoviť svoje heslo.",
     "yourPublicKey": "Váš verejný kľúč",
     "messageInfo": "Informácie o správe",
@@ -1577,9 +1469,7 @@
     "messageType": "Typ správy",
     "sender": "Odosielateľ",
     "openGallery": "Otvoriť galériu",
-    "removeFromSpace": "Odstrániť zo priestoru",
     "start": "Začať",
-    "pleaseEnterRecoveryKeyDescription": "Ak chcete odomknúť svoje staré správy, zadajte svoj kľúč na obnovenie, ktorý bol vygenerovaný v predchádzajúcej relácii. Váš kľúč na obnovenie NIE je vaše heslo.",
     "publish": "Zverejniť",
     "openChat": "Otvoriť chat",
     "markAsRead": "Označiť ako prečítané",
@@ -1590,12 +1480,9 @@
     "confirmEventUnpin": "Ste si istí, že chcete trvalo odopnúť udalosť?",
     "emojis": "Emotikony",
     "placeCall": "Zavolať",
-    "voiceCall": "Hlasový hovor",
     "unsupportedAndroidVersion": "Nepodporovaná verzia Androidu",
     "unsupportedAndroidVersionLong": "Táto funkcia vyžaduje novšiu verziu Androidu. Skontrolujte aktualizácie alebo podporu Lineage OS.",
-    "videoCallsBetaWarning": "Upozorňujeme, že videohovory sú momentálne v beta verzii. Nemusia fungovať podľa očakávaní alebo vôbec na všetkých platformách.",
     "experimentalVideoCalls": "Experimentálne videohovory",
-    "emailOrUsername": "Email alebo používateľské meno",
     "addWidget": "Pridať widget",
     "widgetVideo": "Video",
     "widgetEtherpad": "Textová poznámka",
@@ -1617,35 +1504,19 @@
     "youKickedAndBanned": "🙅‍♀️ Vyhodili ste a zabanovali ste {user}",
     "youUnbannedUser": "Odomkli ste {user}",
     "hasKnocked": "🚪 {user} zaklopal",
-    "usersMustKnock": "Používatelia musia zaklopať",
-    "noOneCanJoin": "Nikto sa nemôže pripojiť",
     "knock": "Klop",
     "users": "Používatelia",
-    "unlockOldMessages": "Odomknúť staré správy",
-    "storeInSecureStorageDescription": "Uložte kľúč na obnovenie do zabezpečeného úložiska tohto zariadenia.",
-    "saveKeyManuallyDescription": "Uložte tento kľúč manuálne spustením dialógu zdieľania systému alebo schránky.",
-    "storeInAndroidKeystore": "Uložiť do Android KeyStore",
-    "storeInAppleKeyChain": "Uložiť do Apple KeyChain",
-    "storeSecurlyOnThisDevice": "Uložiť bezpečne na tomto zariadení",
     "countFiles": "{count} súborov",
     "user": "Používateľ",
     "custom": "Vlastné",
-    "foregroundServiceRunning": "Táto notifikácia sa zobrazí, keď beží popredná služba.",
-    "screenSharingTitle": "zdieľanie obrazovky",
-    "screenSharingDetail": "Zdieľate svoju obrazovku v FuffyChat",
     "whyIsThisMessageEncrypted": "Prečo je táto správa nečitateľná?",
     "noKeyForThisMessage": "Toto sa môže stať, ak bola správa odoslaná skôr, ako ste sa prihlásili do svojho účtu na tomto zariadení.\n\nJe tiež možné, že odosielateľ zablokoval vaše zariadenie alebo došlo k problémom s internetovým pripojením.\n\nDokážete prečítať správu na inom relácii? Potom môžete správu preniesť z nej! Prejdite do Nastavenia > Zariadenia a uistite sa, že vaše zariadenia si navzájom overili. Keď opäť otvoríte miestnosť a obe relácie budú v popredí, kľúče sa automaticky prenesú.\n\nNechcete stratiť kľúče pri odhlásení alebo prepínaní zariadení? Uistite sa, že ste povolili zálohu chatu v nastaveniach.",
     "newGroup": "Nová skupina",
     "newSpace": "Nový priestor",
-    "enterSpace": "Vstúpiť do priestoru",
     "allSpaces": "Všetky priestory",
     "hidePresences": "Skryť zoznam stavu?",
     "doNotShowAgain": "Nezobrazovať znova",
     "wasDirectChatDisplayName": "Prázdny chat (bol {oldDisplayName})",
-    "newSpaceDescription": "Priestory vám umožňujú zjednotiť vaše chaty a vytvoriť súkromné alebo verejné komunity.",
-    "encryptThisChat": "Zašifrovať tento chat",
-    "disableEncryptionWarning": "Z bezpečnostných dôvodov nemôžete vypnúť šifrovanie v chate, kde bolo predtým povolené.",
-    "sorryThatsNotPossible": "Prepáčte... to nie je možné",
     "deviceKeys": "Kľúče zariadenia:",
     "reopenChat": "Znova otvoriť rozhovor",
     "noBackupWarning": "Varovanie! Bez povolenia zálohy chatu stratíte prístup k šifrovaným správam. Odporúča sa najskôr povoliť zálohu chatu pred odhlásením.",
@@ -1658,7 +1529,6 @@
     "openLinkInBrowser": "Otvoriť odkaz v prehliadači",
     "reportErrorDescription": "😞 Je mi ľúto. Niečo sa pokazilo. Ak chcete, môžete túto chybu nahlásiť vývojárom.",
     "report": "Nahlásiť",
-    "setTheme": "Nastaviť tému:",
     "setColorTheme": "Nastaviť farebnú tému:",
     "invite": "Pozvať",
     "inviteGroupChat": "📨 Pozvať do skupinového chatu",
@@ -1677,12 +1547,8 @@
     "yourGlobalUserIdIs": "Váš globálny používateľský identifikátor je: ",
     "noUsersFoundWithQuery": "Bohužiaľ, s \"{query}\" sa nenašiel žiadny používateľ. Skontrolujte, či ste neurobili preklep.",
     "knocking": "Klopanie",
-    "chatCanBeDiscoveredViaSearchOnServer": "Chat je možné nájsť cez vyhľadávanie na {server}",
-    "searchChatsRooms": "Hľadať #chaty, @používatelia...",
     "nothingFound": "Nič sa nenašlo...",
     "groupName": "Názov skupiny",
-    "createGroupAndInviteUsers": "Vytvoriť skupinu a pozvať používateľov",
-    "groupCanBeFoundViaSearch": "Skupina je možné nájsť prostredníctvom vyhľadávania",
     "wrongRecoveryKey": "Prepáčte... zdá sa, že toto nie je správny kľúč na obnovenie.",
     "startConversation": "Začať konverzáciu",
     "commandHint_sendraw": "Odoslať surový JSON",
@@ -1696,11 +1562,8 @@
     "pleaseChooseAStrongPassword": "Vyberte si silné heslo",
     "passwordsDoNotMatch": "Heslá sa nezhodujú",
     "passwordIsWrong": "Zadané heslo je nesprávne",
-    "publicChatAddresses": "Verejné adresy chatu",
-    "createNewAddress": "Vytvoriť novú adresu",
     "joinSpace": "Pripojiť sa k priestoru",
     "publicSpaces": "Verejné priestory",
-    "addChatOrSubSpace": "Pridať chat alebo podpriestor",
     "subspace": "Podpriestor",
     "decline": "Odmietnuť",
     "thisDevice": "Toto zariadenie:",
@@ -1709,15 +1572,11 @@
     "searchMore": "Hľadať viac...",
     "gallery": "Galéria",
     "files": "Súbory",
-    "sessionLostBody": "Vaša relácia bola stratená. Prosím, nahláste túto chybu vývojárom na {url}. Chybová správa je: {error}",
-    "restoreSessionBody": "Aplikácia sa teraz snaží obnoviť vašu reláciu zo zálohy. Prosím, nahláste túto chybu vývojárom na {url}. Chybová správa je: {error}",
     "sendReadReceipts": "Poslať potvrdenia o prečítaní",
     "sendTypingNotificationsDescription": "Ostatní účastníci chatu vidia, keď píšete novú správu.",
     "sendReadReceiptsDescription": "Ostatní účastníci chatu vidia, keď ste správu prečítali.",
     "formattedMessages": "Formátované správy",
     "formattedMessagesDescription": "Zobrazte bohatý obsah správy, ako je tučné písmo pomocou markdown.",
-    "verifyOtherUser": "🔐 Overiť iného používateľa",
-    "verifyOtherUserDescription": "Ak overíte iného používateľa, môžete si byť istí, že skutočne viete, komu píšete. 💪\n\nKeď začnete overovanie, vy aj druhý používateľ uvidíte v aplikácii vyskakovacie okno. Tam uvidíte sériu emoji alebo čísel, ktoré si musíte navzájom porovnať.\n\nNajlepším spôsobom je stretnúť sa alebo začať videohovor. 🧑‍🤝‍🧑",
     "verifyOtherDevice": "🔐 Overiť iné zariadenie",
     "verifyOtherDeviceDescription": "Keď overíte iné zariadenie, tieto zariadenia môžu vymieňať kľúče, čím sa zvýši vaša celková bezpečnosť. 💪 Keď začnete overovanie, v oboch zariadeniach sa objaví vyskakovacie okno. Tam uvidíte sériu emoji alebo čísel, ktoré si musíte navzájom porovnať. Je najlepšie mať obe zariadenia po ruke pred začatím overovania. 🤳",
     "acceptedKeyVerification": "{sender} prijal overenie kľúča",
@@ -1753,10 +1612,6 @@
     "updateInstalled": "🎉 Aktualizácia {version} nainštalovaná!",
     "changelog": "Zmeny v systéme",
     "sendCanceled": "Odoslanie zrušené",
-    "loginWithMatrixId": "Prihlásiť sa pomocou Matrix-ID",
-    "discoverHomeservers": "Objavte domáce servery",
-    "whatIsAHomeserver": "Čo je to domáci server?",
-    "homeserverDescription": "Všetky vaše údaje sú uložené na domácom serveri, rovnako ako u poskytovateľa e-mailových služieb. Môžete si vybrať, ktorý domáci server chcete použiť, pričom stále môžete komunikovať so všetkými. Viac sa dozviete na https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Nezdá sa, že ide o kompatibilný domáci server. Zlá URL?",
     "calculatingFileSize": "Vypočítavanie veľkosti súboru...",
     "prepareSendingAttachment": "Príprava na odoslanie prílohy...",
@@ -1768,11 +1623,9 @@
     "oneOfYourDevicesIsNotVerified": "Jedno z vašich zariadení nie je overené",
     "noticeChatBackupDeviceVerification": "Poznámka: Keď pripojíte všetky svoje zariadenia k zálohe chatu, automaticky sa overia.",
     "continueText": "Pokračovať",
-    "welcomeText": "Ahoj Ahoj 👋 Toto je FluffyChat. Môžete sa prihlásiť na akýkoľvek domáci server, ktorý je kompatibilný s https://matrix.org. A potom chatovať s kýmkoľvek. Je to obrovská decentralizovaná sieť správ!",
     "blur": "Rozmazanie:",
     "opacity": "Priehľadnosť:",
     "setWallpaper": "Nastaviť tapetu",
-    "manageAccount": "Spravovať účet",
     "noContactInformationProvided": "Server neposkytuje žiadne platné kontaktné informácie",
     "contactServerAdmin": "Kontaktovať správcu servera",
     "contactServerSecurity": "Kontaktovať bezpečnosť servera",
@@ -1791,11 +1644,8 @@
     "unableToJoinChat": "Nedá sa pripojiť ku chatu. Možno druhá strana už ukončila konverzáciu.",
     "previous": "Predchádzajúce",
     "otherPartyNotLoggedIn": "Druhá strana momentálne nie je prihlásená a nemôže prijímať správy!",
-    "appWantsToUseForLogin": "Použiť '{server}' na prihlásenie",
-    "appWantsToUseForLoginDescription": "Týmto umožňujete aplikácii a webovej stránke zdieľať informácie o vás.",
     "open": "Otvoriť",
     "waitingForServer": "Čaká sa na server...",
-    "appIntroduction": "FluffyChat vám umožňuje chatovať s priateľmi cez rôzne messengery. Viac sa dozviete na https://matrix.org alebo jednoducho klepnite na *Pokračovať*.",
     "newChatRequest": "📩 Nová požiadavka na chat",
     "contentNotificationSettings": "Nastavenia oznámení obsahu",
     "generalNotificationSettings": "Všeobecné nastavenia oznámení",
@@ -1870,11 +1720,9 @@
     "taTooltip": "L2 použitie s prekladateľskou asistenciou",
     "interactiveTranslatorSliderHeader": "Interaktívny prekladač",
     "interactiveGrammarSliderHeader": "Interaktívny kontrolór gramatiky",
-    "interactiveTranslatorRequired": "Požadované",
     "waTooltip": "L2 použitie bez asistencie",
     "interactiveTranslator": "Pomocník pre preklad",
     "noIdenticalLanguages": "Vyberte, prosím, odlišné základné a cieľové jazyky",
-    "searchBy": "Hľadať podľa krajiny a jazykov",
     "joinWithClassCode": "Pripojiť sa ku kurzu",
     "languageLevelPreA1": "Novice Low (Pre A1)",
     "languageLevelA1": "Nováčik Stred (A1)",
@@ -1895,19 +1743,14 @@
     "saveChanges": "Uložiť zmeny",
     "publicProfileTitle": "Povoliť, aby ma našli vo vyhľadávaní",
     "publicProfileDesc": "Zapnutím umožníte ostatným používateľom nájsť váš profil vo globálnom vyhľadávači a posielať žiadosti o chat. V tomto momente môžete prijať alebo odmietnuť žiadosť.",
-    "errorDisableIT": "Pomoc s prekladom je vypnutá.",
-    "errorDisableIGC": "Pomoc s gramatikou je vypnutá.",
     "errorDisableITUserDesc": "Kliknite sem na aktualizáciu nastavení pomoci s prekladom",
     "errorDisableIGCUserDesc": "Kliknite sem na aktualizáciu nastavení pomoci s gramatikou",
     "errorDisableITClassDesc": "Prekladová pomoc je vypnutá pre kurz, v ktorom sa nachádza tento chat.",
     "errorDisableIGCClassDesc": "Pomoc s gramatikou je vypnutá pre kurz, v ktorom sa nachádza tento chat.",
-    "error405Title": "Jazyky nie sú nastavené",
     "error405Desc": "Prosím, nastavte si svoje jazyky v Hlavnom menu > Nastavenia učenia.",
     "termsAndConditions": "Podmienkami a podmienkami",
     "andCertifyIAmAtLeast13YearsOfAge": " a potvrdzujem, že mám najmenej 16 rokov.",
-    "error502504Title": "Wow, je online veľa študentov!",
     "error502504Desc": "Nástroje na preklad a gramatiku môžu byť pomalé alebo nedostupné, kým Pangea boty dobehnú.",
-    "error404Title": "Chyba prekladu!",
     "error404Desc": "Pangea Bot si nie je istý, ako to preložiť...",
     "errorPleaseRefresh": "Pozeráme sa na to! Prosím, načítajte stránku znova a skúste to znova.",
     "connectedToStaging": "Pripojené k Stagingu",
@@ -1945,13 +1788,9 @@
     "definitionsToolName": "Definície slov",
     "definitionsToolDescription": "Keď je aktivované, slová podčiarknuté modrou farbou je možné kliknúť pre definície. Kliknite na správy pre prístup k definíciám.",
     "welcomeBack": "Vitajte späť! Ak ste boli súčasťou pilotného projektu 2023-2024, kontaktujte nás pre vašu špeciálnu pilotnú predplatnú službu. Ak ste učiteľ, ktorý zakúpil (alebo vaša inštitúcia zakúpila) licencie pre vašu triedu, kontaktujte nás pre vašu učiteľskú predplatnú službu.",
-    "downloadTxtFile": "Stiahnuť textový súbor",
-    "downloadCSVFile": "Stiahnuť CSV súbor",
     "promotionalSubscriptionDesc": "Momentálne máte doživotnú propagačnú predplatnú službu. Kontaktujte support@pangea.chat pre pomoc s zmenou predplatného.",
     "originalSubscriptionPlatform": "Predplatné zakúpené cez {purchasePlatform}",
     "oneWeekTrial": "Jedno týždňová skúšobná verzia",
-    "downloadXLSXFile": "Stiahnuť Excel súbor",
-    "unkDisplayName": "Neznámy",
     "wwCountryDisplayName": "Celosvetovo",
     "afCountryDisplayName": "Afganistan",
     "axCountryDisplayName": "Alandské ostrovy",
@@ -2246,7 +2085,6 @@
     "chatCapacityHasBeenChanged": "Kapacita chatu bola zmenená",
     "chatCapacitySetTooLow": "Kapacita chatu musí byť najmenej {count}.",
     "chatCapacityExplanation": "Kapacita chatu obmedzuje počet členov, ktorí môžu byť v chate.",
-    "tooManyRequest": "Príliš veľa požiadaviek, skúste to neskôr.",
     "enterNumber": "Zadajte celé číslo.",
     "practice": "Cvičiť",
     "versionNotFound": "Verzia nenájdená",
@@ -2256,7 +2094,6 @@
     "deleteSubscriptionWarningTitle": "Máte aktívne predplatné",
     "deleteSubscriptionWarningBody": "Vymazanie vášho účtu automaticky nezruší vaše predplatné.",
     "manageSubscription": "Spravovať predplatné",
-    "error520Title": "Prosím, skúste to znova.",
     "error520Desc": "Prepáčte, nerozumeli sme vašej správe...",
     "wordsUsed": "Použité slová",
     "level": "Úroveň",
@@ -2274,7 +2111,6 @@
     "other": "Iné",
     "levelShort": "ÚROVEŇ {level}",
     "noCapacityLimit": "Žiadne obmedzenie kapacity",
-    "downloadGroupText": "Stiahnuť text skupiny",
     "notificationsOn": "Oznámenia zapnuté",
     "notificationsOff": "Oznámenia vypnuté",
     "joinWithCode": "Pripojiť sa s kódom",
@@ -2338,24 +2174,12 @@
     "whatIsTheMorphTag": "Čo je {morphologicalFeature} z '{wordForm}'?",
     "dataAvailable": "Dostupnosť údajov",
     "available": "Dostupné",
-    "pangeaBotIsFallible": "Pangea Bot tiež robí chyby!",
-    "whatIsMeaning": "Čo znamená '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Zhodujte významy so slovami v správe!",
-    "doubleClickToEdit": "Dvojitým kliknutím upravíte.",
-    "topicLabel": "Téma",
-    "topicPlaceholder": "Vyberte tému...",
-    "modePlaceholder": "Vyberte režim...",
-    "learningObjectiveLabel": "Cieľ učenia",
-    "learningObjectivePlaceholder": "Vyberte cieľ učenia...",
-    "targetLanguageLabel": "Cieľový jazyk",
     "cefrLevelLabel": "Úroveň CEFR",
     "image": "Obrázok",
     "video": "Video",
     "nan": "Nepoužiteľné",
-    "addVocabulary": "Pridať slovnú zásobu",
     "instructions": "Inštrukcie",
-    "numberOfLearners": "Počet študentov",
-    "mustBeInteger": "Musí byť celé číslo, napr. 1, 2, 3, ...",
     "constructUsePvmDesc": "Vytvorené vo zvukovej správe",
     "leaveSpaceDescription": "Opustením kurzu opustíte všetky chaty v ňom. Ostatní používatelia uvidia, že ste opustili kurz.",
     "constructUseCorMmDesc": "Správny význam správy",
@@ -2370,7 +2194,6 @@
     "ttsDisabledBody": "Môžete povoliť prehrávanie textu do reči vo vašich nastaveniach učenia",
     "noSpaceDescriptionYet": "Ešte nebolo vytvorené žiadne popis kurzu.",
     "tooLargeToSend": "Táto správa je príliš veľká na odoslanie",
-    "exitWithoutSaving": "Ste si istí, že chcete odísť bez uloženia?",
     "enableAutocorrectPopupTitle": "Pridajte klávesnicu cieľového jazyka prechádzaním do:",
     "enableAutocorrectPopupSteps": "  • Nastavenia\n  • Všeobecné\n  • Klávesnica\n  • Klávesnice\n  • Pridať novú klávesnicu",
     "enableAutocorrectPopupDescription": "Po výbere jazyka môžete kliknúť na malú ikonu glóbusu v ľavom spodnom rohu klávesnice na aktiváciu novozaloženej klávesnice.",
@@ -2381,11 +2204,8 @@
     "displayName": "Zobrazované meno",
     "leaveRoomDescription": "Chystáte sa opustiť tento chat. Ostatní používatelia uvidia, že ste opustili chat.",
     "confirmUserId": "Prosím, potvrďte svoje používateľské meno v Pangea Chate, aby ste mohli vymazať svoj účet.",
-    "startingToday": "Od dnešného dňa",
-    "oneWeekFreeTrial": "Jedno týždňové bezplatné skúšobné obdobie",
     "paidSubscriptionStarts": "Začína {startDate}",
     "cancelInSubscriptionSettings": "• Zrušiť kedykoľvek v nastaveniach predplatného",
-    "cancelToAvoidCharges": "• Zrušiť pred {trialEnds} aby ste sa vyhli poplatkom",
     "downloadGboard": "Stiahnuť Gboard",
     "autocorrectNotAvailable": "Bohužiaľ, vaša platforma momentálne nepodporuje túto funkciu. Sledujte ďalší vývoj!",
     "pleaseUpdateApp": "Prosím, aktualizujte aplikáciu, aby ste mohli pokračovať.",
@@ -2395,17 +2215,12 @@
     "knockSpaceSuccess": "Požiadali ste o pripojenie k tomuto kurzu! Administrátor vám odpovie, keď to obdrží 😀",
     "chooseWordAudioInstructionsBody": "Počúvajte úplnú správu. Potom zodpovedajte audia slovami.",
     "chooseMorphsInstructionsBody": "Kliknite na puzzle kúsky pre gramatické otázky!",
-    "pleaseEnterInt": "Prosím, zadajte číslo",
     "home": "Domov",
     "join": "Pripojiť sa",
     "resetInstructionTooltipsTitle": "Obnoviť návody na inštrukcie",
     "resetInstructionTooltipsDesc": "Kliknite pre zobrazenie návodov na inštrukcie ako pre úplného nováčika.",
-    "randomize": "Náhodne",
     "clear": "Vyčistiť",
-    "featuredActivities": "Odporúčané",
     "save": "Uložiť",
-    "startChat": "Začať rozhovor",
-    "translationProblem": "Problém s prekladom",
     "askToJoin": "Požiadať o pripojenie",
     "emptyChatWarningTitle": "Chat je prázdny",
     "emptyChatWarningDesc": "Nepozvali ste nikoho do svojho chatu. Prejdite do nastavení chatu a pozvite svojich kontaktov alebo bota. Môžete to urobiť aj neskôr.",
@@ -2435,17 +2250,13 @@
     "timesUsedIndependently": "Počet použití samostatne",
     "timesUsedWithAssistance": "Počet použití s pomocou",
     "shareInviteCode": "Zdieľať pozývací kód: {code}",
-    "leaderboard": "Rebríček",
     "skipForNow": "Preskočiť zatiaľ",
     "permissions": "Oprávnenia",
     "spaceChildPermission": "Kto môže pridávať nové chaty do tohto kurzu",
-    "addEnvironmentOverride": "Pridať prepísanie prostredia",
     "defaultOption": "Predvolené",
     "deleteChatDesc": "Ste si istí, že chcete vymazať tento chat? Bude vymazaný pre všetkých účastníkov a všetky správy v chate už nebudú dostupné na prax alebo analytiku učenia.",
     "deleteSpaceDesc": "Kurz a akékoľvek vybrané chaty budú vymazané pre všetkých účastníkov a všetky správy v chate už nebudú dostupné na prax alebo analytiku učenia. Táto akcia sa nedá vrátiť.",
     "launch": "Spustiť",
-    "searchChats": "Hľadať chaty",
-    "maxFifty": "Max 50",
     "configureSpace": "Konfigurovať kurz",
     "pinMessages": "Pripnúť správy",
     "setJoinRules": "Nastaviť pravidlá pripojenia",
@@ -2479,9 +2290,6 @@
     "failedToFetchTranscription": "Nepodarilo sa načítať prepis",
     "deleteEmptySpaceDesc": "Kurz bude vymazaný pre všetkých účastníkov. Táto akcia sa nedá vrátiť späť.",
     "regenerate": "Obnoviť",
-    "mySavedActivities": "Moje uložené aktivity",
-    "noSavedActivities": "Žiadne uložené aktivity",
-    "saveActivity": "Uložiť túto aktivitu",
     "failedToPlayVideo": "Nepodarilo sa spustiť video",
     "done": "Hotovo",
     "inThisSpace": "V tomto kurze",
@@ -2492,13 +2300,9 @@
     "numInvited": "{count} pozvaných",
     "saved": "Uložené",
     "reset": "Obnoviť",
-    "errorFetchingActivitiesMessage": "Nepodarilo sa načítať aktivity",
     "errorFetchingDefinition": "Nepodarilo sa načítať definíciu",
     "errorProcessAnalytics": "Nepodarilo sa spracovať analytiku",
     "errorDownloading": "Sťahovanie zlyhalo",
-    "errorLoadingSpaceChildren": "Nepodarilo sa načítať chaty v rámci tohto kurzu",
-    "unexpectedError": "Neočakávaná chyba.",
-    "pleaseReload": "Prosím, načítajte znova a skúste to znova.",
     "translationError": "Chyba prekladu",
     "check": "Skontrolovať",
     "unableToFindRoom": "Nenašiel sa žiadny chat alebo kurz s týmto kódom. Skúste to znova.",
@@ -2507,19 +2311,14 @@
     "request": "Žiadosť",
     "requestAll": "Požiadať o všetko",
     "confirmMessageUnpin": "Ste si istí, že chcete odopnúť túto správu?",
-    "saveAndLaunch": "Uložiť a spustiť",
-    "launchToSpace": "Spustiť do kurzu",
     "pending": "Čaká sa",
     "inactive": "Neaktívne",
-    "confirmRole": "Potvrdiť rolu",
     "openRoleLabel": "OTVORENÁ",
     "finishedTheActivity": "🎯 {username} ukončil túto aktivitu",
     "activitySummaryError": "Prehľady aktivít nie sú dostupné",
     "requestSummaries": "Požiadať o prehľady",
-    "generatingNewActivities": "Ste prvým používateľom tohto jazykového páru! Prosím, venujte nám chvíľu, pripravujeme aktivity špeciálne pre vás.",
     "requestAccessTitle": "Požiadať o prístup k analytike?",
     "requestAccessDesc": "Chceli by ste požiadať o prístup na zobrazenie analytiky účastníkov?\n\nAk účastníci súhlasia, administrátori tohto kurzu budú môcť vidieť ich:\n    • celkovú slovnú zásobu\n    • celkové gramatické koncepty\n    • počet dokončených aktivít\n    • špecifické gramatické koncepty použité, správne a nesprávne\n\nNebudú môcť vidieť ich:\n    • správy v chatoch mimo kurzu\n    • zoznam slovnej zásoby",
-    "requestAccess": "Požiadať o prístup ({count})",
     "analyticsInactiveTitle": "Žiadosti o prístup od neaktívnych používateľov nemohli byť odoslané",
     "analyticsInactiveDesc": "Neaktívni používatelia, ktorí sa neprihlásili od zavedenia tejto funkcie, neuvidia vašu žiadosť.\n\nTlačidlo Požiadavka sa zobrazí, keď sa vrátia. Môžete žiadosť znova odoslať neskôr kliknutím na tlačidlo Požiadavka pod ich menom, keď bude dostupné.",
     "accessRequestedTitle": "Žiadosť o prístup k analytike",
@@ -2542,8 +2341,6 @@
     "accessDesc": "Môžete spraviť svoj kurz otvorený svetu! Alebo, urobiť svoj kurz súkromným a zabezpečeným.",
     "createGroupChatDesc": "Kde začínajú a končia aktivity, skupinové chaty zostanú otvorené na bežnú komunikáciu.",
     "deleteDesc": "Iba správcovia môžu vymazať kurz. Ide o deštruktívnu akciu, ktorá odstráni všetkých používateľov a vymaže všetky vybrané chaty v kurze. Postupujte opatrne.",
-    "noCourseFound": "Ó, tento kurz potrebuje plán!\n\nPlány kurzov sú sledom tém a aktivít konverzácie.",
-    "additionalParticipants": "+ {num} ďalších",
     "whatNow": "Čo teraz?",
     "chooseNextActivity": "Vyberte svoju ďalšiu aktivitu!",
     "letsGo": "Poďme na to",
@@ -2556,13 +2353,11 @@
     "waitNotDone": "Čakaj, ešte som neskončil!",
     "waitingForOthersToFinish": "Čakáme na ostatných, aby dokončili...",
     "generatingSummary": "Analyzujeme chat a generujeme výsledky",
-    "findCourse": "Nájsť kurz",
     "pingParticipantsNotification": "{user} hľadá používateľov na pripojenie k relácii aktivity v {room}",
     "course": "Kurz",
     "courses": "Kurzy",
     "goToCourse": "Prejsť na kurz: {course}",
     "activityComplete": "Táto aktivita bola dokončená. Súhrn aktivity by mal byť dostupný nižšie.",
-    "startNewSession": "Začať novú reláciu",
     "joinOpenSession": "Pripojiť sa k otvorenej relácii",
     "activityNotFound": "Aktivita nenájdená",
     "myActivities": "Moje aktivity",
@@ -2753,10 +2548,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clearArchive": {
         "type": "String",
         "placeholders": {}
@@ -2869,19 +2660,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@createGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -2933,18 +2712,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -2993,19 +2760,11 @@
             }
         }
     },
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@extremeOffensive": {
         "type": "String",
         "placeholders": {}
     },
     "@fontSize": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3133,10 +2892,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMatrixServer": {
         "type": "String",
         "placeholders": {
@@ -3200,10 +2955,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addAccount": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@editBundlesForAccount": {
         "type": "String",
         "placeholders": {}
@@ -3217,10 +2968,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableMultiAccounts": {
         "type": "String",
         "placeholders": {}
     },
@@ -3260,10 +3007,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pin": {
         "type": "String",
         "placeholders": {}
@@ -3281,10 +3024,6 @@
         "placeholders": {}
     },
     "@pleaseEnter4Digits": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKey": {
         "type": "String",
         "placeholders": {}
     },
@@ -3351,14 +3090,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@sendImages": {
         "type": "String",
         "placeholders": {
@@ -3399,14 +3130,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@startedACall": {
         "type": "String",
         "placeholders": {
@@ -3435,10 +3158,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unavailable": {
         "type": "String",
         "placeholders": {}
@@ -3463,15 +3182,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -3503,15 +3214,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3562,10 +3265,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3574,15 +3273,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3706,43 +3397,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3762,18 +3421,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
@@ -3787,10 +3434,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3813,22 +3456,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3883,10 +3510,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3970,31 +3593,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -4050,23 +3653,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4106,28 +3697,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4145,14 +3714,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4345,22 +3906,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4416,10 +3961,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4429,10 +3970,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4508,27 +4045,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4846,10 +4367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4859,10 +4376,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4950,14 +4463,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4974,10 +4479,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4990,15 +4491,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5150,14 +4643,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5171,14 +4656,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6401,10 +5878,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6445,10 +5918,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6521,10 +5990,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6794,47 +6259,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6854,19 +6279,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6930,10 +6343,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6974,14 +6383,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6993,14 +6394,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -7038,10 +6431,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7058,27 +6447,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7202,10 +6575,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7215,10 +6584,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7235,14 +6600,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7382,18 +6739,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7442,10 +6787,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7455,18 +6796,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7509,23 +6838,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7549,10 +6866,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7560,14 +6873,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7672,18 +6977,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7736,10 +7029,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7766,10 +7055,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7950,7 +7235,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Skontrolujte zajtra aktualizácie aktivity.",
-    "activityDropdownDesc": "Keď dokončíte túto aktivitu, kliknite nižšie",
     "languageMismatchTitle": "Nesúlad jazyka",
     "languageMismatchDesc": "Váš cieľový jazyk nezodpovedá jazyku tejto aktivity. Chcete aktualizovať svoj cieľový jazyk?",
     "reportWordIssueTooltip": "Nahlásiť problém s informáciami o slove",
@@ -7963,10 +7247,6 @@
     "selectAll": "Vybrať všetko",
     "deselectAll": "Zrušiť výber všetkého",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8015,17 +7295,11 @@
         "placeholders": {}
     },
     "startOwn": "Začať vlastné",
-    "joinCourseDesc": "Každý kurz má 8-10 sekvenčných tém s radom aktivít na učenie jazyka založených na úlohách.",
     "newMessageInPangeaChat": "🗨️ Nová správa v Pangea chate",
     "shareCourse": "Zdieľať kurz",
     "addCourse": "Pridať kurz",
-    "joinPublicCourse": "Pripojiť sa k verejnému kurzu",
     "vocabLevelsDesc": "Sem pôjdu slovíčka, keď ich vylepšíte na vyššiu úroveň!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8038,10 +7312,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8060,7 +7330,6 @@
     "emojiView": "Zobrazenie emoji",
     "feedbackDialogDesc": "Robím chyby tiež! Niečo, čo by mi pomohlo zlepšiť sa?",
     "contactHasBeenInvitedToTheCourse": "Kontakt bol pozvaný na kurz",
-    "activityStatsButtonTooltip": "Informácie o aktivite",
     "allow": "Povoliť",
     "deny": "Odmietnuť",
     "enabledRenewal": "Povoliť obnovenie predplatného",
@@ -8328,10 +7597,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9387,16 +8652,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktivity na odomknutie nasledujúcej témy",
-    "activitiesToUnlockTopicDesc": "Nastavte počet aktivít na odomknutie nasledujúcej témy kurzu",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Správna prax definície slovnej zásoby",
     "constructUseIncLMDesc": "Nesprávna prax definície slovnej zásoby",
     "constructUseCorLADesc": "Správna prax audio slovnej zásoby",
@@ -9404,7 +8659,6 @@
     "constructUseBonus": "Bonus počas praxe slovnej zásoby",
     "practiceVocab": "Cvičenie slovnej zásoby",
     "selectMeaning": "Vyberte význam",
-    "selectAudio": "Vyberte zodpovedajúce audio",
     "anotherRound": "Ďalšie kolo",
     "activitySettingsOverrideWarning": "Jazyk a jazyková úroveň určené plánom aktivity",
     "voice": "Hlas",
@@ -9436,10 +8690,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9457,12 +8707,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Stiahnutie bolo zahájené",
     "webDownloadPermissionMessage": "Ak váš prehliadač blokuje sťahovanie, prosím, povolte sťahovanie pre túto stránku.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9557,11 +8802,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Niečo sa pokazilo a my na tom tvrdo pracujeme, aby sme to opravili. Skontrolujte to neskôr.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Povoliť pomoc pri písaní",
     "autoIGCToolDescription": "Automaticky spustiť nástroje Pangea Chat na opravu odoslaných správ do cieľového jazyka.",
     "@autoIGCToolName": {
@@ -9617,24 +8857,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatika",
-    "spanTypeWordChoice": "Výber slov",
     "spanTypeSpelling": "Pravopis",
     "spanTypePunctuation": "Interpunkcia",
     "spanTypeStyle": "Štýl",
     "spanTypeFluency": "Plynulosť",
     "spanTypeAccents": "Prízvuky",
     "spanTypeCapitalization": "Veľké písmená",
-    "spanTypeCorrection": "Oprava",
     "spanFeedbackTitle": "Nahlásiť problém s opravou",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9659,10 +8888,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9675,13 +8900,7 @@
     "longPressToRecordVoiceMessage": "Dlhé stlačenie na nahrávanie hlasovej správy.",
     "pause": "Pozastaviť",
     "resume": "Pokračovať",
-    "newSubSpace": "Nový podpriestor",
-    "moveToDifferentSpace": "Presunúť do iného priestoru",
-    "removeFromSpaceDescription": "Chat bude odstránený z priestoru, ale stále sa zobrazí vo vašom zozname chatov.",
     "countChats": "{chats} chaty",
-    "spaceMemberOf": "Člen priestoru {spaces}",
-    "spaceMemberOfCanKnock": "Člen priestoru {spaces} môže zaklopať",
-    "donate": "Darovať",
     "startedAPoll": "{username} začal anketu.",
     "poll": "Anketa",
     "startPoll": "Začať anketu",
@@ -9705,23 +8924,15 @@
     "newStickerPack": "Nový balík nálepiek",
     "stickerPackName": "Názov balíka nálepiek",
     "attribution": "Pripísanie",
-    "skipChatBackup": "Preskočiť zálohu chatu",
-    "skipChatBackupWarning": "Ste si istý? Bez povolenia zálohy chatu môžete stratiť prístup k svojim správam, ak prepnite svoje zariadenie.",
-    "loadingMessages": "Načítavanie správ",
-    "setupChatBackup": "Nastaviť zálohu chatu",
     "noMoreResultsFound": "Nenašli sa žiadne ďalšie výsledky",
     "chatSearchedUntil": "Chat bol prehľadávaný do {time}",
     "federationBaseUrl": "Základná URL federácie",
     "clientWellKnownInformation": "Informácie o klientovi:",
     "baseUrl": "Základná URL",
     "identityServer": "Identitný server:",
-    "versionWithNumber": "Verzia: {version}",
     "logs": "Záznamy",
-    "advancedConfigs": "Pokročilé nastavenia",
     "advancedConfigurations": "Pokročilé konfigurácie",
-    "signInWithLabel": "Prihlásiť sa pomocou:",
     "selectAllWords": "Vyberte všetky slová, ktoré počujete v audiu",
-    "joinCourseForActivities": "Pridajte sa k kurzu, aby ste vyskúšali aktivity.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9758,18 +8969,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9777,26 +8976,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9902,22 +9081,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9946,19 +9109,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9966,15 +9117,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10175,11 +9318,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "V triede? Zadajte svoj kód na pripojenie sem.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automaticky zvýrazniť audio správy",
     "selectAudioMessagesOnPlayDescription": "Automaticky zvýrazniť audio správy pri prehrávaní",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10223,18 +9361,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Tento kurz má témy s menej ako {input} aktivitami. Prosím, zadajte číslo menšie alebo rovné {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Kliknite sem, aby ste sa znova prihlásili.",
     "@clickToLogin": {
@@ -10651,17 +9777,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Kreslený žltý medveď s vystrčenými rukami v nadšení.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Vyberte slová, aby ste sa o nich dozvedeli viac",
     "requireAnalyticsAccessTitle": "Vyžaduje sa prístup k analytike na pripojenie",
     "requireAnalyticsAccessDesc": "Účastníci musia poskytnúť prístup k svojim analytickým údajom o učení, aby sa mohli pripojiť k tomuto kurzu",
     "analyticsAccessNoticeTitle": "Vyžaduje sa prístup k analytike",
     "analyticsAccessNoticeDesc": "Pripojením sa k tomuto kurzu súhlasíte s poskytnutím prístupu administrátorom k vašim analytickým údajom o učení.",
-    "skipOnboardingClassCodeDesc": "Učíte sa nezávisle? Nebojte sa, môžete:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10679,10 +9799,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10711,7 +9827,6 @@
     "pickCefrLevelTeacherStepTitle": "Akú úroveň učíte?",
     "pickCefrLevelStudentStepTitle": "Akú úroveň máte?",
     "customCourseStepTitle": "Vyplňte tento formulár, aby ste získali vlastný kurz",
-    "aboutYourClass": "O vašej triede",
     "courseCodeStepErrorMessage": "Skontrolujte svoj kód a skúste to znova",
     "institution": "Inštitúcia",
     "courseGoals": "Ciele kurzu",
@@ -10754,10 +9869,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10874,12 +9985,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logo Pangea Chat",
     "introChatDetails": "Povedz ahoj! Predstav sa svojim spoluúčastníkom kurzu, nájdi priateľov a chatovať mimo aktivít.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10923,11 +10029,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Akcie aktivity",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Nástroje na výslovnosť",
     "audioTranscription": "AI prepis zvuku",
     "visualLearnerSupport": "Podpora vizuálnych žiakov",
@@ -10968,7 +10069,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Pridajte sa k kurzu, ktorý obsahuje túto aktivitu, aby ste ju mohli hrať.",
     "resizeCoursePanel": "Zmeniť veľkosť panelu kurzu",
     "undo": "Zrušiť",
     "unlock": "Odomknúť",
@@ -10982,7 +10082,6 @@
     "addCourseBrowsePublic": "Prehľadávať verejné kurzy",
     "browsePublicCourses": "Prehľadávať verejné kurzy",
     "editProfile": "Upraviť profil",
-    "numObjectives": "{count} ciele",
     "mapSearchHint": "Hľadať aktivity",
     "mapSearchNoResults": "Žiadne zhodné výsledky",
     "mapFilterAllLanguages": "Všetky jazyky",
@@ -10991,7 +10090,6 @@
     "mapFilterCompleted": "Dokončené",
     "mapFilterReset": "Obnoviť",
     "activityTypeConversation": "Konverzácia",
-    "lockedMissionRequirement": "Dokončite predchádzajúcu misiu, aby ste odomkli",
     "playAgain": "Hraj znova",
     "reviewActivity": "Prehľad",
     "mapEmptyInView": "Tu nie je nič na vašej úrovni alebo jazyku. Rozšírte svoje filtre alebo priblížte.",
@@ -11006,14 +10104,9 @@
     "scrollToBottom": "Posuňte sa na dno",
     "courseImage": "Obrázok kurzu",
     "avatarPreview": "Náhľad avatara",
-    "activityPhoto": "Fotografia aktivity",
     "emotePreview": "Náhľad emócie: {name}",
     "activityLabel": "Aktivita: {title}",
     "resetMapView": "Obnoviť zobrazenie mapy",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11066,14 +10159,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11103,10 +10188,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11163,10 +10244,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_sl.arb
+++ b/lib/l10n/intl_sl.arb
@@ -286,8 +286,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "Varnostna kopija klepeta je nastavljena.",
-    "@yourChatBackupHasBeenSetUp": {},
     "chatBackup": "Varnostno kopiranje klepeta",
     "@chatBackup": {
         "type": "String",
@@ -440,11 +438,6 @@
             }
         }
     },
-    "areGuestsAllowedToJoin": "Ali se lahko gostujoči uporabniki pridružijo",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "admin": "Admin",
     "@admin": {
         "type": "String",
@@ -486,11 +479,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Varnostna kopija klepeta je zavarovana z varnostnim ključem. Prosimo, pazite, da ga ne izgubite.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "commandHint_myroomnick": "Nastavite prikazno ime za to sobo",
     "@commandHint_myroomnick": {
         "type": "String",
@@ -498,11 +486,6 @@
     },
     "connect": "Povežite se",
     "@connect": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "Kontakt je bil povabljen v skupino",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -551,11 +534,6 @@
     },
     "create": "Ustvari",
     "@create": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "createNewSpace": "Nov prostor",
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -638,7 +616,6 @@
     "commandHint_discardsession": "Opusti sejo",
     "commandHint_dm": "Začni neposreden klepet\nUporabi --no-encryption za onemogočitev šifriranja",
     "checkList": "Preveri seznam",
-    "countInvited": "{count} povabljenih",
     "createGroup": "Ustvari skupino",
     "delete": "Izbriši",
     "deleteAccount": "Izbriši račun",
@@ -660,9 +637,6 @@
     "emoteKeyboardNoRecents": "Nedavno uporabljeni emoti se bodo prikazali tukaj...",
     "emotePacks": "Paketi emojijev za sobo",
     "emoteSettings": "Nastavitve emojijev",
-    "globalChatId": "Globalni ID klepeta",
-    "accessAndVisibility": "Dostop in vidljivost",
-    "accessAndVisibilityDescription": "Kdo sme sodelovati v tem klepetu in kako ga je mogoče odkriti.",
     "calls": "Klici",
     "customEmojisAndStickers": "Lastni emojiji in nalepke",
     "customEmojisAndStickersBody": "Dodajte ali delite lastne emojije ali nalepke, ki jih je mogoče uporabiti v katerem koli klepetu.",
@@ -670,7 +644,6 @@
     "emptyChat": "Prazen klepet",
     "enableEmotesGlobally": "Omogoči paket emojijev globalno",
     "enableEncryption": "Omogoči šifriranje",
-    "enableEncryptionWarning": "Več ne boste mogli izklopiti šifriranja. Ste prepričani?",
     "encrypted": "Šifrirano",
     "encryption": "Šifriranje",
     "encryptionNotEnabled": "Šifriranje ni omogočeno",
@@ -678,7 +651,6 @@
     "enterAnEmailAddress": "Vnesite e-poštni naslov",
     "homeserver": "Strežnik doma",
     "errorObtainingLocation": "Napaka pri pridobivanju lokacije: {error}",
-    "everythingReady": "Vse pripravljeno!",
     "extremeOffensive": "Izjemno žaljivo",
     "fileName": "Ime datoteke",
     "fluffychat": "FluffyChat",
@@ -687,9 +659,7 @@
     "fromJoining": "Od včlanitve",
     "fromTheInvitation": "Iz povabila",
     "group": "Skupina",
-    "chatDescription": "Opis klepeta",
     "chatDescriptionHasBeenChanged": "Opis klepeta je bil spremenjen",
-    "groupIsPublic": "Skupina je javna",
     "groups": "Skupine",
     "groupWith": "Skupina z {displayname}",
     "guestsAreForbidden": "Gostom je prepovedano",
@@ -711,7 +681,6 @@
     "incorrectPassphraseOrKey": "Napačna geslovna fraza ali ključ za obnovo",
     "inoffensive": "Nežaljivo",
     "inviteContact": "Vabilo stiku",
-    "inviteContactToGroup": "Povabi stik v {groupName}",
     "noChatDescriptionYet": "Še ni ustvarjen opis klepeta.",
     "tryAgain": "Poskusi znova",
     "invalidServerName": "Neveljavno ime strežnika",
@@ -732,7 +701,6 @@
     "leave": "Iščä",
     "leftTheChat": "Zapustil je pogovor",
     "lightTheme": "Svetla",
-    "loadCountMoreParticipants": "Naloži {count} več udeležencev",
     "dehydrate": "Izvozi sejo in počisti napravo",
     "dehydrateWarning": "Ta dejanja ni mogoče razveljaviti. Poskrbite, da varno shranite varnostno kopijo datoteke.",
     "hydrate": "Obnovi iz varnostne kopije",
@@ -741,7 +709,6 @@
     "locationDisabledNotice": "Lokacijske storitve so onemogočene. Prosimo, omogočite jih, da lahko delite svojo lokacijo.",
     "locationPermissionDeniedNotice": "Dovoljenje za lokacijo je zavrnjeno. Prosimo, dovolite, da lahko delite svojo lokacijo.",
     "login": "Prijava",
-    "logInTo": "Prijavite se v {homeserver}",
     "logout": "Odjava",
     "mention": "Omenitev",
     "messages": "Sporočila",
@@ -756,8 +723,6 @@
     "no": "Ne",
     "noConnectionToTheServer": "Ni povezave s strežnikom",
     "noEmotesFound": "Ni najdenih emojijev. 😕",
-    "noEncryptionForPublicRooms": "Šifriranje lahko aktivirate šele, ko soba ni več javno dostopna.",
-    "noGoogleServicesWarning": "Firebase Cloud Messaging ni na voljo na vaši napravi. Za prejemanje potisnih obvestil priporočamo namestitev ntfy. Z ntfy ali drugim enotnim ponudnikom potisnih obvestil lahko prejemate potisna obvestila na varen način. Nlajdete ga lahko v PlayStore ali F-Droidu.",
     "noMatrixServer": "{server1} ni strežnik matrix, ali naj uporabim {server2} namesto tega?",
     "shareInviteLink": "Deli povabilo povezavo",
     "scanQrCode": "Skeniraj QR kodo",
@@ -779,12 +744,10 @@
     "openCamera": "Odpri kamero",
     "openVideoCamera": "Odpri kamero za video",
     "oneClientLoggedOut": "Eden od vaših odjemalcev je bil odjavljen",
-    "addAccount": "Dodaj račun",
     "editBundlesForAccount": "Uredi pakete za ta račun",
     "addToBundle": "Dodaj v paket",
     "removeFromBundle": "Odstrani iz tega paketa",
     "bundleName": "Ime paketa",
-    "enableMultiAccounts": "(BETA) Omogoči več računov na tej napravi",
     "openInMaps": "Odpri v zemljevidih",
     "link": "Povezava",
     "serverRequiresEmail": "Ta strežnik mora potrditi vaš e-poštni naslov za registracijo.",
@@ -796,7 +759,6 @@
     "passwordHasBeenChanged": "Geslo je bilo spremenjeno",
     "overview": "Pregled",
     "passwordRecoverySettings": "Nastavitve obnove gesla",
-    "passwordRecovery": "Obnova gesla",
     "people": "Ljudje",
     "pickImage": "Izberi sliko",
     "pin": "Pripni",
@@ -805,7 +767,6 @@
     "pleaseChooseAPasscode": "Prosim, izberi geslo",
     "pleaseClickOnLink": "Prosimo, kliknite na povezavo v e-pošti in nadaljujte.",
     "pleaseEnter4Digits": "Prosimo, vnesite 4 števke ali pustite prazno za onemogočitev zaklepa aplikacije.",
-    "pleaseEnterRecoveryKey": "Prosimo, vnesite svoj ključ za obnovo:",
     "pleaseEnterYourPassword": "Prosimo, vnesite svoje geslo",
     "pleaseEnterYourPin": "Prosimo, vnesite svoj PIN",
     "pleaseEnterYourUsername": "Prosimo, vnesite svoje uporabniško ime",
@@ -825,7 +786,6 @@
     "rejectedTheInvitation": "{username} je zavrnil vabilo",
     "removeAllOtherDevices": "Odstrani vse druge naprave",
     "removedBy": "Odstranjeno s strani {username}",
-    "removeDevice": "Odstrani napravo",
     "unbanFromChat": "Odkleni iz klepeta",
     "removeYourAvatar": "Odstrani svoj avatar",
     "replaceRoomWithNewerVersion": "Zamenjaj sobo z novejšo različico",
@@ -837,8 +797,6 @@
     "saveFile": "Shrani datoteko",
     "search": "Išči",
     "security": "Varnost",
-    "recoveryKey": "Ključ za obnovo",
-    "recoveryKeyLost": "Izgubljen ključ za obnovo?",
     "send": "Pošlji",
     "sendAMessage": "Pošlji sporočilo",
     "sendAsText": "Pošlji kot besedilo",
@@ -857,7 +815,6 @@
     "separateChatTypes": "Ločene neposredne pogovore in skupine",
     "setAsCanonicalAlias": "Nastavi kot glavno vzdevko",
     "setChatDescription": "Nastavi opis pogovora",
-    "setPermissionsLevel": "Nastavi raven dovoljenj",
     "setStatus": "Nastavi status",
     "settings": "Nastavitve",
     "share": "Deli",
@@ -867,8 +824,6 @@
     "presencesToggle": "Prikaži sporočila o statusu drugih uporabnikov",
     "skip": "Preskoči",
     "sourceCode": "Izvorna koda",
-    "spaceIsPublic": "Prostor je javni",
-    "spaceName": "Ime prostora",
     "startedACall": "{senderName} je začel klic",
     "status": "Status",
     "statusExampleMessage": "Kako si danes?",
@@ -880,7 +835,6 @@
     "theyMatch": "Ujemajo se",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "Preveč zahtevkov. Poskusite znova kasneje!",
-    "transferFromAnotherDevice": "Prenesi z druge naprave",
     "tryToSendAgain": "Poskusi znova poslati",
     "unavailable": "Ni na voljo",
     "unbannedUser": "{username} je odblokiral {targetName}",
@@ -890,7 +844,6 @@
     "unknownEvent": "Neznan dogodek '{type}'",
     "unmuteChat": "Odkleni klepet",
     "unpin": "Odstrani iz priponk",
-    "unreadChats": "{unreadCount, plural, =1{1 neprebrani klepet} other{{unreadCount} neprebranih klepetov}}",
     "userAndOthersAreTyping": "{username} in {count} drugih tipkajočé…",
     "userAndUserAreTyping": "{username} in {username2} tipkajočé…",
     "userIsTyping": "{username} tipkačé…",
@@ -903,8 +856,6 @@
     "verifyStart": "Začni overjanje",
     "verifySuccess": "Uspešno ste overili!",
     "verifyTitle": "Overjanje družega računa",
-    "videoCall": "Video klic",
-    "visibilityOfTheChatHistory": "Vidnost zgodovine klepeta",
     "visibleForAllParticipants": "Vidno vsem udeležnim",
     "visibleForEveryone": "Vidno vsem",
     "voiceMessage": "Glasovno sporočilo",
@@ -914,10 +865,7 @@
     "wallpaper": "Tapeta:",
     "warning": "Opozorilo!",
     "weSentYouAnEmail": "Poslali smo vam e-pošto",
-    "whoCanPerformWhichAction": "Kdo lahko izvede katero dejanje",
-    "whoIsAllowedToJoinThisGroup": "Kdo sme pristopiti k tej skupini",
     "whyDoYouWantToReportThis": "Zakaj želite prijaviti to?",
-    "wipeChatBackup": "Izbrisati varnostno kopijo klepeta za ustvarjanje nove ključe za obnovo?",
     "withTheseAddressesRecoveryDescription": "Z temi naslovi lahko obnovite svoje geslo.",
     "writeAMessage": "Napišite sporočilo…",
     "yes": "Da",
@@ -930,9 +878,7 @@
     "messageType": "Vrsta sporočila",
     "sender": "Pošiljatelj",
     "openGallery": "Odpri galerijo",
-    "removeFromSpace": "Odstrani iz prostora",
     "start": "Začni",
-    "pleaseEnterRecoveryKeyDescription": "Za odklepanje starih sporočil vnesite ključ za obnovitev, ki je bil ustvarjen v prejšnji seji. Vaš ključ za obnovitev NI vaše geslo.",
     "publish": "Objavi",
     "openChat": "Odpri klepet",
     "markAsRead": "Označi kot prebrano",
@@ -943,12 +889,9 @@
     "confirmEventUnpin": "Ste prepričani, da želite trajno odpniti dogodek?",
     "emojis": "Emojiji",
     "placeCall": "Pokliči",
-    "voiceCall": "Glasovni klic",
     "unsupportedAndroidVersion": "Nepodprta različica Androida",
     "unsupportedAndroidVersionLong": "Ta funkcija zahteva novejšo različico Androida. Prosimo, preverite posodobitve ali podporo Lineage OS.",
-    "videoCallsBetaWarning": "Upoštevajte, da so video klici trenutno v beta različici. Morda ne delujejo po pričakovanjih ali sploh ne delujejo na vseh platformah.",
     "experimentalVideoCalls": "Eksperimentalni video klici",
-    "emailOrUsername": "E-pošta ali uporabniško ime",
     "addWidget": "Dodaj pripomoček",
     "widgetVideo": "Video",
     "widgetEtherpad": "Zapisek besedila",
@@ -970,35 +913,19 @@
     "youKickedAndBanned": "🙅‍♀️ Izključil/a in prepovedal/a si {user}",
     "youUnbannedUser": "Odklenil/a si {user}",
     "hasKnocked": "🚪 {user} je potrkal/a",
-    "usersMustKnock": "Uporabniki morajo potrkati",
-    "noOneCanJoin": "Nihče se ne more pridružiti",
     "knock": "Potrkaj",
     "users": "Uporabniki",
-    "unlockOldMessages": "Odkleni stare sporočila",
-    "storeInSecureStorageDescription": "Shrani ključ za obnovo v varno shrambo tega naprave.",
-    "saveKeyManuallyDescription": "Ročno shrani ta ključ s sprožitvijo sistema za deljenje ali odložišča.",
-    "storeInAndroidKeystore": "Shrani v Android KeyStore",
-    "storeInAppleKeyChain": "Shrani v Apple KeyChain",
-    "storeSecurlyOnThisDevice": "Varnostno shrani na tej napravi",
     "countFiles": "{count} datotek",
     "user": "Uporabnik",
     "custom": "Po meri",
-    "foregroundServiceRunning": "To obvestilo se prikaže, ko je v ospredju aktivna storitev.",
-    "screenSharingTitle": "deljenje zaslona",
-    "screenSharingDetail": "Delite svoj zaslon v FuffyChat",
     "whyIsThisMessageEncrypted": "Zakaj je to sporočilo neberljivo?",
     "noKeyForThisMessage": "To se lahko zgodi, če je bilo sporočilo poslano pred vašim prijavo na ta naprava.\n\nPrav tako je mogoče, da je pošiljatelj blokiral vašo napravo ali pa je prišlo do težav z internetno povezavo.\n\nAli lahko sporočilo preberete na drugi seji? Potem ga lahko prenesete iz nje! Pojdite v Nastavitve > Naprave in se prepričajte, da sta vaši napravi med seboj preverjeni. Ko naslednjič odprete sobo in sta obe seji v ospredju, se bodo ključi samodejno prenesli.\n\nNe želite izgubiti ključev ob odjavi ali preklopu naprav? Prepričajte se, da ste omogočili varnostno kopiranje klepeta v nastavitvah.",
     "newGroup": "Nova skupina",
     "newSpace": "Nov prostor",
-    "enterSpace": "Vstopi v prostor",
     "allSpaces": "Vsi prostori",
     "hidePresences": "Skriti seznam statusov?",
     "doNotShowAgain": "Ne prikazuj znova",
     "wasDirectChatDisplayName": "Prazno klepetanje (bilo {oldDisplayName})",
-    "newSpaceDescription": "Prostori vam omogočajo združevanje klepetov in gradnjo zasebnih ali javnih skupnosti.",
-    "encryptThisChat": "Šifriraj ta klepet",
-    "disableEncryptionWarning": "Zaradi varnosti ne morete onemogočiti šifriranja v klepetu, kjer je bilo prej omogočeno.",
-    "sorryThatsNotPossible": "Oprostite... to ni mogoče",
     "deviceKeys": "Ključi naprave:",
     "reopenChat": "Ponovno odpri klepet",
     "noBackupWarning": "Opozorilo! Brez omogočitve varnostne kopije klepeta boste izgubili dostop do šifriranih sporočil. Priporočamo, da najprej omogočite varnostno kopijo klepeta, preden se odjavite.",
@@ -1011,7 +938,6 @@
     "openLinkInBrowser": "Odpri povezavo v brskalniku",
     "reportErrorDescription": "😞 O, ne. Prišlo je do napake. Če želite, lahko to napako prijavite razvijalcem.",
     "report": "prijavi",
-    "setTheme": "Nastavi temo:",
     "setColorTheme": "Nastavi barvno temo:",
     "invite": "Vabilo",
     "inviteGroupChat": "📨 Vabilo v skupinski klepet",
@@ -1030,12 +956,8 @@
     "yourGlobalUserIdIs": "Vaš globalni uporabniški ID je: ",
     "noUsersFoundWithQuery": "Na žalost ni bilo mogoče najti uporabnika z \"{query}\". Preverite, ali ste naredili tipkarsko napako.",
     "knocking": "Klop",
-    "chatCanBeDiscoveredViaSearchOnServer": "Razgovor je mogoče odkriti prek iskanja na {server}",
-    "searchChatsRooms": "Išči #pogovore, @uporabnike...",
     "nothingFound": "Ničesar ni bilo najdeno...",
     "groupName": "Ime skupine",
-    "createGroupAndInviteUsers": "Ustvari skupino in povabi uporabnike",
-    "groupCanBeFoundViaSearch": "Skupino je mogoče najti prek iskanja",
     "wrongRecoveryKey": "Oprostite... zdi se, da to ni pravilen ključ za obnovo.",
     "startConversation": "Začni pogovor",
     "commandHint_sendraw": "Pošlji surogi json",
@@ -1049,11 +971,8 @@
     "pleaseChooseAStrongPassword": "Prosim, izberite močno geslo",
     "passwordsDoNotMatch": "Gesli se ne ujemata",
     "passwordIsWrong": "Vnesena gesla ni pravilna",
-    "publicChatAddresses": "Javne naslove klepetov",
-    "createNewAddress": "Ustvari nov naslov",
     "joinSpace": "Pridruži se prostoru",
     "publicSpaces": "Javni prostori",
-    "addChatOrSubSpace": "Dodaj klepet ali podprostor",
     "subspace": "Podprostor",
     "decline": "Zavrni",
     "thisDevice": "Ta naprava:",
@@ -1062,15 +981,11 @@
     "searchMore": "Išči še več...",
     "gallery": "Galerija",
     "files": "Datoteke",
-    "sessionLostBody": "Vaša seja je izgubljena. Prosimo, prijavite to napako razvijalcem na {url}. Sporočilo napake je: {error}",
-    "restoreSessionBody": "Aplikacija poskuša obnoviti vašo sejo iz varnostne kopije. Prosimo, prijavite to napako razvijalcem na {url}. Sporočilo napake je: {error}",
     "sendReadReceipts": "Pošlji potrdila o branju",
     "sendTypingNotificationsDescription": "Drugi udeleženci v klepetu lahko vidijo, kdaj tipkate novo sporočilo.",
     "sendReadReceiptsDescription": "Drugi udeleženci v klepetu lahko vidijo, kdaj ste prebrali sporočilo.",
     "formattedMessages": "Oblikovana sporočila",
     "formattedMessagesDescription": "Prikaži bogato vsebino sporočil, kot je krepko besedilo z uporabo markdowna.",
-    "verifyOtherUser": "🔐 Preveri drugega uporabnika",
-    "verifyOtherUserDescription": "Če preverite drugega uporabnika, ste lahko prepričani, da resnično veste, komu pišete. 💪\n\nKo začnete preverjanje, boste vi in drugi uporabnik videli pojavno okno v aplikaciji. Tam boste nato videli vrsto emojijev ali številk, ki jih morate primerjati med seboj.\n\nNajboljši način za to je, da se srečate ali začnete video klic. 👭",
     "verifyOtherDevice": "🔐 Preveri drugo napravo",
     "verifyOtherDeviceDescription": "Ko preverite drugo napravo, te naprave lahko izmenjujejo ključe, kar povečuje vašo celotno varnost. 💪 Ko začnete preverjanje, se v aplikaciji na obeh napravah prikaže pojavno okno. Tam boste nato videli vrsto emojijev ali številk, ki jih morate primerjati med seboj. Najbolje je, da imate obe napravi pri roki, preden začnete preverjanje. 🤳",
     "acceptedKeyVerification": "{sender} je potrdil preverjanje ključa",
@@ -1106,10 +1021,6 @@
     "updateInstalled": "🎉 Posodobitev {version} je nameščena!",
     "changelog": "Spremembe",
     "sendCanceled": "Pošiljanje preklicano",
-    "loginWithMatrixId": "Prijava z Matrix-ID-jem",
-    "discoverHomeservers": "Odkrijte domače strežnike",
-    "whatIsAHomeserver": "Kaj je domači strežnik?",
-    "homeserverDescription": "Vsi vaši podatki so shranjeni na domačem strežniku, podobno kot pri ponudniku e-pošte. Lahko izberete, kateri domači strežnik želite uporabljati, medtem ko lahko še vedno komunicirate z vsemi. Več informacij na https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Zdi se, da ni združljiv domači strežnik. Napačen URL?",
     "calculatingFileSize": "Izračun velikosti datoteke...",
     "prepareSendingAttachment": "Priprava pošiljanja priponke...",
@@ -1121,11 +1032,9 @@
     "oneOfYourDevicesIsNotVerified": "Ena od vaših naprav ni preverjena",
     "noticeChatBackupDeviceVerification": "Opomba: Ko povežete vse svoje naprave s varnostno kopijo klepeta, so samodejno preverjene.",
     "continueText": "Nadaljuj",
-    "welcomeText": "Hej hej 👋 To je FluffyChat. Lahko se prijavite na kateri koli domači strežnik, ki je združljiv z https://matrix.org. In nato klepetajte z vsakim. To je velika decentralizirana mreža za sporočila!",
     "blur": "Zameglitev:",
     "opacity": "Neprosojnost:",
     "setWallpaper": "Nastavi ozadje",
-    "manageAccount": "Upravljanje računa",
     "noContactInformationProvided": "Strežnik ne zagotavlja veljavnih kontaktnih informacij",
     "contactServerAdmin": "Kontaktirajte skrbnika strežnika",
     "contactServerSecurity": "Kontaktirajte varnost strežnika",
@@ -1144,11 +1053,8 @@
     "unableToJoinChat": "Ni mogoče sodelovati v klepetu. Morda je druga stran že zaprla pogovor.",
     "previous": "Prejšnje",
     "otherPartyNotLoggedIn": "Druga stran trenutno ni prijavljena in zato ne more prejemati sporočil!",
-    "appWantsToUseForLogin": "Uporabi '{server}' za prijavo",
-    "appWantsToUseForLoginDescription": "S tem dovolite aplikaciji in spletnemu mestu deliti informacije o vas.",
     "open": "Odpri",
     "waitingForServer": "Čakanje na strežnik...",
-    "appIntroduction": "FluffyChat vam omogoča klepet z vašimi prijatelji prek različnih sporočilnih storitev. Več informacij na https://matrix.org ali preprosto tapnite *Nadaljuj*.",
     "newChatRequest": "📩 Nova zahteva za klepet",
     "contentNotificationSettings": "Nastavitve obvestil o vsebini",
     "generalNotificationSettings": "Splošne nastavitve obvestil",
@@ -1225,11 +1131,9 @@
     "taTooltip": "L2 uporaba z prevajalsko pomočjo",
     "interactiveTranslatorSliderHeader": "Interaktivni prevajalnik",
     "interactiveGrammarSliderHeader": "Interaktivni preverjevalnik slovnice",
-    "interactiveTranslatorRequired": "Zahtevano",
     "waTooltip": "Uporaba L2 brez pomoči",
     "interactiveTranslator": "Pomoč pri prevajanju",
     "noIdenticalLanguages": "Prosim, izberi različne osnovne in ciljne jezike",
-    "searchBy": "Išči po državi in jezikih",
     "joinWithClassCode": "Pridruži se tečaju",
     "languageLevelPreA1": "Novice Low (Pre A1)",
     "languageLevelA1": "Novice Mid (A1)",
@@ -1250,19 +1154,14 @@
     "saveChanges": "Shrani spremembe",
     "publicProfileTitle": "Dovolim, da je moj profil najden v iskanju",
     "publicProfileDesc": "Z vklopom omogočite drugim uporabnikom, da najdejo vaš profil v globalni iskalni vrstici in pošljejo zahteve za klepet. V tem trenutku lahko izberete, ali želite sprejeti ali zavrniti zahtevo.",
-    "errorDisableIT": "Pomoč pri prevajanju je izklopljena.",
-    "errorDisableIGC": "Pomoč pri slovnici je izklopljena.",
     "errorDisableITUserDesc": "Kliknite tukaj za posodobitev nastavitev pomoči pri prevajanju",
     "errorDisableIGCUserDesc": "Kliknite tukaj za posodobitev nastavitev pomoči pri slovnici",
     "errorDisableITClassDesc": "Pomoč pri prevajanju je izklopljena za tečaj, v katerem je ta klepet.",
     "errorDisableIGCClassDesc": "Pomoč pri slovnici je izklopljena za tečaj, v katerem je ta klepet.",
-    "error405Title": "Jeziki niso nastavljeni",
     "error405Desc": "Prosimo, nastavite svoje jezike v Glavnem meniju > Nastavitve učenja.",
     "termsAndConditions": "Pogoji in določila",
     "andCertifyIAmAtLeast13YearsOfAge": "in potrjujem, da sem starejši od 16 let.",
-    "error502504Title": "Vau, veliko je študentov na spletu!",
     "error502504Desc": "Orodja za prevajanje in slovnico so lahko počasna ali nedosegljiva, medtem ko se bot Pangea posodablja.",
-    "error404Title": "Napaka pri prevajanju!",
     "error404Desc": "Bot Pangea ni prepričan, kako naj to prevede...",
     "errorPleaseRefresh": "Preučujemo to! Prosimo, osvežite stran in poskusite znova.",
     "connectedToStaging": "Povezano s testnim okoljem",
@@ -1300,13 +1199,9 @@
     "definitionsToolName": "Določitve besed",
     "definitionsToolDescription": "Ko je omogočeno, so besede podčrtane v modro in jih je mogoče klikniti za definicije. Kliknite na sporočila za dostop do definicij.",
     "welcomeBack": "Dobrodošli nazaj! Če ste bili del pilotnega programa 2023-2024, nas kontaktirajte za vašo posebno pilotno naročnino. Če ste učitelj, ki je (ali vaša institucija je) kupila licence za vašo razred, nas kontaktirajte za vašo učiteljsko naročnino.",
-    "downloadTxtFile": "Prenesi besedilno datoteko",
-    "downloadCSVFile": "Prenesi CSV datoteko",
     "promotionalSubscriptionDesc": "Trenutno imate doživljenjsko promocijsko naročnino. Pišite na support@pangea.chat za pomoč pri spremembi vaše naročnine.",
     "originalSubscriptionPlatform": "Naročnina kupljena prek {purchasePlatform}",
     "oneWeekTrial": "Preizkus za en teden",
-    "downloadXLSXFile": "Prenesi Excel datoteko",
-    "unkDisplayName": "Neznano",
     "wwCountryDisplayName": "Po vsem svetu",
     "afCountryDisplayName": "Afganistan",
     "axCountryDisplayName": "Otočja Aland",
@@ -1601,7 +1496,6 @@
     "chatCapacityHasBeenChanged": "Kapaciteta klepeta je bila spremenjena",
     "chatCapacitySetTooLow": "Kapaciteta klepeta mora biti vsaj {count}.",
     "chatCapacityExplanation": "Kapaciteta klepeta omejuje število članov, ki so lahko v klepetu.",
-    "tooManyRequest": "Preveč zahtev, poskusite znova kasneje.",
     "enterNumber": "Vnesite celotno število.",
     "practice": "Vaja",
     "versionNotFound": "Različica ni najdena",
@@ -1611,7 +1505,6 @@
     "deleteSubscriptionWarningTitle": "Imate aktivno naročnino",
     "deleteSubscriptionWarningBody": "Brisanje vašega računa ne bo samodejno preklicalo vaše naročnine.",
     "manageSubscription": "Upravljanje naročnine",
-    "error520Title": "Poskusite znova.",
     "error520Desc": "Oprostite, nismo mogli razumeti vaše sporočilo...",
     "wordsUsed": "Uporabljene besede",
     "level": "Raven",
@@ -1629,7 +1522,6 @@
     "other": "Drugo",
     "levelShort": "RAV {level}",
     "noCapacityLimit": "Brez omejitve zmogljivosti",
-    "downloadGroupText": "Prenesi skupinsko besedilo",
     "notificationsOn": "Obvestila vključena",
     "notificationsOff": "Obvestila izključena",
     "joinWithCode": "Pridruži se s kodo",
@@ -1693,24 +1585,12 @@
     "whatIsTheMorphTag": "Kaj je {morphologicalFeature} od '{wordForm}'?",
     "dataAvailable": "Razpoložljivost podatkov",
     "available": "Na voljo",
-    "pangeaBotIsFallible": "Pangea Bot tudi dela napake!",
-    "whatIsMeaning": "Kaj pomeni '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Ujemajte pomene z besedami v sporočilu!",
-    "doubleClickToEdit": "Dvakrat kliknite za urejanje.",
-    "topicLabel": "Tema",
-    "topicPlaceholder": "Izberi temo...",
-    "modePlaceholder": "Izberi način...",
-    "learningObjectiveLabel": "Učni cilj",
-    "learningObjectivePlaceholder": "Izberi učni cilj...",
-    "targetLanguageLabel": "Ciljni jezik",
     "cefrLevelLabel": "Raven CEFR",
     "image": "Slika",
     "video": "Video",
     "nan": "Ni applicable",
-    "addVocabulary": "Dodaj besedišče",
     "instructions": "Navodila",
-    "numberOfLearners": "Število učencev",
-    "mustBeInteger": "Mora biti celo število, npr. 1, 2, 3, ...",
     "constructUsePvmDesc": "Ustvarjeno v zvočni sporočilu",
     "leaveSpaceDescription": "Če zapustite tečaj, boste zapustili vse klepete znotraj njega. Drugi uporabniki bodo videli, da ste zapustili tečaj.",
     "constructUseCorMmDesc": "Pravilno pomen sporočila",
@@ -1725,7 +1605,6 @@
     "ttsDisabledBody": "V nastavitvah učenja lahko omogočite pretvorbo besedila v govor",
     "noSpaceDescriptionYet": "Še ni ustvarjen opis tečaja.",
     "tooLargeToSend": "To sporočilo je preveliko za pošiljanje",
-    "exitWithoutSaving": "Ste prepričani, da želite zapustiti brez shranjevanja?",
     "enableAutocorrectPopupTitle": "Dodajte tipkovnico za ciljni jezik tako, da greste na:",
     "enableAutocorrectPopupSteps": "  • Nastavitve\n  • Splošno\n  • Tipkovnica\n  • Tipkovnice\n  • Dodaj novo tipkovnico",
     "enableAutocorrectPopupDescription": "Ko je jezik izbran, lahko kliknete na majhno ikono zemljevide na spodnjem levem delu tipkovnice, da aktivirate novo nameščeno tipkovnico.",
@@ -1736,11 +1615,8 @@
     "displayName": "Prikazno ime",
     "leaveRoomDescription": "Približujete se izstopu iz tega klepeta. Drugi uporabniki bodo videli, da ste zapustili klepet.",
     "confirmUserId": "Prosimo, potrdite svoje uporabniško ime Pangea Chata, da izbrišete svoj račun.",
-    "startingToday": "Začnite danes",
-    "oneWeekFreeTrial": "En teden brezplačne preizkušnje",
     "paidSubscriptionStarts": "Začne se {startDate}",
     "cancelInSubscriptionSettings": " • Prekliči kadarkoli v nastavitvah naročnine",
-    "cancelToAvoidCharges": " • Prekliči pred {trialEnds}, da se izognete stroškom",
     "downloadGboard": "Prenesi Gboard",
     "autocorrectNotAvailable": "Na žalost vaša platforma trenutno ni podprta za to funkcijo. Ostanite z nami za nadaljnji razvoj!",
     "pleaseUpdateApp": "Prosimo, posodobite aplikacijo za nadaljevanje.",
@@ -1750,17 +1626,12 @@
     "knockSpaceSuccess": "Zahtevali ste, da se pridružite temu tečaju! Administrator bo odgovoril na vašo zahtevo, ko jo bo prejel 😀",
     "chooseWordAudioInstructionsBody": "Poslušajte celotno sporočilo. Nato ujemajte zvočne posnetke z besedami.",
     "chooseMorphsInstructionsBody": "Kliknite na sestavljene dele za vprašanja o slovnici!",
-    "pleaseEnterInt": "Vnesite številko",
     "home": "Domov",
     "join": "Pridruži se",
     "resetInstructionTooltipsTitle": "Ponastavi nasvete za navodila",
     "resetInstructionTooltipsDesc": "Kliknite, da prikažete nasvete za navodila, kot za popolnega novega uporabnika.",
-    "randomize": "Naključno",
     "clear": "Počisti",
-    "featuredActivities": "Prikazano",
     "save": "Shrani",
-    "startChat": "Začni pogovor",
-    "translationProblem": "Težava pri prevajanju",
     "askToJoin": "Prosi za vstop",
     "emptyChatWarningTitle": "Pogovor je prazen",
     "emptyChatWarningDesc": "Niste povabili nikogar v svoj klepet. Pojdite na nastavitve klepeta, da povabite svoje stike ali bota. To lahko storite tudi kasneje.",
@@ -1790,17 +1661,13 @@
     "timesUsedIndependently": "Št. uporabe neodvisno",
     "timesUsedWithAssistance": "Št. uporabe z pomočjo",
     "shareInviteCode": "Deli kodo povabila: {code}",
-    "leaderboard": "Lestvica",
     "skipForNow": "Za zdaj preskoči",
     "permissions": "Dovoljenja",
     "spaceChildPermission": "Kdo lahko doda nove pogovore v ta tečaj",
-    "addEnvironmentOverride": "Dodaj prepis okolja",
     "defaultOption": "Privzeto",
     "deleteChatDesc": "Ali ste prepričani, da želite izbrisati ta pogovor? Izbrisal se bo za vse udeležence in vsi sporočili v pogovoru ne bodo več na voljo za prakso ali analitiko učenja.",
     "deleteSpaceDesc": "Tečaj in vsi izbrani pogovori bodo izbrisani za vse udeležence in vsi sporočili v pogovoru ne bodo več na voljo za prakso ali analitiko učenja. Ta dejanja ni mogoče razveljaviti.",
     "launch": "Zaženi",
-    "searchChats": "Išči klepete",
-    "maxFifty": "Največ 50",
     "configureSpace": "Konfiguriraj tečaj",
     "pinMessages": "Pripni sporočila",
     "setJoinRules": "Nastavi pravila za vstop",
@@ -1834,9 +1701,6 @@
     "failedToFetchTranscription": "Ni uspelo pridobiti prepis",
     "deleteEmptySpaceDesc": "Tečaj bo izbrisan za vse udeležence. Te dejanje ni mogoče razveljaviti.",
     "regenerate": "Ponovno ustvari",
-    "mySavedActivities": "Moje shranjene dejavnosti",
-    "noSavedActivities": "Ni shranjenih dejavnosti",
-    "saveActivity": "Shrani to dejavnost",
     "failedToPlayVideo": "Ne uspe prikazati videoposnetka",
     "done": "Dokončano",
     "inThisSpace": "V tem prostoru",
@@ -1847,13 +1711,9 @@
     "numInvited": "{count} povabljenih",
     "saved": "Shranjeno",
     "reset": "Ponastavi",
-    "errorFetchingActivitiesMessage": "Ne uspe pridobiti dejavnosti",
     "errorFetchingDefinition": "Ne uspe pridobiti definicije",
     "errorProcessAnalytics": "Ne uspe obdelati analitike",
     "errorDownloading": "Prenos ni uspel",
-    "errorLoadingSpaceChildren": "Ne uspe naložiti klepetov znotraj tega tečaja",
-    "unexpectedError": "Nepričakovana napaka.",
-    "pleaseReload": "Prosimo, osvežite stran in poskusite znova.",
     "translationError": "Napaka pri prevajanju",
     "check": "Preveri",
     "unableToFindRoom": "Ni najdenega klepeta ali tečaja s tem kodo. Poskusite znova.",
@@ -1862,19 +1722,14 @@
     "request": "Zahteva",
     "requestAll": "Zahtevaj vse",
     "confirmMessageUnpin": "Ste prepričani, da želite odpeti to sporočilo?",
-    "saveAndLaunch": "Shrani in zaženi",
-    "launchToSpace": "Zaženi v tečaj",
     "pending": "V obravnavi",
     "inactive": "Neaktivno",
-    "confirmRole": "Potrdi vlogo",
     "openRoleLabel": "ODPRTO",
     "finishedTheActivity": "🎯 {username} je zaključil to dejavnost",
     "activitySummaryError": "Povzetki dejavnosti niso na voljo",
     "requestSummaries": "Zahtevaj povzetke",
-    "generatingNewActivities": "Ste prvi uporabnik tega jezika! Prosim, vzemite si minuto, pripravljamo dejavnosti prav za vas.",
     "requestAccessTitle": "Zahtevaj dostop do analitike?",
     "requestAccessDesc": "Ali želite zaprositi za dostop do ogledanja analitike udeležencev?\n\nČe se udeleženci strinjajo, bodo skrbniki tega tečaja lahko videli:\n    • skupni slovar\n    • skupne gramatične koncepte\n    • število opravljenih dejavnosti\n    • specifične uporabljene gramatične koncepte, pravilno in nepravilno\n\nNe bodo mogli videti:\n    • sporočil v klepetih zunaj tečaja\n    • seznam slovarja",
-    "requestAccess": "Zahtevaj dostop ({count})",
     "analyticsInactiveTitle": "Zahtevki za neaktivne uporabnike niso bili poslani",
     "analyticsInactiveDesc": "Neaktivni uporabniki, ki se niso prijavili od uvedbe te funkcije, ne bodo videli vašega zahtevka.\n\nGumb Zaženi se bo pojavil, ko se vrnejo. Kasneje lahko ponovno pošljete zahtevo s klikom na gumb Zaženi pod njihovim imenom, ko bo na voljo.",
     "accessRequestedTitle": "Zahteva za dostop do analitike",
@@ -1897,8 +1752,6 @@
     "accessDesc": "Lahko naredite svoj tečaj odprt za svet! Ali pa, naredite svoj tečaj zaseben in varen.",
     "createGroupChatDesc": "Medtem ko se aktivnosti začnejo in končajo, bodo skupinski klepeti ostali odprti za rutinsko komunikacijo.",
     "deleteDesc": "Samo skrbniki lahko izbrišejo tečaj. To je uničujoča dejanje, ki odstrani vse uporabnike in izbriše vse izbrane klepete znotraj tečaja. Bodite previdni.",
-    "noCourseFound": "O, ta tečaj potrebuje načrt!\n\nNačrti tečaja so zaporedje tem in dejavnosti pogovorov.",
-    "additionalParticipants": "+ {num} drugih",
     "whatNow": "Kaj zdaj?",
     "chooseNextActivity": "Izberi svojo naslednjo dejavnost!",
     "letsGo": "Gremo",
@@ -1911,13 +1764,11 @@
     "waitNotDone": "Počakaj, še nisem končal!",
     "waitingForOthersToFinish": "Čakam, da ostali zaključijo...",
     "generatingSummary": "Analiziram klepet in ustvarjam rezultate",
-    "findCourse": "Najdi tečaj",
     "pingParticipantsNotification": "{user} išče uporabnike za sodelovanje v aktivnosti v {room}",
     "course": "Tečaj",
     "courses": "Tečaji",
     "goToCourse": "Pojdi na tečaj: {course}",
     "activityComplete": "Ta dejavnost je zaključena. Povzetek dejavnosti bi moral biti na voljo spodaj.",
-    "startNewSession": "Začni novo sejo",
     "joinOpenSession": "Pridruži se odprti seji",
     "activityNotFound": "Aktivnosti ni bilo mogoče najti",
     "myActivities": "Moje dejavnosti",
@@ -2134,14 +1985,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@createGroup": {
         "type": "String",
         "placeholders": {}
@@ -2226,18 +2069,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -2263,10 +2094,6 @@
         "placeholders": {}
     },
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2306,10 +2133,6 @@
             }
         }
     },
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@extremeOffensive": {
         "type": "String",
         "placeholders": {}
@@ -2342,15 +2165,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@chatDescriptionHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -2448,14 +2263,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "@noChatDescriptionYet": {
         "type": "String",
@@ -2573,14 +2380,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@dehydrate": {
         "type": "String",
         "placeholders": {}
@@ -2612,14 +2411,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@logout": {
         "type": "String",
@@ -2674,14 +2465,6 @@
         "placeholders": {}
     },
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2780,10 +2563,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addAccount": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@editBundlesForAccount": {
         "type": "String",
         "placeholders": {}
@@ -2797,10 +2576,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableMultiAccounts": {
         "type": "String",
         "placeholders": {}
     },
@@ -2848,10 +2623,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@people": {
         "type": "String",
         "placeholders": {}
@@ -2885,10 +2656,6 @@
         "placeholders": {}
     },
     "@pleaseEnter4Digits": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKey": {
         "type": "String",
         "placeholders": {}
     },
@@ -2991,10 +2758,6 @@
             }
         }
     },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unbanFromChat": {
         "type": "String",
         "placeholders": {}
@@ -3036,14 +2799,6 @@
         "placeholders": {}
     },
     "@security": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
         "type": "String",
         "placeholders": {}
     },
@@ -3147,10 +2902,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@setStatus": {
         "type": "String",
         "placeholders": {}
@@ -3188,14 +2939,6 @@
         "placeholders": {}
     },
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -3251,10 +2994,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@tryToSendAgain": {
         "type": "String",
         "placeholders": {}
@@ -3301,14 +3040,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -3387,14 +3118,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@visibleForAllParticipants": {
         "type": "String",
         "placeholders": {}
@@ -3431,19 +3154,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -3495,15 +3206,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3554,10 +3257,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3566,15 +3265,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3698,43 +3389,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3754,18 +3413,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
@@ -3779,10 +3426,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3805,22 +3448,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3875,10 +3502,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3962,31 +3585,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -4042,23 +3645,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4098,28 +3689,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4137,14 +3706,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4337,22 +3898,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4408,10 +3953,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4421,10 +3962,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4500,27 +4037,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4846,10 +4367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4859,10 +4376,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4950,14 +4463,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4974,10 +4479,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4990,15 +4491,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5150,14 +4643,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5171,14 +4656,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6401,10 +5878,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6445,10 +5918,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6521,10 +5990,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6794,47 +6259,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6854,19 +6279,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6930,10 +6343,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6974,14 +6383,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6993,14 +6394,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -7038,10 +6431,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7058,27 +6447,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7202,10 +6575,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7215,10 +6584,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7235,14 +6600,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7382,18 +6739,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7442,10 +6787,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7455,18 +6796,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7509,23 +6838,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7549,10 +6866,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7560,14 +6873,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7672,18 +6977,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7736,10 +7029,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7766,10 +7055,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7950,7 +7235,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Vrnite se jutri za posodobitve aktivnosti.",
-    "activityDropdownDesc": "Ko končate s to aktivnostjo, kliknite spodaj",
     "languageMismatchTitle": "Neujemanje jezika",
     "languageMismatchDesc": "Vaš ciljni jezik se ne ujema z jezikom te aktivnosti. Posodobiti ciljni jezik?",
     "reportWordIssueTooltip": "Prijavi težavo z informacijami o besedi",
@@ -7963,10 +7247,6 @@
     "selectAll": "Izberi vse",
     "deselectAll": "Prekliči izbor vseh",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8015,17 +7295,11 @@
         "placeholders": {}
     },
     "startOwn": "Začni svojo lastno",
-    "joinCourseDesc": "Vsak tečaj ima 8-10 zaporednih tem z vrsto dejavnosti za učenje jezika na podlagi nalog.",
     "newMessageInPangeaChat": "🗨️ Nova sporočilo v klepetu Pangea",
     "shareCourse": "Deli tečaj",
     "addCourse": "Dodaj tečaj",
-    "joinPublicCourse": "Pridruži se javnemu tečaju",
     "vocabLevelsDesc": "Tukaj bodo šle besede za besednjak, ko jih boste nadgradili!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8038,10 +7312,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8060,7 +7330,6 @@
     "emojiView": "Pogled emojijev",
     "feedbackDialogDesc": "Tudi jaz delam napake! Kaj lahko storim, da se izboljšam?",
     "contactHasBeenInvitedToTheCourse": "Kontakt je bil povabljen na tečaj",
-    "activityStatsButtonTooltip": "Informacije o dejavnosti",
     "allow": "Dovoli",
     "deny": "Zavrni",
     "enabledRenewal": "Omogoči obnavljanje naročnine",
@@ -8328,10 +7597,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9387,16 +8652,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Dejavnosti za odklepanje naslednje teme",
-    "activitiesToUnlockTopicDesc": "Določite število dejavnosti za odklepanje naslednje teme tečaja",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Pravilna praksa definicije besedi",
     "constructUseIncLMDesc": "Napačna praksa definicije besedi",
     "constructUseCorLADesc": "Pravilna praksa avdio besedi",
@@ -9404,7 +8659,6 @@
     "constructUseBonus": "Bonus med prakso besedi",
     "practiceVocab": "Vadite besedi",
     "selectMeaning": "Izberite pomen",
-    "selectAudio": "Izberite ustrezen avdio",
     "anotherRound": "Še en krog",
     "activitySettingsOverrideWarning": "Jezik in jezikovna raven sta določena z načrtom aktivnosti",
     "voice": "Glas",
@@ -9436,10 +8690,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9457,12 +8707,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Prenos je bil začet",
     "webDownloadPermissionMessage": "Če vaš brskalnik blokira prenose, prosimo, omogočite prenose za to spletno mesto.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9557,11 +8802,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Nekaj je šlo narobe in trdo delamo na tem, da to popravimo. Preverite znova kasneje.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Omogoči pomoč pri pisanju",
     "autoIGCToolDescription": "Samodejno zaženi orodja Pangea Chat za popravljanje poslanih sporočil v ciljni jezik.",
     "@autoIGCToolName": {
@@ -9617,24 +8857,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatika",
-    "spanTypeWordChoice": "Izbira besed",
     "spanTypeSpelling": "Pravopis",
     "spanTypePunctuation": "Interpunkcija",
     "spanTypeStyle": "Slog",
     "spanTypeFluency": "Sposobnost",
     "spanTypeAccents": "Naglaski",
     "spanTypeCapitalization": "Velike začetnice",
-    "spanTypeCorrection": "Popravek",
     "spanFeedbackTitle": "Poročilo o težavi s popravkom",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9659,10 +8888,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9675,13 +8900,7 @@
     "longPressToRecordVoiceMessage": "Dolgo pritisnite za snemanje glasovnega sporočila.",
     "pause": "Pavza",
     "resume": "Nadaljuj",
-    "newSubSpace": "Nov podprostor",
-    "moveToDifferentSpace": "Premakni se v drug prostor",
-    "removeFromSpaceDescription": "Klepet bo odstranjen iz prostora, vendar se bo še vedno prikazoval na vašem seznamu klepetov.",
     "countChats": "{chats} klepetov",
-    "spaceMemberOf": "Član prostora {spaces}",
-    "spaceMemberOfCanKnock": "Član prostora {spaces} lahko potrka",
-    "donate": "Doniraj",
     "startedAPoll": "{username} je začel anketo.",
     "poll": "Anketa",
     "startPoll": "Začni anketo",
@@ -9705,23 +8924,15 @@
     "newStickerPack": "Nov paket nalepk",
     "stickerPackName": "Ime paketa nalepk",
     "attribution": "Pripis",
-    "skipChatBackup": "Preskoči varnostno kopiranje klepeta",
-    "skipChatBackupWarning": "Ali ste prepričani? Brez omogočanja varnostnega kopiranja klepeta lahko izgubite dostop do svojih sporočil, če spremenite napravo.",
-    "loadingMessages": "Nalagam sporočila",
-    "setupChatBackup": "Nastavi varnostno kopiranje klepeta",
     "noMoreResultsFound": "Ni več najdenih rezultatov",
     "chatSearchedUntil": "Klepeta iskanega do {time}",
     "federationBaseUrl": "Osnovni URL federacije",
     "clientWellKnownInformation": "Informacije o stranki - dobro znane:",
     "baseUrl": "Osnovni URL",
     "identityServer": "Identitetni strežnik:",
-    "versionWithNumber": "Različica: {version}",
     "logs": "Dnevniki",
-    "advancedConfigs": "Napredne nastavitve",
     "advancedConfigurations": "Napredne konfiguracije",
-    "signInWithLabel": "Prijavite se z:",
     "selectAllWords": "Izberite vse besede, ki jih slišite v avdio posnetku",
-    "joinCourseForActivities": "Pridružite se tečaju, da preizkusite aktivnosti.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9758,18 +8969,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9777,26 +8976,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9902,22 +9081,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9946,19 +9109,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9966,15 +9117,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10175,11 +9318,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "V razredu? Tukaj vnesite svoj kodo za pridružitev.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Samodejno označevanje avdio sporočil",
     "selectAudioMessagesOnPlayDescription": "Samodejno označite avdio sporočila, ko se predvajajo",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10223,18 +9361,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Ta tečaj ima teme z manj kot {input} aktivnostmi. Prosimo, vnesite število, ki je manjše ali enako {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Kliknite tukaj, da se ponovno prijavite.",
     "@clickToLogin": {
@@ -10651,17 +9777,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Risani rumeni medved z dvignjenimi rokami v navdušenju.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Izberite besede, da se o njih naučite več",
     "requireAnalyticsAccessTitle": "Zahtevajte dostop do analitike za pridružitev",
     "requireAnalyticsAccessDesc": "Udeleženci morajo odobriti dostop do svojih učnih analitik, da se pridružijo temu tečaju",
     "analyticsAccessNoticeTitle": "Zahtevan dostop do analitike",
     "analyticsAccessNoticeDesc": "Z vstopom v ta tečaj se strinjate, da administratorjem omogočite dostop do vaših učnih analitik.",
-    "skipOnboardingClassCodeDesc": "Učite se neodvisno? Ne skrbite, lahko:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10679,10 +9799,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10711,7 +9827,6 @@
     "pickCefrLevelTeacherStepTitle": "Katero raven učite?",
     "pickCefrLevelStudentStepTitle": "Katero raven ste?",
     "customCourseStepTitle": "Izpolnite ta obrazec za prilagojen tečaj",
-    "aboutYourClass": "O vaši učni skupini",
     "courseCodeStepErrorMessage": "Prosimo, preverite svojo kodo in poskusite znova",
     "institution": "Ustanova",
     "courseGoals": "Cilji tečaja",
@@ -10754,10 +9869,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10874,12 +9985,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logo",
     "introChatDetails": "Pozdravite se! Predstavite se svojim soudeležencem tečaja, najdite prijatelje in klepetajte zunaj aktivnosti.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10923,11 +10029,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Dejavnosti",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Orodja za izgovor",
     "audioTranscription": "AI transkripcija zvoka",
     "visualLearnerSupport": "Podpora vizualnim učencem",
@@ -10968,7 +10069,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Pridružite se tečaju, ki vključuje to dejavnost, da jo igrate.",
     "resizeCoursePanel": "Spremeni velikost panela tečaja",
     "undo": "Razveljavi",
     "unlock": "Odkleni",
@@ -10982,7 +10082,6 @@
     "addCourseBrowsePublic": "Brskajte po javnih tečajih",
     "browsePublicCourses": "Brskajte po javnih tečajih",
     "editProfile": "Uredi profil",
-    "numObjectives": "{count} ciljev",
     "mapSearchHint": "Išči aktivnosti",
     "mapSearchNoResults": "Brez ujemanj v pogledu",
     "mapFilterAllLanguages": "Vsi jeziki",
@@ -10991,7 +10090,6 @@
     "mapFilterCompleted": "Dokončano",
     "mapFilterReset": "Ponastavi",
     "activityTypeConversation": "Pogovor",
-    "lockedMissionRequirement": "Dokončajte prejšnjo nalogo, da jo odklenete",
     "playAgain": "Igraj znova",
     "reviewActivity": "Pregled",
     "mapEmptyInView": "Tu ni ničesar na vaši ravni ali jeziku. Razširite svoje filtre ali poglejte od daleč.",
@@ -11006,14 +10104,9 @@
     "scrollToBottom": "Pomakni se na dno",
     "courseImage": "Slika tečaja",
     "avatarPreview": "Predogled avatarja",
-    "activityPhoto": "Fotografija aktivnosti",
     "emotePreview": "Predogled emojija: {name}",
     "activityLabel": "Dejavnost: {title}",
     "resetMapView": "Ponastavi pogled na zemljevid",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11066,14 +10159,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11103,10 +10188,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11163,10 +10244,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_sr.arb
+++ b/lib/l10n/intl_sr.arb
@@ -77,11 +77,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Да ли је гостима дозвољен приступ",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Сигурни сте?",
     "@areYouSure": {
         "type": "String",
@@ -344,11 +339,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Ваша резервна копија ћаскања је обезбеђена кључем. Немојте да га изгубите.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Детаљи ћаскања",
     "@chatDetails": {
         "type": "String",
@@ -458,11 +448,6 @@
     },
     "connect": "Повежи се",
     "@connect": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "Особа је позвана у групу",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -660,11 +645,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Шифровање више нећете моћи да искључите. Сигурни сте?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Шифровано",
     "@encrypted": {
         "type": "String",
@@ -691,11 +671,6 @@
     },
     "enterAnEmailAddress": "Унесите адресу е-поште",
     "@enterAnEmailAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "Све је спремно!",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -736,11 +711,6 @@
     },
     "group": "Група",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Група је јавна",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -834,15 +804,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Позови особу у групу {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Позван",
     "@invited": {
@@ -955,15 +916,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Учитај још {count} учесника",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Учитавам… Сачекајте.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -978,15 +930,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Пријава на {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Одјава",
     "@logout": {
@@ -1050,16 +993,6 @@
     },
     "noEmotesFound": "Нема емотија. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Шифровање се може активирати након што соба престане да буде јавно доступна.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Чини се да немате Гугл услуге на телефону. То је добра одлука за вашу приватност! Да би се протурале нотификације у FluffyChat, препоручујемо коришћење https://microg.org/ или https://unifiedpush.org/",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1169,11 +1102,6 @@
     },
     "passwordHasBeenChanged": "Лозинка је промењена",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Опоравак лозинке",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1317,11 +1245,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Уклони уређај",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Уклони изгнанство",
     "@unbanFromChat": {
@@ -1467,11 +1390,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Одреди ниво дозволе",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Постави статус",
     "@setStatus": {
         "type": "String",
@@ -1561,11 +1479,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Пренос са другог уређаја",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Покушај слање поново",
     "@tryToSendAgain": {
         "type": "String",
@@ -1621,15 +1534,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, other{непрочитаних ћаскања: {unreadCount}}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} и {count} корисника куцају…",
     "@userAndOthersAreTyping": {
@@ -1715,16 +1619,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Видео позив",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Одреди видљивост историје",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "видљиво свим учесницима",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1770,23 +1664,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "ко може шта да ради",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Ко може да се придружи групи",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Зашто желите ово да пријавите?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Да обришем резервну копију како би направио нови сигурносни кључ?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1863,7 +1742,6 @@
     "space": "Prostor",
     "spaces": "Prostori",
     "cantOpenUri": "Ne mogu da otvorim URI {uri}",
-    "yourChatBackupHasBeenSetUp": "Vaša sigurnosna kopija razgovora je postavljena.",
     "commandHint_markasdm": "Označi kao sobu za direktne poruke za dati Matrix ID",
     "commandHint_markasgroup": "Označi kao grupu",
     "commandHint_clearcache": "Očisti keš",
@@ -1874,20 +1752,14 @@
     "commandInvalid": "Nevažeća komanda",
     "commandMissing": "{command} nije komanda.",
     "checkList": "Lista za proveru",
-    "countInvited": "{count} pozvanih",
     "createGroup": "Kreiraj grupu",
-    "createNewSpace": "Novi prostor",
     "chatPermissions": "Dozvole za čet",
     "emoteKeyboardNoRecents": "Nedavno korišćeni emoti će se pojaviti ovde...",
-    "globalChatId": "ID globalnog četa",
-    "accessAndVisibility": "Pristup i vidljivost",
-    "accessAndVisibilityDescription": "Ko sme da se pridruži ovom četu i kako se čat može otkriti.",
     "calls": "Pozivi",
     "customEmojisAndStickers": "Prilagođeni emojiji i stikeri",
     "customEmojisAndStickersBody": "Dodajte ili delite prilagođene emojije ili stikere koji se mogu koristiti u bilo kojoj chat sobi.",
     "homeserver": "Kućni server",
     "errorObtainingLocation": "Greška pri dobijanju lokacije: {error}",
-    "chatDescription": "Opis četa",
     "chatDescriptionHasBeenChanged": "Opis četa je promenjen",
     "hideRedactedMessages": "Sakrij redigovane poruke",
     "hideRedactedMessagesBody": "Ako neko rediguje poruku, ta poruka više neće biti vidljiva u chatu.",
@@ -1913,32 +1785,25 @@
     "obtainingLocation": "Добијање локације…",
     "openVideoCamera": "Отворите камеру за видео",
     "oneClientLoggedOut": "Један од ваших клијената је одјављен",
-    "addAccount": "Додај налог",
     "editBundlesForAccount": "Уредите пакете за овај налог",
     "addToBundle": "Додај у пакет",
     "removeFromBundle": "Уклони из овог пакета",
     "bundleName": "Име пакета",
-    "enableMultiAccounts": "(BETA) Omogući više naloga na ovom uređaju",
     "openInMaps": "Otvori u mapama",
     "link": "Veza",
     "serverRequiresEmail": "Ovaj server mora da potvrdi vašu email adresu za registraciju.",
     "overview": "Pregled",
     "passwordRecoverySettings": "Podešavanja oporavka lozinke",
-    "pleaseEnterRecoveryKey": "Unesite vašu ključ za oporavak:",
     "redactedBy": "Uredio {username}",
     "directChat": "Direktni razgovor",
     "redactedByBecause": "Uredio {username} jer: \"{reason}\"",
     "saveFile": "Sačuvaj fajl",
-    "recoveryKey": "Ključ za oporavak",
-    "recoveryKeyLost": "Izgubljen ključ za oporavak?",
     "sendAsText": "Pošalji kao tekst",
     "sendImages": "Pošalji {count} sliku",
     "separateChatTypes": "Odvojeni Direktni razgovori i Grupe",
     "setChatDescription": "Поставите опис разговора",
     "shareLocation": "Дели локацију",
     "presencesToggle": "Прикажи статус поруке од других корисника",
-    "spaceIsPublic": "Место је јавно",
-    "spaceName": "Име простора",
     "synchronizingPleaseWait": "Синхронизујемо… Молимо сачекајте.",
     "synchronizingPleaseWaitCounter": " Синхронизујемо… ({percentage}%)",
     "unverified": "Непотврђено",
@@ -1947,9 +1812,7 @@
     "messageType": "Тип поруке",
     "sender": "Пошиљалац",
     "openGallery": "Отвори галерију",
-    "removeFromSpace": "Уклони из простора",
     "start": "Почетак",
-    "pleaseEnterRecoveryKeyDescription": "Да бисте откључали старе поруке, унесите свој кључ за опоравак који је генерисан у претходној сесији. Ваш кључ за опоравак НИЈЕ ваша лозинка.",
     "publish": "Објави",
     "openChat": "Отвори ћаскање",
     "markAsRead": "Обележи као прочитано",
@@ -1960,12 +1823,9 @@
     "confirmEventUnpin": "Да ли сте сигурни да желите трајно уклонити залепљену активност?",
     "emojis": "Емотикони",
     "placeCall": "Позови",
-    "voiceCall": "Гласовни позив",
     "unsupportedAndroidVersion": "Неподржана верзија Андроид-а",
     "unsupportedAndroidVersionLong": "Ова функција захтева новију верзију Андроид-а. Молимо проверите да ли постоје ажурирања или подршка за Lineage OS.",
-    "videoCallsBetaWarning": "Молимо имајте у виду да су видео позиви тренутно у бета верзији. Могућe да не раде како се очекује или уопште не раде на свим платформама.",
     "experimentalVideoCalls": "Експериментални видео позиви",
-    "emailOrUsername": "Емаил или корисничко име",
     "addWidget": "Dodaj vidžet",
     "widgetVideo": "Video",
     "widgetEtherpad": "Tekst beleška",
@@ -1987,35 +1847,19 @@
     "youKickedAndBanned": "🙅 Izašao si i zabranio {user}",
     "youUnbannedUser": "Otključali ste {user}",
     "hasKnocked": "🚪 {user} je pokucao",
-    "usersMustKnock": "Korisnici moraju da pokucaju",
-    "noOneCanJoin": "Niko ne može da se pridruži",
     "knock": "Kucaj",
     "users": "Korisnici",
-    "unlockOldMessages": "Otključaj stare poruke",
-    "storeInSecureStorageDescription": "Sačuvajte ključ za oporavak u sigurnoj memoriji ovog uređaja.",
-    "saveKeyManuallyDescription": "Ručno sačuvajte ovaj ključ pokretanjem dijaloga za deljenje sistema ili clipboarda.",
-    "storeInAndroidKeystore": "Sačuvaj u Android Keystore-u",
-    "storeInAppleKeyChain": "Sačuvaj u Apple KeyChain-u",
-    "storeSecurlyOnThisDevice": "Sigurno sačuvaj na ovom uređaju",
     "countFiles": "{count} fajlova",
     "user": "Korisnik",
     "custom": "Prilagođeno",
-    "foregroundServiceRunning": "Ova obaveštenje se pojavljuje kada je usluga u prvom planu aktivna.",
-    "screenSharingTitle": "deljenje ekrana",
-    "screenSharingDetail": "Delite da deliteš svoj ekran u FuffyChat-u",
     "whyIsThisMessageEncrypted": "Zašto je ova poruka nečitljiva?",
     "noKeyForThisMessage": "Ovo se može desiti ako je poruka poslata pre nego što ste se prijavili na svoj nalog na ovom uređaju.\n\nTakođe je moguće da je pošiljalac blokirao vaš uređaj ili je došlo do problema sa internet konekcijom.\n\nDa li možete da pročitate poruku na drugoj sesiji? Tada možete prebaciti poruku sa nje! Idite na Podešavanja > Uređaji i uverite se da su vaši uređaji verifikovani međusobno. Kada sledeći put otvorite sobu i obe sesije budu u prvom planu, ključevi će biti automatski preneti.\n\nNe želite da izgubite ključeve pri odjavi ili prebacivanju uređaja? Uverite se da ste omogućili bekap četa u podešavanjima.",
     "newGroup": "Nova grupa",
     "newSpace": "Novi prostor",
-    "enterSpace": "Uđi u prostor",
     "allSpaces": "Svi prostori",
     "hidePresences": "Sakrij listu statusa?",
     "doNotShowAgain": "Ne prikazuj ponovo",
     "wasDirectChatDisplayName": "Prazan čat (bio {oldDisplayName})",
-    "newSpaceDescription": "Prostori vam omogućavaju da objedinite svoje razgovore i izgradite privatne ili javne zajednice.",
-    "encryptThisChat": "Šifruj ovaj razgovor",
-    "disableEncryptionWarning": "Iz bezbednosnih razloga ne možete onemogućiti šifrovanje u razgovoru gde je ranije omogućeno.",
-    "sorryThatsNotPossible": "Izvinite... to nije moguće",
     "deviceKeys": "Ključevi uređaja:",
     "reopenChat": "Ponovo otvorite razgovor",
     "noBackupWarning": "Upozorenje! Bez omogućavanja sigurnosne kopije razgovora, izgubićete pristup svojim šifrovanim porukama. Toplo preporučujemo da prvo omogućite sigurnosnu kopiju razgovora pre odjavljivanja.",
@@ -2028,7 +1872,6 @@
     "openLinkInBrowser": "Otvori link u pretraživaču",
     "reportErrorDescription": "😞 Oh ne. Nešto je pošlo po zlu. Ako želite, možete prijaviti ovu grešku programerima.",
     "report": "prijavi",
-    "setTheme": "Postavi temu:",
     "setColorTheme": "Постави тему боја:",
     "invite": "Позови",
     "inviteGroupChat": "📨 Позови групни разговор",
@@ -2047,12 +1890,8 @@
     "yourGlobalUserIdIs": "Ваш глобални кориснички ID је: ",
     "noUsersFoundWithQuery": "Нажалост, није пронађен ниједан корисник са \"{query}\". Проверите да ли сте направили грешку у тастатури.",
     "knocking": "Куцање",
-    "chatCanBeDiscoveredViaSearchOnServer": "Разговор се може открити преко претраге на {server}",
-    "searchChatsRooms": "Pretraži #chatove, @korisnike...",
     "nothingFound": "Ništa nije pronađeno...",
     "groupName": "Ime grupe",
-    "createGroupAndInviteUsers": "Napravite grupu i pozovite korisnike",
-    "groupCanBeFoundViaSearch": "Grupu možete pronaći putem pretrage",
     "wrongRecoveryKey": "Izvinite... čini se da ovo nije tačan ključ za oporavak.",
     "startConversation": "Započni razgovor",
     "commandHint_sendraw": "Pošalji sirovi json",
@@ -2066,11 +1905,8 @@
     "pleaseChooseAStrongPassword": "Molimo odaberite jaku lozinku",
     "passwordsDoNotMatch": "Lozinke se ne poklapaju",
     "passwordIsWrong": "Uneta lozinka je pogrešna",
-    "publicChatAddresses": "Javne adrese za chat",
-    "createNewAddress": "Kreiraj novu adresu",
     "joinSpace": "Pridruži se prostoru",
     "publicSpaces": "Javni prostori",
-    "addChatOrSubSpace": "Dodaj chat ili podprostor",
     "subspace": "Podprostor",
     "decline": "Odbij",
     "thisDevice": "Ovaj uređaj:",
@@ -2079,15 +1915,11 @@
     "searchMore": "Pretraži više...",
     "gallery": "Galerija",
     "files": "Fajlovi",
-    "sessionLostBody": "Vaša sesija je izgubljena. Molimo vas da prijavite ovu grešku programerima na {url}. Poruka greške je: {error}",
-    "restoreSessionBody": "Aplikacija sada pokušava da povrati vašu sesiju iz rezervne kopije. Molimo vas da prijavite ovu grešku programerima na {url}. Poruka greške je: {error}",
     "sendReadReceipts": "Pošalji potvrde o čitanju",
     "sendTypingNotificationsDescription": "Drugi učesnici u chatu mogu videti kada kucate novu poruku.",
     "sendReadReceiptsDescription": "Други учесници у ћаскању могу видети када сте прочитали поруку.",
     "formattedMessages": "Форматоване поруке",
     "formattedMessagesDescription": "Прикажите богат садржај порука као што су наглашени текст користећи маркдаун.",
-    "verifyOtherUser": "🔐 Потврди другог корисника",
-    "verifyOtherUserDescription": "Ако потврдите другог корисника, можете бити сигурни да знате са ким заиста пишете. 💪\n\nКада започнете верификацију, ви и други корисник ћете видети попуп у апликацији. Тамо ћете затим видети серију емодзија или бројева које морате упоредити једни са другима.\n\nНајбољи начин за то је да се састанете или започнете видео позив. 👫",
     "verifyOtherDevice": "🔐 Потврди други уређај",
     "verifyOtherDeviceDescription": "Када потврдите други уређај, ти уређаји могу размењивати кључеве, што повећава вашу укупну безбедност. 💪 Када започнете верификацију, појавиће се попуп у апликацији на оба уређаја. Тамо ћете затим видети серију емодзија или бројева које морате упоредити. Најбоље је да имате оба уређаја при руци пре него што започнете верификацију. 🤳",
     "acceptedKeyVerification": "{sender} је прихватио верификацију кључа",
@@ -2123,10 +1955,6 @@
     "updateInstalled": "🎉 Ažuriranje {version} instalirano!",
     "changelog": "Izmena dnevnika",
     "sendCanceled": "Slanje otkazano",
-    "loginWithMatrixId": "Пријавите се помоћу Matrix-ID",
-    "discoverHomeservers": "Откријте домаћине сервера",
-    "whatIsAHomeserver": "Шта је домаћин сервер?",
-    "homeserverDescription": "Сви ваши подаци се чувају на домаћину сервера, као и код провајдера е-поште. Можете изабрати који домаћин сервера желите да користите, а и даље можете комуницирати са свима. Сазнајте више на https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Изгледа да није компатибилан домаћин сервера. Погрешан URL?",
     "calculatingFileSize": "Пресметање величине датотеке...",
     "prepareSendingAttachment": "Припрема слања прилога...",
@@ -2138,11 +1966,9 @@
     "oneOfYourDevicesIsNotVerified": "Једна од ваших уређаја није верификована",
     "noticeChatBackupDeviceVerification": "Напомена: Када повежете све своје уређаје на резервну копију ћаскања, они се аутоматски верификују.",
     "continueText": "Настави",
-    "welcomeText": "Здраво Здраво 👋 Ово је FluffyChat. Можете се пријавити на било који домаћин сервер, који је компатибилан са https://matrix.org. И онда ћаскајте са свима. То је огромна децентрализована мрежа за размену порука!",
     "blur": "Замагљивање:",
     "opacity": "Прозирност:",
     "setWallpaper": "Постави позадину",
-    "manageAccount": "Управљање налогом",
     "noContactInformationProvided": "Server ne pruža nikakve važeće kontakt informacije",
     "contactServerAdmin": "Kontaktirajte administratora servera",
     "contactServerSecurity": "Kontaktirajte sigurnost servera",
@@ -2161,11 +1987,8 @@
     "unableToJoinChat": "Nije moguće pridružiti se chatu. Možda je druga strana već zatvorila razgovor.",
     "previous": "Prethodno",
     "otherPartyNotLoggedIn": "Druga strana trenutno nije prijavljena i stoga ne može primati poruke!",
-    "appWantsToUseForLogin": "Koristi '{server}' za prijavu",
-    "appWantsToUseForLoginDescription": "Ovime dozvoljavate aplikaciji i veb sajtu da dele informacije o vama.",
     "open": "Otvoreno",
     "waitingForServer": "Čekanje na server...",
-    "appIntroduction": "FluffyChat vam omogućava da komunicirate sa prijateljima preko različitih menadžera poruka. Saznajte više na https://matrix.org ili jednostavno dodirnite *Nastavi*.",
     "newChatRequest": "📩 Nova zahtev za chat",
     "contentNotificationSettings": "Podešavanja obaveštenja sadržaja",
     "generalNotificationSettings": "Opšta podešavanja obaveštenja",
@@ -2240,11 +2063,9 @@
     "taTooltip": "L2 upotreba sa pomoć za prevod",
     "interactiveTranslatorSliderHeader": "Interaktivni prevodilac",
     "interactiveGrammarSliderHeader": "Interaktivni proveravač gramatike",
-    "interactiveTranslatorRequired": "Obavezno",
     "waTooltip": "Korišćenje L2 bez pomoći",
     "interactiveTranslator": "Pomoć pri prevođenju",
     "noIdenticalLanguages": "Molimo izaberite različite osnovne i ciljne jezike",
-    "searchBy": "Pretraži po zemlji i jezicima",
     "joinWithClassCode": "Присоединиться к курсу",
     "languageLevelPreA1": "Почетник Низак (Пре A1)",
     "languageLevelA1": "Почетник Средњи (A1)",
@@ -2265,19 +2086,14 @@
     "saveChanges": "Sačuvaj izmene",
     "publicProfileTitle": "Dozvoli da moj profil bude pronađen u pretrazi",
     "publicProfileDesc": "Uključivanjem, omogućavate drugim korisnicima da pronađu vaš profil u globalnoj traci za pretragu i pošalju zahteve za chat. U ovom trenutku, možete odabrati da li ćete prihvatiti ili odbiti zahtev.",
-    "errorDisableIT": "Pomoć pri prevođenju je isključena.",
-    "errorDisableIGC": "Pomoć u gramatici je isključena.",
     "errorDisableITUserDesc": "Kliknite ovde da biste ažurirali postavke pomoći u prevodu",
     "errorDisableIGCUserDesc": "Kliknite ovde da biste ažurirali postavke pomoći u gramatici",
     "errorDisableITClassDesc": "Pomoć u prevodu je isključena za kurs u kojem se nalazi ovaj chat.",
     "errorDisableIGCClassDesc": "Pomoć u gramatici je isključena za kurs u kojem se nalazi ovaj chat.",
-    "error405Title": "Jezici nisu postavljeni",
     "error405Desc": "Molimo vas da postavite svoje jezike u Glavnom meniju > Postavke učenja.",
     "termsAndConditions": "Uslovima i odredbama",
     "andCertifyIAmAtLeast13YearsOfAge": " i potvrđujem da imam najmanje 16 godina.",
-    "error502504Title": "Vau, mnogo je učenika online!",
     "error502504Desc": "Alati za prevod i gramatiku mogu biti spori ili nedostupni dok Pangea botovi ne stignu do trenutka.",
-    "error404Title": "Greška u prevodu!",
     "error404Desc": "Pangea Bot nije siguran kako da prevede to...",
     "errorPleaseRefresh": "Radimo na tome! Molimo vas da osvežite stranicu i pokušate ponovo.",
     "connectedToStaging": "Povezano sa Staging-om",
@@ -2315,13 +2131,9 @@
     "definitionsToolName": "Дефиниције речи",
     "definitionsToolDescription": "Када је омогућено, речи подвучене плавом бојом могу се кликнути за дефиниције. Кликните поруке за приступ дефиницијама.",
     "welcomeBack": "Добродошли назад! Ако сте били део пилот програма 2023-2024, контактирајте нас за вашу посебну пилот претплату. Ако сте наставник који је (или ваша институција је) купио лиценце за вашу класу, контактирајте нас за вашу наставничку претплату.",
-    "downloadTxtFile": "Преузми текстуалну датотеку",
-    "downloadCSVFile": "Преузми CSV датотеку",
     "promotionalSubscriptionDesc": "Тренутно имате трајну промотивну претплату. Пошаљите поруку support@pangea.chat за помоћ у променама ваше претплате.",
     "originalSubscriptionPlatform": "Претплата купљена преко {purchasePlatform}",
     "oneWeekTrial": "Пробни период од једне недеље",
-    "downloadXLSXFile": "Преузми Excel датотеку",
-    "unkDisplayName": "Nepoznato",
     "wwCountryDisplayName": "Celom svet",
     "afCountryDisplayName": "Avganistan",
     "axCountryDisplayName": "Olandski Ostrva",
@@ -2616,7 +2428,6 @@
     "chatCapacityHasBeenChanged": "Капацитет чета је промењен",
     "chatCapacitySetTooLow": "Капацитет чета мора бити најмање {count}.",
     "chatCapacityExplanation": "Капацитет чета ограничава број чланова који могу бити у чату.",
-    "tooManyRequest": "Превише захтева, покушајте поново касније.",
     "enterNumber": "Молимо унесите целобројну вредност.",
     "practice": "Vežbajte",
     "versionNotFound": "Verzija nije pronađena",
@@ -2626,7 +2437,6 @@
     "deleteSubscriptionWarningTitle": "Imate aktivnu pretplatu",
     "deleteSubscriptionWarningBody": "Brisanje vašeg naloga neće automatski otkazati vašu pretplatu.",
     "manageSubscription": "Upravljanje pretplatom",
-    "error520Title": "Молимо покушајте поново.",
     "error520Desc": "Извините, нисмо могли да разумемо вашу поруку...",
     "wordsUsed": "Коришћене речи",
     "level": "Ниво",
@@ -2644,7 +2454,6 @@
     "other": "Друго",
     "levelShort": "Ниво {level}",
     "noCapacityLimit": "Нема ограничења капацитета",
-    "downloadGroupText": "Преузми текст групе",
     "notificationsOn": "Обавештења укључена",
     "notificationsOff": "Обавештења искључена",
     "joinWithCode": "Придружите се са кодом",
@@ -2708,24 +2517,12 @@
     "whatIsTheMorphTag": "Šta je {morphologicalFeature} od '{wordForm}'?",
     "dataAvailable": "Dostupnost podataka",
     "available": "Dostupno",
-    "pangeaBotIsFallible": "Pangea Bot pravi greške takođe!",
-    "whatIsMeaning": "Šta znači '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Usklađuj značenja sa rečima u poruci!",
-    "doubleClickToEdit": "Dvoklik za uređivanje.",
-    "topicLabel": "Tema",
-    "topicPlaceholder": "Izaberi temu...",
-    "modePlaceholder": "Izaberi način...",
-    "learningObjectiveLabel": "Cilj učenja",
-    "learningObjectivePlaceholder": "Izaberi cilj učenja...",
-    "targetLanguageLabel": "Ciljni jezik",
     "cefrLevelLabel": "CEFR nivo",
     "image": "Слика",
     "video": "Видео",
     "nan": "Непримењиво",
-    "addVocabulary": "Додај речник",
     "instructions": "Упутства",
-    "numberOfLearners": "Број ученика",
-    "mustBeInteger": "Мора бити цео број нпр. 1, 2, 3, ...",
     "constructUsePvmDesc": "Произведено у гласовној поруци",
     "leaveSpaceDescription": "Напуштањем курса, напуштаћете све ћаскаонице у њему. Остали корисници ће видети да сте напустили курс.",
     "constructUseCorMmDesc": "Тачно значење поруке",
@@ -2740,7 +2537,6 @@
     "ttsDisabledBody": "Možete omogućiti tekst-u-izgovor u vašim postavkama učenja",
     "noSpaceDescriptionYet": "Još uvek nije kreiran opis kursa.",
     "tooLargeToSend": "Ova poruka je prevelika za slanje",
-    "exitWithoutSaving": "Da li ste sigurni da želite da izađete bez čuvanja?",
     "enableAutocorrectPopupTitle": "Dodajte tastaturu za ciljni jezik tako što ćete otići na:",
     "enableAutocorrectPopupSteps": "  • Podešavanja\n  • Opšte\n  • Tastatura\n  • Tastature\n  • Dodaj novu tastaturu",
     "enableAutocorrectPopupDescription": "Nakon što odaberete jezik, možete kliknuti na malu globus ikonu na donjem levom uglu vaše tastature da aktivirate novu tastaturu.",
@@ -2751,11 +2547,8 @@
     "displayName": "Prikazno ime",
     "leaveRoomDescription": "Upravo napuštate ovaj chat. Ostali korisnici će videti da ste napustili chat.",
     "confirmUserId": "Молимо вас да потврдите своје корисничко име на Pangea Chat-у како бисте избрисали свој налог.",
-    "startingToday": "Од данас",
-    "oneWeekFreeTrial": "Једнонедељна бесплатна проба",
     "paidSubscriptionStarts": "Почиње {startDate}",
     "cancelInSubscriptionSettings": "• Откажите у било ком тренутку у подешавањима претплате",
-    "cancelToAvoidCharges": "• Откажите пре {trialEnds} да бисте избегли наплату",
     "downloadGboard": "Преузми Gboard",
     "autocorrectNotAvailable": "Нажалост, ваша платформа тренутно није подржана за ову функцију. Останите у току за даљи развој!",
     "pleaseUpdateApp": "Молимо вас да ажурирате апликацију да бисте наставили.",
@@ -2765,17 +2558,12 @@
     "knockSpaceSuccess": "Затражили сте да се придружите овом курсу! Админ ће одговорити на ваш захтев када га прими 😄",
     "chooseWordAudioInstructionsBody": "Слушајте целу поруку. Затим ускладите аудио записе са речима.",
     "chooseMorphsInstructionsBody": "Кликните на делове загонетке за граматичка питања!",
-    "pleaseEnterInt": "Молимо унесите број",
     "home": "Почетна",
     "join": "Придружи се",
     "resetInstructionTooltipsTitle": "Ресетујте упутства",
     "resetInstructionTooltipsDesc": "Кликните да бисте приказали упутства као за потпуно новог корисника.",
-    "randomize": "Рандомизуј",
     "clear": "Обриши",
-    "featuredActivities": "Истакнуте",
     "save": "Сачувај",
-    "startChat": "Почни ћаскање",
-    "translationProblem": "Проблем са преводом",
     "askToJoin": "Питај да се придружиш",
     "emptyChatWarningTitle": "Ћаскање је празно",
     "emptyChatWarningDesc": "Нисте позвали никога у ваше ћаскање. Идите у подешавања ћаскања да бисте позвали своје контакте или бота. Ово можете урадити и касније.",
@@ -2805,17 +2593,13 @@
     "timesUsedIndependently": "Пута коришћено самостално",
     "timesUsedWithAssistance": "Пута коришћено уз помоћ",
     "shareInviteCode": "Подели код позива: {code}",
-    "leaderboard": "Табела резултата",
     "skipForNow": "Прескочи за сада",
     "permissions": "Дозволе",
     "spaceChildPermission": "Ко може додавати нове разговоре у овај курс",
-    "addEnvironmentOverride": "Додајте промену окружења",
     "defaultOption": "Подразумевано",
     "deleteChatDesc": "Да ли сте сигурни да желите да избришете овај разговор? Он ће бити избрисан за све учеснике, а све поруке унутар разговора више неће бити доступне за праксу или аналитике учења.",
     "deleteSpaceDesc": "Курс и било који изабрани разговори ће бити избрисани за све учеснике, а све поруке унутар разговора више неће бити доступне за праксу или аналитике учења. Ова акција се не може опозвати.",
     "launch": "Покрени",
-    "searchChats": "Тражи разговоре",
-    "maxFifty": "Максимум 50",
     "configureSpace": "Конфигуриши курс",
     "pinMessages": "Залепи поруке",
     "setJoinRules": "Постави правила придруживања",
@@ -2849,9 +2633,6 @@
     "failedToFetchTranscription": "Учитавање транскрипције није успело",
     "deleteEmptySpaceDesc": "Курс ће бити избрисан за све учеснике. Ова акција се не може опозвати.",
     "regenerate": "Поново генериши",
-    "mySavedActivities": "Моје сачуване активности",
-    "noSavedActivities": "Нема сачуваних активности",
-    "saveActivity": "Сачувај ову активност",
     "failedToPlayVideo": "Учитавање видеа није успело",
     "done": "Завршено",
     "inThisSpace": "У овом курсу",
@@ -2862,13 +2643,9 @@
     "numInvited": "{count} pozvan",
     "saved": "Sačuvano",
     "reset": "Resetuj",
-    "errorFetchingActivitiesMessage": "Neuspešno preuzimanje aktivnosti",
     "errorFetchingDefinition": "Neuspešno preuzimanje definicije",
     "errorProcessAnalytics": "Neuspešno procesiranje analitike",
     "errorDownloading": "Preuzimanje nije uspelo",
-    "errorLoadingSpaceChildren": "Neuspešno učitavanje razgovora unutar ovog kursa",
-    "unexpectedError": "Nepredviđena greška.",
-    "pleaseReload": "Molimo vas, osvežite i pokušajte ponovo.",
     "translationError": "Greška u prevodu",
     "check": "Proveri",
     "unableToFindRoom": "Nije pronađen ni razgovor ni kurs sa tim kodom. Molimo pokušajte ponovo.",
@@ -2877,19 +2654,14 @@
     "request": "Zahtev",
     "requestAll": "Zahtevaj sve",
     "confirmMessageUnpin": "Da li ste sigurni da želite da otpinjete ovu poruku?",
-    "saveAndLaunch": "Sačuvaj i pokreni",
-    "launchToSpace": "Pokreni u kursu",
     "pending": "Na čekanju",
     "inactive": "Neaktivno",
-    "confirmRole": "Potvrdi ulogu",
     "openRoleLabel": "OTVORENO",
     "finishedTheActivity": "🎯 {username} završio ovu aktivnost",
     "activitySummaryError": "Sažeci aktivnosti nisu dostupni",
     "requestSummaries": "Zatraži sažetke",
-    "generatingNewActivities": "Vi ste prvi korisnik ovog para jezika! Molimo vas da pričekate minut, pripremamo aktivnosti baš za vas.",
     "requestAccessTitle": "Zatraži pristup analitici?",
     "requestAccessDesc": "Želite li da zatražite pristup za pregled analitike učesnika?\n\nAko se učesnici slože, administratori ovog kursa će moći da vide:\n    • ukupni vokabular\n    • ukupne gramatičke koncepte\n    • ukupne sesije aktivnosti završene\n    • specifične gramatičke koncepte korišćene, tačno i netačno\n\nNeće moći da vide:\n    • poruke u čatovima izvan kursa\n    • listu vokabulara",
-    "requestAccess": "Zatraži pristup ({count})",
     "analyticsInactiveTitle": "Zahtevi za neaktivne korisnike nisu mogli biti poslati",
     "analyticsInactiveDesc": "Neaktivni korisnici koji se nisu prijavili od kada je ova funkcija uvedena neće videti vaš zahtev.\n\nDugme za zahtev će se pojaviti kada se vrate. Možete ponovo poslati zahtev kasnije klikom na dugme Zatraži pristup ispod njihovog imena kada bude dostupno.",
     "accessRequestedTitle": "Zahtev za pristup analitici",
@@ -2912,8 +2684,6 @@
     "accessDesc": "Možete učiniti svoj kurs otvorenim za sve! Ili, učiniti ga privatnim i sigurnim.",
     "createGroupChatDesc": "Dok sesije aktivnosti počinju i završavaju, grupni chatovi će ostati otvoreni za rutinsku komunikaciju.",
     "deleteDesc": "Samo administratori mogu obrisati kurs. Ovo je destruktivna radnja koja uklanja sve korisnike i briše sve odabrane chatove unutar kursa. Budite oprezni.",
-    "noCourseFound": "O, ovaj kurs zahteva plan!\n\nPlanovi kurseva su niz tema i aktivnosti razgovora.",
-    "additionalParticipants": "+ {num} drugih",
     "whatNow": "Шта сада?",
     "chooseNextActivity": "Изаберите следећу активност!",
     "letsGo": "Крећемо",
@@ -2926,13 +2696,11 @@
     "waitNotDone": "Čekaj, još nisam gotov!",
     "waitingForOthersToFinish": "Чекамо да остали заврше...",
     "generatingSummary": "Анализирање разговора и генерисање резултата",
-    "findCourse": "Пронађи курс",
     "pingParticipantsNotification": "{user} traži korisnike da se pridruže sesiji aktivnosti u {room}",
     "course": "Kurs",
     "courses": "Kursevi",
     "goToCourse": "Idi na kurs: {course}",
     "activityComplete": "Ova aktivnost je završena. Sažetak aktivnosti bi trebao biti dostupan ispod.",
-    "startNewSession": "Započni novu sesiju",
     "joinOpenSession": "Pridruži se otvorenoj sesiji",
     "activityNotFound": "Aktivnost nije pronađena",
     "myActivities": "Moje aktivnosti",
@@ -3136,10 +2904,6 @@
             }
         }
     },
-    "@yourChatBackupHasBeenSetUp": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@commandHint_markasdm": {
         "type": "String",
         "placeholders": {}
@@ -3184,19 +2948,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@createGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3205,18 +2957,6 @@
         "placeholders": {}
     },
     "@emoteKeyboardNoRecents": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3243,10 +2983,6 @@
                 "type": "String"
             }
         }
-    },
-    "@chatDescription": {
-        "type": "String",
-        "placeholders": {}
     },
     "@chatDescriptionHasBeenChanged": {
         "type": "String",
@@ -3355,10 +3091,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addAccount": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@editBundlesForAccount": {
         "type": "String",
         "placeholders": {}
@@ -3372,10 +3104,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableMultiAccounts": {
         "type": "String",
         "placeholders": {}
     },
@@ -3396,10 +3124,6 @@
         "placeholders": {}
     },
     "@passwordRecoverySettings": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKey": {
         "type": "String",
         "placeholders": {}
     },
@@ -3430,14 +3154,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@sendAsText": {
         "type": "String",
         "placeholders": {}
@@ -3463,14 +3179,6 @@
         "placeholders": {}
     },
     "@presencesToggle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -3510,15 +3218,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3569,10 +3269,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3581,15 +3277,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3713,43 +3401,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3769,18 +3425,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
@@ -3794,10 +3438,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3820,22 +3460,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3890,10 +3514,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3977,31 +3597,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -4057,23 +3657,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4113,28 +3701,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4152,14 +3718,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4352,22 +3910,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4423,10 +3965,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4436,10 +3974,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4515,27 +4049,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4853,10 +4371,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4866,10 +4380,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4957,14 +4467,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4981,10 +4483,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4997,15 +4495,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5157,14 +4647,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5178,14 +4660,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6408,10 +5882,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6452,10 +5922,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6528,10 +5994,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6801,47 +6263,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6861,19 +6283,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6937,10 +6347,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6981,14 +6387,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -7000,14 +6398,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -7045,10 +6435,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7065,27 +6451,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7209,10 +6579,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7222,10 +6588,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7242,14 +6604,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7389,18 +6743,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7449,10 +6791,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7462,18 +6800,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7516,23 +6842,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7556,10 +6870,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7567,14 +6877,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7679,18 +6981,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7743,10 +7033,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7773,10 +7059,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7957,7 +7239,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Погледајте сутра за ажурирања активности.",
-    "activityDropdownDesc": "Када завршите ову активност, кликните испод",
     "languageMismatchTitle": "Неслагање језика",
     "languageMismatchDesc": "Ваш циљани језик се не поклапа са језиком ове активности. Желите ли да ажурирате свој циљани језик?",
     "reportWordIssueTooltip": "Пријавите проблем са информацијама о речи",
@@ -7970,10 +7251,6 @@
     "selectAll": "Изабери све",
     "deselectAll": "Одмотај све",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8022,17 +7299,11 @@
         "placeholders": {}
     },
     "startOwn": "Pokreni sopstveni",
-    "joinCourseDesc": "Svaki kurs ima 8-10 sekvencijalnih tema sa nizom aktivnosti za učenje jezika zasnovanih na zadacima.",
     "newMessageInPangeaChat": "🗨️ Novi poruka u Pangea Četu",
     "shareCourse": "Podeli kurs",
     "addCourse": "Dodaj kurs",
-    "joinPublicCourse": "Pridruži se javnom kursu",
     "vocabLevelsDesc": "Ovde će ići reči vokabulara nakon što ih podignete na viši nivo!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8045,10 +7316,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8067,7 +7334,6 @@
     "emojiView": "Prikaz emojija",
     "feedbackDialogDesc": "I ja pravim greške! Ima li nešto što bi mi pomoglo da se poboljšam?",
     "contactHasBeenInvitedToTheCourse": "Kontakt je pozvan na kurs",
-    "activityStatsButtonTooltip": "Informacije o aktivnosti",
     "allow": "Dozvoli",
     "deny": "Odbij",
     "enabledRenewal": "Omogući obnavljanje pretplate",
@@ -8335,10 +7601,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9394,16 +8656,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktivnosti za otključavanje sledeće teme",
-    "activitiesToUnlockTopicDesc": "Postavite broj aktivnosti za otključavanje sledeće teme kursa",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Praktikovanje ispravne definicije reči",
     "constructUseIncLMDesc": "Praktikovanje pogrešne definicije reči",
     "constructUseCorLADesc": "Praktikovanje ispravnog audio sadržaja reči",
@@ -9411,7 +8663,6 @@
     "constructUseBonus": "Bonus tokom praktikovanja reči",
     "practiceVocab": "Vežbajte rečnik",
     "selectMeaning": "Izaberite značenje",
-    "selectAudio": "Izaberite odgovarajući audio",
     "anotherRound": "Još jedan krug",
     "activitySettingsOverrideWarning": "Jezik i nivo jezika određeni planom aktivnosti",
     "voice": "Glas",
@@ -9443,10 +8694,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9464,12 +8711,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Preuzimanje je pokrenuto",
     "webDownloadPermissionMessage": "Ako vaš pregledač blokira preuzimanja, molimo omogućite preuzimanja za ovu stranicu.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9564,11 +8806,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Nešto je pošlo po zlu, i mi marljivo radimo na rešenju. Proverite ponovo kasnije.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Omogući pomoć pri pisanju",
     "autoIGCToolDescription": "Automatski pokreni Pangea Chat alate za ispravljanje poslatih poruka na ciljni jezik.",
     "@autoIGCToolName": {
@@ -9624,24 +8861,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Gramatika",
-    "spanTypeWordChoice": "Izbor reči",
     "spanTypeSpelling": "Pravopis",
     "spanTypePunctuation": "Interpunkcija",
     "spanTypeStyle": "Stil",
     "spanTypeFluency": "Tečnost",
     "spanTypeAccents": "Akcenti",
     "spanTypeCapitalization": "Velika slova",
-    "spanTypeCorrection": "Ispravka",
     "spanFeedbackTitle": "Prijavi problem sa ispravkom",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9666,10 +8892,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9682,13 +8904,7 @@
     "longPressToRecordVoiceMessage": "Dugo pritisnite da snimite glasovnu poruku.",
     "pause": "Pauza",
     "resume": "Nastavi",
-    "newSubSpace": "Novi podprostor",
-    "moveToDifferentSpace": "Premesti u drugi prostor",
-    "removeFromSpaceDescription": "Razgovor će biti uklonjen iz prostora, ali će se i dalje pojavljivati u tvojoj listi razgovora.",
     "countChats": "{chats} razgovora",
-    "spaceMemberOf": "Član prostora {spaces}",
-    "spaceMemberOfCanKnock": "Član prostora {spaces} može da pokuca",
-    "donate": "Doniraj",
     "startedAPoll": "{username} je započeo anketu.",
     "poll": "Anketa",
     "startPoll": "Započni anketu",
@@ -9712,23 +8928,15 @@
     "newStickerPack": "Novi paket nalepnica",
     "stickerPackName": "Ime paketa nalepnica",
     "attribution": "Priznanje",
-    "skipChatBackup": "Preskoči rezervnu kopiju čata",
-    "skipChatBackupWarning": "Da li ste sigurni? Bez omogućavanja rezervne kopije čata možete izgubiti pristup svojim porukama ako promenite uređaj.",
-    "loadingMessages": "Učitavanje poruka",
-    "setupChatBackup": "Postavi rezervnu kopiju čata",
     "noMoreResultsFound": "Nema više pronađenih rezultata",
     "chatSearchedUntil": "Čat pretražen do {time}",
     "federationBaseUrl": "Osnovni URL federacije",
     "clientWellKnownInformation": "Informacije o klijentu:",
     "baseUrl": "Osnovni URL",
     "identityServer": "Identitet Server:",
-    "versionWithNumber": "Verzija: {version}",
     "logs": "Dnevnici",
-    "advancedConfigs": "Napredne konfiguracije",
     "advancedConfigurations": "Napredne konfiguracije",
-    "signInWithLabel": "Prijavite se sa:",
     "selectAllWords": "Izaberite sve reči koje čujete u audio zapisu",
-    "joinCourseForActivities": "Pridružite se kursu da biste isprobali aktivnosti.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9765,18 +8973,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9784,26 +8980,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9909,22 +9085,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9953,19 +9113,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9973,15 +9121,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10182,11 +9322,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "U razredu? Stavite svoj kod za pridruživanje ovde.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automatski istakni audio poruke",
     "selectAudioMessagesOnPlayDescription": "Automatski istakni audio poruke kada se reprodukuju",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10230,18 +9365,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Ovaj kurs ima teme sa manje od {input} aktivnosti. Molimo unesite broj manji ili jednak {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Kliknite ovde da se ponovo prijavite.",
     "@clickToLogin": {
@@ -10658,17 +9781,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Crtački žuti medved sa podignutim rukama u uzbuđenju.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Izaberite reči da biste saznali više o njima",
     "requireAnalyticsAccessTitle": "Zahteva se pristup analitici za pridruživanje",
     "requireAnalyticsAccessDesc": "Učesnici moraju odobriti pristup svojim analitikama učenja da bi se pridružili ovom kursu",
     "analyticsAccessNoticeTitle": "Zahteva se pristup analitici",
     "analyticsAccessNoticeDesc": "Pridruživanjem ovom kursu, slažete se da administratorima omogućite pristup vašim analitikama učenja.",
-    "skipOnboardingClassCodeDesc": "Učite samostalno? Ne brinite, možete:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10686,10 +9803,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10718,7 +9831,6 @@
     "pickCefrLevelTeacherStepTitle": "Koji nivo podučavate?",
     "pickCefrLevelStudentStepTitle": "Koji nivo ste?",
     "customCourseStepTitle": "Ispunite ovaj obrazac da dobijete prilagođeni kurs",
-    "aboutYourClass": "O vašoj klasi",
     "courseCodeStepErrorMessage": "Proverite svoj kod i pokušajte ponovo",
     "institution": "Institucija",
     "courseGoals": "Ciljevi kursa",
@@ -10761,10 +9873,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10881,12 +9989,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat логотип",
     "introChatDetails": "Реци здраво! Представи се својим колегама учесницима курса, пронађи пријатеље и ћаскај ван активности.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10930,11 +10033,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Akcije aktivnosti",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Alati za izgovor",
     "audioTranscription": "AI transkripcija zvuka",
     "visualLearnerSupport": "Podrška za vizuelne učenike",
@@ -10975,7 +10073,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Pridružite se kursu koji uključuje ovu aktivnost da biste je igrali.",
     "resizeCoursePanel": "Promenite veličinu panela kursa",
     "undo": "Poništi",
     "unlock": "Otključaj",
@@ -10989,7 +10086,6 @@
     "addCourseBrowsePublic": "Pretraži javne kurseve",
     "browsePublicCourses": "Pretraži javne kurseve",
     "editProfile": "Izmeni profil",
-    "numObjectives": "{count} ciljeva",
     "mapSearchHint": "Pretraži aktivnosti",
     "mapSearchNoResults": "Nema podudaranja u pregledu",
     "mapFilterAllLanguages": "Svi jezici",
@@ -10998,7 +10094,6 @@
     "mapFilterCompleted": "Završeno",
     "mapFilterReset": "Poništi",
     "activityTypeConversation": "Razgovor",
-    "lockedMissionRequirement": "Završite prethodnu misiju da biste otključali",
     "playAgain": "Igraj ponovo",
     "reviewActivity": "Pregled",
     "mapEmptyInView": "Nema ništa ovde na vašem nivou ili jeziku. Proširite svoje filtere ili zumirajte.",
@@ -11013,14 +10108,9 @@
     "scrollToBottom": "Pomeri na dno",
     "courseImage": "Slika kursa",
     "avatarPreview": "Pregled avatara",
-    "activityPhoto": "Fotografija aktivnosti",
     "emotePreview": "Pregled emota: {name}",
     "activityLabel": "Aktivnost: {title}",
     "resetMapView": "Resetuj prikaz mape",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11073,14 +10163,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11110,10 +10192,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11170,10 +10248,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_sv.arb
+++ b/lib/l10n/intl_sv.arb
@@ -72,11 +72,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Får gästanvändare gå med",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Är du säker?",
     "@areYouSure": {
         "type": "String",
@@ -352,11 +347,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Kontakten har blivit inbjuden till gruppen",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Innehållet har rapporterats till server-admins",
     "@contentHasBeenReported": {
         "type": "String",
@@ -541,11 +531,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Du kommer inte ha fortsatt möjlighet till att inaktivera krypteringen. Är du säker?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Krypterad",
     "@encrypted": {
         "type": "String",
@@ -607,11 +592,6 @@
     },
     "group": "Grupp",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Gruppen är publik",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -705,15 +685,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Bjud in kontakt till {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Inbjuden",
     "@invited": {
@@ -826,15 +797,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Ladda {count} mer deltagare",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Laddar... Var god vänta.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -849,15 +811,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Logga in till {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Logga ut",
     "@logout": {
@@ -921,11 +874,6 @@
     },
     "noEmotesFound": "Hittade inga dekaler. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "De ser ut som att du inte har google-tjänster på din telefon. Det är ett bra beslut för din integritet! För att få aviseringar i FluffyChat rekommenderar vi att använda https://microg.org/ eller https://unifiedpush.org/ .",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1025,11 +973,6 @@
     },
     "passwordHasBeenChanged": "Lösenordet har ändrats",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Återställ lösenord",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1153,11 +1096,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Ta bort enhet",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Ta bort chatt-blockering",
     "@unbanFromChat": {
@@ -1287,11 +1225,6 @@
                 "type": "String"
             }
         }
-    },
-    "setPermissionsLevel": "Ställ in behörighetsnivå",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
     },
     "setStatus": "Ställ in status",
     "@setStatus": {
@@ -1433,15 +1366,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "unreadChats": "{unreadCount, plural, =1{en oläst chatt} other{{unreadCount} olästa chattar}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "userAndOthersAreTyping": "{username} och {count} andra skriver…",
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -1521,16 +1445,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Videosamtal",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Chatt-historikens synlighet",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Synlig för alla deltagare",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1573,16 +1487,6 @@
     },
     "weSentYouAnEmail": "Vi skickade dig ett e-postmeddelande",
     "@weSentYouAnEmail": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoCanPerformWhichAction": "Vem kan utföra vilken åtgärd",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Vilka som är tilllåtna att ansluta till denna grupp",
-    "@whoIsAllowedToJoinThisGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1741,11 +1645,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "everythingReady": "Allt är klart!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "errorObtainingLocation": "Fel vid erhållande av plats: {error}",
     "@errorObtainingLocation": {
         "type": "String",
@@ -1757,11 +1656,6 @@
     },
     "editRoomAliases": "Redigera rum alias",
     "@editRoomAliases": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "createNewSpace": "Nytt utrymme",
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1814,11 +1708,6 @@
         "type": "String",
         "description": "Usage hint for the command /myroomnick"
     },
-    "noEncryptionForPublicRooms": "Du kan endast aktivera kryptering när rummet inte längre är publikt tillgängligt.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "noMatrixServer": "{server1} är inte en matrix server, använd {server2} istället?",
     "@noMatrixServer": {
         "type": "String",
@@ -1866,16 +1755,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceName": "Utrymmes namn",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Utrymme är publikt",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "showPassword": "Visa lösenord",
     "@showPassword": {
         "type": "String",
@@ -1920,23 +1799,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "wipeChatBackup": "Radera din chatt-backup för att skapa en ny återställningsnyckel?",
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "verified": "Verifierad",
     "@verified": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "transferFromAnotherDevice": "Överför till annan enhet",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "Din chatt backup är skyddad av en säkerhetsnyckel. Se till att du inte förlorar den.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -1959,8 +1823,6 @@
     "@homeserver": {},
     "oneClientLoggedOut": "En av dina klienter har loggats ut",
     "@oneClientLoggedOut": {},
-    "addAccount": "Lägg till konto",
-    "@addAccount": {},
     "editBundlesForAccount": "Lägg till paket för detta konto",
     "@editBundlesForAccount": {},
     "addToBundle": "Utöka paket",
@@ -1979,8 +1841,6 @@
     "@time": {},
     "sender": "Avsändare",
     "@sender": {},
-    "removeFromSpace": "Ta bort från utrymme",
-    "@removeFromSpace": {},
     "start": "Starta",
     "@start": {},
     "openGallery": "Öppna galleri",
@@ -2011,22 +1871,14 @@
     "@sendOnEnter": {},
     "scanQrCode": "Skanna QR-kod",
     "@scanQrCode": {},
-    "yourChatBackupHasBeenSetUp": "Din chatt-backup har konfigurerats.",
-    "@yourChatBackupHasBeenSetUp": {},
     "removeFromBundle": "Ta bort från paket",
     "@removeFromBundle": {},
-    "enableMultiAccounts": "(BETA) Aktivera multi-konton på denna enhet",
-    "@enableMultiAccounts": {},
     "emojis": "Uttryckssymboler",
     "@emojis": {},
     "placeCall": "Ring",
     "@placeCall": {},
-    "voiceCall": "Röstsamtal",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "Inget stöd för denna version av Android",
     "@unsupportedAndroidVersion": {},
-    "videoCallsBetaWarning": "Videosamtal är för närvarande under testning. De kanske inte fungerar som det är tänkt eller på alla plattformar.",
-    "@videoCallsBetaWarning": {},
     "unsupportedAndroidVersionLong": "Denna funktion kräver en senare version av Android.",
     "@unsupportedAndroidVersionLong": {},
     "dismiss": "Avfärda",
@@ -2049,8 +1901,6 @@
     "@confirmEventUnpin": {},
     "experimentalVideoCalls": "Experimentella videosamtal",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "Användarnamn eller e-postadress",
-    "@emailOrUsername": {},
     "addWidget": "Lägg till widget",
     "@addWidget": {},
     "widgetVideo": "Video",
@@ -2069,8 +1919,6 @@
     "@widgetJitsi": {},
     "widgetNameError": "Vänligen ange ett visningsnamn.",
     "@widgetNameError": {},
-    "storeSecurlyOnThisDevice": "Lagra säkert på denna enhet",
-    "@storeSecurlyOnThisDevice": {},
     "youJoinedTheChat": "Du gick med i chatten",
     "@youJoinedTheChat": {},
     "youAcceptedTheInvitation": "👍 Du accepterade inbjudan",
@@ -2094,8 +1942,6 @@
     },
     "commandHint_markasgroup": "Märk som grupp",
     "@commandHint_markasgroup": {},
-    "recoveryKeyLost": "Borttappad återställningsnyckel?",
-    "@recoveryKeyLost": {},
     "youHaveWithdrawnTheInvitationFor": "Du har återkallat inbjudan till {user}",
     "@youHaveWithdrawnTheInvitationFor": {
         "placeholders": {
@@ -2112,8 +1958,6 @@
             }
         }
     },
-    "unlockOldMessages": "Lås upp äldre meddelanden",
-    "@unlockOldMessages": {},
     "newSpace": "Nytt utrymme",
     "@newSpace": {},
     "googlyEyesContent": "{senderName} skickar dig googly ögon",
@@ -2129,25 +1973,15 @@
     "@dehydrate": {},
     "dehydrateWarning": "Denna åtgärd kan inte ångras. Försäkra dig om att backupen är i säkert förvar.",
     "@dehydrateWarning": {},
-    "recoveryKey": "Återställningsnyckel",
-    "@recoveryKey": {},
     "separateChatTypes": "Separata direktchattar och grupper",
     "@separateChatTypes": {
         "type": "String",
         "placeholders": {}
     },
-    "pleaseEnterRecoveryKeyDescription": "Ange din återställningsnyckel från en tidigare session för att låsa upp äldre meddelanden. Din återställningsnyckel är INTE ditt lösenord.",
-    "@pleaseEnterRecoveryKeyDescription": {},
-    "encryptThisChat": "Kryptera denna chatt",
-    "@encryptThisChat": {},
     "noBackupWarning": "Varning! Om du inte aktiverar säkerhetskopiering av chattar så tappar du åtkomst till krypterade meddelanden. Det är rekommenderat att du aktiverar säkerhetskopiering innan du loggar ut.",
     "@noBackupWarning": {},
     "noOtherDevicesFound": "Inga andra enheter hittades",
     "@noOtherDevicesFound": {},
-    "disableEncryptionWarning": "Av säkerhetsskäl kan du inte stänga av kryptering i en chatt där det tidigare aktiverats.",
-    "@disableEncryptionWarning": {},
-    "sorryThatsNotPossible": "Det där är inte möjligt",
-    "@sorryThatsNotPossible": {},
     "confirmMatrixId": "Bekräfta ditt Matrix-ID för att radera ditt konto.",
     "@confirmMatrixId": {},
     "supposedMxid": "Detta bör vara {mxid}",
@@ -2159,18 +1993,10 @@
             }
         }
     },
-    "pleaseEnterRecoveryKey": "Ange din återställningsnyckel:",
-    "@pleaseEnterRecoveryKey": {},
     "commandHint_markasdm": "Märk som rum för direktmeddelanden för det givante Matrix ID",
     "@commandHint_markasdm": {},
     "user": "Användare",
     "@user": {},
-    "storeInSecureStorageDescription": "Lagra återställningsnyckeln på säker plats på denna enhet.",
-    "@storeInSecureStorageDescription": {},
-    "storeInAppleKeyChain": "Lagra i Apples nyckelkedja (KeyChain)",
-    "@storeInAppleKeyChain": {},
-    "foregroundServiceRunning": "Denna avisering visas när förgrundstjänsten körs.",
-    "@foregroundServiceRunning": {},
     "custom": "Anpassad",
     "@custom": {},
     "countFiles": "{count} filer",
@@ -2181,16 +2007,12 @@
             }
         }
     },
-    "screenSharingTitle": "skärmdelning",
-    "@screenSharingTitle": {},
     "noKeyForThisMessage": "Detta kan hända om meddelandet skickades innan du loggade in på ditt konto i den här enheten.\n\nDet kan också vara så att avsändaren har blockerat din enhet eller att något gick fel med internetanslutningen.\n\nKan du läsa meddelandet i en annan session? I sådana fall kan du överföra meddelandet från den sessionen! Gå till Inställningar > Enhet och säkerställ att dina enheter har verifierat varandra. När du öppnar rummet nästa gång och båda sessionerna är i förgrunden, så kommer nycklarna att överföras automatiskt.\n\nVill du inte förlora nycklarna vid utloggning eller när du byter enhet? Säkerställ att du har aktiverat säkerhetskopiering för chatten i inställningarna.",
     "@noKeyForThisMessage": {},
     "fileIsTooBigForServer": "Servern informerar om att filen är för stor för att skickas.",
     "@fileIsTooBigForServer": {},
     "deviceKeys": "Enhetsnycklar:",
     "@deviceKeys": {},
-    "enterSpace": "Gå till utrymme",
-    "@enterSpace": {},
     "commandHint_googly": "Skicka några googly ögon",
     "@commandHint_googly": {},
     "commandHint_cuddle": "Skicka en omfamning",
@@ -2210,8 +2032,6 @@
     },
     "hydrate": "Återställ från säkerhetskopia",
     "@hydrate": {},
-    "screenSharingDetail": "Du delar din skärm i FluffyChat",
-    "@screenSharingDetail": {},
     "youRejectedTheInvitation": "Du avvisade inbjudan",
     "@youRejectedTheInvitation": {},
     "youBannedUser": "Du förbjöd {user}",
@@ -2246,10 +2066,6 @@
             }
         }
     },
-    "saveKeyManuallyDescription": "Spara nyckeln manuellt genom att aktivera dela-funktionen eller urklippshanteraren på enheten.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "Lagra i Androids nyckellagring (KeyStore)",
-    "@storeInAndroidKeystore": {},
     "whyIsThisMessageEncrypted": "Varför kan inte detta meddelande läsas?",
     "@whyIsThisMessageEncrypted": {},
     "newGroup": "Ny grupp",
@@ -2267,8 +2083,6 @@
             }
         }
     },
-    "newSpaceDescription": "Utrymmen möjliggör konsolidering av chattar och att bygga privata eller offentliga gemenskaper.",
-    "@newSpaceDescription": {},
     "reopenChat": "Återöppna chatt",
     "@reopenChat": {},
     "jumpToLastReadMessage": "Hoppa till det senast lästa meddelandet",
@@ -2298,8 +2112,6 @@
     "@unbanUserDescription": {},
     "messagesStyle": "Meddelanden:",
     "@messagesStyle": {},
-    "chatDescription": "Chattbeskrivning",
-    "@chatDescription": {},
     "pushNotificationsNotAvailable": "Aviseringar är inte tillgängligt",
     "@pushNotificationsNotAvailable": {},
     "invalidServerName": "Ogiltigt servernamn",
@@ -2393,8 +2205,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setTheme": "Välj tema:",
-    "@setTheme": {},
     "replace": "Ersätt",
     "@replace": {},
     "createGroup": "Skapa grupp",
@@ -2407,8 +2217,6 @@
     "@invite": {},
     "blockListDescription": "Du kan blockera användare som stör dig. Du kommer inte få några meddelanden eller rum-inbjudningar från användarna på din personliga blocklista.",
     "@blockListDescription": {},
-    "createGroupAndInviteUsers": "Skapa en grupp och bjud in användare",
-    "@createGroupAndInviteUsers": {},
     "initAppError": "Ett problem skedde när appen initierades",
     "@initAppError": {},
     "thisDevice": "Denna enhet:",
@@ -2423,8 +2231,6 @@
     "@passwordIsWrong": {},
     "pleaseEnterYourCurrentPassword": "Vänligen skriv ditt nuvarande lösenord",
     "@pleaseEnterYourCurrentPassword": {},
-    "groupCanBeFoundViaSearch": "Gruppen kan hittas genom sökning",
-    "@groupCanBeFoundViaSearch": {},
     "noUsersFoundWithQuery": "Tyvärr kunde ingen användare hittas med ”{query}”. Vänligen kontrollera om du gjort ett stavfel.",
     "@noUsersFoundWithQuery": {
         "type": "String",
@@ -2454,24 +2260,10 @@
     "@subspace": {},
     "select": "Ange val",
     "@select": {},
-    "sessionLostBody": "Din session är förlorad. Vänligen rapportera detta fel till utvecklarna här: {url}. Felmeddelandet är: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "pleaseChooseAStrongPassword": "Vänligen välj ett starkt lösenord",
     "@pleaseChooseAStrongPassword": {},
     "blockUsername": "Ignorera användarnamn",
     "@blockUsername": {},
-    "addChatOrSubSpace": "Lägg till chatt eller underutrymme",
-    "@addChatOrSubSpace": {},
     "groupName": "Gruppnamn",
     "@groupName": {},
     "leaveEmptyToClearStatus": "Lämna tom för att ta bort din status.",
@@ -2480,30 +2272,14 @@
     "@joinSpace": {},
     "searchForUsers": "Sök efter @användare…",
     "@searchForUsers": {},
-    "restoreSessionBody": "Appen försöker nu få tillbaks din session från backupen. Vänligen rapportera detta problem till utvecklarna här: {url}. Felmeddelandet är: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "databaseMigrationTitle": "Databasen är optimerad",
     "@databaseMigrationTitle": {},
-    "searchChatsRooms": "Sök efter #chattar, @användare…",
-    "@searchChatsRooms": {},
     "databaseMigrationBody": "Var vänlig vänta. Detta kan ta en stund.",
     "@databaseMigrationBody": {},
     "sendTypingNotificationsDescription": "Andra deltagare i en diskussion kan se när du skriver.",
     "@sendTypingNotificationsDescription": {},
     "formattedMessagesDescription": "Visa formaterat meddelandeinnehåll som fet stil med markdown.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Verifiera användaren",
-    "@verifyOtherUser": {},
     "formattedMessages": "Formaterade meddelanden",
     "@formattedMessages": {},
     "canceledKeyVerification": "{sender} avbröt nyckelverifieringen",
@@ -2566,8 +2342,6 @@
     },
     "incomingMessages": "Inkommande meddelanden",
     "@incomingMessages": {},
-    "verifyOtherUserDescription": "Om du verifierar en användare så kan du vara säker på vem du verkligen skriver till. 💪\n\nNär du påbörjar en verifiering så ser du och den andra användaren en popup-ruta i appen. I den rutan ser du ett antal tecken som du jämför med vad den andra användaren ser.\n\nDet bästa sättet att göra detta är att träffas fysiskt, eller genom att starta ett videosamtal. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDeviceDescription": "När du verifierar en enhet så kan era enheter utväxla nycklar, vilket förbättrar säkerheten. 💪 När du påbörjar en verifiering så ser du en popup-ruta på båda enheterna. I den rutan ser du ett antal tecken som du jämför med det som visas på den andra enheten. Det är bäst att ha båda enheterna till hands innan du påbörjar verifieringen. 🤳",
     "@verifyOtherDeviceDescription": {},
     "isReadyForKeyVerification": "{sender} är redo för nyckelverifiering",
@@ -2601,10 +2375,6 @@
     "space": "Plats",
     "spaces": "Platser",
     "checkList": "Checklista",
-    "countInvited": "{count} inbjudna",
-    "globalChatId": "Global chatt-ID",
-    "accessAndVisibility": "Åtkomst och synlighet",
-    "accessAndVisibilityDescription": "Vem som har tillstånd att delta i denna chatt och hur den kan upptäckas.",
     "calls": "Samtal",
     "customEmojisAndStickers": "Anpassade emojis och klistermärken",
     "customEmojisAndStickersBody": "Lägg till eller dela anpassade emojis eller klistermärken som kan användas i vilken som helst chatt.",
@@ -2616,13 +2386,8 @@
     "sendImages": "Skicka {count} bild",
     "synchronizingPleaseWaitCounter": "Synkroniserar… ({percentage}%)",
     "invitedBy": "📩 Inbjuden av {user}",
-    "usersMustKnock": "Användare måste knacka",
-    "noOneCanJoin": "Ingen kan gå med",
     "knock": "Knacka",
     "knocking": "Knackar",
-    "chatCanBeDiscoveredViaSearchOnServer": "Chat kan upptäckas via sökningen på {server}",
-    "publicChatAddresses": "Publika chattadresser",
-    "createNewAddress": "Skapa ny adress",
     "searchIn": "Sök i chatten \"{chat}\"...",
     "searchMore": "Sök mer...",
     "gallery": "Galleri",
@@ -2650,10 +2415,6 @@
     "updateInstalled": "🎉 Uppdatering {version} installerad!",
     "changelog": "Ändringslogg",
     "sendCanceled": "Skickandet avbrutet",
-    "loginWithMatrixId": "Logga in med Matrix-ID",
-    "discoverHomeservers": "Upptäck hemservrar",
-    "whatIsAHomeserver": "Vad är en hemserver?",
-    "homeserverDescription": "All din data lagras på hemservern, precis som en e-postleverantör. Du kan välja vilken hemserver du vill använda, samtidigt som du kan kommunicera med alla. Läs mer på https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Verkar inte vara en kompatibel hemserver. Fel URL?",
     "calculatingFileSize": "Beräknar filstorlek...",
     "prepareSendingAttachment": "Förbereder sändning av bilaga...",
@@ -2665,11 +2426,9 @@
     "oneOfYourDevicesIsNotVerified": "En av dina enheter är inte verifierad",
     "noticeChatBackupDeviceVerification": "Obs: När du ansluter alla dina enheter till chattbackupen verifieras de automatiskt.",
     "continueText": "Fortsätt",
-    "welcomeText": "Hej Hej 👋 Det här är FluffyChat. Du kan logga in på vilken hemserver som helst som är kompatibel med https://matrix.org. Och sedan chatta med vem som helst. Det är ett stort decentraliserat meddelandenätverk!",
     "blur": "Oskärpa:",
     "opacity": "Opacitet:",
     "setWallpaper": "Ställ in bakgrundsbild",
-    "manageAccount": "Hantera konto",
     "noContactInformationProvided": "Servern tillhandahåller ingen giltig kontaktinformation",
     "contactServerAdmin": "Kontakta serveradministratör",
     "contactServerSecurity": "Kontakta serverns säkerhet",
@@ -2688,11 +2447,8 @@
     "unableToJoinChat": "Kan inte gå med i chatten. Kanske har den andra parten redan avslutat samtalet.",
     "previous": "Föregående",
     "otherPartyNotLoggedIn": "Den andra parten är för närvarande inte inloggad och kan därför inte ta emot meddelanden!",
-    "appWantsToUseForLogin": "Använd '{server}' för att logga in",
-    "appWantsToUseForLoginDescription": "Du tillåter härmed appen och webbplatsen att dela information om dig.",
     "open": "Öppna",
     "waitingForServer": "Väntar på server...",
-    "appIntroduction": "FluffyChat låter dig chatta med dina vänner över olika meddelandetjänster. Läs mer på https://matrix.org eller tryck bara på *Fortsätt*.",
     "newChatRequest": "📩 Ny chattförfrågan",
     "contentNotificationSettings": "Inställningar för innehållsaviseringar",
     "generalNotificationSettings": "Allmänna aviseringar",
@@ -2767,11 +2523,9 @@
     "taTooltip": "L2 användning med översättningshjälp",
     "interactiveTranslatorSliderHeader": "Interaktiv översättare",
     "interactiveGrammarSliderHeader": "Interaktiv grammatikkontroll",
-    "interactiveTranslatorRequired": "Obligatorisk",
     "waTooltip": "L2 användning utan hjälp",
     "interactiveTranslator": "Översättningshjälp",
     "noIdenticalLanguages": "Vänligen välj olika grund- och målspråk",
-    "searchBy": "Sök efter land och språk",
     "joinWithClassCode": "Gå med i kurs",
     "languageLevelPreA1": "Novis Låg (Pre A1)",
     "languageLevelA1": "Novis Mid (A1)",
@@ -2792,19 +2546,14 @@
     "saveChanges": "Spara ändringar",
     "publicProfileTitle": "Låt andra hitta min profil i sökningen",
     "publicProfileDesc": "Genom att slå på detta kan andra användare hitta din profil i den globala sökfältet och skicka förfrågningar om att chatta. Då kan du välja att acceptera eller neka förfrågan.",
-    "errorDisableIT": "Översättningshjälp är avstängd.",
-    "errorDisableIGC": "Grammatikhjälp är avstängd.",
     "errorDisableITUserDesc": "Klicka här för att uppdatera inställningar för översättningshjälp",
     "errorDisableIGCUserDesc": "Klicka här för att uppdatera inställningar för grammatikhjälp",
     "errorDisableITClassDesc": "Översättningshjälp är avstängd för kursen som denna chatt tillhör.",
     "errorDisableIGCClassDesc": "Grammatikhjälp är avstängd för kursen som denna chatt tillhör.",
-    "error405Title": "Språk inte inställda",
     "error405Desc": "Vänligen ställ in dina språk i Huvudmeny > Inlärningsinställningar.",
     "termsAndConditions": "Villkor",
     "andCertifyIAmAtLeast13YearsOfAge": " och intygar att jag är minst 16 år gammal.",
-    "error502504Title": "Wow, det är många elever online!",
     "error502504Desc": "Översättnings- och grammatverktyg kan vara långsamma eller otillgängliga medan Pangea-botar hänger med.",
-    "error404Title": "Översättningsfel!",
     "error404Desc": "Pangea-boten är inte säker på hur den ska översätta det...",
     "errorPleaseRefresh": "Vi undersöker det! Vänligen ladda om och prova igen.",
     "connectedToStaging": "Ansluten till staging",
@@ -2842,13 +2591,9 @@
     "definitionsToolName": "Ordboksdefinitioner",
     "definitionsToolDescription": "När den är aktiverad kan ord understrukna i blått klickas för definitioner. Klicka på meddelanden för att få tillgång till definitioner.",
     "welcomeBack": "Välkommen tillbaka! Om du var en del av pilotprogrammet 2023-2024, kontakta oss för din specialpilotprenumeration. Om du är lärare som har (eller din institution har) köpt licenser för din klass, kontakta oss för din lärarprenumeration.",
-    "downloadTxtFile": "Ladda ner textfil",
-    "downloadCSVFile": "Ladda ner CSV-fil",
     "promotionalSubscriptionDesc": "Du har för närvarande ett livstidskampanjabonnemang. Skicka ett meddelande till support@pangea.chat för hjälp med att ändra ditt abonnemang.",
     "originalSubscriptionPlatform": "Abonnemang köpt via {purchasePlatform}",
     "oneWeekTrial": "En veckas provperiod",
-    "downloadXLSXFile": "Ladda ner Excel-fil",
-    "unkDisplayName": "Okänd",
     "wwCountryDisplayName": "Världen",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Ålandöarna",
@@ -3143,7 +2888,6 @@
     "chatCapacityHasBeenChanged": "Chattkapacitet ändrad",
     "chatCapacitySetTooLow": "Chattkapaciteten måste vara minst {count}.",
     "chatCapacityExplanation": "Chattkapacitet begränsar antalet medlemmar som får vara med i en chatt.",
-    "tooManyRequest": "För många förfrågningar, försök igen senare.",
     "enterNumber": "Vänligen ange ett heltal.",
     "practice": "Öva",
     "versionNotFound": "Version hittades inte",
@@ -3153,7 +2897,6 @@
     "deleteSubscriptionWarningTitle": "Du har ett aktivt abonnemang",
     "deleteSubscriptionWarningBody": "Att radera ditt konto kommer inte automatiskt att avbryta ditt abonnemang.",
     "manageSubscription": "Hantera abonnemang",
-    "error520Title": "Vänligen försök igen.",
     "error520Desc": "Tyvärr kunde vi inte förstå ditt meddelande...",
     "wordsUsed": "Använda ord",
     "level": "Nivå",
@@ -3171,7 +2914,6 @@
     "other": "Annat",
     "levelShort": "NIVÅ {level}",
     "noCapacityLimit": "Ingen kapacitetsgräns",
-    "downloadGroupText": "Ladda ner grupptext",
     "notificationsOn": "Aviseringar på",
     "notificationsOff": "Aviseringar av",
     "joinWithCode": "Gå med med kod",
@@ -3235,24 +2977,12 @@
     "whatIsTheMorphTag": "Vad är {morphologicalFeature} för '{wordForm}'?",
     "dataAvailable": "Data tillgänglig",
     "available": "Tillgänglig",
-    "pangeaBotIsFallible": "Pangea Bot gör också misstag!",
-    "whatIsMeaning": "Vad betyder '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Matcha betydelser med orden i meddelandet!",
-    "doubleClickToEdit": "Dubbelklicka för att redigera.",
-    "topicLabel": "Ämne",
-    "topicPlaceholder": "Välj ett ämne...",
-    "modePlaceholder": "Välj en lägen...",
-    "learningObjectiveLabel": "Lärandemål",
-    "learningObjectivePlaceholder": "Välj ett lärandemål...",
-    "targetLanguageLabel": "Mål språk",
     "cefrLevelLabel": "CEFR-nivå",
     "image": "Bild",
     "video": "Video",
     "nan": "Ej tillämpligt",
-    "addVocabulary": "Lägg till vokabulär",
     "instructions": "Instruktioner",
-    "numberOfLearners": "Antal elever",
-    "mustBeInteger": "Må vara ett heltal, t.ex. 1, 2, 3, ...",
     "constructUsePvmDesc": "Producerad i röstmeddelande",
     "leaveSpaceDescription": "Genom att lämna kursen kommer du att lämna alla chattar inom den. Andra användare kommer att se att du har lämnat kursen.",
     "constructUseCorMmDesc": "Korrekt meddelandebetydelse",
@@ -3267,7 +2997,6 @@
     "ttsDisabledBody": "Du kan aktivera text-till-tal i dina inlärningsinställningar",
     "noSpaceDescriptionYet": "Inget kursbeskrivning har skapats än.",
     "tooLargeToSend": "Detta meddelande är för stort för att skicka",
-    "exitWithoutSaving": "Är du säker på att du vill lämna utan att spara?",
     "enableAutocorrectPopupTitle": "Lägg till ditt tangentbord för målspråket genom att gå till:",
     "enableAutocorrectPopupSteps": "  • Inställningar\n  • Allmänt\n  • Tangentbord\n  • Tangentbord\n  • Lägg till nytt tangentbord",
     "enableAutocorrectPopupDescription": "När språket är valt kan du klicka på den lilla globikonen längst ner till vänster på ditt tangentbord för att aktivera det nyinstallerade tangentbordet.",
@@ -3278,11 +3007,8 @@
     "displayName": "Visningsnamn",
     "leaveRoomDescription": "Du är på väg att lämna denna chatt. Andra användare kommer att se att du har lämnat chatten.",
     "confirmUserId": "Vänligen bekräfta ditt Pangea Chat-användarnamn för att kunna radera ditt konto.",
-    "startingToday": "Från och med idag",
-    "oneWeekFreeTrial": "En veckas gratis provperiod",
     "paidSubscriptionStarts": "Startar {startDate}",
     "cancelInSubscriptionSettings": "• Avbryt när som helst i prenumerationsinställningarna",
-    "cancelToAvoidCharges": "• Avbryt innan {trialEnds} för att undvika avgifter",
     "downloadGboard": "Ladda ner Gboard",
     "autocorrectNotAvailable": "Tyvärr stöds inte din plattform för den här funktionen för tillfället. Håll utkik efter vidareutveckling!",
     "pleaseUpdateApp": "Uppdatera appen för att fortsätta.",
@@ -3292,17 +3018,12 @@
     "knockSpaceSuccess": "Du har begärt att gå med i den här kursen! En administratör kommer att svara på din förfrågan när de mottagit den 😄",
     "chooseWordAudioInstructionsBody": "Lyssna på hela meddelandet. Matcha sedan ljuden med orden.",
     "chooseMorphsInstructionsBody": "Klicka på pusselbitarna för grammatikfrågor!",
-    "pleaseEnterInt": "Vänligen ange ett nummer",
     "home": "Hem",
     "join": "Gå med",
     "resetInstructionTooltipsTitle": "Återställ instruktionstips",
     "resetInstructionTooltipsDesc": "Klicka för att visa instruktionstips som för en helt ny användare.",
-    "randomize": "Slumpa",
     "clear": "Rensa",
-    "featuredActivities": "Utvalda",
     "save": "Spara",
-    "startChat": "Starta en chatt",
-    "translationProblem": "Översättningsproblem",
     "askToJoin": "Be om att få gå med",
     "emptyChatWarningTitle": "Chatt är tom",
     "emptyChatWarningDesc": "Du har inte bjudit in någon till din chatt. Gå till Chattinställningar för att bjuda in dina kontakter eller Bot. Du kan också göra detta senare.",
@@ -3332,17 +3053,13 @@
     "timesUsedIndependently": "Användningstider självständigt",
     "timesUsedWithAssistance": "Användningstider med hjälp",
     "shareInviteCode": "Dela inbjudningskod: {code}",
-    "leaderboard": "Topplista",
     "skipForNow": "Hoppa över för tillfället",
     "permissions": "Behörigheter",
     "spaceChildPermission": "Vem kan lägga till nya chattar i denna kurs",
-    "addEnvironmentOverride": "Lägg till miljööverskridande",
     "defaultOption": "Standard",
     "deleteChatDesc": "Är du säker på att du vill radera denna chatt? Den kommer att raderas för alla deltagare och alla meddelanden i chatten kommer inte längre att vara tillgängliga för övning eller inlärningsanalys.",
     "deleteSpaceDesc": "Kursen och eventuella valda chattar kommer att raderas för alla deltagare och alla meddelanden i chatten kommer inte längre att vara tillgängliga för övning eller inlärningsanalys. Denna åtgärd kan inte ångras.",
     "launch": "Starta",
-    "searchChats": "Sök chattar",
-    "maxFifty": "Max 50",
     "configureSpace": "Konfigurera kurs",
     "pinMessages": "Fäst meddelanden",
     "setJoinRules": "Ställ in anslutningsregler",
@@ -3376,9 +3093,6 @@
     "failedToFetchTranscription": "Det gick inte att hämta transkriptionen",
     "deleteEmptySpaceDesc": "Kursen kommer att raderas för alla deltagare. Denna åtgärd kan inte ångras.",
     "regenerate": "Regenerera",
-    "mySavedActivities": "Mina sparade aktiviteter",
-    "noSavedActivities": "Inga sparade aktiviteter",
-    "saveActivity": "Spara denna aktivitet",
     "failedToPlayVideo": "Det gick inte att spela upp videon",
     "done": "Klart",
     "inThisSpace": "I denna kurs",
@@ -3389,13 +3103,9 @@
     "numInvited": "{count} inbjudna",
     "saved": "Sparad",
     "reset": "Återställ",
-    "errorFetchingActivitiesMessage": "Misslyckades med att hämta aktiviteter",
     "errorFetchingDefinition": "Misslyckades med att hämta definition",
     "errorProcessAnalytics": "Misslyckades med att bearbeta analysdata",
     "errorDownloading": "Nedladdning misslyckades",
-    "errorLoadingSpaceChildren": "Misslyckades med att ladda chattar inom denna kurs",
-    "unexpectedError": "Oväntat fel.",
-    "pleaseReload": "Vänligen ladda om och försök igen.",
     "translationError": "Översättningsfel",
     "check": "Kontrollera",
     "unableToFindRoom": "Ingen chatt eller kurs hittades med den koden. Vänligen försök igen.",
@@ -3404,19 +3114,14 @@
     "request": "Begäran",
     "requestAll": "Begär alla",
     "confirmMessageUnpin": "Är du säker på att du vill avfästa detta meddelande?",
-    "saveAndLaunch": "Spara och starta",
-    "launchToSpace": "Starta till kurs",
     "pending": "Väntar",
     "inactive": "Inaktiv",
-    "confirmRole": "Bekräfta roll",
     "openRoleLabel": "ÖPPEN",
     "finishedTheActivity": "🎯 {username} avslutade denna aktivitet",
     "activitySummaryError": "Sammanfattningar av aktivitet är otillgängliga",
     "requestSummaries": "Begär sammanfattningar",
-    "generatingNewActivities": "Du är den första användaren för detta språkpar! Ge oss en minut, vi förbereder aktiviteter speciellt för dig.",
     "requestAccessTitle": "Begär åtkomst till analys?",
     "requestAccessDesc": "Vill du begära tillgång för att se deltagaranalys?\n\nOm deltagarna samtycker, kommer administratörer av denna kurs att kunna se deras:\n    • totala ordförråd\n    • totala grammatikbegrepp\n    • totala genomförda aktivitetsessioner\n    • specifika grammatikbegrepp som används, korrekt och felaktigt\n\nDe kommer inte att kunna se deras:\n    • meddelanden i chattar utanför kursen\n    • ordförrådslista",
-    "requestAccess": "Begär tillgång ({count})",
     "analyticsInactiveTitle": "Förfrågningar till inaktiva användare kunde inte skickas",
     "analyticsInactiveDesc": "Inaktiva användare som inte har loggat in sedan denna funktion infördes kommer inte att se din förfrågan.\n\nKnappen Begär kommer att visas när de återvänder. Du kan skicka om förfrågan senare genom att klicka på knappen Begär under deras namn när den är tillgänglig.",
     "accessRequestedTitle": "Begäran om tillgång till analys",
@@ -3439,8 +3144,6 @@
     "accessDesc": "Du kan göra din kurs öppen för världen! Eller, gör din kurs privat och säker.",
     "createGroupChatDesc": "Medan aktivitetsessioner startar och slutar, förblir gruppchattar öppna för rutinkommunikation.",
     "deleteDesc": "Endast administratörer kan radera en kurs. Detta är en destruktiv åtgärd som tar bort alla användare och raderar alla valda chattar inom kursen. Fortsätt med försiktighet.",
-    "noCourseFound": "Åh, den här kursen behöver en plan!\n\nKursplaner är en sekvens av ämnen och samtalsaktiviteter.",
-    "additionalParticipants": "+ {num} andra",
     "whatNow": "Vad nu?",
     "chooseNextActivity": "Välj din nästa aktivitet!",
     "letsGo": "Låt oss åka",
@@ -3453,13 +3156,11 @@
     "waitNotDone": "Vänta, jag är inte klar!",
     "waitingForOthersToFinish": "Väntar på att resten ska bli klara...",
     "generatingSummary": "Analyserar chatten och genererar resultat",
-    "findCourse": "Hitta en kurs",
     "pingParticipantsNotification": "{user} letar efter användare att delta i aktivitetssessionen i {room}",
     "course": "Kurs",
     "courses": "Kurser",
     "goToCourse": "Gå till kurs: {course}",
     "activityComplete": "Den här aktiviteten är klar. Sammanfattningen av aktiviteten bör finnas nedanför.",
-    "startNewSession": "Starta ny session",
     "joinOpenSession": "Gå med i öppen session",
     "activityNotFound": "Aktivitet inte hittad",
     "myActivities": "Mina aktiviteter",
@@ -3571,26 +3272,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -3647,35 +3328,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@knocking": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
         "type": "String",
         "placeholders": {}
     },
@@ -3816,22 +3473,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -3887,10 +3528,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -3900,10 +3537,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -3979,27 +3612,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4317,10 +3934,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4330,10 +3943,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4421,14 +4030,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4445,10 +4046,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4461,15 +4058,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4621,14 +4210,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4642,14 +4223,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5872,10 +5445,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5916,10 +5485,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5992,10 +5557,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6265,47 +5826,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6325,19 +5846,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6401,10 +5910,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6445,14 +5950,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6464,14 +5961,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6509,10 +5998,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6529,27 +6014,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6673,10 +6142,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6686,10 +6151,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6706,14 +6167,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6853,18 +6306,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6913,10 +6354,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6926,18 +6363,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6980,23 +6405,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7020,10 +6433,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7031,14 +6440,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7143,18 +6544,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7207,10 +6596,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7237,10 +6622,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7421,7 +6802,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Kolla tillbaka imorgon för aktivitetsuppdateringar.",
-    "activityDropdownDesc": "När du är klar med denna aktivitet, klicka nedan",
     "languageMismatchTitle": "Språkmatchning saknas",
     "languageMismatchDesc": "Ditt målspråk matchar inte språket för denna aktivitet. Vill du uppdatera ditt målspråk?",
     "reportWordIssueTooltip": "Rapportera problem med ordinformation",
@@ -7434,10 +6814,6 @@
     "selectAll": "Välj alla",
     "deselectAll": "Avmarkera alla",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7486,17 +6862,11 @@
         "placeholders": {}
     },
     "startOwn": "Starta min egen",
-    "joinCourseDesc": "Varje kurs har 8-10 sekventiella ämnen med en rad uppgiftsbaserade språkinlärningsaktiviteter.",
     "newMessageInPangeaChat": "📩 Nytt meddelande i Pangea Chat",
     "shareCourse": "Dela kurs",
     "addCourse": "Lägg till en kurs",
-    "joinPublicCourse": "Gå med i offentlig kurs",
     "vocabLevelsDesc": "Det här är platsen där vokabulärord kommer att hamna när du har nivåer upp dem!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7509,10 +6879,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7531,7 +6897,6 @@
     "emojiView": "Emoji-vy",
     "feedbackDialogDesc": "Jag gör misstag också! Något för att hjälpa mig att förbättra?",
     "contactHasBeenInvitedToTheCourse": "Kontakten har blivit inbjuden till kursen",
-    "activityStatsButtonTooltip": "Aktivitetsinformation",
     "allow": "Tillåt",
     "deny": "Neka",
     "enabledRenewal": "Aktivera prenumerationsförnyelse",
@@ -7799,10 +7164,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8858,16 +8219,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Aktiviteter för att låsa upp nästa ämne",
-    "activitiesToUnlockTopicDesc": "Ange antalet aktiviteter för att låsa upp nästa kursämne",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Korrekt vokabulär definitionsövning",
     "constructUseIncLMDesc": "Inkorrekt vokabulär definitionsövning",
     "constructUseCorLADesc": "Korrekt vokabulär ljudövning",
@@ -8875,7 +8226,6 @@
     "constructUseBonus": "Bonus under vokabulärövning",
     "practiceVocab": "Öva vokabulär",
     "selectMeaning": "Välj betydelsen",
-    "selectAudio": "Välj den matchande ljudfilen",
     "anotherRound": "En runda till",
     "activitySettingsOverrideWarning": "Språk och språknivå bestäms av aktivitetsplanen",
     "voice": "Röst",
@@ -8907,10 +8257,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8928,12 +8274,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Nedladdning initierad",
     "webDownloadPermissionMessage": "Om din webbläsare blockerar nedladdningar, vänligen aktivera nedladdningar för den här sidan.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9028,11 +8369,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Något gick fel, och vi arbetar hårt för att åtgärda det. Kolla igen senare.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Aktivera skrivhjälp",
     "autoIGCToolDescription": "Kör automatiskt Pangea Chat-verktyg för att korrigera skickade meddelanden till målspråket.",
     "@autoIGCToolName": {
@@ -9088,24 +8424,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Grammatik",
-    "spanTypeWordChoice": "Orval",
     "spanTypeSpelling": "Stavning",
     "spanTypePunctuation": "Interpunktion",
     "spanTypeStyle": "Stil",
     "spanTypeFluency": "Flyt",
     "spanTypeAccents": "Accenter",
     "spanTypeCapitalization": "Versalisering",
-    "spanTypeCorrection": "Korrigering",
     "spanFeedbackTitle": "Rapportera korrigeringsproblem",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9130,10 +8455,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9146,13 +8467,7 @@
     "longPressToRecordVoiceMessage": "Tryck länge för att spela in röstmeddelande.",
     "pause": "Pausa",
     "resume": "Fortsätt",
-    "newSubSpace": "Nytt underområde",
-    "moveToDifferentSpace": "Flytta till ett annat område",
-    "removeFromSpaceDescription": "Chatten kommer att tas bort från rummet men kommer fortfarande att visas i din chattlista.",
     "countChats": "{chats} chattar",
-    "spaceMemberOf": "Rumsmedlem i {spaces}",
-    "spaceMemberOfCanKnock": "Rumsmedlem i {spaces} kan knacka",
-    "donate": "Donera",
     "startedAPoll": "{username} startade en omröstning.",
     "poll": "Omröstning",
     "startPoll": "Starta omröstning",
@@ -9176,23 +8491,15 @@
     "newStickerPack": "Nytt klistermärkespaket",
     "stickerPackName": "Namn på klistermärkespaket",
     "attribution": "Attribution",
-    "skipChatBackup": "Hoppa över chattbackup",
-    "skipChatBackupWarning": "Är du säker? Utan att aktivera chattbackup kan du förlora tillgången till dina meddelanden om du byter enhet.",
-    "loadingMessages": "Laddar meddelanden",
-    "setupChatBackup": "Ställ in chattbackup",
     "noMoreResultsFound": "Inga fler resultat hittades",
     "chatSearchedUntil": "Chatt sökt till {time}",
     "federationBaseUrl": "Federation Bas-URL",
     "clientWellKnownInformation": "Klient-Välkända Information:",
     "baseUrl": "Bas-URL",
     "identityServer": "Identitetsserver:",
-    "versionWithNumber": "Version: {version}",
     "logs": "Loggar",
-    "advancedConfigs": "Avancerade inställningar",
     "advancedConfigurations": "Avancerade konfigurationer",
-    "signInWithLabel": "Logga in med:",
     "selectAllWords": "Välj alla ord du hör i ljudet",
-    "joinCourseForActivities": "Gå med i en kurs för att prova aktiviteter.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9229,18 +8536,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9248,26 +8543,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9373,22 +8648,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9417,19 +8676,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9437,15 +8684,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9646,11 +8885,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "I en klass? Sätt in din anslutningskod här.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Automatiskt markera ljudmeddelanden",
     "selectAudioMessagesOnPlayDescription": "Automatiskt markera ljudmeddelanden när de spelas",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9694,18 +8928,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Denna kurs har ämnen med färre än {input} aktiviteter. Vänligen ange ett nummer som är mindre än eller lika med {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Klicka här för att logga in igen.",
     "@clickToLogin": {
@@ -10122,17 +9344,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "En tecknad gul björn med armarna uppsträckta i förtjusning.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Välj ord för att lära dig mer om dem",
     "requireAnalyticsAccessTitle": "Kräv analysåtkomst för att delta",
     "requireAnalyticsAccessDesc": "Deltagare måste ge åtkomst till sina lärandeanalyser för att delta i den här kursen",
     "analyticsAccessNoticeTitle": "Analysåtkomst krävs",
     "analyticsAccessNoticeDesc": "Genom att delta i den här kursen godkänner du att ge administratörer åtkomst till dina lärandeanalyser.",
-    "skipOnboardingClassCodeDesc": "Lär dig självständigt? Oroa dig inte, du kan:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10150,10 +9366,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10182,7 +9394,6 @@
     "pickCefrLevelTeacherStepTitle": "Vilken nivå undervisar du?",
     "pickCefrLevelStudentStepTitle": "Vilken nivå är du på?",
     "customCourseStepTitle": "Fyll i detta formulär för att få en anpassad kurs",
-    "aboutYourClass": "Om din klass",
     "courseCodeStepErrorMessage": "Vänligen kontrollera din kod och försök igen",
     "institution": "Institution",
     "courseGoals": "Kursmål",
@@ -10225,10 +9436,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10345,12 +9552,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat-logotyp",
     "introChatDetails": "Säg hej! Presentera dig för dina kurskamrater, hitta vänner och chatta utanför aktiviteter.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10394,11 +9596,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Aktivitetsåtgärder",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Uttalsverktyg",
     "audioTranscription": "AI ljudtranskription",
     "visualLearnerSupport": "Stöd för visuella inlärare",
@@ -10439,7 +9636,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Gå med i en kurs som inkluderar denna aktivitet för att spela den.",
     "resizeCoursePanel": "Ändra storlek på kurspanelen",
     "undo": "Ångra",
     "unlock": "Lås upp",
@@ -10453,7 +9649,6 @@
     "addCourseBrowsePublic": "Bläddra bland offentliga kurser",
     "browsePublicCourses": "Bläddra bland offentliga kurser",
     "editProfile": "Redigera profil",
-    "numObjectives": "{count} mål",
     "mapSearchHint": "Sök aktiviteter",
     "mapSearchNoResults": "Inga träffar i vyn",
     "mapFilterAllLanguages": "Alla språk",
@@ -10462,7 +9657,6 @@
     "mapFilterCompleted": "Avslutad",
     "mapFilterReset": "Återställ",
     "activityTypeConversation": "Konversation",
-    "lockedMissionRequirement": "Avsluta den föregående uppdraget för att låsa upp",
     "playAgain": "Spela igen",
     "reviewActivity": "Granska",
     "mapEmptyInView": "Ingenting här på din nivå eller språk. Bredare dina filter eller zooma ut.",
@@ -10477,14 +9671,9 @@
     "scrollToBottom": "Scrolla till botten",
     "courseImage": "Kursbild",
     "avatarPreview": "Avatarförhandsvisning",
-    "activityPhoto": "Aktivitetsfoto",
     "emotePreview": "Emoteförhandsvisning: {name}",
     "activityLabel": "Aktivitet: {title}",
     "resetMapView": "Återställ kartvyn",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10537,14 +9726,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10574,10 +9755,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10634,10 +9811,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_ta.arb
+++ b/lib/l10n/intl_ta.arb
@@ -26,17 +26,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "globalChatId": "உலகளாவிய அரட்டை ஐடி",
-    "@globalChatId": {},
-    "accessAndVisibility": "அணுகல் மற்றும் தெரிவுநிலை",
-    "@accessAndVisibility": {},
     "onlineKeyBackupEnabled": "நிகழ்நிலை விசை காப்புப்பிரதி இயக்கப்பட்டது",
     "@onlineKeyBackupEnabled": {
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKey": "மீட்பு விசை",
-    "@recoveryKey": {},
     "setStatus": "நிலையை அமைக்கவும்",
     "@setStatus": {
         "type": "String",
@@ -192,11 +186,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "குழுவிற்கு தொடர்பு அழைக்கப்பட்டுள்ளது",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "passphraseOrKey": "கடவுச்சொல் அல்லது மீட்பு விசை",
     "@passphraseOrKey": {
         "type": "String",
@@ -270,8 +259,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "voiceCall": "குரல் அழைப்பு",
-    "@voiceCall": {},
     "youKickedAndBanned": "🙅 நீங்கள் உதைத்து தடைசெய்துள்ளீர்கள் {user}",
     "@youKickedAndBanned": {
         "placeholders": {
@@ -288,8 +275,6 @@
             }
         }
     },
-    "storeInAppleKeyChain": "ஆப்பிள் கீச்சினில் சேமிக்கவும்",
-    "@storeInAppleKeyChain": {},
     "searchForUsers": "@Users ஐத் தேடுங்கள் ...",
     "@searchForUsers": {},
     "pleaseEnterYourCurrentPassword": "உங்கள் தற்போதைய கடவுச்சொல்லை உள்ளிடவும்",
@@ -411,11 +396,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "createNewSpace": "புதிய இடம்",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "synchronizingPleaseWait": "ஒத்திசைத்தல்… தயவுசெய்து காத்திருங்கள்.",
     "@synchronizingPleaseWait": {
         "type": "String",
@@ -433,22 +413,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "unreadChats": "{unreadCount, plural, =1{1 unread chat} other{{unreadCount} unread chats}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "verifyTitle": "பிற கணக்கை சரிபார்க்கிறது",
     "@verifyTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "videoCall": "வீடியோ அழைப்பு",
-    "@videoCall": {
         "type": "String",
         "placeholders": {}
     },
@@ -545,8 +511,6 @@
     },
     "sendOnEnter": "Enter ஐ அனுப்பவும்",
     "@sendOnEnter": {},
-    "pleaseEnterRecoveryKey": "உங்கள் மீட்பு விசையை உள்ளிடவும்:",
-    "@pleaseEnterRecoveryKey": {},
     "dehydrate": "ஏற்றுமதி அமர்வு மற்றும் சாதனத்தை துடைக்கவும்",
     "@dehydrate": {},
     "ok": "சரி",
@@ -605,27 +569,13 @@
     },
     "bundleName": "மூட்டை பெயர்",
     "@bundleName": {},
-    "enableMultiAccounts": "(பீட்டா) இந்த சாதனத்தில் பல கணக்குகளை இயக்கவும்",
-    "@enableMultiAccounts": {},
     "remove": "அகற்று",
     "@remove": {
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKeyLost": "மீட்பு விசை இழந்ததா?",
-    "@recoveryKeyLost": {},
     "sendAMessage": "ஒரு செய்தியை அனுப்பவும்",
     "@sendAMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "இடம் பொது",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "transferFromAnotherDevice": "மற்றொரு சாதனத்திலிருந்து மாற்றவும்",
-    "@transferFromAnotherDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -692,8 +642,6 @@
     "@widgetEtherpad": {},
     "widgetCustom": "தனிப்பயன்",
     "@widgetCustom": {},
-    "unlockOldMessages": "பழைய செய்திகளைத் திறக்கவும்",
-    "@unlockOldMessages": {},
     "serverLimitReached": "சேவையக வரம்பு அடைந்தது! {seconds} விநாடிகள் காத்திருக்கிறது ...",
     "@serverLimitReached": {
         "type": "integer",
@@ -811,10 +759,6 @@
     },
     "errorAddingWidget": "விட்செட்டைச் சேர்ப்பதில் பிழை.",
     "@errorAddingWidget": {},
-    "storeSecurlyOnThisDevice": "இந்த சாதனத்தில் பாதுகாப்பாக சேமிக்கவும்",
-    "@storeSecurlyOnThisDevice": {},
-    "screenSharingTitle": "திரை பகிர்வு",
-    "@screenSharingTitle": {},
     "newGroup": "புதிய குழு",
     "@newGroup": {},
     "noOtherDevicesFound": "வேறு சாதனங்கள் எதுவும் கிடைக்கவில்லை",
@@ -830,11 +774,6 @@
     },
     "askSSSSSign": "மற்ற நபரில் கையெழுத்திட, தயவுசெய்து உங்கள் பாதுகாப்பான கடை பாச்ஃபிரேச் அல்லது மீட்பு விசையை உள்ளிடவும்.",
     "@askSSSSSign": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "areGuestsAllowedToJoin": "விருந்தினர் பயனர்கள் சேர அனுமதிக்கப்படுகிறார்களா",
-    "@areGuestsAllowedToJoin": {
         "type": "String",
         "placeholders": {}
     },
@@ -912,22 +851,10 @@
     "@sendingAttachment": {},
     "continueText": "தொடரவும்",
     "@continueText": {},
-    "welcomeText": "ஏய் ஏய் 👋 இது பஞ்சுபோன்றது. Https://matrix.org உடன் இணக்கமான எந்த ஓம்சர்வரில் நீங்கள் உள்நுழையலாம். பின்னர் யாருடனும் அரட்டையடிக்கவும். இது ஒரு பெரிய பரவலாக்கப்பட்ட செய்தியிடல் நெட்வொர்க்!",
-    "@welcomeText": {},
     "name": "பெயர்",
     "@name": {},
     "username": "பயனர்பெயர்",
     "@username": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoCanPerformWhichAction": "எந்த செயலைச் செய்ய முடியும்",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "இந்த குழுவில் சேர யார் அனுமதிக்கப்படுகிறார்கள்",
-    "@whoIsAllowedToJoinThisGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -967,18 +894,10 @@
     },
     "placeCall": "அழைப்பு இடு",
     "@placeCall": {},
-    "videoCallsBetaWarning": "வீடியோ அழைப்புகள் தற்போது பீட்டாவில் உள்ளன என்பதை நினைவில் கொள்க. அவர்கள் எதிர்பார்த்தபடி வேலை செய்யக்கூடாது அல்லது எல்லா தளங்களிலும் வேலை செய்யக்கூடாது.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "சோதனை வீடியோ அழைப்புகள்",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "மின்னஞ்சல் அல்லது பயனர்பெயர்",
-    "@emailOrUsername": {},
-    "noOneCanJoin": "யாரும் சேர முடியாது",
-    "@noOneCanJoin": {},
     "newSpace": "புதிய இடம்",
     "@newSpace": {},
-    "enterSpace": "இடத்தை உள்ளிடவும்",
-    "@enterSpace": {},
     "wasDirectChatDisplayName": "வெற்று அரட்டை ({oldDisplayName})",
     "@wasDirectChatDisplayName": {
         "type": "String",
@@ -992,8 +911,6 @@
     "@openLinkInBrowser": {},
     "reportErrorDescription": "😭 ஓ இல்லை. ஏதோ தவறு நடந்தது. நீங்கள் விரும்பினால், இந்த பிழையை டெவலப்பர்களிடம் புகாரளிக்கலாம்.",
     "@reportErrorDescription": {},
-    "setTheme": "கருப்பொருள் அமைக்கவும்:",
-    "@setTheme": {},
     "invite": "அழைக்கவும்",
     "@invite": {},
     "wrongPinEntered": "தவறான முள் நுழைந்தது! {seconds} விநாடிகளில் மீண்டும் முயற்சிக்கவும் ...",
@@ -1011,15 +928,6 @@
     "@kickUserDescription": {},
     "learnMore": "மேலும் அறிக",
     "@learnMore": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "{server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "knockRestricted": "நாக் தடை",
     "@knockRestricted": {},
     "bannedUser": "{username} தடைசெய்யப்பட்ட {targetName}",
@@ -1220,15 +1128,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "ஏற்றவும் {count} மேலும் பங்கேற்பாளர்கள்",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "dehydrateWarning": "இந்த செயலை செயல்தவிர்க்க முடியாது. காப்புப்பிரதி கோப்பை பாதுகாப்பாக சேமித்து வைக்கவும்.",
     "@dehydrateWarning": {},
     "loadMore": "மேலும் ஏற்றவும்…",
@@ -1250,11 +1149,6 @@
     },
     "newMessageInFluffyChat": "Fuf பஞ்சுபோன்ற புதிய செய்தி",
     "@newMessageInFluffyChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "அறை இனி பகிரங்கமாக அணுக முடியாதவுடன் மட்டுமே நீங்கள் குறியாக்கத்தை செயல்படுத்த முடியும்.",
-    "@noEncryptionForPublicRooms": {
         "type": "String",
         "placeholders": {}
     },
@@ -1304,8 +1198,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "addAccount": "கணக்கைச் சேர்க்கவும்",
-    "@addAccount": {},
     "openInMaps": "வரைபடங்களில் திறந்திருக்கும்",
     "@openInMaps": {
         "type": "String",
@@ -1382,11 +1274,6 @@
             }
         }
     },
-    "setPermissionsLevel": "இசைவு அளவை அமைக்கவும்",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "settings": "அமைப்புகள்",
     "@settings": {
         "type": "String",
@@ -1454,8 +1341,6 @@
     "@messageType": {},
     "databaseMigrationTitle": "தரவுத்தளம் உகந்ததாக உள்ளது",
     "@databaseMigrationTitle": {},
-    "usersMustKnock": "பயனர்கள் தட்ட வேண்டும்",
-    "@usersMustKnock": {},
     "allSpaces": "அனைத்து இடங்களும்",
     "@allSpaces": {},
     "importFromZipFile": ".Zip கோப்பிலிருந்து இறக்குமதி செய்யுங்கள்",
@@ -1626,13 +1511,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "உங்கள் அரட்டை காப்புப்பிரதி அமைக்கப்பட்டுள்ளது.",
-    "@yourChatBackupHasBeenSetUp": {},
-    "chatBackupDescription": "உங்கள் பழைய செய்திகள் மீட்பு விசையுடன் பாதுகாக்கப்படுகின்றன. நீங்கள் அதை இழக்கவில்லை என்பதை உறுதிப்படுத்திக் கொள்ளுங்கள்.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "commandHint_markasdm": "கொடுக்கப்பட்ட மேட்ரிக்சிற்கான நேரடி செய்தி அறையாக குறிக்கவும்",
     "@commandHint_markasdm": {},
     "commandHint_ban": "கொடுக்கப்பட்ட பயனரை இந்த அறையிலிருந்து தடை செய்யுங்கள்",
@@ -1748,8 +1626,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "accessAndVisibilityDescription": "இந்த அரட்டையில் யார் சேர அனுமதிக்கப்படுகிறார்கள், அரட்டையை எவ்வாறு கண்டுபிடிப்பது.",
-    "@accessAndVisibilityDescription": {},
     "calls": "அழைப்புகள்",
     "@calls": {},
     "customEmojisAndStickers": "தனிப்பயன் ஈமோசிகள் மற்றும் ச்டிக்கர்கள்",
@@ -1768,11 +1644,6 @@
     },
     "enableEncryption": "குறியாக்கத்தை இயக்கவும்",
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "enableEncryptionWarning": "நீங்கள் இனி குறியாக்கத்தை முடக்க முடியாது. நீங்கள் உறுதியாக இருக்கிறீர்களா?",
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1806,11 +1677,6 @@
             }
         }
     },
-    "everythingReady": "எல்லாம் தயாராக!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "மிகவும் தாக்குதல்",
     "@extremeOffensive": {
         "type": "String",
@@ -1818,13 +1684,6 @@
     },
     "group": "குழு",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatDescription": "அரட்டை விளக்கம்",
-    "@chatDescription": {},
-    "groupIsPublic": "குழு பொது",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -1842,15 +1701,6 @@
     },
     "block": "தொகுதி",
     "@block": {},
-    "inviteContactToGroup": "{groupName} க்கு தொடர்பை அழை",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
     "noChatDescriptionYet": "அரட்டை விளக்கம் இதுவரை உருவாக்கப்படவில்லை.",
     "@noChatDescriptionYet": {},
     "invalidServerName": "தவறான சேவையக பெயர்",
@@ -1908,15 +1758,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "logInTo": "{homeserver} இல் உள்நுழைக",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
-    },
     "messages": "செய்திகள்",
     "@messages": {
         "type": "String",
@@ -1965,11 +1806,6 @@
     "@overview": {},
     "passwordRecoverySettings": "கடவுச்சொல் மீட்பு அமைப்புகள்",
     "@passwordRecoverySettings": {},
-    "passwordRecovery": "கடவுச்சொல் மீட்பு",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pleaseChoose": "தயவுசெய்து தேர்வு செய்யவும்",
     "@pleaseChoose": {
         "type": "String",
@@ -2138,11 +1974,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceName": "விண்வெளி பெயர்",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "status": "நிலை",
     "@status": {
         "type": "String",
@@ -2224,11 +2055,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "wipeChatBackup": "புதிய மீட்பு விசையை உருவாக்க உங்கள் அரட்டை காப்புப்பிரதியைத் துடைக்கவா?",
-    "@wipeChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "withTheseAddressesRecoveryDescription": "இந்த முகவரிகள் மூலம் உங்கள் கடவுச்சொல்லை மீட்டெடுக்கலாம்.",
     "@withTheseAddressesRecoveryDescription": {
         "type": "String",
@@ -2244,10 +2070,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "removeFromSpace": "இடத்திலிருந்து அகற்று",
-    "@removeFromSpace": {},
-    "pleaseEnterRecoveryKeyDescription": "உங்கள் பழைய செய்திகளைத் திறக்க, முந்தைய அமர்வில் உருவாக்கப்பட்ட உங்கள் மீட்பு விசையை உள்ளிடவும். உங்கள் மீட்பு விசை உங்கள் கடவுச்சொல் அல்ல.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "confirmEventUnpin": "நிகழ்வை நிரந்தரமாக அவிழ்ப்பது உறுதி?",
     "@confirmEventUnpin": {},
     "youJoinedTheChat": "நீங்கள் அரட்டையில் சேர்ந்தீர்கள்",
@@ -2306,12 +2128,6 @@
     "@knock": {},
     "users": "பயனர்கள்",
     "@users": {},
-    "storeInSecureStorageDescription": "மீட்பு விசையை இந்த சாதனத்தின் பாதுகாப்பான சேமிப்பகத்தில் சேமிக்கவும்.",
-    "@storeInSecureStorageDescription": {},
-    "saveKeyManuallyDescription": "கணினி பகிர்வு உரையாடல் அல்லது கிளிப்போர்டைத் தூண்டுவதன் மூலம் இந்த விசையை கைமுறையாக சேமிக்கவும்.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "ஆண்ட்ராய்டு கீச்டோரில் சேமிக்கவும்",
-    "@storeInAndroidKeystore": {},
     "countFiles": "{count} கோப்புகள்",
     "@countFiles": {
         "placeholders": {
@@ -2322,10 +2138,6 @@
     },
     "custom": "தனிப்பயன்",
     "@custom": {},
-    "foregroundServiceRunning": "முன்புற பணி இயங்கும்போது இந்த அறிவிப்பு தோன்றும்.",
-    "@foregroundServiceRunning": {},
-    "screenSharingDetail": "உங்கள் திரையை FUFFYCHAT இல் பகிர்கிறீர்கள்",
-    "@screenSharingDetail": {},
     "whyIsThisMessageEncrypted": "இந்த செய்தி ஏன் படிக்க முடியாதது?",
     "@whyIsThisMessageEncrypted": {},
     "noKeyForThisMessage": "இந்த சாதனத்தில் உங்கள் கணக்கில் கையொப்பமிடுவதற்கு முன்பு செய்தி அனுப்பப்பட்டால் இது நிகழலாம்.\n\n அனுப்புநர் உங்கள் சாதனத்தைத் தடுத்துள்ளார் அல்லது இணைய இணைப்பில் ஏதேனும் தவறு ஏற்பட்டுள்ளது.\n\n மற்றொரு அமர்வில் செய்தியைப் படிக்க முடியுமா? அதிலிருந்து செய்தியை மாற்றலாம்! அமைப்புகள்> சாதனங்களுக்குச் சென்று, உங்கள் சாதனங்கள் ஒருவருக்கொருவர் சரிபார்த்துள்ளன என்பதை உறுதிப்படுத்தவும். அடுத்த முறை நீங்கள் அறையைத் திறக்கும்போது, இரண்டு அமர்வுகளும் முன்னணியில் இருக்கும்போது, விசைகள் தானாகவே அனுப்பப்படும்.\n\n வெளியேறும்போது அல்லது சாதனங்களை மாற்றும்போது விசைகளை இழக்க நீங்கள் விரும்பவில்லையா? அமைப்புகளில் அரட்டை காப்புப்பிரதியை நீங்கள் இயக்கியுள்ளீர்கள் என்பதை உறுதிப்படுத்திக் கொள்ளுங்கள்.",
@@ -2334,12 +2146,6 @@
     "@hidePresences": {},
     "doNotShowAgain": "மீண்டும் காட்ட வேண்டாம்",
     "@doNotShowAgain": {},
-    "newSpaceDescription": "உங்கள் அரட்டைகளை ஒருங்கிணைத்து தனியார் அல்லது பொது சமூகங்களை உருவாக்க இடைவெளிகள் உங்களை அனுமதிக்கிறது.",
-    "@newSpaceDescription": {},
-    "disableEncryptionWarning": "பாதுகாப்பு காரணங்களுக்காக நீங்கள் ஒரு அரட்டையில் குறியாக்கத்தை முடக்க முடியாது, அது இதற்கு முன்பு இயக்கப்பட்டிருக்கிறது.",
-    "@disableEncryptionWarning": {},
-    "sorryThatsNotPossible": "மன்னிக்கவும் ... அது சாத்தியமில்லை",
-    "@sorryThatsNotPossible": {},
     "noBackupWarning": "எச்சரிக்கை! அரட்டை காப்புப்பிரதியை இயக்காமல், உங்கள் மறைகுறியாக்கப்பட்ட செய்திகளுக்கான அணுகலை இழப்பீர்கள். வெளியேறுவதற்கு முன் முதலில் அரட்டை காப்புப்பிரதியை இயக்க மிகவும் பரிந்துரைக்கப்படுகிறது.",
     "@noBackupWarning": {},
     "fileIsTooBigForServer": "அனுப்ப முடியவில்லை! சேவையகம் {max} வரை இணைப்புகளை மட்டுமே ஆதரிக்கிறது.",
@@ -2374,16 +2180,10 @@
     "@makeAdminDescription": {},
     "knocking": "தட்டுதல்",
     "@knocking": {},
-    "searchChatsRooms": "#Chats, Us பயனர்களைத் தேடுங்கள் ...",
-    "@searchChatsRooms": {},
     "nothingFound": "எதுவும் கிடைக்கவில்லை ...",
     "@nothingFound": {},
     "groupName": "குழு பெயர்",
     "@groupName": {},
-    "createGroupAndInviteUsers": "ஒரு குழுவை உருவாக்கி பயனர்களை அழைக்கவும்",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "தேடல் வழியாக குழுவை காணலாம்",
-    "@groupCanBeFoundViaSearch": {},
     "wrongRecoveryKey": "மன்னிக்கவும் ... இது சரியான மீட்பு விசையாகத் தெரியவில்லை.",
     "@wrongRecoveryKey": {},
     "databaseMigrationBody": "தயவுசெய்து காத்திருங்கள். இது ஒரு கணம் ஆகலாம்.",
@@ -2396,32 +2196,14 @@
     "@passwordsDoNotMatch": {},
     "joinSpace": "விண்வெளியில் சேரவும்",
     "@joinSpace": {},
-    "addChatOrSubSpace": "அரட்டை அல்லது துணை இடத்தைச் சேர்க்கவும்",
-    "@addChatOrSubSpace": {},
     "initAppError": "பயன்பாட்டைத் தொடங்கும்போது பிழை ஏற்பட்டது",
     "@initAppError": {},
-    "sessionLostBody": "உங்கள் அமர்வு தொலைந்துவிட்டது. {url} இல் டெவலப்பர்களிடம் இந்தப் பிழையைப் புகாரளிக்கவும். பிழை செய்தி: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendTypingNotificationsDescription": "அரட்டையில் பங்கேற்பாளர்கள் நீங்கள் ஒரு புதிய செய்தியைத் தட்டச்சு செய்யும் போது காணலாம்.",
     "@sendTypingNotificationsDescription": {},
     "sendReadReceiptsDescription": "அரட்டையில் பங்கேற்பாளர்கள் நீங்கள் ஒரு செய்தியைப் படிக்கும்போது பார்க்கலாம்.",
     "@sendReadReceiptsDescription": {},
     "formattedMessagesDescription": "மார்க் டவுனைப் பயன்படுத்தி தைரியமான உரை போன்ற பணக்கார செய்தி உள்ளடக்கத்தைக் காண்பி.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "Poser மற்ற பயனரை சரிபார்க்கவும்",
-    "@verifyOtherUser": {},
-    "verifyOtherUserDescription": "நீங்கள் மற்றொரு பயனரைச் சரிபார்த்தால், நீங்கள் உண்மையில் யாருக்கு எழுதுகிறீர்கள் என்பது உங்களுக்குத் தெரியும் என்பதை நீங்கள் உறுதியாக நம்பலாம். 💪\n\nநீங்கள் ஒரு சரிபார்ப்பைத் தொடங்கும்போது, நீங்களும் மற்ற பயனரும் பயன்பாட்டில் ஒரு பாப்அப்பைக் காண்பீர்கள். நீங்கள் ஒருவருக்கொருவர் ஒப்பிட வேண்டிய தொடர்ச்சியான ஈமோசிகள் அல்லது எண்களைக் காண்பீர்கள்.\n\nஇதைச் செய்வதற்கான சிறந்த வழி வீடியோ அழைப்பைச் சந்திப்பது அல்லது தொடங்குவது. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDeviceDescription": "நீங்கள் மற்றொரு சாதனத்தைச் சரிபார்க்கும்போது, அந்தச் சாதனங்கள் விசைகளைப் பரிமாறிக்கொள்ளலாம், உங்கள் ஒட்டுமொத்த பாதுகாப்பை அதிகரிக்கும். 💪 நீங்கள் ஒரு சரிபார்ப்பைத் தொடங்கும்போது, இரண்டு சாதனங்களிலும் பயன்பாட்டில் ஒரு பாப்அப் தோன்றும். நீங்கள் ஒருவருக்கொருவர் ஒப்பிட வேண்டிய தொடர்ச்சியான ஈமோசிகள் அல்லது எண்களைக் காண்பீர்கள். நீங்கள் சரிபார்ப்பைத் தொடங்குவதற்கு முன்பு இரண்டு சாதனங்களையும் எளிதில் வைத்திருப்பது நல்லது. 🤳",
     "@verifyOtherDeviceDescription": {},
     "canceledKeyVerification": "{sender} ரத்து செய்யப்பட்ட விசை சரிபார்ப்பு",
@@ -2519,8 +2301,6 @@
     },
     "changelog": "மாற்றபதிவு",
     "@changelog": {},
-    "homeserverDescription": "உங்கள் எல்லா தரவுகளும் ஒரு மின்னஞ்சல் வழங்குநரைப் போலவே ஓம்சர்வரில் சேமிக்கப்படுகின்றன. நீங்கள் எந்த ஓம்சர்வரை பயன்படுத்த விரும்புகிறீர்கள் என்பதை நீங்கள் தேர்வு செய்யலாம், அதே நேரத்தில் நீங்கள் எல்லோரிடமும் தொடர்பு கொள்ளலாம். Https://matrix.org இல் மேலும் அறிக.",
-    "@homeserverDescription": {},
     "calculatingFileSize": "கோப்பு அளவைக் கணக்கிடுகிறது ...",
     "@calculatingFileSize": {},
     "compressVideo": "அமைக்கும் வீடியோ ...",
@@ -2541,8 +2321,6 @@
     "@oneOfYourDevicesIsNotVerified": {},
     "noticeChatBackupDeviceVerification": "குறிப்பு: உங்கள் எல்லா சாதனங்களையும் அரட்டை காப்புப்பிரதியுடன் இணைக்கும்போது, அவை தானாகவே சரிபார்க்கப்படும்.",
     "@noticeChatBackupDeviceVerification": {},
-    "manageAccount": "கணக்கை நிர்வகிக்கவும்",
-    "@manageAccount": {},
     "noContactInformationProvided": "சேவையகம் எந்த சரியான தொடர்பு தகவலையும் வழங்காது",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "சேவையக நிர்வாகி தொடர்பு",
@@ -2641,11 +2419,6 @@
             }
         }
     },
-    "visibilityOfTheChatHistory": "அரட்டை வரலாற்றின் தெரிவுநிலை",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "you": "நீங்கள்",
     "@you": {
         "type": "String",
@@ -2703,12 +2476,6 @@
     },
     "notAnImage": "படக் கோப்பு அல்ல.",
     "@notAnImage": {},
-    "encryptThisChat": "இந்த அரட்டையை குறியாக்கவும்",
-    "@encryptThisChat": {},
-    "publicChatAddresses": "பொது அரட்டை முகவரிகள்",
-    "@publicChatAddresses": {},
-    "createNewAddress": "புதிய முகவரியை உருவாக்கவும்",
-    "@createNewAddress": {},
     "boldText": "தைரியமான உரை",
     "@boldText": {},
     "italicText": "சாய்வு உரை",
@@ -2741,12 +2508,6 @@
             }
         }
     },
-    "loginWithMatrixId": "மேட்ரிக்ச்-ஐடியுடன் உள்நுழைக",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "ஓம்சர்சர்களைக் கண்டறியவும்",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "ஓம்சர்வர் என்றால் என்ன?",
-    "@whatIsAHomeserver": {},
     "doesNotSeemToBeAValidHomeserver": "இணக்கமான ஓம்சர்வர் என்று தெரியவில்லை. தவறான URL?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "noMoreChatsFound": "இனி அரட்டைகள் கிடைக்கவில்லை ...",
@@ -2802,27 +2563,10 @@
     },
     "unbanUserDescription": "அவர்கள் முயற்சித்தால் பயனர் மீண்டும் அரட்டையை உள்ளிட முடியும்.",
     "@unbanUserDescription": {},
-    "restoreSessionBody": "ஆப்ஸ் இப்போது உங்கள் அமர்வை காப்புப்பிரதியிலிருந்து மீட்டெடுக்க முயற்சிக்கிறது. {url} இல் டெவலப்பர்களிடம் இந்தப் பிழையைப் புகாரளிக்கவும். பிழை செய்தி: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendReadReceipts": "வாசிப்பு ரசீதுகளை அனுப்பவும்",
     "@sendReadReceipts": {},
     "unableToJoinChat": "அரட்டையில் சேர முடியவில்லை. ஒருவேளை மற்ற கட்சி ஏற்கனவே உரையாடலை மூடியிருக்கலாம்.",
     "@unableToJoinChat": {},
-    "noGoogleServicesWarning": "ஃபயர்பேச் முகில் செய்தி உங்கள் சாதனத்தில் கிடைக்கவில்லை. இன்னும் புச் அறிவிப்புகளைப் பெற, NTFY ஐ நிறுவ பரிந்துரைக்கிறோம். NTFY அல்லது மற்றொரு ஒருங்கிணைந்த புச் வழங்குநருடன் நீங்கள் தரவு பாதுகாப்பான வழியில் புச் அறிவிப்புகளைப் பெறலாம். நீங்கள் பிளேச்டோரிலிருந்து அல்லது எஃப்-டிராய்டிலிருந்து NTFY ஐ பதிவிறக்கம் செய்யலாம்.",
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "scanQrCode": "QR குறியீட்டை ச்கேன் செய்யுங்கள்",
     "@scanQrCode": {},
     "obtainingLocation": "இருப்பிடத்தைப் பெறுதல்…",
@@ -2842,11 +2586,6 @@
     },
     "participant": "பங்கேற்பாளர்",
     "@participant": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "removeDevice": "சாதனத்தை அகற்று",
-    "@removeDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -2877,15 +2616,6 @@
     "@commandHint_roomupgrade": {},
     "checkList": "சரிபார்ப்பு பட்டியல்",
     "@checkList": {},
-    "countInvited": "{count} அழைக்கப்பட்டது",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "synchronizingPleaseWaitCounter": " ஒத்திசைத்தல்… ({percentage}%)",
     "@synchronizingPleaseWaitCounter": {
         "type": "String",
@@ -2899,23 +2629,10 @@
     "@previous": {},
     "otherPartyNotLoggedIn": "மற்ற கட்சி தற்போது உள்நுழைந்திருக்கவில்லை, எனவே செய்திகளைப் பெற முடியாது!",
     "@otherPartyNotLoggedIn": {},
-    "appWantsToUseForLogin": "உள்நுழைய '{server}' ஐப் பயன்படுத்தவும்",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "உங்களைப் பற்றிய தகவல்களைப் பகிர பயன்பாடு மற்றும் வலைத்தளத்தை இதன்மூலம் அனுமதிக்கிறீர்கள்.",
-    "@appWantsToUseForLoginDescription": {},
     "open": "திற",
     "@open": {},
     "waitingForServer": "சேவையகத்திற்காக காத்திருக்கிறது ...",
     "@waitingForServer": {},
-    "appIntroduction": "வெவ்வேறு தூதர்களில் உங்கள் நண்பர்களுடன் அரட்டையடிக்க உங்களை பஞ்சுபோன்றது உங்களை அனுமதிக்கிறது. Https://matrix.org இல் மேலும் அறிக அல்லது *தொடரவும் *தட்டவும்.",
-    "@appIntroduction": {},
     "newChatRequest": "அரட்டை கோரிக்கை",
     "@newChatRequest": {},
     "contentNotificationSettings": "உள்ளடக்க அறிவிப்பு அமைப்புகள்",
@@ -3081,11 +2798,9 @@
     "taTooltip": "மொழிபெயர்ப்பு உதவியுடன் பயன்படுத்தவும்",
     "interactiveTranslatorSliderHeader": "இணைய செயலாக்க மொழிபெயர்ப்பாளர்",
     "interactiveGrammarSliderHeader": "இணைய இலக்கண சரிபார்ப்பான்",
-    "interactiveTranslatorRequired": "தேவை",
     "waTooltip": "உதவியுடன் இல்லாமல் பயன்படுத்தவும்",
     "interactiveTranslator": "பெயர்ப்பு உதவி",
     "noIdenticalLanguages": "தயவுசெய்து வேறுபட்ட அடிப்படை மற்றும் இலக்கு மொழிகளை தேர்ந்தெடுக்கவும்",
-    "searchBy": "நாடு மற்றும் மொழிகளால் தேடவும்",
     "joinWithClassCode": "பாடத்துடன் சேரவும்",
     "languageLevelPreA1": "புதியவர் குறைந்த (முன் A1)",
     "languageLevelA1": "புதிய நடுவண் (A1)",
@@ -3106,19 +2821,14 @@
     "saveChanges": "மாற்றங்களைச் சேமிக்கவும்",
     "publicProfileTitle": "என் சுயவிவரத்தை தேடலில் கண்டுபிடிக்க அனுமதி அளிக்கவும்",
     "publicProfileDesc": "தயவுசெய்து இயக்கு, மற்ற பயனர்கள் உங்கள் சுயவிவரத்தை உலகளாவிய தேடல் பட்டியில் கண்டுபிடித்து உரையாடலுக்கு கோரிக்கைகள் அனுப்ப முடியும். இப்போது, நீங்கள் கோரிக்கையை ஏற்க அல்லது மறுக்க முடியும்.",
-    "errorDisableIT": "பெயர்ப்பு உதவி அணைக்கப்பட்டுள்ளது.",
-    "errorDisableIGC": "வாக்கிய அமைப்பு உதவி அணைக்கப்பட்டுள்ளது.",
     "errorDisableITUserDesc": "பெயர்ப்பு உதவி அமைப்புகளை புதுப்பிக்க இங்கே கிளிக் செய்யவும்",
     "errorDisableIGCUserDesc": "வாக்கிய அமைப்பு உதவி அமைப்புகளை புதுப்பிக்க இங்கே கிளிக் செய்யவும்",
     "errorDisableITClassDesc": "இந்த உரையாடல் உள்ள பாடத்திற்கான பெயர்ப்பு உதவி அணைக்கப்பட்டுள்ளது.",
     "errorDisableIGCClassDesc": "இந்த உரையாடல் உள்ள பாடத்திற்கான வாக்கிய அமைப்பு உதவி அணைக்கப்பட்டுள்ளது.",
-    "error405Title": "மொழிகள் அமைக்கப்படவில்லை",
     "error405Desc": "தயவுசெய்து உங்கள் மொழிகளை முதன்மை மெனு > கற்றல் அமைப்புகளில் அமைக்கவும்.",
     "termsAndConditions": "விதிகள் மற்றும் நிபந்தனைகள்",
     "andCertifyIAmAtLeast13YearsOfAge": " மற்றும் நான் குறைந்தபட்சம் 16 வயதுடையவன் என்பதை சான்றளிக்கின்றேன்.",
-    "error502504Title": "வாவ், ஆன்லைனில் பல மாணவர்கள் உள்ளனர்!",
     "error502504Desc": "பெய்ஜியா பாட்டுகள் பின்தொடரும்போது மொழிபெயர்ப்பு மற்றும் இலக்கண கருவிகள் மெதுவாக அல்லது கிடைக்காமல் இருக்கலாம்.",
-    "error404Title": "மொழிபெயர்ப்பு பிழை!",
     "error404Desc": "பெய்ஜியா பாட்டுக்கு அது எப்படி மொழிபெயர்க்க வேண்டும் என்று தெரியவில்லை...",
     "errorPleaseRefresh": "நாம் இதை ஆராய்கிறோம்! தயவுசெய்து மீண்டும் ஏற்றவும் மற்றும் முயற்சிக்கவும்.",
     "connectedToStaging": "ஸ்டேஜிங்குடன் இணைக்கப்பட்டுள்ளது",
@@ -3156,13 +2866,9 @@
     "definitionsToolName": "வார்த்தை வரையறைகள்",
     "definitionsToolDescription": "செயலாக்கப்பட்டால், நீல நிறத்தில் கீழே உள்ள வார்த்தைகளை கிளிக் செய்து வரையறைகளைப் பெறலாம். வரையறைகளை அணுகுவதற்காக செய்திகள் மீது கிளிக் செய்யவும்.",
     "welcomeBack": "மீண்டும் வரவேற்கிறோம்! நீங்கள் 2023-2024 பைலட் பகுதியாக இருந்தால், உங்கள் சிறப்பு பைலட் சந்தாவுக்காக எங்களை தொடர்பு கொள்ளவும். நீங்கள் ஆசிரியராக இருந்தால் (அல்லது உங்கள் நிறுவனம் உங்கள் வகுப்புக்கான உரிமங்களை வாங்கியிருந்தால்), ஆசிரியர் சந்தாவுக்காக எங்களை தொடர்பு கொள்ளவும்.",
-    "downloadTxtFile": "உரை கோப்பை பதிவிறக்கம் செய்க",
-    "downloadCSVFile": "CSV கோப்பை பதிவிறக்கம் செய்க",
     "promotionalSubscriptionDesc": "நீங்கள் தற்போது வாழ்நாள் விளம்பர சந்தாவை பெற்றுள்ளீர்கள். உங்கள் சந்தாவை மாற்ற உதவிக்கு support@pangea.chat க்கு செய்தி அனுப்பவும்.",
     "originalSubscriptionPlatform": "கொள்முதல் செய்யப்பட்ட சந்தா {purchasePlatform} மூலம்",
     "oneWeekTrial": "ஒரு வார சோதனை",
-    "downloadXLSXFile": "எக்செல் கோப்பை பதிவிறக்கம் செய்க",
-    "unkDisplayName": "அறியப்படாதது",
     "wwCountryDisplayName": "உலகளாவிய",
     "afCountryDisplayName": "அப்கானிஸ்தான்",
     "axCountryDisplayName": "ஆலந்து தீவுகள்",
@@ -3457,7 +3163,6 @@
     "chatCapacityHasBeenChanged": "பேச்சு திறன் மாற்றப்பட்டது",
     "chatCapacitySetTooLow": "பேச்சு திறன் குறைந்தது {count} ஆக இருக்க வேண்டும்.",
     "chatCapacityExplanation": "பேச்சு திறன் என்பது ஒரு பேச்சில் அனுமதிக்கப்பட்ட உறுப்பினர்களின் எண்ணிக்கையை வரையறுக்கிறது.",
-    "tooManyRequest": "மிகவும் அதிகமான கோரிக்கைகள், தயவுசெய்து பின்னர் முயற்சிக்கவும்.",
     "enterNumber": "தயவுசெய்து முழு எண் மதிப்பை உள்ளிடவும்.",
     "practice": "பயிற்சி",
     "versionNotFound": "பதிப்பு காணப்படவில்லை",
@@ -3467,7 +3172,6 @@
     "deleteSubscriptionWarningTitle": "உங்களுக்கு ஒரு செயலில் உள்ள சந்தா உள்ளது",
     "deleteSubscriptionWarningBody": "உங்கள் கணக்கை நீக்குவது தானாகவே உங்கள் சந்தாவை ரத்து செய்யாது.",
     "manageSubscription": "சந்தாவை நிர்வகி",
-    "error520Title": "தயவுசெய்து மீண்டும் முயற்சிக்கவும்.",
     "error520Desc": "மன்னிக்கவும், உங்கள் செய்தியை புரிந்துகொள்ள முடியவில்லை...",
     "wordsUsed": "பயன்படுத்தப்பட்ட வார்த்தைகள்",
     "level": "நிலை",
@@ -3485,7 +3189,6 @@
     "other": "மற்றவை",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "திறனில் எந்த வரம்பும் இல்லை",
-    "downloadGroupText": "குழு உரையை பதிவிறக்கம் செய்யவும்",
     "notificationsOn": "அறிவிப்புகள் இயங்கும்",
     "notificationsOff": "அறிவிப்புகள் நிறுத்தப்பட்டது",
     "joinWithCode": "குறியீடு கொண்டு சேரவும்",
@@ -3549,24 +3252,12 @@
     "whatIsTheMorphTag": "'{wordForm}' இன் {morphologicalFeature} என்ன?",
     "dataAvailable": "தகவல் கிடைக்கிறது",
     "available": "கிடைக்கிறது",
-    "pangeaBotIsFallible": "பாங்கியா பாட்டும் தவறுகள் செய்யும்!",
-    "whatIsMeaning": "'{lemma}' என்றால் என்ன?",
     "chooseLemmaMeaningInstructionsBody": "செய்தியில் உள்ள சொற்களுடன் பொருள்களை பொருத்தவும்!",
-    "doubleClickToEdit": "தொட்டச்செய்தி மூலம் திருத்தவும்.",
-    "topicLabel": "தலைப்பு",
-    "topicPlaceholder": "ஒரு தலைப்பை தேர்ந்தெடுக்கவும்...",
-    "modePlaceholder": "ஒரு முறையை தேர்ந்தெடுக்கவும்...",
-    "learningObjectiveLabel": "கற்றல் நோக்கம்",
-    "learningObjectivePlaceholder": "ஒரு கற்றல் நோக்கத்தை தேர்ந்தெடுக்கவும்...",
-    "targetLanguageLabel": "இலக்கு மொழி",
     "cefrLevelLabel": "CEFR நிலை",
     "image": "படம்",
     "video": "வீடியோ",
     "nan": "பயன்பாடில்லை",
-    "addVocabulary": "பொருளைச் சேர்க்கவும்",
     "instructions": "வழிகாட்டுதல்கள்",
-    "numberOfLearners": "கற்றலாளர்களின் எண்ணிக்கை",
-    "mustBeInteger": "இது ஒரு முழு எண் ஆக வேண்டும் உதாரணமாக 1, 2, 3, ...",
     "constructUsePvmDesc": "குரல் செய்தியில் உருவாக்கப்பட்டது",
     "leaveSpaceDescription": "பாடத்திலிருந்து வெளியேறுவதன் மூலம், நீங்கள் அதில் உள்ள அனைத்து உரையாடல்களையும் விட்டு செல்லுவீர்கள். மற்ற பயனர்கள் நீங்கள் பாடத்திலிருந்து வெளியேறியதை காண்பார்கள்.",
     "constructUseCorMmDesc": "சரியான செய்தி பொருள்",
@@ -3581,7 +3272,6 @@
     "ttsDisabledBody": "உங்கள் கற்றல் அமைப்புகளில் உரை-தொகுப்பை இயக்கு முடியும்",
     "noSpaceDescriptionYet": "இப்போது வரை பாடநெறி விளக்கம் உருவாக்கப்படவில்லை.",
     "tooLargeToSend": "இந்த செய்தி அனுப்ப மிகவும் பெரியது",
-    "exitWithoutSaving": "சேமிக்காமல் வெளியே செல்ல விரும்புகிறீர்களா?",
     "enableAutocorrectPopupTitle": "உங்கள் இலக்கு மொழி விசைப்பலகையை சேர்க்க கீழே செல்லவும்:",
     "enableAutocorrectPopupSteps": "  • அமைப்புகள்\n  • பொது\n  • விசைப்பலகை\n  • விசைப்பலகைகள்\n  • புதிய விசைப்பலகையைச் சேர்க்கவும்",
     "enableAutocorrectPopupDescription": "மொழி தேர்வு செய்யப்பட்ட பின், உங்கள் விசைப்பலகையின் கீழே இடது பக்கத்தில் உள்ள சிறிய உலகக் குறியீட்டை கிளிக் செய்து புதிய நிறுவப்பட்ட விசைப்பலகையை செயல்படுத்தலாம்.",
@@ -3592,11 +3282,8 @@
     "displayName": "காட்சி பெயர்",
     "leaveRoomDescription": "இந்த உரையாடலை நீங்கள் விட்டு செல்லப் போகிறீர்கள். மற்ற பயனர்கள் நீங்கள் விட்டு சென்றதை காண்பார்கள்.",
     "confirmUserId": "உங்கள் பாங்கியா உரையாடல் பயனர்பெயரை உறுதிப்படுத்தவும், உங்கள் கணக்கை நீக்கவும்.",
-    "startingToday": "இன்று தொடக்கம்",
-    "oneWeekFreeTrial": "ஒரு வார இலவச சோதனை",
     "paidSubscriptionStarts": "{startDate} முதல்",
     "cancelInSubscriptionSettings": "• சந்தா அமைப்புகளில் எப்போது வேண்டுமானாலும் ரத்து செய்யவும்",
-    "cancelToAvoidCharges": "• கட்டணங்களைத் தவிர்க்க {trialEnds} க்கு முன் ரத்து செய்யவும்",
     "downloadGboard": "Gboard ஐ பதிவிறக்கம் செய்யவும்",
     "autocorrectNotAvailable": "துரதிருஷ்டவசமாக, உங்கள் தளத்திற்கு இந்த அம்சம் தற்போது ஆதரிக்கப்படவில்லை. மேலும் மேம்பாட்டுக்காக காத்திருக்கவும்!",
     "pleaseUpdateApp": "தயவுசெய்து செயலியை புதுப்பிக்கவும் தொடரவும்.",
@@ -3606,17 +3293,12 @@
     "knockSpaceSuccess": "இந்த பாடத்திட்டத்தில் சேர விரும்புகிறீர்கள்! நீங்கள் அதை பெறும்போது ஒரு நிர்வாகி உங்கள் கோரிக்கைக்கு பதில் அளிப்பார் 😀",
     "chooseWordAudioInstructionsBody": "முழுமையான செய்தியை கேளுங்கள். பின்னர் ஆடியோவை சொற்களுடன் பொருத்தவும்.",
     "chooseMorphsInstructionsBody": "இலக்கண கேள்விகளுக்கான புதிர் துண்டுகளை கிளிக் செய்யவும்!",
-    "pleaseEnterInt": "தயவுசெய்து ஒரு எண்ணை உள்ளிடவும்",
     "home": "முகப்பு",
     "join": "சேரவும்",
     "resetInstructionTooltipsTitle": "வழிகாட்டல் குறிப்புகளை மீட்டமைக்கவும்",
     "resetInstructionTooltipsDesc": "புதிய பயனராக உள்ளவர்களுக்கு போல வழிகாட்டல் குறிப்புகளை காட்ட கிளிக் செய்யவும்.",
-    "randomize": "தற்செயலாக்கு",
     "clear": "அழி",
-    "featuredActivities": "சிறப்பானவை",
     "save": "சேமிக்கவும்",
-    "startChat": "உரையாடலைத் தொடங்கவும்",
-    "translationProblem": "பெயர்ப்பு பிரச்சனை",
     "askToJoin": "சேர வேண்டுகோள் விடுங்கள்",
     "emptyChatWarningTitle": "செய்தி காலி",
     "emptyChatWarningDesc": "நீங்கள் யாரையும் உங்கள் உரையாடலுக்கு அழைக்கவில்லை. தொடர்புகளை அழைக்க அல்லது பாட்டை அழைக்க உரையாடல் அமைப்புகளுக்கு செல்லவும். இதை பின்னர் செய்யவும் முடியும்.",
@@ -3646,17 +3328,13 @@
     "timesUsedIndependently": "தனித்தனமாக பயன்படுத்தப்பட்ட நேரங்கள்",
     "timesUsedWithAssistance": "உதவியுடன் பயன்படுத்தப்பட்ட நேரங்கள்",
     "shareInviteCode": "அழைப்புக் குறியீடு பகிரவும்: {code}",
-    "leaderboard": "தலைவரிசை",
     "skipForNow": "இப்போது தவிர்க்கவும்",
     "permissions": "அனுமதிகள்",
     "spaceChildPermission": "இந்த பாடத்துக்கு புதிய உரையாடல்களை யார் சேர்க்கலாம்",
-    "addEnvironmentOverride": "சூழல் மாற்றத்தைச் சேர்க்கவும்",
     "defaultOption": "இயல்பு",
     "deleteChatDesc": "இந்த உரையாடலை நீக்க விரும்புகிறீர்களா? இது அனைத்து பங்கேற்பாளர்களுக்கும் நீக்கப்படும் மற்றும் உரையாடலுக்குள் உள்ள அனைத்து செய்திகளும் பயிற்சி அல்லது கற்றல் பகுப்பாய்வுகளுக்கு இனி கிடைக்காது.",
     "deleteSpaceDesc": "பாடம் மற்றும் தேர்ந்தெடுத்த உரையாடல்கள் அனைத்தும் அனைத்து பங்கேற்பாளர்களுக்கும் நீக்கப்படும் மற்றும் உரையாடலுக்குள் உள்ள அனைத்து செய்திகளும் பயிற்சி அல்லது கற்றல் பகுப்பாய்வுகளுக்கு இனி கிடைக்காது. இந்த நடவடிக்கை திருத்த முடியாது.",
     "launch": "துவக்கம்",
-    "searchChats": "உரையாடல்களைத் தேடு",
-    "maxFifty": "அதிகபட்சம் 50",
     "configureSpace": "பாடத்தைக் கட்டமைக்கவும்",
     "pinMessages": "செய்திகளை பின் இடுக",
     "setJoinRules": "சேரும் விதிகளை அமைக்கவும்",
@@ -3690,9 +3368,6 @@
     "failedToFetchTranscription": "பதிவை பெற முடியவில்லை",
     "deleteEmptySpaceDesc": "பாடத்திலுள்ள அனைத்து பங்கேற்பாளர்களுக்கும் இது நீக்கப்படும். இந்த நடவடிக்கை திரும்ப முடியாது.",
     "regenerate": "மீண்டும் உருவாக்கு",
-    "mySavedActivities": "எனது சேமிக்கப்பட்ட செயல்பாடுகள்",
-    "noSavedActivities": "சேமிக்கப்பட்ட செயல்பாடுகள் இல்லை",
-    "saveActivity": "இந்த செயல்பாட்டை சேமிக்கவும்",
     "failedToPlayVideo": "வீடியோ播放 முடியவில்லை",
     "done": "முடிந்தது",
     "inThisSpace": "இந்த பாடத்தில்",
@@ -3703,13 +3378,9 @@
     "numInvited": "{count} அழைக்கப்பட்டவர்கள்",
     "saved": "சேமிக்கப்பட்டது",
     "reset": "மீட்டமைக்கவும்",
-    "errorFetchingActivitiesMessage": "செயல்பாடுகளை பெற முடியவில்லை",
     "errorFetchingDefinition": "வரையறையை பெற முடியவில்லை",
     "errorProcessAnalytics": "புள்ளிவிவரங்களை செயலாக்க முடியவில்லை",
     "errorDownloading": "பதிவிறக்கம் தோல்வியுற்றது",
-    "errorLoadingSpaceChildren": "இந்த பாடத்திட்டத்தின் உள்ள உரையாடல்களை ஏற்ற முடியவில்லை",
-    "unexpectedError": "எதிர்பாராத பிழை.",
-    "pleaseReload": "தயவுசெய்து மீண்டும் ஏற்றவும் மற்றும் மீண்டும் முயற்சிக்கவும்.",
     "translationError": "பெயர்ப்பு பிழை",
     "check": "சரிபார்க்கவும்",
     "unableToFindRoom": "அந்த குறியீட்டுடன் எந்த உரையாடலும் அல்லது பாடத்திட்டமும் கிடைக்கவில்லை. மீண்டும் முயற்சிக்கவும்.",
@@ -3718,19 +3389,14 @@
     "request": "விண்ணப்பிக்கவும்",
     "requestAll": "அனைத்தையும் கோரவும்",
     "confirmMessageUnpin": "இந்த செய்தியை நீக்க விரும்புகிறீர்களா?",
-    "saveAndLaunch": "சேமித்து துவக்கவும்",
-    "launchToSpace": "பாடத்துக்கு துவக்கவும்",
     "pending": "காத்திருக்கிறது",
     "inactive": "செயலற்றது",
-    "confirmRole": "பங்கு உறுதிப்படுத்தவும்",
     "openRoleLabel": "திறந்தது",
     "finishedTheActivity": "🎯 {username} இந்த செயல்பாட்டை முடித்தார்",
     "activitySummaryError": "செயல்பாட்டு சுருக்கங்கள் கிடைக்கவில்லை",
     "requestSummaries": "சுருக்கங்களை கோரவும்",
-    "generatingNewActivities": "இந்த மொழி ஜோடியின் முதல் பயனர் நீங்கள்! தயவுசெய்து ஒரு நிமிடம் காத்திருக்கவும், நாங்கள் உங்களுக்காக செயல்பாடுகளை தயாரித்து வருகின்றோம்.",
     "requestAccessTitle": "அணுகல் பகுப்பாய்வு கோரிக்கையா?",
     "requestAccessDesc": "பங்கேற்பாளர்களின் பகுப்பாய்வை காண விரும்புகிறீர்களா?\n\nபங்கேற்பாளர்கள் ஒப்புக்கொண்டால், இந்த பாடக்குறிப்பின் நிர்வாகிகள் அவர்களின்:\n    • மொத்த சொற்பொருள்\n    • மொத்த இலக்கண கருத்துக்கள்\n    • மொத்த செயல்பாட்டு அமர்வுகள் முடிக்கப்பட்டவை\n    • பயன்படுத்தப்பட்ட, சரியான மற்றும் தவறான இலக்கண கருத்துக்கள்\n\nஅவர்கள் பார்க்க முடியாது:\n    • பாடக்குறிப்பைத் தவிர மற்ற உரையாடல்களில் செய்திகள்\n    • சொற்பொருள் பட்டியல்",
-    "requestAccess": "வினவல் அணுகல் ({count})",
     "analyticsInactiveTitle": "செயல்பாட்டில் இல்லாத பயனர்களுக்கு கோரிக்கைகள் அனுப்ப முடியாது",
     "analyticsInactiveDesc": "இந்த அம்சம் அறிமுகப்படுத்தப்பட்டதிலிருந்து உள்நுழையாத செயல்பாட்டில் இல்லாத பயனர்கள் உங்கள் கோரிக்கையை காண முடியாது.\n\nபயனர் திரும்பும்போது, கோரிக்கை பொத்தான் தோன்றும். அவர்கள் பெயரின் கீழ் உள்ள கோரிக்கை பொத்தானை கிளிக் செய்து பின்னர் மீண்டும் அனுப்பலாம்.",
     "accessRequestedTitle": "பகுப்பாய்வு அணுகல் கோரிக்கை",
@@ -3753,8 +3419,6 @@
     "accessDesc": "உங்கள் பாடத்தைக் உலகிற்கு திறக்கலாம்! அல்லது, தனிப்பட்ட மற்றும் பாதுகாப்பானதாக மாற்றவும்.",
     "createGroupChatDesc": "செயல்பாட்டுக் கூட்டங்கள் தொடங்கும் மற்றும் முடிவடையும் இடம், குழு உரையாடல்கள் வழக்கமான தொடர்புக்கு திறந்தவையாக இருக்கும்.",
     "deleteDesc": "பாடத்தைக் நீக்குவதற்கு மட்டுமே நிர்வாகிகள் அனுமதிக்கின்றனர். இது அனைத்து பயனர்களையும் நீக்கி, தேர்ந்தெடுத்த அனைத்து உரையாடல்களையும் அழிக்கும் அழிப்பான நடவடிக்கை. கவனமாக செயல்படவும்.",
-    "noCourseFound": "ஓ, இந்த பாடத்துக்கு ஒரு திட்டம் தேவை!\n\nபாடத்திட்டங்கள் என்பது தலைப்புகளின் தொடரும் மற்றும் உரையாடல் செயல்பாடுகளின் தொகுப்பாகும்.",
-    "additionalParticipants": "+ {num} மற்றவர்கள்",
     "whatNow": "இப்போது என்ன?",
     "chooseNextActivity": "உங்கள் அடுத்த செயல்பாட்டை தேர்ந்தெடுக்கவும்!",
     "letsGo": "போய்ச் செல்லலாம்",
@@ -3767,13 +3431,11 @@
     "waitNotDone": "காத்திருங்கள், நான் முடிக்கவில்லை!",
     "waitingForOthersToFinish": "மற்றவர்களும் முடிக்க காத்திருக்கிறது...",
     "generatingSummary": "செயல்பாட்டை பகுப்பாய்வு செய்து முடிவுகளை உருவாக்குகிறது",
-    "findCourse": "பாடத்தைக் கண்டுபிடி",
     "pingParticipantsNotification": "{user} {room} இல் செயல்பாட்டில் சேர பங்கேற்பாளர்களை தேடுகிறார்",
     "course": "பாடம்",
     "courses": "பாடங்கள்",
     "goToCourse": "பாடத்துக்கு செல்லவும்: {course}",
     "activityComplete": "இந்த செயல்பாடு முடிந்துவிட்டது. செயல்பாட்டின் சுருக்கம் கீழே கிடைக்கும்.",
-    "startNewSession": "புதிய அமர்வை தொடங்கவும்",
     "joinOpenSession": "திறந்த அமர்வில் சேரவும்",
     "activityNotFound": "செயல்பாடு காணப்படவில்லை",
     "myActivities": "எனது செயல்பாடுகள்",
@@ -3856,10 +3518,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3869,10 +3527,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -3960,14 +3614,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -3984,10 +3630,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4000,15 +3642,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4160,14 +3794,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4181,14 +3807,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5411,10 +5029,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5455,10 +5069,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5531,10 +5141,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5804,47 +5410,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5864,19 +5430,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -5940,10 +5494,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -5984,14 +5534,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6003,14 +5545,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6048,10 +5582,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6068,27 +5598,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6212,10 +5726,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6225,10 +5735,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6245,14 +5751,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6392,18 +5890,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6452,10 +5938,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6465,18 +5947,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6519,23 +5989,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6559,10 +6017,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6570,14 +6024,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6682,18 +6128,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6746,10 +6180,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6776,10 +6206,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -6960,7 +6386,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "நாளை மீண்டும் செயல்பாட்டின் புதுப்பிப்புகளுக்காக சரிபார்க்கவும்.",
-    "activityDropdownDesc": "இந்த செயல்பாட்டை முடித்தவுடன், கீழே கிளிக் செய்யவும்",
     "languageMismatchTitle": "மொழி பொருந்தாமை",
     "languageMismatchDesc": "உங்கள் இலக்கு மொழி இந்த செயல்பாட்டின் மொழியுடன் பொருந்தவில்லை. உங்கள் இலக்கு மொழியை புதுப்பிக்க விரும்புகிறீர்களா?",
     "reportWordIssueTooltip": "வார்த்தை தகவல் பிரச்சனையை அறிக்கையிடவும்",
@@ -6973,10 +6398,6 @@
     "selectAll": "அனைத்தையும் தேர்வு செய்யவும்",
     "deselectAll": "அனைத்தையும் தேர்வு நீக்கவும்",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7025,17 +6446,11 @@
         "placeholders": {}
     },
     "startOwn": "என் சொந்தத்தைத் தொடங்கு",
-    "joinCourseDesc": "ஒவ்வொரு பாடத்திலும் 8-10 வரிசைப்படுத்தப்பட்ட தலைப்புகள் மற்றும் பணிப்படிப்படையிலான மொழி கற்றல் செயல்பாடுகள் உள்ளன.",
     "newMessageInPangeaChat": "💬 பாங்கியா சாட்டில் புதிய செய்தி",
     "shareCourse": "பாடத்தைக் பகிரவும்",
     "addCourse": "பாடத்தைச் சேர்க்கவும்",
-    "joinPublicCourse": "பொது பாடத்தில் சேரவும்",
     "vocabLevelsDesc": "நீங்கள் அவற்றை மேம்படுத்தியபின் சொற்பொருள் வார்த்தைகள் இங்கே செல்லும்!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7048,10 +6463,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7070,7 +6481,6 @@
     "emojiView": "எமோஜி காட்சி",
     "feedbackDialogDesc": "நான் தவறுகள் செய்கிறேன்! என்னால் மேம்பட உதவுவதற்கான எதுவும்?",
     "contactHasBeenInvitedToTheCourse": "தொடர்பு கற்கைநெறிக்கு அழைக்கப்பட்டுள்ளது",
-    "activityStatsButtonTooltip": "செயல்பாட்டு தகவல்",
     "allow": "அனுமதிக்கவும்",
     "deny": "மறுக்கவும்",
     "enabledRenewal": "சந்தா புதுப்பிப்பை செயல்படுத்தவும்",
@@ -7338,10 +6748,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8397,16 +7803,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "அடுத்த தலைப்பை திறக்க செயல்பாடுகள்",
-    "activitiesToUnlockTopicDesc": "அடுத்த பாடத்தொகுப்பை திறக்க செயல்பாடுகளின் எண்ணிக்கையை அமைக்கவும்",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "சரியான சொல் வரையறை பயிற்சி",
     "constructUseIncLMDesc": "தவறான சொல் வரையறை பயிற்சி",
     "constructUseCorLADesc": "சரியான சொல் ஒலிப்பதிவு பயிற்சி",
@@ -8414,7 +7810,6 @@
     "constructUseBonus": "சொல் பயிற்சியின் போது போனஸ்",
     "practiceVocab": "சொற்களை பயிற்சி செய்யுங்கள்",
     "selectMeaning": "அர்த்தத்தை தேர்ந்தெடுக்கவும்",
-    "selectAudio": "ஒலியை தேர்ந்தெடுக்கவும்",
     "anotherRound": "மற்றொரு சுற்று",
     "activitySettingsOverrideWarning": "செயல்பாட்டு திட்டத்தால் நிர்ணயிக்கப்பட்ட மொழி மற்றும் மொழி நிலை",
     "voice": "குரல்",
@@ -8446,10 +7841,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8467,12 +7858,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "பதிவிறக்கம் தொடங்கப்பட்டது",
     "webDownloadPermissionMessage": "உங்கள் உலாவி பதிவிறக்கங்களை தடுக்கும் என்றால், தயவுசெய்து இந்த தளத்திற்கு பதிவிறக்கங்களை செயல்படுத்தவும்.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8567,11 +7953,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "எதோ தவறு ஏற்பட்டது, அதை சரிசெய்ய நாங்கள் கடுமையாக வேலை செய்கிறோம். பின்னர் மீண்டும் சரிபார்க்கவும்.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "எழுத்து உதவியை செயல்படுத்தவும்",
     "autoIGCToolDescription": "அனுப்பிய செய்திகளை இலக்கு மொழிக்கு சரிசெய்ய பாஙோ உரையாடல் கருவிகளை தானாகவே இயக்கவும்.",
     "@autoIGCToolName": {
@@ -8627,24 +8008,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "இயல்பியல்",
-    "spanTypeWordChoice": "சொல் தேர்வு",
     "spanTypeSpelling": "எழுத்துப்பிழை",
     "spanTypePunctuation": "இணைச்சொல்",
     "spanTypeStyle": "அழகு",
     "spanTypeFluency": "தரிசனம்",
     "spanTypeAccents": "உயர்த்தல்கள்",
     "spanTypeCapitalization": "முதலெழுத்து",
-    "spanTypeCorrection": "திருத்தம்",
     "spanFeedbackTitle": "திருத்தப் பிரச்சினையைப் புகாரளிக்கவும்",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8669,10 +8039,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8683,13 +8049,7 @@
     "longPressToRecordVoiceMessage": "ஒலிப் செய்தியை பதிவு செய்ய நீண்ட அழுத்தவும்.",
     "pause": "நிறுத்தவும்",
     "resume": "மீண்டும் தொடங்கவும்",
-    "newSubSpace": "புதிய துணை இடம்",
-    "moveToDifferentSpace": "மற்ற இடத்திற்கு நகரவும்",
-    "removeFromSpaceDescription": "சாட் இடத்திலிருந்து நீக்கப்படும் ஆனால் உங்கள் சாட் பட்டியலில் இன்னும் தோன்றும்.",
     "countChats": "{chats} சாட்கள்",
-    "spaceMemberOf": "{spaces} இடத்தின் உறுப்பினராக",
-    "spaceMemberOfCanKnock": "{spaces} இடத்தின் உறுப்பினர்கள் தட்டலாம்",
-    "donate": "தானம் செய்யுங்கள்",
     "startedAPoll": "{username} ஒரு கருத்துக்கணிப்பை தொடங்கினார்.",
     "poll": "கருத்துக்கணிப்பு",
     "startPoll": "கருத்துக்கணிப்பை தொடங்குங்கள்",
@@ -8713,23 +8073,15 @@
     "newStickerPack": "புதிய ஸ்டிக்கர் தொகுப்பு",
     "stickerPackName": "ஸ்டிக்கர் தொகுப்பின் பெயர்",
     "attribution": "அங்கீகாரம்",
-    "skipChatBackup": "சாட் காப்புப்பதிவை தவிர்க்கவும்",
-    "skipChatBackupWarning": "நீங்கள் உறுதியாக இருக்கிறீர்களா? சாட் காப்புப்பதிவை இயக்காமல் நீங்கள் உங்கள் சாதனத்தை மாற்றினால் உங்கள் செய்திகளுக்கு அணுகலை இழக்கலாம்.",
-    "loadingMessages": "செய்திகளை ஏற்றுகிறது",
-    "setupChatBackup": "சாட் காப்புப்பதிவை அமைக்கவும்",
     "noMoreResultsFound": "மேலும் முடிவுகள் கிடைக்கவில்லை",
     "chatSearchedUntil": "சாட் {time} வரை தேடப்பட்டது",
     "federationBaseUrl": "ஃபெடரேஷன் அடிப்படை URL",
     "clientWellKnownInformation": "கிளையன்ட்-நன்கு-அறியப்பட்ட தகவல்:",
     "baseUrl": "அடிப்படை URL",
     "identityServer": "அடையாள சேவையகம்:",
-    "versionWithNumber": "பதிப்பு: {version}",
     "logs": "பதிவுகள்",
-    "advancedConfigs": "மேம்பட்ட அமைப்புகள்",
     "advancedConfigurations": "மேம்பட்ட கட்டமைப்புகள்",
-    "signInWithLabel": "உள்நுழைய:",
     "selectAllWords": "நீங்கள் ஒலியில் கேட்கும் அனைத்து சொற்களையும் தேர்ந்தெடுக்கவும்",
-    "joinCourseForActivities": "செயல்பாடுகளை முயற்சிக்க ஒரு பாடத்தில் சேரவும்.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -8758,18 +8110,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -8777,26 +8117,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -8902,22 +8222,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8946,19 +8250,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8966,15 +8258,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9175,11 +8459,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "ஒரு வகுப்பில் இருக்கிறீர்களா? உங்கள் சேர்க்கை குறியீட்டை இங்கே வையுங்கள்.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "ஆட்டோ-உயர்த்த audio செய்திகள்",
     "selectAudioMessagesOnPlayDescription": "விளையாடும் போது audio செய்திகளை தானாக உயர்த்தவும்",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9223,18 +8502,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "இந்த பாடத்தில் {input} செயல்பாடுகளுக்கு குறைவான தலைப்புகள் உள்ளன. தயவுசெய்து {minValue} க்குக் குறைவான அல்லது சமமான எண் உள்ளிடவும்.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "மீண்டும் உள்நுழைய இங்கே கிளிக் செய்யவும்.",
     "@clickToLogin": {
@@ -9651,17 +8918,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "ஒரு கார்டூன் பாணியில் உருவாக்கப்பட்ட மஞ்சள் கரடி, அதன் கைகள் உற்சாகத்தில் உயர்த்தப்பட்டுள்ளன.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "கற்றுக்கொள்ள மேலும் தகவலுக்கு வார்த்தைகளை தேர்ந்தெடுக்கவும்",
     "requireAnalyticsAccessTitle": "சேர்வதற்கு பகுப்பாய்வு அணுகல் தேவை",
     "requireAnalyticsAccessDesc": "பங்கேற்பாளர்கள் இந்த பாடத்தில் சேர்வதற்கு தங்கள் கற்றல் பகுப்பாய்வுக்கு அணுகலை வழங்க வேண்டும்",
     "analyticsAccessNoticeTitle": "பகுப்பாய்வு அணுகல் தேவை",
     "analyticsAccessNoticeDesc": "இந்த பாடத்தில் சேர்வதன் மூலம், நீங்கள் நிர்வாகிகளுக்கு உங்கள் கற்றல் பகுப்பாய்வுக்கு அணுகலை வழங்க ஒப்புக்கொள்கிறீர்கள்.",
-    "skipOnboardingClassCodeDesc": "சுயமாக கற்றுக்கொள்கிறீர்களா? கவலைப்பட வேண்டாம், நீங்கள்:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9679,10 +8940,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9711,7 +8968,6 @@
     "pickCefrLevelTeacherStepTitle": "நீங்கள் எது நிலையை கற்பிக்கிறீர்கள்?",
     "pickCefrLevelStudentStepTitle": "நீங்கள் எது நிலை?",
     "customCourseStepTitle": "ஒரு தனிப்பயன் பாடத்திற்கான இந்த படிவத்தை நிரப்பவும்",
-    "aboutYourClass": "உங்கள் வகுப்பைப் பற்றி",
     "courseCodeStepErrorMessage": "தயவுசெய்து உங்கள் குறியீட்டை சரிபார்க்கவும் மற்றும் மீண்டும் முயற்சிக்கவும்",
     "institution": "நிறுவனம்",
     "courseGoals": "பாடத்திட்ட இலக்குகள்",
@@ -9754,10 +9010,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9874,12 +9126,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "பாஙேஆ சாட் லோகோ",
     "introChatDetails": "வணக்கம் சொல்லுங்கள்! உங்கள் சக பாடநெறி பங்கேற்பாளர்களுக்கு உங்களை அறிமுகப்படுத்துங்கள், நண்பர்களை கண்டுபிடிக்கவும், செயல்பாடுகளுக்கு வெளியே உரையாடவும்.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9923,11 +9170,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "செயல்பாட்டு நடவடிக்கைகள்",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "உச்சரிப்பு கருவிகள்",
     "audioTranscription": "ஏ.ஐ. ஒலிப்பதிவு",
     "visualLearnerSupport": "காணொளி கற்றல் ஆதரவு",
@@ -9968,7 +9210,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "இந்த செயல்பாட்டை விளையாட ஒரு பாடத்தை சேர்க்கவும்.",
     "resizeCoursePanel": "பாடப் பானலின் அளவை மாற்றவும்",
     "undo": "மீட்டெடுக்கவும்",
     "unlock": "திறக்கவும்",
@@ -9982,7 +9223,6 @@
     "addCourseBrowsePublic": "பொது பாடங்களை உலாவவும்",
     "browsePublicCourses": "பொது பாடங்களை உலாவவும்",
     "editProfile": "சுயவிவரத்தை திருத்தவும்",
-    "numObjectives": "{count} குறிக்கோள்கள்",
     "mapSearchHint": "செயல்பாடுகளை தேடவும்",
     "mapSearchNoResults": "காண்பில் பொருத்தங்கள் இல்லை",
     "mapFilterAllLanguages": "எல்லா மொழிகளும்",
@@ -9991,7 +9231,6 @@
     "mapFilterCompleted": "முடிந்தது",
     "mapFilterReset": "மீட்டமை",
     "activityTypeConversation": "சரசரி",
-    "lockedMissionRequirement": "அன்லாக் செய்ய முந்தைய மிஷனை முடிக்கவும்",
     "playAgain": "மீண்டும் விளையாடவும்",
     "reviewActivity": "மதிப்பீடு",
     "mapEmptyInView": "உங்கள் நிலை அல்லது மொழியில் இங்கு எதுவும் இல்லை. உங்கள் வடிகட்டிகளை விரிவாக்கவும் அல்லது வெளியே zoom செய்யவும்.",
@@ -10006,14 +9245,9 @@
     "scrollToBottom": "கீழே உருட்டவும்",
     "courseImage": "பாடத்தின் படம்",
     "avatarPreview": "அவதார் முன்னோட்டம்",
-    "activityPhoto": "செயல்பாட்டு படம்",
     "emotePreview": "எமோட் முன்னோட்டம்: {name}",
     "activityLabel": "செயல்: {title}",
     "resetMapView": "மெப்பத்தை மீட்டமைக்கவும்",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10066,14 +9300,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10103,10 +9329,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10163,10 +9385,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_te.arb
+++ b/lib/l10n/intl_te.arb
@@ -47,7 +47,6 @@
     "appLock": "అప్ లాక్",
     "appLockDescription": "పిన్ కోడ్‌తో ఉపయోగించకుండా ఉన్నప్పుడు యాప్‌ను లాక్ చేయండి",
     "archive": "ఆర్కైవ్",
-    "areGuestsAllowedToJoin": "అతిథి వినియోగదారులు చేరడానికి అనుమతి ఉందా?",
     "areYouSure": "మీకు నిశ్చయమా?",
     "areYouSureYouWantToLogout": "మీరు లాగౌట్ చేయాలనుకుంటున్నారా?",
     "askSSSSSign": "ఇతర వ్యక్తి సంతకం చేయగలిగేందుకు, దయచేసి మీ సురక్షిత స్టోర్ పాస్‌ఫ్రేజ్ లేదా రికవరీ కీని నమోదు చేయండి.",
@@ -92,9 +91,7 @@
     "changeYourAvatar": "మీ అవతారాన్ని మార్చండి",
     "channelCorruptedDecryptError": "ఎన్క్రిప్షన్ దెబ్బతింది",
     "chat": "చాట్",
-    "yourChatBackupHasBeenSetUp": "మీ చాట్ బ్యాకప్ సెట్ చేయబడింది.",
     "chatBackup": "చాట్ బ్యాకప్",
-    "chatBackupDescription": "మీ పాత సందేశాలు రికవరీ కీతో సురక్షితంగా ఉన్నాయి. దాన్ని కోల్పోకూడదు.",
     "chatDetails": "చాట్ వివరాలు",
     "chats": "చాట్లు",
     "chooseAStrongPassword": "శక్తివంతమైన పాస్వర్డ్ ఎంచుకోండి",
@@ -127,7 +124,6 @@
     "configureChat": "చాట్‌ను కాన్ఫిగర్ చేయండి",
     "confirm": "నిర్ధారించండి",
     "connect": "కనెక్ట్ చేయండి",
-    "contactHasBeenInvitedToTheGroup": "సంపర్కం గ్రూప్‌కు ఆహ్వానించబడింది",
     "contentHasBeenReported": "విషయాన్ని సర్వర్ అడ్మిన్లకు నివేదించారు",
     "copiedToClipboard": "క్లిప్‌బోర్డుకు కాపీ చేయబడింది",
     "copy": "నకలు చేయి",
@@ -135,11 +131,9 @@
     "couldNotDecryptMessage": "సందేశాన్ని డీక్రిప్ట్ చేయలేకపోయారు: {error}",
     "checkList": "పరిశీలన జాబితా",
     "countParticipants": "{count} పాల్గొనేవారు",
-    "countInvited": "{count} ఆహ్వానించబడ్డారు",
     "create": "సృష్టించు",
     "createdTheChat": "💬 {username} చాట్‌ను సృష్టించారు",
     "createGroup": "గ్రూప్ సృష్టించు",
-    "createNewSpace": "కొత్త స్థలం",
     "currentlyActive": "ప్రస్తుతం క్రియాశీలంగా ఉంది",
     "darkTheme": "అంధకార",
     "dateAndTimeOfDay": "{date}, {timeOfDay}",
@@ -165,9 +159,6 @@
     "emoteKeyboardNoRecents": "ఇటీవల ఉపయోగించిన ఎమోట్స్ ఇక్కడ కనిపిస్తాయి...",
     "emotePacks": "గదికి ఎమోట్స్ ప్యాక్స్",
     "emoteSettings": "ఎమోట్స్ సెట్టింగ్స్",
-    "globalChatId": "గ్లోబల్ చాట్ ID",
-    "accessAndVisibility": "ప్రవేశం మరియు దృశ్యమానత",
-    "accessAndVisibilityDescription": "ఈ చాట్‌లో ఎవరు చేరుకోవచ్చో మరియు చాట్ ఎలా కనుగొనబడుతుందో.",
     "calls": "కాల్‌లు",
     "customEmojisAndStickers": "అభిరుచికర ఎమోజీలు మరియు స్టికర్స్",
     "customEmojisAndStickersBody": "ఏదైనా చాట్‌లో ఉపయోగించగలిగే అనుకూల ఎమోజీలు లేదా స్టికర్స్ జోడించండి లేదా పంచుకోండి.",
@@ -175,7 +166,6 @@
     "emptyChat": "ఖాళీ చాట్",
     "enableEmotesGlobally": "గ్లోబల్‌గా ఎమోట్స్ ప్యాక్‌ను సక్రియం చేయండి",
     "enableEncryption": "ఎన్క్రిప్షన్‌ను సక్రియం చేయండి",
-    "enableEncryptionWarning": "మీరు ఇకపై ఎన్క్రిప్షన్‌ను డిసేబుల్ చేయలేరు. మీరు ఖచ్చితంగా చేయాలనుకుంటున్నారా?",
     "encrypted": "ఎన్క్రిప్టెడ్",
     "encryption": "ఎన్క్రిప్షన్",
     "encryptionNotEnabled": "ఎన్క్రిప్షన్ సక్రియం చేయబడలేదు",
@@ -183,7 +173,6 @@
     "enterAnEmailAddress": "ఇమెయిల్ చిరునామాను నమోదు చేయండి",
     "homeserver": "హోమ్‌సర్వర్",
     "errorObtainingLocation": "స్థానం పొందడంలో లోపం: {error}",
-    "everythingReady": "అన్నీ సిద్ధంగా ఉన్నాయి!",
     "extremeOffensive": "అత్యంత దుర్వినియోగకరమైనది",
     "fileName": "ఫైల్ పేరు",
     "fluffychat": "ఫ్లఫీచాట్",
@@ -192,9 +181,7 @@
     "fromJoining": "చేరడం నుండి",
     "fromTheInvitation": "ఆహ్వానం నుండి",
     "group": "గుంపు",
-    "chatDescription": "చాట్ వివరణ",
     "chatDescriptionHasBeenChanged": "చాట్ వివరణ మార్చబడింది",
-    "groupIsPublic": "గుంపు ప్రజాస్వామ్యంగా ఉంది",
     "groups": "గుంపులు",
     "groupWith": "{displayname} తో గుంపు",
     "guestsAreForbidden": "అతిథులు నిషేధించబడ్డారు",
@@ -216,7 +203,6 @@
     "incorrectPassphraseOrKey": "తప్పు పాస్‌ఫ్రేజ్ లేదా రికవరీ కీ",
     "inoffensive": "అపరిశుద్ధం",
     "inviteContact": "సంప్రదింపుని ఆహ్వానించండి",
-    "inviteContactToGroup": "{groupName} కు సంప్రదింపుని ఆహ్వానించండి",
     "noChatDescriptionYet": "ఇప్పటికే చాట్ వివరణ సృష్టించబడలేదు.",
     "tryAgain": "మళ్ళీ ప్రయత్నించండి",
     "invalidServerName": "చెల్లని సర్వర్ పేరు",
@@ -237,7 +223,6 @@
     "leave": "నిష్క్రమించండి",
     "leftTheChat": "చాట్ నుండి నిష్క్రమించారు",
     "lightTheme": "కాంతివంతమైన",
-    "loadCountMoreParticipants": "మరిన్ని పాల్గొనేవారిని లోడ్ చేయండి {count}",
     "dehydrate": "సెషన్ ఎగుమతి చేసి పరికరాన్ని శుభ్రం చేయండి",
     "dehydrateWarning": "ఈ చర్యను తిరిగి చేయలేరు. బ్యాకప్ ఫైల్‌ను సురక్షితంగా నిల్వ చేయండి.",
     "hydrate": "బ్యాకప్ ఫైల్ నుండి పునరుద్ధరించండి",
@@ -246,7 +231,6 @@
     "locationDisabledNotice": "స్థాన సేవలు ఆపబడ్డాయి. మీ స్థానాన్ని పంచుకోవడానికి వాటిని సక్రియం చేయండి.",
     "locationPermissionDeniedNotice": "స్థాన అనుమతి తిరస్కరించబడింది. మీ స్థానాన్ని పంచుకోవడానికి వాటిని అనుమతించండి.",
     "login": "లాగిన్ చేయండి",
-    "logInTo": "{homeserver}కి లాగిన్ చేయండి",
     "logout": "లాగౌట్",
     "mention": "గుర్తింపు",
     "messages": "సందేశాలు",
@@ -261,8 +245,6 @@
     "no": "లేదు",
     "noConnectionToTheServer": "సర్వర్‌తో కనెక్షన్ లేదు",
     "noEmotesFound": "ఎమోట్స్ కనుగొనబడలేదు. 😕",
-    "noEncryptionForPublicRooms": "రూమ్ ఇకపై పబ్లిక్‌గా అందుబాటులో లేకపోతే మాత్రమే ఎన్‌క్రిప్షన్‌ను సక్రియం చేయవచ్చు.",
-    "noGoogleServicesWarning": "ఫైర్బేస్ క్లౌడ్ మెసేజింగ్ మీ పరికరంలో అందుబాటులో ఉండకపోవచ్చు. పుష్ నోటిఫికేషన్లు పొందడానికి, ntfyని ఇన్‌స్టాల్ చేయమని మేము సిఫార్సు చేస్తున్నాము. ntfy లేదా మరొక యూనిఫైడ్ పుష్ ప్రొవైడర్‌తో మీరు డేటా సురక్షితంగా పుష్ నోటిఫికేషన్లు పొందవచ్చు. ntfyని PlayStore లేదా F-Droid నుండి డౌన్లోడ్ చేయవచ్చు.",
     "noMatrixServer": "{server1} ఒక మ్యాట్రిక్స్ సర్వర్ కాదు, బదులుగా {server2} ఉపయోగించాలా?",
     "shareInviteLink": "ఆహ్వాన లింక్‌ను పంచుకోండి",
     "scanQrCode": "QR కోడ్‌ను స్కాన్ చేయండి",
@@ -284,12 +266,10 @@
     "openCamera": "క్యామేరా తెరవండి",
     "openVideoCamera": "వీడియో కోసం క్యామేరా తెరవండి",
     "oneClientLoggedOut": "మీ క్లయింట్‌లలో ఒకరు లాగౌట్ అయ్యారు",
-    "addAccount": "ఖాతాను జోడించండి",
     "editBundlesForAccount": "ఈ ఖాతాకు బండిలను సవరించండి",
     "addToBundle": "బండిల్‌కు జోడించండి",
     "removeFromBundle": "ఈ బండిల్ నుండి తొలగించండి",
     "bundleName": "బండిల్ పేరు",
-    "enableMultiAccounts": "(BETA) ఈ డివైస్‌పై బహుళ ఖాతాలను సక్రియం చేయండి",
     "openInMaps": "మ్యాప్స్‌లో తెరవండి",
     "link": "లింక్",
     "serverRequiresEmail": "ఈ సర్వర్ నమోదు కోసం మీ ఇమెయిల్ చిరునామాను ధృవీకరించాల్సి ఉంటుంది.",
@@ -301,7 +281,6 @@
     "passwordHasBeenChanged": "పాస్వర్డ్ మార్చబడింది",
     "overview": "సారాంశం",
     "passwordRecoverySettings": "పాస్వర్డ్ రికవరీ సెట్టింగ్స్",
-    "passwordRecovery": "పాస్వర్డ్ రికవరీ",
     "people": "మానవులు",
     "pickImage": "చిత్రాన్ని ఎంచుకోండి",
     "pin": "పిన్",
@@ -310,7 +289,6 @@
     "pleaseChooseAPasscode": "దయచేసి పాస్ కోడ్ ఎంచుకోండి",
     "pleaseClickOnLink": "దయచేసి ఇమెయిల్‌లో లింక్‌పై క్లిక్ చేసి తర్వాత కొనసాగించండి.",
     "pleaseEnter4Digits": "దయచేసి 4 అంకెలను నమోదు చేయండి లేదా యాప్ లాక్‌ను అచేతనం చేయడానికి ఖాళీగా ఉంచండి.",
-    "pleaseEnterRecoveryKey": "దయచేసి మీ రికవరీ కీని నమోదు చేయండి:",
     "pleaseEnterYourPassword": "దయచేసి మీ పాస్వర్డ్‌ను నమోదు చేయండి",
     "pleaseEnterYourPin": "దయచేసి మీ పిన్‌ను నమోదు చేయండి",
     "pleaseEnterYourUsername": "దయచేసి మీ యూజర్‌నేమ్‌ను నమోదు చేయండి",
@@ -330,7 +308,6 @@
     "rejectedTheInvitation": "{username} ఆహ్వానాన్ని తిరస్కరించారు",
     "removeAllOtherDevices": "అన్ని ఇతర పరికరాలను తొలగించండి",
     "removedBy": "{username} ద్వారా తొలగించబడింది",
-    "removeDevice": "పరికరాన్ని తొలగించండి",
     "unbanFromChat": "చాట్ నుండి బాన్ను తీసివేయండి",
     "removeYourAvatar": "మీ అవతారాన్ని తొలగించండి",
     "replaceRoomWithNewerVersion": "గదిని కొత్త వెర్షన్‌తో మార్చండి",
@@ -342,8 +319,6 @@
     "saveFile": "ఫైల్‌ను సేవ్ చేయండి",
     "search": "శోధన",
     "security": "భద్రత",
-    "recoveryKey": "పునరుద్ధరణ కీ",
-    "recoveryKeyLost": "పునరుద్ధరణ కీ కోల్పోయారా?",
     "send": "పంపండి",
     "sendAMessage": "సందేశం పంపండి",
     "sendAsText": "టెక్స్ట్‌గా పంపండి",
@@ -362,7 +337,6 @@
     "separateChatTypes": "ప్రత్యేక డైరెక్ట్ చాట్స్ మరియు గ్రూపులు",
     "setAsCanonicalAlias": "ప్రధాన అలియాస్‌గా సెట్ చేయండి",
     "setChatDescription": "చాట్ వివరణ సెట్ చేయండి",
-    "setPermissionsLevel": "అనుమతుల స్థాయిని సెట్ చేయండి",
     "setStatus": "స్థితిని సెట్ చేయండి",
     "settings": "సెట్టింగ్స్",
     "share": "పంచుకోండి",
@@ -372,8 +346,6 @@
     "presencesToggle": "ఇతర వినియోగదారుల నుండి స్థితి సందేశాలను చూపించండి",
     "skip": "దాటండి",
     "sourceCode": "మూల కోడ్",
-    "spaceIsPublic": "అవకాశం ప్రజలకు అందుబాటులో ఉంది",
-    "spaceName": "అవకాశం పేరు",
     "startedACall": "{senderName} కాల్ ప్రారంభించారు",
     "status": "స్థితి",
     "statusExampleMessage": "మీరు ఈ రోజు ఎలా ఉన్నారు?",
@@ -385,7 +357,6 @@
     "theyMatch": "అవి సరిపోతున్నాయి",
     "title": "ఫ్లఫీచాట్",
     "tooManyRequestsWarning": "అధిక అభ్యర్థనలు. దయచేసి తర్వాత ప్రయత్నించండి!",
-    "transferFromAnotherDevice": "ఇంకొక పరికరం నుండి బదిలీ చేయండి",
     "tryToSendAgain": "మళ్ళీ పంపడానికి ప్రయత్నించండి",
     "unavailable": "అందుబాటులో లేదు",
     "unbannedUser": "{username} {targetName} ను బాన్డును తొలగించారు",
@@ -395,7 +366,6 @@
     "unknownEvent": "అజ్ఞాత సంఘటన '{type}'",
     "unmuteChat": "చాట్ నిశబ్దం తొలగించు",
     "unpin": "పిన్ తొలగించు",
-    "unreadChats": "{unreadCount, plural, =1{1 చదవని చాట్} other{{unreadCount} చదవని చాట్లు}}",
     "userAndOthersAreTyping": "{username} మరియు {count} ఇతరులు టైప్ చేస్తున్నారు…",
     "userAndUserAreTyping": "{username} మరియు {username2} టైప్ చేస్తున్నారు…",
     "userIsTyping": "{username} టైప్ చేస్తున్నారు…",
@@ -408,8 +378,6 @@
     "verifyStart": "నిర్ధారణ ప్రారంభించండి",
     "verifySuccess": "మీరు విజయవంతంగా నిర్ధారించారు!",
     "verifyTitle": "ఇతర ఖాతాను నిర్ధారించడం",
-    "videoCall": "వీడియో కాల్",
-    "visibilityOfTheChatHistory": "చాట్ చరిత్ర యొక్క దృశ్యమానత",
     "visibleForAllParticipants": "అన్ని పాల్గొనేవారికి కనిపిస్తుంది",
     "visibleForEveryone": "అందరికీ కనిపిస్తుంది",
     "voiceMessage": "శబ్ద సందేశం",
@@ -419,10 +387,7 @@
     "wallpaper": "వాల్‌పేపర్:",
     "warning": "హెచ్చరిక!",
     "weSentYouAnEmail": "మేము మీకు ఇమెయిల్ పంపాము",
-    "whoCanPerformWhichAction": "ఎవరికి ఏ చర్య చేయగలరు",
-    "whoIsAllowedToJoinThisGroup": "ఈ గ్రూప్‌లో చేరడానికి ఎవరికీ అనుమతి ఉంది",
     "whyDoYouWantToReportThis": "మీరు దీన్ని నివేదించాలనుకుంటున్న కారణం ఏమిటి?",
-    "wipeChatBackup": "మీ చాట్ బ్యాకప్‌ను తొలగించి కొత్త రికవరీ కీని సృష్టించాలనుకుంటున్నారా?",
     "withTheseAddressesRecoveryDescription": "ఈ చిరునామాలతో మీరు మీ పాస్వర్డ్‌ను రికవర్ చేయవచ్చు.",
     "writeAMessage": "సందేశం రాయండి…",
     "yes": "అవును",
@@ -435,9 +400,7 @@
     "messageType": "సందేశం రకం",
     "sender": "పంపినవాడు",
     "openGallery": "గ్యాలరీని తెరవండి",
-    "removeFromSpace": "అంతస్థలంలో నుండి తొలగించండి",
     "start": "ప్రారంభించండి",
-    "pleaseEnterRecoveryKeyDescription": "మీ పాత సందేశాలను అన్లాక్ చేయడానికి, దయచేసి గత సెషన్‌లో రూపొందించిన మీ రికవరీ కీని నమోదు చేయండి. మీ రికవరీ కీ మీ పాస్‌వర్డ్ కాదు.",
     "publish": "ప్రచురించండి",
     "openChat": "చాట్‌ను తెరవండి",
     "markAsRead": "వాచినట్లుగా గుర్తించండి",
@@ -448,12 +411,9 @@
     "confirmEventUnpin": "ఈ ఈవెంట్‌ను శాశ్వతంగా పిన్ నుండి తొలగించాలనుకుంటున్నారా?",
     "emojis": "ఎమోజీలు",
     "placeCall": "కాల్ పెట్టండి",
-    "voiceCall": "వాయిస్ కాల్",
     "unsupportedAndroidVersion": "అమర్యాద Android వెర్షన్",
     "unsupportedAndroidVersionLong": "ఈ ఫీచర్‌కు కొత్త Android వెర్షన్ అవసరం. దయచేసి నవీకరణలు లేదా Lineage OS మద్దతు కోసం తనిఖీ చేయండి.",
-    "videoCallsBetaWarning": "దయచేసి గమనించండి, వీడియో కాల్స్ ప్రస్తుతం బీటా లో ఉన్నాయి. అవి అన్ని ప్లాట్‌ఫారమ్‌లపై ఆశించినట్లుగా పనిచేయకపోవచ్చు లేదా పనిచేయకపోవచ్చు.",
     "experimentalVideoCalls": "పరీక్షాత్మక వీడియో కాల్స్",
-    "emailOrUsername": "ఇమెయిల్ లేదా వినియోగదారు పేరు",
     "addWidget": "విడ్జెట్ జోడించండి",
     "widgetVideo": "వీడియో",
     "widgetEtherpad": "పాఠ్య నోట్",
@@ -475,35 +435,19 @@
     "youKickedAndBanned": "🙅 మీరు {user} ను తొలగించి నిషేధించారు",
     "youUnbannedUser": "మీరు {user} యొక్క నిషేధాన్ని తొలగించారు",
     "hasKnocked": "🚪 {user} గోడ తట్టారు",
-    "usersMustKnock": "వినియోగదారులు గోడ తట్టాలి",
-    "noOneCanJoin": "ఎవరూ చేరుకోలేరు",
     "knock": "గోడ తట్టండి",
     "users": "వినియోగదారులు",
-    "unlockOldMessages": "పాత సందేశాలను అన్లాక్ చేయండి",
-    "storeInSecureStorageDescription": "ఈ డివైస్ యొక్క సురక్షిత నిల్వలో రికవరీ కీని నిల్వ చేయండి.",
-    "saveKeyManuallyDescription": "సిస్టమ్ షేర్ డైలాగ్ లేదా క్లిప్‌బోర్డ్‌ను ట్రిగ్గర్ చేసి ఈ కీని మాన్యువల్‌గా సేవ్ చేయండి.",
-    "storeInAndroidKeystore": "Android కీస్టోర్‌లో నిల్వ చేయండి",
-    "storeInAppleKeyChain": "Apple కీచైన్‌లో నిల్వ చేయండి",
-    "storeSecurlyOnThisDevice": "ఈ డివైస్‌పై సురక్షితంగా నిల్వ చేయండి",
     "countFiles": "{count} ఫైళ్లు",
     "user": "వినియోగదారు",
     "custom": "అనుకూలీకరించబడింది",
-    "foregroundServiceRunning": "ఫోరగ్రౌండ్ సర్వీస్ నడుస్తున్నప్పుడు ఈ నోటిఫికేషన్ కనిపిస్తుంది.",
-    "screenSharingTitle": "స్క్రీన్ షేరింగ్",
-    "screenSharingDetail": "మీరు FuffyChatలో మీ స్క్రీన్‌ను షేర్ చేస్తున్నారు",
     "whyIsThisMessageEncrypted": "ఈ సందేశం ఎందుకు చదవలేనిది?",
     "noKeyForThisMessage": "మీరు ఈ సందేశాన్ని పంపినప్పుడు మీరు మీ ఖాతాలో సైన్ ఇన్ చేయకపోవచ్చు లేదా మీ డివైస్‌ను బ్లాక్ చేసినట్లు ఉండవచ్చు లేదా ఇంటర్నెట్ కనెక్షన్‌లో ఏదైనా తప్పు జరిగినట్లు ఉండవచ్చు.\n\nమరొక సెషన్‌లో మీరు సందేశాన్ని చదవగలరా? అప్పుడు మీరు దాన్ని ట్రాన్స్‌ఫర్ చేయవచ్చు! సెట్టింగ్స్ > డివైసెస్‌కు వెళ్లి మీ డివైసులు ఒకరినొకరు ధృవీకరించుకున్నాయో లేదో నిర్ధారించుకోండి. మీరు రూమ్‌ను తదుపరి ఓపెన్ చేసినప్పుడు మరియు రెండు సెషన్లు ఫార్గ్రౌండ్‌లో ఉన్నప్పుడు, కీలు స్వయంచాలకంగా ట్రాన్స్‌మిట్ అవుతాయి.\n\nలాగౌట్ చేయడం లేదా డివైసులు మార్చడం సమయంలో కీలు కోల్పోకుండా ఉండాలనుకుంటే, చాట్ బ్యాకప్‌ను సెట్టింగ్స్‌లో ఎనేబుల్ చేయండి.",
     "newGroup": "కొత్త గ్రూప్",
     "newSpace": "కొత్త స్పేస్",
-    "enterSpace": "స్పేస్‌లో ప్రవేశించండి",
     "allSpaces": "అన్ని స్పేసులు",
     "hidePresences": "స్థితి జాబితాను దాచాలా?",
     "doNotShowAgain": "మళ్లీ చూపించవద్దు",
     "wasDirectChatDisplayName": "ఖాళీ చాట్ (పూర్వపు {oldDisplayName})",
-    "newSpaceDescription": "స్పేస్‌లు మీ చాట్లను ఏకీకృతం చేయడానికి మరియు ప్రైవేట్ లేదా పబ్లిక్ కమ్యూనిటీలను నిర్మించడానికి అనుమతిస్తాయి.",
-    "encryptThisChat": "ఈ చాట్‌ను గుప్తీకరించండి",
-    "disableEncryptionWarning": "భద్రత కారణాల వల్ల, మీరు ఇప్పటికే ఎనేబుల్ చేసిన చాట్‌లో గుప్తీకరణను ఆపలేరు.",
-    "sorryThatsNotPossible": "క్షమించండి... అది సాధ్యపడదు",
     "deviceKeys": "పరికరం కీలు:",
     "reopenChat": "మళ్లీ చాట్‌ను తెరవండి",
     "noBackupWarning": "హెచ్చరిక! చాట్ బ్యాకప్‌ను ఎనేబుల్ చేయకపోతే, మీరు మీ గుప్తీకరించిన సందేశాలకు యాక్సెస్ కోల్పోతారు. లాగౌట్ చేయడానికి ముందు చాట్ బ్యాకప్‌ను మొదటిగా ఎనేబుల్ చేయడం చాలా సిఫార్సు చేయబడింది.",
@@ -516,7 +460,6 @@
     "openLinkInBrowser": "లింక్‌ను బ్రౌజర్‌లో తెరవండి",
     "reportErrorDescription": "😞 ఓహ్. ఏదైనా తప్పింది. మీరు కోరుకుంటే, ఈ బగ్‌ను డెవలపర్లకు నివేదించవచ్చు.",
     "report": "నివేదించండి",
-    "setTheme": "థీమ్ సెట్ చేయండి:",
     "setColorTheme": "రంగు థీమ్ సెట్ చేయండి:",
     "invite": "ఆహ్వానించండి",
     "inviteGroupChat": "📨 గ్రూప్ చాట్‌కు ఆహ్వానించండి",
@@ -535,12 +478,8 @@
     "yourGlobalUserIdIs": "మీ గ్లోబల్ యూజర్-ID: ",
     "noUsersFoundWithQuery": "దురదృష్టవశాత్తూ \"{query}\" తో ఏ యూజర్‌ను కనుగొనలేకపోయాము. దయచేసి టైపో చేయలేదో అని తనిఖీ చేయండి.",
     "knocking": "ముద్దు పెట్టడం",
-    "chatCanBeDiscoveredViaSearchOnServer": "చాట్‌ను {server} పై శోధన ద్వారా కనుగొనవచ్చు",
-    "searchChatsRooms": "#చాట్లు, @యూజర్లు కోసం శోధన చేయండి...",
     "nothingFound": "ఏమీ కనుగొనబడలేదు...",
     "groupName": "గుంపు పేరు",
-    "createGroupAndInviteUsers": "గుంపును సృష్టించండి మరియు యూజర్లను ఆహ్వానించండి",
-    "groupCanBeFoundViaSearch": "శోధన ద్వారా గుంపును కనుగొనవచ్చు",
     "wrongRecoveryKey": "క్షమించండి... ఇది సరైన రికవరీ కీ అనిపించడంలేదు.",
     "startConversation": "సంభాషణ ప్రారంభించండి",
     "commandHint_sendraw": "అడిగిన JSON పంపండి",
@@ -554,11 +493,8 @@
     "pleaseChooseAStrongPassword": "దయచేసి బలమైన పాస్వర్డ్‌ను ఎంచుకోండి",
     "passwordsDoNotMatch": "పాస్వర్డ్లు సరిపోలడం లేదు",
     "passwordIsWrong": "మీరు నమోదు చేసిన పాస్వర్డ్ తప్పు",
-    "publicChatAddresses": "జనసామాన చాట్ చిరునామాలు",
-    "createNewAddress": "కొత్త చిరునామా సృష్టించండి",
     "joinSpace": "అంతర్గత స్థలంలో చేరండి",
     "publicSpaces": "జనసామాన స్థలాలు",
-    "addChatOrSubSpace": "చాట్ లేదా ఉపస్థలం జోడించండి",
     "subspace": "ఉపస్థలం",
     "decline": "నిరాకరించండి",
     "thisDevice": "ఈ పరికరం:",
@@ -567,15 +503,11 @@
     "searchMore": "మరింత శోధించండి...",
     "gallery": "గ్యాలరీ",
     "files": "ఫైళ్లు",
-    "sessionLostBody": "మీ సెషన్ కోల్పోయారు. దయచేసి ఈ లోపాన్ని {url} వద్ద డెవలపర్లకు నివేదించండి. లోప సందేశం: {error}",
-    "restoreSessionBody": "అప్లికేషన్ ఇప్పుడు బ్యాకప్ నుండి మీ సెషన్‌ను పునరుద్ధరించడానికి ప్రయత్నిస్తోంది. దయచేసి ఈ లోపాన్ని డెవలపర్లకు {url} వద్ద నివేదించండి. లోప సందేశం: {error}",
     "sendReadReceipts": "చదివిన రసీదులు పంపండి",
     "sendTypingNotificationsDescription": "చాట్‌లో ఇతర పాల్గొనేవారు మీరు కొత్త సందేశం టైప్ చేస్తున్నప్పుడు చూడగలరు.",
     "sendReadReceiptsDescription": "చాట్‌లో ఇతర పాల్గొనేవారు మీరు సందేశాన్ని చదివినప్పుడు చూడగలరు.",
     "formattedMessages": "ఫార్మాట్ చేసిన సందేశాలు",
     "formattedMessagesDescription": "మార్క్డౌన్ ఉపయోగించి బోల్డ్ టెక్స్ట్ వంటి సమృద్ధి సందేశ కంటెంట్‌ను ప్రదర్శించండి.",
-    "verifyOtherUser": "🔐 ఇతర వినియోగదారుని ధృవీకరించండి",
-    "verifyOtherUserDescription": "మీరు మరొక వినియోగదారుని ధృవీకరించినప్పుడు, మీరు నిజంగా ఎవరికీ రాస్తున్నారో తెలుసుకోవచ్చును. 💪\n\nధృవీకరణ ప్రారంభించినప్పుడు, మీరు మరియు ఇతర వినియోగదారుడు యాప్‌లో ఒక పాప్‌ప్ చూడగలుగుతారు. అక్కడ మీరు అనేక ఎమోజీలు లేదా సంఖ్యలను చూడగలుగుతారు, వాటిని మీరు పరస్పరం పోల్చాలి.\n\nఇది చేయడానికి ఉత్తమ మార్గం కలుసుకోవడం లేదా వీడియో కాల్ ప్రారంభించడం. 👭",
     "verifyOtherDevice": "🔐 ఇతర పరికరాన్ని ధృవీకరించండి",
     "verifyOtherDeviceDescription": "మీరు మరొక పరికరాన్ని ధృవీకరించినప్పుడు, ఆ పరికరాలు కీలు మార్పిడి చేయగలవు, ఇది మీ మొత్తం భద్రతను పెంచుతుంది. 💪 ధృవీకరణ ప్రారంభించినప్పుడు, రెండు పరికరాల్లో యాప్‌లో ఒక పాప్‌ప్ కనిపిస్తుంది. అక్కడ మీరు అనేక ఎమోజీలు లేదా సంఖ్యలను చూడగలుగుతారు, వాటిని మీరు పరస్పరం పోల్చాలి. ధృవీకరణ ప్రారంభించడానికి ముందు రెండు పరికరాలు సిద్ధంగా ఉండటం ఉత్తమం. 🤳",
     "acceptedKeyVerification": "{sender} కీ ధృవీకరణను అంగీకరించారు",
@@ -611,10 +543,6 @@
     "updateInstalled": "🎉 నవీకరణ {version} ఇన్‌స్టాల్ చేయబడింది!",
     "changelog": "మార్పుల చిట్టా",
     "sendCanceled": "పంపడం రద్దయింది",
-    "loginWithMatrixId": "మ్యాట్రిక్స్-ID తో లాగిన్ చేయండి",
-    "discoverHomeservers": "హోమ్‌సర్వర్లను కనుగొనండి",
-    "whatIsAHomeserver": "హోమ్‌సర్వర్ అంటే ఏమిటి?",
-    "homeserverDescription": "మీ అన్ని డేటా హోమ్‌సర్వర్‌లో నిల్వ ఉంటుంది, అదే ఇమెయిల్ ప్రొవైడర్‌లా. మీరు ఏ హోమ్‌సర్వర్ ఉపయోగించాలో ఎంచుకోవచ్చు, ఇంకా మీరు అందరితో కమ్యూనికేట్ చేయగలుగుతారు. మరింత తెలుసుకోండి https://matrix.org వద్ద.",
     "doesNotSeemToBeAValidHomeserver": "సరైన హోమ్‌సర్వర్ కాదు అనిపిస్తోంది. తప్పు URL?",
     "calculatingFileSize": "ఫైల్ పరిమాణం లెక్కించబడుతోంది...",
     "prepareSendingAttachment": "జోడింపును పంపడానికి సిద్ధం చేయండి...",
@@ -626,11 +554,9 @@
     "oneOfYourDevicesIsNotVerified": "మీ డివైస్‌లలో ఒకటి నిర్ధారించబడలేదు",
     "noticeChatBackupDeviceVerification": "గమనిక: మీరు మీ అన్ని డివైస్‌లను చాట్ బ్యాకప్‌కు కనెక్ట్ చేసినప్పుడు, అవి ఆటోమేటిక్‌గా నిర్ధారించబడతాయి.",
     "continueText": "కొనసాగించండి",
-    "welcomeText": "హే హే 👋 ఇది ఫ్లఫీచాట్. మీరు ఏ హోమ్‌సర్వర్‌తోనైనా సైన్ ఇన్ చేయవచ్చు, ఇది https://matrix.org తో అనుకూలంగా ఉంటుంది. తరువాత ఎవరితోనైనా చాట్ చేయండి. ఇది ఒక పెద్ద డీసెంట్రలైజ్డ్ మెసేజింగ్ నెట్‌వర్క్!",
     "blur": "ధూదం:",
     "opacity": "అపారదర్శకత:",
     "setWallpaper": "వాల్‌పేపర్‌ను సెట్ చేయండి",
-    "manageAccount": "ఖాతాను నిర్వహించండి",
     "noContactInformationProvided": "సర్వర్ ఏదైనా చెల్లుబాటు అయ్యే సంప్రదింపు సమాచారం అందించలేదు",
     "contactServerAdmin": "సర్వర్ అడ్మిన్‌ను సంప్రదించండి",
     "contactServerSecurity": "సర్వర్ భద్రతను సంప్రదించండి",
@@ -649,11 +575,8 @@
     "unableToJoinChat": "చాట్‌లో చేరలేరు. మరొక పార్టీ ఇప్పటికే సంభాషణను మూసివేసి ఉండవచ్చు.",
     "previous": "మునుపటి",
     "otherPartyNotLoggedIn": "ఇతర పార్టీ ప్రస్తుతం లాగిన్ కాలేదు కాబట్టి సందేశాలు అందుకోలేరు!",
-    "appWantsToUseForLogin": "'{server}' ఉపయోగించి లాగిన్ అవ్వండి",
-    "appWantsToUseForLoginDescription": "మీ గురించి సమాచారం భాగస్వామ్యం చేయడానికి మీరు అనుమతిస్తున్నారు.",
     "open": "తెరవండి",
     "waitingForServer": "సర్వర్ కోసం వేచివున్నది...",
-    "appIntroduction": "ఫ్లఫీచాట్ మీకు వివిధ మెసేజర్లలో మీ స్నేహితులతో చాట్ చేయడానికి అనుమతిస్తుంది. మరింత తెలుసుకోండి https://matrix.org లేదా కేవలం *కొనసాగించు* పై ట్యాప్ చేయండి.",
     "newChatRequest": "📩 కొత్త చాట్ అభ్యర్థన",
     "contentNotificationSettings": "విషయ సూచన నోటిఫికేషన్ సెట్టింగులు",
     "generalNotificationSettings": "సాధారణ నోటిఫికేషన్ సెట్టింగులు",
@@ -730,11 +653,9 @@
     "taTooltip": "అనువాద సహాయంతో L2 ఉపయోగించండి",
     "interactiveTranslatorSliderHeader": "ఇంటరాక్టివ్ అనువాదకుడు",
     "interactiveGrammarSliderHeader": "ఇంటరాక్టివ్ వ్యాకరణ తనిఖీ",
-    "interactiveTranslatorRequired": "అవసరం",
     "waTooltip": "సహాయం లేకుండా L2 ఉపయోగం",
     "interactiveTranslator": "అనువాద సహాయం",
     "noIdenticalLanguages": "దయచేసి వేర్వేరు బేస్ మరియు టార్గెట్ భాషలను ఎంచుకోండి",
-    "searchBy": "దేశం మరియు భాషల ద్వారా శోధించండి",
     "joinWithClassCode": "కోర్సులో చేరండి",
     "languageLevelPreA1": "నవీన్ తక్కువ (ప్రి A1)",
     "languageLevelA1": "నవీన్ మిడ్ (A1)",
@@ -755,19 +676,14 @@
     "saveChanges": "మార్పులను సేవ్ చేయండి",
     "publicProfileTitle": "నా ప్రొఫైల్‌ను శోధనలో కనుగొనడానికి అనుమతించండి",
     "publicProfileDesc": "ఆన్ చేయడం ద్వారా, మీరు ఇతర వినియోగదారులు మీ ప్రొఫైల్‌ను గ్లోబల్ శోధన బార్‌లో కనుగొనగలుగుతారు మరియు చాట్ కోసం అభ్యర్థనలు పంపగలుగుతారు. ఈ సమయంలో, మీరు ఆ అభ్యర్థనను అంగీకరించాలా లేదా తిరస్కరించాలా అనే ఎంపిక ఉంటుంది.",
-    "errorDisableIT": "అనువాద సహాయం ఆఫ్ చేయబడింది.",
-    "errorDisableIGC": "వ్యాకరణ సహాయం ఆఫ్ చేయబడింది.",
     "errorDisableITUserDesc": "అనువాద సహాయం సెట్టింగులను నవీకరించడానికి ఇక్కడ క్లిక్ చేయండి",
     "errorDisableIGCUserDesc": "వ్యాకరణ సహాయం సెట్టింగులను నవీకరించడానికి ఇక్కడ క్లిక్ చేయండి",
     "errorDisableITClassDesc": "ఈ చాట్ ఉన్న కోర్సుకు అనువాద సహాయం ఆఫ్ చేయబడింది.",
     "errorDisableIGCClassDesc": "ఈ చాట్ ఉన్న కోర్సుకు వ్యాకరణ సహాయం ఆఫ్ చేయబడింది.",
-    "error405Title": "భాషలు సెట్ చేయబడలేదు",
     "error405Desc": "దయచేసి మీ భాషలను ప్రధాన మెనూ > శిక్షణ సెట్టింగుల్లో సెట్ చేయండి.",
     "termsAndConditions": "నిబంధనలు మరియు షరతులు",
     "andCertifyIAmAtLeast13YearsOfAge": "మరియు నేను కనీసం 16 సంవత్సరాల వయస్సు ఉన్నానని ధృవీకరిస్తున్నాను.",
-    "error502504Title": "వావ్, ఆన్‌లైన్‌లో చాలా మంది విద్యార్థులు ఉన్నారు!",
     "error502504Desc": "పాంజియా బాట్స్ ట్రాన్స్‌లేషన్ మరియు వ్యాకరణ సాధనాలు ఆలస్యంగా ఉండవచ్చు లేదా అందుబాటులో ఉండకపోవచ్చు.",
-    "error404Title": "అనువాద లోపం!",
     "error404Desc": "పాంజియా బాట్ దాన్ని ఎలా అనువదించాలో తెలియదు...",
     "errorPleaseRefresh": "మేము దీని గురించి చూస్తున్నాము! దయచేసి పేజీని రిఫ్రెష్ చేసి మళ్లీ ప్రయత్నించండి.",
     "connectedToStaging": "స్టేజింగ్‌కు కనెక్ట్ అయ్యింది",
@@ -805,13 +721,9 @@
     "definitionsToolName": "పదాల నిర్వచనాలు",
     "definitionsToolDescription": "సక్రియం చేసినప్పుడు, నీలం రంగులో అండర్‌లైన్ చేయబడిన పదాలను నిర్వచనాల కోసం క్లిక్ చేయవచ్చు. నిర్వచనాలను పొందడానికి సందేశాలను క్లిక్ చేయండి.",
     "welcomeBack": "మళ్లీ స్వాగతం! మీరు 2023-2024 పైలట్‌లో భాగమైతే, మీ ప్రత్యేక పైలట్ సబ్‌స్క్రిప్షన్ కోసం మమ్మల్ని సంప్రదించండి. మీరు టీచర్ అయితే (లేదా మీ సంస్థ తరగతి కోసం లైసెన్సులు కొనుగోలు చేసిందైతే), మీ టీచర్ సబ్‌స్క్రిప్షన్ కోసం మమ్మల్ని సంప్రదించండి.",
-    "downloadTxtFile": "టెక్స్ట్ ఫైల్ డౌన్లోడ్ చేయండి",
-    "downloadCSVFile": "CSV ఫైల్ డౌన్లోడ్ చేయండి",
     "promotionalSubscriptionDesc": "మీకు ప్రస్తుతం జీవితకాల ప్రచార సబ్‌స్క్రిప్షన్ ఉంది. మీ సబ్‌స్క్రిప్షన్ మార్చడానికి support@pangea.chat కు సందేశం పంపండి.",
     "originalSubscriptionPlatform": "{purchasePlatform} ద్వారా కొనుగోలు చేసిన సబ్‌స్క్రిప్షన్",
     "oneWeekTrial": "ఒక వారపు ట్రయల్",
-    "downloadXLSXFile": "ఎక్సెల్ ఫైల్ డౌన్లోడ్ చేయండి",
-    "unkDisplayName": "అజ్ఞాతం",
     "wwCountryDisplayName": "ప్రపంచవ్యాప్తంగా",
     "afCountryDisplayName": "అఫ్గానిస్తాన్",
     "axCountryDisplayName": "ఆలాండ్ దీవులు",
@@ -1106,7 +1018,6 @@
     "chatCapacityHasBeenChanged": "చాట్ సామర్థ్యం మార్చబడింది",
     "chatCapacitySetTooLow": "చాట్ సామర్థ్యం కనీసం {count} ఉండాలి.",
     "chatCapacityExplanation": "చాట్ సామర్థ్యం అనేది చాట్‌లో అనుమతించబడిన సభ్యుల సంఖ్యను పరిమితం చేస్తుంది.",
-    "tooManyRequest": "అధిక అభ్యర్థనలు, దయచేసి తర్వాత ప్రయత్నించండి.",
     "enterNumber": "దయచేసి మొత్తం సంఖ్య విలువను నమోదు చేయండి.",
     "practice": "అభ్యాసం",
     "versionNotFound": "వర్షన్ కనుగొనబడలేదు",
@@ -1116,7 +1027,6 @@
     "deleteSubscriptionWarningTitle": "మీకు క్రియాశీల సబ్‌స్క్రిప్షన్ ఉంది",
     "deleteSubscriptionWarningBody": "మీ ఖాతాను తొలగించడం స్వయంచాలకంగా మీ సబ్‌స్క్రిప్షన్‌ను రద్దు చేయదు.",
     "manageSubscription": "సబ్‌స్క్రిప్షన్ నిర్వహించండి",
-    "error520Title": "దయచేసి మళ్లీ ప్రయత్నించండి.",
     "error520Desc": "క్షమించండి, మీ సందేశాన్ని మనం అర్థం చేసుకోలేకపోయాము...",
     "wordsUsed": "పదాలు ఉపయోగించబడ్డాయి",
     "level": "స్థాయి",
@@ -1134,7 +1044,6 @@
     "other": "ఇతర",
     "levelShort": "LvL {level}",
     "noCapacityLimit": "సామర్థ్య పరిమితి లేదు",
-    "downloadGroupText": "గుంపు టెక్స్ట్‌ను డౌన్లోడ్ చేయండి",
     "notificationsOn": "అధిష్టానాలు ఆన్",
     "notificationsOff": "అధిష్టానాలు ఆఫ్",
     "joinWithCode": "కోడ్‌తో చేరండి",
@@ -1198,24 +1107,12 @@
     "whatIsTheMorphTag": "'{wordForm}' యొక్క {morphologicalFeature} ఏమిటి?",
     "dataAvailable": "డేటా అందుబాటులో ఉంది",
     "available": "అందుబాటులో ఉంది",
-    "pangeaBotIsFallible": "పాంజియా బాట్ కూడా తప్పులు చేస్తుంది!",
-    "whatIsMeaning": "'{lemma}' అంటే ఏమిటి?",
     "chooseLemmaMeaningInstructionsBody": "సందేశంలో ఉన్న పదాలతో అర్థాలను సరిపోల్చండి!",
-    "doubleClickToEdit": "సవరించడానికి డబుల్ క్లిక్ చేయండి.",
-    "topicLabel": "విషయం",
-    "topicPlaceholder": "ఒక విషయం ఎంచుకోండి...",
-    "modePlaceholder": "ఒక మోడ్ ఎంచుకోండి...",
-    "learningObjectiveLabel": "అధ్యయన లక్ష్యం",
-    "learningObjectivePlaceholder": "ఒక అధ్యయన లక్ష్యాన్ని ఎంచుకోండి...",
-    "targetLanguageLabel": "లక్ష్య భాష",
     "cefrLevelLabel": "CEFR స్థాయి",
     "image": "చిత్రం",
     "video": "వీడియో",
     "nan": "అన్వయించదు",
-    "addVocabulary": "శబ్దకోశం జోడించండి",
     "instructions": "సూచనలు",
-    "numberOfLearners": "అభ్యాసకుల సంఖ్య",
-    "mustBeInteger": "ఇది ఒక పూర్తి సంఖ్యగా ఉండాలి ఉదా: 1, 2, 3, ...",
     "constructUsePvmDesc": "శబ్ద సందేశంలో ఉత్పత్తి చేయబడింది",
     "leaveSpaceDescription": "కోర్సును వదిలితే, మీరు అందులో ఉన్న అన్ని చాట్‌లను వదులుతారు. ఇతర వినియోగదారులు మీరు కోర్సును వదిలినట్లు చూడగలరు.",
     "constructUseCorMmDesc": "సరైన సందేశ అర్థం",
@@ -1230,7 +1127,6 @@
     "ttsDisabledBody": "మీరు మీ అభ్యాస సెట్టింగ్స్‌లో టెక్స్ట్-టు-స్పీచ్ ను సక్రియం చేయవచ్చు",
     "noSpaceDescriptionYet": "ఇప్పటికే కోర్సు వివరణ సృష్టించబడలేదు.",
     "tooLargeToSend": "ఈ సందేశం పంపడానికి చాలా పెద్దది",
-    "exitWithoutSaving": "సేవ్ చేయకుండా బయటకు వెళ్లాలనుకుంటున్నారా?",
     "enableAutocorrectPopupTitle": "మీ లక్ష్య భాష కీబోర్డ్‌ను జోడించడానికి ఈ క్రింది దశలను అనుసరించండి:",
     "enableAutocorrectPopupSteps": "  • సెట్టింగ్స్\n  • జనరల్\n  • కీబోర్డ్\n  • కీబోర్డ్స్\n  • కొత్త కీబోర్డ్ జోడించండి",
     "enableAutocorrectPopupDescription": "భాషను ఎంచుకున్న తర్వాత, మీ కీబోర్డ్ దిగువ ఎడమ వైపు ఉన్న చిన్న గ్లోబ్ ఐకాన్ పై క్లిక్ చేసి కొత్తగా ఇన్‌స్టాల్ చేసిన కీబోర్డ్‌ను యాక్టివేట్ చేయవచ్చు.",
@@ -1241,11 +1137,8 @@
     "displayName": "ప్రదర్శన పేరు",
     "leaveRoomDescription": "మీరు ఈ చాట్‌ను విడిచిపోతున్నారు. ఇతర వినియోగదారులు మీరు చాట్‌ను విడిచిపోవడాన్ని చూడగలుగుతారు.",
     "confirmUserId": "దయచేసి మీ పాంజియా చాట్ యూజర్‌నేమ్‌ను ధృవీకరించండి, తద్వారా మీ ఖాతాను తొలగించవచ్చు.",
-    "startingToday": "ఈ రోజు నుండి ప్రారంభం",
-    "oneWeekFreeTrial": "ఒక వారపు ఉచిత ట్రయల్",
     "paidSubscriptionStarts": "{startDate} నుండి ప్రారంభం",
     "cancelInSubscriptionSettings": " • సబ్‌స్క్రిప్షన్ సెట్టింగ్స్‌లో ఎప్పుడైనా రద్దు చేయండి",
-    "cancelToAvoidCharges": " • ఛార్జీలను నివారించడానికి {trialEnds}కు ముందు రద్దు చేయండి",
     "downloadGboard": "Gboard డౌన్లోడ్ చేయండి",
     "autocorrectNotAvailable": "దురదృష్టవశాత్తు, మీ ప్లాట్‌ఫారమ్ ప్రస్తుతం ఈ ఫీచర్‌కు మద్దతు ఇవ్వదు. మరింత అభివృద్ధి కోసం ఎదురుచూడండి!",
     "pleaseUpdateApp": "దయచేసి కొనసాగించడానికి యాప్‌ను నవీకరించండి.",
@@ -1255,17 +1148,12 @@
     "knockSpaceSuccess": "మీరు ఈ కోర్సులో చేరాలని కోరుకున్నారు! మీరు దాన్ని పొందినప్పుడు అడ్మిన్ మీకు స్పందిస్తారు 😃",
     "chooseWordAudioInstructionsBody": "పూర్తి సందేశాన్ని వినండి. తర్వాత ఆడియోలను పదాలతో సరిపోల్చండి.",
     "chooseMorphsInstructionsBody": "వ్యాకరణ ప్రశ్నలకు పజిల్ భాగాలను క్లిక్ చేయండి!",
-    "pleaseEnterInt": "దయచేసి సంఖ్యను నమోదు చేయండి",
     "home": "హోమ్",
     "join": "చేరండి",
     "resetInstructionTooltipsTitle": "నిర్దేశన టూల్‌టిప్స్ రీసెట్ చేయండి",
     "resetInstructionTooltipsDesc": "కొత్త వినియోగదారుని కోసం నిర్దేశన టూల్‌టిప్స్ చూపించడానికి క్లిక్ చేయండి.",
-    "randomize": "యాదృచ్ఛికం చేయండి",
     "clear": "తొలగించండి",
-    "featuredActivities": "ప్రధాన",
     "save": "సేవ్ చేయండి",
-    "startChat": "చాట్ ప్రారంభించండి",
-    "translationProblem": "అనువాద సమస్య",
     "askToJoin": "చేరడానికి అడగండి",
     "emptyChatWarningTitle": "చాట్ ఖాళీగా ఉంది",
     "emptyChatWarningDesc": "మీరు ఎవ్వరినీ మీ చాట్‌కు ఆహ్వానించలేదు. సంప్రదింపులు లేదా బాట్‌ను ఆహ్వానించడానికి చాట్ సెట్టింగ్స్‌కు వెళ్లండి. మీరు దీన్ని తర్వాత కూడా చేయవచ్చు.",
@@ -1295,17 +1183,13 @@
     "timesUsedIndependently": "స్వతంత్రంగా ఉపయోగించిన సమయాలు",
     "timesUsedWithAssistance": "సహాయం తో ఉపయోగించిన సమయాలు",
     "shareInviteCode": "ఆహ్వాన కోడ్ పంచుకోండి: {code}",
-    "leaderboard": "నాయకుల పట్టిక",
     "skipForNow": "ఇప్పుడే దాటవేయండి",
     "permissions": "అనుమతులు",
     "spaceChildPermission": "ఈ కోర్సుకు కొత్త చాట్‌లను ఎవరు జోడించగలరు",
-    "addEnvironmentOverride": "పరిసరాల ఓవర్‌రైడ్ జోడించండి",
     "defaultOption": "డిఫాల్ట్",
     "deleteChatDesc": "మీకు ఈ చాట్‌ను తొలగించాలనుకుంటున్నారా? ఇది అన్ని పాల్గొనేవారికి తొలగించబడుతుంది మరియు చాట్‌లోని అన్ని సందేశాలు ఇకపై అభ్యాసం లేదా నేర్చుకునే విశ్లేషణలకు అందుబాటులో ఉండవు.",
     "deleteSpaceDesc": "కోర్సు మరియు ఎంచుకున్న చాట్‌లు అన్ని పాల్గొనేవారికి తొలగించబడతాయి మరియు చాట్‌లోని అన్ని సందేశాలు ఇకపై అభ్యాసం లేదా నేర్చుకునే విశ్లేషణలకు అందుబాటులో ఉండవు. ఈ చర్యను తిరిగి చేయలేరు.",
     "launch": "ప్రారంభించండి",
-    "searchChats": "చాట్‌లను శోధించండి",
-    "maxFifty": "గరిష్ట 50",
     "configureSpace": "కోర్సును కాన్ఫిగర్ చేయండి",
     "pinMessages": "సందేశాలను పిన్ చేయండి",
     "setJoinRules": "చేరే నియమాలను సెట్ చేయండి",
@@ -1339,9 +1223,6 @@
     "failedToFetchTranscription": "ట్రాన్స్క్రిప్షన్ పొందడంలో విఫలమైంది",
     "deleteEmptySpaceDesc": "కోర్సును అన్ని పాల్గొనేవారికి తొలగించబడుతుంది. ఈ చర్యను తిరిగి చేయలేరు.",
     "regenerate": "మళ్లీ సృష్టించండి",
-    "mySavedActivities": "నా సేవ్ చేసిన కార్యకలాపాలు",
-    "noSavedActivities": "ఏ సేవ్ చేసిన కార్యకలాపాలు లేవు",
-    "saveActivity": "ఈ కార్యకలాపాన్ని సేవ్ చేయండి",
     "failedToPlayVideo": "వీడియో ప్లే చేయడంలో విఫలమైంది",
     "done": "పూర్తయింది",
     "inThisSpace": "ఈ కోర్సులో",
@@ -1352,13 +1233,9 @@
     "numInvited": "{count} ఆహ్వానించబడ్డారు",
     "saved": "సేవ్ చేయబడింది",
     "reset": "రీసెట్ చేయండి",
-    "errorFetchingActivitiesMessage": "క్రియలను పొందడంలో విఫలమైంది",
     "errorFetchingDefinition": "నిర్వచనాన్ని పొందడంలో విఫలమైంది",
     "errorProcessAnalytics": "విశ్లేషణలను ప్రాసెస్ చేయడంలో విఫలమైంది",
     "errorDownloading": "డౌన్లోడ్ విఫలమైంది",
-    "errorLoadingSpaceChildren": "ఈ కోర్సులో చాట్లను లోడ్ చేయడంలో విఫలమైంది",
-    "unexpectedError": "అప్రతീക്ഷిత దోషం.",
-    "pleaseReload": "దయచేసి రीलోడ్ చేసి మళ్లీ ప్రయత్నించండి.",
     "translationError": "అనువాద లోపం",
     "check": "తనిఖీ చేయండి",
     "unableToFindRoom": "ఆ కోడ్‌తో చాట్ లేదా కోర్సు కనుగొనబడలేదు. దయచేసి మళ్లీ ప్రయత్నించండి.",
@@ -1367,19 +1244,14 @@
     "request": "అభ్యర్థన",
     "requestAll": "అన్ని అభ్యర్థనలు",
     "confirmMessageUnpin": "మీరు ఈ సందేశాన్ని అన్‌పిన్ చేయాలనుకుంటున్నారా?",
-    "saveAndLaunch": "సేవ్ చేసి ప్రారంభించండి",
-    "launchToSpace": "కోర్సుకు ప్రారంభించండి",
     "pending": "వేచి ఉంది",
     "inactive": "చురుకైనది కాదు",
-    "confirmRole": "పాత్రను నిర్ధారించండి",
     "openRoleLabel": "తెరవుట",
     "finishedTheActivity": "🎯 {username} ఈ కార్యకలాపాన్ని ముగించారు",
     "activitySummaryError": "కార్యకలాప సారాంశాలు అందుబాటులో లేవు",
     "requestSummaries": "సారాంశాలను అభ్యర్థించండి",
-    "generatingNewActivities": "మీరు ఈ భాష జత యొక్క మొదటి వినియోగదారు! దయచేసి ఒక నిమిషం ఇవ్వండి, మేము మీ కోసం మాత్రమే కార్యకలాపాలను సిద్ధం చేస్తున్నాము.",
     "requestAccessTitle": "విశ్లేషణ యాక్సెస్‌ను అభ్యర్థించాలా?",
     "requestAccessDesc": "పాల్గొనేవారి విశ్లేషణలను చూడటానికి యాక్సెస్ కోరాలనుకుంటున్నారా?\n\nపాల్గొనేవారు అంగీకరిస్తే, ఈ కోర్సు అడ్మిన్స్ వారి వీక్షణ సాధ్యమవుతుంది:\n    • మొత్తం పదజాలం\n    • మొత్తం వ్యాకరణ భావనలు\n    • మొత్తం కార్యకలాప సెషన్లు పూర్తి చేయబడినవి\n    • ఉపయోగించిన, సరిగా మరియు తప్పుగా ఉన్న ప్రత్యేక వ్యాకరణ భావనలు\n\nఅవి వీక్షించలేవు:\n    • కోర్సు వెలుపల చాట్ సందేశాలు\n    • పదజాల జాబితా",
-    "requestAccess": "అభ్యర్థన చేయండి ({count})",
     "analyticsInactiveTitle": "చర్యలేని వినియోగదారులకు అభ్యర్థనలు పంపలేరు",
     "analyticsInactiveDesc": "ఈ ఫీచర్ ప్రవేశపెట్టినప్పటి నుండి లాగిన్ కాలేదని చర్యలేని వినియోగదారులు మీ అభ్యర్థనను చూడలేరు.\n\nవారు తిరిగి వచ్చినప్పుడు, రిక్వెస్ట్ బటన్ కనిపిస్తుంది. అందుబాటులో ఉన్నప్పుడు వారి పేరుపై క్లిక్ చేసి మీరు తర్వాత కూడా అభ్యర్థనను పంపవచ్చు.",
     "accessRequestedTitle": "విశ్లేషణ యాక్సెస్ అభ్యర్థన",
@@ -1402,8 +1274,6 @@
     "accessDesc": "మీ కోర్సును ప్రపంచానికి తెరవవచ్చు! లేదా, మీ కోర్సును ప్రైవేట్ చేసి భద్రపరచవచ్చు.",
     "createGroupChatDesc": "అభ్యాస సెషన్లు ప్రారంభమై ముగిసే సమయంలో, గుంపు చాట్‌లు సాధారణ కమ్యూనికేషన్ కోసం తెరవబడతాయి.",
     "deleteDesc": "కేవలం అడ్మిన్లు మాత్రమే కోర్సును తొలగించగలరు. ఇది ఒక ధ్వంసక చర్యగా ఉంటుంది, ఇది అన్ని వినియోగదారులను తొలగిస్తుంది మరియు కోర్సులోని అన్ని ఎంపిక చేసిన చాట్‌లను డిలీట్ చేస్తుంది. జాగ్రత్తగా ముందుకు పోవండి.",
-    "noCourseFound": "అయ్యనది, ఈ కోర్సుకు ఒక ప్రణాళిక అవసరం!\n\nకోర్సు ప్రణాళికలు విషయాల శ్రేణి మరియు సంభాషణ కార్యకలాపాల సమూహం.",
-    "additionalParticipants": "+ {num} ఇతరులు",
     "whatNow": "ఇప్పుడు ఏమి చేయాలి?",
     "chooseNextActivity": "మీ తదుపరి కార్యకలాపాన్ని ఎంచుకోండి!",
     "letsGo": "చెళ్దాం",
@@ -1416,13 +1286,11 @@
     "waitNotDone": "కాస్త ఆగండి, నేను ఇంకా పూర్తిగా చేయలేదు!",
     "waitingForOthersToFinish": "మిగతావారు ముగించడానికి వేచివున్నారు...",
     "generatingSummary": "చాట్‌ను విశ్లేషించి ఫలితాలను సృష్టించడం",
-    "findCourse": "కోర్సును కనుగొనండి",
     "pingParticipantsNotification": "{user} {room}లో కార్యకలాప సెషన్‌లో చేరడానికి వినియోగదారులను చూస్తున్నారు",
     "course": "కోర్సు",
     "courses": "కోర్సులు",
     "goToCourse": "కోర్సుకు వెళ్లండి: {course}",
     "activityComplete": "ఈ కార్యకలాపం పూర్తయింది. క్రింద కార్యకలాప సారాంశం అందుబాటులో ఉండాలి.",
-    "startNewSession": "కొత్త సెషన్ ప్రారంభించండి",
     "joinOpenSession": "ఓపెన్ సెషన్‌లో చేరండి",
     "activityNotFound": "చర్య కనుగొనబడలేదు",
     "myActivities": "నా కార్యకలాపాలు",
@@ -1636,10 +1504,6 @@
         "placeholders": {}
     },
     "@archive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@areGuestsAllowedToJoin": {
         "type": "String",
         "placeholders": {}
     },
@@ -1915,15 +1779,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@yourChatBackupHasBeenSetUp": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@chatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -2059,10 +1915,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@contentHasBeenReported": {
         "type": "String",
         "placeholders": {}
@@ -2099,14 +1951,6 @@
             }
         }
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@create": {
         "type": "String",
         "placeholders": {}
@@ -2120,10 +1964,6 @@
         }
     },
     "@createGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -2234,18 +2074,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -2271,10 +2099,6 @@
         "placeholders": {}
     },
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2314,10 +2138,6 @@
             }
         }
     },
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@extremeOffensive": {
         "type": "String",
         "placeholders": {}
@@ -2350,15 +2170,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@chatDescriptionHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -2456,14 +2268,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "@noChatDescriptionYet": {
         "type": "String",
@@ -2581,14 +2385,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@dehydrate": {
         "type": "String",
         "placeholders": {}
@@ -2620,14 +2416,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@logout": {
         "type": "String",
@@ -2682,14 +2470,6 @@
         "placeholders": {}
     },
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2788,10 +2568,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addAccount": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@editBundlesForAccount": {
         "type": "String",
         "placeholders": {}
@@ -2805,10 +2581,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableMultiAccounts": {
         "type": "String",
         "placeholders": {}
     },
@@ -2856,10 +2628,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@people": {
         "type": "String",
         "placeholders": {}
@@ -2893,10 +2661,6 @@
         "placeholders": {}
     },
     "@pleaseEnter4Digits": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKey": {
         "type": "String",
         "placeholders": {}
     },
@@ -2999,10 +2763,6 @@
             }
         }
     },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unbanFromChat": {
         "type": "String",
         "placeholders": {}
@@ -3044,14 +2804,6 @@
         "placeholders": {}
     },
     "@security": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
         "type": "String",
         "placeholders": {}
     },
@@ -3155,10 +2907,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@setStatus": {
         "type": "String",
         "placeholders": {}
@@ -3196,14 +2944,6 @@
         "placeholders": {}
     },
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -3259,10 +2999,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@tryToSendAgain": {
         "type": "String",
         "placeholders": {}
@@ -3309,14 +3045,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -3395,14 +3123,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@visibleForAllParticipants": {
         "type": "String",
         "placeholders": {}
@@ -3439,19 +3159,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -3503,15 +3211,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3562,10 +3262,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3574,15 +3270,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3706,43 +3394,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3762,18 +3418,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
@@ -3787,10 +3431,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3813,22 +3453,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3883,10 +3507,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3970,31 +3590,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -4050,23 +3650,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -4106,28 +3694,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -4145,14 +3711,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -4345,22 +3903,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4416,10 +3958,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4429,10 +3967,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4508,27 +4042,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4854,10 +4372,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4867,10 +4381,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4958,14 +4468,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4982,10 +4484,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4998,15 +4496,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5158,14 +4648,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -5179,14 +4661,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6409,10 +5883,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6453,10 +5923,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6529,10 +5995,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6802,47 +6264,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6862,19 +6284,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6938,10 +6348,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6982,14 +6388,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -7001,14 +6399,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -7046,10 +6436,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -7066,27 +6452,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -7210,10 +6580,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -7223,10 +6589,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -7243,14 +6605,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7390,18 +6744,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7450,10 +6792,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7463,18 +6801,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7517,23 +6843,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7557,10 +6871,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7568,14 +6878,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7680,18 +6982,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7744,10 +7034,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7774,10 +7060,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7958,7 +7240,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "క్రియాశీలత నవీకరణల కోసం రేపు తిరిగి చెక్ చేయండి.",
-    "activityDropdownDesc": "మీరు ఈ క్రియాశీలతతో ముగించాక, క్రింద క్లిక్ చేయండి",
     "languageMismatchTitle": "భాష మిస్మ్యాచ్",
     "languageMismatchDesc": "మీ లక్ష్య భాష ఈ క్రియాశీలత భాషతో సరిపోలడం లేదు. మీ లక్ష్య భాషను నవీకరించాలనుకుంటున్నారా?",
     "reportWordIssueTooltip": "పద సమాచారం సమస్యను నివేదించండి",
@@ -7971,10 +7252,6 @@
     "selectAll": "అన్ని ఎంచుకోండి",
     "deselectAll": "అన్ని తొలగించండి",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8023,17 +7300,11 @@
         "placeholders": {}
     },
     "startOwn": "నాకు స్వంతంగా ప్రారంభించండి",
-    "joinCourseDesc": "ప్రతి కోర్సుకు 8-10 వరుసగా ఉన్న విషయాలు ఉంటాయి, వాటితో పాటు టాస్క్ ఆధారిత భాషా అభ్యాస కార్యకలాపాలు ఉంటాయి.",
     "newMessageInPangeaChat": "💬 పాంగియా చాట్‌లో కొత్త సందేశం",
     "shareCourse": "కోర్సును పంచుకోండి",
     "addCourse": "కోర్సును జోడించండి",
-    "joinPublicCourse": "పబ్లిక్ కోర్సులో చేరండి",
     "vocabLevelsDesc": "మీరు వాటిని లెవెల్ చేయగానే ఇది వాక్యబోధన పదాలు అక్కడికి పోతాయి!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8046,10 +7317,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8068,7 +7335,6 @@
     "emojiView": "ఇమోజీ వీక్షణ",
     "feedbackDialogDesc": "నేను కూడా తప్పులు చేస్తాను! నాకు మెరుగుపరచడానికి ఏదైనా సహాయం చేయగలరా?",
     "contactHasBeenInvitedToTheCourse": "సంప్రదింపును కోర్సుకు ఆహ్వానించారు",
-    "activityStatsButtonTooltip": "చర్య సమాచారం",
     "allow": "అనుమతించు",
     "deny": "అంగీకరించు",
     "enabledRenewal": "సబ్‌స్క్రిప్షన్ పునరుద్ధరణను ప్రారంభించు",
@@ -8336,10 +7602,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9395,16 +8657,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "తరువాతి అంశాన్ని అన్లాక్ చేయడానికి కార్యకలాపాలు",
-    "activitiesToUnlockTopicDesc": "తరువాతి కోర్సు అంశాన్ని అన్లాక్ చేయడానికి కార్యకలాపాల సంఖ్యను సెట్ చేయండి",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "సరైన పదకోశ నిర్వచన అభ్యాసం",
     "constructUseIncLMDesc": "తప్పు పదకోశ నిర్వచన అభ్యాసం",
     "constructUseCorLADesc": "సరైన పదకోశ ఆడియో అభ్యాసం",
@@ -9412,7 +8664,6 @@
     "constructUseBonus": "పదకోశ అభ్యాసం సమయంలో బోనస్",
     "practiceVocab": "పదకోశాన్ని అభ్యాసం చేయండి",
     "selectMeaning": "అర్థాన్ని ఎంచుకోండి",
-    "selectAudio": "సమానమైన ఆడియోను ఎంచుకోండి",
     "anotherRound": "మరొక రౌండ్",
     "activitySettingsOverrideWarning": "కార్యకలాపం ప్రణాళిక ద్వారా నిర్ణయించబడిన భాష మరియు భాష స్థాయి",
     "voice": "శబ్దం",
@@ -9444,10 +8695,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9465,12 +8712,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "డౌన్‌లోడ్ ప్రారంభించబడింది",
     "webDownloadPermissionMessage": "మీ బ్రౌజర్ డౌన్‌లోడ్లను అడ్డిస్తే, దయచేసి ఈ సైట్ కోసం డౌన్‌లోడ్లను ప్రారంభించండి.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9565,11 +8807,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "ఏదో తప్పు జరిగింది, మరియు మేము దీన్ని సరిదిద్దడానికి కష్టపడుతున్నాము. తర్వాత మళ్లీ తనిఖీ చేయండి.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "రాయడం సహాయాన్ని ప్రారంభించండి",
     "autoIGCToolDescription": "సమర్పించిన సందేశాలను లక్ష్య భాషకు సరిదిద్దడానికి పాంజియా చాట్ సాధనాలను ఆటోమేటిక్‌గా నడపండి.",
     "@autoIGCToolName": {
@@ -9625,24 +8862,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "వ్యాకరణం",
-    "spanTypeWordChoice": "పద ఎంపిక",
     "spanTypeSpelling": "అక్షరరూపం",
     "spanTypePunctuation": "పంక్తి చిహ్నాలు",
     "spanTypeStyle": "శైలి",
     "spanTypeFluency": "ప్రవాహం",
     "spanTypeAccents": "ఉచ్చారణలు",
     "spanTypeCapitalization": "పెద్ద అక్షరాలు",
-    "spanTypeCorrection": "సరిదిద్దు",
     "spanFeedbackTitle": "సరిదిద్దు సమస్యను నివేదించండి",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9667,10 +8893,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9683,13 +8905,7 @@
     "longPressToRecordVoiceMessage": "శబ్ద సందేశాన్ని రికార్డ్ చేయడానికి దీర్ఘంగా నొక్కండి.",
     "pause": "ఆపండి",
     "resume": "పునఃప్రారంభించండి",
-    "newSubSpace": "కొత్త ఉప స్థలం",
-    "moveToDifferentSpace": "వేరే స్థలానికి కదలండి",
-    "removeFromSpaceDescription": "చాట్ స్థలంలో నుండి తొలగించబడుతుంది కానీ మీ చాట్ జాబితాలో ఇంకా కనిపిస్తుంది.",
     "countChats": "{chats} చాట్లు",
-    "spaceMemberOf": "{spaces} స్థలానికి సభ్యుడు",
-    "spaceMemberOfCanKnock": "{spaces} స్థలానికి సభ్యుడు తట్టుకోవచ్చు",
-    "donate": "దానం చేయండి",
     "startedAPoll": "{username} ఓటు ప్రారంభించారు.",
     "poll": "ఓటు",
     "startPoll": "ఓటు ప్రారంభించండి",
@@ -9713,23 +8929,15 @@
     "newStickerPack": "కొత్త స్టిక్కర్ ప్యాక్",
     "stickerPackName": "స్టిక్కర్ ప్యాక్ పేరు",
     "attribution": "అట్రిబ్యూషన్",
-    "skipChatBackup": "చాట్ బ్యాకప్‌ను దాటించండి",
-    "skipChatBackupWarning": "మీరు ఖచ్చితంగా ఉన్నారా? చాట్ బ్యాకప్‌ను ప్రారంభించకుండా ఉంటే, మీరు మీ పరికరాన్ని మార్చినప్పుడు మీ సందేశాలకు యాక్సెస్ కోల్పోతారు.",
-    "loadingMessages": "సందేశాలను లోడ్ చేస్తున్నది",
-    "setupChatBackup": "చాట్ బ్యాకప్‌ను సెటప్ చేయండి",
     "noMoreResultsFound": "ఇంకా ఫలితాలు లభించలేదు",
     "chatSearchedUntil": "చాట్ {time} వరకు శోధించబడింది",
     "federationBaseUrl": "ఫెడరేషన్ బేస్ URL",
     "clientWellKnownInformation": "క్లయింట్-వెల్-కన్వన్ సమాచారం:",
     "baseUrl": "బేస్ URL",
     "identityServer": "ఐడెంటిటీ సర్వర్:",
-    "versionWithNumber": "వర్షన్: {version}",
     "logs": "లాగ్‌లు",
-    "advancedConfigs": "అధికారం కాన్ఫిగ్స్",
     "advancedConfigurations": "అధికారం కాన్ఫిగరేషన్స్",
-    "signInWithLabel": "సైన్ ఇన్ చేయండి:",
     "selectAllWords": "మీరు ఆడియోలో వినే అన్ని పదాలను ఎంచుకోండి",
-    "joinCourseForActivities": "చర్యలను ప్రయత్నించడానికి ఒక కోర్సులో చేరండి.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9766,18 +8974,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9785,26 +8981,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9910,22 +9086,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9954,19 +9114,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9974,15 +9122,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10183,11 +9323,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "ఒక తరగతిలో ఉన్నారా? మీ చేరిక కోడ్‌ను ఇక్కడ ఉంచండి.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "ఆడియో సందేశాలను ఆటో-హైలైట్ చేయండి",
     "selectAudioMessagesOnPlayDescription": "ఆడినప్పుడు ఆడియో సందేశాలను ఆటోమేటిక్‌గా హైలైట్ చేయండి",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10231,18 +9366,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "ఈ కోర్సులో {input} కార్యకలాపాల కంటే తక్కువ ఉన్న అంశాలు ఉన్నాయి. దయచేసి {minValue} కంటే తక్కువ లేదా సమానమైన సంఖ్యను నమోదు చేయండి.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "ఇక్కడ క్లిక్ చేసి తిరిగి సైన్ ఇన్ చేయండి.",
     "@clickToLogin": {
@@ -10659,17 +9782,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "ఒక కార్టూన్ శైలిలో ఉన్న పసుపు త熊, ఉత్సాహంతో చేతులు ఎత్తి ఉంది.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "వివరంగా తెలుసుకోవడానికి పదాలను ఎంచుకోండి",
     "requireAnalyticsAccessTitle": "చేరడానికి విశ్లేషణ యాక్సెస్ అవసరం",
     "requireAnalyticsAccessDesc": "ఈ కోర్సులో చేరడానికి పాల్గొనేవారు తమ అభ్యాస విశ్లేషణకు యాక్సెస్ ఇవ్వాలి",
     "analyticsAccessNoticeTitle": "విశ్లేషణ యాక్సెస్ అవసరం",
     "analyticsAccessNoticeDesc": "ఈ కోర్సులో చేరడం ద్వారా, మీరు నిర్వాహకులకు మీ అభ్యాస విశ్లేషణకు యాక్సెస్ ఇవ్వడానికి అంగీకరిస్తున్నారు.",
-    "skipOnboardingClassCodeDesc": "స్వతంత్రంగా అభ్యసిస్తున్నారా? ఆందోళన చెందవద్దు, మీరు:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10687,10 +9804,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10719,7 +9832,6 @@
     "pickCefrLevelTeacherStepTitle": "మీరు ఏ స్థాయిలో బోధిస్తున్నారు?",
     "pickCefrLevelStudentStepTitle": "మీరు ఏ స్థాయిలో ఉన్నారు?",
     "customCourseStepTitle": "కస్టమ్ కోర్సు పొందడానికి ఈ ఫారమ్‌ను నింపండి",
-    "aboutYourClass": "మీ తరగతి గురించి",
     "courseCodeStepErrorMessage": "దయచేసి మీ కోడ్‌ను తనిఖీ చేసి మళ్లీ ప్రయత్నించండి",
     "institution": "సంస్థ",
     "courseGoals": "కోర్సు లక్ష్యాలు",
@@ -10762,10 +9874,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10882,12 +9990,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "పాంజియా చాట్ లోగో",
     "introChatDetails": "హలో చెప్పండి! మీ సహచర కోర్సు పాల్గొనేవారికి మీను పరిచయం చేయండి, స్నేహితులను కనుగొనండి, మరియు కార్యకలాపాల వెలుపల చాట్ చేయండి.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10931,11 +10034,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "చర్యల చర్యలు",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "ఉచ్చారణ సాధనాలు",
     "audioTranscription": "ఏఐ ఆడియో ట్రాన్స్క్రిప్షన్",
     "visualLearnerSupport": "దృశ్య విద్యార్థి మద్దతు",
@@ -10976,7 +10074,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "ఈ కార్యకలాపాన్ని ఆడడానికి ఈ కోర్సులో చేరండి.",
     "resizeCoursePanel": "కోర్సు ప్యానెల్‌ను పరిమాణం మార్చండి",
     "undo": "తిరిగి చేయండి",
     "unlock": "అన్లాక్ చేయండి",
@@ -10990,7 +10087,6 @@
     "addCourseBrowsePublic": "ప్రజా కోర్సులను బ్రౌజ్ చేయండి",
     "browsePublicCourses": "ప్రజా కోర్సులను బ్రౌజ్ చేయండి",
     "editProfile": "ప్రొఫైల్ సవరించండి",
-    "numObjectives": "{count} లక్ష్యాలు",
     "mapSearchHint": "చర్యలను శోధించండి",
     "mapSearchNoResults": "చూపులో సరిపోలడం లేదు",
     "mapFilterAllLanguages": "అన్ని భాషలు",
@@ -10999,7 +10095,6 @@
     "mapFilterCompleted": "పూర్తి",
     "mapFilterReset": "మళ్లీ సెట్ చేయండి",
     "activityTypeConversation": "సంభాషణ",
-    "lockedMissionRequirement": "అన్లాక్ చేయడానికి మునుపటి మిషన్‌ను పూర్తి చేయండి",
     "playAgain": "మళ్లీ ఆడండి",
     "reviewActivity": "సమీక్ష",
     "mapEmptyInView": "మీ స్థాయిలో లేదా భాషలో ఇక్కడ ఏమి లేదు. మీ ఫిల్టర్లను విస్తరించండి లేదా జూమ్ అవుట్ చేయండి.",
@@ -11014,14 +10109,9 @@
     "scrollToBottom": "కిందకు స్క్రోల్ చేయండి",
     "courseImage": "కోర్సు చిత్రం",
     "avatarPreview": "అవతార్ ప్రివ్యూ",
-    "activityPhoto": "చర్య ఫోటో",
     "emotePreview": "ఎమోట్ ప్రివ్యూ: {name}",
     "activityLabel": "చర్య: {title}",
     "resetMapView": "నకశా దృశ్యాన్ని పునఃసెట్ చేయండి",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11074,14 +10164,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11111,10 +10193,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11171,10 +10249,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_th.arb
+++ b/lib/l10n/intl_th.arb
@@ -34,11 +34,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "ผู้ใช้ทั่วไปได้รับอนุญาตให้เข้าร่วมหรือไม่",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "sendOnEnter": "ส่งเมื่อกด enter",
     "@sendOnEnter": {},
     "answeredTheCall": "{senderName} รับสายแล้ว",
@@ -284,28 +279,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@reportErrorDescription": {},
     "@directChats": {
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
-    "@addAccount": {},
     "@close": {
         "type": "String",
         "placeholders": {}
@@ -449,10 +427,6 @@
             }
         }
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youAcceptedTheInvitation": {},
     "@banFromChat": {
         "type": "String",
@@ -565,10 +539,6 @@
             }
         }
     },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unbanUserDescription": {},
     "@userAndUserAreTyping": {
         "type": "String",
@@ -609,9 +579,6 @@
     },
     "@link": {},
     "@widgetUrlError": {},
-    "@emailOrUsername": {},
-    "@newSpaceDescription": {},
-    "@chatDescription": {},
     "@next": {
         "type": "String",
         "placeholders": {}
@@ -632,8 +599,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@enterSpace": {},
-    "@encryptThisChat": {},
     "@fileName": {
         "type": "String",
         "placeholders": {}
@@ -659,7 +624,6 @@
         "placeholders": {}
     },
     "@reopenChat": {},
-    "@pleaseEnterRecoveryKey": {},
     "@create": {
         "type": "String",
         "placeholders": {}
@@ -682,10 +646,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@addWidget": {},
     "@removeAllOtherDevices": {
         "type": "String",
@@ -703,10 +663,6 @@
         }
     },
     "@noKeyForThisMessage": {},
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@inviteText": {
         "type": "String",
         "placeholders": {
@@ -736,11 +692,6 @@
         }
     },
     "@pushNotificationsNotAvailable": {},
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {},
     "@replaceRoomWithNewerVersion": {
         "type": "String",
         "placeholders": {}
@@ -749,10 +700,6 @@
     "@invalidServerName": {},
     "@chatPermissions": {},
     "@voiceMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -765,7 +712,6 @@
         }
     },
     "@sender": {},
-    "@storeInAndroidKeystore": {},
     "@hideRedactedEvents": {
         "type": "String",
         "placeholders": {}
@@ -822,10 +768,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@passwordHasBeenChanged": {
         "type": "String",
         "placeholders": {}
@@ -842,7 +784,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveKeyManuallyDescription": {},
     "@none": {
         "type": "String",
         "placeholders": {}
@@ -853,14 +794,6 @@
         "placeholders": {}
     },
     "@whyIsThisMessageEncrypted": {},
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "@rejectedTheInvitation": {
         "type": "String",
         "placeholders": {
@@ -878,26 +811,16 @@
             }
         }
     },
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@or": {
         "type": "String",
         "placeholders": {}
     },
     "@dehydrateWarning": {},
     "@noOtherDevicesFound": {},
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@emptyChat": {
         "type": "String",
         "placeholders": {}
     },
-    "@storeSecurlyOnThisDevice": {},
-    "@yourChatBackupHasBeenSetUp": {},
     "@chatBackup": {
         "type": "String",
         "placeholders": {}
@@ -914,7 +837,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {},
     "@unmuteChat": {
         "type": "String",
         "placeholders": {}
@@ -942,14 +864,6 @@
     "@participant": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@yes": {
         "type": "String",
@@ -1022,7 +936,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@unlockOldMessages": {},
     "@identity": {
         "type": "String",
         "placeholders": {}
@@ -1183,7 +1096,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterRecoveryKeyDescription": {},
     "@guestsAreForbidden": {
         "type": "String",
         "placeholders": {}
@@ -1335,7 +1247,6 @@
         "description": "State that {command} is not a valid /command."
     },
     "@redactMessageDescription": {},
-    "@recoveryKey": {},
     "@redactMessage": {
         "type": "String",
         "placeholders": {}
@@ -1398,10 +1309,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@verifyStart": {
         "type": "String",
         "placeholders": {}
@@ -1416,7 +1323,6 @@
         "placeholders": {}
     },
     "@serverRequiresEmail": {},
-    "@screenSharingTitle": {},
     "@widgetCustom": {},
     "@sentCallInformations": {
         "type": "String",
@@ -1504,7 +1410,6 @@
         "placeholders": {}
     },
     "@messageInfo": {},
-    "@disableEncryptionWarning": {},
     "@directChat": {},
     "@encryptionNotEnabled": {
         "type": "String",
@@ -1527,21 +1432,15 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {},
     "@enterAnEmailAddress": {
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {},
     "@commandHint_kick": {
         "type": "String",
         "description": "Usage hint for the command /kick"
     },
     "@copiedToClipboard": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1587,10 +1486,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@learnMore": {},
     "@iHaveClickedOnLink": {
         "type": "String",
@@ -1609,7 +1504,6 @@
     },
     "@newGroup": {},
     "@bundleName": {},
-    "@removeFromSpace": {},
     "@dateAndTimeOfDay": {
         "type": "String",
         "placeholders": {
@@ -1655,10 +1549,6 @@
         "placeholders": {}
     },
     "@pleaseEnterANumber": {},
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@youKicked": {
         "placeholders": {
             "user": {
@@ -1701,22 +1591,12 @@
             }
         }
     },
-    "@sorryThatsNotPossible": {},
     "@oopsSomethingWentWrong": {
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@shareInviteLink": {},
     "@commandHint_markasdm": {},
-    "@recoveryKeyLost": {},
     "@messages": {
         "type": "String",
         "placeholders": {}
@@ -1727,14 +1607,6 @@
     },
     "@deviceKeys": {},
     "@waitingPartnerNumbers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -1762,15 +1634,10 @@
         "type": "String",
         "placeholders": {}
     },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@settings": {
         "type": "String",
         "placeholders": {}
     },
-    "@setTheme": {},
     "@changeTheHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -1791,10 +1658,6 @@
                 "type": "String"
             }
         }
-    },
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
     },
     "@changeDeviceName": {
         "type": "String",
@@ -1936,7 +1799,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@storeInSecureStorageDescription": {},
     "@openChat": {},
     "@kickUserDescription": {},
     "@sendAMessage": {
@@ -1948,13 +1810,11 @@
         "placeholders": {}
     },
     "@pinMessage": {},
-    "@screenSharingDetail": {},
     "@muteChat": {
         "type": "String",
         "placeholders": {}
     },
     "@invite": {},
-    "@enableMultiAccounts": {},
     "@emotePacks": {
         "type": "String",
         "placeholders": {}
@@ -2010,9 +1870,7 @@
     "changeTheNameOfTheGroup": "เปลี่ยนชื่อกลุ่ม",
     "changeYourAvatar": "เปลี่ยนรูปโปรไฟล์ของคุณ",
     "channelCorruptedDecryptError": "การเข้ารหัสถูกทำลาย",
-    "yourChatBackupHasBeenSetUp": "การสำรองข้อมูลแชทของคุณได้ตั้งค่าแล้ว",
     "chatBackup": "การสำรองข้อมูลแชท",
-    "chatBackupDescription": "ข้อความเก่า ๆ ของคุณได้รับการป้องกันด้วยกุญแจกู้คืน กรุณาอย่าทำให้สูญหาย",
     "chats": "แชท",
     "chooseAStrongPassword": "เลือกรหัสผ่านที่แข็งแรง",
     "clearArchive": "ล้างข้อมูลเก่า",
@@ -2044,18 +1902,15 @@
     "configureChat": "กำหนดค่าการแชท",
     "confirm": "ยืนยัน",
     "connect": "เชื่อมต่อ",
-    "contactHasBeenInvitedToTheGroup": "ได้เชิญผู้ติดต่อเข้ากลุ่มแล้ว",
     "contentHasBeenReported": "เนื้อหาได้รับรายงานไปยังผู้ดูแลเซิร์ฟเวอร์แล้ว",
     "copiedToClipboard": "คัดลอกไปยังคลิปบอร์ดแล้ว",
     "copyToClipboard": "คัดลอกไปยังคลิปบอร์ด",
     "couldNotDecryptMessage": "ไม่สามารถถอดรหัสข้อความได้: {error}",
     "checkList": "รายการตรวจสอบ",
     "countParticipants": "{count} ผู้เข้าร่วม",
-    "countInvited": "{count} ได้รับเชิญ",
     "create": "สร้าง",
     "createdTheChat": "💬 {username} สร้างแชทแล้ว",
     "createGroup": "สร้างกลุ่ม",
-    "createNewSpace": "สร้างพื้นที่ใหม่",
     "currentlyActive": "กำลังใช้งานอยู่",
     "darkTheme": "มืด",
     "dateAndTimeOfDay": "{date}, {timeOfDay}",
@@ -2079,9 +1934,6 @@
     "emoteKeyboardNoRecents": "อีโมจิที่ใช้บ่อยจะแสดงที่นี่...",
     "emotePacks": "แพ็คอีโมจิสำหรับห้อง",
     "emoteSettings": "การตั้งค่าอิโมจิ",
-    "globalChatId": "รหัสแชททั่วโลก",
-    "accessAndVisibility": "การเข้าถึงและการมองเห็น",
-    "accessAndVisibilityDescription": "ใครสามารถเข้าร่วมแชทนี้ได้และแชทนี้สามารถค้นพบได้อย่างไร",
     "calls": "การโทร",
     "customEmojisAndStickers": "อิโมจิและสติกเกอร์ที่กำหนดเอง",
     "customEmojisAndStickersBody": "เพิ่มหรือแชร์อิโมจิหรือสติกเกอร์ที่กำหนดเองซึ่งสามารถใช้ในแชทใดก็ได้",
@@ -2089,7 +1941,6 @@
     "emptyChat": "แชทว่างเปล่า",
     "enableEmotesGlobally": "เปิดใช้งแพ็คอิโมจิทั่วโลก",
     "enableEncryption": "เปิดใช้งการเข้ารหัส",
-    "enableEncryptionWarning": "คุณจะไม่สามารถปิดการเข้ารหัสได้อีกต่อไป คุณแน่ใจหรือไม่?",
     "encrypted": "เข้ารหัสแล้ว",
     "encryption": "การเข้ารหัส",
     "encryptionNotEnabled": "การเข้ารหัสยังไม่ได้เปิดใช้งาน",
@@ -2097,7 +1948,6 @@
     "enterAnEmailAddress": "ป้อนที่อยู่อีเมล",
     "homeserver": "เซิร์ฟเวอร์บ้าน",
     "errorObtainingLocation": "เกิดข้อผิดพลาดในการรับตำแหน่ง: {error}",
-    "everythingReady": "ทุกอย่างพร้อมแล้ว!",
     "extremeOffensive": "รุนแรงมาก",
     "fileName": "ชื่อไฟล์",
     "fontSize": "ขนาดตัวอักษร",
@@ -2105,9 +1955,7 @@
     "fromJoining": "จากการเข้าร่วม",
     "fromTheInvitation": "จากคำเชิญ",
     "group": "กลุ่ม",
-    "chatDescription": "คำอธิบายแชท",
     "chatDescriptionHasBeenChanged": "คำอธิบายแชทถูกเปลี่ยนแปลง",
-    "groupIsPublic": "กลุ่มสาธารณะ",
     "groups": "กลุ่ม",
     "groupWith": "กลุ่มกับ {displayname}",
     "guestsAreForbidden": "ไม่อนุญาตให้แขกเข้าร่วม",
@@ -2128,7 +1976,6 @@
     "incorrectPassphraseOrKey": "รหัสผ่านหรือกุญแจกู้คืนไม่ถูกต้อง",
     "inoffensive": "ไม่รุนแรง",
     "inviteContact": "เชิญผู้ติดต่อ",
-    "inviteContactToGroup": "เชิญผู้ติดต่อเข้าร่วม {groupName}",
     "noChatDescriptionYet": "ยังไม่ได้สร้างคำอธิบายแชท",
     "tryAgain": "ลองอีกครั้ง",
     "invalidServerName": "ชื่อเซิร์ฟเวอร์ไม่ถูกต้อง",
@@ -2149,7 +1996,6 @@
     "leave": "ออกจาก",
     "leftTheChat": "ออกจากแชทแล้ว",
     "lightTheme": "แสง",
-    "loadCountMoreParticipants": "โหลดผู้เข้าร่วมเพิ่มเติม {count}",
     "dehydrate": "ส่งออกเซสชันและล้างข้อมูลอุปกรณ์",
     "dehydrateWarning": "ไม่สามารถยกเลิกการดำเนินการนี้ได้ โปรดเก็บไฟล์สำรองข้อมูลอย่างปลอดภัย",
     "hydrate": "กู้คืนจากไฟล์สำรองข้อมูล",
@@ -2158,7 +2004,6 @@
     "locationDisabledNotice": "บริการตำแหน่งถูกปิดใช้งาน กรุณาเปิดใช้งานเพื่อแชร์ตำแหน่งของคุณ",
     "locationPermissionDeniedNotice": "สิทธิ์ตำแหน่งถูกปฏิเสธ กรุณาให้สิทธิ์เพื่อแชร์ตำแหน่งของคุณ",
     "login": "เข้าสู่ระบบ",
-    "logInTo": "เข้าสู่ระบบ {homeserver}",
     "logout": "ออกจากระบบ",
     "mention": "กล่าวถึง",
     "messages": "ข้อความ",
@@ -2173,8 +2018,6 @@
     "no": "ไม่",
     "noConnectionToTheServer": "ไม่สามารถเชื่อมต่อกับเซิร์ฟเวอร์",
     "noEmotesFound": "ไม่พบอีโมจิ 😝",
-    "noEncryptionForPublicRooms": "คุณสามารถเปิดใช้งานการเข้ารหัสได้เมื่อห้องไม่สามารถเข้าถึงได้สาธารณะอีกต่อไป",
-    "noGoogleServicesWarning": "Firebase Cloud Messaging ดูเหมือนจะไม่พร้อมใช้งานบนอุปกรณ์ของคุณ เพื่อรับการแจ้งเตือนแบบพุชต่อเนื่อง เรายินดีแนะนำให้ติดตั้ง ntfy ด้วย ntfy หรือผู้ให้บริการ Push รวมอื่น ๆ คุณสามารถดาวน์โหลด ntfy จาก PlayStore หรือ F-Droid",
     "noMatrixServer": "{server1} ไม่ใช่เซิร์ฟเวอร์ matrix ใช้ {server2} แทนไหม?",
     "shareInviteLink": "แชร์ลิงก์เชิญ",
     "scanQrCode": "สแกนรหัส QR",
@@ -2196,12 +2039,10 @@
     "openCamera": "เปิดกล้อง",
     "openVideoCamera": "เปิดกล้องสำหรับวิดีโอ",
     "oneClientLoggedOut": "ไคลเอนต์ของคุณหนึ่งรายได้ออกจากระบบแล้ว",
-    "addAccount": "เพิ่มบัญชี",
     "editBundlesForAccount": "แก้ไขกลุ่มสำหรับบัญชีนี้",
     "addToBundle": "เพิ่มในกลุ่ม",
     "removeFromBundle": "เอาออกจากกลุ่มนี้",
     "bundleName": "ชื่อกลุ่ม",
-    "enableMultiAccounts": "(เบต้า) เปิดใช้งานหลายบัญชีบนอุปกรณ์นี้",
     "openInMaps": "เปิดในแผนที่",
     "link": "ลิงก์",
     "serverRequiresEmail": "เซิร์ฟเวอร์นี้ต้องการตรวจสอบอีเมลของคุณเพื่อการลงทะเบียน",
@@ -2213,7 +2054,6 @@
     "passwordHasBeenChanged": "รหัสผ่านถูกเปลี่ยนแล้ว",
     "overview": "ภาพรวม",
     "passwordRecoverySettings": "การตั้งค่าการกู้คืนรหัสผ่าน",
-    "passwordRecovery": "การกู้คืนรหัสผ่าน",
     "people": "ผู้คน",
     "pickImage": "เลือกภาพ",
     "play": "เล่น {fileName}",
@@ -2221,7 +2061,6 @@
     "pleaseChooseAPasscode": "กรุณาเลือกรหัสผ่าน",
     "pleaseClickOnLink": "กรุณาคลิกที่ลิงก์ในอีเมลแล้วดำเนินการต่อ",
     "pleaseEnter4Digits": "กรุณาใส่ตัวเลข 4 หลักหรือเว้นว่างเพื่อปิดการล็อคแอป",
-    "pleaseEnterRecoveryKey": "กรุณาใส่คีย์กู้คืนของคุณ:",
     "pleaseEnterYourPassword": "กรุณาใส่รหัสผ่านของคุณ",
     "pleaseEnterYourPin": "กรุณาใส่ PIN ของคุณ",
     "pleaseEnterYourUsername": "กรุณาใส่ชื่อผู้ใช้ของคุณ",
@@ -2241,7 +2080,6 @@
     "rejectedTheInvitation": "{username} ปฏิเสธคำเชิญ",
     "removeAllOtherDevices": "ลบอุปกรณ์อื่นทั้งหมด",
     "removedBy": "ถูกลบโดย {username}",
-    "removeDevice": "ลบอุปกรณ์",
     "unbanFromChat": "ปลดแบนจากแชท",
     "removeYourAvatar": "ลบภาพโปรไฟล์ของคุณ",
     "replaceRoomWithNewerVersion": "แทนที่ห้องด้วยเวอร์ชันใหม่กว่า",
@@ -2253,8 +2091,6 @@
     "saveFile": "บันทึกไฟล์",
     "search": "ค้นหา",
     "security": "ความปลอดภัย",
-    "recoveryKey": "คีย์กู้คืน",
-    "recoveryKeyLost": "คีย์กู้คืนสูญหาย?",
     "sendAMessage": "ส่งข้อความ",
     "sendAsText": "ส่งเป็นข้อความ",
     "sendAudio": "ส่งเสียง",
@@ -2272,7 +2108,6 @@
     "separateChatTypes": "แยกแชทตรงและกลุ่ม",
     "setAsCanonicalAlias": "ตั้งเป็นชื่อเรียกหลัก",
     "setChatDescription": "ตั้งคำอธิบายแชท",
-    "setPermissionsLevel": "ตั้งระดับสิทธิ์",
     "setStatus": "ตั้งสถานะ",
     "settings": "การตั้งค่า",
     "share": "แชร์",
@@ -2282,8 +2117,6 @@
     "presencesToggle": "แสดงข้อความสถานะจากผู้ใช้อื่น",
     "skip": "ข้าม",
     "sourceCode": "รหัสต้นฉบับ",
-    "spaceIsPublic": "พื้นที่สาธารณะ",
-    "spaceName": "ชื่อพื้นที่",
     "startedACall": "{senderName} เริ่มการโทร",
     "status": "สถานะ",
     "statusExampleMessage": "คุณเป็นอย่างไรบ้างวันนี้?",
@@ -2295,7 +2128,6 @@
     "theyMatch": "ตรงกัน",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "คำขอมากเกินไป กรุณาลองใหม่อีกครั้งในภายหลัง!",
-    "transferFromAnotherDevice": "โอนย้ายจากอุปกรณ์อื่น",
     "tryToSendAgain": "ลองส่งอีกครั้ง",
     "unavailable": "ไม่พร้อมใช้งาน",
     "unbannedUser": "{username} ยกเลิกการแบน {targetName}",
@@ -2305,7 +2137,6 @@
     "unknownEvent": "เหตุการณ์ที่ไม่รู้จัก '{type}'",
     "unmuteChat": "เปิดเสียงแชท",
     "unpin": "ยกเลิกปักหมุด",
-    "unreadChats": "{unreadCount, plural, =1{แชทที่ยังไม่ได้อ่าน 1 รายการ} other{{unreadCount} รายการที่ยังไม่ได้อ่าน}}",
     "userAndOthersAreTyping": "{username} และ {count} คนอื่นกำลังพิมพ์…",
     "userAndUserAreTyping": "{username} และ {username2} กำลังพิมพ์…",
     "userIsTyping": "{username} กำลังพิมพ์…",
@@ -2318,8 +2149,6 @@
     "verifyStart": "เริ่มการยืนยันตัวตน",
     "verifySuccess": "คุณยืนยันตัวตนสำเร็จแล้ว!",
     "verifyTitle": "กำลังตรวจสอบบัญชีอื่น",
-    "videoCall": "วิดีโอคอล",
-    "visibilityOfTheChatHistory": "ความสามารถในการมองเห็นประวัติแชท",
     "visibleForAllParticipants": "มองเห็นได้สำหรับผู้เข้าร่วมทุกคน",
     "visibleForEveryone": "มองเห็นได้สำหรับทุกคน",
     "voiceMessage": "ข้อความเสียง",
@@ -2329,10 +2158,7 @@
     "wallpaper": "วอลเปเปอร์:",
     "warning": "คำเตือน!",
     "weSentYouAnEmail": "เราได้ส่งอีเมลให้คุณแล้ว",
-    "whoCanPerformWhichAction": "ใครสามารถดำเนินการใดได้บ้าง",
-    "whoIsAllowedToJoinThisGroup": "ใครได้รับอนุญาตให้เข้าร่วมกลุ่มนี้",
     "whyDoYouWantToReportThis": "ทำไมคุณถึงต้องการรายงานเรื่องนี้?",
-    "wipeChatBackup": "ลบข้อมูลสำรองการแชทของคุณเพื่อสร้างกุญแจกู้คืนใหม่หรือไม่?",
     "withTheseAddressesRecoveryDescription": "ด้วยที่อยู่เหล่านี้คุณสามารถกู้คืนรหัสผ่านของคุณได้",
     "writeAMessage": "เขียนข้อความ…",
     "yes": "ใช่",
@@ -2345,9 +2171,7 @@
     "messageType": "ประเภทข้อความ",
     "sender": "ผู้ส่ง",
     "openGallery": "เปิดแกลเลอรี่",
-    "removeFromSpace": "ลบออกจากพื้นที่",
     "start": "เริ่มต้น",
-    "pleaseEnterRecoveryKeyDescription": "เพื่อปลดล็อกข้อความเก่าของคุณ กรุณาใส่กุญแจกู้คืนที่สร้างขึ้นในเซสชันก่อนหน้านี้ กุญแจกู้คืนของคุณไม่ใช่รหัสผ่านของคุณ",
     "publish": "เผยแพร่",
     "openChat": "เปิดแชท",
     "markAsRead": "ทำเครื่องหมายว่าอ่านแล้ว",
@@ -2358,12 +2182,9 @@
     "confirmEventUnpin": "คุณแน่ใจหรือว่าต้องการยกเลิกปักหมุดกิจกรรมนี้ถาวร?",
     "emojis": "อิโมจิ",
     "placeCall": "วางสาย",
-    "voiceCall": "สายเสียง",
     "unsupportedAndroidVersion": "เวอร์ชัน Android ที่ไม่รองรับ",
     "unsupportedAndroidVersionLong": "คุณสมบัตินี้ต้องการเวอร์ชัน Android ที่ใหม่กว่า กรุณาตรวจสอบการอัปเดตหรือการสนับสนุน Lineage OS",
-    "videoCallsBetaWarning": "โปรดทราบว่าการโทรวิดีโอยังอยู่ในเวอร์ชันเบต้า อาจทำงานไม่ตรงตามคาดหวังหรือไม่ทำงานเลยบนแพลตฟอร์มทั้งหมด",
     "experimentalVideoCalls": "การโทรวิดีโอทดลอง",
-    "emailOrUsername": "อีเมลหรือชื่อผู้ใช้",
     "addWidget": "เพิ่มวิดเจ็ต",
     "widgetVideo": "วิดีโอ",
     "widgetEtherpad": "บันทึกข้อความ",
@@ -2385,35 +2206,19 @@
     "youKickedAndBanned": "🙅‍♀️ คุณเตะและแบน {user}",
     "youUnbannedUser": "คุณยกเลิกการแบน {user}",
     "hasKnocked": "🚪 {user} ได้เคาะแล้ว",
-    "usersMustKnock": "ผู้ใช้ต้องเคาะก่อนเข้า",
-    "noOneCanJoin": "ไม่มีใครสามารถเข้าร่วมได้",
     "knock": "เคาะ",
     "users": "ผู้ใช้",
-    "unlockOldMessages": "ปลดล็อกข้อความเก่า",
-    "storeInSecureStorageDescription": "เก็บกุญแจกู้คืนในที่เก็บข้อมูลที่ปลอดภัยของอุปกรณ์นี้",
-    "saveKeyManuallyDescription": "บันทึกกุญแจนี้ด้วยตนเองโดยการเปิดกล่องโต้ตอบแชร์ของระบบหรือคลิปบอร์ด",
-    "storeInAndroidKeystore": "เก็บใน Android KeyStore",
-    "storeInAppleKeyChain": "เก็บใน Apple KeyChain",
-    "storeSecurlyOnThisDevice": "เก็บอย่างปลอดภัยบนอุปกรณ์นี้",
     "countFiles": "{count} ไฟล์",
     "user": "ผู้ใช้",
     "custom": "กำหนดเอง",
-    "foregroundServiceRunning": "การแจ้งเตือนนี้ปรากฏเมื่อบริการในพื้นหลังทำงาน",
-    "screenSharingTitle": "การแชร์หน้าจอ",
-    "screenSharingDetail": "คุณกำลังแชร์หน้าจอของคุณใน FuffyChat",
     "whyIsThisMessageEncrypted": "ทำไมข้อความนี้ถึงอ่านไม่ออก?",
     "noKeyForThisMessage": "อาจเกิดขึ้นได้หากข้อความถูกส่งก่อนที่คุณจะลงชื่อเข้าใช้บัญชีของคุณบนอุปกรณ์นี้\n\nอาจเป็นไปได้ว่าผู้ส่งบล็อกอุปกรณ์ของคุณหรือมีปัญหาเกี่ยวกับการเชื่อมต่ออินเทอร์เน็ต\n\nคุณสามารถอ่านข้อความบนเซสชันอื่นได้ไหม? จากนั้นคุณสามารถถ่ายโอนข้อความจากเซสชันนั้น! ไปที่ การตั้งค่า > อุปกรณ์ และตรวจสอบให้อุปกรณ์ของคุณได้รับการยืนยันซึ่งกันและกัน เมื่อคุณเปิดห้องในครั้งถัดไปและทั้งสองเซสชันอยู่ในโฟกัส คีย์จะถูกส่งโดยอัตโนมัติ\n\nคุณไม่ต้องการให้คีย์หายเมื่อออกจากระบบหรือเปลี่ยนอุปกรณ์? ตรวจสอบให้แน่ใจว่าคุณได้เปิดใช้งานการสำรองข้อมูลแชทในการตั้งค่า",
     "newGroup": "กลุ่มใหม่",
     "newSpace": "พื้นที่ใหม่",
-    "enterSpace": "เข้าสู่พื้นที่",
     "allSpaces": "พื้นที่ทั้งหมด",
     "hidePresences": "ซ่อนรายการสถานะ?",
     "doNotShowAgain": "ไม่แสดงอีก",
     "wasDirectChatDisplayName": "แชทว่างเปล่า (เดิม {oldDisplayName})",
-    "newSpaceDescription": "Spaces ช่วยให้คุณรวมการสนทนาของคุณและสร้างชุมชนส่วนตัวหรือสาธารณะ",
-    "encryptThisChat": "เข้ารหัสแชทนี้",
-    "disableEncryptionWarning": "เพื่อความปลอดภัย คุณไม่สามารถปิดการเข้ารหัสในแชทที่เปิดใช้งานไว้ก่อนหน้านี้ได้",
-    "sorryThatsNotPossible": "ขออภัย... นั่นเป็นไปไม่ได้",
     "deviceKeys": "กุญแจอุปกรณ์:",
     "reopenChat": "เปิดแชทอีกครั้ง",
     "noBackupWarning": "คำเตือน! หากไม่เปิดใช้งานการสำรองข้อมูลแชท คุณจะสูญเสียการเข้าถึงข้อความที่เข้ารหัสของคุณ แนะนำให้เปิดใช้งานการสำรองข้อมูลแชทก่อนออกจากระบบ",
@@ -2426,7 +2231,6 @@
     "openLinkInBrowser": "เปิดลิงก์ในเบราว์เซอร์",
     "reportErrorDescription": "😞 โอ้ไม่ เกิดข้อผิดพลาดขึ้น หากต้องการ คุณสามารถรายงานบั๊กนี้ให้กับนักพัฒนา",
     "report": "รายงาน",
-    "setTheme": "ตั้งธีม:",
     "setColorTheme": "ตั้งธีมสี:",
     "invite": "เชิญ",
     "inviteGroupChat": "📨 เชิญเข้าร่วมกลุ่มแชท",
@@ -2445,12 +2249,8 @@
     "yourGlobalUserIdIs": "รหัสผู้ใช้ทั่วโลกของคุณคือ: ",
     "noUsersFoundWithQuery": "น่าเสียดาย ไม่พบผู้ใช้ที่ตรงกับ \"{query}\" กรุณาตรวจสอบว่าคุณพิมพ์ผิดหรือไม่",
     "knocking": "เคาะประตู",
-    "chatCanBeDiscoveredViaSearchOnServer": "สามารถค้นหาแชทได้ผ่านการค้นหาใน {server}",
-    "searchChatsRooms": "ค้นหา #แชท, @ผู้ใช้...",
     "nothingFound": "ไม่พบอะไร...",
     "groupName": "ชื่อกลุ่ม",
-    "createGroupAndInviteUsers": "สร้างกลุ่มและเชิญชวนผู้ใช้",
-    "groupCanBeFoundViaSearch": "สามารถค้นหากลุ่มได้ผ่านการค้นหา",
     "wrongRecoveryKey": "ขออภัย... ดูเหมือนว่าคีย์กู้คืนนี้จะไม่ถูกต้อง",
     "startConversation": "เริ่มการสนทนา",
     "commandHint_sendraw": "ส่ง JSON ดิบ",
@@ -2464,11 +2264,8 @@
     "pleaseChooseAStrongPassword": "โปรดเลือกรหัสผ่านที่แข็งแรง",
     "passwordsDoNotMatch": "รหัสผ่านไม่ตรงกัน",
     "passwordIsWrong": "รหัสผ่านที่คุณป้อนผิด",
-    "publicChatAddresses": "ที่อยู่แชทสาธารณะ",
-    "createNewAddress": "สร้างที่อยู่ใหม่",
     "joinSpace": "เข้าร่วมพื้นที่",
     "publicSpaces": "พื้นที่สาธารณะ",
-    "addChatOrSubSpace": "เพิ่มแชทหรือพื้นที่ย่อย",
     "subspace": "พื้นที่ย่อย",
     "decline": "ปฏิเสธ",
     "thisDevice": "อุปกรณ์นี้:",
@@ -2477,15 +2274,11 @@
     "searchMore": "ค้นหาเพิ่มเติม...",
     "gallery": "แกลเลอรี่",
     "files": "ไฟล์",
-    "sessionLostBody": "เซสชันของคุณหายไป กรุณารายงานข้อผิดพลาดนี้ให้กับนักพัฒนาที่ {url} ข้อความผิดพลาดคือ: {error}",
-    "restoreSessionBody": "แอปกำลังพยายามกู้คืนเซสชันของคุณจากการสำรองข้อมูล กรุณารายงานข้อผิดพลาดนี้ให้กับนักพัฒนาที่ {url} ข้อความผิดพลาดคือ: {error}",
     "sendReadReceipts": "ส่งการแจ้งเตือนเมื่ออ่านแล้ว",
     "sendTypingNotificationsDescription": "ผู้เข้าร่วมคนอื่นในแชทสามารถเห็นเมื่อคุณกำลังพิมพ์ข้อความใหม่",
     "sendReadReceiptsDescription": "ผู้เข้าร่วมคนอื่นในแชทสามารถเห็นเมื่อคุณได้อ่านข้อความแล้ว",
     "formattedMessages": "ข้อความที่จัดรูปแบบแล้ว",
     "formattedMessagesDescription": "แสดงเนื้อหาข้อความที่มีรูปแบบ เช่น ตัวหนา โดยใช้มาร์กดาวน์",
-    "verifyOtherUser": "🔐 ยืนยันตัวตนผู้ใช้อื่น",
-    "verifyOtherUserDescription": "หากคุณยืนยันตัวตนผู้ใช้อื่น คุณจะมั่นใจได้ว่าคุณกำลังเขียนข้อความให้กับใครจริง ๆ 💪\n\nเมื่อคุณเริ่มการยืนยัน ตัวคุณและผู้ใช้อื่นจะเห็นป็อปอัปในแอปพลิเคชัน ซึ่งจะมีอิโมจิหรือหมายเลขที่คุณต้องเปรียบเทียบกัน\n\nวิธีที่ดีที่สุดคือการนัดพบหรือเริ่มวิดีโอคอล 👭",
     "verifyOtherDevice": "🔐 ยืนยันอุปกรณ์อื่น",
     "verifyOtherDeviceDescription": "เมื่อคุณยืนยันอุปกรณ์อื่น อุปกรณ์เหล่านั้นสามารถแลกเปลี่ยนกุญแจ ซึ่งจะเพิ่มความปลอดภัยโดยรวมของคุณ 💪 เมื่อคุณเริ่มการยืนยัน จะมีป็อปอัปปรากฏในแอปบนทั้งสองอุปกรณ์ ซึ่งจะมีอิโมจิหรือหมายเลขที่คุณต้องเปรียบเทียบกัน ควรมีอุปกรณ์ทั้งสองพร้อมก่อนเริ่มการยืนยัน 🤳",
     "acceptedKeyVerification": "{sender} ยอมรับการยืนยันกุญแจ",
@@ -2521,10 +2314,6 @@
     "updateInstalled": "🎉 อัปเดต {version} ติดตั้งแล้ว!",
     "changelog": "บันทึกการเปลี่ยนแปลง",
     "sendCanceled": "การส่งถูกยกเลิก",
-    "loginWithMatrixId": "เข้าสู่ระบบด้วย Matrix-ID",
-    "discoverHomeservers": "ค้นหาเซิร์ฟเวอร์หลัก",
-    "whatIsAHomeserver": "homeserver คืออะไร?",
-    "homeserverDescription": "ข้อมูลของคุณทั้งหมดถูกเก็บไว้บน homeserver เช่นเดียวกับผู้ให้บริการอีเมล คุณสามารถเลือกใช้ homeserver ใดก็ได้ ในขณะที่คุณยังสามารถสื่อสารกับทุกคนได้ เรียนรู้เพิ่มเติมได้ที่ https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "ดูเหมือนจะไม่ใช่ homeserver ที่รองรับ URL ผิดหรือไม่?",
     "calculatingFileSize": "กำลังคำนวณขนาดไฟล์...",
     "prepareSendingAttachment": "เตรียมส่งไฟล์แนบ...",
@@ -2536,11 +2325,9 @@
     "oneOfYourDevicesIsNotVerified": "อุปกรณ์ของคุณหนึ่งเครื่องยังไม่ได้รับการยืนยัน",
     "noticeChatBackupDeviceVerification": "หมายเหตุ: เมื่อคุณเชื่อมต่ออุปกรณ์ทั้งหมดของคุณกับการสำรองข้อมูลแชท พวกเขาจะได้รับการยืนยันโดยอัตโนมัติ",
     "continueText": "ดำเนินการต่อ",
-    "welcomeText": "สวัสดี สวัสดี 👋 นี่คือ FluffyChat คุณสามารถเข้าสู่ระบบได้ที่ homeserver ใดก็ได้ที่รองรับ https://matrix.org แล้วสนทนากับใครก็ได้ มันคือเครือข่ายส่งข้อความแบบกระจายขนาดใหญ่!",
     "blur": "เบลอ:",
     "opacity": "ความทึบ:",
     "setWallpaper": "ตั้งพื้นหลัง",
-    "manageAccount": "จัดการบัญชี",
     "noContactInformationProvided": "เซิร์ฟเวอร์ไม่ได้ให้ข้อมูลติดต่อที่ถูกต้องใด ๆ",
     "contactServerAdmin": "ติดต่อผู้ดูแลเซิร์ฟเวอร์",
     "contactServerSecurity": "ติดต่อความปลอดภัยของเซิร์ฟเวอร์",
@@ -2559,11 +2346,8 @@
     "unableToJoinChat": "ไม่สามารถเข้าร่วมแชทได้ อาจเป็นไปได้ว่าฝ่ายอื่นได้ปิดการสนทนาแล้ว",
     "previous": "ก่อนหน้า",
     "otherPartyNotLoggedIn": "ฝ่ายอื่นยังไม่ได้เข้าสู่ระบบ จึงไม่สามารถรับข้อความได้!",
-    "appWantsToUseForLogin": "ใช้ '{server}' เพื่อเข้าสู่ระบบ",
-    "appWantsToUseForLoginDescription": "คุณอนุญาตให้แอปและเว็บไซต์แชร์ข้อมูลเกี่ยวกับคุณ",
     "open": "เปิด",
     "waitingForServer": "กำลังรอเซิร์ฟเวอร์...",
-    "appIntroduction": "FluffyChat ให้คุณแชทกับเพื่อนของคุณผ่านแอปพลิเคชันส่งข้อความต่าง ๆ เรียนรู้เพิ่มเติมได้ที่ https://matrix.org หรือแตะ *ดำเนินการต่อ*",
     "newChatRequest": "📩 คำขอแชทใหม่",
     "contentNotificationSettings": "การตั้งค่าการแจ้งเตือนเนื้อหา",
     "generalNotificationSettings": "การตั้งค่าการแจ้งเตือนทั่วไป",
@@ -2640,11 +2424,9 @@
     "taTooltip": "ใช้ L2 พร้อมความช่วยเหลือด้านการแปล",
     "interactiveTranslatorSliderHeader": "นักแปลแบบโต้ตอบ",
     "interactiveGrammarSliderHeader": "เครื่องตรวจสอบไวยากรณ์แบบโต้ตอบ",
-    "interactiveTranslatorRequired": "จำเป็น",
     "waTooltip": "ใช้ L2 โดยไม่ต้องความช่วยเหลือ",
     "interactiveTranslator": "ความช่วยเหลือในการแปล",
     "noIdenticalLanguages": "โปรดเลือกภาษาพื้นฐานและภาษาปลายทางที่แตกต่างกัน",
-    "searchBy": "ค้นหาตามประเทศและภาษา",
     "joinWithClassCode": "เข้าร่วมคอร์ส",
     "languageLevelPreA1": "ระดับเริ่มต้นต่ำ (Pre A1)",
     "languageLevelA1": "มือใหม่ ระดับกลาง (A1)",
@@ -2665,19 +2447,14 @@
     "saveChanges": "บันทึกการเปลี่ยนแปลง",
     "publicProfileTitle": "อนุญาตให้ค้นหาโปรไฟล์ของฉันในค้นหา",
     "publicProfileDesc": "โดยการเปิดใช้งาน คุณอนุญาตให้ผู้ใช้คนอื่นค้นหาโปรไฟล์ของคุณในแถบค้นหาโลกและส่งคำขอแชท ในขณะนี้ คุณสามารถเลือกที่จะยอมรับหรือปฏิเสธคำขอได้",
-    "errorDisableIT": "ความช่วยเหลือด้านการแปลถูกปิดใช้งาน",
-    "errorDisableIGC": "ความช่วยเหลือด้านไวยากรณ์ถูกปิดใช้งาน",
     "errorDisableITUserDesc": "คลิกที่นี่เพื่ออัปเดตการตั้งค่าการช่วยเหลือด้านการแปล",
     "errorDisableIGCUserDesc": "คลิกที่นี่เพื่ออัปเดตการตั้งค่าการช่วยเหลือด้านไวยากรณ์",
     "errorDisableITClassDesc": "การช่วยเหลือด้านการแปลถูกปิดใช้งานสำหรับหลักสูตรที่แชทนี้อยู่",
     "errorDisableIGCClassDesc": "การช่วยเหลือด้านไวยากรณ์ถูกปิดใช้งานสำหรับหลักสูตรที่แชทนี้อยู่",
-    "error405Title": "ภาษายังไม่ได้ตั้งค่า",
     "error405Desc": "กรุณาตั้งค่าภาษาของคุณในเมนหลัก > การตั้งค่าการเรียนรู้",
     "termsAndConditions": "ข้อกำหนดและเงื่อนไข",
     "andCertifyIAmAtLeast13YearsOfAge": " และรับรองว่าฉันมีอายุอย่างน้อย 16 ปี",
-    "error502504Title": "ว้าว มีนักเรียนออนไลน์จำนวนมาก!",
     "error502504Desc": "เครื่องมือแปลและไวยากรณ์อาจช้าหรือไม่สามารถใช้งานได้ในขณะนี้ ขณะที่บอทพังเผา Pangea กำลังตามทัน",
-    "error404Title": "เกิดข้อผิดพลาดในการแปล!",
     "error404Desc": "Pangea Bot ไม่แน่ใจว่าจะจะแปลอย่างไร...",
     "errorPleaseRefresh": "เรากำลังตรวจสอบอยู่! กรุณารีเฟรชหน้าและลองใหม่อีกครั้ง",
     "connectedToStaging": "เชื่อมต่อกับสเตจ",
@@ -2715,13 +2492,9 @@
     "definitionsToolName": "คำจำกัดความของคำ",
     "definitionsToolDescription": "เมื่อเปิดใช้งาน คำที่ขีดเส้นใต้เป็นสีน้ำเงินสามารถคลิกเพื่อดูคำจำกัดความ คลิกที่ข้อความเพื่อเข้าถึงคำจำกัดความ",
     "welcomeBack": "ยินดีต้อนรับกลับ! หากคุณเป็นส่วนหนึ่งของโครงการนำร่อง 2023-2024 กรุณาติดต่อเราเพื่อรับการสมัครสมาชิกพิเศษ หากคุณเป็นครูที่ได้ซื้อใบอนุญาตสำหรับชั้นเรียนของคุณ ติดต่อเราเพื่อรับสมัครสมาชิกครู",
-    "downloadTxtFile": "ดาวน์โหลดไฟล์ข้อความ",
-    "downloadCSVFile": "ดาวน์โหลดไฟล์ CSV",
     "promotionalSubscriptionDesc": "คุณมีการสมัครสมาชิกโปรโมชั่นตลอดชีพในปัจจุบัน ติดต่อ support@pangea.chat เพื่อขอความช่วยเหลือในการเปลี่ยนแปลงการสมัครสมาชิกของคุณ",
     "originalSubscriptionPlatform": "การสมัครสมาชิกที่ซื้อผ่าน {purchasePlatform}",
     "oneWeekTrial": "ทดลองใช้หนึ่งสัปดาห์",
-    "downloadXLSXFile": "ดาวน์โหลดไฟล์ Excel",
-    "unkDisplayName": "ไม่ทราบ",
     "wwCountryDisplayName": "ทั่วโลก",
     "afCountryDisplayName": "อัฟกานิสถาน",
     "axCountryDisplayName": "หมู่เกาะอันลันด์",
@@ -3016,7 +2789,6 @@
     "chatCapacityHasBeenChanged": "ความจุแชทได้เปลี่ยนแปลงแล้ว",
     "chatCapacitySetTooLow": "ความจุแชทต้องอย่างน้อย {count}",
     "chatCapacityExplanation": "ความจุแชทจำกัดจำนวนสมาชิกที่อนุญาตในแชท",
-    "tooManyRequest": "คำขอมากเกินไป กรุณาลองใหม่ภายหลัง",
     "enterNumber": "กรุณาใส่ค่าตัวเลขเต็ม",
     "practice": "ฝึกฝน",
     "versionNotFound": "ไม่พบเวอร์ชัน",
@@ -3026,7 +2798,6 @@
     "deleteSubscriptionWarningTitle": "คุณมีการสมัครสมาชิกที่ใช้งานอยู่",
     "deleteSubscriptionWarningBody": "การลบบัญชีของคุณจะไม่ยกเลิกการสมัครสมาชิกโดยอัตโนมัติ",
     "manageSubscription": "จัดการการสมัครสมาชิก",
-    "error520Title": "โปรดลองอีกครั้ง",
     "error520Desc": "ขออภัย เราไม่เข้าใจข้อความของคุณ...",
     "wordsUsed": "คำที่ใช้แล้ว",
     "level": "ระดับ",
@@ -3045,7 +2816,6 @@
     "other": "อื่น ๆ",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "ไม่มีขีดจำกัดความจุ",
-    "downloadGroupText": "ดาวน์โหลดข้อความกลุ่ม",
     "notificationsOn": "เปิดการแจ้งเตือน",
     "notificationsOff": "ปิดการแจ้งเตือน",
     "joinWithCode": "เข้าร่วมด้วยรหัส",
@@ -3109,24 +2879,12 @@
     "whatIsTheMorphTag": "อะไรคือ {morphologicalFeature} ของ '{wordForm}'?",
     "dataAvailable": "ข้อมูลพร้อมใช้งาน",
     "available": "พร้อมใช้งาน",
-    "pangeaBotIsFallible": "Pangea Bot ก็ทำผิดพลาดได้เช่นกัน!",
-    "whatIsMeaning": "ความหมายของ '{lemma}' คืออะไร?",
     "chooseLemmaMeaningInstructionsBody": "จับคู่ความหมายกับคำในข้อความ!",
-    "doubleClickToEdit": "ดับเบิลคลิกเพื่อแก้ไข.",
-    "topicLabel": "หัวข้อ",
-    "topicPlaceholder": "เลือกหัวข้อ...",
-    "modePlaceholder": "เลือกโหมด...",
-    "learningObjectiveLabel": "วัตถุประสงค์การเรียนรู้",
-    "learningObjectivePlaceholder": "เลือกวัตถุประสงค์การเรียนรู้...",
-    "targetLanguageLabel": "ภาษาปลายทาง",
     "cefrLevelLabel": "ระดับ CEFR",
     "image": "ภาพ",
     "video": "วิดีโอ",
     "nan": "ไม่สามารถใช้ได้",
-    "addVocabulary": "เพิ่มคำศัพท์",
     "instructions": "คำแนะนำ",
-    "numberOfLearners": "จำนวนผู้เรียน",
-    "mustBeInteger": "ต้องเป็นจำนวนเต็ม เช่น 1, 2, 3, ...",
     "constructUsePvmDesc": "ผลิตในรูปแบบข้อความเสียง",
     "leaveSpaceDescription": "เมื่อออกจากคอร์ส คุณจะออกจากแชททั้งหมดภายในคอร์สนั้น ผู้ใช้อื่นจะเห็นว่าคุณได้ออกจากคอร์สแล้ว",
     "constructUseCorMmDesc": "ความหมายของข้อความถูกต้อง",
@@ -3141,7 +2899,6 @@
     "ttsDisabledBody": "คุณสามารถเปิดใช้งานข้อความเป็นเสียงในการตั้งค่าการเรียนรู้ของคุณ",
     "noSpaceDescriptionYet": "ยังไม่ได้สร้างคำอธิบายหลักสูตร",
     "tooLargeToSend": "ข้อความนี้มีขนาดใหญ่มากที่จะส่ง",
-    "exitWithoutSaving": "คุณแน่ใจหรือว่าต้องการออกโดยไม่บันทึก?",
     "enableAutocorrectPopupTitle": "เพิ่มแป้นพิมพ์ภาษาที่คุณตั้งเป้าไว้โดยไปที่:",
     "enableAutocorrectPopupSteps": "  • การตั้งค่า\n  • ทั่วไป\n  • คีย์บอร์ด\n  • คีย์บอร์ด\n  • เพิ่มคีย์บอร์ดใหม่",
     "enableAutocorrectPopupDescription": "เมื่อเลือกภาษาแล้ว คุณสามารถคลิกไอคอนโลกเล็กที่มุมล่างซ้ายของคีย์บอร์ดเพื่อเปิดใช้งานคีย์บอร์ดที่ติดตั้งใหม่",
@@ -3152,11 +2909,8 @@
     "displayName": "ชื่อแสดง",
     "leaveRoomDescription": "คุณกำลังจะออกจากแชทนี้ ผู้ใช้อื่นจะเห็นว่าคุณได้ออกจากแชทแล้ว",
     "confirmUserId": "กรุณายืนยันชื่อผู้ใช้ Pangea Chat ของคุณเพื่อทำการลบบัญชีของคุณ",
-    "startingToday": "เริ่มตั้งแต่วันนี้",
-    "oneWeekFreeTrial": "ทดลองใช้งานฟรีหนึ่งสัปดาห์",
     "paidSubscriptionStarts": "เริ่มต้น {startDate}",
     "cancelInSubscriptionSettings": "• ยกเลิกได้ทุกเมื่อในการตั้งค่าการสมัครสมาชิก",
-    "cancelToAvoidCharges": "• ยกเลิกก่อน {trialEnds} เพื่อหลีกเลี่ยงค่าธรรมเนียม",
     "downloadGboard": "ดาวน์โหลด Gboard",
     "autocorrectNotAvailable": "น่าเสียดายที่แพลตฟอร์มของคุณในปัจจุบันไม่รองรับคุณสมบัตินี้ โปรดติดตามการพัฒนาต่อไป!",
     "pleaseUpdateApp": "กรุณาอัปเดตแอปเพื่อดำเนินการต่อ",
@@ -3166,17 +2920,12 @@
     "knockSpaceSuccess": "คุณได้ส่งคำขอเข้าร่วมคอร์สนี้! ผู้ดูแลระบบจะตอบสนองคำขอของคุณเมื่อได้รับ 😀",
     "chooseWordAudioInstructionsBody": "ฟังข้อความให้ครบถ้วน จากนั้นจับคู่เสียงกับคำ",
     "chooseMorphsInstructionsBody": "คลิกชิ้นส่วนจิ๊กซอว์สำหรับคำถามทางไวยากรณ์!",
-    "pleaseEnterInt": "กรุณาใส่หมายเลข",
     "home": "หน้าแรก",
     "join": "เข้าร่วม",
     "resetInstructionTooltipsTitle": "รีเซ็ตคำแนะนำเครื่องมือช่วย",
     "resetInstructionTooltipsDesc": "คลิกเพื่อแสดงคำแนะนำเครื่องมือช่วย เช่นเดียวกับผู้ใช้ใหม่",
-    "randomize": "สุ่ม",
     "clear": "ล้าง",
-    "featuredActivities": "กิจกรรมเด่น",
     "save": "บันทึก",
-    "startChat": "เริ่มแชท",
-    "translationProblem": "ปัญหาการแปล",
     "askToJoin": "ขอเข้าร่วม",
     "emptyChatWarningTitle": "แชทว่างเปล่า",
     "emptyChatWarningDesc": "คุณยังไม่ได้เชิญใครเข้าร่วมแชทของคุณ ไปที่การตั้งค่าแชทเพื่อเชิญรายชื่อติดต่อของคุณหรือบอท คุณยังสามารถทำได้ในภายหลัง",
@@ -3206,17 +2955,13 @@
     "timesUsedIndependently": "จำนวนครั้งที่ใช้โดยอิสระ",
     "timesUsedWithAssistance": "จำนวนครั้งที่ใช้ร่วมกับความช่วยเหลือ",
     "shareInviteCode": "แชร์รหัสเชิญ: {code}",
-    "leaderboard": "กระดานผู้นำ",
     "skipForNow": "ข้ามก่อน",
     "permissions": "สิทธิ์",
     "spaceChildPermission": "ใครสามารถเพิ่มแชทใหม่ในหลักสูตรนี้ได้",
-    "addEnvironmentOverride": "เพิ่มการตั้งค่าสภาพแวดล้อมทดแทน",
     "defaultOption": "ค่าเริ่มต้น",
     "deleteChatDesc": "คุณแน่ใจหรือไม่ว่าต้องการลบแชทนี้? มันจะถูกลบสำหรับผู้เข้าร่วมทุกคนและข้อความทั้งหมดในแชทจะไม่สามารถใช้งานได้อีกต่อไปสำหรับการฝึกฝนหรือวิเคราะห์การเรียนรู้",
     "deleteSpaceDesc": "หลักสูตรและแชทที่เลือกจะถูกลบสำหรับผู้เข้าร่วมทุกคนและข้อความทั้งหมดในแชทจะไม่สามารถใช้งานได้อีกต่อไปสำหรับการฝึกฝนหรือวิเคราะห์การเรียนรู้ การดำเนินการนี้ไม่สามารถย้อนกลับได้",
     "launch": "เปิดตัว",
-    "searchChats": "ค้นหาแชท",
-    "maxFifty": "สูงสุด 50",
     "configureSpace": "กำหนดค่าห้องเรียน",
     "pinMessages": "ปักหมุดข้อความ",
     "setJoinRules": "ตั้งกฎการเข้าร่วม",
@@ -3250,9 +2995,6 @@
     "failedToFetchTranscription": "ไม่สามารถดึงข้อมูลการถอดเสียงได้",
     "deleteEmptySpaceDesc": "หลักสูตรจะถูกลบสำหรับผู้เข้าร่วมทั้งหมด การดำเนินการนี้ไม่สามารถย้อนกลับได้",
     "regenerate": "สร้างใหม่",
-    "mySavedActivities": "กิจกรรมที่บันทึกไว้ของฉัน",
-    "noSavedActivities": "ไม่มีการบันทึกกิจกรรม",
-    "saveActivity": "บันทึกกิจกรรมนี้",
     "failedToPlayVideo": "ไม่สามารถเล่นวิดีโอได้",
     "done": "เสร็จสิ้น",
     "inThisSpace": "ในหลักสูตรนี้",
@@ -3263,13 +3005,9 @@
     "numInvited": "{count} เชิญ",
     "saved": "บันทึกแล้ว",
     "reset": "รีเซ็ต",
-    "errorFetchingActivitiesMessage": "ไม่สามารถดึงกิจกรรมได้",
     "errorFetchingDefinition": "ไม่สามารถดึงคำจำกัดความได้",
     "errorProcessAnalytics": "ไม่สามารถประมวลผลวิเคราะห์ได้",
     "errorDownloading": "การดาวน์โหลดล้มเหลว",
-    "errorLoadingSpaceChildren": "ไม่สามารถโหลดแชทภายในหลักสูตรนี้ได้",
-    "unexpectedError": "เกิดข้อผิดพลาดที่ไม่คาดคิด",
-    "pleaseReload": "กรุณารีเฟรชและลองใหม่อีกครั้ง",
     "check": "ตรวจสอบ",
     "unableToFindRoom": "ไม่พบแชทหรือหลักสูตรที่มีรหัสนี้ กรุณาลองใหม่อีกครั้ง",
     "numCompletedActivities": "จำนวนกิจกรรมที่เสร็จสมบูรณ์",
@@ -3277,19 +3015,14 @@
     "request": "คำขอ",
     "requestAll": "ขอทั้งหมด",
     "confirmMessageUnpin": "คุณแน่ใจหรือไม่ว่าต้องการยกเลิกการตรึงข้อความนี้?",
-    "saveAndLaunch": "บันทึกและเริ่มต้น",
-    "launchToSpace": "เริ่มต้นสู่คอร์ส",
     "pending": "รอดำเนินการ",
     "inactive": "ไม่ทำงาน",
-    "confirmRole": "ยืนยันบทบาท",
     "openRoleLabel": "เปิด",
     "finishedTheActivity": "🎯 {username} สรุปกิจกรรมนี้",
     "activitySummaryError": "ไม่สามารถดูสรุปกิจกรรมได้",
     "requestSummaries": "ขอสรุปข้อมูล",
-    "generatingNewActivities": "คุณเป็นผู้ใช้รายแรกของกลุ่มภาษานี้! กรุณารอสักครู่ เรากำลังเตรียมกิจกรรมสำหรับคุณโดยเฉพาะ",
     "requestAccessTitle": "ขอเข้าถึงการวิเคราะห์หรือไม่?",
     "requestAccessDesc": "คุณต้องการขอเข้าถึงเพื่อดูข้อมูลวิเคราะห์ผู้เข้าร่วมใช่ไหม?\n\nถ้าผู้เข้าร่วมยอมรับ ผู้ดูแลหลักสูตรนี้จะสามารถดูข้อมูลของพวกเขาได้:\n    • คำศัพท์ทั้งหมด\n    • แนวคิดไวยากรณ์ทั้งหมด\n    • จำนวนเซสชันกิจกรรมที่ทำเสร็จ\n    • แนวคิดไวยากรณ์เฉพาะที่ใช้ ทั้งถูกต้องและผิด\n\nพวกเขาจะไม่สามารถดูได้:\n    • ข้อความในแชทนอกหลักสูตร\n    • รายการคำศัพท์",
-    "requestAccess": "ขอเข้าถึง ({count})",
     "analyticsInactiveTitle": "ไม่สามารถส่งคำขอไปยังผู้ใช้ที่ไม่ใช้งานได้",
     "analyticsInactiveDesc": "ผู้ใช้ที่ไม่ได้เข้าสู่ระบบตั้งแต่เปิดใช้งานคุณสมบัตินี้จะไม่เห็นคำขอของคุณ\n\nปุ่มขอจะปรากฏเมื่อพวกเขากลับมา คุณสามารถส่งคำขออีกครั้งได้โดยคลิกปุ่มขอภายใต้ชื่อของพวกเขาเมื่อพร้อมใช้งาน",
     "accessRequestedTitle": "คำขอเข้าถึงข้อมูลวิเคราะห์",
@@ -3312,8 +3045,6 @@
     "accessDesc": "คุณสามารถทำให้หลักสูตรของคุณเปิดสู่โลก หรือ ทำให้เป็นส่วนตัวและปลอดภัย",
     "createGroupChatDesc": "ในขณะที่เซสชันกิจกรรมเริ่มและสิ้นสุด กลุ่มแชทจะเปิดอยู่เพื่อการสื่อสารประจำวัน",
     "deleteDesc": "เฉพาะผู้ดูแลระบบเท่านั้นที่สามารถลบหลักสูตรได้ นี่เป็นการดำเนินการที่ทำลายล้าง ซึ่งจะลบผู้ใช้ทั้งหมดและลบแชทที่เลือกภายในหลักสูตร โปรดดำเนินการด้วยความระมัดระวัง",
-    "noCourseFound": "โอ้ หลักสูตรนี้ต้องการแผน!\n\nแผนหลักสูตรเป็นลำดับของหัวข้อและกิจกรรมสนทนา",
-    "additionalParticipants": "+ {num} คนอื่นๆ",
     "whatNow": "ตอนนี้ทำอะไรดี?",
     "chooseNextActivity": "เลือกกิจกรรมถัดไปของคุณ!",
     "letsGo": "ไปกันเลย",
@@ -3326,13 +3057,11 @@
     "waitNotDone": "รอหน่อย ฉันยังไม่เสร็จ!",
     "waitingForOthersToFinish": "รอให้คนอื่นเสร็จสิ้น...",
     "generatingSummary": "วิเคราะห์แชทและสร้างผลลัพธ์",
-    "findCourse": "ค้นหาคอร์ส",
     "pingParticipantsNotification": "{user} กำลังมองหาผู้ใช้เพื่อเข้าร่วมเซสชันกิจกรรมใน {room}",
     "course": "หลักสูตร",
     "courses": "หลักสูตร",
     "goToCourse": "ไปที่หลักสูตร: {course}",
     "activityComplete": "กิจกรรมนี้เสร็จสมบูรณ์แล้ว สรุปกิจกรรมควรพร้อมใช้งานด้านล่าง",
-    "startNewSession": "เริ่มเซสชันใหม่",
     "joinOpenSession": "เข้าร่วมเซสชันเปิด",
     "activityNotFound": "ไม่พบกิจกรรม",
     "myActivities": "กิจกรรมของฉัน",
@@ -3445,26 +3174,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -3541,14 +3250,6 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
@@ -3573,31 +3274,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3653,23 +3334,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3709,28 +3378,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -3748,14 +3395,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3948,22 +3587,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4019,10 +3642,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4032,10 +3651,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4111,27 +3726,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4449,10 +4048,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4462,10 +4057,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4553,14 +4144,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4577,10 +4160,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4593,15 +4172,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4753,14 +4324,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4774,14 +4337,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6004,10 +5559,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6048,10 +5599,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6124,10 +5671,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6397,47 +5940,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6457,19 +5960,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6533,10 +6024,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6577,14 +6064,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6596,14 +6075,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6641,10 +6112,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6661,27 +6128,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6805,10 +6256,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6818,10 +6265,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6838,14 +6281,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6985,18 +6420,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7045,10 +6468,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7058,18 +6477,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7112,23 +6519,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7152,10 +6547,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7163,14 +6554,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7275,18 +6658,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7339,10 +6710,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7369,10 +6736,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7553,7 +6916,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "ตรวจสอบอีกครั้งในวันพรุ่งนี้เพื่ออัปเดตกิจกรรม",
-    "activityDropdownDesc": "เมื่อคุณทำกิจกรรมนี้เสร็จแล้ว ให้คลิกด้านล่าง",
     "languageMismatchTitle": "ภาษาที่ไม่ตรงกัน",
     "languageMismatchDesc": "ภาษาที่คุณตั้งเป้าหมายไม่ตรงกับภาษาของกิจกรรมนี้ ต้องการอัปเดตภาษาที่ตั้งเป้าหมายไหม?",
     "reportWordIssueTooltip": "รายงานปัญหาข้อมูลคำศัพท์",
@@ -7566,10 +6928,6 @@
     "selectAll": "เลือกทั้งหมด",
     "deselectAll": "ยกเลิกเลือกทั้งหมด",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7618,17 +6976,11 @@
         "placeholders": {}
     },
     "startOwn": "เริ่มต้นของฉันเอง",
-    "joinCourseDesc": "แต่ละหลักสูตรมีหัวข้อเรียงลำดับ 8-10 หัวข้อ พร้อมกิจกรรมการเรียนรู้ภาษาที่ใช้ภารกิจเป็นฐาน",
     "newMessageInPangeaChat": "📩 ข้อความใหม่ใน Pangea Chat",
     "shareCourse": "แชร์หลักสูตร",
     "addCourse": "เพิ่มหลักสูตร",
-    "joinPublicCourse": "เข้าร่วมหลักสูตรสาธารณะ",
     "vocabLevelsDesc": "นี่คือที่ที่คำศัพท์จะไปเมื่อคุณเลเวลอัปมันแล้ว!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7641,10 +6993,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7663,7 +7011,6 @@
     "emojiView": "มุมมองอีโมจิ",
     "feedbackDialogDesc": "ฉันก็ทำผิดพลาดเหมือนกัน! มีอะไรที่จะช่วยให้ฉันพัฒนาขึ้นไหม?",
     "contactHasBeenInvitedToTheCourse": "ติดต่อได้รับเชิญเข้าร่วมหลักสูตร",
-    "activityStatsButtonTooltip": "ข้อมูลกิจกรรม",
     "allow": "อนุญาต",
     "deny": "ปฏิเสธ",
     "enabledRenewal": "เปิดใช้งานการต่ออายุการสมัครสมาชิก",
@@ -7931,10 +7278,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8990,16 +8333,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "กิจกรรมเพื่อปลดล็อกหัวข้อถัดไป",
-    "activitiesToUnlockTopicDesc": "กำหนดจำนวนกิจกรรมเพื่อปลดล็อกหัวข้อหลักสูตรถัดไป",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "การฝึกฝนความหมายคำศัพท์ที่ถูกต้อง",
     "constructUseIncLMDesc": "การฝึกฝนความหมายคำศัพท์ที่ไม่ถูกต้อง",
     "constructUseCorLADesc": "การฝึกฝนเสียงคำศัพท์ที่ถูกต้อง",
@@ -9007,7 +8340,6 @@
     "constructUseBonus": "โบนัสระหว่างการฝึกคำศัพท์",
     "practiceVocab": "ฝึกคำศัพท์",
     "selectMeaning": "เลือกความหมาย",
-    "selectAudio": "เลือกเสียงที่ตรงกัน",
     "anotherRound": "อีกหนึ่งรอบ",
     "activitySettingsOverrideWarning": "ภาษาและระดับภาษาที่กำหนดโดยแผนกิจกรรม",
     "voice": "เสียง",
@@ -9039,10 +8371,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9060,12 +8388,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "เริ่มการดาวน์โหลด",
     "webDownloadPermissionMessage": "หากเบราว์เซอร์ของคุณบล็อกการดาวน์โหลด โปรดเปิดใช้งานการดาวน์โหลดสำหรับเว็บไซต์นี้.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9160,11 +8483,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "มีบางอย่างผิดพลาด และเรากำลังทำงานอย่างหนักเพื่อแก้ไข ตรวจสอบอีกครั้งในภายหลัง.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "เปิดใช้งานความช่วยเหลือในการเขียน",
     "autoIGCToolDescription": "เรียกใช้เครื่องมือ Pangea Chat โดยอัตโนมัติเพื่อแก้ไขข้อความที่ส่งไปยังภาษาที่ต้องการ.",
     "@autoIGCToolName": {
@@ -9220,24 +8538,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "ไวยากรณ์",
-    "spanTypeWordChoice": "การเลือกคำ",
     "spanTypeSpelling": "การสะกด",
     "spanTypePunctuation": "เครื่องหมายวรรคตอน",
     "spanTypeStyle": "สไตล์",
     "spanTypeFluency": "ความคล่องแคล่ว",
     "spanTypeAccents": "สำเนียง",
     "spanTypeCapitalization": "การใช้ตัวพิมพ์ใหญ่",
-    "spanTypeCorrection": "การแก้ไข",
     "spanFeedbackTitle": "รายงานปัญหาการแก้ไข",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9262,10 +8569,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9278,13 +8581,7 @@
     "longPressToRecordVoiceMessage": "กดค้างเพื่อบันทึกข้อความเสียง.",
     "pause": "หยุดชั่วคราว",
     "resume": "ดำเนินการต่อ",
-    "newSubSpace": "พื้นที่ย่อยใหม่",
-    "moveToDifferentSpace": "ย้ายไปยังพื้นที่อื่น",
-    "removeFromSpaceDescription": "การสนทนาจะถูกลบออกจากพื้นที่ แต่ยังคงปรากฏในรายการสนทนาของคุณ",
     "countChats": "{chats} การสนทนา",
-    "spaceMemberOf": "สมาชิกพื้นที่ของ {spaces}",
-    "spaceMemberOfCanKnock": "สมาชิกพื้นที่ของ {spaces} สามารถเคาะได้",
-    "donate": "บริจาค",
     "startedAPoll": "{username} ได้เริ่มการสำรวจความคิดเห็น",
     "poll": "การสำรวจความคิดเห็น",
     "startPoll": "เริ่มการสำรวจความคิดเห็น",
@@ -9308,23 +8605,15 @@
     "newStickerPack": "แพ็คสติกเกอร์ใหม่",
     "stickerPackName": "ชื่อแพ็คสติกเกอร์",
     "attribution": "การให้เครดิต",
-    "skipChatBackup": "ข้ามการสำรองข้อมูลแชท",
-    "skipChatBackupWarning": "คุณแน่ใจหรือไม่? หากไม่เปิดใช้งานการสำรองข้อมูลแชท คุณอาจสูญเสียการเข้าถึงข้อความของคุณหากคุณเปลี่ยนอุปกรณ์.",
-    "loadingMessages": "กำลังโหลดข้อความ",
-    "setupChatBackup": "ตั้งค่าการสำรองข้อมูลแชท",
     "noMoreResultsFound": "ไม่พบผลลัพธ์เพิ่มเติม",
     "chatSearchedUntil": "ค้นหาแชทจนถึง {time}",
     "federationBaseUrl": "URL ฐานของการรวมกลุ่ม",
     "clientWellKnownInformation": "ข้อมูลที่รู้จักของลูกค้า:",
     "baseUrl": "URL ฐาน",
     "identityServer": "เซิร์ฟเวอร์ประจำตัว:",
-    "versionWithNumber": "เวอร์ชัน: {version}",
     "logs": "บันทึก",
-    "advancedConfigs": "การตั้งค่าขั้นสูง",
     "advancedConfigurations": "การกำหนดค่าขั้นสูง",
-    "signInWithLabel": "ลงชื่อเข้าใช้ด้วย:",
     "selectAllWords": "เลือกทุกคำที่คุณได้ยินในเสียง",
-    "joinCourseForActivities": "เข้าร่วมหลักสูตรเพื่อทดลองกิจกรรม.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9361,18 +8650,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9380,26 +8657,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9505,22 +8762,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9549,19 +8790,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9569,15 +8798,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9778,11 +8999,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "อยู่ในชั้นเรียน? ใส่รหัสเข้าร่วมของคุณที่นี่.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "เน้นข้อความเสียงโดยอัตโนมัติ",
     "selectAudioMessagesOnPlayDescription": "เน้นข้อความเสียงโดยอัตโนมัติเมื่อเล่น",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9826,18 +9042,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "หลักสูตรนี้มีหัวข้อที่มีกิจกรรมน้อยกว่า {input} กิจกรรม กรุณาใส่หมายเลขที่น้อยกว่าหรือเท่ากับ {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "คลิกที่นี่เพื่อลงชื่อเข้าใช้อีกครั้ง.",
     "@clickToLogin": {
@@ -10254,17 +9458,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "หมีการ์ตูนสีเหลืองที่ยกแขนขึ้นด้วยความตื่นเต้น",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "เลือกคำเพื่อเรียนรู้เพิ่มเติมเกี่ยวกับพวกเขา",
     "requireAnalyticsAccessTitle": "ต้องการการเข้าถึงการวิเคราะห์เพื่อเข้าร่วม",
     "requireAnalyticsAccessDesc": "ผู้เข้าร่วมต้องอนุญาตการเข้าถึงการวิเคราะห์การเรียนรู้ของตนเพื่อเข้าร่วมหลักสูตรนี้",
     "analyticsAccessNoticeTitle": "ต้องการการเข้าถึงการวิเคราะห์",
     "analyticsAccessNoticeDesc": "โดยการเข้าร่วมหลักสูตรนี้ คุณตกลงที่จะอนุญาตให้ผู้ดูแลระบบเข้าถึงการวิเคราะห์การเรียนรู้ของคุณ",
-    "skipOnboardingClassCodeDesc": "เรียนรู้ด้วยตนเอง? ไม่ต้องกังวล คุณสามารถ:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10282,10 +9480,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10314,7 +9508,6 @@
     "pickCefrLevelTeacherStepTitle": "คุณสอนระดับไหน?",
     "pickCefrLevelStudentStepTitle": "คุณอยู่ระดับไหน?",
     "customCourseStepTitle": "กรอกแบบฟอร์มนี้เพื่อรับคอร์สที่กำหนดเอง",
-    "aboutYourClass": "เกี่ยวกับชั้นเรียนของคุณ",
     "courseCodeStepErrorMessage": "กรุณาตรวจสอบรหัสของคุณและลองอีกครั้ง",
     "institution": "สถาบัน",
     "courseGoals": "เป้าหมายของหลักสูตร",
@@ -10357,10 +9550,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10477,12 +9666,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "โลโก้ Pangea Chat",
     "introChatDetails": "สวัสดี! แนะนำตัวเองให้เพื่อนร่วมหลักสูตรของคุณรู้จัก หาเพื่อน และสนทนานอกกิจกรรม",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10526,11 +9710,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "การกระทำกิจกรรม",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "เครื่องมือการออกเสียง",
     "audioTranscription": "การถอดเสียง AI",
     "visualLearnerSupport": "การสนับสนุนผู้เรียนแบบมองเห็น",
@@ -10571,7 +9750,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "เข้าร่วมหลักสูตรที่รวมกิจกรรมนี้เพื่อเล่นมัน",
     "resizeCoursePanel": "ปรับขนาดแผงหลักสูตร",
     "undo": "ย้อนกลับ",
     "unlock": "ปลดล็อก",
@@ -10585,7 +9763,6 @@
     "addCourseBrowsePublic": "เรียกดูหลักสูตรสาธารณะ",
     "browsePublicCourses": "เรียกดูหลักสูตรสาธารณะ",
     "editProfile": "แก้ไขโปรไฟล์",
-    "numObjectives": "{count} เป้าหมาย",
     "mapSearchHint": "ค้นหากิจกรรม",
     "mapSearchNoResults": "ไม่มีผลลัพธ์ในมุมมอง",
     "mapFilterAllLanguages": "ทุกภาษา",
@@ -10594,7 +9771,6 @@
     "mapFilterCompleted": "เสร็จสิ้น",
     "mapFilterReset": "รีเซ็ต",
     "activityTypeConversation": "การสนทนา",
-    "lockedMissionRequirement": "ทำภารกิจที่แล้วให้เสร็จเพื่อปลดล็อก",
     "playAgain": "เล่นอีกครั้ง",
     "reviewActivity": "ตรวจสอบ",
     "mapEmptyInView": "ไม่มีอะไรที่นี่ในระดับหรือภาษาของคุณ ขยายตัวกรองของคุณหรือซูมออก",
@@ -10609,14 +9785,9 @@
     "scrollToBottom": "เลื่อนลงไปที่ด้านล่าง",
     "courseImage": "ภาพหลักสูตร",
     "avatarPreview": "ตัวอย่างอวาตาร์",
-    "activityPhoto": "ภาพกิจกรรม",
     "emotePreview": "ตัวอย่างอิโมจิ: {name}",
     "activityLabel": "กิจกรรม: {title}",
     "resetMapView": "รีเซ็ตมุมมองแผนที่",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10669,14 +9840,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10706,10 +9869,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10766,10 +9925,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -85,11 +85,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Misafir kullanıcıların katılmasına izin veriliyor mu",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Emin misiniz?",
     "@areYouSure": {
         "type": "String",
@@ -366,11 +361,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "Eski mesajlarınız bir kurtarma anahtarı ile güvence altına alındı. Lütfen kaybetmediğinizden emin olun.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "Sohbet ayrıntıları",
     "@chatDetails": {
         "type": "String",
@@ -502,11 +492,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Kişi gruba davet edildi",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "İçerik, sunucu yöneticilerine bildirildi",
     "@contentHasBeenReported": {
         "type": "String",
@@ -558,11 +543,6 @@
                 "type": "String"
             }
         }
-    },
-    "createNewSpace": "Yeni alan",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
     },
     "currentlyActive": "Şu anda etkin",
     "@currentlyActive": {
@@ -706,11 +686,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Artık şifrelemeyi devre dışı bırakamayacaksınız. Emin misiniz?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "Şifreli",
     "@encrypted": {
         "type": "String",
@@ -749,11 +724,6 @@
             }
         }
     },
-    "everythingReady": "Herşey hazır!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "Aşırı rahatsız edici",
     "@extremeOffensive": {
         "type": "String",
@@ -791,11 +761,6 @@
     },
     "group": "Grup",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Grup herkese açık",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -889,15 +854,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Kişiyi {groupName} grubuna davet et",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Davet edildi",
     "@invited": {
@@ -1010,15 +966,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "{count} katılımcı daha yükle",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Yükleniyor… Lütfen bekleyin.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -1043,15 +990,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "{homeserver} üzerinde oturum aç",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Oturumu kapat",
     "@logout": {
@@ -1115,16 +1053,6 @@
     },
     "noEmotesFound": "İfade bulunamadı. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Şifrelemeyi yalnızca oda artık herkese açık olmadığında etkinleştirebilirsiniz.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Görünüşe göre cihazınızda Firebase Cloud Messaging yok. Buna rağmen bildirim almaya devam etmek için ntfy yüklemenizi öneriyoruz. ntfy veya başka bir Unified Push sağlayıcısı ile anlık bildirimlerinizi güvenli bir şekilde alabilirsiniz. ntfy'ı PlayStore veya F-Droid'den indirebilirsiniz.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1256,11 +1184,6 @@
     },
     "passwordHasBeenChanged": "Parola değiştirildi",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "Parola kurtarma",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1404,11 +1327,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Aygıtı kaldır",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Sohbet engelini kaldır",
     "@unbanFromChat": {
@@ -1563,11 +1481,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "İzin seviyesini ayarla",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Durumu ayarla",
     "@setStatus": {
         "type": "String",
@@ -1609,16 +1522,6 @@
     },
     "sourceCode": "Kaynak kodları",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Alan herkese açık",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Alan adı",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1677,11 +1580,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Başka bir aygıttan aktar",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Tekrar göndermeyi deneyin",
     "@tryToSendAgain": {
         "type": "String",
@@ -1737,15 +1635,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 okunmamış sohbet} other{{unreadCount} okunmamış sohbet}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} ve {count} diğer kişi yazıyor…",
     "@userAndOthersAreTyping": {
@@ -1831,16 +1720,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Görüntülü arama",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Sohbet geçmişi görünürlüğü",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Tüm katılımcılar için görünür",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1886,23 +1765,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Kim hangi eylemi gerçekleştirebilir",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Bu gruba kimler katılabilir",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Bunu neden bildirmek istiyorsunuz?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Yeni bir kurtarma anahtarı oluşturmak için sohbet yedeğiniz silinsin mi?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1949,8 +1813,6 @@
     "@homeserver": {},
     "serverRequiresEmail": "Bu sunucunun kayıt için e-posta adresinizi doğrulaması gerekiyor.",
     "@serverRequiresEmail": {},
-    "enableMultiAccounts": "(BETA) Bu aygıtta çoklu hesapları etkinleştir",
-    "@enableMultiAccounts": {},
     "bundleName": "Paket adı",
     "@bundleName": {},
     "removeFromBundle": "Bu paketten kaldır",
@@ -1959,14 +1821,10 @@
     "@addToBundle": {},
     "editBundlesForAccount": "Bu hesap için paketleri düzenle",
     "@editBundlesForAccount": {},
-    "addAccount": "Hesap ekle",
-    "@addAccount": {},
     "oneClientLoggedOut": "İstemcilerinizden birinin oturumu kapatıldı",
     "@oneClientLoggedOut": {},
     "link": "Bağlantı",
     "@link": {},
-    "yourChatBackupHasBeenSetUp": "Sohbet yedeklemeniz ayarlandı.",
-    "@yourChatBackupHasBeenSetUp": {},
     "unverified": "Doğrulanmadı",
     "@unverified": {},
     "repeatPassword": "Parolayı tekrarlayın",
@@ -1981,8 +1839,6 @@
     "@sender": {},
     "openGallery": "Galeriyi aç",
     "@openGallery": {},
-    "removeFromSpace": "Alandan kaldır",
-    "@removeFromSpace": {},
     "start": "Başla",
     "@start": {},
     "commandHint_clearcache": "Önbelleği temizleyin",
@@ -2036,8 +1892,6 @@
     "@emojis": {},
     "placeCall": "Arama yap",
     "@placeCall": {},
-    "voiceCall": "Sesli arama",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "Desteklenmeyen Android sürümü",
     "@unsupportedAndroidVersion": {},
     "unsupportedAndroidVersionLong": "Bu özellik daha yeni bir Android sürümü gerektiriyor. Lütfen güncellemelere veya LineageOS desteğine bakın.",
@@ -2046,12 +1900,8 @@
     "@pinMessage": {},
     "confirmEventUnpin": "Etkinliğin sabitlemesini kalıcı olarak kaldırmak istediğinizden emin misiniz?",
     "@confirmEventUnpin": {},
-    "videoCallsBetaWarning": "Görüntülü aramaların şu anda beta aşamasında olduğunu lütfen unutmayın. Tüm platformlarda beklendiği gibi veya hiç çalışmayabilirler.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "Deneysel görüntülü aramalar",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "E-posta veya kullanıcı adı",
-    "@emailOrUsername": {},
     "widgetJitsi": "Jitsi Meet",
     "@widgetJitsi": {},
     "widgetCustom": "Özel",
@@ -2137,28 +1987,8 @@
             }
         }
     },
-    "storeInAppleKeyChain": "Apple KeyChain'de sakla",
-    "@storeInAppleKeyChain": {},
-    "pleaseEnterRecoveryKey": "Lütfen kurtarma anahtarınızı girin:",
-    "@pleaseEnterRecoveryKey": {},
-    "recoveryKeyLost": "Kurtarma anahtarı kayıp mı?",
-    "@recoveryKeyLost": {},
-    "pleaseEnterRecoveryKeyDescription": "Eski mesajlarınızın kilidini açmak için lütfen önceki bir oturumda oluşturulan kurtarma anahtarınızı girin. Kurtarma anahtarınız parolanız DEĞİLDİR.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "users": "Kullanıcılar",
     "@users": {},
-    "storeInSecureStorageDescription": "Kurtarma anahtarını bu aygıtın güvenli deposunda saklayın.",
-    "@storeInSecureStorageDescription": {},
-    "recoveryKey": "Kurtarma anahtarı",
-    "@recoveryKey": {},
-    "storeInAndroidKeystore": "Android KeyStore'da sakla",
-    "@storeInAndroidKeystore": {},
-    "unlockOldMessages": "Eski mesajların kilidini aç",
-    "@unlockOldMessages": {},
-    "saveKeyManuallyDescription": "Sistem paylaşımı iletişim kutusunu veya panoyu tetikleyerek bu anahtarı elle kaydedin.",
-    "@saveKeyManuallyDescription": {},
-    "storeSecurlyOnThisDevice": "Bu aygıtta güvenli bir şekilde sakla",
-    "@storeSecurlyOnThisDevice": {},
     "countFiles": "{count} dosya",
     "@countFiles": {
         "placeholders": {
@@ -2196,20 +2026,12 @@
     "@whyIsThisMessageEncrypted": {},
     "noKeyForThisMessage": "Bu durum, mesaj siz bu aygıtta hesabınızda oturum açmadan önce gönderildiyse meydana gelebilir.\n\nGönderenin aygıtınızı engellemiş olması veya internet bağlantısında bir sorun olması da mümkündür.\n\nMesajı başka bir oturumda okuyabiliyor musunuz? O zaman mesajı oradan aktarabilirsiniz! Ayarlar > Aygıtlar bölümüne gidin ve aygıtlarınızın birbirini doğruladığından emin olun. Odayı bir sonraki sefer açtığınızda ve her iki oturum da ön planda olduğunda, anahtarlar otomatik olarak iletilecektir.\n\nOturumu kapatırken veya aygıt değiştirirken anahtarları kaybetmek istemiyor musunuz? Ayarlarda sohbet yedeklemesini etkinleştirdiğinizden emin olun.",
     "@noKeyForThisMessage": {},
-    "screenSharingTitle": "ekran paylaşımı",
-    "@screenSharingTitle": {},
-    "enterSpace": "Alana gir",
-    "@enterSpace": {},
     "allSpaces": "Tüm alanlar",
     "@allSpaces": {},
-    "foregroundServiceRunning": "Bu bildirim, ön plan hizmeti çalışırken görünür.",
-    "@foregroundServiceRunning": {},
     "newGroup": "Yeni grup",
     "@newGroup": {},
     "newSpace": "Yeni alan",
     "@newSpace": {},
-    "screenSharingDetail": "Ekranınızı FuffyChat'te paylaşıyorsunuz",
-    "@screenSharingDetail": {},
     "doNotShowAgain": "Tekrar gösterme",
     "@doNotShowAgain": {},
     "googlyEyesContent": "{senderName} size şaşkın gözler gönderiyor",
@@ -2254,14 +2076,6 @@
             }
         }
     },
-    "newSpaceDescription": "Alanlar, sohbetlerinizi birleştirmenize ve özel veya genel topluluklar oluşturmanıza olanak tanır.",
-    "@newSpaceDescription": {},
-    "encryptThisChat": "Bu sohbeti şifrele",
-    "@encryptThisChat": {},
-    "disableEncryptionWarning": "Güvenlik nedeniyle, daha önce etkinleştirildiği bir sohbette şifrelemeyi devre dışı bırakamazsınız.",
-    "@disableEncryptionWarning": {},
-    "sorryThatsNotPossible": "Üzgünüm... bu mümkün değil",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "Aygıt anahtarları:",
     "@deviceKeys": {},
     "reopenChat": "Sohbeti yeniden aç",
@@ -2313,8 +2127,6 @@
     "@createGroup": {},
     "shareInviteLink": "Davet bağlantısını paylaş",
     "@shareInviteLink": {},
-    "setTheme": "Temayı ayarla:",
-    "@setTheme": {},
     "setColorTheme": "Renk temasını ayarla:",
     "@setColorTheme": {},
     "tryAgain": "Tekrar deneyin",
@@ -2327,8 +2139,6 @@
     "@invite": {},
     "chatPermissions": "Sohbet izinleri",
     "@chatPermissions": {},
-    "chatDescription": "Sohbet açıklaması",
-    "@chatDescription": {},
     "noChatDescriptionYet": "Daha sohbet açıklaması oluşturulmadı.",
     "@noChatDescriptionYet": {},
     "invalidServerName": "Geçersiz sunucu adı",
@@ -2406,10 +2216,6 @@
     "@pleaseEnterANumber": {},
     "kickUserDescription": "Kullanıcı sohbetten atılır ancak yasaklanmaz. Herkese açık sohbetlerde kullanıcı istediği zaman yeniden katılabilir.",
     "@kickUserDescription": {},
-    "createGroupAndInviteUsers": "Bir grup oluşturun ve kullanıcıları davet edin",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "Grup, arama ile bulunabilir",
-    "@groupCanBeFoundViaSearch": {},
     "noUsersFoundWithQuery": "Ne yazık ki \"{query}\" ile kullanıcı bulunamadı. Lütfen bir yazım hatası yapıp yapmadığınızı kontrol edin.",
     "@noUsersFoundWithQuery": {
         "type": "String",
@@ -2423,8 +2229,6 @@
     "@yourGlobalUserIdIs": {},
     "groupName": "Grup ismi",
     "@groupName": {},
-    "searchChatsRooms": "#sohbetler, @kullanıcılar... için arama yapın",
-    "@searchChatsRooms": {},
     "blockListDescription": "Sizi rahatsız eden kullanıcıları engelleyebilirsiniz. Kişisel engelleme listenizdeki kullanıcılardan herhangi bir mesaj veya oda daveti alamazsınız.",
     "@blockListDescription": {},
     "startConversation": "Görüşme başlat",
@@ -2447,8 +2251,6 @@
     "@pleaseEnterYourCurrentPassword": {},
     "pleaseChooseAStrongPassword": "Lütfen güçlü bir parola seçin",
     "@pleaseChooseAStrongPassword": {},
-    "addChatOrSubSpace": "Sohbet veya alt alan ekle",
-    "@addChatOrSubSpace": {},
     "canceledKeyVerification": "{sender} anahtar doğrulamayı iptal etti",
     "@canceledKeyVerification": {
         "type": "String",
@@ -2462,18 +2264,6 @@
     "@joinSpace": {},
     "newPassword": "Yeni parola",
     "@newPassword": {},
-    "sessionLostBody": "Oturumunuz kayboldu. Lütfen bu hatayı {url} adresinde geliştiricilere bildirin. Hata mesajı: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "subspace": "Alt alan",
     "@subspace": {},
     "thisDevice": "Bu aygıt:",
@@ -2495,12 +2285,6 @@
     "@commandHint_unignore": {},
     "appLockDescription": "Kullanılmadığında PIN kodu ile uygulamayı kilitle",
     "@appLockDescription": {},
-    "globalChatId": "Genel sohbet kimliği",
-    "@globalChatId": {},
-    "accessAndVisibility": "Erişim ve görünürlük",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Bu sohbete kimlerin katılmasına izin verilir ve sohbet nasıl keşfedilebilir.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Aramalar",
     "@calls": {},
     "customEmojisAndStickers": "Özel emojiler ve çıkartmalar",
@@ -2517,10 +2301,6 @@
     "@knock": {},
     "knocking": "Tıklat",
     "@knocking": {},
-    "usersMustKnock": "Kullanıcılar tıklatmalı",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Kimse katılamaz",
-    "@noOneCanJoin": {},
     "nothingFound": "Hiçbir şey bulunamadı...",
     "@nothingFound": {},
     "sendReadReceiptsDescription": "Sohbetteki diğer katılımcılar bir mesajı okuduğunuzu görebilir.",
@@ -2546,15 +2326,6 @@
     "@overview": {},
     "decline": "Reddet",
     "@decline": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Sohbet {server} üzerinde aranarak keşfedilebilir",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "leaveEmptyToClearStatus": "Durumunuzu temizlemek için boş bırakın.",
     "@leaveEmptyToClearStatus": {},
     "select": "Seç",
@@ -2563,27 +2334,11 @@
     "@passwordsDoNotMatch": {},
     "passwordIsWrong": "Girdiğiniz parola yanlış",
     "@passwordIsWrong": {},
-    "publicChatAddresses": "Herkese açık sohbet adresleri",
-    "@publicChatAddresses": {},
-    "createNewAddress": "Yeni adres oluştur",
-    "@createNewAddress": {},
     "acceptedKeyVerification": "{sender} anahtar doğrulamayı kabul etti",
     "@acceptedKeyVerification": {
         "type": "String",
         "placeholders": {
             "sender": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Uygulama şimdi oturumunuzu yedekten geri yüklemeye çalışıyor. Lütfen bu hatayı {url} adresinde geliştiricilere bildirin. Hata mesajı: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
                 "type": "String"
             }
         }
@@ -2621,8 +2376,6 @@
             }
         }
     },
-    "verifyOtherUser": "🔐 Diğer kullanıcıyı doğrula",
-    "@verifyOtherUser": {},
     "startedKeyVerification": "{sender} anahtar doğrulama başlattı",
     "@startedKeyVerification": {
         "type": "String",
@@ -2638,8 +2391,6 @@
     "@discover": {},
     "incomingMessages": "Gelen mesajlar",
     "@incomingMessages": {},
-    "verifyOtherUserDescription": "Başka bir kullanıcıyı doğrularsanız, gerçekten kime yazdığınızı bildiğinizden emin olabilirsiniz. 💪\n\nBir doğrulama başlattığınızda, siz ve diğer kullanıcı uygulamada bir açılır pencere görecektir. Orada birbirinizle karşılaştırmanız gereken bir dizi emoji veya sayı göreceksiniz.\n\nBunu yapmanın en iyi yolu buluşmak veya bir görüntülü arama başlatmaktır. 👭",
-    "@verifyOtherUserDescription": {},
     "stickers": "Çıkartmalar",
     "@stickers": {},
     "unreadChatsInApp": "{appname}: {unread} okunmayan sohbet",
@@ -2762,14 +2513,6 @@
     "@sendCanceled": {},
     "noChatsFoundHere": "Burada henüz sohbet bulunamadı. Aşağıdaki düğmeyi kullanarak biriyle yeni bir sohbet başlatın. ⤵️",
     "@noChatsFoundHere": {},
-    "loginWithMatrixId": "Matrix kimliği ile oturum aç",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Ana sunucuları keşfet",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Ana sunucu nedir?",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "Tüm verileriniz tıpkı bir e-posta sağlayıcısı gibi ana sunucuda saklanır. Hangi ana sunucuyu kullanmak istediğinizi seçebilir ve herkesle iletişim kurmaya devam edebilirsiniz. https://matrix.org adresinden daha fazla bilgi edinin.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "Uyumlu bir ana sunucu gibi görünmüyor. Yanlış URL mi?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "prepareSendingAttachment": "Ek gönderilmeye hazırlanıyor...",
@@ -2813,8 +2556,6 @@
     "@opacity": {},
     "setWallpaper": "Duvar kağıdı seç",
     "@setWallpaper": {},
-    "manageAccount": "Hesabı yönet",
-    "@manageAccount": {},
     "noContactInformationProvided": "Sunucu geçerli bir iletişim bilgisi sunmadı",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "Sunucu yöneticisiyle iletişime geçin",
@@ -2867,8 +2608,6 @@
             }
         }
     },
-    "welcomeText": "Hey Hey 👋 Karşınızda FluffyChat. https://matrix.org ile uyumlu herhangi bir homeserver'a giriş yapabilirsiniz. Ve herkesle konuşabilirsiniz. Bu koca bir merkeziyetsiz mesajlaşma ağı!",
-    "@welcomeText": {},
     "setCustomPermissionLevel": "Özel izin düzeyi ayarla",
     "@setCustomPermissionLevel": {},
     "setPermissionsLevelDescription": "Lütfen aşağıdan önceden tanımlanmış bir rol seçin veya 0 ile 100 arasında bir özel izin seviyesi girin.",
@@ -2881,15 +2620,6 @@
     "@commandHint_roomupgrade": {},
     "checkList": "Kontrol listesi",
     "@checkList": {},
-    "countInvited": "{count} davet edildi",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "synchronizingPleaseWaitCounter": " Senkronize ediliyor… ({percentage}%)",
     "@synchronizingPleaseWaitCounter": {
         "type": "String",
@@ -2901,11 +2631,8 @@
     },
     "previous": "Önceki",
     "otherPartyNotLoggedIn": "Diğer taraf şu anda giriş yapmadı ve bu nedenle mesaj alamaz!",
-    "appWantsToUseForLogin": "'{server}' kullanarak giriş yap",
-    "appWantsToUseForLoginDescription": "Bu uygulama ve web sitesinin sizinle ilgili bilgileri paylaşmasına izin veriyorsunuz.",
     "open": "Aç",
     "waitingForServer": "Sunucu bekleniyor...",
-    "appIntroduction": "FluffyChat, farklı mesajlaşma uygulamalarındaki arkadaşlarınızla sohbet etmenizi sağlar. Daha fazla bilgi için https://matrix.org adresine bakın veya sadece *Devam* düğmesine dokunun.",
     "newChatRequest": "📩 Yeni sohbet isteği",
     "contentNotificationSettings": "İçerik bildirim ayarları",
     "generalNotificationSettings": "Genel bildirim ayarları",
@@ -2980,11 +2707,9 @@
     "taTooltip": "Çeviri yardımıyla L2 kullanımı",
     "interactiveTranslatorSliderHeader": "Etkileşimli Çevirmen",
     "interactiveGrammarSliderHeader": "Etkileşimli Dilbilgisi Denetleyici",
-    "interactiveTranslatorRequired": "Gerekli",
     "waTooltip": "Yardım olmadan L2 kullanımı",
     "interactiveTranslator": "Çeviri yardımı",
     "noIdenticalLanguages": "Lütfen farklı temel ve hedef diller seçin",
-    "searchBy": "Ülke ve dillerle ara",
     "joinWithClassCode": "Derse katıl",
     "languageLevelPreA1": "Acemi Düşük (Pre A1)",
     "languageLevelA1": "Acemi Orta (A1)",
@@ -3005,19 +2730,14 @@
     "saveChanges": "Değişiklikleri kaydet",
     "publicProfileTitle": "Profilimin aramada bulunmasına izin ver",
     "publicProfileDesc": "Açılırsa, diğer kullanıcıların profilinizi küresel arama çubuğunda bulmasına ve sohbet istekleri göndermesine olanak tanırsınız. Bu noktada, isteği kabul etmeyi veya reddetmeyi seçebilirsiniz.",
-    "errorDisableIT": "Çeviri yardımı devre dışı bırakıldı.",
-    "errorDisableIGC": "Dilbilgisi yardımı devre dışı bırakıldı.",
     "errorDisableITUserDesc": "Çeviri yardımı ayarlarını güncellemek için buraya tıklayın",
     "errorDisableIGCUserDesc": "Dilbilgisi yardımı ayarlarını güncellemek için buraya tıklayın",
     "errorDisableITClassDesc": "Bu sohbetin bulunduğu kursta çeviri yardımı devre dışı bırakılmıştır.",
     "errorDisableIGCClassDesc": "Bu sohbetin bulunduğu kursta dilbilgisi yardımı devre dışı bırakılmıştır.",
-    "error405Title": "Diller ayarlanmamış",
     "error405Desc": "Lütfen Ana Menü > Öğrenme Ayarları'ndan dillerinizi ayarlayın.",
     "termsAndConditions": "Şartlar ve Koşullar",
     "andCertifyIAmAtLeast13YearsOfAge": " ve en az 16 yaşında olduğumu onaylıyorum.",
-    "error502504Title": "Vay canına, çok sayıda öğrenci çevrimiçi!",
     "error502504Desc": "Çeviri ve dilbilgisi araçları, Pangea botları güncellenirken yavaş veya kullanılamayabilir.",
-    "error404Title": "Çeviri hatası!",
     "error404Desc": "Pangea Bot bunun nasıl çevrileceğinden emin değil...",
     "errorPleaseRefresh": "Bunu inceliyoruz! Lütfen sayfayı yeniden yükleyin ve tekrar deneyin.",
     "connectedToStaging": "Test ortamına bağlı",
@@ -3055,13 +2775,9 @@
     "definitionsToolName": "Kelime Tanımları",
     "definitionsToolDescription": "Etkinleştirildiğinde, mavi ile altı çizili kelimelere tıklayarak tanımlarına ulaşabilirsiniz. Tanımlara erişmek için mesajlara tıklayın.",
     "welcomeBack": "Tekrar hoş geldiniz! 2023-2024 pilotunun bir parçasıysanız, lütfen özel pilot aboneliğiniz için bizimle iletişime geçin. Bir öğretmen veya kurumunuzun sınıfınız için lisans satın aldıysa, öğretmen aboneliğiniz için bizimle iletişime geçin.",
-    "downloadTxtFile": "Metin Dosyası İndir",
-    "downloadCSVFile": "CSV Dosyası İndir",
     "promotionalSubscriptionDesc": "Şu anda ömür boyu promosyon aboneliğiniz var. Aboneliğinizi değiştirmek için support@pangea.chat adresine mesaj gönderin.",
     "originalSubscriptionPlatform": "Abonelik {purchasePlatform} üzerinden satın alındı",
     "oneWeekTrial": "Bir Haftalık Deneme",
-    "downloadXLSXFile": "Excel Dosyasını İndir",
-    "unkDisplayName": "Bilinmeyen",
     "wwCountryDisplayName": "Dünya Çapında",
     "afCountryDisplayName": "Afganistan",
     "axCountryDisplayName": "Aland Adaları",
@@ -3356,7 +3072,6 @@
     "chatCapacityHasBeenChanged": "Sohbet kapasitesi değiştirildi",
     "chatCapacitySetTooLow": "Sohbet kapasitesi en az {count} olmalıdır.",
     "chatCapacityExplanation": "Sohbet kapasitesi, bir sohbette izin verilen üye sayısını sınırlar.",
-    "tooManyRequest": "Çok fazla istek var, lütfen daha sonra tekrar deneyin.",
     "enterNumber": "Lütfen tam sayı değeri girin.",
     "practice": "Pratik yap",
     "versionNotFound": "Sürüm Bulunamadı",
@@ -3366,7 +3081,6 @@
     "deleteSubscriptionWarningTitle": "Aktif bir aboneliğiniz var",
     "deleteSubscriptionWarningBody": "Hesabınızı silmek aboneliğinizi otomatik olarak iptal etmez.",
     "manageSubscription": "Aboneliği Yönet",
-    "error520Title": "Lütfen tekrar deneyin.",
     "error520Desc": "Üzgünüz, mesajınızı anlayamadık...",
     "wordsUsed": "Kullanılan Kelimeler",
     "level": "Seviye",
@@ -3384,7 +3098,6 @@
     "other": "Diğer",
     "levelShort": "Seviy {level}",
     "noCapacityLimit": "Kapasite sınırı yok",
-    "downloadGroupText": "Grup metnini indir",
     "notificationsOn": "Bildirimler açık",
     "notificationsOff": "Bildirimler kapalı",
     "joinWithCode": "Kodu kullanarak katıl",
@@ -3448,24 +3161,12 @@
     "whatIsTheMorphTag": "{wordForm}'un {morphologicalFeature} nedir?",
     "dataAvailable": "Veri kullanılabilirliği",
     "available": "Mevcut",
-    "pangeaBotIsFallible": "Pangea Bot da hata yapabilir!",
-    "whatIsMeaning": "{lemma} ne anlama geliyor?",
     "chooseLemmaMeaningInstructionsBody": "Mesajdaki kelimelerle anlamları eşleştir!",
-    "doubleClickToEdit": "Düzenlemek için çift tıklayın.",
-    "topicLabel": "Konu",
-    "topicPlaceholder": "Bir konu seçin...",
-    "modePlaceholder": "Bir mod seçin...",
-    "learningObjectiveLabel": "Öğrenme Hedefi",
-    "learningObjectivePlaceholder": "Bir öğrenme hedefi seçin...",
-    "targetLanguageLabel": "Hedef dil",
     "cefrLevelLabel": "CEFR seviyesi",
     "image": "Görüntü",
     "video": "Video",
     "nan": "Uygulanamaz",
-    "addVocabulary": "Kelime dağarcığı ekle",
     "instructions": "Talimatlar",
-    "numberOfLearners": "Öğrenci sayısı",
-    "mustBeInteger": "Bir tam sayı olmalı, örn. 1, 2, 3, ...",
     "constructUsePvmDesc": "Sesli mesajda üretilmiştir",
     "leaveSpaceDescription": "Kursu terk ederek, içindeki tüm sohbetleri terk etmiş olacaksınız. Diğer kullanıcılar kursu terk ettiğinizi görecektir.",
     "constructUseCorMmDesc": "Doğru mesaj anlamı",
@@ -3480,7 +3181,6 @@
     "ttsDisabledBody": "Öğrenme ayarlarınızda metin-konuşmayı etkinleştirebilirsiniz",
     "noSpaceDescriptionYet": "Henüz herhangi bir kurs açıklaması oluşturulmadı.",
     "tooLargeToSend": "Bu mesaj gönderilemeyecek kadar büyük",
-    "exitWithoutSaving": "Kaydetmeden çıkmak istediğinizden emin misiniz?",
     "enableAutocorrectPopupTitle": "Hedef dil klavyenizi eklemek için şu adımları izleyin:",
     "enableAutocorrectPopupSteps": "  • Ayarlar\n  • Genel\n  • Klavye\n  • Klavyeler\n  • Yeni Klavye Ekle",
     "enableAutocorrectPopupDescription": "Dil seçildikten sonra, klavyenizin sol alt köşesindeki küçük dünya simgesine tıklayarak yeni yüklenen klavyeyi etkinleştirebilirsiniz.",
@@ -3491,11 +3191,8 @@
     "displayName": "Görünen isim",
     "leaveRoomDescription": "Bu sohbette ayrılmak üzeresiniz. Diğer kullanıcılar sizin ayrıldığınızı görecek.",
     "confirmUserId": "Lütfen hesabınızı silmek için Pangea Sohbet kullanıcı adınızı onaylayın.",
-    "startingToday": "Bugünden itibaren",
-    "oneWeekFreeTrial": "Bir hafta ücretsiz deneme",
     "paidSubscriptionStarts": "{startDate} tarihinden itibaren başlar",
     "cancelInSubscriptionSettings": "• Abonelik ayarlarından istediğiniz zaman iptal edin",
-    "cancelToAvoidCharges": "• Ücret alınmaması için {trialEnds} tarihinden önce iptal edin",
     "downloadGboard": "Gboard'u İndir",
     "autocorrectNotAvailable": "Maalesef, bu özellik şu anda platformunuzda desteklenmemektedir. Daha fazla geliştirme için bizi izlemeye devam edin!",
     "pleaseUpdateApp": "Devam etmek için lütfen uygulamayı güncelleyin.",
@@ -3505,17 +3202,12 @@
     "knockSpaceSuccess": "Bu kursa katılmak istediğinizi belirttiniz! Bir yönetici, talebinizi aldığında yanıt verecek 😄",
     "chooseWordAudioInstructionsBody": "Tam mesajı dinleyin. Ardından sesleri kelimelerle eşleştirin.",
     "chooseMorphsInstructionsBody": "Dilbilgisi soruları için yapboz parçalarına tıklayın!",
-    "pleaseEnterInt": "Lütfen bir sayı girin",
     "home": "Ana Sayfa",
     "join": "Katıl",
     "resetInstructionTooltipsTitle": "Talimat ipuçlarını sıfırla",
     "resetInstructionTooltipsDesc": "Yeni bir kullanıcı gibi talimat ipuçlarını göstermek için tıklayın.",
-    "randomize": "Rastgeleleştir",
     "clear": "Temizle",
-    "featuredActivities": "Öne çıkanlar",
     "save": "Kaydet",
-    "startChat": "Sohbet başlat",
-    "translationProblem": "Çeviri sorunu",
     "askToJoin": "Katılmak için sor",
     "emptyChatWarningTitle": "Sohbet boş",
     "emptyChatWarningDesc": "Kimseyi sohbetine davet etmedin. Kişilerini veya Bot'u davet etmek için Sohbet ayarlarına git. Ayrıca bunu daha sonra da yapabilirsin.",
@@ -3545,17 +3237,13 @@
     "timesUsedIndependently": "Bağımsız kullanımlar",
     "timesUsedWithAssistance": "Yardımla kullanımlar",
     "shareInviteCode": "Davet kodunu paylaş: {code}",
-    "leaderboard": "Liderlik Tablosu",
     "skipForNow": "Şimdilik atla",
     "permissions": "İzinler",
     "spaceChildPermission": "Bu derse yeni sohbetler ekleyebilecek kişiler",
-    "addEnvironmentOverride": "Ortam geçersizliği ekle",
     "defaultOption": "Varsayılan",
     "deleteChatDesc": "Bu sohbeti silmek istediğinizden emin misiniz? Tüm katılımcılar için silinecek ve sohbet içindeki tüm mesajlar artık pratik veya öğrenme analitiği için kullanılabilir olmayacaktır.",
     "deleteSpaceDesc": "Ders ve seçilen sohbetler tüm katılımcılar için silinecek ve sohbet içindeki tüm mesajlar artık pratik veya öğrenme analitiği için kullanılabilir olmayacaktır. Bu işlem geri alınamaz.",
     "launch": "Başlat",
-    "searchChats": "Sohbetleri ara",
-    "maxFifty": "Maksimum 50",
     "configureSpace": "Dersi yapılandır",
     "pinMessages": "Mesajları sabitle",
     "setJoinRules": "Katılma kurallarını ayarla",
@@ -3589,9 +3277,6 @@
     "failedToFetchTranscription": "Yazıya dökme alınamadı",
     "deleteEmptySpaceDesc": "Kurs tüm katılımcılar için silinecek. Bu işlem geri alınamaz.",
     "regenerate": "Yeniden oluştur",
-    "mySavedActivities": "Kaydedilen Aktivitelerim",
-    "noSavedActivities": "Kaydedilen aktivite yok",
-    "saveActivity": "Bu aktiviteyi kaydet",
     "failedToPlayVideo": "Videoyu oynatamadı",
     "done": "Tamamlandı",
     "inThisSpace": "Bu kursta",
@@ -3602,13 +3287,9 @@
     "numInvited": "{count} davet edildi",
     "saved": "Kaydedildi",
     "reset": "Sıfırla",
-    "errorFetchingActivitiesMessage": "Aktiviteler alınamadı",
     "errorFetchingDefinition": "Tanım alınamadı",
     "errorProcessAnalytics": "Analitikler işlenemedi",
     "errorDownloading": "İndirme başarısız oldu",
-    "errorLoadingSpaceChildren": "Bu kurs içindeki sohbetler yüklenemedi",
-    "unexpectedError": "Beklenmedik hata.",
-    "pleaseReload": "Lütfen yeniden yükleyin ve tekrar deneyin.",
     "translationError": "Çeviri hatası",
     "check": "Kontrol et",
     "unableToFindRoom": "Bu kodla eşleşen sohbet veya kurs bulunamadı. Lütfen tekrar deneyin.",
@@ -3617,19 +3298,14 @@
     "request": "İstek",
     "requestAll": "Tümünü İste",
     "confirmMessageUnpin": "Bu mesajı sabitlemeyi kaldırmak istediğinizden emin misiniz?",
-    "saveAndLaunch": "Kaydet ve Başlat",
-    "launchToSpace": "Kursa başlat",
     "pending": "Beklemede",
     "inactive": "Pasif",
-    "confirmRole": "Rolü onayla",
     "openRoleLabel": "AÇIK",
     "finishedTheActivity": "🎯 {username} bu etkinliği tamamladı",
     "activitySummaryError": "Etkinlik özetleri kullanılamıyor",
     "requestSummaries": "Özetleri talep et",
-    "generatingNewActivities": "Bu dil çifti için ilk kullanıcı sizsiniz! Lütfen bir dakika verin, sizin için etkinlikler hazırlıyoruz.",
     "requestAccessTitle": "Analitik erişimi talep edilsin mi?",
     "requestAccessDesc": "Katılımcıların analitiklerini görüntüleme erişimi talep etmek ister misiniz?\n\nKatılımcılar kabul ederse, bu kursun yöneticileri:\n    • toplam kelime dağarcığını\n    • toplam dilbilgisi kavramlarını\n    • tamamlanan toplam etkinlik oturumlarını\n    • doğru ve yanlış kullanılan belirli dilbilgisi kavramlarını görebilecekler.\n\nGörme imkanları olmayacak:\n    • kurs dışındaki sohbetlerdeki mesajlar\n    • kelime listesi",
-    "requestAccess": "Erişim iste ({count})",
     "analyticsInactiveTitle": "Etkin olmayan kullanıcılara yapılan istekler gönderilemedi",
     "analyticsInactiveDesc": "Bu özellik tanıtıldıktan sonra giriş yapmamış etkin olmayan kullanıcılar isteğinizi görmeyecek.\n\nKullanıcı geri döndüğünde İstek düğmesi görünecek. Kullanıcı adlarının altındaki İstek düğmesine tıklayarak isteği daha sonra yeniden gönderebilirsiniz.",
     "accessRequestedTitle": "Analitik Erişim Talebi",
@@ -3652,8 +3328,6 @@
     "accessDesc": "Kursunuzu dünyaya açık hale getirebilirsiniz! Ya da, kursunuzu özel ve güvenli yapabilirsiniz.",
     "createGroupChatDesc": "Etkinlik oturumları başlar ve biterken, grup sohbetleri rutin iletişim için açık kalacaktır.",
     "deleteDesc": "Sadece yöneticiler kursu silebilir. Bu, tüm kullanıcıları kaldıran ve kurs içindeki tüm seçili sohbetleri silen yıkıcı bir işlemdir. Dikkatli ilerleyin.",
-    "noCourseFound": "Ah, bu kursun bir planı olmalı!\n\nKurs planları, konu ve sohbet etkinliklerinin sırasıdır.",
-    "additionalParticipants": "+ {num} diğer",
     "whatNow": "Şimdi ne olacak?",
     "chooseNextActivity": "Bir sonraki etkinliğinizi seçin!",
     "letsGo": "Hadi başlayalım",
@@ -3666,13 +3340,11 @@
     "waitNotDone": "Bekle, henüz bitirmedim!",
     "waitingForOthersToFinish": "Diğerlerinin bitirmesini bekliyorum...",
     "generatingSummary": "Sohbeti analiz ediyor ve sonuçlar oluşturuyor",
-    "findCourse": "Bir kurs bul",
     "pingParticipantsNotification": "{user} {room} içindeki etkinlik oturumuna katılacak kullanıcılar arıyor",
     "course": "Kurs",
     "courses": "Kurslar",
     "goToCourse": "Kursa git: {course}",
     "activityComplete": "Bu etkinlik tamamlandı. Etkinlik özeti aşağıda bulunabilir.",
-    "startNewSession": "Yeni oturum başlat",
     "joinOpenSession": "Açık oturuma katıl",
     "activityNotFound": "Etkinlik bulunamadı",
     "myActivities": "Benim etkinliklerim",
@@ -3723,27 +3395,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4061,10 +3717,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4074,10 +3726,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4165,14 +3813,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4189,10 +3829,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4205,15 +3841,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4365,14 +3993,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4386,14 +4006,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5616,10 +5228,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5660,10 +5268,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5736,10 +5340,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6009,47 +5609,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6069,19 +5629,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6145,10 +5693,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6189,14 +5733,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6208,14 +5744,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6253,10 +5781,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6273,27 +5797,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6417,10 +5925,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6430,10 +5934,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6450,14 +5950,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6597,18 +6089,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6657,10 +6137,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6670,18 +6146,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6724,23 +6188,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6764,10 +6216,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6775,14 +6223,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6887,18 +6327,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6951,10 +6379,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6981,10 +6405,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7165,7 +6585,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Yarına kadar etkinlik güncellemelerini kontrol edin.",
-    "activityDropdownDesc": "Bu etkinliği tamamladıktan sonra aşağıdaki butona tıklayın",
     "languageMismatchTitle": "Dil uyuşmazlığı",
     "languageMismatchDesc": "Hedef diliniz, bu etkinliğin diliyle uyuşmuyor. Hedef dilinizi güncellemek ister misiniz?",
     "reportWordIssueTooltip": "Kelime bilgisi sorununu bildir",
@@ -7178,10 +6597,6 @@
     "selectAll": "Tümünü seç",
     "deselectAll": "Tüm seçimleri kaldır",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7230,17 +6645,11 @@
         "placeholders": {}
     },
     "startOwn": "Kendi başıma başla",
-    "joinCourseDesc": "Her kurs, dizi halinde 8-10 konu ve görev tabanlı dil öğrenme etkinlikleri içerir.",
     "newMessageInPangeaChat": "🗨️ Pangea Sohbetinde yeni mesaj",
     "shareCourse": "Kursu paylaş",
     "addCourse": "Bir kurs ekle",
-    "joinPublicCourse": "Herkese açık kursa katıl",
     "vocabLevelsDesc": "Kelime seviyelerini yükselttiğinizde buraya kelimeler gelir!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7253,10 +6662,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7275,7 +6680,6 @@
     "emojiView": "Emoji görünümü",
     "feedbackDialogDesc": "Ben de hata yapıyorum! Gelişmeme yardımcı olacak bir şey var mı?",
     "contactHasBeenInvitedToTheCourse": "İletişim kişisi kursa davet edildi",
-    "activityStatsButtonTooltip": "Etkinlik bilgisi",
     "allow": "İzin ver",
     "deny": "Reddet",
     "enabledRenewal": "Abonelik Yenilemeyi Etkinleştir",
@@ -7543,10 +6947,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8602,16 +8002,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Sonraki Konuyu Açmak için Aktiviteler",
-    "activitiesToUnlockTopicDesc": "Sonraki kurs konusunu açmak için aktivite sayısını ayarlayın",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Doğru kelime tanımı pratiği",
     "constructUseIncLMDesc": "Yanlış kelime tanımı pratiği",
     "constructUseCorLADesc": "Doğru kelime ses pratiği",
@@ -8619,7 +8009,6 @@
     "constructUseBonus": "Kelime pratiği sırasında bonus",
     "practiceVocab": "Kelime pratiği yap",
     "selectMeaning": "Anlamı seç",
-    "selectAudio": "Eşleşen sesi seç",
     "anotherRound": "Bir tur daha",
     "activitySettingsOverrideWarning": "Etkinlik planı tarafından belirlenen dil ve dil seviyesi",
     "voice": "Ses",
@@ -8651,10 +8040,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8672,12 +8057,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "İndirme başlatıldı",
     "webDownloadPermissionMessage": "Tarayıcınız indirmeleri engelliyorsa, lütfen bu site için indirmeleri etkinleştirin.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8772,11 +8152,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Bir şeyler yanlış gitti ve biz bunu düzeltmek için yoğun bir şekilde çalışıyoruz. Lütfen daha sonra tekrar kontrol edin.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Yazma yardımını etkinleştir",
     "autoIGCToolDescription": "Gönderilen mesajları hedef dile düzeltmek için Pangea Chat araçlarını otomatik olarak çalıştır.",
     "@autoIGCToolName": {
@@ -8832,24 +8207,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Dilbilgisi",
-    "spanTypeWordChoice": "Kelime Seçimi",
     "spanTypeSpelling": "Yazım",
     "spanTypePunctuation": "Noktalama",
     "spanTypeStyle": "Üslup",
     "spanTypeFluency": "Akıcılık",
     "spanTypeAccents": "Aksanlar",
     "spanTypeCapitalization": "Büyük Harf Kullanımı",
-    "spanTypeCorrection": "Düzeltme",
     "spanFeedbackTitle": "Düzeltme sorununu bildir",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8874,10 +8238,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8890,13 +8250,7 @@
     "longPressToRecordVoiceMessage": "Sesli mesaj kaydetmek için uzun basın.",
     "pause": "Duraklat",
     "resume": "Devam et",
-    "newSubSpace": "Yeni alt alan",
-    "moveToDifferentSpace": "Farklı alana taşı",
-    "removeFromSpaceDescription": "Sohbet alanından kaldırılacak ancak sohbet listenizde görünmeye devam edecek.",
     "countChats": "{chats} sohbet",
-    "spaceMemberOf": "{spaces} alan üyesi",
-    "spaceMemberOfCanKnock": "{spaces} alan üyesi kapıyı çalabilir",
-    "donate": "Bağış yap",
     "startedAPoll": "{username} bir anket başlattı.",
     "poll": "Anket",
     "startPoll": "Anket başlat",
@@ -8920,23 +8274,15 @@
     "newStickerPack": "Yeni çıkartma paketi",
     "stickerPackName": "Çıkartma paketi adı",
     "attribution": "Atıf",
-    "skipChatBackup": "Sohbet yedeğini atla",
-    "skipChatBackupWarning": "Emin misiniz? Sohbet yedeğini etkinleştirmeden cihazınızı değiştirirseniz mesajlarınıza erişimi kaybedebilirsiniz.",
-    "loadingMessages": "Mesajlar yükleniyor",
-    "setupChatBackup": "Sohbet yedeğini ayarla",
     "noMoreResultsFound": "Daha fazla sonuç bulunamadı",
     "chatSearchedUntil": "Sohbet {time} tarihine kadar arandı",
     "federationBaseUrl": "Federasyon Temel URL'si",
     "clientWellKnownInformation": "İstemci-Bilinen Bilgiler:",
     "baseUrl": "Temel URL",
     "identityServer": "Kimlik Sunucusu:",
-    "versionWithNumber": "Sürüm: {version}",
     "logs": "Günlükler",
-    "advancedConfigs": "Gelişmiş Yapılandırmalar",
     "advancedConfigurations": "Gelişmiş yapılandırmalar",
-    "signInWithLabel": "Giriş yapın:",
     "selectAllWords": "Sesli olarak duyduğunuz tüm kelimeleri seçin",
-    "joinCourseForActivities": "Etkinlikleri denemek için bir kursa katılın.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -8973,18 +8319,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -8992,26 +8326,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9117,22 +8431,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9161,19 +8459,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9181,15 +8467,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9390,11 +8668,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Bir derste misin? Katılma kodunu buraya yaz.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Sesli mesajları otomatik vurgula",
     "selectAudioMessagesOnPlayDescription": "Oynatıldığında sesli mesajları otomatik olarak vurgula",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9438,18 +8711,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Bu kursun {input} aktiviteden daha az aktiviteye sahip konuları var. Lütfen {minValue} veya daha az bir sayı girin.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Tekrar giriş yapmak için buraya tıklayın.",
     "@clickToLogin": {
@@ -9866,17 +9127,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Heyecanla kollarını kaldırmış, karikatür tarzı sarı bir ayı.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Daha fazla bilgi edinmek için kelimeleri seçin",
     "requireAnalyticsAccessTitle": "Katılmak için analiz erişimi gereklidir",
     "requireAnalyticsAccessDesc": "Katılımcıların bu kursa katılmak için öğrenme analizlerine erişim izni vermesi gerekmektedir",
     "analyticsAccessNoticeTitle": "Analiz Erişimi Gereklidir",
     "analyticsAccessNoticeDesc": "Bu kursa katılarak, yöneticilere öğrenme analizlerinize erişim izni vermeyi kabul edersiniz.",
-    "skipOnboardingClassCodeDesc": "Bağımsız öğreniyor musunuz? Endişelenmeyin, şunları yapabilirsiniz:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9894,10 +9149,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9926,7 +9177,6 @@
     "pickCefrLevelTeacherStepTitle": "Hangi seviyede ders veriyorsunuz?",
     "pickCefrLevelStudentStepTitle": "Hangi seviyedesiniz?",
     "customCourseStepTitle": "Özel bir kurs almak için bu formu doldurun",
-    "aboutYourClass": "Sınıfınız Hakkında",
     "courseCodeStepErrorMessage": "Lütfen kodunuzu kontrol edin ve tekrar deneyin",
     "institution": "Kurum",
     "courseGoals": "Kurs Hedefleri",
@@ -9969,10 +9219,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10089,12 +9335,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logosu",
     "introChatDetails": "Merhaba de! Diğer kurs katılımcılarına kendini tanıt, arkadaşlar bul ve etkinliklerin dışında sohbet et.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10138,11 +9379,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Etkinlik eylemleri",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Telaffuz araçları",
     "audioTranscription": "Yapay zeka ses transkripsiyonu",
     "visualLearnerSupport": "Görsel öğrenici desteği",
@@ -10183,7 +9419,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Bu etkinliği oynamak için bu etkinliği içeren bir kursa katılın.",
     "resizeCoursePanel": "Kurs panelini yeniden boyutlandır",
     "undo": "Geri al",
     "unlock": "Kilidi aç",
@@ -10197,7 +9432,6 @@
     "addCourseBrowsePublic": "Açık kursları göz atın",
     "browsePublicCourses": "Açık kursları göz atın",
     "editProfile": "Profili düzenle",
-    "numObjectives": "{count} hedef",
     "mapSearchHint": "Aktiviteleri ara",
     "mapSearchNoResults": "Görüntüde eşleşme yok",
     "mapFilterAllLanguages": "Tüm diller",
@@ -10206,7 +9440,6 @@
     "mapFilterCompleted": "Tamamlandı",
     "mapFilterReset": "Sıfırla",
     "activityTypeConversation": "Konuşma",
-    "lockedMissionRequirement": "Kilidi açmak için önceki görevi tamamlayın",
     "playAgain": "Tekrar oyna",
     "reviewActivity": "Gözden geçir",
     "mapEmptyInView": "Seviyenizde veya dilinizde burada hiçbir şey yok. Filtrelerinizi genişletin veya uzaklaştırın.",
@@ -10221,14 +9454,9 @@
     "scrollToBottom": "Sona kaydır",
     "courseImage": "Kurs resmi",
     "avatarPreview": "Avatar önizlemesi",
-    "activityPhoto": "Etkinlik fotoğrafı",
     "emotePreview": "Emote önizlemesi: {name}",
     "activityLabel": "Etkinlik: {title}",
     "resetMapView": "Harita görünümünü sıfırla",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10281,14 +9509,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10318,10 +9538,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10378,10 +9594,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_uk.arb
+++ b/lib/l10n/intl_uk.arb
@@ -63,11 +63,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Чи дозволено гостям приєднуватись",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Ви впевнені?",
     "@areYouSure": {
         "type": "String",
@@ -323,11 +318,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Контакт був запрошений в групу",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "copiedToClipboard": "Скопійовано в буфер обміну",
     "@copiedToClipboard": {
         "type": "String",
@@ -452,11 +442,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "Ви більше не зможете вимкнути шифрування. Ви впевнені?",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encryption": "Шифрування",
     "@encryption": {
         "type": "String",
@@ -503,11 +488,6 @@
     },
     "group": "Група",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "Загальнодоступна група",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -566,15 +546,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Запросити контакт до {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "Запрошено",
     "@invited": {
@@ -677,15 +648,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Завантажити ще {count} учасників",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "Завантаження… Будь ласка, зачекайте.",
     "@loadingPleaseWait": {
         "type": "String",
@@ -700,15 +662,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "Увійти до {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Вийти",
     "@logout": {
@@ -742,11 +695,6 @@
     },
     "noEmotesFound": "Емодзі не знайдено. 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Схоже, Firebase Cloud Messaging недоступна на вашому пристрої. Щоб отримувати push-сповіщення, радимо встановити ntfy. За допомогою ntfy або іншого постачальника Unified Push ви можете отримувати push-сповіщення у безпечний спосіб. Ви можете завантажити ntfy з PlayStore або з F-Droid.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -875,11 +823,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "Вилучити пристрій",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "Розблокувати у бесіді",
     "@unbanFromChat": {
@@ -1156,16 +1099,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Відеовиклик",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Видимість історії бесіди",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Видима для всіх учасників",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1198,11 +1131,6 @@
     },
     "wallpaper": "Шпалери:",
     "@wallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Кому дозволено приєднуватися до цієї групи",
-    "@whoIsAllowedToJoinThisGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1363,11 +1291,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "createNewSpace": "Новий простір",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "enableEncryption": "Увімкнути шифрування",
     "@enableEncryption": {
         "type": "String",
@@ -1461,11 +1384,6 @@
     },
     "weSentYouAnEmail": "Ми надіслали вам електронний лист",
     "@weSentYouAnEmail": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Стерти резервну копію бесіди, щоб створити новий ключ відновлення?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1643,18 +1561,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Перенесення з іншого пристрою",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "sendMessages": "Надсилати повідомлення",
     "@sendMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoCanPerformWhichAction": "Хто і яку дію може виконувати",
-    "@whoCanPerformWhichAction": {
         "type": "String",
         "placeholders": {}
     },
@@ -1673,11 +1581,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "everythingReady": "Усе готово!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "homeserver": "Домашній сервер",
     "@homeserver": {},
     "groups": "Групи",
@@ -1690,23 +1593,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "noEncryptionForPublicRooms": "Активувати шифрування можна лише тоді, коли кімната більше не буде загальнодоступною.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "Ваші повідомлення захищені ключем відновлення. Переконайтеся, що ви не втратите його.",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatBackup": "Резервне копіювання бесіди",
     "@chatBackup": {
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "Рез. копію чату налаштовано.",
-    "@yourChatBackupHasBeenSetUp": {},
     "clearArchive": "Очистити архів",
     "@clearArchive": {},
     "commandHint_html": "Надіслати текст у форматі HTML",
@@ -1749,10 +1640,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "addAccount": "Додати обліковий запис",
-    "@addAccount": {},
-    "enableMultiAccounts": "(БЕТА) Увімкнути кілька облікових записів на цьому пристрої",
-    "@enableMultiAccounts": {},
     "openInMaps": "Відкрити в картах",
     "@openInMaps": {
         "type": "String",
@@ -1780,11 +1667,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "Указати рівні дозволів",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "shareLocation": "Поділитися місцеперебуванням",
     "@shareLocation": {
         "type": "String",
@@ -1799,15 +1681,6 @@
     "@unavailable": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 непрочитана бесіда} few{{unreadCount} непрочитані бесіди} many{{unreadCount} непрочитаних бесід} other{{unreadCount} непрочитані бесіди}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "withTheseAddressesRecoveryDescription": "За допомогою цих адрес ви можете відновити свій пароль.",
     "@withTheseAddressesRecoveryDescription": {
@@ -1902,11 +1775,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "passwordRecovery": "Відновлення пароля",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "people": "Люди",
     "@people": {
         "type": "String",
@@ -1922,11 +1790,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceName": "Назва простору",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "warning": "Попередження!",
     "@warning": {
         "type": "String",
@@ -1934,11 +1797,6 @@
     },
     "yourPublicKey": "Ваш відкритий ключ",
     "@yourPublicKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Простір загальнодоступний",
-    "@spaceIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -1981,8 +1839,6 @@
     "@openGallery": {},
     "sender": "Відправник",
     "@sender": {},
-    "removeFromSpace": "Вилучити з простору",
-    "@removeFromSpace": {},
     "start": "Почати",
     "@start": {},
     "commandHint_discardsession": "Відкинути сеанс",
@@ -2042,14 +1898,8 @@
     "@placeCall": {},
     "unsupportedAndroidVersion": "Непідтримувана версія Android",
     "@unsupportedAndroidVersion": {},
-    "voiceCall": "Голосовий виклик",
-    "@voiceCall": {},
     "unsupportedAndroidVersionLong": "Для цієї функції потрібна новіша версія Android. Перевірте наявність оновлень або підтримку Lineage OS.",
     "@unsupportedAndroidVersionLong": {},
-    "videoCallsBetaWarning": "Зауважте, що відеовиклики на ранньому етапі розробки. Вони можуть працювати не так, як очікувалося, або взагалі не працювати на всіх платформах.",
-    "@videoCallsBetaWarning": {},
-    "emailOrUsername": "Електронна адреса або ім’я користувача",
-    "@emailOrUsername": {},
     "experimentalVideoCalls": "Експериментальні відеовиклики",
     "@experimentalVideoCalls": {},
     "addWidget": "Додати віджет",
@@ -2137,28 +1987,8 @@
             }
         }
     },
-    "saveKeyManuallyDescription": "Збережіть цей ключ вручну, запустивши діалогове вікно спільного доступу до системи або буфер обміну.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "Зберегти в Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Зберегти в Apple KeyChain",
-    "@storeInAppleKeyChain": {},
-    "storeSecurlyOnThisDevice": "Зберегти безпечно на цей пристрій",
-    "@storeSecurlyOnThisDevice": {},
-    "pleaseEnterRecoveryKeyDescription": "Щоб розблокувати старі повідомлення, введіть ключ відновлення, згенерований у попередньому сеансі. Ваш ключ відновлення це НЕ ваш пароль.",
-    "@pleaseEnterRecoveryKeyDescription": {},
-    "pleaseEnterRecoveryKey": "Введіть ключ відновлення:",
-    "@pleaseEnterRecoveryKey": {},
-    "recoveryKey": "Ключ відновлення",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Ключ відновлення втрачено?",
-    "@recoveryKeyLost": {},
     "users": "Користувачі",
     "@users": {},
-    "unlockOldMessages": "Розблокувати старі повідомлення",
-    "@unlockOldMessages": {},
-    "storeInSecureStorageDescription": "Збережіть ключ відновлення в безпечному сховищі цього пристрою.",
-    "@storeInSecureStorageDescription": {},
     "countFiles": "{count} файлів",
     "@countFiles": {
         "placeholders": {
@@ -2196,20 +2026,12 @@
     "@whyIsThisMessageEncrypted": {},
     "noKeyForThisMessage": "Це може статися, якщо повідомлення було надіслано до того, як ви ввійшли у свій обліковий запис на цьому пристрої.\n\nТакож можливо, що відправник заблокував ваш пристрій або щось пішло не так з під'єднанням до інтернету.\n\nЧи можете ви прочитати повідомлення на іншому сеансі? Тоді ви зможете перенести повідомлення з нього! Перейдіть до Налаштування > Пристрої та переконайтеся, що ваші пристрої перевірили один одного. Коли ви відкриєте кімнату наступного разу й обидва сеанси будуть на активні, ключі будуть передані автоматично.\n\nВи ж не хочете втрачати ключі після виходу або зміни пристроїв? Переконайтеся, що ви ввімкнули резервне копіювання бесід у налаштуваннях.",
     "@noKeyForThisMessage": {},
-    "foregroundServiceRunning": "Це сповіщення з'являється під час роботи основної служби.",
-    "@foregroundServiceRunning": {},
-    "screenSharingTitle": "спільний доступ до екрана",
-    "@screenSharingTitle": {},
     "newGroup": "Нова група",
     "@newGroup": {},
     "newSpace": "Новий простір",
     "@newSpace": {},
-    "enterSpace": "Увійти в простір",
-    "@enterSpace": {},
     "allSpaces": "Усі простори",
     "@allSpaces": {},
-    "screenSharingDetail": "Ви ділитеся своїм екраном FuffyChat",
-    "@screenSharingDetail": {},
     "doNotShowAgain": "Не показувати знову",
     "@doNotShowAgain": {},
     "commandHint_cuddle": "Надіслати пригортайку",
@@ -2254,14 +2076,6 @@
             }
         }
     },
-    "newSpaceDescription": "Простори дозволяють об'єднувати ваші бесіди та створювати приватні або загальнодоступні спільноти.",
-    "@newSpaceDescription": {},
-    "encryptThisChat": "Зашифрувати цю бесіду",
-    "@encryptThisChat": {},
-    "disableEncryptionWarning": "З міркувань безпеки ви не можете вимкнути шифрування в бесіді, ув якій воно було ввімкнене раніше.",
-    "@disableEncryptionWarning": {},
-    "sorryThatsNotPossible": "Вибачте... це неможливо",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "Ключі пристрою:",
     "@deviceKeys": {},
     "reopenChat": "Відновити бесіду",
@@ -2315,14 +2129,10 @@
     "@shareInviteLink": {},
     "tryAgain": "Повторіть спробу",
     "@tryAgain": {},
-    "setTheme": "Налаштувати тему:",
-    "@setTheme": {},
     "setColorTheme": "Налаштувати колірну тему:",
     "@setColorTheme": {},
     "chatPermissions": "Дозволи бесіди",
     "@chatPermissions": {},
-    "chatDescription": "Опис бесіди",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "Опис бесіди змінено",
     "@chatDescriptionHasBeenChanged": {},
     "noChatDescriptionYet": "Опис бесіди ще не створено.",
@@ -2408,14 +2218,10 @@
     "@kickUserDescription": {},
     "blockListDescription": "Ви можете заблокувати користувачів, які вас турбують. Ви не зможете отримувати жодних повідомлень або запрошень до кімнати від користувачів з вашого персонального списку блокування.",
     "@blockListDescription": {},
-    "createGroupAndInviteUsers": "Створити групу та запросити користувачів",
-    "@createGroupAndInviteUsers": {},
     "startConversation": "Розпочати розмову",
     "@startConversation": {},
     "blockedUsers": "Заблоковані користувачі",
     "@blockedUsers": {},
-    "groupCanBeFoundViaSearch": "Групу можна знайти через пошук",
-    "@groupCanBeFoundViaSearch": {},
     "noUsersFoundWithQuery": "На жаль, не знайдено жодного користувача з запитом \"{query}\".Перевірте, чи не було допущено помилки.",
     "@noUsersFoundWithQuery": {
         "type": "String",
@@ -2439,8 +2245,6 @@
     "@groupName": {},
     "databaseMigrationTitle": "Базу даних оптимізовано",
     "@databaseMigrationTitle": {},
-    "searchChatsRooms": "Пошук для #chats, @users...",
-    "@searchChatsRooms": {},
     "databaseMigrationBody": "Зачекайте, будь ласка. Це може тривати деякий час.",
     "@databaseMigrationBody": {},
     "thisDevice": "Цей пристрій:",
@@ -2465,40 +2269,14 @@
     "@select": {},
     "pleaseChooseAStrongPassword": "Виберіть надійний пароль",
     "@pleaseChooseAStrongPassword": {},
-    "addChatOrSubSpace": "Додати бесіду або підпростір",
-    "@addChatOrSubSpace": {},
     "leaveEmptyToClearStatus": "Лишіть порожнім, щоб оновити статус.",
     "@leaveEmptyToClearStatus": {},
     "joinSpace": "Приєднатися до простору",
     "@joinSpace": {},
     "searchForUsers": "Пошук @користувачів...",
     "@searchForUsers": {},
-    "sessionLostBody": "Ваш сеанс втрачено. Будь ласка, повідомте про цю помилку розробникам за адресою {url}. Текст помилки: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "initAppError": "Виникла помилка під час запуску застосунку",
     "@initAppError": {},
-    "restoreSessionBody": "Наразі застосунок намагається відновити ваш сеанс з резервної копії. Будь ласка, повідомте про цю помилку розробникам за адресою {url}. Текст помилки: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "acceptedKeyVerification": "{sender} погоджується звірити ключі",
     "@acceptedKeyVerification": {
         "type": "String",
@@ -2538,10 +2316,6 @@
     "@sendTypingNotificationsDescription": {},
     "formattedMessagesDescription": "Показувати розширений вміст повідомлень, наприклад, жирний текст, використовуючи markdown.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Звірити іншого користувача",
-    "@verifyOtherUser": {},
-    "verifyOtherUserDescription": "Якщо ви звіряєте іншого користувача, ви можете бути впевнені, що знаєте, кому ви насправді пишете. 💪\n\nКоли ви почнете звірення, ви та інший користувач побачите спливне вікно в застосунку. Там ви побачите набір смайликів або чисел, які вам потрібно буде порівняти між собою.\n\nНайкращий спосіб зробити це — зустрітися або розпочати відеовиклик. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDeviceDescription": "Коли ви звіряєте інший пристрій, ці пристрої можуть обмінюватися ключами, підвищуючи вашу загальну безпеку. 💪 Коли ви розпочнете звірення, в застосунку на обох пристроях з'явиться спливне вікно. Там ви побачите набір смайликів або чисел, які вам потрібно буде порівняти між собою. Найкраще мати обидва пристрої під рукою перед початком звірення. 🤳",
     "@verifyOtherDeviceDescription": {},
     "verifyOtherDevice": "🔐 Звірити інший пристрій",
@@ -2601,20 +2375,12 @@
     "@restricted": {},
     "swipeRightToLeftToReply": "Посунути праворуч або ліворуч, щоб відповісти",
     "@swipeRightToLeftToReply": {},
-    "globalChatId": "Глобальний ID бесіди",
-    "@globalChatId": {},
-    "accessAndVisibility": "Доступ і видимість",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Хто може приєднатися до цієї бесіди і як її можна знайти.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Виклики",
     "@calls": {},
     "customEmojisAndStickers": "Власні емодзі та наліпки",
     "@customEmojisAndStickers": {},
     "customEmojisAndStickersBody": "Додавайте або діліться власними емодзі або наліпками, які можна використовувати в будь-якій бесіді.",
     "@customEmojisAndStickersBody": {},
-    "createNewAddress": "Створити нову адресу",
-    "@createNewAddress": {},
     "commandHint_unignore": "Не ігнорувати цей Matrix ID",
     "@commandHint_unignore": {},
     "knockRestricted": "Стук обмежено",
@@ -2637,21 +2403,6 @@
     "@knocking": {},
     "noDatabaseEncryption": "Шифрування бази даних не підтримується на цій платформі",
     "@noDatabaseEncryption": {},
-    "usersMustKnock": "Користувачі повинні постукатись",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Ніхто не може приєднатись",
-    "@noOneCanJoin": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Бесіду можна знайти за допомогою пошуку на {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "publicChatAddresses": "Адреси загальнодоступної бесіди",
-    "@publicChatAddresses": {},
     "searchMore": "Шукати ще...",
     "@searchMore": {},
     "gallery": "Галерея",
@@ -2762,14 +2513,6 @@
     "@sendCanceled": {},
     "noChatsFoundHere": "Бесід ще немає. Розпочніть спілкування натиснувши кнопку нижче. ⤵️",
     "@noChatsFoundHere": {},
-    "loginWithMatrixId": "Увійти за допомогою Matrix-ID",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Знайти домашні сервери",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Що таке домашній сервер?",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "Усі ваші дані зберігаються на домашньому сервері, так само як у постачальника послуг електронної пошти. Ви можете вибрати, який домашній сервер ви хочете використовувати, водночас ви можете спілкуватися з усіма. Докладніше на https://matrix.org.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "Здається, це несумісний домашній сервер. Неправильна URL-адреса?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "calculatingFileSize": "Обчислення розміру файлу...",
@@ -2809,10 +2552,6 @@
     "@noticeChatBackupDeviceVerification": {},
     "continueText": "Продовжити",
     "@continueText": {},
-    "manageAccount": "Керувати обліковим записом",
-    "@manageAccount": {},
-    "welcomeText": "Привіт-привіт 👋 Це FluffyChat. Ви можете увійти на будь-який сервер, сумісний із https://matrix.org. А потім спілкуватися з будь-ким. Це величезна децентралізована мережа для обміну повідомленнями!",
-    "@welcomeText": {},
     "blur": "Розмиття:",
     "@blur": {},
     "opacity": "Прозорість:",
@@ -2890,23 +2629,10 @@
     "@crossVerifiedDevicesIfEnabled": {},
     "crossVerifiedDevices": "З перехресною верифікацією пристроїв",
     "@crossVerifiedDevices": {},
-    "appWantsToUseForLogin": "Використати '{server}', щоб увійти",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Цим ви дозволяєте застосунку та вебсайту ділитися інформацією про вас.",
-    "@appWantsToUseForLoginDescription": {},
     "open": "Відкрити",
     "@open": {},
     "waitingForServer": "Очікування сервера...",
     "@waitingForServer": {},
-    "appIntroduction": "FluffyChat дає змогу спілкуватися з друзями у різних месенджерах. Дізнайтеся більше на https://matrix.org або просто натисніть *Продовжити*.",
-    "@appIntroduction": {},
     "shareKeysWithDescription": "Яким пристроям довіряти, щоб вони могли читати ваші повідомлення в зашифрованих бесідах?",
     "@shareKeysWithDescription": {},
     "verifiedDevicesOnly": "Лише верифіковані пристрої",
@@ -3054,15 +2780,6 @@
             }
         }
     },
-    "countInvited": "Запрошено {count}",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "checkList": "Контрольний список",
     "@checkList": {},
     "commandHint_logout": "Вийти на цьому пристрої",
@@ -3085,12 +2802,6 @@
     "@pause": {},
     "resume": "Продовжити",
     "@resume": {},
-    "newSubSpace": "Новий вкладений простір",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Перемістити в інший простір",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "Бесіду буде видалено з простору, та вона залишиться у вашому списку бесід.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} бесід",
     "@countChats": {
         "type": "String",
@@ -3100,26 +2811,6 @@
             }
         }
     },
-    "spaceMemberOf": "Учасник {spaces} просторів",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "Учасник просторів {spaces} може постукати",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "Задонатити",
-    "@donate": {},
     "startedAPoll": "Нове опитування від {username}.",
     "@startedAPoll": {
         "type": "String",
@@ -3147,12 +2838,6 @@
     "@allowMultipleAnswers": {},
     "pollHasBeenEnded": "Опитування завершилось",
     "@pollHasBeenEnded": {},
-    "skipChatBackupWarning": "Ви впевнені? Без резервного копіювання бесід ви можете втратити доступ до повідомлень, якщо ви зміните пристрій.",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "Завантажуються повідомлення",
-    "@loadingMessages": {},
-    "setupChatBackup": "Налаштувати резервне копіювання бесід",
-    "@setupChatBackup": {},
     "replyInThread": "Відповісти у вітці",
     "@replyInThread": {},
     "saveChanges": "Зберегти зміни",
@@ -3171,8 +2856,6 @@
     "@stickerPackName": {},
     "attribution": "Атрибуція",
     "@attribution": {},
-    "skipChatBackup": "Пропустити резервне копіювання бесід",
-    "@skipChatBackup": {},
     "thread": "Вітка",
     "@thread": {},
     "backToMainChat": "Повернутись до основної бесіди",
@@ -3207,11 +2890,9 @@
     "taTooltip": "Використання L2 з перекладацькою допомогою",
     "interactiveTranslatorSliderHeader": "Інтерактивний перекладач",
     "interactiveGrammarSliderHeader": "Інтерактивний перевірник граматики",
-    "interactiveTranslatorRequired": "Обов’язково",
     "waTooltip": "Використання L2 без допомоги",
     "interactiveTranslator": "Допомога з перекладом",
     "noIdenticalLanguages": "Будь ласка, оберіть різні мови для бази та цілі",
-    "searchBy": "Пошук за країною та мовами",
     "joinWithClassCode": "Приєднатися до курсу",
     "languageLevelPreA1": "Новачок Низький (Перед A1)",
     "languageLevelA1": "Новачок Середній (A1)",
@@ -3231,19 +2912,14 @@
     "whatIsYourBaseLanguage": "Яка ваша базова мова?",
     "publicProfileTitle": "Дозволити знаходити мій профіль у пошуку",
     "publicProfileDesc": "Увімкнувши цю опцію, ви дозволяєте іншим користувачам знаходити ваш профіль у глобальній пошуковій стрічці та надсилати запити на чат. На цьому етапі ви можете прийняти або відхилити запит.",
-    "errorDisableIT": "Допомога з перекладом вимкнена.",
-    "errorDisableIGC": "Допомога з граматикою вимкнена.",
     "errorDisableITUserDesc": "Натисніть тут, щоб оновити налаштування допомоги з перекладом",
     "errorDisableIGCUserDesc": "Натисніть тут, щоб оновити налаштування допомоги з граматикою",
     "errorDisableITClassDesc": "Допомога з перекладом вимкнена для курсу, у якому ведеться цей чат.",
     "errorDisableIGCClassDesc": "Допомога з граматикою вимкнена для курсу, у якому ведеться цей чат.",
-    "error405Title": "Мови не налаштовані",
     "error405Desc": "Будь ласка, налаштуйте свої мови у Головному меню > Налаштування навчання.",
     "termsAndConditions": "Умовами та положеннями",
     "andCertifyIAmAtLeast13YearsOfAge": " і підтверджую, що мені щонайменше 16 років.",
-    "error502504Title": "Вау, багато студентів онлайн!",
     "error502504Desc": "Інструменти перекладу та граматики можуть працювати повільно або бути недоступними, поки боти Pangea наздоганяють.",
-    "error404Title": "Помилка перекладу!",
     "error404Desc": "Бот Pangea не впевнений, як це перекласти...",
     "errorPleaseRefresh": "Ми цим займаємося! Будь ласка, перезавантажте сторінку та спробуйте ще раз.",
     "connectedToStaging": "Підключено до тестового середовища",
@@ -3281,13 +2957,9 @@
     "definitionsToolName": "Визначення слів",
     "definitionsToolDescription": "Коли активовано, слова підкреслені синім можна натиснути для перегляду визначень. Натискайте повідомлення для доступу до визначень.",
     "welcomeBack": "Ласкаво просимо назад! Якщо ви були учасником пілотного проекту 2023-2024 років, будь ласка, зв’яжіться з нами для отримання вашої спеціальної підписки на пілотний проект. Якщо ви вчитель, який (або ваша установа) придбав ліцензії для вашого класу, зв’яжіться з нами для отримання підписки вчителя.",
-    "downloadTxtFile": "Завантажити текстовий файл",
-    "downloadCSVFile": "Завантажити CSV-файл",
     "promotionalSubscriptionDesc": "У вас наразі безстрокова промо-підписка. Напишіть support@pangea.chat для допомоги у зміні підписки.",
     "originalSubscriptionPlatform": "Підписка, придбана через {purchasePlatform}",
     "oneWeekTrial": "Тестовий період один тиждень",
-    "downloadXLSXFile": "Завантажити файл Excel",
-    "unkDisplayName": "Невідомо",
     "wwCountryDisplayName": "Світовий",
     "afCountryDisplayName": "Афганістан",
     "axCountryDisplayName": "Острови Аланд",
@@ -3582,7 +3254,6 @@
     "chatCapacityHasBeenChanged": "Місткість чату змінена",
     "chatCapacitySetTooLow": "Місткість чату має бути не менше {count}.",
     "chatCapacityExplanation": "Місткість чату обмежує кількість учасників, дозволених у чаті.",
-    "tooManyRequest": "Занадто багато запитів, будь ласка, спробуйте пізніше.",
     "enterNumber": "Будь ласка, введіть ціле число.",
     "practice": "Практика",
     "versionNotFound": "Версія не знайдена",
@@ -3592,7 +3263,6 @@
     "deleteSubscriptionWarningTitle": "У вас активна підписка",
     "deleteSubscriptionWarningBody": "Видалення вашого облікового запису не скасує автоматично вашу підписку.",
     "manageSubscription": "Керувати підпискою",
-    "error520Title": "Будь ласка, спробуйте ще раз.",
     "error520Desc": "Вибачте, ми не змогли зрозуміти ваше повідомлення...",
     "wordsUsed": "Використані слова",
     "level": "Рівень",
@@ -3610,7 +3280,6 @@
     "other": "Інше",
     "levelShort": "Рівень {level}",
     "noCapacityLimit": "Обмежень по місткості немає",
-    "downloadGroupText": "Завантажити текст групи",
     "notificationsOn": "Сповіщення увімкнено",
     "notificationsOff": "Сповіщення вимкнено",
     "joinWithCode": "Приєднатися за кодом",
@@ -3674,24 +3343,12 @@
     "whatIsTheMorphTag": "Що таке {morphologicalFeature} для '{wordForm}'?",
     "dataAvailable": "Доступність даних",
     "available": "Доступно",
-    "pangeaBotIsFallible": "Pangea Bot також робить помилки!",
-    "whatIsMeaning": "Що означає '{lemma}'?",
     "chooseLemmaMeaningInstructionsBody": "Зіставте значення з словами у повідомленні!",
-    "doubleClickToEdit": "Двічі клацніть для редагування.",
-    "topicLabel": "Тема",
-    "topicPlaceholder": "Обрати тему...",
-    "modePlaceholder": "Обрати режим...",
-    "learningObjectiveLabel": "Мета навчання",
-    "learningObjectivePlaceholder": "Обрати мету навчання...",
-    "targetLanguageLabel": "Мова цілі",
     "cefrLevelLabel": "Рівень CEFR",
     "image": "Зображення",
     "video": "Відео",
     "nan": "Не застосовується",
-    "addVocabulary": "Додати словниковий запас",
     "instructions": "Інструкції",
-    "numberOfLearners": "Кількість учнів",
-    "mustBeInteger": "Має бути цілим числом, наприклад 1, 2, 3, ...",
     "constructUsePvmDesc": "Створено у голосовому повідомленні",
     "leaveSpaceDescription": "Залишаючи курс, ви залишаєте всі чати в ньому. Інші користувачі побачать, що ви покинули курс.",
     "constructUseCorMmDesc": "Правильне значення повідомлення",
@@ -3706,7 +3363,6 @@
     "ttsDisabledBody": "Ви можете увімкнути озвучування тексту у налаштуваннях навчання",
     "noSpaceDescriptionYet": "Ще не створено опис курсу.",
     "tooLargeToSend": "Це повідомлення занадто велике для відправки",
-    "exitWithoutSaving": "Ви впевнені, що хочете вийти без збереження?",
     "enableAutocorrectPopupTitle": "Додайте клавіатуру цільової мови, перейшовши до:",
     "enableAutocorrectPopupSteps": "  • Налаштування\n  • Загальні\n  • Клавіатура\n  • Клавіатури\n  • Додати нову клавіатуру",
     "enableAutocorrectPopupDescription": "Після вибору мови ви можете натиснути маленьку іконку глобуса в нижньому лівому куті клавіатури, щоб активувати нововстановлену клавіатуру.",
@@ -3717,11 +3373,8 @@
     "displayName": "Відображуване ім'я",
     "leaveRoomDescription": "Ви збираєтеся покинути цей чат. Інші користувачі побачать, що ви покинули чат.",
     "confirmUserId": "Будь ласка, підтвердіть своє ім'я користувача Pangea Chat, щоб видалити свій обліковий запис.",
-    "startingToday": "Починаючи з сьогоднішнього дня",
-    "oneWeekFreeTrial": "Безкоштовна пробна версія на один тиждень",
     "paidSubscriptionStarts": "Починається {startDate}",
     "cancelInSubscriptionSettings": "• Скасувати у будь-який час у налаштуваннях підписки",
-    "cancelToAvoidCharges": "• Скасувати перед {trialEnds}, щоб уникнути списань",
     "downloadGboard": "Завантажити Gboard",
     "autocorrectNotAvailable": "На жаль, ця функція наразі не підтримується вашою платформою. Залишайтеся з нами для подальшого розвитку!",
     "pleaseUpdateApp": "Будь ласка, оновіть додаток для продовження.",
@@ -3731,17 +3384,12 @@
     "knockSpaceSuccess": "Ви подали заявку приєднатися до цього курсу! Адміністратор відповість на ваше запитання, коли отримає його 😀",
     "chooseWordAudioInstructionsBody": "Прослухайте повне повідомлення. Потім зіставте аудіо з словами.",
     "chooseMorphsInstructionsBody": "Натисніть на частини головоломки для граматичних питань!",
-    "pleaseEnterInt": "Будь ласка, введіть число",
     "home": "Головна",
     "join": "Приєднатися",
     "resetInstructionTooltipsTitle": "Скинути підказки інструкцій",
     "resetInstructionTooltipsDesc": "Натисніть, щоб показати підказки інструкцій, як для нових користувачів.",
-    "randomize": "Випадковий порядок",
     "clear": "Очистити",
-    "featuredActivities": "Рекомендовані",
     "save": "Зберегти",
-    "startChat": "Почати чат",
-    "translationProblem": "Проблема з перекладом",
     "askToJoin": "Попросити приєднатися",
     "emptyChatWarningTitle": "Чат порожній",
     "emptyChatWarningDesc": "Ви не запросили нікого до свого чату. Перейдіть у налаштування чату, щоб запросити свої контакти або бота. Ви також можете зробити це пізніше.",
@@ -3771,17 +3419,13 @@
     "timesUsedIndependently": "Кількість використань самостійно",
     "timesUsedWithAssistance": "Кількість використань з допомогою",
     "shareInviteCode": "Поділіться кодом запрошення: {code}",
-    "leaderboard": "Таблиця лідерів",
     "skipForNow": "Пропустити наразі",
     "permissions": "Дозволи",
     "spaceChildPermission": "Хто може додавати нові чати до цього курсу",
-    "addEnvironmentOverride": "Додати переозначення середовища",
     "defaultOption": "За замовчуванням",
     "deleteChatDesc": "Ви впевнені, що хочете видалити цей чат? Він буде видалений для всіх учасників, і всі повідомлення в чаті більше не будуть доступні для практики або аналітики навчання.",
     "deleteSpaceDesc": "Курс і будь-які вибрані чати будуть видалені для всіх учасників, і всі повідомлення в чаті більше не будуть доступні для практики або аналітики навчання. Цю дію неможливо скасувати.",
     "launch": "Запустити",
-    "searchChats": "Пошук чатів",
-    "maxFifty": "Максимум 50",
     "configureSpace": "Налаштувати курс",
     "pinMessages": "Закріпити повідомлення",
     "setJoinRules": "Встановити правила приєднання",
@@ -3815,9 +3459,6 @@
     "failedToFetchTranscription": "Не вдалося отримати транскрипцію",
     "deleteEmptySpaceDesc": "Курс буде видалено для всіх учасників. Цю дію неможливо скасувати.",
     "regenerate": "Перегенерувати",
-    "mySavedActivities": "Мої збережені активності",
-    "noSavedActivities": "Збережених активностей немає",
-    "saveActivity": "Зберегти цю активність",
     "failedToPlayVideo": "Не вдалося відтворити відео",
     "done": "Готово",
     "inThisSpace": "У цьому курсі",
@@ -3828,13 +3469,9 @@
     "numInvited": "{count} запрошено",
     "saved": "Збережено",
     "reset": "Скинути",
-    "errorFetchingActivitiesMessage": "Не вдалося отримати активності",
     "errorFetchingDefinition": "Не вдалося отримати визначення",
     "errorProcessAnalytics": "Не вдалося обробити аналітику",
     "errorDownloading": "Завантаження не вдалося",
-    "errorLoadingSpaceChildren": "Не вдалося завантажити чати в межах цього курсу",
-    "unexpectedError": "Несподівана помилка.",
-    "pleaseReload": "Будь ласка, перезавантажте та спробуйте знову.",
     "translationError": "Помилка перекладу",
     "check": "Перевірити",
     "unableToFindRoom": "Чат або курс з цим кодом не знайдено. Будь ласка, спробуйте ще раз.",
@@ -3843,19 +3480,14 @@
     "request": "Запит",
     "requestAll": "Запитати все",
     "confirmMessageUnpin": "Ви впевнені, що хочете відкріпити це повідомлення?",
-    "saveAndLaunch": "Зберегти та запустити",
-    "launchToSpace": "Запустити в курс",
     "pending": "Очікує",
     "inactive": "Неактивний",
-    "confirmRole": "Підтвердити роль",
     "openRoleLabel": "ВІДКРИТА",
     "finishedTheActivity": "🎯 {username} завершив цю активність",
     "activitySummaryError": "Зведення активностей недоступне",
     "requestSummaries": "Запитати зведення",
-    "generatingNewActivities": "Ви перший користувач цієї пари мов! Будь ласка, зачекайте хвилину, ми готуємо активності саме для вас.",
     "requestAccessTitle": "Запросити доступ до аналітики?",
     "requestAccessDesc": "Бажаєте запросити доступ до перегляду аналітики учасників?\n\nЯкщо учасники погоджуються, адміністратори цього курсу зможуть переглядати їх:\n    • загальний словниковий запас\n    • загальні граматичні концепції\n    • кількість завершених сесій активності\n    • конкретні граматичні концепції, використані правильно та неправильно\n\nВони не зможуть переглядати:\n    • повідомлення у чатах поза межами курсу\n    • список словникових запасів",
-    "requestAccess": "Запитати доступ ({count})",
     "analyticsInactiveTitle": "Запити до неактивних користувачів не можуть бути надіслані",
     "analyticsInactiveDesc": "Неактивні користувачі, які не входили з моменту впровадження цієї функції, не побачать ваш запит.\n\nКнопка «Запит» з'явиться, коли вони повернуться. Ви зможете повторно надіслати запит пізніше, натиснувши кнопку «Запит» під їхнім ім'ям, коли вона стане доступною.",
     "accessRequestedTitle": "Запит на доступ до аналітики",
@@ -3878,8 +3510,6 @@
     "accessDesc": "Ви можете зробити свій курс відкритим для світу! Або зробити його приватним і захищеним.",
     "createGroupChatDesc": "Оскільки сесії активності починаються і закінчуються, групові чати залишаться відкритими для рутинного спілкування.",
     "deleteDesc": "Тільки адміністратори можуть видалити курс. Це руйнівна дія, яка видаляє всіх користувачів і всі обрані чати в межах курсу. Дійте обережно.",
-    "noCourseFound": "Ой, цьому курсу потрібен план!\n\nПлани курсу — це послідовність тем і активностей для спілкування.",
-    "additionalParticipants": "+ {num} інших",
     "whatNow": "Що далі?",
     "chooseNextActivity": "Обирайте свою наступну активність!",
     "letsGo": "Поїхали",
@@ -3892,13 +3522,11 @@
     "waitNotDone": "Зачекай, я ще не закінчив!",
     "waitingForOthersToFinish": "Очікування завершення інших...",
     "generatingSummary": "Аналіз чату та створення результатів",
-    "findCourse": "Знайти курс",
     "pingParticipantsNotification": "{user} шукає користувачів для приєднання до сесії активності в {room}",
     "course": "Курс",
     "courses": "Курси",
     "goToCourse": "Перейти до курсу: {course}",
     "activityComplete": "Ця активність завершена. Підсумок активності має бути доступний нижче.",
-    "startNewSession": "Почати нову сесію",
     "joinOpenSession": "Приєднатися до відкритої сесії",
     "activityNotFound": "Активність не знайдено",
     "myActivities": "Мої активності",
@@ -3972,10 +3600,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3985,10 +3609,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4072,14 +3692,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4096,10 +3708,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4112,15 +3720,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4272,14 +3872,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4293,14 +3885,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5523,10 +5107,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5567,10 +5147,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5643,10 +5219,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5916,47 +5488,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5976,19 +5508,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6052,10 +5572,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6096,14 +5612,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6115,14 +5623,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6160,10 +5660,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6180,27 +5676,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6324,10 +5804,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6337,10 +5813,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6357,14 +5829,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6504,18 +5968,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6564,10 +6016,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6577,18 +6025,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6631,23 +6067,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6671,10 +6095,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6682,14 +6102,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6794,18 +6206,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6858,10 +6258,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6888,10 +6284,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7072,7 +6464,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Перевірте завтра оновлення активності.",
-    "activityDropdownDesc": "Коли закінчите цю активність, натисніть нижче",
     "languageMismatchTitle": "Несумісність мови",
     "languageMismatchDesc": "Мова вашої цільової мови не співпадає з мовою цієї активності. Оновити цільову мову?",
     "reportWordIssueTooltip": "Повідомити про проблему з інформацією слова",
@@ -7085,10 +6476,6 @@
     "selectAll": "Вибрати все",
     "deselectAll": "Скасувати вибір всього",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7137,17 +6524,11 @@
         "placeholders": {}
     },
     "startOwn": "Почати свою власну",
-    "joinCourseDesc": "Кожен курс має 8-10 послідовних тем із різноманітними завданнями для вивчення мови.",
     "newMessageInPangeaChat": "🗨️ Нове повідомлення у чаті Pangea",
     "shareCourse": "Поділитися курсом",
     "addCourse": "Додати курс",
-    "joinPublicCourse": "Приєднатися до публічного курсу",
     "vocabLevelsDesc": "Тут з'являться слова словника, коли ви їх підвищите рівень!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7160,10 +6541,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7182,7 +6559,6 @@
     "emojiView": "Перегляд емодзі",
     "feedbackDialogDesc": "Я також роблю помилки! Що-небудь, щоб допомогти мені покращитися?",
     "contactHasBeenInvitedToTheCourse": "Контакт був запрошений на курс",
-    "activityStatsButtonTooltip": "Інформація про активність",
     "allow": "Дозволити",
     "deny": "Відхилити",
     "enabledRenewal": "Увімкнути продовження підписки",
@@ -7450,10 +6826,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8509,16 +7881,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Дії для розблокування наступної теми",
-    "activitiesToUnlockTopicDesc": "Встановіть кількість дій для розблокування наступної теми курсу",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Правильна практика визначення словникового запасу",
     "constructUseIncLMDesc": "Неправильна практика визначення словникового запасу",
     "constructUseCorLADesc": "Правильна практика аудіо словникового запасу",
@@ -8526,7 +7888,6 @@
     "constructUseBonus": "Бонус під час практики словникового запасу",
     "practiceVocab": "Практика словникового запасу",
     "selectMeaning": "Виберіть значення",
-    "selectAudio": "Виберіть відповідне аудіо",
     "anotherRound": "Ще один раунд",
     "activitySettingsOverrideWarning": "Мова та рівень мови визначаються планом активності",
     "voice": "Голос",
@@ -8558,10 +7919,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8579,12 +7936,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Завантаження розпочато",
     "webDownloadPermissionMessage": "Якщо ваш браузер блокує завантаження, будь ласка, увімкніть завантаження для цього сайту.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8679,11 +8031,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Щось пішло не так, і ми наполегливо працюємо над виправленням. Перевірте пізніше.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Увімкнути допомогу в написанні",
     "autoIGCToolDescription": "Автоматично запускати інструменти Pangea Chat для виправлення надісланих повідомлень на цільову мову.",
     "@autoIGCToolName": {
@@ -8739,24 +8086,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Граматика",
-    "spanTypeWordChoice": "Вибір слів",
     "spanTypeSpelling": "Орфографія",
     "spanTypePunctuation": "Пунктуація",
     "spanTypeStyle": "Стиль",
     "spanTypeFluency": "Вільність",
     "spanTypeAccents": "Акценти",
     "spanTypeCapitalization": "Великі літери",
-    "spanTypeCorrection": "Виправлення",
     "spanFeedbackTitle": "Повідомити про проблему з виправленням",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8781,10 +8117,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8795,13 +8127,9 @@
     "clientWellKnownInformation": "Інформація відомого клієнта:",
     "baseUrl": "Базова URL",
     "identityServer": "Сервер ідентичності:",
-    "versionWithNumber": "Версія: {version}",
     "logs": "Журнали",
-    "advancedConfigs": "Розширені налаштування",
     "advancedConfigurations": "Розширені конфігурації",
-    "signInWithLabel": "Увійти за допомогою:",
     "selectAllWords": "Виберіть усі слова, які ви чуєте в аудіо",
-    "joinCourseForActivities": "Приєднайтеся до курсу, щоб спробувати активності.",
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8830,19 +8158,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8850,15 +8166,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9059,11 +8367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "У класі? Введіть свій код приєднання тут.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Автоматичне виділення аудіоповідомлень",
     "selectAudioMessagesOnPlayDescription": "Автоматично виділяти аудіоповідомлення під час відтворення",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9107,18 +8410,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Цей курс має теми з менш ніж {input} активностями. Будь ласка, введіть число, менше або рівне {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Натисніть тут, щоб увійти знову.",
     "@clickToLogin": {
@@ -9535,17 +8826,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Мультяшний жовтий ведмідь з піднятими в захват руках.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Виберіть слова, щоб дізнатися про них більше",
     "requireAnalyticsAccessTitle": "Необхідний доступ до аналітики для приєднання",
     "requireAnalyticsAccessDesc": "Учасники повинні надати доступ до своїх навчальних аналітик, щоб приєднатися до цього курсу",
     "analyticsAccessNoticeTitle": "Необхідний доступ до аналітики",
     "analyticsAccessNoticeDesc": "Приєднуючись до цього курсу, ви погоджуєтеся надати адміністраторам доступ до своїх навчальних аналітик.",
-    "skipOnboardingClassCodeDesc": "Навчаєтеся самостійно? Не хвилюйтеся, ви можете:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9563,10 +8848,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9595,7 +8876,6 @@
     "pickCefrLevelTeacherStepTitle": "Який рівень ви викладаєте?",
     "pickCefrLevelStudentStepTitle": "Який у вас рівень?",
     "customCourseStepTitle": "Заповніть цю форму, щоб отримати індивідуальний курс",
-    "aboutYourClass": "Про ваш клас",
     "courseCodeStepErrorMessage": "Будь ласка, перевірте свій код і спробуйте ще раз",
     "institution": "Установа",
     "courseGoals": "Цілі курсу",
@@ -9638,10 +8918,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9758,12 +9034,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Логотип Pangea Chat",
     "introChatDetails": "Скажіть привіт! Познайомтеся з вашими товаришами по курсу, знайдіть друзів і спілкуйтеся поза межами активностей.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9807,11 +9078,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Дії активності",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Інструменти вимови",
     "audioTranscription": "AI транскрипція аудіо",
     "visualLearnerSupport": "Підтримка візуальних учнів",
@@ -9852,7 +9118,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Приєднайтеся до курсу, який включає цю активність, щоб грати в неї.",
     "resizeCoursePanel": "Змінити розмір панелі курсу",
     "undo": "Скасувати",
     "unlock": "Розблокувати",
@@ -9866,7 +9131,6 @@
     "addCourseBrowsePublic": "Переглянути публічні курси",
     "browsePublicCourses": "Переглянути публічні курси",
     "editProfile": "Редагувати профіль",
-    "numObjectives": "{count} цілей",
     "mapSearchHint": "Шукати активності",
     "mapSearchNoResults": "Немає збігів у виді",
     "mapFilterAllLanguages": "Усі мови",
@@ -9875,7 +9139,6 @@
     "mapFilterCompleted": "Завершено",
     "mapFilterReset": "Скинути",
     "activityTypeConversation": "Розмова",
-    "lockedMissionRequirement": "Завершіть попередню місію, щоб розблокувати",
     "playAgain": "Грати знову",
     "reviewActivity": "Огляд",
     "mapEmptyInView": "Тут нічого немає на вашому рівні або мові. Розширте свої фільтри або зменшіть масштаб.",
@@ -9890,14 +9153,9 @@
     "scrollToBottom": "Прокрутити донизу",
     "courseImage": "Зображення курсу",
     "avatarPreview": "Попередній перегляд аватара",
-    "activityPhoto": "Фото активності",
     "emotePreview": "Попередній перегляд емодзі: {name}",
     "activityLabel": "Активність: {title}",
     "resetMapView": "Скинути вигляд карти",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9950,14 +9208,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9987,10 +9237,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10047,10 +9293,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_uz.arb
+++ b/lib/l10n/intl_uz.arb
@@ -168,11 +168,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Mehmon foydalanuvchilarga qo‘shilishga ruxsat berilganmi",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Ishonchingiz komilmi?",
     "@areYouSure": {
         "type": "String",
@@ -453,15 +448,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "yourChatBackupHasBeenSetUp": "Suhbat zaxirangiz sozlandi.",
-    "@yourChatBackupHasBeenSetUp": {},
     "chatBackup": "Suhbat zaxirasi",
     "@chatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "Eski xabarlaringiz tiklash kaliti bilan himoyalangan. Uni yo‘qotib qo‘ymasligingizga ishonch hosil qiling.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -624,11 +612,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Kontakt guruhga taklif qilindi",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "contentHasBeenReported": "Kontent server administratorlariga xabar qilindi",
     "@contentHasBeenReported": {
         "type": "String",
@@ -674,15 +657,6 @@
             }
         }
     },
-    "countInvited": "{count} taklif qilindi",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "create": "Yaratish",
     "@create": {
         "type": "String",
@@ -699,11 +673,6 @@
     },
     "createGroup": "Guruh yaratish",
     "@createGroup": {},
-    "createNewSpace": "Yangi maydon",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "currentlyActive": "Hozirda faol",
     "@currentlyActive": {
         "type": "String",
@@ -781,12 +750,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "globalChatId": "Ommaviy suhbat IDʼsi",
-    "@globalChatId": {},
-    "accessAndVisibility": "Kirish va koʻrinish",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "Bu suhbatga kim qoʻshilishi mumkin va suhbatni qanday topish mumkin.",
-    "@accessAndVisibilityDescription": {},
     "calls": "Qoʻngʻiroqlar",
     "@calls": {},
     "customEmojisAndStickers": "Maxsus emojilar va stikerlar",
@@ -810,11 +773,6 @@
     },
     "enableEncryption": "Shifrlashni yoqish",
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "enableEncryptionWarning": "Siz endi shifrlashni oʻchira olmaysiz. Ishonchingiz komilmi?",
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -858,15 +816,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatDescription": "Suhbat tavsifi",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "Suhbat tavsifi oʻzgartirildi",
     "@chatDescriptionHasBeenChanged": {},
-    "groupIsPublic": "Guruh ommaviy",
-    "@groupIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "groups": "Guruhlar",
     "@groups": {
         "type": "String",
@@ -956,15 +907,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "Kontaktni {groupName} ga taklif qiling",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "noChatDescriptionYet": "Hali suhbat tavsifi yaratilmagan.",
     "@noChatDescriptionYet": {},
@@ -1102,11 +1044,6 @@
             }
         }
     },
-    "everythingReady": "Hammasi tayyor!",
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "extremeOffensive": "O‘ta haqoratomuz",
     "@extremeOffensive": {
         "type": "String",
@@ -1184,15 +1121,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "Yana {count} ishtirokchini yuklang",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "dehydrate": "Sessiyani eksport qilish va qurilmani oʻchirish",
     "@dehydrate": {},
     "dehydrateWarning": "Bu amalni bekor qilib boʻlmaydi. Zaxira faylini xavfsiz saqlang.",
@@ -1223,15 +1151,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "{homeserver} ga kirish",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "Chiqish",
     "@logout": {
@@ -1297,16 +1216,6 @@
     },
     "noEmotesFound": "Hech qanday emoteʼlar topilmadi 😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "Shifrlashni faqat guruh endi hamma uchun ochiq bo'lmay qolgandan keyingina faollashtirishingiz mumkin.",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "Firebase Cloud Messaging qurilmangizda mavjud emasga o'xshaydi. Push-bildirishnomalarni olishda davom etish uchun ntfy-ni o'rnatishingizni tavsiya qilamiz. NTFY yoki boshqa Unified Push provayderi yordamida siz ma'lumotlar xavfsizligini ta'minlash orqali push-bildirishnomalarni olishingiz mumkin. Siz ntfy-ni PlayStore yoki F-Droid-dan yuklab olishingiz mumkin.",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1417,8 +1326,6 @@
     },
     "oneClientLoggedOut": "Mijozlaringizdan biri tizimdan chiqdi",
     "@oneClientLoggedOut": {},
-    "addAccount": "Hisob qoʻshish",
-    "@addAccount": {},
     "editBundlesForAccount": "Bu hisob uchun toʻplamlarni tahrirlash",
     "@editBundlesForAccount": {},
     "addToBundle": "Toʻplamga qoʻshish",
@@ -1427,8 +1334,6 @@
     "@removeFromBundle": {},
     "bundleName": "Toʻplam nomi",
     "@bundleName": {},
-    "enableMultiAccounts": "(BETA) Ushbu qurilmada bir nechta hisoblarni yoqish",
-    "@enableMultiAccounts": {},
     "openInMaps": "Xaritalarda ochish",
     "@openInMaps": {
         "type": "String",
@@ -1472,11 +1377,6 @@
     "@overview": {},
     "passwordRecoverySettings": "Parolni qayta tiklash sozlamalari",
     "@passwordRecoverySettings": {},
-    "passwordRecovery": "Parolni qayta tiklash",
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "people": "Odamlar",
     "@people": {
         "type": "String",
@@ -1521,8 +1421,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "pleaseEnterRecoveryKey": "Iltimos, tiklash kalitingizni kiriting:",
-    "@pleaseEnterRecoveryKey": {},
     "pleaseEnterYourPassword": "Iltimos parolingizni kiriting",
     "@pleaseEnterYourPassword": {
         "type": "String",
@@ -1638,11 +1536,6 @@
             }
         }
     },
-    "removeDevice": "Qurilmani oʻchirish",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "unbanFromChat": "Suhbat blokidan chiqazish",
     "@unbanFromChat": {
         "type": "String",
@@ -1698,10 +1591,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "recoveryKey": "Tiklash kaliti",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "Tiklash kaliti yo‘qolib qoldimi?",
-    "@recoveryKeyLost": {},
     "send": "Yuborish",
     "@send": {
         "type": "String",
@@ -1816,11 +1705,6 @@
     },
     "setChatDescription": "Suhbat tavsifini sozlash",
     "@setChatDescription": {},
-    "setPermissionsLevel": "Ruxsatlar darajasini belgilash",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "Holatni sozlash",
     "@setStatus": {
         "type": "String",
@@ -1867,16 +1751,6 @@
     },
     "sourceCode": "Manba kodi",
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "Guruh ochiq",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceName": "Guruh nomi",
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -1944,11 +1818,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Boshqa qurilmadan uzatish",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "Qayta yuborishga urining",
     "@tryToSendAgain": {
         "type": "String",
@@ -2004,15 +1873,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 ta oʻqilmagan suhbat} other{{unreadCount} ta o‘qilmagan chat}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} va yana {count} kishi yozmoqda…",
     "@userAndOthersAreTyping": {
@@ -2100,16 +1960,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "Video chaqiruv",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "Suhbat tarixining ko‘rinishi",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "Barcha ishtirokchilarga ko‘rinadi",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -2155,23 +2005,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "Kim qaysi amalni bajarishi mumkin",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "Bu guruhga kim qo‘shilishi mumkin",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "Nima uchun bu haqda xabar bermoqchisiz?",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "Yangi tiklash kalitini yaratish uchun suhbat zaxirasi tozalansinmi?",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -2220,30 +2055,12 @@
     "@sender": {},
     "openGallery": "Galereyani ochish",
     "@openGallery": {},
-    "removeFromSpace": "Guruhdan olib tashlash",
-    "@removeFromSpace": {},
     "start": "Boshlash",
     "@start": {},
-    "usersMustKnock": "Foydalanuvchilar taqillatishi kerak",
-    "@usersMustKnock": {},
-    "noOneCanJoin": "Hech kim qoʻshila olmaydi",
-    "@noOneCanJoin": {},
     "knock": "Taqillating",
     "@knock": {},
     "users": "Foydalanuvchilar",
     "@users": {},
-    "unlockOldMessages": "Eski xabarlarni qulfdan chiqaring",
-    "@unlockOldMessages": {},
-    "storeInSecureStorageDescription": "Qayta tiklash kalitini ushbu qurilmaning xavfsiz xotirasida saqlang.",
-    "@storeInSecureStorageDescription": {},
-    "saveKeyManuallyDescription": "Tizim ulashish dialog oynasi yoki buferni ishga tushirish orqali ushbu kalitni qoʻlda saqlang.",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "Android KeyStoreʼda saqlang",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "Apple KeyChainʼda saqlang",
-    "@storeInAppleKeyChain": {},
-    "storeSecurlyOnThisDevice": "Ushbu qurilmada xavfsiz saqlang",
-    "@storeSecurlyOnThisDevice": {},
     "countFiles": "{count} fayllar",
     "@countFiles": {
         "placeholders": {
@@ -2256,12 +2073,6 @@
     "@user": {},
     "custom": "Maxsus",
     "@custom": {},
-    "foregroundServiceRunning": "Bu bildirishnoma old plan xizmati ishlab turgan paytda paydo bo‘ladi.",
-    "@foregroundServiceRunning": {},
-    "screenSharingTitle": "Ekranni ulashish",
-    "@screenSharingTitle": {},
-    "screenSharingDetail": "Siz ekraningizni FuffyChat’da ulashmoqdasiz",
-    "@screenSharingDetail": {},
     "whyIsThisMessageEncrypted": "Nima uchun bu xabarni oʻqib boʻlmaydi?",
     "@whyIsThisMessageEncrypted": {},
     "noKeyForThisMessage": "Bu xabar siz ushbu qurilmada hisobingizga kirishdan oldin yuborilgan boʻlsa sodir boʻlishi mumkin.\n\nShuningdek, joʻnatuvchi qurilmangizni bloklagan yoki internet ulanishida biron bir muammo yuzaga kelgan boʻlishi mumkin.\n\nXabarni boshqa sessiyada oʻqiy olasizmi? Keyin xabarni undan uzatishingiz mumkin! Sozlamalar > Qurilmalar boʻlimiga oʻting va qurilmalaringiz bir-birini tasdiqlaganligiga ishonch hosil qiling. Keyingi safar xonani ochganingizda va ikkala sessiya ham oldinda boʻlganda, kalitlar avtomatik ravishda uzatiladi.\n\nTizimdan chiqishda yoki qurilmalarni almashtirishda kalitlarni yoʻqotishni xohlamaysizmi? Sozlamalarda suhbatning zaxira nusxasini yoqganingizga ishonch hosil qiling.",
@@ -2270,8 +2081,6 @@
     "@newGroup": {},
     "newSpace": "Yangi maydon",
     "@newSpace": {},
-    "enterSpace": "Maydonga kirish",
-    "@enterSpace": {},
     "allSpaces": "Barcha maydonlar",
     "@allSpaces": {},
     "hidePresences": "Holat roʻyxati yashirilsinmi?",
@@ -2287,16 +2096,10 @@
             }
         }
     },
-    "newSpaceDescription": "Maydonlar sizga suhbatlaringizni birlashtirish va shaxsiy yoki ommaviy hamjamiyatlarni yaratish imkonini beradi.",
-    "@newSpaceDescription": {},
     "openChat": "Suhbatni ochish",
     "@openChat": {},
     "youJoinedTheChat": "Siz suhbatga qoʻshildingiz",
     "@youJoinedTheChat": {},
-    "encryptThisChat": "Bu suhbatni shifrlash",
-    "@encryptThisChat": {},
-    "disableEncryptionWarning": "Xavfsizlik nuqtai nazaridan, agar u ilgari yoqilgan boʻlsa, suhbatda shifrlashni oʻchirib qoʻyolmaysiz.",
-    "@disableEncryptionWarning": {},
     "reopenChat": "Suhbatni qayta ochish",
     "@reopenChat": {},
     "noBackupWarning": "Diqqat! Suhbatni zaxiralashni yoqmasangiz, shifrlangan xabarlaringizga kirish huquqini yoʻqotasiz. Tizimdan chiqishdan oldin chatni zaxiralashni yoqishingiz tavsiya etiladi.",
@@ -2313,21 +2116,6 @@
     "@unbanUserDescription": {},
     "kickUserDescription": "Foydalanuvchi suhbatdan chiqarib yuboriladi, ammo taqiqlanmaydi. Ommaviy chatlarda foydalanuvchi istalgan vaqtda qayta qoʻshilishi mumkin.",
     "@kickUserDescription": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "Suhbatni {server} saytidagi qidiruv orqali topish mumkin",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "searchChatsRooms": "Qidiruv #chats, @users...",
-    "@searchChatsRooms": {},
-    "publicChatAddresses": "Ommaviy suhbat manzillari",
-    "@publicChatAddresses": {},
-    "addChatOrSubSpace": "Suhbat yoki sub-maydon qoʻshing",
-    "@addChatOrSubSpace": {},
     "searchIn": "Suhbat \"{chat}\"da qidiring...",
     "@searchIn": {
         "type": "String",
@@ -2369,20 +2157,14 @@
     "@chatPermissionsDescription": {},
     "noticeChatBackupDeviceVerification": "Eslatma: Barcha qurilmalaringizni suhbat zaxira nusxasiga ulaganingizda, ular avtomatik ravishda tasdiqlanadi.",
     "@noticeChatBackupDeviceVerification": {},
-    "welcomeText": "Hey Hey 👋 Bu FluffyChat. Siz https://matrix.org bilan mos keladigan istalgan uy serveriga kirishingiz mumkin. Va keyin istalgan kishi bilan suhbatlashishingiz mumkin. Bu ulkan markazlashtirilmagan xabar almashish tarmog'i!",
-    "@welcomeText": {},
     "unableToJoinChat": "Chatga qoʻshilib boʻlmadi. Ehtimol, boshqa tomon suhbatni allaqachon yopib qoʻygan.",
     "@unableToJoinChat": {},
-    "appIntroduction": "FluffyChat sizga turli messenjerlar orqali doʻstlaringiz bilan suhbatlashish imkonini beradi. Batafsil maʼlumotni https://matrix.org saytida oling yoki shunchaki *Davom etish* tugmasini bosing.",
-    "@appIntroduction": {},
     "newChatRequest": "📩 Yangi suhbat uchun soʻrov",
     "@newChatRequest": {},
     "shareKeysWithDescription": "Shifrlangan suhbatlarda xabarlaringizni oʻqishlari uchun qaysi qurilmalarga ishonish kerak?",
     "@shareKeysWithDescription": {},
     "enterNewChat": "Yangi suhbatga kirish",
     "@enterNewChat": {},
-    "removeFromSpaceDescription": "Suhbat maydondan olib tashlanadi, lekin hali ham suhbatlarlar ro‘yxatida chiqadi.",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} suhbatlar",
     "@countChats": {
         "type": "String",
@@ -2394,8 +2176,6 @@
     },
     "backToMainChat": "Asosiy suhbatga qaytish",
     "@backToMainChat": {},
-    "pleaseEnterRecoveryKeyDescription": "Eski xabarlaringizni qulfdan chiqarish uchun, iltimos, avvalgi seansdan yaratilgan tiklash kalitingizni kiriting. Sizning tiklash kalitingiz parolingiz EMAS.",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "publish": "Nashr qilish",
     "@publish": {},
     "markAsRead": "Oʻqilgan sifatida belgilash",
@@ -2422,24 +2202,16 @@
     "@confirmEventUnpin": {},
     "placeCall": "Qoʻngʻiroq qilish",
     "@placeCall": {},
-    "voiceCall": "Ovozli qoʻngʻiroq",
-    "@voiceCall": {},
     "unsupportedAndroidVersion": "Qoʻllab-quvvatlanmaydigan Android versiyasi",
     "@unsupportedAndroidVersion": {},
     "unsupportedAndroidVersionLong": "Bu funksiya Androidning yangi versiyasini talab qiladi. Iltimos, yangilanishlar yoki Lineage OS qoʻllab-quvvatlashini tekshiring.",
     "@unsupportedAndroidVersionLong": {},
-    "videoCallsBetaWarning": "Iltimos, video qoʻngʻiroqlar hozirda beta-versiyada ekanligini unutmang. Ular kutilganidek ishlamasligi yoki barcha platformalarda umuman ishlamasligi mumkin.",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "Tajriba video qoʻngʻiroqlar",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "Elektron pochta yoki foydalanuvchi nomi",
-    "@emailOrUsername": {},
     "addWidget": "Vidjet qoʻshish",
     "@addWidget": {},
     "widgetVideo": "Video",
     "@widgetVideo": {},
-    "sorryThatsNotPossible": "Kechirasiz... bu mumkin emas",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "Qurilma kalitlari:",
     "@deviceKeys": {},
     "noOtherDevicesFound": "Boshqa qurilma topilmadi",
@@ -2474,8 +2246,6 @@
     "@reportErrorDescription": {},
     "report": "hisobot",
     "@report": {},
-    "setTheme": "Mavzu tanlash:",
-    "@setTheme": {},
     "setColorTheme": "Rang mavzusini sozlash:",
     "@setColorTheme": {},
     "invite": "Taklif qilish",
@@ -2510,10 +2280,6 @@
     "@nothingFound": {},
     "groupName": "Guruh nomi",
     "@groupName": {},
-    "createGroupAndInviteUsers": "Guruh yaratish va foydalanuvchilarni taklif qilish",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "Guruh qidiruv orqali topilishi mumkin",
-    "@groupCanBeFoundViaSearch": {},
     "wrongRecoveryKey": "Kechirasiz... bu toʻgʻri tiklash kaliti emasga oʻxshaydi.",
     "@wrongRecoveryKey": {},
     "startConversation": "Suhbat boshlash",
@@ -2540,8 +2306,6 @@
     "@passwordsDoNotMatch": {},
     "passwordIsWrong": "Siz kiritgan maxfiy soʻz xato",
     "@passwordIsWrong": {},
-    "createNewAddress": "Yangi manzil yarating",
-    "@createNewAddress": {},
     "joinSpace": "Maydonga qoʻshiling",
     "@joinSpace": {},
     "publicSpaces": "Ommaviy maydonlar",
@@ -2560,40 +2324,12 @@
     "@gallery": {},
     "files": "Fayllar",
     "@files": {},
-    "sessionLostBody": "Seansingiz yoʻqoldi. Iltimos, ushbu xato haqida {url} manzilidagi dasturchilarga xabar bering. Xato xabari: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Ilova endi seansingizni zaxira nusxasidan tiklashga harakat qiladi. Iltimos, ushbu xato haqida {url} manzilidagi dasturchilarga xabar bering. Xato xabari: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendReadReceipts": "Oʻqilganlik haqida xabarnomalarni yuborish",
     "@sendReadReceipts": {},
     "formattedMessages": "Formatlangan xabarlar",
     "@formattedMessages": {},
     "formattedMessagesDescription": "Markdown yordamida qalin matn kabi boy xabar mazmunini koʻrsating.",
     "@formattedMessagesDescription": {},
-    "verifyOtherUser": "🔐 Boshqa foydalanuvchini tasdiqlang",
-    "@verifyOtherUser": {},
-    "verifyOtherUserDescription": "Agar siz boshqa foydalanuvchini tasdiqlasangiz, aslida kimga yozayotganingizni bilishingizga amin boʻlishingiz mumkin. 💪\n\nTekshiruvni boshlaganingizda, siz va boshqa foydalanuvchi ilovada qalqib chiquvchi oynani koʻrasiz. Keyin u yerda siz bir-biringiz bilan taqqoslashingiz kerak boʻlgan bir qator emojilar yoki raqamlarni koʻrasiz.\n\nBuning eng yaxshi usuli - uchrashish yoki video qoʻngʻiroqni boshlash. 👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDevice": "🔐 Boshqa qurilmani tasdiqlang",
     "@verifyOtherDevice": {},
     "verifyOtherDeviceDescription": "Boshqa qurilmani tasdiqlaganingizda, bu qurilmalar kalitlarni almashishi mumkin, bu umumiy xavfsizligingizni oshiradi. 💪 Tasdiqlashni boshlaganingizda, ikkala qurilmada ham ilovada qalqib chiquvchi oyna paydo bo‘ladi. U yerda siz bir-biri bilan taqqoslashingiz kerak bo‘lgan emojilar yoki raqamlar qatorini ko‘rasiz. Tasdiqlashni boshlashdan oldin ikkala qurilma ham yoningizda bo‘lgani ma’qul. ✓",
@@ -2774,14 +2510,6 @@
     "@changelog": {},
     "sendCanceled": "Yuborish bekor qilindi",
     "@sendCanceled": {},
-    "loginWithMatrixId": "Matriks-ID bilan kirish",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "Uy serverlarini kashf eting",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "Uy serveri nima?",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "Barcha ma’lumotlaringiz xuddi elektron pochta provayderi kabi homeserverda saqlanadi. Siz qaysi uy serveridan foydalanishni tanlashingiz mumkin, shu bilan birga siz hamma bilan muloqot qilishingiz mumkin. Batafsil: https://matrix.org.",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "Uy serveri mos emasga o‘xshaydi. URL xato kiritilganmi?",
     "@doesNotSeemToBeAValidHomeserver": {},
     "calculatingFileSize": "Fayl hajmi hisoblanmoqda...",
@@ -2825,8 +2553,6 @@
     "@opacity": {},
     "setWallpaper": "Fon rasmini sozlash",
     "@setWallpaper": {},
-    "manageAccount": "Hisobni boshqarish",
-    "@manageAccount": {},
     "noContactInformationProvided": "Server hech qanday yaroqli kontakt axborotini taqdim etmaydi",
     "@noContactInformationProvided": {},
     "contactServerAdmin": "Server administratori bilan bog‘lanish",
@@ -2861,17 +2587,6 @@
     "@previous": {},
     "otherPartyNotLoggedIn": "Narigi tomon hozirda hisobingizga kirmagan va shuning uchun xabarlarni qabul qila olmaydi!",
     "@otherPartyNotLoggedIn": {},
-    "appWantsToUseForLogin": "Hisobga kirish '{server}' ishlating",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Siz bu bilan ilova va veb-saytga siz haqingizdagi axborotni ulashishga ruxsat berasiz.",
-    "@appWantsToUseForLoginDescription": {},
     "open": "Ochish",
     "@open": {},
     "waitingForServer": "Server kutilmoqda...",
@@ -2983,30 +2698,6 @@
     "@pause": {},
     "resume": "Davom etish",
     "@resume": {},
-    "newSubSpace": "Yangi quyi maydon",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "Boshqa maydonga o‘tish",
-    "@moveToDifferentSpace": {},
-    "spaceMemberOf": "{spaces} maydoni a’zosi",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "{spaces} maydoni a’zosi eshikni taqillatishi mumkin",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "Xayriya qilmoq",
-    "@donate": {},
     "startedAPoll": "{username} so‘rovnoma boshladi.",
     "@startedAPoll": {
         "type": "String",
@@ -3185,14 +2876,6 @@
     "@stickerPackName": {},
     "attribution": "Atributsiya",
     "@attribution": {},
-    "skipChatBackup": "Chat zaxirasini tashlab ketish",
-    "@skipChatBackup": {},
-    "skipChatBackupWarning": "Ishonchingiz komilmi? Chat zaxirasini yoqmasdan qurilmangizni almashtirsangiz, xabarlaringizga kira olmay qolishingiz mumkin.",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "Xabarlar yuklanmoqda",
-    "@loadingMessages": {},
-    "setupChatBackup": "Chat zaxirasini sozlash",
-    "@setupChatBackup": {},
     "@@locale": "uz",
     "@@last_modified": "2026-07-13 10:06:32.062450",
     "noMoreResultsFound": "Boshqa natijalar topilmadi",
@@ -3201,11 +2884,8 @@
     "clientWellKnownInformation": "Mijoz-Yaxtirilgan Ma'lumot:",
     "baseUrl": "Asosiy URL",
     "identityServer": "Identifikatsiya Serveri:",
-    "versionWithNumber": "Versiya: {version}",
     "logs": "Jurnallar",
-    "advancedConfigs": "Kengaytirilgan Sozlamalar",
     "advancedConfigurations": "Kengaytirilgan sozlamalar",
-    "signInWithLabel": "Kirish:",
     "ignore": "Bloklash",
     "ignoredUsers": "Bloklangan foydalanuvchilar",
     "writeAMessageLangCodes": "{l1} yoki {l2} da yozing...",
@@ -3214,11 +2894,9 @@
     "taTooltip": "L2 tarjima yordamida foydalanish",
     "interactiveTranslatorSliderHeader": "Interaktiv tarjimon",
     "interactiveGrammarSliderHeader": "Interaktiv grammatik tekshiruvchi",
-    "interactiveTranslatorRequired": "Majburiy",
     "waTooltip": "Yordam bilan L2 foydalanish",
     "interactiveTranslator": "Tarjimaga yordam",
     "noIdenticalLanguages": "Iltimos, asosiy va maqsad tillarini farqlang",
-    "searchBy": "Mamlakat va tillar bo'yicha qidirish",
     "joinWithClassCode": "Kursga qo'shiling",
     "languageLevelPreA1": "Yangi boshlovchi past (Pre A1)",
     "languageLevelA1": "Yangi boshlovchi o'rtacha (A1)",
@@ -3238,19 +2916,14 @@
     "whatIsYourBaseLanguage": "Asosiy tilingiz nima?",
     "publicProfileTitle": "Profilimni qidiruvda topishga ruxsat berish",
     "publicProfileDesc": "Yoqib qo'ysangiz, boshqa foydalanuvchilar sizning profilingizni global qidiruv panelida topishlari va chat so'rovlari yuborishlari mumkin. Shu vaqtdan boshlab, siz so'rovni qabul qilish yoki rad etishni tanlashingiz mumkin.",
-    "errorDisableIT": "Tarjimaga yordam o'chirilgan.",
-    "errorDisableIGC": "Grammatika yordam o'chirilgan.",
     "errorDisableITUserDesc": "Tarjimaga yordam sozlamalarini yangilash uchun bu yerga bosing",
     "errorDisableIGCUserDesc": "Grammatika yordam sozlamalarini yangilash uchun bu yerga bosing",
     "errorDisableITClassDesc": "Ushbu suhbat bo'lib o'tadigan kurs uchun tarjima yordamchi o'chirilgan.",
     "errorDisableIGCClassDesc": "Ushbu suhbat bo'lib o'tadigan kurs uchun grammatik yordam o'chirilgan.",
-    "error405Title": "Tillar belgilangan emas",
     "error405Desc": "Iltimos, Asosiy menyu > O'rganish sozlamalarida tillaringizni belgilang.",
     "termsAndConditions": "Shartlar va shartlar",
     "andCertifyIAmAtLeast13YearsOfAge": " va kamida 16 yoshda ekanligimni tasdiqlayman.",
-    "error502504Title": "Vau, ko'p talabalar onlayn!",
     "error502504Desc": "Tarjimalar va grammatik vositalar sekin yoki mavjud bo'lmasligi mumkin, Pangea botlari yangilanishni kutmoqda.",
-    "error404Title": "Tarjima xatosi!",
     "error404Desc": "Pangea Bot bu qanday tarjima qilishni bilmayapti...",
     "errorPleaseRefresh": "Biz bu muammoni hal qilmoqdamiz! Iltimos, sahifani yangilang va qayta urinib ko'ring.",
     "connectedToStaging": "Staging bilan ulanish amalga oshirildi",
@@ -3288,13 +2961,9 @@
     "definitionsToolName": "So'zlarning ta'rifi",
     "definitionsToolDescription": "Faollashtirilganda, ko'k chiziq bilan belgilangan so'zlarni bosish orqali ta'riflarni ko'rish mumkin. Ta'riflarni olish uchun xabarlarni bosing.",
     "welcomeBack": "Qaytganingiz uchun xush kelibsiz! Agar siz 2023-2024 yilgi pilot dasturining bir qismi bo'lgan bo'lsangiz, iltimos, maxsus pilot obunangiz uchun biz bilan bog'laning. Agar siz o'qituvchi bo'lsangiz (yoki o'quv muassasangiz) sinfingiz uchun litsenziyalar sotib olgan bo'lsa, o'qituvchi obunangiz uchun biz bilan bog'laning.",
-    "downloadTxtFile": "Matn faylini yuklab olish",
-    "downloadCSVFile": "CSV faylini yuklab olish",
     "promotionalSubscriptionDesc": "Hozirda sizda umrboqiy reklama obunasi mavjud. Obunangizni o'zgartirish uchun support@pangea.chat ga xabar yuboring.",
     "originalSubscriptionPlatform": "Obuna {purchasePlatform} orqali sotib olingan",
     "oneWeekTrial": "Bir haftalik sinov",
-    "downloadXLSXFile": "Excel faylini yuklab olish",
-    "unkDisplayName": "Noma'lum",
     "wwCountryDisplayName": "Dunyo bo'ylab",
     "afCountryDisplayName": "Afg'oniston",
     "axCountryDisplayName": "Aland orollari",
@@ -3589,7 +3258,6 @@
     "chatCapacityHasBeenChanged": "Suhbat sigʻimi oʻzgartirildi",
     "chatCapacitySetTooLow": "Suhbat sigʻimi kamida {count} boʻlishi kerak.",
     "chatCapacityExplanation": "Suhbat sigʻimi chatga qoʻshiladigan aʼzolar sonini cheklaydi.",
-    "tooManyRequest": "Juda ko'p so'rov, iltimos, keyinroq urinib ko'ring.",
     "enterNumber": "Iltimos, butun son qiymatini kiriting.",
     "practice": "Amaliyot",
     "versionNotFound": "Versiya topilmadi",
@@ -3599,7 +3267,6 @@
     "deleteSubscriptionWarningTitle": "Sizda faol obuna bor",
     "deleteSubscriptionWarningBody": "Hisobingizni o'chirish avtomatik ravishda obunangizni bekor qilmaydi.",
     "manageSubscription": "Obunani boshqarish",
-    "error520Title": "Iltimos, qayta urinib ko'ring.",
     "error520Desc": "Kechirasiz, biz sizning xabaringizni tushuna olmadik...",
     "wordsUsed": "Foydalanilgan so'zlar",
     "level": "Daraja",
@@ -3617,7 +3284,6 @@
     "other": "Boshqa",
     "levelShort": "SAV {level}",
     "noCapacityLimit": "Imkoniyat cheklovi yo'q",
-    "downloadGroupText": "Guruh matnini yuklab olish",
     "notificationsOn": "Bildirishnomalar yoqilgan",
     "notificationsOff": "Bildirishnomalar o'chirilgan",
     "joinWithCode": "Kodni kiriting va qo'shiling",
@@ -3681,24 +3347,12 @@
     "whatIsTheMorphTag": "'{wordForm}' ning {morphologicalFeature} nima?",
     "dataAvailable": "Ma'lumot mavjudligi",
     "available": "Mavjud",
-    "pangeaBotIsFallible": "Pangea Bot ham xato qilishi mumkin!",
-    "whatIsMeaning": "'{lemma}' ning ma'nosi nima?",
     "chooseLemmaMeaningInstructionsBody": "Xabar ichidagi so'zlar bilan ma'nolarni moslang!",
-    "doubleClickToEdit": "Tahrirlash uchun ikki marta bosish.",
-    "topicLabel": "Mavzu",
-    "topicPlaceholder": "Mavzuni tanlang...",
-    "modePlaceholder": "Rejimni tanlang...",
-    "learningObjectiveLabel": "Oʻrganish maqsadi",
-    "learningObjectivePlaceholder": "Oʻrganish maqsadini tanlang...",
-    "targetLanguageLabel": "Maʼlumot tili",
     "cefrLevelLabel": "CEFR darajasi",
     "image": "Rasm",
     "video": "Video",
     "nan": "Qoʻllanilmaydi",
-    "addVocabulary": "Soʻz boyligini qoʻshish",
     "instructions": "Koʻrsatmalar",
-    "numberOfLearners": "Oʻquvchilar soni",
-    "mustBeInteger": "Integer bo'lishi kerak, masalan, 1, 2, 3, ...",
     "constructUsePvmDesc": "Ovozli xabar ishlab chiqarilgan",
     "leaveSpaceDescription": "Kursdan chiqib, siz uning ichidagi barcha chatlardan chiqasiz. Boshqa foydalanuvchilar sizning kursdan chiqqaningizni ko'radilar.",
     "constructUseCorMmDesc": "To'g'ri xabar ma'nosi",
@@ -3713,7 +3367,6 @@
     "ttsDisabledBody": "O'qish sozlamalarida matn-to-speechni yoqishingiz mumkin",
     "noSpaceDescriptionYet": "Hali kurs tavsifi yaratilmagan.",
     "tooLargeToSend": "Ushbu xabar yuborish uchun juda katta",
-    "exitWithoutSaving": "Haqiqatan ham saqlamasdan chiqmoqchimisiz?",
     "enableAutocorrectPopupTitle": "Maqsadli til klaviaturasini qo'shish uchun quyidagiga o'ting:",
     "enableAutocorrectPopupSteps": "  • Sozlamalar\n  • Umumiy\n  • Klaviatura\n  • Klaviaturalar\n  • Yangi klaviatura qo'shish",
     "enableAutocorrectPopupDescription": "Til tanlangandan so'ng, klaviaturangizning pastki chap tomonidagi kichik dunyo ikonkasini bosib, yangi o'rnatilgan klaviaturani faollashtirishingiz mumkin.",
@@ -3724,11 +3377,8 @@
     "displayName": "Ko'rsatish nomi",
     "leaveRoomDescription": "Siz bu chatdan chiqmoqdasiz. Boshqa foydalanuvchilar siz chatdan chiqganingizni ko'radilar.",
     "confirmUserId": "Iltimos, hisobingizni o'chirish uchun Pangea Chat foydalanuvchi nomingizni tasdiqlang.",
-    "startingToday": "Bugundan boshlab",
-    "oneWeekFreeTrial": "Bir hafta bepul sinov muddati",
     "paidSubscriptionStarts": "{startDate} dan boshlab",
     "cancelInSubscriptionSettings": " • Obuna sozlamalarida istalgan vaqtda bekor qiling",
-    "cancelToAvoidCharges": " • To'lovlardan qochish uchun {trialEnds} dan oldin bekor qiling",
     "downloadGboard": "Gboard-ni yuklab oling",
     "autocorrectNotAvailable": "Afsuski, platformangiz hozirda bu funksiyani qo'llab-quvvatlamaydi. Keyingi rivojlanishlarni kuzatib boring!",
     "pleaseUpdateApp": "Iltimos, davom etish uchun ilovani yangilang.",
@@ -3738,17 +3388,12 @@
     "knockSpaceSuccess": "Siz bu kursga qo'shilishni so'radingiz! Administrator sizning so'rovingizni olgach, javob beradi 😄",
     "chooseWordAudioInstructionsBody": "To‘liq xabarni tinglang. So‘ngra, audiolarni so‘zlar bilan moslang.",
     "chooseMorphsInstructionsBody": "Grammatika savollari uchun mozaika bo‘laklarini bosing!",
-    "pleaseEnterInt": "Iltimos, raqam kiriting",
     "home": "Bosh sahifa",
     "join": "Qo‘shilish",
     "resetInstructionTooltipsTitle": "Ko‘rsatma iplarini tiklash",
     "resetInstructionTooltipsDesc": "Yangi foydalanuvchi uchun ko‘rsatma iplarini ko‘rsatish uchun bosing.",
-    "randomize": "Tasodifiy qilish",
     "clear": "Tozalash",
-    "featuredActivities": "Taqdim etilgan",
     "save": "Saqlash",
-    "startChat": "Suhbatni boshlash",
-    "translationProblem": "Tarjimada muammo",
     "askToJoin": "Qo‘shilishni so‘rash",
     "emptyChatWarningTitle": "Suhbat bo‘sh",
     "emptyChatWarningDesc": "Siz hech kimni suhbatga taklif qilmagansiz. Kontaktlaringiz yoki Botni taklif qilish uchun Suhbat sozlamalariga o‘ting. Buni keyinroq ham qilishingiz mumkin.",
@@ -3778,17 +3423,13 @@
     "timesUsedIndependently": "Mustaqil ishlatilgan vaqtlari",
     "timesUsedWithAssistance": "Yordam bilan ishlatilgan vaqtlari",
     "shareInviteCode": "Taklif kodini ulash: {code}",
-    "leaderboard": "Boshqaruv jadvali",
     "skipForNow": "Hozircha o'tkazib yuborish",
     "permissions": "Ruxsatlar",
     "spaceChildPermission": "Kim yangi chatlarni bu kursga qo'shishi mumkin",
-    "addEnvironmentOverride": "Muhitni o'zgartirishni qo'shish",
     "defaultOption": "Standart",
     "deleteChatDesc": "Siz ushbu suhbatni o'chirmoqchimisiz? Bu barcha ishtirokchilar uchun o'chiriladi va suhbatdagi barcha xabarlar mashq yoki o'rganish analitikasi uchun mavjud bo'lmaydi.",
     "deleteSpaceDesc": "Kurs va tanlangan har qanday suhbatlar barcha ishtirokchilar uchun o'chiriladi va suhbatdagi barcha xabarlar mashq yoki o'rganish analitikasi uchun mavjud bo'lmaydi. Bu amalni bekor qilish mumkin emas.",
     "launch": "Ishga tushurish",
-    "searchChats": "Suhbatlarni qidirish",
-    "maxFifty": "Maksimal 50",
     "configureSpace": "Kursni sozlash",
     "pinMessages": "Xabarlarni pin qilish",
     "setJoinRules": "Qo'shilish qoidalarini o'rnating",
@@ -3822,9 +3463,6 @@
     "failedToFetchTranscription": "Yozib olishni olish muvaffaqiyatsiz bo'ldi",
     "deleteEmptySpaceDesc": "Kurs barcha ishtirokchilari uchun o'chiriladi. Bu harakatni bekor qilish mumkin emas.",
     "regenerate": "Qayta yaratish",
-    "mySavedActivities": "Mening saqlangan faoliyatlarim",
-    "noSavedActivities": "Saqlangan faoliyatlar mavjud emas",
-    "saveActivity": "Ushbu faoliyatni saqlash",
     "failedToPlayVideo": "Video ijro etishda xatolik yuz berdi",
     "done": "Bajarildi",
     "inThisSpace": "Ushbu kursda",
@@ -3835,13 +3473,9 @@
     "numInvited": "{count} ta taklif qilindi",
     "saved": "Saqlangan",
     "reset": "Qayta boshlash",
-    "errorFetchingActivitiesMessage": "Faoliyatlarni olishda xato",
     "errorFetchingDefinition": "Taqrifni olishda xato",
     "errorProcessAnalytics": "Tahlilni qayta ishlashda xato",
     "errorDownloading": "Yuklab olish muvaffaqiyatsiz",
-    "errorLoadingSpaceChildren": "Ushbu kurs ichidagi chatlarni yuklashda xato",
-    "unexpectedError": "Kutilmagan xato.",
-    "pleaseReload": "Iltimos, yangilang va qayta urinib ko'ring.",
     "translationError": "Tarjimada xato",
     "check": "Tekshirish",
     "unableToFindRoom": "Ushbu kod bilan chat yoki kurs topilmadi. Iltimos, qayta urinib ko'ring.",
@@ -3850,19 +3484,14 @@
     "request": "So'rov",
     "requestAll": "Hammasini so'rash",
     "confirmMessageUnpin": "Ushbu xabarni pin qilishdan voz kechmoqchimisiz?",
-    "saveAndLaunch": "Saqlash va ishga tushirish",
-    "launchToSpace": "Kursga ishga tushirish",
     "pending": "Kutilmoqda",
     "inactive": "Faol emas",
-    "confirmRole": "Rolni tasdiqlash",
     "openRoleLabel": "OCHIQ",
     "finishedTheActivity": "🎯 {username} bu faoliyatni yakunladi",
     "activitySummaryError": "Faoliyatlar haqida ma'lumotlar mavjud emas",
     "requestSummaries": "So'rovlar xulosasi",
-    "generatingNewActivities": "Siz bu til juftligining birinchi foydalanuvchisiz! Iltimos, bir daqiqa kuting, biz siz uchun faoliyatlarni tayyorlamoqdamiz.",
     "requestAccessTitle": "Analitika kirish huquqini so'rash?",
     "requestAccessDesc": "Ishtirokchilarning analitikasini ko'rish uchun kirish huquqini so'rashni xohlaysizmi?\n\nAgar ishtirokchilar rozilik bildirsa, siz ularning:\n    • umumiy lug'at\n    • umumiy grammatik tushunchalar\n    • bajarilgan faoliyat sessiyalari\n    • foydalanilgan, to'g'ri va noto'g'ri grammatik tushunchalarni ko'rishingiz mumkin.\n\nSiz ularning:\n    • kurs tashqarisidagi chatdagi xabarlarini\n    • lug'at ro'yxatini ko'rish imkoniyatiga ega bo'lmaysiz.",
-    "requestAccess": "Kirish huquqini so'rash ({count})",
     "analyticsInactiveTitle": "Faol bo'lmagan foydalanuvchilarga so'rov yuborib bo'lmadi",
     "analyticsInactiveDesc": "Bu funksiyani joriy etilganidan buyon tizimga kirmagan faol bo'lmagan foydalanuvchilar sizning so'rovingizni ko'rmaydi.\n\nSo'rov tugmasi ular qaytib kelgach paydo bo'ladi. Siz keyinchalik ularning ismi ostida joylashgan So'rov tugmasini bosib, so'rovni qayta yuborishingiz mumkin.",
     "accessRequestedTitle": "Analitika kirish so'rovi",
@@ -3885,8 +3514,6 @@
     "accessDesc": "Kursingizni dunyo uchun ochishingiz mumkin! Yoki, kursingizni shaxsiy va xavfsiz qiling.",
     "createGroupChatDesc": "Faoliyat sessiyalari boshlanib va tugagan joyda, guruh chatlari muntazam muloqot uchun ochiq qoladi.",
     "deleteDesc": "Faqat administratorlar kursni o‘chirishi mumkin. Bu xavfli harakat bo‘lib, barcha foydalanuvchilarni olib tashlaydi va kurs ichidagi barcha tanlangan chatlarni o‘chiradi. Ehtiyot bo‘ling.",
-    "noCourseFound": "Oh, bu kurs uchun reja kerak!\n\nKurs rejalari mavzular va suhbat faoliyatlarining ketma-ketligidir.",
-    "additionalParticipants": "+ {num} boshqalar",
     "whatNow": "Endi nima qilish kerak?",
     "chooseNextActivity": "Keyingi faoliyatingizni tanlang!",
     "letsGo": "Boshlaymiz",
@@ -3903,7 +3530,6 @@
     "courses": "Kurslar",
     "goToCourse": "Kursga o'tish: {course}",
     "activityComplete": "Ushbu faoliyat yakunlandi. Faoliyat xulosasi quyida bo'lishi kerak.",
-    "startNewSession": "Yangi sessiya boshlash",
     "joinOpenSession": "Ochiq sessiyaga qo'shiling",
     "activityNotFound": "Faoliyat topilmadi",
     "myActivities": "Mening faoliyatlarim",
@@ -3927,7 +3553,6 @@
     "loginToAccount": "Hisobimga kirish",
     "languages": "Tilllar",
     "startOwn": "O'z faoliyatimni boshlash",
-    "joinCourseDesc": "Har bir kursda 8-10 ketma-ket mavzular va turli vazifaga asoslangan til o'rganish faoliyatlari mavjud.",
     "courseCodeHint": "Kurs kodi",
     "signupOption": "Qanday ro'yhatdan o'tmoqchisiz?",
     "withApple": "Apple bilan",
@@ -3949,7 +3574,6 @@
     "inviteYourFriends": "Do'stlaringizni taklif qiling",
     "playWithAI": "Hozir uchun AI bilan o'ynang",
     "courseStartDesc": "Pangea Bot har doim tayyor!\n\n...lekin o'rganish do'stlar bilan yaxshiroq!",
-    "activityDropdownDesc": "Bu faoliyatni tugatgach, quyidagicha bosishingiz mumkin",
     "languageMismatchTitle": "Til mos kelmasligi",
     "emptyChatSearch": "Xabarlar yoki chatlar topilmadi. Iltimos, qidiruvingiz to'g'ri yozilganligiga ishonch hosil qiling.",
     "languageMismatchDesc": "Sizning maqsad tilingiz bu faoliyat tiliga mos kelmaydi. Maqsad tilingizni yangilashni xohlaysizmi?",
@@ -3965,7 +3589,6 @@
     "newMessageInPangeaChat": "📝 Pangea Chatda yangi xabar",
     "shareCourse": "Kursni ulash",
     "addCourse": "Kurs qo'shish",
-    "joinPublicCourse": "Jamoat kursiga qo'shiling",
     "vocabLevelsDesc": "Bu yerda so'zlar darajangiz oshgan sayin joylashadi!",
     "activityAnalyticsTooltipBody": "Bu sizning saqlangan faoliyatlaringizni ko'rib chiqish va mashq qilish uchun.",
     "numSavedActivities": "Saqlangan faoliyatlar soni",
@@ -3978,7 +3601,6 @@
     "feedbackDialogDesc": "Men ham xato qilaman! Menga yaxshilashga yordam beradigan nimadir bormi?",
     "contactHasBeenInvitedToTheCourse": "Aloqa kursga taklif qilindi",
     "inviteFriends": "Do'stlarni taklif qilish",
-    "activityStatsButtonTooltip": "Faoliyat ma'lumotlari",
     "allow": "Ruxsat berish",
     "deny": "Rad etish",
     "enabledRenewal": "Obunani yangilashni yoqish",
@@ -4234,7 +3856,6 @@
     "constructUseBonus": "So'z amaliyoti davomida bonus",
     "practiceVocab": "So'z boyligini mashq qilish",
     "selectMeaning": "Ma'noni tanlang",
-    "selectAudio": "Mos audio tanlang",
     "anotherRound": "Yana bir marta",
     "ssoDialogTitle": "Kirishni yakunlash uchun kuting",
     "ssoDialogDesc": "Biz sizga xavfsiz kirish uchun yangi yorliq ochdik.",
@@ -4242,12 +3863,9 @@
     "disableLanguageToolsTitle": "Til vositalarini o'chirish",
     "disableLanguageToolsDesc": "Avtomatik til yordamini o'chirmoqchimisiz?",
     "screenSizeWarning": "Eng yaxshi tajriba uchun ekran o'lchamingizni kengaytiring.",
-    "activitiesToUnlockTopicTitle": "Keyingi mavzuni ochish uchun faoliyatlar",
-    "activitiesToUnlockTopicDesc": "Keyingi kurs mavzusini ochish uchun faoliyatlar sonini belgilang",
     "activitySettingsOverrideWarning": "Til va til darajasi faoliyat rejasiga muvofiq belgilanadi",
     "voice": "Ovoz",
     "youLeftTheChat": "🚪 Siz chatdan chiqdingiz",
-    "downloadInitiated": "Yuklab olish boshlandi",
     "webDownloadPermissionMessage": "Agar brauzeringiz yuklab olishlarni bloklasa, iltimos, bu sayt uchun yuklab olishlarni yoqing.",
     "exitPractice": "Amaliyot sessiyangizning rivojlanishi saqlanmaydi.",
     "practiceGrammar": "Grammatika amaliyoti",
@@ -4260,27 +3878,22 @@
     "learn": "O'rganish",
     "languageUpdated": "Maqsadli til yangilandi!",
     "knockDesc": "Sizning so'rovingiz kurs adminiga yuborildi! Ular tasdiqlagan taqdirda sizga kirishga ruxsat beriladi.",
-    "findCourse": "Kurs toping",
     "publicInviteDescChat": "Ushbu chatga taklif qilish uchun foydalanuvchilarni qidiring.",
     "publicInviteDescSpace": "Ushbu maydonga taklif qilish uchun foydalanuvchilarni qidiring.",
     "useActivityImageAsChatBackground": "Faoliyat rasmidan chat fonini foydalanish",
     "chatWithSupport": "Qo'llab-quvvatlash bilan chat",
     "newCourseAccess": "Standart holda, kurslar ochiq qidiruvda bo'lib, ularga qo'shilish uchun admin tasdiqlashi talab etiladi. Siz bu sozlamalarni istalgan vaqtda o'zgartirishingiz mumkin.",
-    "courseLoadingError": "Nimadir noto'g'ri ketdi va biz uni tuzatish uchun qattiq ishlayapmiz. Keyinroq yana tekshiring.",
     "onboardingLanguagesTitle": "Qaysi tilni o'rganmoqdasiz?",
     "supportSubtitle": "Savollaringiz bormi? Biz yordam berishga tayyormiz!",
     "autoIGCToolName": "Yozishni yordamchi qilishni yoqing",
     "autoIGCToolDescription": "Avtomatik ravishda Pangea Chat vositalarini ishga tushirib, yuborilgan xabarlarni maqsadli tilga to'g'ri kelishini tekshiradi.",
     "emptyAudioError": "Tizim yozib olish muvaffaqiyatsiz bo'ldi. Iltimos, audio ruxsatlarini tekshiring va qayta urinib ko'ring.",
-    "spanTypeGrammar": "Grammatika",
-    "spanTypeWordChoice": "So'z tanlovi",
     "spanTypeSpelling": "Imlo",
     "spanTypePunctuation": "Punktuatsiya",
     "spanTypeStyle": "Stil",
     "spanTypeFluency": "O'qish tezligi",
     "spanTypeAccents": "Tovushlar",
     "spanTypeCapitalization": "Katta harf bilan yozish",
-    "spanTypeCorrection": "Tuzatish",
     "spanFeedbackTitle": "Tuzatish muammosini xabar qilish",
     "selectAllWords": "Audioda eshitgan barcha so'zlarni tanlang",
     "aboutMeHint": "Menga haqida",
@@ -4291,7 +3904,6 @@
     "greatPractice": "Ajoyib mashq!",
     "usedNoHints": "Yaxshi ish, hech qanday maslahatlardan foydalanmadingiz!",
     "youveCompletedPractice": "Siz mashqni tugatdingiz, yaxshilash uchun davom eting!",
-    "joinCourseForActivities": "Faoliyatlarni sinab ko'rish uchun kursga qo'shiling.",
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -4320,27 +3932,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
         "type": "String",
         "placeholders": {}
     },
-    "@advancedConfigs": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@advancedConfigurations": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@signInWithLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -4383,10 +3979,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4396,10 +3988,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4483,14 +4071,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4507,10 +4087,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4523,15 +4099,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4683,14 +4251,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4704,14 +4264,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5934,10 +5486,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5978,10 +5526,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6054,10 +5598,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6327,47 +5867,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6387,19 +5887,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6463,10 +5951,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6507,14 +5991,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6526,14 +6002,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6571,10 +6039,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6591,27 +6055,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6735,10 +6183,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6748,10 +6192,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6768,14 +6208,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6915,18 +6347,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6975,10 +6395,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6988,18 +6404,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7042,23 +6446,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7082,10 +6474,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7093,14 +6481,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7205,18 +6585,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7291,10 +6659,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7398,10 +6762,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@joinCourseDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@courseCodeHint": {
         "type": "String",
         "placeholders": {}
@@ -7486,10 +6846,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@activityDropdownDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@languageMismatchTitle": {
         "type": "String",
         "placeholders": {}
@@ -7550,10 +6906,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@joinPublicCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@vocabLevelsDesc": {
         "type": "String",
         "placeholders": {}
@@ -7599,10 +6951,6 @@
         "placeholders": {}
     },
     "@inviteFriends": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8634,10 +7982,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8666,14 +8010,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@activitySettingsOverrideWarning": {
         "type": "String",
         "placeholders": {}
@@ -8683,10 +8019,6 @@
         "placeholders": {}
     },
     "@youLeftTheChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadInitiated": {
         "type": "String",
         "placeholders": {}
     },
@@ -8738,10 +8070,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@publicInviteDescChat": {
         "type": "String",
         "placeholders": {}
@@ -8762,10 +8090,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@onboardingLanguagesTitle": {
         "type": "String",
         "placeholders": {}
@@ -8783,14 +8107,6 @@
         "placeholders": {}
     },
     "@emptyAudioError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
         "type": "String",
         "placeholders": {}
     },
@@ -8815,10 +8131,6 @@
         "placeholders": {}
     },
     "@spanTypeCapitalization": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeCorrection": {
         "type": "String",
         "placeholders": {}
     },
@@ -8859,10 +8171,6 @@
         "placeholders": {}
     },
     "@youveCompletedPractice": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9063,11 +8371,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Sinfdasizmi? Ushbu yerga qo'shilish kodini kiriting.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Avtomatik ravishda audio xabarlarni ajratish",
     "selectAudioMessagesOnPlayDescription": "Ovoz berilganda audio xabarlarni avtomatik ravishda ajratish",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9111,18 +8414,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Ushbu kursda {input} faoliyatdan kam bo'lgan mavzular mavjud. Iltimos, {minValue} dan kam yoki teng bo'lgan raqam kiriting.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Qaytadan kirish uchun bu yerga bosing.",
     "@clickToLogin": {
@@ -9539,17 +8830,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Hayajonlangan holda qo'llarini ko'targan, karton uslubidagi sariq ayiq.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "O'rganish uchun so'zlarni tanlang",
     "requireAnalyticsAccessTitle": "Qo'shilish uchun analitika kirishini talab qiladi",
     "requireAnalyticsAccessDesc": "Ishtirokchilar ushbu kursga qo'shilish uchun o'zlarining o'rganish analitikalariga kirish huquqini berishlari kerak",
     "analyticsAccessNoticeTitle": "Analitika kirishi talab qilinadi",
     "analyticsAccessNoticeDesc": "Ushbu kursga qo'shilish orqali siz adminlarga o'z o'rganish analitikangizga kirish huquqini berishga rozi bo'lasiz.",
-    "skipOnboardingClassCodeDesc": "Mustaqil o'rganmoqdamisiz? Xavotir olmang, siz:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9567,10 +8852,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9599,7 +8880,6 @@
     "pickCefrLevelTeacherStepTitle": "Siz qaysi darajada o'qitasiz?",
     "pickCefrLevelStudentStepTitle": "Siz qaysi daradasiz?",
     "customCourseStepTitle": "Maxsus kurs olish uchun ushbu shaklni to'ldiring",
-    "aboutYourClass": "Sizning sinfingiz haqida",
     "courseCodeStepErrorMessage": "Iltimos, kodingizni tekshirib ko'ring va qayta urinib ko'ring",
     "institution": "Muassasa",
     "courseGoals": "Kurs maqsadlari",
@@ -9642,10 +8922,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9762,12 +9038,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat logotipi",
     "introChatDetails": "Salom ayting! O'zingizni kurs ishtirokchilari bilan tanishtiring, do'stlar toping va faoliyatlardan tashqarida suhbatlashing.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9811,11 +9082,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Faoliyat harakatlari",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Talaffuz vositalari",
     "audioTranscription": "AI audio transkriptsiyasi",
     "visualLearnerSupport": "Vizual o'quvchilarni qo'llab-quvvatlash",
@@ -9856,7 +9122,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Bu faoliyatni o'ynash uchun ushbu kursga qo'shiling.",
     "resizeCoursePanel": "Kurs panelini o'lchamini o'zgartirish",
     "undo": "Qaytarish",
     "unlock": "Kilitni ochish",
@@ -9870,7 +9135,6 @@
     "addCourseBrowsePublic": "Ommaviy kurslarni ko'ring",
     "browsePublicCourses": "Ommaviy kurslarni ko'ring",
     "editProfile": "Profilni tahrirlash",
-    "numObjectives": "{count} maqsadlar",
     "mapSearchHint": "Faoliyatlarni qidiring",
     "mapSearchNoResults": "Ko'rinishda hech qanday moslik yo'q",
     "mapFilterAllLanguages": "Barcha tillar",
@@ -9879,7 +9143,6 @@
     "mapFilterCompleted": "Tamamlandi",
     "mapFilterReset": "Qayta tiklash",
     "activityTypeConversation": "Muloqot",
-    "lockedMissionRequirement": "Ochiq qilish uchun oldingi missiyani tugatish",
     "playAgain": "Yana o'ynang",
     "reviewActivity": "Ko'rib chiqish",
     "mapEmptyInView": "Sizning darajangizda yoki tilingizda hech narsa yo'q. Filtrlaringizni kengaytiring yoki zoom qiling.",
@@ -9894,14 +9157,9 @@
     "scrollToBottom": "Pastga aylantiring",
     "courseImage": "Kurs rasmi",
     "avatarPreview": "Avatar oldindan ko‘rish",
-    "activityPhoto": "Faoliyat rasmi",
     "emotePreview": "Emote oldindan ko‘rish: {name}",
     "activityLabel": "Faoliyat: {title}",
     "resetMapView": "Xarita ko'rinishini tiklash",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9954,14 +9212,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9991,10 +9241,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10051,10 +9297,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -62,11 +62,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "Khách vãng lai có được tham gia không",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "Bạn chắc chứ?",
     "@areYouSure": {
         "type": "String",
@@ -82,11 +77,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "Chuyển từ thiết bị khác",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "showPassword": "Hiển thị mật khẩu",
     "@showPassword": {
         "type": "String",
@@ -97,18 +87,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "noEncryptionForPublicRooms": "Bạn chỉ có thể kích hoạt mã hoá khi phòng này không mở",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "next": "Tiếp",
     "@next": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "Mọi thứ đã sẵn sàng!",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -221,11 +201,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "contactHasBeenInvitedToTheGroup": "Liên hệ đã được mời vào nhóm",
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "connect": "Kết nối",
     "@connect": {
         "type": "String",
@@ -258,11 +233,6 @@
     },
     "chatDetails": "Chi tiết cuộc trò chuyện",
     "@chatDetails": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "chatBackupDescription": "Bản sao lưu cuộc trò chuyện của bạn được bảo mật bằng một khoá bảo mật. Bạn đừng làm mất nó.",
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -458,18 +428,12 @@
     "@newGroup": {},
     "pleaseEnterANumber": "Hãy nhập số lớn hơn 0",
     "@pleaseEnterANumber": {},
-    "newSpaceDescription": "Không gian cho phép bạn hợp nhất các cuộc trò chuyện của mình và xây dựng cộng đồng riêng tư hoặc công khai.",
-    "@newSpaceDescription": {},
-    "disableEncryptionWarning": "Vì lý do bảo mật, bạn không thể tắt tính năng mã hóa trong cuộc trò chuyện đã được bật tính năng này trước đó.",
-    "@disableEncryptionWarning": {},
     "makeAdminDescription": "Khi bạn đặt người dùng này làm quản trị viên, bạn không thể hoàn tác việc này vì khi đó họ sẽ có quyền ngang bạn.",
     "@makeAdminDescription": {},
     "setColorTheme": "Chọn màu giao diện:",
     "@setColorTheme": {},
     "openLinkInBrowser": "Mở đường dẫn trong trình duyệt",
     "@openLinkInBrowser": {},
-    "setTheme": "Chọn giao diện:",
-    "@setTheme": {},
     "inviteGroupChat": "📨 Mời nhóm trò chuyện",
     "@inviteGroupChat": {},
     "addToSpace": "Thêm vào không gian",
@@ -542,8 +506,6 @@
     "@learnMore": {},
     "incomingMessages": "Tin nhắn đến",
     "@incomingMessages": {},
-    "encryptThisChat": "Mã hóa cuộc trò chuyện này",
-    "@encryptThisChat": {},
     "noOtherDevicesFound": "Không tìm thấy thiết bị khác",
     "@noOtherDevicesFound": {},
     "fileIsTooBigForServer": "Máy chủ báo cáo rằng tệp tin quá lớn để gửi.",
@@ -554,8 +516,6 @@
     "@importNow": {},
     "allSpaces": "Tất cả không gian",
     "@allSpaces": {},
-    "enterSpace": "Nhập không gian",
-    "@enterSpace": {},
     "jumpToLastReadMessage": "Đi tới tin nhắn đã đọc mới nhất",
     "@jumpToLastReadMessage": {},
     "commandHint_ignore": "Phớt lờ matrix ID này",
@@ -582,8 +542,6 @@
     "@jump": {},
     "hidePresences": "Ẩn danh sách trạng thái?",
     "@hidePresences": {},
-    "sorryThatsNotPossible": "Xin lỗi... không khả dụng",
-    "@sorryThatsNotPossible": {},
     "reopenChat": "Mở lại cuộc trò chuyện",
     "@reopenChat": {},
     "wrongPinEntered": "Nhập sai mã pin! Thử lại sau {seconds} giây...",
@@ -793,7 +751,6 @@
     "changeTheme": "Thay đổi chủ đề",
     "changeYourAvatar": "Đổi ảnh đại diện",
     "channelCorruptedDecryptError": "Mã hóa đã bị hỏng",
-    "yourChatBackupHasBeenSetUp": "Sao lưu trò chuyện của bạn đã được thiết lập.",
     "chats": "Các cuộc trò chuyện",
     "clearArchive": "Xóa kho lưu trữ",
     "commandHint_markasdm": "Đánh dấu là cuộc trò chuyện trực tiếp cho một Matrix ID",
@@ -844,9 +801,6 @@
     "emoteInvalid": "Mã biểu tượng cảm xúc không hợp lệ!",
     "emoteKeyboardNoRecents": "Những biểu tượng cảm xúc sử dụng gần đây sẽ xuất hiện ở đây...",
     "emotePacks": "Gói biểu tượng cho phòng",
-    "globalChatId": "ID trò chuyện toàn cục",
-    "accessAndVisibility": "Quyền truy cập và hiển thị",
-    "accessAndVisibilityDescription": "Ai được phép tham gia cuộc trò chuyện này và cách cuộc trò chuyện có thể được tìm thấy.",
     "calls": "Cuộc gọi",
     "customEmojisAndStickers": "Biểu tượng cảm xúc và nhãn dán tùy chỉnh",
     "customEmojisAndStickersBody": "Thêm hoặc chia sẻ biểu tượng cảm xúc hoặc nhãn dán tùy chỉnh có thể được dùng trong mọi cuộc trò chuyện.",
@@ -854,7 +808,6 @@
     "emptyChat": "Cuộc trò chuyện trống",
     "enableEmotesGlobally": "Bật gói biểu tượng cảm xúc trên toàn bộ hệ thống",
     "enableEncryption": "Bật mã hóa",
-    "enableEncryptionWarning": "Bạn sẽ không thể tắt mã hóa nữa. Bạn có chắc không?",
     "encrypted": "Đã mã hóa",
     "encryption": "Mã hóa",
     "encryptionNotEnabled": "Chưa bật mã hóa",
@@ -886,9 +839,7 @@
     "fromJoining": "Từ khi tham gia",
     "fromTheInvitation": "Từ lời mời",
     "group": "Cuộc trò chuyện",
-    "chatDescription": "Mô tả cuộc trò chuyện",
     "chatDescriptionHasBeenChanged": "Mô tả cuộc trò chuyện đã được thay đổi",
-    "groupIsPublic": "Cuộc trò chuyện công khai",
     "groups": "Các cuộc trò chuyện",
     "groupWith": "Cuộc trò chuyện với {displayname}",
     "@groupWith": {
@@ -931,15 +882,6 @@
     "incorrectPassphraseOrKey": "Cụm mật khẩu hoặc khóa khôi phục không chính xác",
     "inoffensive": "Ít xúc phạm",
     "inviteContact": "Mời liên hệ",
-    "inviteContactToGroup": "Mời liên hệ vào {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
-    },
     "noChatDescriptionYet": "Chưa có mô tả cuộc trò chuyện.",
     "tryAgain": "Thử lại",
     "invalidServerName": "Tên máy chủ không hợp lệ",
@@ -1020,15 +962,6 @@
     "leave": "Rời đi",
     "leftTheChat": "Đã rời khỏi cuộc trò chuyện",
     "lightTheme": "Chủ đề sáng",
-    "loadCountMoreParticipants": "Tải thêm {count} thành viên",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "dehydrate": "Xuất phiên và xóa thiết bị",
     "dehydrateWarning": "Hành động này không thể hoàn tác. Hãy chắc rằng bạn đã lưu trữ tệp sao lưu một cách an toàn.",
     "hydrate": "Khôi phục từ tệp sao lưu",
@@ -1037,15 +970,6 @@
     "locationDisabledNotice": "Dịch vụ vị trí đã bị tắt. Vui lòng bật để chia sẻ vị trí.",
     "locationPermissionDeniedNotice": "Quyền vị trí đã bị từ chối. Vui lòng cấp quyền để chia sẻ vị trí.",
     "login": "Đăng nhập",
-    "logInTo": "Đăng nhập vào {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
-    },
     "logout": "Đăng xuất",
     "mention": "Nhắc đến",
     "messages": "Tin nhắn",
@@ -1059,7 +983,6 @@
     "no": "Không",
     "noConnectionToTheServer": "Không có kết nối đến máy chủ",
     "noEmotesFound": "Không tìm thấy biểu tượng cảm xúc. 😕",
-    "noGoogleServicesWarning": "Firebase Cloud Messaging không khả dụng trên thiết bị của bạn. Để tiếp tục nhận thông báo đẩy, chúng tôi khuyên cài ntfy hoặc một công cụ Unified Push khác. Bạn có thể tải ntfy từ Play Store hoặc F-Droid.",
     "noMatrixServer": "{server1} không phải là máy chủ Matrix, dùng {server2} thay thế?",
     "@noMatrixServer": {
         "type": "String",
@@ -1099,12 +1022,10 @@
     "openCamera": "Mở máy ảnh",
     "openVideoCamera": "Mở máy ảnh quay video",
     "oneClientLoggedOut": "Một trong các phiên của bạn đã bị đăng xuất",
-    "addAccount": "Thêm tài khoản",
     "editBundlesForAccount": "Chỉnh sửa nhóm cho tài khoản này",
     "addToBundle": "Thêm vào nhóm",
     "removeFromBundle": "Xóa khỏi nhóm",
     "bundleName": "Tên nhóm",
-    "enableMultiAccounts": "(BETA) Bật tính năng đa tài khoản trên thiết bị này",
     "openInMaps": "Mở trong bản đồ",
     "link": "Liên kết",
     "serverRequiresEmail": "Máy chủ này yêu cầu xác thực email để đăng ký.",
@@ -1116,7 +1037,6 @@
     "passwordHasBeenChanged": "Mật khẩu đã được thay đổi",
     "overview": "Tổng quan",
     "passwordRecoverySettings": "Cài đặt khôi phục mật khẩu",
-    "passwordRecovery": "Khôi phục mật khẩu",
     "people": "Mọi người",
     "pickImage": "Chọn ảnh",
     "pin": "Ghim",
@@ -1133,7 +1053,6 @@
     "pleaseChooseAPasscode": "Vui lòng chọn mã khóa",
     "pleaseClickOnLink": "Vui lòng nhấn vào liên kết trong email, sau đó tiếp tục. (Trong một vài trường hợp, email có thể bị chuyển vào mục spam hoặc mất đến 5 phút để gửi.)",
     "pleaseEnter4Digits": "Nhập 4 chữ số hoặc để trống để tắt khóa ứng dụng.",
-    "pleaseEnterRecoveryKey": "Vui lòng nhập khóa khôi phục của bạn:",
     "pleaseEnterYourPassword": "Vui lòng nhập mật khẩu",
     "pleaseEnterYourPin": "Vui lòng nhập mã PIN",
     "pleaseEnterYourUsername": "Vui lòng nhập tên người dùng",
@@ -1195,7 +1114,6 @@
             }
         }
     },
-    "removeDevice": "Xóa thiết bị",
     "unbanFromChat": "Bỏ cấm khỏi trò chuyện",
     "removeYourAvatar": "Gỡ ảnh đại diện của bạn",
     "replaceRoomWithNewerVersion": "Thay thế phòng bằng phiên bản mới hơn",
@@ -1207,8 +1125,6 @@
     "saveFile": "Lưu tệp",
     "search": "Tìm kiếm",
     "security": "Bảo mật",
-    "recoveryKey": "Khóa khôi phục",
-    "recoveryKeyLost": "Mất khóa khôi phục?",
     "send": "Gửi",
     "sendAMessage": "Gửi tin nhắn",
     "sendAsText": "Gửi dạng văn bản",
@@ -1283,7 +1199,6 @@
     "separateChatTypes": "Phân loại Nhắn Tin Trực Tiếp và Nhóm",
     "setAsCanonicalAlias": "Đặt làm bí danh chính",
     "setChatDescription": "Đặt mô tả cuộc trò chuyện",
-    "setPermissionsLevel": "Đặt cấp độ quyền",
     "setStatus": "Đặt trạng thái",
     "share": "Chia sẻ",
     "sharedTheLocation": "{username} đã chia sẻ vị trí",
@@ -1299,8 +1214,6 @@
     "presencesToggle": "Hiển thị trạng thái của người khác",
     "skip": "Bỏ qua",
     "sourceCode": "Mã nguồn",
-    "spaceIsPublic": "Không gian là công khai",
-    "spaceName": "Tên",
     "startedACall": "{senderName} đã bắt đầu cuộc gọi",
     "@startedACall": {
         "type": "String",
@@ -1356,15 +1269,6 @@
     },
     "unmuteChat": "Bật thông báo trò chuyện",
     "unpin": "Bỏ ghim",
-    "unreadChats": "{unreadCount, plural, =1{1 trò chuyện chưa đọc} other{{unreadCount} trò chuyện chưa đọc}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
-    },
     "userAndOthersAreTyping": "{username} và {count} người khác đang nhập…",
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -1425,8 +1329,6 @@
     "verifyStart": "Bắt đầu xác minh",
     "verifySuccess": "Bạn đã xác minh thành công!",
     "verifyTitle": "Xác minh tài khoản khác",
-    "videoCall": "Gọi video",
-    "visibilityOfTheChatHistory": "Chế độ hiển thị lịch sử trò chuyện",
     "visibleForAllParticipants": "Hiển thị cho tất cả người tham gia",
     "visibleForEveryone": "Hiển thị cho mọi người",
     "voiceMessage": "Tin nhắn thoại",
@@ -1436,10 +1338,7 @@
     "wallpaper": "Hình nền:",
     "warning": "Cảnh báo!",
     "weSentYouAnEmail": "Chúng tôi vừa gửi email cho bạn",
-    "whoCanPerformWhichAction": "Ai có thể thực hiện hành động gì",
-    "whoIsAllowedToJoinThisGroup": "Ai được phép tham gia cuộc trò chuyện này",
     "whyDoYouWantToReportThis": "Tại sao bạn muốn báo cáo?",
-    "wipeChatBackup": "Xóa sao lưu trò chuyện để tạo khóa khôi phục mới?",
     "withTheseAddressesRecoveryDescription": "Nhờ các địa chỉ này, bạn có thể khôi phục mật khẩu của mình.",
     "writeAMessage": "Viết tin nhắn…",
     "yes": "Có",
@@ -1452,19 +1351,14 @@
     "messageType": "Loại tin nhắn",
     "sender": "Người gửi",
     "openGallery": "Mở thư viện",
-    "removeFromSpace": "Gỡ khỏi không gian",
     "start": "Bắt đầu",
-    "pleaseEnterRecoveryKeyDescription": "Để mở khóa tin nhắn cũ, hãy nhập khóa khôi phục đã tạo ở phiên trước. Khóa khôi phục KHÔNG phải là mật khẩu.",
     "publish": "Công khai",
     "openChat": "Mở trò chuyện",
     "emojis": "Biểu tượng cảm xúc",
     "placeCall": "Gọi",
-    "voiceCall": "Gọi thoại",
     "unsupportedAndroidVersion": "Không hỗ trợ phiên bản Android này",
     "unsupportedAndroidVersionLong": "Tính năng này cần phiên bản Android mới hơn. Hãy kiểm tra bản cập nhật hoặc hỗ trợ Lineage OS.",
-    "videoCallsBetaWarning": "Lưu ý rằng tính năng gọi video đang trong giai đoạn beta. Chúng có thể không hoạt động đúng trên mọi nền tảng.",
     "experimentalVideoCalls": "Gọi video thử nghiệm",
-    "emailOrUsername": "Email hoặc tên người dùng",
     "addWidget": "Thêm widget",
     "widgetVideo": "Video",
     "widgetEtherpad": "Ghi chú văn bản",
@@ -1549,16 +1443,8 @@
             }
         }
     },
-    "usersMustKnock": "Người dùng phải gõ yêu cầu",
-    "noOneCanJoin": "Không ai được tham gia",
     "knock": "Gõ yêu cầu",
     "users": "Người dùng",
-    "unlockOldMessages": "Mở khóa tin nhắn cũ",
-    "storeInSecureStorageDescription": "Lưu khóa khôi phục trong bộ nhớ bảo mật của thiết bị.",
-    "saveKeyManuallyDescription": "Lưu khóa này thủ công qua tính năng chia sẻ hoặc sao chép.",
-    "storeInAndroidKeystore": "Lưu trong Android KeyStore",
-    "storeInAppleKeyChain": "Lưu trong Apple KeyChain",
-    "storeSecurlyOnThisDevice": "Lưu an toàn trên thiết bị này",
     "countFiles": "{count} tệp",
     "@countFiles": {
         "placeholders": {
@@ -1569,9 +1455,6 @@
     },
     "user": "Người dùng",
     "custom": "Tùy chỉnh",
-    "foregroundServiceRunning": "Thông báo này xuất hiện khi dịch vụ nền đang chạy.",
-    "screenSharingTitle": "chia sẻ màn hình",
-    "screenSharingDetail": "Bạn đang chia sẻ màn hình trong FluffyChat",
     "whyIsThisMessageEncrypted": "Vì sao tin nhắn này không đọc được?",
     "noKeyForThisMessage": "Có thể tin nhắn đã được gửi trước khi bạn đăng nhập trên thiết bị này. Hoặc thiết bị của bạn bị chặn hoặc có lỗi kết nối. Nếu bạn đọc được tin trên thiết bị khác, hãy truyền khóa về thiết bị này! Vào Cài đặt > Thiết bị và xác minh lẫn nhau. Khi mở phòng và cả hai thiết bị đều trực tuyến, chúng sẽ tự trao đổi khóa. Không muốn mất khóa khi đăng xuất? Hãy bật sao lưu trò chuyện trong cài đặt.",
     "deviceKeys": "Khóa thiết bị:",
@@ -1580,11 +1463,9 @@
     "taTooltip": "Dùng L2 với hỗ trợ dịch",
     "interactiveTranslatorSliderHeader": "Trình Dịch Tương Tác",
     "interactiveGrammarSliderHeader": "Trình Kiểm Tra Ngữ Pháp Tương Tác",
-    "interactiveTranslatorRequired": "Bắt buộc",
     "waTooltip": "Dùng L2 không trợ giúp",
     "interactiveTranslator": "Hỗ trợ dịch",
     "noIdenticalLanguages": "Vui lòng chọn ngôn ngữ cơ sở và đích khác nhau",
-    "searchBy": "Tìm theo quốc gia và ngôn ngữ",
     "languageLevelPreA1": "Người mới bắt đầu Thấp (Pre A1)",
     "languageLevelA1": "Người mới giữa (A1)",
     "languageLevelA2": "Người mới cao (A2)",
@@ -1612,17 +1493,12 @@
     "saveChanges": "Lưu thay đổi",
     "publicProfileTitle": "Hồ sơ công khai",
     "publicProfileDesc": "Hồ sơ của bạn cần ở chế độ công khai để người khác tìm và gửi yêu cầu trò chuyện. Khi đó, bạn có thể chọn chấp nhận hoặc từ chối.",
-    "errorDisableIT": "Hỗ trợ dịch đã bị tắt.",
-    "errorDisableIGC": "Hỗ trợ ngữ pháp đã bị tắt.",
     "errorDisableITUserDesc": "Nhấn vào đây để cập nhật cài đặt hỗ trợ dịch",
     "errorDisableIGCUserDesc": "Nhấn vào đây để cập nhật cài đặt hỗ trợ ngữ pháp",
-    "error405Title": "Chưa thiết lập ngôn ngữ",
     "error405Desc": "Vui lòng thiết lập ngôn ngữ của bạn trong Menu chính > Cài đặt Học tập.",
     "termsAndConditions": "Điều khoản và Điều kiện",
     "andCertifyIAmAtLeast13YearsOfAge": " và xác nhận tôi ít nhất 16 tuổi.",
-    "error502504Title": "Wow, có rất nhiều học viên đang trực tuyến!",
     "error502504Desc": "Công cụ dịch và ngữ pháp có thể chạy chậm hoặc ngừng hoạt động trong khi bot Pangea đang xử lý.",
-    "error404Title": "Lỗi dịch!",
     "error404Desc": "Pangea Bot chưa biết cách dịch điều này...",
     "errorPleaseRefresh": "Chúng tôi sẽ kiểm tra! Vui lòng tải lại và thử lại.",
     "connectedToStaging": "Bạn đang kết nối với máy chủ thử nghiệm (staging).",
@@ -1659,8 +1535,6 @@
     "definitionsToolName": "Định nghĩa từ",
     "definitionsToolDescription": "Khi bật, từ gạch chân màu xanh có thể được nhấn để xem định nghĩa.",
     "welcomeBack": "Chào mừng trở lại! Nếu bạn đã tham gia chương trình thử nghiệm 2023-2024, hãy liên hệ để nhận gói đặc biệt. Nếu bạn là giáo viên hoặc trường đã mua bản quyền, cũng hãy liên hệ với chúng tôi.",
-    "downloadTxtFile": "Tải tệp văn bản",
-    "downloadCSVFile": "Tải tệp CSV",
     "promotionalSubscriptionDesc": "Hiện bạn có gói khuyến mại trọn đời. Nếu muốn thay đổi, hãy liên hệ support@pangea.chat.",
     "originalSubscriptionPlatform": "Gói đăng ký được mua qua {purchasePlatform}",
     "@originalSubscriptionPlatform": {
@@ -1671,8 +1545,6 @@
         }
     },
     "oneWeekTrial": "Dùng thử 1 tuần",
-    "downloadXLSXFile": "Tải tệp Excel",
-    "unkDisplayName": "Chưa xác định",
     "wwCountryDisplayName": "Toàn thế giới",
     "afCountryDisplayName": "Afghanistan",
     "axCountryDisplayName": "Quần đảo Åland",
@@ -1976,16 +1848,6 @@
     "noTeachersFound": "Không tìm thấy giáo viên nào để báo cáo",
     "yourGlobalUserIdIs": "ID người dùng toàn cục của bạn là: ",
     "knocking": "Đang yêu cầu tham gia",
-    "chatCanBeDiscoveredViaSearchOnServer": "Cuộc trò chuyện có thể được tìm thấy thông qua tìm kiếm trên {server}",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "searchChatsRooms": "Tìm kiếm #cuộc_trò_chuyện, @người_dùng...",
     "trialExpiration": "Bản dùng thử của bạn sẽ hết hạn vào {expiration}",
     "@trialExpiration": {
         "placeholders": {
@@ -2000,8 +1862,6 @@
     "clickToManageSubscription": "Nhấp vào đây để quản lý gói đăng ký.",
     "nothingFound": "Không tìm thấy gì...",
     "groupName": "Tên nhóm",
-    "createGroupAndInviteUsers": "Tạo nhóm và mời người dùng",
-    "groupCanBeFoundViaSearch": "Nhóm có thể được tìm thấy thông qua tìm kiếm",
     "wrongRecoveryKey": "Rất tiếc... Đây không phải là khóa khôi phục chính xác.",
     "startConversation": "Bắt đầu hội thoại",
     "commandHint_sendraw": "Gửi JSON dạng thô",
@@ -2015,11 +1875,8 @@
     "pleaseChooseAStrongPassword": "Vui lòng chọn mật khẩu mạnh",
     "passwordsDoNotMatch": "Mật khẩu không trùng khớp",
     "passwordIsWrong": "Mật khẩu bạn nhập không đúng",
-    "publicChatAddresses": "Địa chỉ trò chuyện công khai",
-    "createNewAddress": "Tạo địa chỉ mới",
     "joinSpace": "Tham gia không gian",
     "publicSpaces": "Không gian công khai",
-    "addChatOrSubSpace": "Thêm cuộc trò chuyện hoặc không gian con",
     "subspace": "Không gian con",
     "decline": "Từ chối",
     "thisDevice": "Thiết bị này:",
@@ -2036,30 +1893,6 @@
     "searchMore": "Tìm thêm...",
     "gallery": "Thư viện",
     "files": "Tệp",
-    "sessionLostBody": "Phiên của bạn đã mất. Vui lòng báo lỗi này cho nhà phát triển tại {url}. Thông báo lỗi: {error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "Ứng dụng sẽ khôi phục phiên của bạn từ sao lưu. Vui lòng báo lỗi này cho nhà phát triển tại {url}. Thông báo lỗi: {error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "signUp": "Đăng ký",
     "pleaseChooseAtLeastChars": "Vui lòng chọn ít nhất {min} ký tự.",
     "@pleaseChooseAtLeastChars": {
@@ -2078,8 +1911,6 @@
     "sendReadReceiptsDescription": "Những thành viên khác thấy khi bạn đã đọc tin nhắn.",
     "formattedMessages": "Tin nhắn có định dạng",
     "formattedMessagesDescription": "Hiển thị nội dung tin nhắn phong phú như văn bản đậm bằng markdown.",
-    "verifyOtherUser": "🔐 Xác minh người dùng khác",
-    "verifyOtherUserDescription": "Khi bạn xác minh người dùng khác, bạn đảm bảo biết chính xác người ấy là ai. Khi bắt đầu xác minh, cả hai sẽ thấy cửa sổ popup để so sánh chuỗi biểu tượng hoặc số. Tốt nhất là gặp trực tiếp hoặc qua cuộc gọi video để xác minh.",
     "verifyOtherDevice": "🔐 Xác minh thiết bị khác",
     "verifyOtherDeviceDescription": "Khi xác minh thiết bị khác, hai thiết bị có thể trao đổi khóa, tăng bảo mật tổng thể. Khi bắt đầu xác minh, cả hai thiết bị sẽ thấy một popup so sánh chuỗi biểu tượng hoặc số. Hãy chuẩn bị sẵn hai thiết bị trước khi xác minh.",
     "acceptedKeyVerification": "{sender} đã chấp nhận xác minh khóa",
@@ -2164,12 +1995,10 @@
     "roomFull": "Phòng đã đạt giới hạn.",
     "chatCapacityHasBeenChanged": "Giới hạn thành viên trò chuyện đã thay đổi",
     "chatCapacityExplanation": "Hạn chế số lượng người dùng thường (không phải quản trị viên) có thể tham gia cuộc trò chuyện.",
-    "tooManyRequest": "Quá nhiều yêu cầu, vui lòng thử lại sau.",
     "enterNumber": "Vui lòng nhập một số nguyên lớn hơn 0.",
     "noDatabaseEncryption": "Nền tảng này không hỗ trợ mã hóa cơ sở dữ liệu",
     "thereAreCountUsersBlocked": "Hiện có {count} người dùng bị chặn.",
     "knockRestricted": "Hạn chế gõ yêu cầu",
-    "createNewSpace": "Tạo không gian mới",
     "practice": "Luyện tập",
     "previous": "Trước",
     "versionNotFound": "Không tìm thấy phiên bản",
@@ -2193,7 +2022,6 @@
     "deleteSubscriptionWarningTitle": "Bạn đang có gói đăng ký hoạt động",
     "deleteSubscriptionWarningBody": "Việc xóa tài khoản sẽ không hủy gói đăng ký của bạn.",
     "manageSubscription": "Quản lý gói đăng ký",
-    "error520Title": "Hãy thử lại.",
     "error520Desc": "Xin lỗi, chúng tôi không thể hiểu tin nhắn của bạn...",
     "wordsUsed": "Từ đã dùng",
     "level": "Cấp độ",
@@ -2246,10 +2074,6 @@
         }
     },
     "changelog": "Nhật ký thay đổi",
-    "loginWithMatrixId": "Đăng nhập với Matrix-ID",
-    "discoverHomeservers": "Khám phá máy chủ",
-    "whatIsAHomeserver": "Máy chủ là gì?",
-    "homeserverDescription": "Tất cả dữ liệu của bạn sẽ lưu trên máy chủ, tương tự nhà cung cấp email. Bạn có thể chọn bất kỳ máy chủ nào tương thích và vẫn trò chuyện với mọi người. Tìm hiểu thêm tại https://matrix.org.",
     "doesNotSeemToBeAValidHomeserver": "Có vẻ đây không phải máy chủ tương thích. URL sai?",
     "grammar": "Ngữ pháp",
     "contactHasBeenInvitedToTheChat": "Liên hệ đã được mời vào cuộc trò chuyện",
@@ -2272,7 +2096,6 @@
         }
     },
     "noCapacityLimit": "Không giới hạn sức chứa",
-    "downloadGroupText": "Tải nội dung nhóm",
     "notificationsOn": "Bật thông báo",
     "notificationsOff": "Tắt thông báo",
     "calculatingFileSize": "Đang tính kích thước tệp...",
@@ -2303,11 +2126,9 @@
     },
     "oneOfYourDevicesIsNotVerified": "Một trong các thiết bị của bạn chưa được xác minh",
     "noticeChatBackupDeviceVerification": "Lưu ý: Khi bạn thêm tất cả thiết bị vào sao lưu trò chuyện, chúng sẽ tự động được xác minh.",
-    "welcomeText": "Chào bạn 👋 Đây là FluffyChat. Bạn có thể đăng nhập vào bất kỳ máy chủ nào tương thích với https://matrix.org, và trò chuyện với mọi người. Đây là một mạng nhắn tin phi tập trung!",
     "blur": "Mờ:",
     "opacity": "Độ trong suốt:",
     "setWallpaper": "Đặt hình nền",
-    "manageAccount": "Quản lý tài khoản",
     "noContactInformationProvided": "Máy chủ không cung cấp thông tin liên hệ hợp lệ",
     "contactServerAdmin": "Liên hệ quản trị viên máy chủ",
     "contactServerSecurity": "Liên hệ bảo mật máy chủ",
@@ -2404,49 +2225,15 @@
     },
     "dataAvailable": "Dữ liệu khả dụng",
     "available": "Khả dụng",
-    "pangeaBotIsFallible": "Pangea Bot cũng có thể mắc lỗi!",
-    "whatIsMeaning": "Từ '{lemma}' có nghĩa là gì?",
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            },
-            "partOfSpeech": {
-                "type": "String"
-            }
-        }
-    },
-    "doubleClickToEdit": "Nhấp đúp để chỉnh sửa.",
     "otherPartyNotLoggedIn": "Bên kia hiện không đăng nhập, không thể nhận tin!",
-    "topicLabel": "Chủ đề",
-    "topicPlaceholder": "Chọn một chủ đề...",
-    "modePlaceholder": "Chọn một chế độ...",
-    "learningObjectiveLabel": "Mục tiêu học tập",
-    "learningObjectivePlaceholder": "Chọn một mục tiêu học tập...",
-    "targetLanguageLabel": "Ngôn ngữ đích",
     "cefrLevelLabel": "Trình độ CEFR",
     "image": "Hình ảnh",
     "video": "Video",
     "nan": "Không áp dụng",
-    "addVocabulary": "Thêm từ vựng",
     "instructions": "Hướng dẫn",
-    "numberOfLearners": "Số lượng người học",
-    "mustBeInteger": "Phải là số nguyên, ví dụ: 1, 2, 3...",
     "constructUsePvmDesc": "Đã sử dụng trong tin nhắn thoại",
-    "appWantsToUseForLogin": "Dùng '{server}' để đăng nhập",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "appWantsToUseForLoginDescription": "Bạn cho phép ứng dụng và trang web chia sẻ thông tin về bạn.",
     "open": "Mở",
     "waitingForServer": "Đang đợi phản hồi từ máy chủ...",
-    "appIntroduction": "FluffyChat cho phép bạn trò chuyện với bạn bè trên nhiều nền tảng khác nhau. Tìm hiểu thêm tại https://matrix.org hoặc nhấn *Tiếp tục*.",
     "constructUseCorMmDesc": "Đúng trong ý nghĩa tin nhắn",
     "constructUseIncMmDesc": "Sai trong ý nghĩa tin nhắn",
     "constructUseIgnMmDesc": "Bỏ qua trong ý nghĩa tin nhắn",
@@ -2540,7 +2327,6 @@
     "ttsDisbledTitle": "Tính năng chuyển văn bản thành giọng nói đã bị tắt",
     "ttsDisabledBody": "Bạn có thể bật tính năng chuyển văn bản thành giọng nói trong cài đặt học tập của bạn",
     "tooLargeToSend": "Tin nhắn này quá lớn để gửi",
-    "exitWithoutSaving": "Bạn có chắc chắn muốn rời đi mà không lưu không?",
     "enableAutocorrectPopupTitle": "Thêm bàn phím ngôn ngữ mục tiêu của bạn bằng cách vào:",
     "enableAutocorrectPopupSteps": "  • Cài đặt\n  • Chung\n  • Bàn phím\n  • Bàn phím\n  • Thêm bàn phím mới",
     "enableAutocorrectPopupDescription": "Khi ngôn ngữ được chọn, bạn có thể nhấp vào biểu tượng quả địa cầu nhỏ ở góc dưới bên trái của bàn phím để kích hoạt bàn phím mới được cài đặt.",
@@ -2551,8 +2337,6 @@
     "displayName": "Tên hiển thị",
     "leaveRoomDescription": "Bạn sắp rời khỏi cuộc trò chuyện này. Những người dùng khác sẽ thấy rằng bạn đã rời khỏi cuộc trò chuyện.",
     "confirmUserId": "Vui lòng xác nhận tên người dùng Pangea Chat của bạn để xóa tài khoản.",
-    "startingToday": "Bắt đầu từ hôm nay",
-    "oneWeekFreeTrial": "Thử nghiệm miễn phí một tuần",
     "paidSubscriptionStarts": "Bắt đầu từ {startDate}",
     "@paidSubscriptionStarts": {
         "type": "String",
@@ -2563,15 +2347,6 @@
         }
     },
     "cancelInSubscriptionSettings": "• Hủy bất cứ lúc nào trong cài đặt đăng ký",
-    "cancelToAvoidCharges": "• Hủy trước {trialEnds} để tránh bị tính phí",
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
-    },
     "downloadGboard": "Tải Gboard",
     "autocorrectNotAvailable": "Rất tiếc, nền tảng của bạn hiện không được hỗ trợ cho tính năng này. Hãy theo dõi để biết thêm thông tin phát triển!",
     "takeAPhoto": "Chụp một bức ảnh",
@@ -2613,17 +2388,12 @@
     "morphAnalyticsListBody": "Đây là tất cả các khái niệm ngữ pháp trong ngôn ngữ bạn đang học! Bạn sẽ mở khóa chúng khi gặp phải trong khi trò chuyện. Nhấp để xem chi tiết.",
     "chooseWordAudioInstructionsBody": "Nghe toàn bộ tin nhắn. Sau đó, khớp các âm thanh với các từ.",
     "chooseMorphsInstructionsBody": "Nhấp vào các mảnh ghép cho các câu hỏi ngữ pháp!",
-    "pleaseEnterInt": "Vui lòng nhập một số",
     "home": "Trang chủ",
     "join": "Tham gia",
     "resetInstructionTooltipsTitle": "Đặt lại hướng dẫn công cụ",
     "resetInstructionTooltipsDesc": "Nhấp để hiển thị hướng dẫn công cụ như cho một người dùng hoàn toàn mới.",
-    "randomize": "Ngẫu nhiên hóa",
     "clear": "Xóa",
-    "featuredActivities": "Nổi bật",
     "save": "Lưu",
-    "startChat": "Bắt đầu trò chuyện",
-    "translationProblem": "Vấn đề dịch thuật",
     "askToJoin": "Yêu cầu tham gia",
     "emptyChatWarningTitle": "Trò chuyện trống",
     "emptyChatWarningDesc": "Bạn chưa mời ai vào trò chuyện của mình. Đi đến cài đặt trò chuyện để mời danh bạ hoặc Bot của bạn. Bạn cũng có thể làm điều này sau.",
@@ -2655,7 +2425,6 @@
     "timesUsedIndependently": "Số lần sử dụng độc lập",
     "timesUsedWithAssistance": "Số lần sử dụng với sự trợ giúp",
     "shareInviteCode": "Chia sẻ mã mời: {code}",
-    "leaderboard": "Bảng xếp hạng",
     "skipForNow": "Bỏ qua tạm thời",
     "@enterNewChat": {
         "type": "String",
@@ -2689,10 +2458,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -2709,27 +2474,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -2861,19 +2610,13 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
     },
     "permissions": "Quyền hạn",
-    "addEnvironmentOverride": "Thêm ghi đè môi trường",
     "defaultOption": "Mặc định",
     "launch": "Khởi động",
-    "searchChats": "Tìm kiếm cuộc trò chuyện",
     "pinMessages": "Ghim tin nhắn",
     "setJoinRules": "Đặt quy tắc tham gia",
     "displayNavigationRail": "Hiển thị thanh điều hướng trên di động",
@@ -2887,19 +2630,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addEnvironmentOverride": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@defaultOption": {
         "type": "String",
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
         "type": "String",
         "placeholders": {}
     },
@@ -2940,14 +2675,12 @@
         "placeholders": {}
     },
     "checkList": "Danh sách kiểm tra",
-    "countInvited": "{count} người được mời",
     "sentVoiceMessage": "🎙️ {duration} - Tin nhắn thoại từ {sender}",
     "commandHint_logout": "Đăng xuất khỏi thiết bị hiện tại của bạn",
     "commandHint_logoutall": "Đăng xuất khỏi tất cả các thiết bị đang hoạt động",
     "customReaction": "Phản ứng tùy chỉnh",
     "constructUseCollected": "Được thu thập trong trò chuyện",
     "deleteChatDesc": "Bạn có chắc chắn muốn xóa trò chuyện này không? Nó sẽ bị xóa cho tất cả người tham gia và tất cả tin nhắn trong trò chuyện sẽ không còn khả dụng cho việc thực hành hoặc phân tích học tập.",
-    "maxFifty": "Tối đa 50",
     "activities": "Hoạt động",
     "access": "Truy cập",
     "private": "Riêng tư",
@@ -2965,9 +2698,6 @@
     "transcriptionFailed": "Không thể chuyển đổi âm thanh",
     "failedToFetchTranscription": "Không thể lấy bản chuyển đổi",
     "regenerate": "Tạo lại",
-    "mySavedActivities": "Các hoạt động đã lưu của tôi",
-    "noSavedActivities": "Không có hoạt động nào đã lưu",
-    "saveActivity": "Lưu hoạt động này",
     "failedToPlayVideo": "Không thể phát video",
     "done": "Xong",
     "myContacts": "Danh bạ của tôi",
@@ -2977,14 +2707,6 @@
     "@checkList": {
         "type": "String",
         "placeholders": {}
-    },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@sentVoiceMessage": {
         "type": "String",
@@ -3014,10 +2736,6 @@
         "placeholders": {}
     },
     "@deleteChatDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -3089,18 +2807,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -3135,13 +2841,9 @@
     },
     "chatCapacitySetTooLow": "Dung lượng trò chuyện phải ít nhất là {count}.",
     "reset": "Đặt lại",
-    "errorFetchingActivitiesMessage": "Không thể lấy hoạt động",
     "errorFetchingDefinition": "Không thể lấy định nghĩa",
     "errorProcessAnalytics": "Không thể xử lý phân tích",
     "errorDownloading": "Tải xuống thất bại",
-    "errorLoadingSpaceChildren": "Không thể tải trò chuyện trong không gian này",
-    "unexpectedError": "Lỗi không mong đợi.",
-    "pleaseReload": "Vui lòng tải lại và thử lại.",
     "translationError": "Lỗi dịch thuật",
     "check": "Kiểm tra",
     "unableToFindRoom": "Không tìm thấy trò chuyện hoặc không gian nào với mã đó. Vui lòng thử lại.",
@@ -3157,10 +2859,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -3170,18 +2868,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -3224,19 +2910,14 @@
     "request": "Yêu cầu",
     "requestAll": "Yêu cầu tất cả",
     "confirmMessageUnpin": "Bạn có chắc chắn muốn bỏ ghim tin nhắn này không?",
-    "saveAndLaunch": "Lưu và khởi chạy",
-    "launchToSpace": "Khởi chạy vào khóa học",
     "pending": "Đang chờ",
     "inactive": "Không hoạt động",
-    "confirmRole": "Xác nhận vai trò",
     "openRoleLabel": "MỞ",
     "finishedTheActivity": "🎯 {username} đã kết thúc hoạt động này",
     "activitySummaryError": "Không thể lấy tóm tắt hoạt động",
     "requestSummaries": "Yêu cầu tóm tắt",
-    "generatingNewActivities": "Bạn là người dùng đầu tiên của cặp ngôn ngữ này! Vui lòng chờ một phút, chúng tôi đang chuẩn bị hoạt động dành riêng cho bạn.",
     "requestAccessTitle": "Yêu cầu quyền truy cập phân tích?",
     "requestAccessDesc": "Bạn có muốn yêu cầu quyền truy cập để xem phân tích người tham gia?\n\nNếu các người tham gia đồng ý, quản trị viên của khóa học này sẽ có thể xem:\n    • tổng số từ vựng\n    • tổng số khái niệm ngữ pháp\n    • tổng số phiên hoạt động đã hoàn thành\n    • các khái niệm ngữ pháp cụ thể đã sử dụng, đúng và sai\n\nHọ sẽ không thể xem:\n    • tin nhắn trong các cuộc trò chuyện ngoài khóa học\n    • danh sách từ vựng",
-    "requestAccess": "Yêu cầu quyền truy cập ({count})",
     "analyticsInactiveTitle": "Không thể gửi yêu cầu tới người dùng không hoạt động",
     "analyticsInactiveDesc": "Người dùng không hoạt động kể từ khi tính năng này được giới thiệu sẽ không thấy yêu cầu của bạn.\n\nNút Yêu cầu sẽ xuất hiện khi họ trở lại. Bạn có thể gửi lại yêu cầu sau bằng cách nhấn nút Yêu cầu dưới tên của họ khi nó khả dụng.",
     "accessRequestedTitle": "Yêu cầu truy cập phân tích",
@@ -3259,8 +2940,6 @@
     "accessDesc": "Bạn có thể làm cho khóa học của mình mở cho thế giới! Hoặc, làm cho khóa học của bạn riêng tư và an toàn.",
     "createGroupChatDesc": "Trong khi các phiên hoạt động bắt đầu và kết thúc, nhóm trò chuyện sẽ luôn mở để giao tiếp định kỳ.",
     "deleteDesc": "Chỉ quản trị viên mới có thể xóa khóa học. Đây là hành động phá hủy, sẽ xóa tất cả người dùng và tất cả các cuộc trò chuyện đã chọn trong khóa học. Hãy cẩn thận khi thực hiện.",
-    "noCourseFound": "Ôi, khóa học này cần có kế hoạch!\n\nKế hoạch khóa học là một chuỗi các chủ đề và hoạt động trò chuyện.",
-    "additionalParticipants": "+ {num} người khác",
     "whatNow": "Bây giờ làm gì?",
     "chooseNextActivity": "Chọn hoạt động tiếp theo của bạn!",
     "letsGo": "Đi nào",
@@ -3273,13 +2952,11 @@
     "waitNotDone": "Chờ một chút, tôi chưa xong!",
     "waitingForOthersToFinish": "Đang chờ những người khác hoàn thành...",
     "generatingSummary": "Phân tích cuộc trò chuyện và tạo kết quả",
-    "findCourse": "Tìm khóa học",
     "pingParticipantsNotification": "{user} đang tìm kiếm người dùng để tham gia phiên hoạt động trong {room}",
     "course": "Khóa học",
     "courses": "Các khóa học",
     "goToCourse": "Đi tới khóa học: {course}",
     "activityComplete": "Hoạt động này đã hoàn thành. Tóm tắt hoạt động sẽ có sẵn bên dưới.",
-    "startNewSession": "Bắt đầu phiên mới",
     "joinOpenSession": "Tham gia phiên mở",
     "activityNotFound": "Hoạt động không tìm thấy",
     "myActivities": "Hoạt động của tôi",
@@ -3448,23 +3125,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -3488,10 +3153,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -3499,14 +3160,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -3611,18 +3264,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -3675,10 +3316,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -3705,10 +3342,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -3889,7 +3522,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "Kiểm tra lại vào ngày mai để cập nhật hoạt động.",
-    "activityDropdownDesc": "Khi bạn hoàn thành hoạt động này, nhấn vào bên dưới",
     "languageMismatchTitle": "Không khớp ngôn ngữ",
     "languageMismatchDesc": "Ngôn ngữ mục tiêu của bạn không khớp với ngôn ngữ của hoạt động này. Cập nhật ngôn ngữ mục tiêu của bạn?",
     "reportWordIssueTooltip": "Báo cáo vấn đề về thông tin từ",
@@ -3902,10 +3534,6 @@
     "selectAll": "Chọn tất cả",
     "deselectAll": "Bỏ chọn tất cả",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -3954,17 +3582,11 @@
         "placeholders": {}
     },
     "startOwn": "Bắt đầu của riêng tôi",
-    "joinCourseDesc": "Mỗi khóa học có 8-10 chủ đề theo trình tự với nhiều hoạt động học ngôn ngữ dựa trên nhiệm vụ.",
     "newMessageInPangeaChat": "🔊 Tin nhắn mới trong Pangea Chat",
     "shareCourse": "Chia sẻ khóa học",
     "addCourse": "Thêm khóa học",
-    "joinPublicCourse": "Tham gia khóa học công khai",
     "vocabLevelsDesc": "Đây là nơi các từ vựng sẽ xuất hiện sau khi bạn nâng cấp chúng!",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -3977,10 +3599,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -4027,7 +3645,6 @@
     "emojiView": "Chế độ xem biểu tượng cảm xúc",
     "feedbackDialogDesc": "Tôi cũng mắc lỗi! Có điều gì để giúp tôi cải thiện không?",
     "contactHasBeenInvitedToTheCourse": "Liên hệ đã được mời tham gia khóa học",
-    "activityStatsButtonTooltip": "Thông tin hoạt động",
     "allow": "Cho phép",
     "deny": "Từ chối",
     "enabledRenewal": "Kích hoạt gia hạn đăng ký",
@@ -4295,10 +3912,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -5354,16 +4967,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "Các hoạt động để mở khóa chủ đề tiếp theo",
-    "activitiesToUnlockTopicDesc": "Đặt số lượng hoạt động để mở khóa chủ đề khóa học tiếp theo",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "Thực hành định nghĩa từ vựng đúng",
     "constructUseIncLMDesc": "Thực hành định nghĩa từ vựng sai",
     "constructUseCorLADesc": "Thực hành âm thanh từ vựng đúng",
@@ -5371,7 +4974,6 @@
     "constructUseBonus": "Thưởng trong quá trình thực hành từ vựng",
     "practiceVocab": "Thực hành từ vựng",
     "selectMeaning": "Chọn nghĩa",
-    "selectAudio": "Chọn âm thanh phù hợp",
     "anotherRound": "Một vòng nữa",
     "activitySettingsOverrideWarning": "Ngôn ngữ và cấp độ ngôn ngữ được xác định bởi kế hoạch hoạt động",
     "voice": "Giọng nói",
@@ -5403,10 +5005,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -5424,12 +5022,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "Tải xuống đã được khởi động",
     "webDownloadPermissionMessage": "Nếu trình duyệt của bạn chặn tải xuống, vui lòng bật tải xuống cho trang web này.",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -5524,11 +5117,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "Đã xảy ra sự cố, và chúng tôi đang nỗ lực khắc phục. Vui lòng kiểm tra lại sau.",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "Bật trợ giúp viết",
     "autoIGCToolDescription": "Tự động chạy các công cụ Pangea Chat để sửa các tin nhắn đã gửi sang ngôn ngữ mục tiêu.",
     "@autoIGCToolName": {
@@ -5584,24 +5172,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "Ngữ pháp",
-    "spanTypeWordChoice": "Lựa chọn từ",
     "spanTypeSpelling": "Chính tả",
     "spanTypePunctuation": "Dấu câu",
     "spanTypeStyle": "Phong cách",
     "spanTypeFluency": "Lưu loát",
     "spanTypeAccents": "Giọng điệu",
     "spanTypeCapitalization": "Chữ hoa",
-    "spanTypeCorrection": "Sửa lỗi",
     "spanFeedbackTitle": "Báo cáo vấn đề sửa lỗi",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -5626,10 +5203,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -5642,13 +5215,7 @@
     "longPressToRecordVoiceMessage": "Nhấn và giữ để ghi âm tin nhắn thoại.",
     "pause": "Tạm dừng",
     "resume": "Tiếp tục",
-    "newSubSpace": "Không gian phụ mới",
-    "moveToDifferentSpace": "Chuyển đến không gian khác",
-    "removeFromSpaceDescription": "Cuộc trò chuyện sẽ bị xóa khỏi không gian nhưng vẫn xuất hiện trong danh sách trò chuyện của bạn.",
     "countChats": "{chats} cuộc trò chuyện",
-    "spaceMemberOf": "Thành viên không gian của {spaces}",
-    "spaceMemberOfCanKnock": "Thành viên không gian của {spaces} có thể gõ cửa",
-    "donate": "Đóng góp",
     "startedAPoll": "{username} đã bắt đầu một cuộc thăm dò.",
     "poll": "Cuộc thăm dò",
     "startPoll": "Bắt đầu cuộc thăm dò",
@@ -5672,23 +5239,15 @@
     "newStickerPack": "Gói nhãn dán mới",
     "stickerPackName": "Tên gói nhãn dán",
     "attribution": "Ghi nhận",
-    "skipChatBackup": "Bỏ qua sao lưu trò chuyện",
-    "skipChatBackupWarning": "Bạn có chắc không? Nếu không bật sao lưu trò chuyện, bạn có thể mất quyền truy cập vào tin nhắn của mình nếu bạn chuyển đổi thiết bị.",
-    "loadingMessages": "Đang tải tin nhắn",
-    "setupChatBackup": "Thiết lập sao lưu trò chuyện",
     "noMoreResultsFound": "Không tìm thấy kết quả nào nữa",
     "chatSearchedUntil": "Trò chuyện đã được tìm kiếm đến {time}",
     "federationBaseUrl": "URL cơ sở Liên bang",
     "clientWellKnownInformation": "Thông tin Khách hàng-Đã biết:",
     "baseUrl": "URL cơ sở",
     "identityServer": "Máy chủ danh tính:",
-    "versionWithNumber": "Phiên bản: {version}",
     "logs": "Nhật ký",
-    "advancedConfigs": "Cấu hình nâng cao",
     "advancedConfigurations": "Cấu hình nâng cao",
-    "signInWithLabel": "Đăng nhập bằng:",
     "selectAllWords": "Chọn tất cả các từ bạn nghe trong âm thanh",
-    "joinCourseForActivities": "Tham gia một khóa học để thử các hoạt động.",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -5725,18 +5284,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -5744,26 +5291,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -5869,22 +5396,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -5913,19 +5424,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -5933,15 +5432,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -6142,11 +5633,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "Trong một lớp học? Đặt mã tham gia của bạn ở đây.",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "Tự động làm nổi bật tin nhắn âm thanh",
     "selectAudioMessagesOnPlayDescription": "Tự động làm nổi bật tin nhắn âm thanh khi phát",
     "@selectAudioMessagesOnPlayToolName": {
@@ -6190,18 +5676,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "Khóa học này có các chủ đề với ít hơn {input} hoạt động. Vui lòng nhập một số nhỏ hơn hoặc bằng {minValue}.",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "Nhấn vào đây để đăng nhập lại.",
     "@clickToLogin": {
@@ -6618,17 +6092,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "Một con gấu màu vàng hoạt hình với đôi tay giơ lên trong sự phấn khích.",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "Chọn từ để tìm hiểu thêm về chúng",
     "requireAnalyticsAccessTitle": "Cần quyền truy cập phân tích để tham gia",
     "requireAnalyticsAccessDesc": "Người tham gia phải cấp quyền truy cập vào phân tích học tập của họ để tham gia khóa học này",
     "analyticsAccessNoticeTitle": "Cần quyền truy cập phân tích",
     "analyticsAccessNoticeDesc": "Bằng cách tham gia khóa học này, bạn đồng ý cấp quyền truy cập cho quản trị viên vào phân tích học tập của bạn.",
-    "skipOnboardingClassCodeDesc": "Học độc lập? Đừng lo, bạn có thể:",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -6646,10 +6114,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -6678,7 +6142,6 @@
     "pickCefrLevelTeacherStepTitle": "Bạn dạy cấp độ nào?",
     "pickCefrLevelStudentStepTitle": "Bạn đang ở cấp độ nào?",
     "customCourseStepTitle": "Điền vào mẫu này để có một khóa học tùy chỉnh",
-    "aboutYourClass": "Về lớp học của bạn",
     "courseCodeStepErrorMessage": "Vui lòng kiểm tra mã của bạn và thử lại",
     "institution": "Tổ chức",
     "courseGoals": "Mục tiêu khóa học",
@@ -6721,10 +6184,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -6841,12 +6300,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Logo Pangea Chat",
     "introChatDetails": "Chào bạn! Giới thiệu bản thân với những người tham gia khóa học khác, tìm bạn bè và trò chuyện ngoài các hoạt động.",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -6890,11 +6344,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "Hành động hoạt động",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "Công cụ phát âm",
     "audioTranscription": "Chuyển đổi âm thanh AI",
     "visualLearnerSupport": "Hỗ trợ người học trực quan",
@@ -6935,7 +6384,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "Tham gia một khóa học bao gồm hoạt động này để chơi.",
     "resizeCoursePanel": "Thay đổi kích thước bảng khóa học",
     "undo": "Hoàn tác",
     "unlock": "Mở khóa",
@@ -6949,7 +6397,6 @@
     "addCourseBrowsePublic": "Duyệt các khóa học công khai",
     "browsePublicCourses": "Duyệt các khóa học công khai",
     "editProfile": "Chỉnh sửa hồ sơ",
-    "numObjectives": "{count} mục tiêu",
     "mapSearchHint": "Tìm kiếm hoạt động",
     "mapSearchNoResults": "Không có kết quả nào trong chế độ xem",
     "mapFilterAllLanguages": "Tất cả các ngôn ngữ",
@@ -6958,7 +6405,6 @@
     "mapFilterCompleted": "Đã hoàn thành",
     "mapFilterReset": "Đặt lại",
     "activityTypeConversation": "Cuộc trò chuyện",
-    "lockedMissionRequirement": "Hoàn thành nhiệm vụ trước để mở khóa",
     "playAgain": "Chơi lại",
     "reviewActivity": "Xem lại",
     "mapEmptyInView": "Không có gì ở cấp độ hoặc ngôn ngữ của bạn. Mở rộng bộ lọc của bạn hoặc thu nhỏ.",
@@ -6973,14 +6419,9 @@
     "scrollToBottom": "Cuộn xuống dưới cùng",
     "courseImage": "Hình ảnh khóa học",
     "avatarPreview": "Xem trước avatar",
-    "activityPhoto": "Ảnh hoạt động",
     "emotePreview": "Xem trước biểu cảm: {name}",
     "activityLabel": "Hoạt động: {title}",
     "resetMapView": "Đặt lại chế độ xem bản đồ",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -7033,14 +6474,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -7070,10 +6503,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -7130,10 +6559,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_yue.arb
+++ b/lib/l10n/intl_yue.arb
@@ -19,9 +19,7 @@
     "changeYourAvatar": "更換你的頭像",
     "channelCorruptedDecryptError": "加密已被破壞",
     "chat": "聊天",
-    "yourChatBackupHasBeenSetUp": "你嘅聊天備份已經設置好。",
     "chatBackup": "聊天備份",
-    "chatBackupDescription": "你嘅舊訊息已用恢復金鑰保護。請確保你唔會丟失佢。",
     "chatDetails": "聊天詳情",
     "chats": "聊天",
     "chooseAStrongPassword": "揀一個強密碼",
@@ -54,7 +52,6 @@
     "configureChat": "配置聊天",
     "confirm": "確認",
     "connect": "連接",
-    "contactHasBeenInvitedToTheGroup": "聯絡人已被邀請加入群組",
     "contentHasBeenReported": "內容已向伺服器管理員報告",
     "copiedToClipboard": "複製到剪貼簿",
     "copy": "複製",
@@ -62,11 +59,9 @@
     "couldNotDecryptMessage": "無法解密訊息：{error}",
     "checkList": "檢查清單",
     "countParticipants": "{count} 位參與者",
-    "countInvited": "{count} 位已邀請",
     "create": "建立",
     "createdTheChat": "📈 {username} 建立咗對話",
     "createGroup": "建立群組",
-    "createNewSpace": "新空間",
     "currentlyActive": "目前活躍",
     "darkTheme": "深色",
     "dateAndTimeOfDay": "{date}，{timeOfDay}",
@@ -92,9 +87,6 @@
     "emoteKeyboardNoRecents": "最近使用的表情符號將顯示在這裡...",
     "emotePacks": "房間表情包",
     "emoteSettings": "表情符號設定",
-    "globalChatId": "全域聊天ID",
-    "accessAndVisibility": "存取權限及可見性",
-    "accessAndVisibilityDescription": "誰可以加入此聊天以及如何發現此聊天。",
     "calls": "通話",
     "customEmojisAndStickers": "自訂表情符號及貼圖",
     "customEmojisAndStickersBody": "新增或分享可在任何聊天中使用的自訂表情符號或貼圖。",
@@ -102,7 +94,6 @@
     "emptyChat": "空聊天",
     "enableEmotesGlobally": "全局啟用表情包",
     "enableEncryption": "啟用加密",
-    "enableEncryptionWarning": "你將無法再禁用加密。你確定嗎？",
     "encrypted": "已加密",
     "encryption": "加密",
     "encryptionNotEnabled": "未啟用加密",
@@ -110,7 +101,6 @@
     "enterAnEmailAddress": "輸入電子郵件地址",
     "homeserver": "主伺服器",
     "errorObtainingLocation": "獲取位置時出錯：{error}",
-    "everythingReady": "一切準備就緒！",
     "extremeOffensive": "極度冒犯",
     "fileName": "檔案名稱",
     "fluffychat": "FluffyChat",
@@ -119,9 +109,7 @@
     "fromJoining": "由加入",
     "fromTheInvitation": "由邀請",
     "group": "群組",
-    "chatDescription": "聊天描述",
     "chatDescriptionHasBeenChanged": "聊天描述已更改",
-    "groupIsPublic": "群組是公開的",
     "groups": "群組",
     "groupWith": "與 {displayname} 的群組",
     "guestsAreForbidden": "禁止訪客",
@@ -143,7 +131,6 @@
     "incorrectPassphraseOrKey": "密碼或恢復金鑰唔啱",
     "inoffensive": "無冒犯",
     "inviteContact": "邀請聯絡人",
-    "inviteContactToGroup": "邀請聯絡人加入{groupName}",
     "noChatDescriptionYet": "尚未建立對話描述。",
     "tryAgain": "再試一次",
     "invalidServerName": "伺服器名稱無效",
@@ -164,7 +151,6 @@
     "leave": "離開",
     "leftTheChat": "已離開聊天",
     "lightTheme": "淺色",
-    "loadCountMoreParticipants": "載入更多參與者 {count}",
     "dehydrate": "導出會話並清除裝置",
     "dehydrateWarning": "此操作無法撤銷。請確保妥善保存備份檔案。",
     "hydrate": "從備份文件恢復",
@@ -173,7 +159,6 @@
     "locationDisabledNotice": "位置服務已被禁用。請啟用以便分享您的位置。",
     "locationPermissionDeniedNotice": "位置權限被拒絕。請授予權限以便分享您的位置。",
     "login": "登入",
-    "logInTo": "登入到 {homeserver}",
     "logout": "登出",
     "mention": "提及",
     "messages": "訊息",
@@ -188,8 +173,6 @@
     "no": "否",
     "noConnectionToTheServer": "未能連接到伺服器",
     "noEmotesFound": "未找到表情符號。😝",
-    "noEncryptionForPublicRooms": "只有在房間不再公開時，才能啟用加密。",
-    "noGoogleServicesWarning": "Firebase 雲端訊息似乎在您的裝置上不可用。為了仍然接收推送通知，我們建議安裝 ntfy。使用 ntfy 或其他統一推送提供者，您可以以安全的數據方式接收推送通知。您可以從 Play 商店或 F-Droid 下載 ntfy。",
     "noMatrixServer": "{server1} 不是矩陣伺服器，請改用 {server2}？",
     "shareInviteLink": "分享邀請連結",
     "scanQrCode": "掃描 QR 碼",
@@ -211,12 +194,10 @@
     "openCamera": "打開相機",
     "openVideoCamera": "打開視頻相機",
     "oneClientLoggedOut": "您的其中一個客戶已登出",
-    "addAccount": "新增帳戶",
     "editBundlesForAccount": "編輯此帳戶的套件",
     "addToBundle": "加入套件",
     "removeFromBundle": "從此套件中移除",
     "bundleName": "套件名稱",
-    "enableMultiAccounts": "(測試版) 在此裝置上啟用多個帳戶",
     "openInMaps": "在地圖中打開",
     "link": "連結",
     "serverRequiresEmail": "此伺服器需要驗證您的電子郵件地址以進行註冊。",
@@ -228,7 +209,6 @@
     "passwordHasBeenChanged": "密碼已更改",
     "overview": "概覽",
     "passwordRecoverySettings": "密碼恢復設置",
-    "passwordRecovery": "密碼恢復",
     "people": "人",
     "pickImage": "選擇圖片",
     "pin": "固定",
@@ -237,7 +217,6 @@
     "pleaseChooseAPasscode": "請選擇一個密碼碼",
     "pleaseClickOnLink": "請點擊電子郵件中的鏈接，然後繼續。",
     "pleaseEnter4Digits": "請輸入4位數字或留空以禁用應用鎖。",
-    "pleaseEnterRecoveryKey": "請輸入您的恢復金鑰：",
     "pleaseEnterYourPassword": "請輸入您的密碼",
     "pleaseEnterYourPin": "請輸入您的密碼",
     "pleaseEnterYourUsername": "請輸入您的用戶名",
@@ -257,7 +236,6 @@
     "rejectedTheInvitation": "{username} 拒絕了邀請",
     "removeAllOtherDevices": "移除所有其他設備",
     "removedBy": "由 {username} 移除",
-    "removeDevice": "移除設備",
     "unbanFromChat": "解除封鎖",
     "removeYourAvatar": "刪除你的頭像",
     "replaceRoomWithNewerVersion": "用較新版本取代房間",
@@ -269,8 +247,6 @@
     "saveFile": "儲存檔案",
     "search": "搜尋",
     "security": "安全",
-    "recoveryKey": "恢復金鑰",
-    "recoveryKeyLost": "遺失恢復金鑰？",
     "send": "傳送",
     "sendAMessage": "傳送訊息",
     "sendAsText": "以文字傳送",
@@ -289,7 +265,6 @@
     "separateChatTypes": "分開直接對話和群組",
     "setAsCanonicalAlias": "設為主要別名",
     "setChatDescription": "設定聊天描述",
-    "setPermissionsLevel": "設定權限等級",
     "setStatus": "設定狀態",
     "settings": "設定",
     "share": "分享",
@@ -299,8 +274,6 @@
     "presencesToggle": "顯示其他用戶嘅狀態訊息",
     "skip": "跳過",
     "sourceCode": "源碼",
-    "spaceIsPublic": "空間係公開嘅",
-    "spaceName": "空間名稱",
     "startedACall": "{senderName} 開始咗一個通話",
     "status": "狀態",
     "statusExampleMessage": "你今日點呀？",
@@ -312,7 +285,6 @@
     "theyMatch": "佢哋啱",
     "title": "FluffyChat",
     "tooManyRequestsWarning": "請求過多。請稍後再試！",
-    "transferFromAnotherDevice": "從另一個設備轉移",
     "tryToSendAgain": "重試發送",
     "unavailable": "暫時無法使用",
     "unbannedUser": "{username} 已解除封禁 {targetName}",
@@ -322,7 +294,6 @@
     "unknownEvent": "未知事件 '{type}'",
     "unmuteChat": "取消靜音聊天",
     "unpin": "取消置頂",
-    "unreadChats": "{unreadCount, plural, =1{1 個未讀聊天} other{{unreadCount} 個未讀聊天}}",
     "userAndOthersAreTyping": "{username} 和 {count} 其他人正在輸入…",
     "userAndUserAreTyping": "{username} 和 {username2} 正在輸入…",
     "userIsTyping": "{username} 正在輸入…",
@@ -335,8 +306,6 @@
     "verifyStart": "開始驗證",
     "verifySuccess": "你已成功驗證！",
     "verifyTitle": "驗證其他帳戶",
-    "videoCall": "視頻通話",
-    "visibilityOfTheChatHistory": "聊天記錄的可見性",
     "visibleForAllParticipants": "所有參與者皆可見",
     "visibleForEveryone": "所有人皆可見",
     "voiceMessage": "語音訊息",
@@ -346,10 +315,7 @@
     "wallpaper": "壁紙：",
     "warning": "警告！",
     "weSentYouAnEmail": "我們已向你發送了一封電子郵件",
-    "whoCanPerformWhichAction": "誰可以執行哪些操作",
-    "whoIsAllowedToJoinThisGroup": "邊個可以加入呢個群組",
     "whyDoYouWantToReportThis": "你點解想舉報呢個？",
-    "wipeChatBackup": "清除你嘅聊天備份以建立一個新嘅恢復密鑰？",
     "withTheseAddressesRecoveryDescription": "用呢啲地址你可以恢復你嘅密碼。",
     "writeAMessage": "寫一條訊息…",
     "yes": "係",
@@ -362,9 +328,7 @@
     "messageType": "訊息類型",
     "sender": "發件人",
     "openGallery": "打開相簿",
-    "removeFromSpace": "從空間移除",
     "start": "開始",
-    "pleaseEnterRecoveryKeyDescription": "要解鎖你嘅舊訊息，請輸入你喺之前會話中生成嘅恢復密鑰。你嘅恢復密鑰唔係你嘅密碼。",
     "publish": "發佈",
     "openChat": "打開聊天",
     "markAsRead": "標記為已讀",
@@ -375,12 +339,9 @@
     "confirmEventUnpin": "你確定要永久取消釘選此事件嗎？",
     "emojis": "表情符號",
     "placeCall": "撥打電話",
-    "voiceCall": "語音通話",
     "unsupportedAndroidVersion": "不支援的 Android 版本",
     "unsupportedAndroidVersionLong": "此功能需要較新版本的 Android。請檢查更新或 Lineage OS 支援情況。",
-    "videoCallsBetaWarning": "請注意，視頻通話目前處於測試階段。它們可能無法按預期工作，或在所有平台上都無法使用。",
     "experimentalVideoCalls": "實驗性視頻通話",
-    "emailOrUsername": "電子郵件或用戶名",
     "addWidget": "加入小工具",
     "widgetVideo": "影片",
     "widgetEtherpad": "文字筆記",
@@ -402,35 +363,19 @@
     "youKickedAndBanned": "🙅 你踢走並封鎖了 {user}",
     "youUnbannedUser": "你已解除對 {user} 的封鎖",
     "hasKnocked": "🚪 {user} 已敲門",
-    "usersMustKnock": "用戶必須敲門",
-    "noOneCanJoin": "沒有人可以加入",
     "knock": "敲門",
     "users": "用戶",
-    "unlockOldMessages": "解鎖舊訊息",
-    "storeInSecureStorageDescription": "將恢復金鑰存放在此裝置的安全存儲中。",
-    "saveKeyManuallyDescription": "通過觸發系統分享對話框或剪貼簿手動保存此金鑰。",
-    "storeInAndroidKeystore": "存放在 Android 金鑰庫",
-    "storeInAppleKeyChain": "存放在 Apple 金鑰鏈",
-    "storeSecurlyOnThisDevice": "在此裝置上安全存放",
     "countFiles": "{count} 個檔案",
     "user": "用戶",
     "custom": "自訂",
-    "foregroundServiceRunning": "當前台服務運行時會顯示此通知。",
-    "screenSharingTitle": "螢幕共享",
-    "screenSharingDetail": "你喺FuffyChat度分享緊你嘅屏幕",
     "whyIsThisMessageEncrypted": "點解呢條訊息係不可讀嘅？",
     "noKeyForThisMessage": "如果你喺呢個裝置登入之前已經發送咗訊息，可能會出現呢個情況。\n\n亦有可能發件人已經封鎖你嘅裝置，或者網絡連接出咗問題。\n\n你喺另一個會話中可以讀到呢條訊息嗎？咁你可以從嗰度轉移訊息！去設定 > 裝置，確保你嘅裝置已經互相驗證。下一次打開房間，兩個會話都喺前景時，密鑰會自動傳送。\n\n你唔想喺登出或切換裝置時失去密鑰？確保你已經喺設定中啟用聊天備份。",
     "newGroup": "新群組",
     "newSpace": "新空間",
-    "enterSpace": "進入空間",
     "allSpaces": "所有空間",
     "hidePresences": "隱藏狀態列表？",
     "doNotShowAgain": "唔再顯示",
     "wasDirectChatDisplayName": "空白聊天（曾經係 {oldDisplayName}）",
-    "newSpaceDescription": "空間讓你整合你嘅聊天，建立私人或公共社區。",
-    "encryptThisChat": "加密此聊天",
-    "disableEncryptionWarning": "出於安全原因，您無法在已啟用加密的聊天中禁用加密。",
-    "sorryThatsNotPossible": "對不起... 這不可能",
     "deviceKeys": "裝置金鑰：",
     "reopenChat": "重新打開聊天",
     "noBackupWarning": "警告！如果不啟用聊天備份，您將失去對加密訊息的存取權。建議在登出前先啟用聊天備份。",
@@ -443,7 +388,6 @@
     "openLinkInBrowser": "在瀏覽器中打開連結",
     "reportErrorDescription": "😞 哎呀。出了點問題。如果願意，您可以向開發者報告此錯誤。",
     "report": "報告",
-    "setTheme": "設定主題：",
     "setColorTheme": "設定色彩主題：",
     "invite": "邀請",
     "inviteGroupChat": "📨 邀請群組聊天",
@@ -462,12 +406,8 @@
     "yourGlobalUserIdIs": "你的全域用戶ID是：",
     "noUsersFoundWithQuery": "很抱歉，未找到符合 \"{query}\" 的用戶。請檢查是否有打錯字。",
     "knocking": "敲門中",
-    "chatCanBeDiscoveredViaSearchOnServer": "聊天可以透過 {server} 的搜尋來發現",
-    "searchChatsRooms": "搜尋 #聊天、@用戶...",
     "nothingFound": "未找到任何內容...",
     "groupName": "群組名稱",
-    "createGroupAndInviteUsers": "建立群組並邀請用戶",
-    "groupCanBeFoundViaSearch": "群組可透過搜尋找到",
     "wrongRecoveryKey": "抱歉... 這似乎不是正確的恢復金鑰。",
     "startConversation": "開始對話",
     "commandHint_sendraw": "傳送原始 JSON",
@@ -481,11 +421,8 @@
     "pleaseChooseAStrongPassword": "請選擇一個強密碼",
     "passwordsDoNotMatch": "密碼不符",
     "passwordIsWrong": "您輸入的密碼錯誤",
-    "publicChatAddresses": "公開聊天地址",
-    "createNewAddress": "建立新地址",
     "joinSpace": "加入空間",
     "publicSpaces": "公共空間",
-    "addChatOrSubSpace": "添加聊天或子空間",
     "subspace": "子空間",
     "decline": "拒絕",
     "thisDevice": "此設備：",
@@ -494,15 +431,11 @@
     "searchMore": "搜索更多...",
     "gallery": "相簿",
     "files": "文件",
-    "sessionLostBody": "您的會話已丟失。請向開發者報告此錯誤，網址為 {url}。錯誤訊息為：{error}",
-    "restoreSessionBody": "應用程式現在嘗試從備份中還原您的會話。請向開發者報告此錯誤，網址為 {url}。錯誤訊息為：{error}",
     "sendReadReceipts": "發送已讀回執",
     "sendTypingNotificationsDescription": "聊天中的其他參與者可以看到你正在輸入新訊息。",
     "sendReadReceiptsDescription": "其他聊天參與者可以看到你何時已讀訊息。",
     "formattedMessages": "格式化訊息",
     "formattedMessagesDescription": "使用 markdown 顯示豐富的訊息內容，例如粗體文字。",
-    "verifyOtherUser": "🔐 驗證其他用戶",
-    "verifyOtherUserDescription": "如果你驗證另一個用戶，你可以確定你真正知道你在寫給誰。 💪\n\n當你開始驗證時，你和另一個用戶會在應用程式中看到一個彈出視窗。然後你會看到一系列的表情符號或數字，你需要彼此比較。\n\n最好的方法是見面或開始視頻通話。 👭",
     "verifyOtherDevice": "🔐 驗證其他裝置",
     "verifyOtherDeviceDescription": "當你驗證另一個裝置時，這些裝置可以交換金鑰，增加你的整體安全性。 💪 當你開始驗證時，兩個裝置上的應用程式都會出現一個彈出視窗。然後你會看到一系列的表情符號或數字，你需要彼此比較。在開始驗證之前，最好準備好兩個裝置。 🤳",
     "acceptedKeyVerification": "{sender} 已接受金鑰驗證",
@@ -538,10 +471,6 @@
     "updateInstalled": "🎉 已安裝更新 {version}！",
     "changelog": "更新日誌",
     "sendCanceled": "發送已取消",
-    "loginWithMatrixId": "用Matrix-ID登入",
-    "discoverHomeservers": "探索家庭伺服器",
-    "whatIsAHomeserver": "什麼是家庭伺服器？",
-    "homeserverDescription": "你的所有資料都存儲在家庭伺服器上，就像電子郵件提供商一樣。你可以選擇使用哪個家庭伺服器，同時仍然可以與所有人通訊。了解更多請訪問 https://matrix.org。",
     "doesNotSeemToBeAValidHomeserver": "似乎不是兼容的家庭伺服器。網址錯誤？",
     "calculatingFileSize": "正在計算檔案大小...",
     "prepareSendingAttachment": "準備傳送附件...",
@@ -553,11 +482,9 @@
     "oneOfYourDevicesIsNotVerified": "你的其中一台裝置未經驗證",
     "noticeChatBackupDeviceVerification": "注意：當你將所有裝置連接到聊天備份時，它們會自動驗證。",
     "continueText": "繼續",
-    "welcomeText": "嘿嘿 👋 這是 FluffyChat。你可以登入任何與 https://matrix.org 兼容的家庭伺服器，然後與任何人聊天。這是一個龐大的去中心化訊息網絡！",
     "blur": "模糊：",
     "opacity": "不透明度：",
     "setWallpaper": "設定壁紙",
-    "manageAccount": "管理帳戶",
     "noContactInformationProvided": "伺服器未提供任何有效的聯絡資料",
     "contactServerAdmin": "聯絡伺服器管理員",
     "contactServerSecurity": "聯絡伺服器安全部門",
@@ -576,11 +503,8 @@
     "unableToJoinChat": "無法加入聊天。可能對方已經結束對話。",
     "previous": "上一個",
     "otherPartyNotLoggedIn": "對方目前未登入，因此無法接收訊息！",
-    "appWantsToUseForLogin": "使用 '{server}' 登入",
-    "appWantsToUseForLoginDescription": "你在此允許應用程式和網站分享你的資訊。",
     "open": "打開",
     "waitingForServer": "等待伺服器...",
-    "appIntroduction": "FluffyChat 讓你可以與不同訊使器的朋友聊天。了解更多請訪問 https://matrix.org 或只需點擊 *繼續*。",
     "newChatRequest": "📩 新的聊天請求",
     "contentNotificationSettings": "內容通知設定",
     "generalNotificationSettings": "一般通知設定",
@@ -657,11 +581,9 @@
     "taTooltip": "用於翻譯協助",
     "interactiveTranslatorSliderHeader": "互動翻譯器",
     "interactiveGrammarSliderHeader": "互動語法檢查器",
-    "interactiveTranslatorRequired": "需要",
     "waTooltip": "無協助使用 L2",
     "interactiveTranslator": "翻譯協助",
     "noIdenticalLanguages": "請選擇不同的基礎語言和目標語言",
-    "searchBy": "按國家和語言搜尋",
     "joinWithClassCode": "加入課程",
     "languageLevelPreA1": "新手低級 (Pre A1)",
     "languageLevelA1": "新手中級 (A1)",
@@ -682,19 +604,14 @@
     "saveChanges": "儲存更改",
     "publicProfileTitle": "允許喺搜尋中搵到我嘅個人資料",
     "publicProfileDesc": "打開呢個功能，其他用戶就可以喺全球搜尋欄搵到你嘅個人資料，並且發送聊天請求。呢個時候，你可以選擇接受或者拒絕請求。",
-    "errorDisableIT": "翻譯協助已關閉。",
-    "errorDisableIGC": "文法協助已關閉。",
     "errorDisableITUserDesc": "點擊此處更新翻譯協助設定",
     "errorDisableIGCUserDesc": "點擊此處更新文法協助設定",
     "errorDisableITClassDesc": "此課程的翻譯協助已關閉。",
     "errorDisableIGCClassDesc": "此課程的文法協助已關閉。",
-    "error405Title": "未設定語言",
     "error405Desc": "請在主選單 > 學習設定中設定您的語言。",
     "termsAndConditions": "條款及細則",
     "andCertifyIAmAtLeast13YearsOfAge": "並證明我已年滿16歲。",
-    "error502504Title": "哇，線上學生很多！",
     "error502504Desc": "在 Pangea 機器人追趕時，翻譯和文法工具可能會較慢或暫時無法使用。",
-    "error404Title": "翻譯錯誤！",
     "error404Desc": "Pangea Bot 唔肯定點樣翻譯嗰個...",
     "errorPleaseRefresh": "我哋正喺研究緊！請重新載入再試一次。",
     "connectedToStaging": "已連接到測試環境",
@@ -732,13 +649,9 @@
     "definitionsToolName": "單詞定義",
     "definitionsToolDescription": "啟用後，藍色底線的單詞可以點擊查看定義。點擊訊息以存取定義。",
     "welcomeBack": "歡迎回來！如果你是2023-2024試點計劃的一部分，請聯繫我們以獲取你的特別試點訂閱。如果你是教師，或者你的機構已為你的班級購買了許可證，請聯繫我們以獲取你的教師訂閱。",
-    "downloadTxtFile": "下載文本文件",
-    "downloadCSVFile": "下載CSV文件",
     "promotionalSubscriptionDesc": "你目前擁有終身促銷訂閱。如需幫助更改訂閱，請聯繫 support@pangea.chat。",
     "originalSubscriptionPlatform": "通過 {purchasePlatform} 購買的訂閱",
     "oneWeekTrial": "一周試用",
-    "downloadXLSXFile": "下載Excel文件",
-    "unkDisplayName": "未知",
     "wwCountryDisplayName": "全球",
     "afCountryDisplayName": "阿富汗",
     "axCountryDisplayName": "奧蘭群島",
@@ -1033,7 +946,6 @@
     "chatCapacityHasBeenChanged": "聊天容量已更改",
     "chatCapacitySetTooLow": "聊天容量至少為 {count}。",
     "chatCapacityExplanation": "聊天容量限制允許加入聊天的成員數量。",
-    "tooManyRequest": "請求過多，請稍後再試。",
     "enterNumber": "請輸入整數值。",
     "practice": "練習",
     "versionNotFound": "找不到版本",
@@ -1043,7 +955,6 @@
     "deleteSubscriptionWarningTitle": "您有一個有效的訂閱",
     "deleteSubscriptionWarningBody": "刪除您的帳戶不會自動取消您的訂閱。",
     "manageSubscription": "管理訂閱",
-    "error520Title": "請再試一次。",
     "error520Desc": "對不起，我們無法理解您的訊息...",
     "wordsUsed": "已用詞彙",
     "level": "等級",
@@ -1061,7 +972,6 @@
     "other": "其他",
     "levelShort": "LVL {level}",
     "noCapacityLimit": "沒有容量限制",
-    "downloadGroupText": "下載群組文字",
     "notificationsOn": "通知已開啟",
     "notificationsOff": "通知已關閉",
     "joinWithCode": "用代碼加入",
@@ -1125,24 +1035,12 @@
     "whatIsTheMorphTag": "'{wordForm}'的{morphologicalFeature}是什麼？",
     "dataAvailable": "資料可用性",
     "available": "可用",
-    "pangeaBotIsFallible": "Pangea 機械人都會犯錯！",
-    "whatIsMeaning": "'{lemma}' 嘅意思係乜？",
     "chooseLemmaMeaningInstructionsBody": "將意思同訊息入面嘅詞配對！",
-    "doubleClickToEdit": "雙擊以編輯。",
-    "topicLabel": "主題",
-    "topicPlaceholder": "揀一個主題...",
-    "modePlaceholder": "揀一個模式...",
-    "learningObjectiveLabel": "學習目標",
-    "learningObjectivePlaceholder": "揀一個學習目標...",
-    "targetLanguageLabel": "目標語言",
     "cefrLevelLabel": "CEFR 級別",
     "image": "圖片",
     "video": "影片",
     "nan": "不適用",
-    "addVocabulary": "添加詞彙",
     "instructions": "指示",
-    "numberOfLearners": "學習者人數",
-    "mustBeInteger": "必須是整數，例如 1、2、3、...",
     "constructUsePvmDesc": "以語音訊息產生",
     "leaveSpaceDescription": "退出課程後，您將離開其中所有的聊天。其他用戶將看到您已離開課程。",
     "constructUseCorMmDesc": "正確的訊息含義",
@@ -1157,7 +1055,6 @@
     "ttsDisabledBody": "您可以在學習設置中啟用文字轉語音",
     "noSpaceDescriptionYet": "尚未創建課程描述。",
     "tooLargeToSend": "此訊息過大，無法傳送",
-    "exitWithoutSaving": "確定要不保存退出嗎？",
     "enableAutocorrectPopupTitle": "通過以下方式添加您的目標語言鍵盤：",
     "enableAutocorrectPopupSteps": "  • 設置\n  • 常規\n  • 鍵盤\n  • 鍵盤\n  • 添加新鍵盤",
     "enableAutocorrectPopupDescription": "選擇語言後，您可以點擊鍵盤左下角的小地球圖標來啟用新安裝的鍵盤。",
@@ -1168,11 +1065,8 @@
     "displayName": "顯示名稱",
     "leaveRoomDescription": "你即將離開此聊天。其他用戶將看到你已離開聊天。",
     "confirmUserId": "請確認你的 Pangea Chat 用戶名以刪除你的帳戶。",
-    "startingToday": "由今日起",
-    "oneWeekFreeTrial": "一星期免費試用",
     "paidSubscriptionStarts": "由 {startDate} 開始",
     "cancelInSubscriptionSettings": "• 可隨時在訂閱設定中取消",
-    "cancelToAvoidCharges": "• 在 {trialEnds} 前取消以避免收費",
     "downloadGboard": "下載 Gboard",
     "autocorrectNotAvailable": "很抱歉，你的平台目前不支援此功能。請留意後續開發！",
     "pleaseUpdateApp": "請更新應用程式以繼續。",
@@ -1182,17 +1076,12 @@
     "knockSpaceSuccess": "你已申請加入此課程！管理員收到申請後會回覆你😊",
     "chooseWordAudioInstructionsBody": "聽完整個訊息。然後將音頻與詞語配對。",
     "chooseMorphsInstructionsBody": "點擊拼圖碎片回答語法問題！",
-    "pleaseEnterInt": "請輸入一個數字",
     "home": "首頁",
     "join": "加入",
     "resetInstructionTooltipsTitle": "重設指引提示",
     "resetInstructionTooltipsDesc": "點擊顯示新用戶嘅指引提示。",
-    "randomize": "隨機",
     "clear": "清除",
-    "featuredActivities": "Featured",
     "save": "Save",
-    "startChat": "Start a chat",
-    "translationProblem": "Translation problem",
     "askToJoin": "請求加入",
     "emptyChatWarningTitle": "對話空空如也",
     "emptyChatWarningDesc": "你未邀請任何人加入對話。請前往對話設定，邀請你的聯絡人或機械人。你亦可以稍後再做。",
@@ -1222,17 +1111,13 @@
     "timesUsedIndependently": "獨立使用次數",
     "timesUsedWithAssistance": "協助下使用次數",
     "shareInviteCode": "分享邀請碼：{code}",
-    "leaderboard": "排行榜",
     "skipForNow": "暫時跳過",
     "permissions": "權限",
     "spaceChildPermission": "誰可以在此課程中新增聊天",
-    "addEnvironmentOverride": "新增環境覆蓋",
     "defaultOption": "預設",
     "deleteChatDesc": "你確定要刪除此聊天嗎？此操作將刪除所有參與者的聊天記錄，且所有訊息將不再供練習或學習分析使用。",
     "deleteSpaceDesc": "此課程及所有選擇的聊天將被刪除，所有訊息將不再供練習或學習分析使用。此操作無法撤銷。",
     "launch": "啟動",
-    "searchChats": "搜尋聊天",
-    "maxFifty": "最多50個",
     "configureSpace": "設定課程",
     "pinMessages": "釘住訊息",
     "setJoinRules": "設定加入規則",
@@ -1266,9 +1151,6 @@
     "failedToFetchTranscription": "獲取轉錄失敗",
     "deleteEmptySpaceDesc": "此課程將被刪除，所有參與者都將失去訪問權限。此操作無法撤銷。",
     "regenerate": "重新生成",
-    "mySavedActivities": "我的已保存活動",
-    "noSavedActivities": "沒有已保存的活動",
-    "saveActivity": "保存此活動",
     "failedToPlayVideo": "播放視頻失敗",
     "done": "完成",
     "inThisSpace": "在此課程中",
@@ -1279,13 +1161,9 @@
     "numInvited": "{count} 已被邀請",
     "saved": "已儲存",
     "reset": "重設",
-    "errorFetchingActivitiesMessage": "獲取活動失敗",
     "errorFetchingDefinition": "獲取定義失敗",
     "errorProcessAnalytics": "處理分析失敗",
     "errorDownloading": "下載失敗",
-    "errorLoadingSpaceChildren": "載入此課程中的聊天失敗",
-    "unexpectedError": "發生未預期的錯誤。",
-    "pleaseReload": "請重新載入並重試。",
     "translationError": "翻譯錯誤",
     "check": "檢查",
     "unableToFindRoom": "找不到該代碼的聊天或課程。請再試一次。",
@@ -1294,19 +1172,14 @@
     "request": "請求",
     "requestAll": "全部請求",
     "confirmMessageUnpin": "你確定要取消釘選此訊息嗎？",
-    "saveAndLaunch": "保存並啟動",
-    "launchToSpace": "發佈到課程",
     "pending": "待處理",
     "inactive": "未啟用",
-    "confirmRole": "確認角色",
     "openRoleLabel": "開放",
     "finishedTheActivity": "🎯 {username} 完成了此活動",
     "activitySummaryError": "活動摘要暫時無法取得",
     "requestSummaries": "請求摘要",
-    "generatingNewActivities": "你係呢個語言配對嘅第一個用戶！請俾我哋一分鐘，我哋正喺準備專屬你嘅活動。",
     "requestAccessTitle": "請求分析訪問？",
     "requestAccessDesc": "你想申請查看參與者分析數據？\n\n如果參與者同意，呢個課程嘅管理員可以睇到佢哋嘅：\n    • 總詞彙量\n    • 總語法概念\n    • 完成嘅活動次數\n    • 使用嘅具體語法概念，正確同錯誤\n\n佢哋唔能睇到：\n    • 課程外嘅聊天訊息\n    • 詞彙清單",
-    "requestAccess": "申請存取 ({count})",
     "analyticsInactiveTitle": "無法向非活躍用戶發出請求",
     "analyticsInactiveDesc": "自從呢個功能推出以來冇登入嘅非活躍用戶，唔會睇到你嘅請求。\n\n佢哋返嚟之後，請求按鈕會出現。你可以喺佢哋嘅名字下面點擊請求按鈕，再次發送請求。",
     "accessRequestedTitle": "分析存取請求",
@@ -1329,8 +1202,6 @@
     "accessDesc": "你可以將課程開放畀全世界！或者，將課程設為私密同安全。",
     "createGroupChatDesc": "活動會議開始同結束，但群組聊天會保持開放，用於日常溝通。",
     "deleteDesc": "只有管理員可以刪除課程。呢個係破壞性操作，會移除所有用戶同刪除課程內所有選擇嘅聊天。請小心操作。",
-    "noCourseFound": "哦，呢個課程需要一個計劃！\n\n課程計劃係一系列主題同對話活動。",
-    "additionalParticipants": "+ {num} 其他人",
     "whatNow": "而家點？",
     "chooseNextActivity": "揀你下一個活動！",
     "letsGo": "我哋出發啦",
@@ -1342,13 +1213,11 @@
     "waitNotDone": "等我仲未做完！",
     "waitingForOthersToFinish": "等其他人完成...",
     "generatingSummary": "分析聊天並生成結果",
-    "findCourse": "尋找課程",
     "pingParticipantsNotification": "{user} 正在尋找用戶加入 {room} 的活動會話",
     "course": "課程",
     "courses": "課程",
     "goToCourse": "前往課程：{course}",
     "activityComplete": "此活動已完成。活動摘要應在下方提供。",
-    "startNewSession": "開始新會話",
     "joinOpenSession": "加入公開會話",
     "activityNotFound": "未找到活動",
     "myActivities": "我嘅活動",
@@ -1392,7 +1261,6 @@
     "inviteYourFriends": "邀請你嘅朋友",
     "playWithAI": "而家同AI玩玩",
     "courseStartDesc": "Pangea Bot隨時準備出發！\n\n...但有朋友一齊學習會更好！",
-    "activityDropdownDesc": "完成呢個活動後，點擊下面",
     "languageMismatchTitle": "語言不符",
     "languageMismatchDesc": "你嘅目標語言同呢個活動嘅語言唔一致。想更新你嘅目標語言嗎？",
     "reportWordIssueTooltip": "報告詞語資訊問題",
@@ -1549,15 +1417,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@yourChatBackupHasBeenSetUp": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@chatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@chatBackupDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -1693,10 +1553,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@contactHasBeenInvitedToTheGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@contentHasBeenReported": {
         "type": "String",
         "placeholders": {}
@@ -1733,14 +1589,6 @@
             }
         }
     },
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@create": {
         "type": "String",
         "placeholders": {}
@@ -1754,10 +1602,6 @@
         }
     },
     "@createGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -1868,18 +1712,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@globalChatId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibility": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@accessAndVisibilityDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@calls": {
         "type": "String",
         "placeholders": {}
@@ -1905,10 +1737,6 @@
         "placeholders": {}
     },
     "@enableEncryption": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableEncryptionWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1948,10 +1776,6 @@
             }
         }
     },
-    "@everythingReady": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@extremeOffensive": {
         "type": "String",
         "placeholders": {}
@@ -1984,15 +1808,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@chatDescriptionHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -2090,14 +1906,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "@noChatDescriptionYet": {
         "type": "String",
@@ -2215,14 +2023,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@dehydrate": {
         "type": "String",
         "placeholders": {}
@@ -2254,14 +2054,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "@logout": {
         "type": "String",
@@ -2316,14 +2108,6 @@
         "placeholders": {}
     },
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -2422,10 +2206,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addAccount": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@editBundlesForAccount": {
         "type": "String",
         "placeholders": {}
@@ -2439,10 +2219,6 @@
         "placeholders": {}
     },
     "@bundleName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enableMultiAccounts": {
         "type": "String",
         "placeholders": {}
     },
@@ -2490,10 +2266,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@passwordRecovery": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@people": {
         "type": "String",
         "placeholders": {}
@@ -2527,10 +2299,6 @@
         "placeholders": {}
     },
     "@pleaseEnter4Digits": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKey": {
         "type": "String",
         "placeholders": {}
     },
@@ -2633,10 +2401,6 @@
             }
         }
     },
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unbanFromChat": {
         "type": "String",
         "placeholders": {}
@@ -2678,14 +2442,6 @@
         "placeholders": {}
     },
     "@security": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKey": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@recoveryKeyLost": {
         "type": "String",
         "placeholders": {}
     },
@@ -2789,10 +2545,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@setStatus": {
         "type": "String",
         "placeholders": {}
@@ -2830,14 +2582,6 @@
         "placeholders": {}
     },
     "@sourceCode": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spaceName": {
         "type": "String",
         "placeholders": {}
     },
@@ -2893,10 +2637,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@tryToSendAgain": {
         "type": "String",
         "placeholders": {}
@@ -2943,14 +2683,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "@userAndOthersAreTyping": {
         "type": "String",
@@ -3029,14 +2761,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@visibleForAllParticipants": {
         "type": "String",
         "placeholders": {}
@@ -3073,19 +2797,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -3137,15 +2849,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@removeFromSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@start": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseEnterRecoveryKeyDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3196,10 +2900,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@voiceCall": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@unsupportedAndroidVersion": {
         "type": "String",
         "placeholders": {}
@@ -3208,15 +2908,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@videoCallsBetaWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@experimentalVideoCalls": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@emailOrUsername": {
         "type": "String",
         "placeholders": {}
     },
@@ -3340,43 +3032,11 @@
             }
         }
     },
-    "@usersMustKnock": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noOneCanJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@knock": {
         "type": "String",
         "placeholders": {}
     },
     "@users": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unlockOldMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInSecureStorageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveKeyManuallyDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAndroidKeystore": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeInAppleKeyChain": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@storeSecurlyOnThisDevice": {
         "type": "String",
         "placeholders": {}
     },
@@ -3396,18 +3056,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@foregroundServiceRunning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@screenSharingDetail": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@whyIsThisMessageEncrypted": {
         "type": "String",
         "placeholders": {}
@@ -3421,10 +3069,6 @@
         "placeholders": {}
     },
     "@newSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@enterSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3447,22 +3091,6 @@
                 "type": "String"
             }
         }
-    },
-    "@newSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@encryptThisChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@disableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@sorryThatsNotPossible": {
-        "type": "String",
-        "placeholders": {}
     },
     "@deviceKeys": {
         "type": "String",
@@ -3517,10 +3145,6 @@
         "placeholders": {}
     },
     "@report": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setTheme": {
         "type": "String",
         "placeholders": {}
     },
@@ -3604,31 +3228,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@searchChatsRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@nothingFound": {
         "type": "String",
         "placeholders": {}
     },
     "@groupName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createGroupAndInviteUsers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@groupCanBeFoundViaSearch": {
         "type": "String",
         "placeholders": {}
     },
@@ -3684,23 +3288,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@publicChatAddresses": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@createNewAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@joinSpace": {
         "type": "String",
         "placeholders": {}
     },
     "@publicSpaces": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addChatOrSubSpace": {
         "type": "String",
         "placeholders": {}
     },
@@ -3740,28 +3332,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "@sendReadReceipts": {
         "type": "String",
         "placeholders": {}
@@ -3779,14 +3349,6 @@
         "placeholders": {}
     },
     "@formattedMessagesDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUser": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@verifyOtherUserDescription": {
         "type": "String",
         "placeholders": {}
     },
@@ -3979,22 +3541,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@loginWithMatrixId": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@discoverHomeservers": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsAHomeserver": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@homeserverDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@doesNotSeemToBeAValidHomeserver": {
         "type": "String",
         "placeholders": {}
@@ -4050,10 +3596,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@welcomeText": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@blur": {
         "type": "String",
         "placeholders": {}
@@ -4063,10 +3605,6 @@
         "placeholders": {}
     },
     "@setWallpaper": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@manageAccount": {
         "type": "String",
         "placeholders": {}
     },
@@ -4142,27 +3680,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
-    "@appWantsToUseForLoginDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@open": {
         "type": "String",
         "placeholders": {}
     },
     "@waitingForServer": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@appIntroduction": {
         "type": "String",
         "placeholders": {}
     },
@@ -4488,10 +4010,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -4501,10 +4019,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4592,14 +4106,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4616,10 +4122,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4632,15 +4134,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4792,14 +4286,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4813,14 +4299,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -6043,10 +5521,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -6087,10 +5561,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -6163,10 +5633,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -6436,47 +5902,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -6496,19 +5922,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6572,10 +5986,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6616,14 +6026,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6635,14 +6037,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6680,10 +6074,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6700,27 +6090,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6844,10 +6218,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6857,10 +6227,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6877,14 +6243,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -7024,18 +6382,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -7084,10 +6430,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -7097,18 +6439,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -7151,23 +6481,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -7191,10 +6509,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -7202,14 +6516,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -7314,18 +6620,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -7374,10 +6668,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -7404,10 +6694,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7591,10 +6877,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@activityDropdownDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@languageMismatchTitle": {
         "type": "String",
         "placeholders": {}
@@ -7677,7 +6959,6 @@
     "appLock": "應用程式鎖定",
     "appLockDescription": "用密碼鎖定應用程式，唔使用時",
     "archive": "存檔",
-    "areGuestsAllowedToJoin": "客人用戶可以加入嗎",
     "areYouSure": "你確定嗎？",
     "areYouSureYouWantToLogout": "你確定要登出嗎？",
     "askSSSSSign": "為了能夠簽署對方，請輸入你的安全存儲密碼或恢復密鑰。",
@@ -7887,10 +7168,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@areYouSure": {
         "type": "String",
         "placeholders": {}
@@ -8025,17 +7302,11 @@
         }
     },
     "startOwn": "開始自己嘅",
-    "joinCourseDesc": "每個課程有8-10個有序嘅主題，配合一系列基於任務嘅語言學習活動。",
     "newMessageInPangeaChat": "📩 Pangea 聊天有新訊息",
     "shareCourse": "分享課程",
     "addCourse": "加入課程",
-    "joinPublicCourse": "加入公開課程",
     "vocabLevelsDesc": "呢度會放你升級後嘅詞彙！",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -8048,10 +7319,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -8070,7 +7337,6 @@
     "emojiView": "表情符號視圖",
     "feedbackDialogDesc": "我也會犯錯！有什麼可以幫助我改進的嗎？",
     "contactHasBeenInvitedToTheCourse": "聯絡人已被邀請參加課程",
-    "activityStatsButtonTooltip": "活動資訊",
     "allow": "允許",
     "deny": "拒絕",
     "enabledRenewal": "啟用訂閱續訂",
@@ -8338,10 +7604,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -9397,16 +8659,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "解鎖下一主題的活動",
-    "activitiesToUnlockTopicDesc": "設置解鎖下一課程主題所需的活動數量",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "正確的詞彙定義練習",
     "constructUseIncLMDesc": "不正確的詞彙定義練習",
     "constructUseCorLADesc": "正確的詞彙音頻練習",
@@ -9414,7 +8666,6 @@
     "constructUseBonus": "詞彙練習期間的獎勵",
     "practiceVocab": "練習詞彙",
     "selectMeaning": "選擇意思",
-    "selectAudio": "選擇匹配的音頻",
     "anotherRound": "再來一輪",
     "activitySettingsOverrideWarning": "活動計劃決定的語言和語言水平",
     "voice": "聲音",
@@ -9446,10 +8697,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -9467,12 +8714,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "下載已啟動",
     "webDownloadPermissionMessage": "如果你的瀏覽器阻止下載，請為此網站啟用下載。",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -9567,11 +8809,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "發生了一些問題，我們正在努力修復。稍後再檢查。",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "啟用寫作輔助",
     "autoIGCToolDescription": "自動運行 Pangea Chat 工具以將發送的消息更正為目標語言。",
     "@autoIGCToolName": {
@@ -9627,24 +8864,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "文法",
-    "spanTypeWordChoice": "用詞選擇",
     "spanTypeSpelling": "拼寫",
     "spanTypePunctuation": "標點符號",
     "spanTypeStyle": "風格",
     "spanTypeFluency": "流暢度",
     "spanTypeAccents": "口音",
     "spanTypeCapitalization": "大寫",
-    "spanTypeCorrection": "更正",
     "spanFeedbackTitle": "報告更正問題",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -9669,10 +8895,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -9685,13 +8907,7 @@
     "longPressToRecordVoiceMessage": "長按以錄製語音消息。",
     "pause": "暫停",
     "resume": "繼續",
-    "newSubSpace": "新子空間",
-    "moveToDifferentSpace": "移動到不同的空間",
-    "removeFromSpaceDescription": "聊天將從空間中移除，但仍會出現在你的聊天列表中。",
     "countChats": "{chats} 個聊天",
-    "spaceMemberOf": "{spaces} 的空間成員",
-    "spaceMemberOfCanKnock": "{spaces} 的空間成員可以敲門",
-    "donate": "捐贈",
     "startedAPoll": "{username} 開始了一個投票。",
     "poll": "投票",
     "startPoll": "開始投票",
@@ -9715,23 +8931,15 @@
     "newStickerPack": "新貼紙包",
     "stickerPackName": "貼紙包名稱",
     "attribution": "歸因",
-    "skipChatBackup": "跳過聊天備份",
-    "skipChatBackupWarning": "你確定嗎？如果不啟用聊天備份，當你更換設備時可能會失去訪問你的消息的權限。",
-    "loadingMessages": "加載消息中",
-    "setupChatBackup": "設置聊天備份",
     "noMoreResultsFound": "沒有更多結果",
     "chatSearchedUntil": "聊天搜索至 {time}",
     "federationBaseUrl": "聯邦基本 URL",
     "clientWellKnownInformation": "客戶端已知信息：",
     "baseUrl": "基本 URL",
     "identityServer": "身份伺服器：",
-    "versionWithNumber": "版本：{version}",
     "logs": "日誌",
-    "advancedConfigs": "高級配置",
     "advancedConfigurations": "高級配置",
-    "signInWithLabel": "使用以下方式登入：",
     "selectAllWords": "選擇你在音頻中聽到的所有單詞",
-    "joinCourseForActivities": "加入課程以嘗試活動。",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -9768,18 +8976,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -9787,26 +8983,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -9912,22 +9088,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -9956,19 +9116,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -9976,15 +9124,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -10190,11 +9330,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "在課堂上？把你的加入代碼放在這裡。",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "自動突出顯示音頻消息",
     "selectAudioMessagesOnPlayDescription": "播放時自動突出顯示音頻消息",
     "@selectAudioMessagesOnPlayToolName": {
@@ -10238,18 +9373,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "這個課程有主題的活動少於 {input} 個。請輸入一個小於或等於 {minValue} 的數字。",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "點擊這裡重新登入。",
     "@clickToLogin": {
@@ -10666,17 +9789,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "一隻卡通風格的黃色熊，興奮地舉起雙臂。",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "選擇單詞以了解更多信息",
     "requireAnalyticsAccessTitle": "需要分析訪問才能加入",
     "requireAnalyticsAccessDesc": "參與者必須授予訪問其學習分析的權限才能加入此課程",
     "analyticsAccessNoticeTitle": "需要分析訪問",
     "analyticsAccessNoticeDesc": "通過加入此課程，您同意授予管理員訪問您的學習分析的權限。",
-    "skipOnboardingClassCodeDesc": "獨立學習？別擔心，您可以：",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -10694,10 +9811,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -10726,7 +9839,6 @@
     "pickCefrLevelTeacherStepTitle": "你教什麼級別？",
     "pickCefrLevelStudentStepTitle": "你是什麼級別？",
     "customCourseStepTitle": "填寫此表格以獲取自定義課程",
-    "aboutYourClass": "關於你的課程",
     "courseCodeStepErrorMessage": "請檢查你的代碼並重試",
     "institution": "機構",
     "courseGoals": "課程目標",
@@ -10769,10 +9881,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -10889,12 +9997,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat 標誌",
     "introChatDetails": "打個招呼！向你的課程參與者介紹自己，尋找朋友，並在活動之外聊天。",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -10938,11 +10041,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "活動行動",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "發音工具",
     "audioTranscription": "AI 音頻轉錄",
     "visualLearnerSupport": "視覺學習者支持",
@@ -10983,7 +10081,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "加入一個包含此活動的課程以進行遊玩。",
     "resizeCoursePanel": "調整課程面板大小",
     "undo": "撤銷",
     "unlock": "解鎖",
@@ -10997,7 +10094,6 @@
     "addCourseBrowsePublic": "瀏覽公共課程",
     "browsePublicCourses": "瀏覽公共課程",
     "editProfile": "編輯個人資料",
-    "numObjectives": "{count} 個目標",
     "mapSearchHint": "搜索活動",
     "mapSearchNoResults": "視圖中沒有匹配項",
     "mapFilterAllLanguages": "所有語言",
@@ -11006,7 +10102,6 @@
     "mapFilterCompleted": "完成",
     "mapFilterReset": "重置",
     "activityTypeConversation": "對話",
-    "lockedMissionRequirement": "完成前一個任務以解鎖",
     "playAgain": "再玩一次",
     "reviewActivity": "檢視",
     "mapEmptyInView": "在你的級別或語言中沒有任何東西。擴大你的篩選或縮小視圖。",
@@ -11021,14 +10116,9 @@
     "scrollToBottom": "滾動到底部",
     "courseImage": "課程圖片",
     "avatarPreview": "頭像預覽",
-    "activityPhoto": "活動照片",
     "emotePreview": "表情預覽: {name}",
     "activityLabel": "活動: {title}",
     "resetMapView": "重置地圖視圖",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -11081,14 +10171,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -11118,10 +10200,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -11178,10 +10256,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -78,11 +78,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "是否允许访客加入",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "你确定吗？",
     "@areYouSure": {
         "type": "String",
@@ -345,11 +340,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "你的消息受恢复密钥保护。请确保你不会丢失它。",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "聊天详情",
     "@chatDetails": {
         "type": "String",
@@ -478,11 +468,6 @@
     },
     "connect": "连接",
     "@connect": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "联系人已被邀请至群组",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -680,11 +665,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "你之后将无法停用加密，确定吗？",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "已加密",
     "@encrypted": {
         "type": "String",
@@ -711,11 +691,6 @@
     },
     "enterAnEmailAddress": "输入一个电子邮件地址",
     "@enterAnEmailAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "一切就绪！",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -756,11 +731,6 @@
     },
     "group": "群组",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "群组是公开的",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -854,15 +824,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "邀请联系人到 {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "已邀请",
     "@invited": {
@@ -975,15 +936,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "加载 {count} 个更多的参与者",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "加载中…请等待。",
     "@loadingPleaseWait": {
         "type": "String",
@@ -998,15 +950,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "登录 {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "退出登录",
     "@logout": {
@@ -1070,16 +1013,6 @@
     },
     "noEmotesFound": "未找到表情。😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "你只能在聊天室不可被公众访问时才能启用加密。",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "看起来你手机上没有 Firebase Cloud Messaging。如果仍希望接收 FluffyChat 的推送通知，推荐安装 ntfy。借助 ntfy 或另一个 Unified Push 程序，你可以以一种数据安全的方式接收推送通知。你可以从 PlayStore 或 F-Droid 商店下载 ntfy。",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1189,11 +1122,6 @@
     },
     "passwordHasBeenChanged": "密码已被更改",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "密码恢复",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1337,11 +1265,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "移除设备",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "从聊天中解封",
     "@unbanFromChat": {
@@ -1496,11 +1419,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "setPermissionsLevel": "设置权限级别",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "设置状态",
     "@setStatus": {
         "type": "String",
@@ -1595,11 +1513,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "从其它设备传输",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "尝试重新发送",
     "@tryToSendAgain": {
         "type": "String",
@@ -1655,15 +1568,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1{1 个未读聊天} other{{unreadCount} 个未读聊天}}",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} 和其他 {count} 人正在输入…",
     "@userAndOthersAreTyping": {
@@ -1749,16 +1653,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "视频通话",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "聊天记录的可见性",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "对所有参与者可见",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1804,23 +1698,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "谁可以执行哪些操作",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "谁可以加入此群组",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "你举报的理由是什么？",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "确定要清除你的聊天记录备份以创建新的恢复密钥吗？",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1902,11 +1781,6 @@
             }
         }
     },
-    "createNewSpace": "创建新空间",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "cantOpenUri": "无法打开 URI {uri}",
     "@cantOpenUri": {
         "type": "String",
@@ -1921,16 +1795,6 @@
         "type": "String",
         "placeholder": {}
     },
-    "spaceName": "空间名称",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "spaceIsPublic": "空间是公开的",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "shareLocation": "分享位置",
     "@shareLocation": {
         "type": "String",
@@ -1943,8 +1807,6 @@
     },
     "sendOnEnter": "按 Enter 键发送",
     "@sendOnEnter": {},
-    "yourChatBackupHasBeenSetUp": "你的聊天记录备份已设置。",
-    "@yourChatBackupHasBeenSetUp": {},
     "scanQrCode": "扫描二维码",
     "@scanQrCode": {},
     "homeserver": "服务器",
@@ -1957,12 +1819,8 @@
     "@unverified": {},
     "repeatPassword": "重复输入密码",
     "@repeatPassword": {},
-    "addAccount": "添加账户",
-    "@addAccount": {},
     "editBundlesForAccount": "编辑此账户的集合",
     "@editBundlesForAccount": {},
-    "enableMultiAccounts": "（测试功能）在此设备上添加多个账户",
-    "@enableMultiAccounts": {},
     "addToBundle": "添加到集合",
     "@addToBundle": {},
     "bundleName": "集合名称",
@@ -1981,8 +1839,6 @@
     "@messageInfo": {},
     "time": "时间",
     "@time": {},
-    "removeFromSpace": "从此空间中移除",
-    "@removeFromSpace": {},
     "start": "开始",
     "@start": {},
     "commandHint_discardsession": "丢弃会话",
@@ -2042,16 +1898,10 @@
     "@unsupportedAndroidVersionLong": {},
     "unsupportedAndroidVersion": "不受支持的 Android 版本",
     "@unsupportedAndroidVersion": {},
-    "voiceCall": "语音通话",
-    "@voiceCall": {},
     "placeCall": "发起通话",
     "@placeCall": {},
-    "videoCallsBetaWarning": "请注意，视频通话目前处于测试阶段。它们可能不能像预期的那样工作，或者在所有平台上都不能工作。",
-    "@videoCallsBetaWarning": {},
     "experimentalVideoCalls": "实验性的视频通话",
     "@experimentalVideoCalls": {},
-    "emailOrUsername": "电子邮箱或用户名",
-    "@emailOrUsername": {},
     "widgetVideo": "视频",
     "@widgetVideo": {},
     "widgetJitsi": "Jitsi Meet",
@@ -2137,26 +1987,6 @@
             }
         }
     },
-    "storeInSecureStorageDescription": "将恢复密钥存储在此设备的安全存储中。",
-    "@storeInSecureStorageDescription": {},
-    "storeInAppleKeyChain": "存储在 Apple KeyChain 中",
-    "@storeInAppleKeyChain": {},
-    "unlockOldMessages": "解锁旧消息",
-    "@unlockOldMessages": {},
-    "pleaseEnterRecoveryKey": "请输入你的恢复密钥：",
-    "@pleaseEnterRecoveryKey": {},
-    "recoveryKey": "恢复密钥",
-    "@recoveryKey": {},
-    "recoveryKeyLost": "丢失了恢复密钥？",
-    "@recoveryKeyLost": {},
-    "pleaseEnterRecoveryKeyDescription": "要解锁你的旧邮件，请输入你在之前会话中生成的恢复密钥。 你的恢复密钥不是你的密码。",
-    "@pleaseEnterRecoveryKeyDescription": {},
-    "saveKeyManuallyDescription": "通过触发系统共享对话框或剪贴板手动保存此密钥。",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "存储在 Android KeyStore 中",
-    "@storeInAndroidKeystore": {},
-    "storeSecurlyOnThisDevice": "安全地存储在此设备上",
-    "@storeSecurlyOnThisDevice": {},
     "users": "用户",
     "@users": {},
     "countFiles": "{count} 个文件",
@@ -2200,16 +2030,8 @@
     "@newGroup": {},
     "newSpace": "新的空间",
     "@newSpace": {},
-    "enterSpace": "进入空间",
-    "@enterSpace": {},
     "allSpaces": "所有空间",
     "@allSpaces": {},
-    "foregroundServiceRunning": "此通知在前台服务运行时出现。",
-    "@foregroundServiceRunning": {},
-    "screenSharingTitle": "屏幕共享",
-    "@screenSharingTitle": {},
-    "screenSharingDetail": "你正在 FluffyChat 中共享屏幕",
-    "@screenSharingDetail": {},
     "doNotShowAgain": "不再显示",
     "@doNotShowAgain": {},
     "googlyEyesContent": "{senderName} 向你发送了“大眼”表情",
@@ -2254,14 +2076,6 @@
             }
         }
     },
-    "newSpaceDescription": "空间让你可以整合聊天并建立私人或公共社区。",
-    "@newSpaceDescription": {},
-    "encryptThisChat": "加密此聊天",
-    "@encryptThisChat": {},
-    "disableEncryptionWarning": "出于安全考虑 ，你不能在之前已启用加密的聊天中禁用加密。",
-    "@disableEncryptionWarning": {},
-    "sorryThatsNotPossible": "非常抱歉……这是做不到的",
-    "@sorryThatsNotPossible": {},
     "deviceKeys": "设备密钥：",
     "@deviceKeys": {},
     "report": "报错",
@@ -2315,8 +2129,6 @@
     "@tryAgain": {},
     "chatPermissions": "聊天权限",
     "@chatPermissions": {},
-    "chatDescription": "聊天描述",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "聊天描述已被更改",
     "@chatDescriptionHasBeenChanged": {},
     "noChatDescriptionYet": "尚未创建聊天描述。",
@@ -2329,8 +2141,6 @@
     "@optionalRedactReason": {},
     "setChatDescription": "设置聊天描述",
     "@setChatDescription": {},
-    "setTheme": "设置主题：",
-    "@setTheme": {},
     "setColorTheme": "设置主题颜色：",
     "@setColorTheme": {},
     "invite": "邀请",
@@ -2408,14 +2218,10 @@
     "@kickUserDescription": {},
     "blockListDescription": "你可以屏蔽打扰你的用户。你将不会收到来自屏蔽列表中用户的任何消息或聊天室邀请。",
     "@blockListDescription": {},
-    "createGroupAndInviteUsers": "创建群组并邀请用户",
-    "@createGroupAndInviteUsers": {},
     "startConversation": "开始对话",
     "@startConversation": {},
     "blockedUsers": "已屏蔽的用户",
     "@blockedUsers": {},
-    "groupCanBeFoundViaSearch": "可通过搜索找到该群组",
-    "@groupCanBeFoundViaSearch": {},
     "noUsersFoundWithQuery": "很遗憾，没有找到有关\"{query}\"的用户。请检查是否输入错误。",
     "@noUsersFoundWithQuery": {
         "type": "String",
@@ -2439,8 +2245,6 @@
     "@groupName": {},
     "databaseMigrationTitle": "数据库已优化",
     "@databaseMigrationTitle": {},
-    "searchChatsRooms": "搜索 #聊天，@用户…",
-    "@searchChatsRooms": {},
     "databaseMigrationBody": "请稍候。可能需要稍等片刻。",
     "@databaseMigrationBody": {},
     "thisDevice": "此设备：",
@@ -2465,8 +2269,6 @@
     "@select": {},
     "pleaseChooseAStrongPassword": "请选择一个强密码",
     "@pleaseChooseAStrongPassword": {},
-    "addChatOrSubSpace": "添加聊天或子空间",
-    "@addChatOrSubSpace": {},
     "leaveEmptyToClearStatus": "留空以清除你的状态。",
     "@leaveEmptyToClearStatus": {},
     "joinSpace": "加入空间",
@@ -2475,36 +2277,10 @@
     "@searchForUsers": {},
     "initAppError": "在初始化应用时发生错误",
     "@initAppError": {},
-    "sessionLostBody": "你的会话已丢失。请将此错误报告给开发者，网址为 {url}。错误消息为：{error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
-    "restoreSessionBody": "应用现在尝试从备份中恢复你的会话。请将此错误报告给开发者，网址为 {url}。错误消息为：{error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "sendTypingNotificationsDescription": "聊天中的其他参与者可以看到你正在输入新消息。",
     "@sendTypingNotificationsDescription": {},
     "formattedMessagesDescription": "使用 Markdown 显示富文本内容，例如加粗文本。",
     "@formattedMessagesDescription": {},
-    "verifyOtherUserDescription": "如果你验证了其他用户，就可以确保你清楚自己正在与谁进行通信。💪\n\n当你开始验证时，你和其他用户将在应用中看到一个弹出窗口。然后你会看到一系列表情符号或数字，你和其他用户需要比较它们是否一致。\n\n最好的方式是线下会面或开始视频通话。👭",
-    "@verifyOtherUserDescription": {},
     "verifyOtherDeviceDescription": "当你验证另一个设备时，这些设备可以交换密钥，从而提高整体安全性。 💪 当你开始验证时，两个设备上的应用都将显示一个弹出窗口。然后你会看到一系列表情符号或数字，你需要比较两个设备上显示的内容。在开始验证之前，最好将两个设备都放在手边。🤳",
     "@verifyOtherDeviceDescription": {},
     "canceledKeyVerification": "{sender} 取消了密钥验证",
@@ -2522,8 +2298,6 @@
     "@formattedMessages": {},
     "verifyOtherDevice": "🔐 验证其它设备",
     "@verifyOtherDevice": {},
-    "verifyOtherUser": "🔐 验证其他用户",
-    "@verifyOtherUser": {},
     "sendReadReceiptsDescription": "聊天中的其他参与者可以看到你是否读过消息。",
     "@sendReadReceiptsDescription": {},
     "acceptedKeyVerification": "{sender} 接受了密钥验证",
@@ -2604,12 +2378,6 @@
     },
     "appLockDescription": "用 pin 码在不用 FluffyChat 时锁定它",
     "@appLockDescription": {},
-    "globalChatId": "全局聊天 ID",
-    "@globalChatId": {},
-    "accessAndVisibility": "访问和可见性",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "谁可以加入此聊天以及怎样发现该聊天。",
-    "@accessAndVisibilityDescription": {},
     "calls": "通话",
     "@calls": {},
     "customEmojisAndStickers": "自定义表情符号和贴纸",
@@ -2622,19 +2390,8 @@
     "@passwordRecoverySettings": {},
     "knock": "请求",
     "@knock": {},
-    "noOneCanJoin": "无人可以加入",
-    "@noOneCanJoin": {},
     "knocking": "正在请求",
     "@knocking": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "可通过搜索 {server} 发现聊天",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "thereAreCountUsersBlocked": "目前有 {count} 名用户被封禁。",
     "@thereAreCountUsersBlocked": {
         "type": "String",
@@ -2646,14 +2403,8 @@
     "@hideInvalidOrUnknownMessageFormats": {},
     "customEmojisAndStickersBody": "添加或分享可用于任何聊天的表情符号或贴纸。",
     "@customEmojisAndStickersBody": {},
-    "usersMustKnock": "用户必须请求加入",
-    "@usersMustKnock": {},
     "noDatabaseEncryption": "数据库加密在此平台上不受支持",
     "@noDatabaseEncryption": {},
-    "publicChatAddresses": "公开聊天的地址",
-    "@publicChatAddresses": {},
-    "createNewAddress": "新建地址",
-    "@createNewAddress": {},
     "searchMore": "搜索更多…",
     "@searchMore": {},
     "gallery": "图库",
@@ -2762,14 +2513,6 @@
     "@sendCanceled": {},
     "noChatsFoundHere": "此处尚未找到聊天。使用下方按钮 ⤵️ 开始和某人的新聊天",
     "@noChatsFoundHere": {},
-    "loginWithMatrixId": "使用 Matrix-ID 登录",
-    "@loginWithMatrixId": {},
-    "discoverHomeservers": "发现主服务器",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "什么是主服务器？",
-    "@whatIsAHomeserver": {},
-    "homeserverDescription": "主服务器上就像电子邮件提供商，你的所有数据都存储在上面。你可以选择你想使用哪个主服务器。在 https://matrix.org 上了解更多信息。",
-    "@homeserverDescription": {},
     "doesNotSeemToBeAValidHomeserver": "似乎不是兼容的主服务器。URL 不正确？",
     "@doesNotSeemToBeAValidHomeserver": {},
     "prepareSendingAttachment": "准备发送附件…",
@@ -2807,8 +2550,6 @@
     "@oneOfYourDevicesIsNotVerified": {},
     "noticeChatBackupDeviceVerification": "注意：当你连接所有设备到聊天备份时，这些设备将被自动验证。",
     "@noticeChatBackupDeviceVerification": {},
-    "welcomeText": "你好呀 👋 欢迎来到 FluffyChat。你可以登录任意兼容 https://matrix.org 的 homeserver，然后和任何人聊天。这是个巨大的去中心化消息网络！",
-    "@welcomeText": {},
     "continueText": "继续",
     "@continueText": {},
     "blur": "模糊：",
@@ -2817,8 +2558,6 @@
     "@opacity": {},
     "setWallpaper": "设置壁纸",
     "@setWallpaper": {},
-    "manageAccount": "管理账户",
-    "@manageAccount": {},
     "aboutHomeserver": "关于 {homeserver}",
     "@aboutHomeserver": {
         "type": "String",
@@ -2873,19 +2612,8 @@
     "@previous": {},
     "otherPartyNotLoggedIn": "另一方当前未登录，因而无法接收消息！",
     "@otherPartyNotLoggedIn": {},
-    "appWantsToUseForLoginDescription": "您特此允许本应用和网站分享关于您的信息。",
-    "@appWantsToUseForLoginDescription": {},
     "open": "打开",
     "@open": {},
-    "appWantsToUseForLogin": "使用 '{server}'服务器登录",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "waitingForServer": "正在等待服务器…",
     "@waitingForServer": {},
     "synchronizingPleaseWaitCounter": " 同步中… ({percentage}%)",
@@ -2897,8 +2625,6 @@
             }
         }
     },
-    "appIntroduction": "FluffyChat 让使用不同即时通信工具的你和你的好友得以聊天。 访问 https://matrix.org 了解详情或轻按 *继续*。",
-    "@appIntroduction": {},
     "newChatRequest": "📩 新的聊天请求",
     "@newChatRequest": {},
     "generalNotificationSettings": "常规通知设置",
@@ -3042,15 +2768,6 @@
     "@youHaveKnocked": {},
     "pleaseWaitUntilInvited": "在来自该聊天室的某人邀请你之前请等待。",
     "@pleaseWaitUntilInvited": {},
-    "countInvited": "邀请了 {count}",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "checkList": "清单",
     "@checkList": {},
     "sentVoiceMessage": "🎙️ {duration} - 来自 {sender} 的语音消息",
@@ -3085,12 +2802,6 @@
     "@pause": {},
     "resume": "继续",
     "@resume": {},
-    "newSubSpace": "新建子空间",
-    "@newSubSpace": {},
-    "moveToDifferentSpace": "移动到别的空间",
-    "@moveToDifferentSpace": {},
-    "removeFromSpaceDescription": "将从空间移除该聊天，但仍出现在聊天列表中。",
-    "@removeFromSpaceDescription": {},
     "countChats": "{chats} 个聊天",
     "@countChats": {
         "type": "String",
@@ -3100,26 +2811,6 @@
             }
         }
     },
-    "spaceMemberOf": "{spaces} 的空间成员",
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "spaceMemberOfCanKnock": "{spaces} 的空间成员可以敲门",
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "donate": "捐赠",
-    "@donate": {},
     "startedAPoll": "{username} 启动了投票。",
     "@startedAPoll": {
         "type": "String",
@@ -3189,14 +2880,6 @@
     "@stickerPackName": {},
     "attribution": "作者",
     "@attribution": {},
-    "skipChatBackup": "跳过聊天备份",
-    "@skipChatBackup": {},
-    "skipChatBackupWarning": "确定吗？不开启聊天备份，如果切换设备可能无法访问消息。",
-    "@skipChatBackupWarning": {},
-    "loadingMessages": "加载消息中",
-    "@loadingMessages": {},
-    "setupChatBackup": "设置聊天备份",
-    "@setupChatBackup": {},
     "changedTheChatDescription": "{username} 更改了聊天描述",
     "@changedTheChatDescription": {},
     "changedTheChatName": "{username} 更改了聊天名",
@@ -3207,11 +2890,9 @@
     "taTooltip": "使用翻译辅助的二级语言",
     "interactiveTranslatorSliderHeader": "互动翻译器",
     "interactiveGrammarSliderHeader": "互动语法检查器",
-    "interactiveTranslatorRequired": "必需",
     "waTooltip": "无需辅助的二级语言",
     "interactiveTranslator": "翻译辅助",
     "noIdenticalLanguages": "请选择不同的基础语言和目标语言",
-    "searchBy": "按国家和语言搜索",
     "joinWithClassCode": "加入课程",
     "languageLevelPreA1": "初学者低级（预 A1）",
     "languageLevelA1": "新手中级 (A1)",
@@ -3231,19 +2912,14 @@
     "whatIsYourBaseLanguage": "你的基础语言是什么？",
     "publicProfileTitle": "允许在搜索中找到我的资料",
     "publicProfileDesc": "开启后，其他用户可以在全球搜索栏中找到你的资料并向你发起聊天请求。此时，你可以选择接受或拒绝请求。",
-    "errorDisableIT": "翻译协助已关闭。",
-    "errorDisableIGC": "语法协助已关闭。",
     "errorDisableITUserDesc": "点击这里更新翻译协助设置",
     "errorDisableIGCUserDesc": "点击这里更新语法协助设置",
     "errorDisableITClassDesc": "此课程中的翻译协助已关闭。",
     "errorDisableIGCClassDesc": "此课程中的语法协助已关闭。",
-    "error405Title": "未设置语言",
     "error405Desc": "请在主菜单 > 学习设置中设置您的语言。",
     "termsAndConditions": "条款和条件",
     "andCertifyIAmAtLeast13YearsOfAge": "并证明我已满16岁。",
-    "error502504Title": "哇，在线的学生很多！",
     "error502504Desc": "在Pangea机器人赶上进度时，翻译和语法工具可能会变慢或不可用。",
-    "error404Title": "翻译错误！",
     "error404Desc": "Pangea机器人不确定如何翻译这个...",
     "errorPleaseRefresh": "我们正在处理！请重新加载并重试。",
     "connectedToStaging": "已连接到预发布环境",
@@ -3281,13 +2957,9 @@
     "definitionsToolName": "单词定义",
     "definitionsToolDescription": "启用后，蓝色下划线的单词可以点击查看定义。点击消息以获取定义。",
     "welcomeBack": "欢迎回来！如果您是2023-2024试点的一部分，请联系我们获取您的特别试点订阅。如果您是教师，或者您的机构为您的班级购买了许可证，请联系我们获取您的教师订阅。",
-    "downloadTxtFile": "下载文本文件",
-    "downloadCSVFile": "下载CSV文件",
     "promotionalSubscriptionDesc": "您目前拥有终身促销订阅。若需帮助更改订阅，请联系 support@pangea.chat。",
     "originalSubscriptionPlatform": "通过 {purchasePlatform} 购买的订阅",
     "oneWeekTrial": "一周试用",
-    "downloadXLSXFile": "下载Excel文件",
-    "unkDisplayName": "未知",
     "wwCountryDisplayName": "全球",
     "afCountryDisplayName": "阿富汗",
     "axCountryDisplayName": "奥兰群岛",
@@ -3582,7 +3254,6 @@
     "chatCapacityHasBeenChanged": "聊天容量已更改",
     "chatCapacitySetTooLow": "聊天容量必须至少为 {count}。",
     "chatCapacityExplanation": "聊天容量限制允许加入聊天的成员人数。",
-    "tooManyRequest": "请求过多，请稍后再试。",
     "enterNumber": "请输入一个整数值。",
     "practice": "练习",
     "versionNotFound": "未找到版本",
@@ -3592,7 +3263,6 @@
     "deleteSubscriptionWarningTitle": "您有一个有效的订阅",
     "deleteSubscriptionWarningBody": "删除您的账户不会自动取消您的订阅。",
     "manageSubscription": "管理订阅",
-    "error520Title": "请再试一次。",
     "error520Desc": "抱歉，我们无法理解您的消息……",
     "wordsUsed": "已使用的单词",
     "level": "等级",
@@ -3610,7 +3280,6 @@
     "other": "其他",
     "levelShort": "等级 {level}",
     "noCapacityLimit": "没有容量限制",
-    "downloadGroupText": "下载群组文本",
     "notificationsOn": "通知已开启",
     "notificationsOff": "通知已关闭",
     "joinWithCode": "用代码加入",
@@ -3674,24 +3343,12 @@
     "whatIsTheMorphTag": "'{wordForm}'的{morphologicalFeature}是什么？",
     "dataAvailable": "数据可用性",
     "available": "可用",
-    "pangeaBotIsFallible": "Pangea机器人也会犯错！",
-    "whatIsMeaning": "'{lemma}'是什么意思？",
     "chooseLemmaMeaningInstructionsBody": "将意思与消息中的单词匹配！",
-    "doubleClickToEdit": "双击编辑。",
-    "topicLabel": "主题",
-    "topicPlaceholder": "选择一个主题...",
-    "modePlaceholder": "选择一种模式...",
-    "learningObjectiveLabel": "学习目标",
-    "learningObjectivePlaceholder": "选择一个学习目标...",
-    "targetLanguageLabel": "目标语言",
     "cefrLevelLabel": "CEFR等级",
     "image": "图片",
     "video": "视频",
     "nan": "不适用",
-    "addVocabulary": "添加词汇",
     "instructions": "说明",
-    "numberOfLearners": "学习者人数",
-    "mustBeInteger": "必须是整数，例如1、2、3等",
     "constructUsePvmDesc": "以语音消息形式生成",
     "leaveSpaceDescription": "退出课程后，您将离开其中所有的聊天。其他用户将看到您已离开课程。",
     "constructUseCorMmDesc": "正确的消息含义",
@@ -3706,7 +3363,6 @@
     "ttsDisabledBody": "您可以在学习设置中启用文本转语音",
     "noSpaceDescriptionYet": "尚未创建课程描述。",
     "tooLargeToSend": "此消息过大，无法发送",
-    "exitWithoutSaving": "你确定要退出而不保存吗？",
     "enableAutocorrectPopupTitle": "通过以下步骤添加目标语言键盘：",
     "enableAutocorrectPopupSteps": "  • 设置\n  • 通用\n  • 键盘\n  • 键盘\n  • 添加新键盘",
     "enableAutocorrectPopupDescription": "选择语言后，可以点击键盘左下角的小地球图标，激活新安装的键盘。",
@@ -3717,11 +3373,8 @@
     "displayName": "显示名称",
     "leaveRoomDescription": "你即将离开此聊天。其他用户将看到你已离开聊天。",
     "confirmUserId": "请确认您的Pangea聊天用户名以删除您的账户。",
-    "startingToday": "从今天开始",
-    "oneWeekFreeTrial": "一周免费试用",
     "paidSubscriptionStarts": "开始于 {startDate}",
     "cancelInSubscriptionSettings": "• 在订阅设置中随时取消",
-    "cancelToAvoidCharges": "• 在 {trialEnds} 之前取消以避免收费",
     "downloadGboard": "下载Gboard",
     "autocorrectNotAvailable": "很抱歉，您的平台目前不支持此功能。请关注后续开发！",
     "pleaseUpdateApp": "请更新应用以继续。",
@@ -3731,17 +3384,12 @@
     "knockSpaceSuccess": "你已请求加入此课程！管理员将在收到请求后回复你 😀",
     "chooseWordAudioInstructionsBody": "听完整个消息，然后将音频与单词匹配。",
     "chooseMorphsInstructionsBody": "点击拼图块以回答语法问题！",
-    "pleaseEnterInt": "请输入一个数字",
     "home": "首页",
     "join": "加入",
     "resetInstructionTooltipsTitle": "重置操作提示",
     "resetInstructionTooltipsDesc": "点击显示像新用户一样的操作提示。",
-    "randomize": "随机",
     "clear": "清除",
-    "featuredActivities": "精选",
     "save": "保存",
-    "startChat": "开始聊天",
-    "translationProblem": "翻译问题",
     "askToJoin": "请求加入",
     "emptyChatWarningTitle": "聊天为空",
     "emptyChatWarningDesc": "你还没有邀请任何人加入你的聊天。前往聊天设置邀请你的联系人或机器人。你也可以稍后再做。",
@@ -3771,17 +3419,13 @@
     "timesUsedIndependently": "独立使用次数",
     "timesUsedWithAssistance": "协助使用次数",
     "shareInviteCode": "分享邀请码：{code}",
-    "leaderboard": "排行榜",
     "skipForNow": "暂时跳过",
     "permissions": "权限",
     "spaceChildPermission": "谁可以向此课程添加新聊天",
-    "addEnvironmentOverride": "添加环境覆盖",
     "defaultOption": "默认",
     "deleteChatDesc": "您确定要删除此聊天吗？它将被所有参与者删除，聊天中的所有消息将不再可用于练习或学习分析。",
     "deleteSpaceDesc": "课程和任何已选择的聊天将被所有参与者删除，聊天中的所有消息将不再可用于练习或学习分析。此操作无法撤销。",
     "launch": "启动",
-    "searchChats": "搜索聊天",
-    "maxFifty": "最多50个",
     "configureSpace": "配置课程",
     "pinMessages": "置顶消息",
     "setJoinRules": "设置加入规则",
@@ -3815,9 +3459,6 @@
     "failedToFetchTranscription": "获取转录失败",
     "deleteEmptySpaceDesc": "课程将被所有参与者删除。此操作无法撤销。",
     "regenerate": "重新生成",
-    "mySavedActivities": "我的已保存活动",
-    "noSavedActivities": "没有已保存的活动",
-    "saveActivity": "保存此活动",
     "failedToPlayVideo": "播放视频失败",
     "done": "完成",
     "inThisSpace": "在此空间",
@@ -3828,13 +3469,9 @@
     "numInvited": "{count} 已被邀请",
     "saved": "已保存",
     "reset": "重置",
-    "errorFetchingActivitiesMessage": "获取活动失败",
     "errorFetchingDefinition": "获取定义失败",
     "errorProcessAnalytics": "处理分析失败",
     "errorDownloading": "下载失败",
-    "errorLoadingSpaceChildren": "加载此课程中的聊天失败",
-    "unexpectedError": "发生意外错误。",
-    "pleaseReload": "请重新加载并重试。",
     "translationError": "翻译错误",
     "check": "检查",
     "unableToFindRoom": "未找到该代码对应的聊天或课程。请重试。",
@@ -3843,19 +3480,14 @@
     "request": "请求",
     "requestAll": "请求全部",
     "confirmMessageUnpin": "您确定要取消置顶此消息吗？",
-    "saveAndLaunch": "保存并启动",
-    "launchToSpace": "发布到课程",
     "pending": "待处理",
     "inactive": "不活跃",
-    "confirmRole": "确认角色",
     "openRoleLabel": "开放",
     "finishedTheActivity": "🎯 {username} 完成了此次活动",
     "activitySummaryError": "无法获取活动总结",
     "requestSummaries": "请求总结",
-    "generatingNewActivities": "你是此语言对的第一个用户！请稍等，我们正在为你准备活动。",
     "requestAccessTitle": "请求分析访问权限？",
     "requestAccessDesc": "你想请求查看参与者分析吗？\n\n如果参与者同意，课程管理员将能够查看他们的：\n    • 词汇总数\n    • 语法概念总数\n    • 完成的活动会话总数\n    • 使用的具体语法概念，正确与错误\n\n他们将无法查看：\n    • 课程外的聊天消息\n    • 词汇列表",
-    "requestAccess": "请求访问（{count}）",
     "analyticsInactiveTitle": "无法向不活跃用户发送请求",
     "analyticsInactiveDesc": "自此功能推出以来未登录的不活跃用户将不会看到你的请求。\n\n当他们返回时，请求按钮会出现。你可以稍后通过点击他们名字下的请求按钮重新发送请求。",
     "accessRequestedTitle": "访问分析请求",
@@ -3878,8 +3510,6 @@
     "accessDesc": "你可以让你的课程对全世界开放！或者，将你的课程设为私密且安全。",
     "createGroupChatDesc": "活动会话开始和结束，而群聊将保持开放以进行日常沟通。",
     "deleteDesc": "只有管理员可以删除课程。这是一个破坏性操作，会删除所有用户和课程内的所有选定聊天。请谨慎操作。",
-    "noCourseFound": "哦，这个课程需要一个计划！\n\n课程计划是一系列主题和对话活动。",
-    "additionalParticipants": "+ {num} 其他人",
     "whatNow": "接下来怎么办？",
     "chooseNextActivity": "选择你的下一个活动！",
     "letsGo": "开始吧",
@@ -3892,13 +3522,11 @@
     "waitNotDone": "等一下，我还没完成！",
     "waitingForOthersToFinish": "等待其他人完成...",
     "generatingSummary": "正在分析聊天内容并生成结果",
-    "findCourse": "查找课程",
     "pingParticipantsNotification": "{user} 正在寻找用户加入 {room} 中的活动会话",
     "course": "课程",
     "courses": "课程",
     "goToCourse": "前往课程：{course}",
     "activityComplete": "此活动已完成。活动摘要应在下方显示。",
-    "startNewSession": "开始新会话",
     "joinOpenSession": "加入公开会话",
     "activityNotFound": "未找到活动",
     "myActivities": "我的活动",
@@ -3972,10 +3600,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3985,10 +3609,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -4072,14 +3692,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4096,10 +3708,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4112,15 +3720,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4272,14 +3872,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4293,14 +3885,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5523,10 +5107,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5567,10 +5147,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5643,10 +5219,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5916,47 +5488,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5976,19 +5508,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -6052,10 +5572,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6096,14 +5612,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6115,14 +5623,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6160,10 +5660,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6180,27 +5676,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6324,10 +5804,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6337,10 +5813,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6357,14 +5829,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6504,18 +5968,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6564,10 +6016,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6577,18 +6025,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6631,23 +6067,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6671,10 +6095,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6682,14 +6102,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6794,18 +6206,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6858,10 +6258,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6888,10 +6284,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -7072,7 +6464,6 @@
         "placeholders": {}
     },
     "feedbackRespDesc": "明天回来查看活动更新。",
-    "activityDropdownDesc": "完成此活动后，点击下面",
     "languageMismatchTitle": "语言不匹配",
     "languageMismatchDesc": "你的目标语言与此活动的语言不匹配。要更新你的目标语言吗？",
     "reportWordIssueTooltip": "报告单词信息问题",
@@ -7085,10 +6476,6 @@
     "selectAll": "全选",
     "deselectAll": "取消全选",
     "@feedbackRespDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityDropdownDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7137,17 +6524,11 @@
         "placeholders": {}
     },
     "startOwn": "开始我的课程",
-    "joinCourseDesc": "每门课程包含8-10个有序的主题，配备一系列基于任务的语言学习活动。",
     "newMessageInPangeaChat": "📩 Pangea 聊天中有新消息",
     "shareCourse": "分享课程",
     "addCourse": "添加课程",
-    "joinPublicCourse": "加入公共课程",
     "vocabLevelsDesc": "这是你提升词汇等级后，词汇将会显示的地方！",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7160,10 +6541,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7182,7 +6559,6 @@
     "emojiView": "表情符号视图",
     "feedbackDialogDesc": "我也会犯错！有什么可以帮助我改进的吗？",
     "contactHasBeenInvitedToTheCourse": "联系人已被邀请参加课程",
-    "activityStatsButtonTooltip": "活动信息",
     "allow": "允许",
     "deny": "拒绝",
     "enabledRenewal": "启用订阅续费",
@@ -7450,10 +6826,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8509,16 +7881,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "解锁下一个主题的活动",
-    "activitiesToUnlockTopicDesc": "设置解锁下一个课程主题所需的活动数量",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "正确的词汇定义练习",
     "constructUseIncLMDesc": "错误的词汇定义练习",
     "constructUseCorLADesc": "正确的词汇音频练习",
@@ -8526,7 +7888,6 @@
     "constructUseBonus": "词汇练习期间的奖励",
     "practiceVocab": "练习词汇",
     "selectMeaning": "选择意思",
-    "selectAudio": "选择匹配的音频",
     "anotherRound": "再来一轮",
     "activitySettingsOverrideWarning": "活动计划确定的语言和语言级别",
     "voice": "声音",
@@ -8558,10 +7919,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8579,12 +7936,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "下载已启动",
     "webDownloadPermissionMessage": "如果您的浏览器阻止下载，请为此网站启用下载。",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8679,11 +8031,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "出现了一些问题，我们正在努力修复。请稍后再检查。",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "启用写作辅助",
     "autoIGCToolDescription": "自动运行 Pangea Chat 工具以将发送的消息纠正为目标语言。",
     "@autoIGCToolName": {
@@ -8739,24 +8086,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "语法",
-    "spanTypeWordChoice": "用词选择",
     "spanTypeSpelling": "拼写",
     "spanTypePunctuation": "标点",
     "spanTypeStyle": "风格",
     "spanTypeFluency": "流利度",
     "spanTypeAccents": "口音",
     "spanTypeCapitalization": "大写",
-    "spanTypeCorrection": "更正",
     "spanFeedbackTitle": "报告更正问题",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8781,10 +8117,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8795,13 +8127,9 @@
     "clientWellKnownInformation": "客户端已知信息：",
     "baseUrl": "基础网址",
     "identityServer": "身份服务器：",
-    "versionWithNumber": "版本：{version}",
     "logs": "日志",
-    "advancedConfigs": "高级配置",
     "advancedConfigurations": "高级配置",
-    "signInWithLabel": "使用以下方式登录：",
     "selectAllWords": "选择你在音频中听到的所有单词",
-    "joinCourseForActivities": "加入课程以尝试活动。",
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8830,19 +8158,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8850,15 +8166,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9059,11 +8367,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "在课堂上？把你的加入代码放在这里。",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "自动高亮音频消息",
     "selectAudioMessagesOnPlayDescription": "播放时自动高亮音频消息",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9107,18 +8410,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "本课程有主题的活动少于 {input} 个。请您输入一个小于或等于 {minValue} 的数字。",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "点击这里重新登录。",
     "@clickToLogin": {
@@ -9535,17 +8826,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "一只卡通风格的黄色熊，兴奋地举起双臂。",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "选择单词以了解更多信息",
     "requireAnalyticsAccessTitle": "需要分析访问权限才能加入",
     "requireAnalyticsAccessDesc": "参与者必须授予访问其学习分析的权限才能加入此课程",
     "analyticsAccessNoticeTitle": "需要分析访问权限",
     "analyticsAccessNoticeDesc": "通过加入此课程，您同意授予管理员访问您的学习分析的权限。",
-    "skipOnboardingClassCodeDesc": "独立学习？别担心，您可以：",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9563,10 +8848,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9595,7 +8876,6 @@
     "pickCefrLevelTeacherStepTitle": "你教什么级别？",
     "pickCefrLevelStudentStepTitle": "你是什么级别？",
     "customCourseStepTitle": "填写此表单以获取自定义课程",
-    "aboutYourClass": "关于您的课程",
     "courseCodeStepErrorMessage": "请检查您的代码并重试",
     "institution": "机构",
     "courseGoals": "课程目标",
@@ -9638,10 +8918,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9758,12 +9034,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea Chat 标志",
     "introChatDetails": "打个招呼！向你的同学介绍自己，寻找朋友，并在活动之外聊天。",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9807,11 +9078,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "活动操作",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "发音工具",
     "audioTranscription": "AI音频转录",
     "visualLearnerSupport": "视觉学习者支持",
@@ -9852,7 +9118,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "加入一个包含此活动的课程以进行游戏。",
     "resizeCoursePanel": "调整课程面板大小",
     "undo": "撤销",
     "unlock": "解锁",
@@ -9866,7 +9131,6 @@
     "addCourseBrowsePublic": "浏览公开课程",
     "browsePublicCourses": "浏览公开课程",
     "editProfile": "编辑个人资料",
-    "numObjectives": "{count} 个目标",
     "mapSearchHint": "搜索活动",
     "mapSearchNoResults": "视图中没有匹配项",
     "mapFilterAllLanguages": "所有语言",
@@ -9875,7 +9139,6 @@
     "mapFilterCompleted": "完成",
     "mapFilterReset": "重置",
     "activityTypeConversation": "对话",
-    "lockedMissionRequirement": "完成前一个任务以解锁",
     "playAgain": "再玩一次",
     "reviewActivity": "回顾",
     "mapEmptyInView": "在您的级别或语言中没有任何内容。扩大您的过滤器或缩小视图。",
@@ -9890,14 +9153,9 @@
     "scrollToBottom": "滚动到底部",
     "courseImage": "课程图片",
     "avatarPreview": "头像预览",
-    "activityPhoto": "活动照片",
     "emotePreview": "表情预览: {name}",
     "activityLabel": "活动: {title}",
     "resetMapView": "重置地图视图",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -9950,14 +9208,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -9987,10 +9237,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10047,10 +9293,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },

--- a/lib/l10n/intl_zh_Hant.arb
+++ b/lib/l10n/intl_zh_Hant.arb
@@ -77,11 +77,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "areGuestsAllowedToJoin": "是否允許訪客加入",
-    "@areGuestsAllowedToJoin": {
-        "type": "String",
-        "placeholders": {}
-    },
     "areYouSure": "您確定嗎？",
     "@areYouSure": {
         "type": "String",
@@ -339,11 +334,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "chatBackupDescription": "您的過往聊天室記錄已被恢復金鑰加密。請您確保不會弄丟它。",
-    "@chatBackupDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatDetails": "對話詳細",
     "@chatDetails": {
         "type": "String",
@@ -381,11 +371,6 @@
     },
     "connect": "連接",
     "@connect": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "contactHasBeenInvitedToTheGroup": "聯絡人已被邀請至群組",
-    "@contactHasBeenInvitedToTheGroup": {
         "type": "String",
         "placeholders": {}
     },
@@ -578,11 +563,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableEncryptionWarning": "您將不能再停用加密，確定嗎？",
-    "@enableEncryptionWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
     "encrypted": "已加密的",
     "@encrypted": {
         "type": "String",
@@ -609,11 +589,6 @@
     },
     "enterAnEmailAddress": "輸入一個電子郵件位址",
     "@enterAnEmailAddress": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "everythingReady": "一切就緒！",
-    "@everythingReady": {
         "type": "String",
         "placeholders": {}
     },
@@ -654,11 +629,6 @@
     },
     "group": "群組",
     "@group": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "groupIsPublic": "群組是公開的",
-    "@groupIsPublic": {
         "type": "String",
         "placeholders": {}
     },
@@ -752,15 +722,6 @@
     "@inviteContact": {
         "type": "String",
         "placeholders": {}
-    },
-    "inviteContactToGroup": "邀請聯絡人到 {groupName}",
-    "@inviteContactToGroup": {
-        "type": "String",
-        "placeholders": {
-            "groupName": {
-                "type": "String"
-            }
-        }
     },
     "invited": "已邀請",
     "@invited": {
@@ -873,15 +834,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "loadCountMoreParticipants": "載入 {count} 個更多的參與者",
-    "@loadCountMoreParticipants": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "loadingPleaseWait": "載入中...... 請稍候。",
     "@loadingPleaseWait": {
         "type": "String",
@@ -896,15 +848,6 @@
     "@login": {
         "type": "String",
         "placeholders": {}
-    },
-    "logInTo": "登入 {homeserver}",
-    "@logInTo": {
-        "type": "String",
-        "placeholders": {
-            "homeserver": {
-                "type": "String"
-            }
-        }
     },
     "logout": "登出",
     "@logout": {
@@ -968,16 +911,6 @@
     },
     "noEmotesFound": "表情符號不存在。😕",
     "@noEmotesFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noEncryptionForPublicRooms": "您只能在這個聊天室不再被允許公開訪問後，才能啟用加密。",
-    "@noEncryptionForPublicRooms": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "noGoogleServicesWarning": "未能在你的裝置找到 Firebase Cloud Messaging(FCM). 如果想要收到通知消息的推送，我們建議安裝 ntfy。在有 ntfy 或其他 Unified Push 應用，便能在資料安全的情況下收到通知的推送。你可以在 Play store 或 F-Droid 下載並安裝 ntfy。",
-    "@noGoogleServicesWarning": {
         "type": "String",
         "placeholders": {}
     },
@@ -1077,11 +1010,6 @@
     },
     "passwordHasBeenChanged": "密碼已被變更",
     "@passwordHasBeenChanged": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "passwordRecovery": "恢復密碼",
-    "@passwordRecovery": {
         "type": "String",
         "placeholders": {}
     },
@@ -1205,11 +1133,6 @@
                 "type": "String"
             }
         }
-    },
-    "removeDevice": "移除裝置",
-    "@removeDevice": {
-        "type": "String",
-        "placeholders": {}
     },
     "unbanFromChat": "解封聊天室",
     "@unbanFromChat": {
@@ -1340,11 +1263,6 @@
             }
         }
     },
-    "setPermissionsLevel": "設定權限等級",
-    "@setPermissionsLevel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "setStatus": "設定狀態",
     "@setStatus": {
         "type": "String",
@@ -1434,11 +1352,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "transferFromAnotherDevice": "從其他裝置傳輸",
-    "@transferFromAnotherDevice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "tryToSendAgain": "再次嘗試傳送",
     "@tryToSendAgain": {
         "type": "String",
@@ -1494,15 +1407,6 @@
     "@unpin": {
         "type": "String",
         "placeholders": {}
-    },
-    "unreadChats": "{unreadCount, plural, =1 {1 unread chat} other { {unreadCount} 個未讀聊天室} }",
-    "@unreadChats": {
-        "type": "String",
-        "placeholders": {
-            "unreadCount": {
-                "type": "int"
-            }
-        }
     },
     "userAndOthersAreTyping": "{username} 和其他 {count} 個人正在輸入...…",
     "@userAndOthersAreTyping": {
@@ -1588,16 +1492,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "videoCall": "視訊通話",
-    "@videoCall": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "visibilityOfTheChatHistory": "聊天室記錄的可見性",
-    "@visibilityOfTheChatHistory": {
-        "type": "String",
-        "placeholders": {}
-    },
     "visibleForAllParticipants": "對所有參與者可見",
     "@visibleForAllParticipants": {
         "type": "String",
@@ -1643,23 +1537,8 @@
         "type": "String",
         "placeholders": {}
     },
-    "whoCanPerformWhichAction": "誰可以執行這個動作",
-    "@whoCanPerformWhichAction": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "whoIsAllowedToJoinThisGroup": "誰可以加入這個群組",
-    "@whoIsAllowedToJoinThisGroup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "whyDoYouWantToReportThis": "您檢舉的原因是什麼？",
     "@whyDoYouWantToReportThis": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "wipeChatBackup": "是否清除您的聊天室記錄備份以建立新的安全金鑰嗎？",
-    "@wipeChatBackup": {
         "type": "String",
         "placeholders": {}
     },
@@ -1786,8 +1665,6 @@
     },
     "repeatPassword": "再次輸入密碼",
     "@repeatPassword": {},
-    "yourChatBackupHasBeenSetUp": "您的聊天室記錄備份已設定。",
-    "@yourChatBackupHasBeenSetUp": {},
     "commandHint_myroomavatar": "設定您的聊天室頭貼（通過 mxc-uri）",
     "@commandHint_myroomavatar": {
         "type": "String",
@@ -1902,14 +1779,10 @@
     },
     "sender": "傳送者",
     "@sender": {},
-    "voiceCall": "語音通話",
-    "@voiceCall": {},
     "blockUsername": "無視使用者名稱",
     "@blockUsername": {},
     "noBackupWarning": "警告！如果不啟用聊天室備份，您將失去對加密訊息的訪問。強烈建議在登出前先啟用聊天室備份。",
     "@noBackupWarning": {},
-    "addChatOrSubSpace": "新增聊天室或子空間",
-    "@addChatOrSubSpace": {},
     "thisDevice": "這個裝置：",
     "@thisDevice": {},
     "separateChatTypes": "分開私訊和群組",
@@ -1995,8 +1868,6 @@
             }
         }
     },
-    "unlockOldMessages": "解鎖舊消息",
-    "@unlockOldMessages": {},
     "noOtherDevicesFound": "未找到其他裝置",
     "@noOtherDevicesFound": {},
     "noUsersFoundWithQuery": "很遺憾，找不到與「{query}」相符的使用者。請檢查是否有打錯字。",
@@ -2020,8 +1891,6 @@
     "@experimentalVideoCalls": {},
     "youAcceptedTheInvitation": "👍 您接受了邀請",
     "@youAcceptedTheInvitation": {},
-    "storeSecurlyOnThisDevice": "在此裝置上安全存儲",
-    "@storeSecurlyOnThisDevice": {},
     "countFiles": "{count} 個文件",
     "@countFiles": {
         "placeholders": {
@@ -2030,8 +1899,6 @@
             }
         }
     },
-    "screenSharingDetail": "您正在 FuffyChat 中分享您的螢幕",
-    "@screenSharingDetail": {},
     "wrongPinEntered": "輸入的密碼錯誤！ {seconds} 秒後再試一次......",
     "@wrongPinEntered": {
         "type": "String",
@@ -2045,8 +1912,6 @@
     "@archiveRoomDescription": {},
     "banUserDescription": "該使用者將被禁止進入聊天室，直到他們被解封之前都無法再次進入聊天室。",
     "@banUserDescription": {},
-    "searchChatsRooms": "搜尋 #chats, @users...",
-    "@searchChatsRooms": {},
     "decline": "拒絕",
     "@decline": {},
     "sendReadReceipts": "傳送已讀回條",
@@ -2102,18 +1967,12 @@
     "@setColorTheme": {},
     "makeAdminDescription": "一旦您讓這個使用者成為管理員，您可能無法撤銷此操作，因為他們將擁有與您相同的權限。",
     "@makeAdminDescription": {},
-    "createGroupAndInviteUsers": "建立群組並邀請使用者",
-    "@createGroupAndInviteUsers": {},
-    "groupCanBeFoundViaSearch": "可以透過搜尋找到群組",
-    "@groupCanBeFoundViaSearch": {},
     "pleaseEnterYourCurrentPassword": "請輸入您當前的密碼",
     "@pleaseEnterYourCurrentPassword": {},
     "widgetCustom": "自訂",
     "@widgetCustom": {},
     "createGroup": "建立群組",
     "@createGroup": {},
-    "enterSpace": "進入空間",
-    "@enterSpace": {},
     "shareLocation": "分享位置",
     "@shareLocation": {
         "type": "String",
@@ -2148,11 +2007,6 @@
         "type": "String",
         "description": "Usage hint for the command /react"
     },
-    "createNewSpace": "新建空間",
-    "@createNewSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "chatPermissions": "聊天室權限",
     "@chatPermissions": {},
     "customEmojisAndStickersBody": "新增或分享可在任何聊天室中使用的自訂表情符號或貼圖。",
@@ -2183,8 +2037,6 @@
     },
     "oneClientLoggedOut": "您的一個客戶端已登出",
     "@oneClientLoggedOut": {},
-    "addAccount": "新增帳號",
-    "@addAccount": {},
     "editBundlesForAccount": "為此帳號編輯套組",
     "@editBundlesForAccount": {},
     "openInMaps": "在地圖中打開",
@@ -2212,13 +2064,6 @@
             }
         }
     },
-    "recoveryKey": "恢復金鑰",
-    "@recoveryKey": {},
-    "spaceName": "空間名稱",
-    "@spaceName": {
-        "type": "String",
-        "placeholders": {}
-    },
     "synchronizingPleaseWait": "正在同步... 請稍候。",
     "@synchronizingPleaseWait": {
         "type": "String",
@@ -2226,18 +2071,12 @@
     },
     "messageInfo": "訊息資訊",
     "@messageInfo": {},
-    "removeFromSpace": "從空間中移除",
-    "@removeFromSpace": {},
-    "pleaseEnterRecoveryKeyDescription": "要解鎖您的舊訊息，請輸入在之前的會話中生成的恢復密鑰。您的恢復密鑰不是您的密碼。",
-    "@pleaseEnterRecoveryKeyDescription": {},
     "emojis": "表情符號",
     "@emojis": {},
     "placeCall": "發起通話",
     "@placeCall": {},
     "unsupportedAndroidVersion": "不支持的Android版本",
     "@unsupportedAndroidVersion": {},
-    "videoCallsBetaWarning": "請注意，視訊通話目前處於測試階段。它們可能不會按預期工作，或者在所有平台上都不工作。",
-    "@videoCallsBetaWarning": {},
     "widgetUrlError": "這不是一個有效的URL。",
     "@widgetUrlError": {},
     "addWidget": "新增小工具",
@@ -2284,10 +2123,6 @@
     "@newSpace": {},
     "doNotShowAgain": "不再顯示",
     "@doNotShowAgain": {},
-    "encryptThisChat": "加密此聊天室",
-    "@encryptThisChat": {},
-    "sorryThatsNotPossible": "抱歉......這是不可能的",
-    "@sorryThatsNotPossible": {},
     "invite": "邀請",
     "@invite": {},
     "removeDevicesDescription": "您將從這個裝置登出，並將不再能夠接收消息。",
@@ -2310,8 +2145,6 @@
     "@pleaseChooseAStrongPassword": {},
     "passwordIsWrong": "您輸入的密碼錯誤",
     "@passwordIsWrong": {},
-    "publicChatAddresses": "公開聊天室地址",
-    "@publicChatAddresses": {},
     "leaveEmptyToClearStatus": "留空以清除您的狀態。",
     "@leaveEmptyToClearStatus": {},
     "select": "選擇",
@@ -2358,22 +2191,12 @@
     "@knockRestricted": {},
     "appLockDescription": "未使用時以密碼鎖定應用程式",
     "@appLockDescription": {},
-    "globalChatId": "全球聊天室 ID",
-    "@globalChatId": {},
-    "accessAndVisibility": "訪問權限和可見性",
-    "@accessAndVisibility": {},
-    "accessAndVisibilityDescription": "誰被允許加入此聊天室以及如何發現聊天室。",
-    "@accessAndVisibilityDescription": {},
     "calls": "通話",
     "@calls": {},
-    "chatDescription": "聊天室描述",
-    "@chatDescription": {},
     "chatDescriptionHasBeenChanged": "聊天室描述已變更",
     "@chatDescriptionHasBeenChanged": {},
     "tryAgain": "再試一次",
     "@tryAgain": {},
-    "pleaseEnterRecoveryKey": "請輸入您的恢復金鑰：",
-    "@pleaseEnterRecoveryKey": {},
     "directChat": "私訊",
     "@directChat": {},
     "register": "註冊",
@@ -2394,22 +2217,8 @@
     "@searchForUsers": {},
     "inviteGroupChat": "📨 邀請群組聊天室",
     "@inviteGroupChat": {},
-    "setTheme": "設定主題：",
-    "@setTheme": {},
     "knocking": "敲門",
     "@knocking": {},
-    "sessionLostBody": "您的會話已丟失。請將此錯誤報告給開發人員，網址為 {url}。錯誤訊息為：{error}",
-    "@sessionLostBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "swipeRightToLeftToReply": "向右滑至左以回覆",
     "@swipeRightToLeftToReply": {},
     "hideRedactedMessagesBody": "如果有人收回一條訊息，該訊息將不再在聊天室中顯示。",
@@ -2436,11 +2245,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "spaceIsPublic": "空間是公開的",
-    "@spaceIsPublic": {
-        "type": "String",
-        "placeholders": {}
-    },
     "dismiss": "解散",
     "@dismiss": {},
     "reactedWith": "{sender} 以 {reaction} 回應",
@@ -2459,18 +2263,6 @@
     "@confirmEventUnpin": {},
     "widgetEtherpad": "文字筆記",
     "@widgetEtherpad": {},
-    "noOneCanJoin": "沒有人可以加入",
-    "@noOneCanJoin": {},
-    "saveKeyManuallyDescription": "通過觸發系統分享對話框或剪貼板手動保存此密鑰。",
-    "@saveKeyManuallyDescription": {},
-    "storeInAndroidKeystore": "存儲在 Android KeyStore",
-    "@storeInAndroidKeystore": {},
-    "storeInAppleKeyChain": "存儲在 Apple KeyChain",
-    "@storeInAppleKeyChain": {},
-    "foregroundServiceRunning": "當前景服務正在運行時會顯示此通知。",
-    "@foregroundServiceRunning": {},
-    "screenSharingTitle": "螢幕分享",
-    "@screenSharingTitle": {},
     "wasDirectChatDisplayName": "空的聊天室（原名稱為 {oldDisplayName} ）",
     "@wasDirectChatDisplayName": {
         "type": "String",
@@ -2480,8 +2272,6 @@
             }
         }
     },
-    "disableEncryptionWarning": "出於安全原因，您不能在之前已加密的聊天室中停用加密。",
-    "@disableEncryptionWarning": {},
     "deviceKeys": "裝置密鑰：",
     "@deviceKeys": {},
     "fileIsTooBigForServer": "無法發送！該伺服器僅支援最大到 {max} 的附件。",
@@ -2543,18 +2333,6 @@
     "@incomingMessages": {},
     "databaseMigrationTitle": "資料庫已最佳化",
     "@databaseMigrationTitle": {},
-    "restoreSessionBody": "應用程式現在嘗試從備份中恢復您的會話。請將此錯誤報告給開發人員，網址為 {url}。錯誤訊息為：{error}",
-    "@restoreSessionBody": {
-        "type": "String",
-        "placeholders": {
-            "url": {
-                "type": "String"
-            },
-            "error": {
-                "type": "String"
-            }
-        }
-    },
     "stickers": "貼圖",
     "@stickers": {},
     "joinSpace": "加入空間",
@@ -2573,10 +2351,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "enableMultiAccounts": "（實驗性功能）在此裝置上啟用多個帳號",
-    "@enableMultiAccounts": {},
-    "recoveryKeyLost": "遺失恢復金鑰？",
-    "@recoveryKeyLost": {},
     "sendAsText": "以文字傳送",
     "@sendAsText": {
         "type": "String"
@@ -2585,21 +2359,10 @@
     "@unverified": {},
     "time": "時間",
     "@time": {},
-    "chatCanBeDiscoveredViaSearchOnServer": "可以透過在 {server} 上的搜尋發現聊天室",
-    "@chatCanBeDiscoveredViaSearchOnServer": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "commandHint_sendraw": "傳送原始 json",
     "@commandHint_sendraw": {},
     "newPassword": "新密碼",
     "@newPassword": {},
-    "createNewAddress": "建立新地址",
-    "@createNewAddress": {},
     "searchIn": "在聊天室「{chat}」中搜尋......",
     "@searchIn": {
         "type": "String",
@@ -2638,28 +2401,16 @@
     "@reportUser": {},
     "unsupportedAndroidVersionLong": "此功能需要較新的 Android 版本。請檢查更新或 Lineage OS 支持。",
     "@unsupportedAndroidVersionLong": {},
-    "emailOrUsername": "電子郵件或使用者名",
-    "@emailOrUsername": {},
     "widgetJitsi": "Jitsi Meet",
     "@widgetJitsi": {},
-    "usersMustKnock": "使用者必須敲門",
-    "@usersMustKnock": {},
     "knock": "敲門",
     "@knock": {},
-    "storeInSecureStorageDescription": "將恢復密鑰存儲在此裝置的安全存儲中。",
-    "@storeInSecureStorageDescription": {},
     "whyIsThisMessageEncrypted": "為什麼這條訊息無法讀取？",
     "@whyIsThisMessageEncrypted": {},
     "noKeyForThisMessage": "如果訊息是在您登入此裝置之前傳送的，就可能會發生這種情況。\n\n也有可能是傳送者已經封鎖了您的裝置，或者網絡連接出了問題。\n\n如果您能在另一個會話中讀取該訊息，那麼您可以從中轉移訊息！前往設定 > 裝置，並確保您的裝置已相互驗證。當您下次打開房間且兩個會話都在前景時，密鑰將自動傳輸。\n\n不想在登出或切換裝置時丟失密鑰？請確保您已在設定中啟用了聊天室備份。",
     "@noKeyForThisMessage": {},
-    "newSpaceDescription": "空間允許您整合您的聊天室並建立私人或公開社群。",
-    "@newSpaceDescription": {},
     "invalidInput": "無效的輸入！",
     "@invalidInput": {},
-    "verifyOtherUser": "🔐 驗證其他使用者",
-    "@verifyOtherUser": {},
-    "verifyOtherUserDescription": "如果您驗證了另一個使用者，您可以確定您真正與誰通信。💪\n\n當您開始驗證時，您和另一個使用者將在應用程式中看到一個彈出視窗。在那裡，您將看到一系列的表情符號或數字，您需要相互比較。\n\n最好的方式是見面或開始視訊通話。👭",
-    "@verifyOtherUserDescription": {},
     "requestedKeyVerification": "{sender} 請求了密鑰驗證",
     "@requestedKeyVerification": {
         "type": "String",
@@ -2749,8 +2500,6 @@
             }
         }
     },
-    "loginWithMatrixId": "以Matrix-ID登入",
-    "@loginWithMatrixId": {},
     "inviteOtherUsers": "邀請其他用戶進入本聊天",
     "@inviteOtherUsers": {},
     "sendRoomNotifications": "傳送一條 @room 群提醒",
@@ -2770,14 +2519,10 @@
     "@chatPermissionsDescription": {},
     "changeGeneralChatSettings": "變更一般聊天設定",
     "@changeGeneralChatSettings": {},
-    "manageAccount": "帳號管理",
-    "@manageAccount": {},
     "changeTheChatPermissions": "變更聊天室權限",
     "@changeTheChatPermissions": {},
     "changeTheVisibilityOfChatHistory": "變更過往聊天記錄可見度",
     "@changeTheVisibilityOfChatHistory": {},
-    "homeserverDescription": "您的所有資料都儲存在歸屬伺服器上，就像電子郵件提供商一樣。 您可以選擇要使用的歸屬伺服器，同時您仍然可以與每個人溝通。 請訪問https://matrix.org瞭解更多資訊。",
-    "@homeserverDescription": {},
     "sendingAttachment": "附件傳送中…",
     "@sendingAttachment": {},
     "compressVideo": "影片壓縮中…",
@@ -2797,10 +2542,6 @@
     "@noChatsFoundHere": {},
     "changeTheDescriptionOfTheGroup": "變更聊天室說明",
     "@changeTheDescriptionOfTheGroup": {},
-    "discoverHomeservers": "探索歸屬伺服器",
-    "@discoverHomeservers": {},
-    "whatIsAHomeserver": "什麼是歸屬伺服器?",
-    "@whatIsAHomeserver": {},
     "calculatingFileSize": "正在計算檔案大小…",
     "@calculatingFileSize": {},
     "prepareSendingAttachment": "準備傳送附件…",
@@ -2828,8 +2569,6 @@
             }
         }
     },
-    "welcomeText": "嘿，嘿👋這是FluffyChat。 您可以登入任何與https://matrix.org相容的歸屬伺服器後和任何人聊天。 這是一個巨大的去中心化訊息網路！",
-    "@welcomeText": {},
     "setWallpaper": "設定背景樣式",
     "@setWallpaper": {},
     "noContactInformationProvided": "伺服器沒有提供任何有效的聯絡資訊",
@@ -2901,15 +2640,6 @@
     "@version": {},
     "unableToJoinChat": "無法加入聊天室。對話可能以被其他方結束。",
     "@unableToJoinChat": {},
-    "appWantsToUseForLogin": "使用「{server} 」伺服器登入",
-    "@appWantsToUseForLogin": {
-        "type": "String",
-        "placeholders": {
-            "server": {
-                "type": "String"
-            }
-        }
-    },
     "italicText": "斜體",
     "@italicText": {},
     "boldText": "粗體",
@@ -2920,14 +2650,10 @@
     "@pleaseFillOut": {},
     "invalidUrl": "無效 url",
     "@invalidUrl": {},
-    "appWantsToUseForLoginDescription": "你特此允許該應用程式和網站分享關於你的信息。",
-    "@appWantsToUseForLoginDescription": {},
     "open": "打開",
     "@open": {},
     "waitingForServer": "等待伺服器中...",
     "@waitingForServer": {},
-    "appIntroduction": "FluffyChat 讓你和你的朋友跨越工具聊天。在 https://matrix.org 了解更多或*繼續*。",
-    "@appIntroduction": {},
     "previous": "上一個",
     "@previous": {},
     "otherPartyNotLoggedIn": "對方現未登入，未能接收訊息 !",
@@ -3041,15 +2767,6 @@
     "@pleaseWaitUntilInvited": {},
     "notificationRuleIsUserMentionDescription": "被@時通知他們。",
     "@notificationRuleIsUserMentionDescription": {},
-    "countInvited": "已邀請{count}位",
-    "@countInvited": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "checkList": "清單",
     "sentVoiceMessage": "🎙️ {duration} - 來自 {sender} 的語音訊息",
     "commandHint_logout": "登出您的當前設備",
@@ -3062,11 +2779,9 @@
     "taTooltip": "与翻译辅助一起使用L2",
     "interactiveTranslatorSliderHeader": "互动翻译器",
     "interactiveGrammarSliderHeader": "互动语法检查器",
-    "interactiveTranslatorRequired": "必需",
     "waTooltip": "无辅助使用L2",
     "interactiveTranslator": "翻譯協助",
     "noIdenticalLanguages": "請選擇不同的基礎語言和目標語言",
-    "searchBy": "按國家和語言搜索",
     "joinWithClassCode": "加入課程",
     "languageLevelPreA1": "新手低級（Pre A1）",
     "languageLevelA1": "新手中級 (A1)",
@@ -3087,19 +2802,14 @@
     "saveChanges": "保存更改",
     "publicProfileTitle": "允許在搜索中找到我的個人資料",
     "publicProfileDesc": "開啟後，您可以讓其他用戶在全球搜索欄中找到您的個人資料並發送聊天請求。此時，您可以選擇接受或拒絕該請求。",
-    "errorDisableIT": "翻譯協助已關閉。",
-    "errorDisableIGC": "語法協助已關閉。",
     "errorDisableITUserDesc": "點擊此處更新翻譯協助設置",
     "errorDisableIGCUserDesc": "點擊此處更新語法協助設置",
     "errorDisableITClassDesc": "此課程已關閉互動翻譯協助。",
     "errorDisableIGCClassDesc": "此課程已關閉互動語法協助。",
-    "error405Title": "未設定語言",
     "error405Desc": "請在主選單 > 學習設定中設定您的語言。",
     "termsAndConditions": "條款與條件",
     "andCertifyIAmAtLeast13YearsOfAge": " 並證明我已年滿16歲。",
-    "error502504Title": "哇，線上學生好多！",
     "error502504Desc": "在 Pangea 機器人追趕時，翻譯和語法工具可能會變慢或無法使用。",
-    "error404Title": "翻譯錯誤！",
     "error404Desc": "Pangea 機器人不確定如何翻譯那個...",
     "errorPleaseRefresh": "我們正在處理！請重新載入並再試一次。",
     "connectedToStaging": "已連接到測試環境",
@@ -3137,13 +2847,9 @@
     "definitionsToolName": "單詞定義",
     "definitionsToolDescription": "啟用後，藍色底線的單詞可以點擊查看定義。點擊訊息以存取定義。",
     "welcomeBack": "歡迎回來！如果您是2023-2024試點計畫的一部分，請聯繫我們以獲取您的特別試點訂閱。如果您是教師，且已為您的班級購買許可證（或您的機構已購買），請聯繫我們以獲取教師訂閱。",
-    "downloadTxtFile": "下載文字檔",
-    "downloadCSVFile": "下載CSV檔",
     "promotionalSubscriptionDesc": "您目前擁有終身促銷訂閱。請聯繫 support@pangea.chat 以獲取更改訂閱的幫助。",
     "originalSubscriptionPlatform": "訂閱平台為 {purchasePlatform}",
     "oneWeekTrial": "一週試用",
-    "downloadXLSXFile": "下載Excel檔",
-    "unkDisplayName": "未知",
     "wwCountryDisplayName": "全球",
     "afCountryDisplayName": "阿富汗",
     "axCountryDisplayName": "奥兰群岛",
@@ -3438,7 +3144,6 @@
     "chatCapacityHasBeenChanged": "聊天容量已更改",
     "chatCapacitySetTooLow": "聊天容量必須至少為 {count}。",
     "chatCapacityExplanation": "聊天容量限制允許加入的成員數量。",
-    "tooManyRequest": "請求過多，請稍後再試。",
     "enterNumber": "請輸入整數值。",
     "practice": "練習",
     "versionNotFound": "未找到版本",
@@ -3448,7 +3153,6 @@
     "deleteSubscriptionWarningTitle": "您有一個有效的訂閱",
     "deleteSubscriptionWarningBody": "刪除您的帳戶不會自動取消您的訂閱。",
     "manageSubscription": "管理訂閱",
-    "error520Title": "請再試一次。",
     "error520Desc": "抱歉，我們無法理解您的訊息...",
     "wordsUsed": "已使用字數",
     "level": "等級",
@@ -3466,7 +3170,6 @@
     "other": "其他",
     "levelShort": "等級 {level}",
     "noCapacityLimit": "沒有容量限制",
-    "downloadGroupText": "下載群組文字",
     "notificationsOn": "通知已開啟",
     "notificationsOff": "通知已關閉",
     "joinWithCode": "用密碼加入",
@@ -3530,24 +3233,12 @@
     "whatIsTheMorphTag": "'{wordForm}'的{morphologicalFeature}是什麼？",
     "dataAvailable": "資料可用性",
     "available": "可用",
-    "pangeaBotIsFallible": "Pangea 機器人也會犯錯！",
-    "whatIsMeaning": "'{lemma}'的意思是什麼？",
     "chooseLemmaMeaningInstructionsBody": "將意思與訊息中的單詞配對！",
-    "doubleClickToEdit": "雙擊以編輯。",
-    "topicLabel": "主題",
-    "topicPlaceholder": "選擇一個主題...",
-    "modePlaceholder": "選擇一個模式...",
-    "learningObjectiveLabel": "學習目標",
-    "learningObjectivePlaceholder": "選擇一個學習目標...",
-    "targetLanguageLabel": "目標語言",
     "cefrLevelLabel": "CEFR 等級",
     "image": "圖片",
     "video": "影片",
     "nan": "不適用",
-    "addVocabulary": "新增詞彙",
     "instructions": "指示",
-    "numberOfLearners": "學習者人數",
-    "mustBeInteger": "必須是整數，例如 1、2、3、...",
     "constructUsePvmDesc": "以語音訊息產生",
     "leaveSpaceDescription": "退出課程後，您將離開所有該課程中的聊天。其他用戶將看到您已離開課程。",
     "constructUseCorMmDesc": "正確的訊息含義",
@@ -3562,7 +3253,6 @@
     "ttsDisabledBody": "您可以在學習設定中啟用文字轉語音",
     "noSpaceDescriptionYet": "尚未建立課程描述。",
     "tooLargeToSend": "此訊息過大，無法傳送",
-    "exitWithoutSaving": "您確定要不儲存直接離開嗎？",
     "enableAutocorrectPopupTitle": "請前往以下位置加入您的目標語言鍵盤：",
     "enableAutocorrectPopupSteps": "  • 設定\n  • 一般\n  • 鍵盤\n  • 鍵盤\n  • 新增鍵盤",
     "enableAutocorrectPopupDescription": "選擇語言後，您可以點擊鍵盤左下角的小地球圖示來啟用新安裝的鍵盤。",
@@ -3573,11 +3263,8 @@
     "displayName": "顯示名稱",
     "leaveRoomDescription": "您即將離開此聊天。其他用戶將看到您已離開聊天。",
     "confirmUserId": "請確認您的 Pangea 聊天用戶名稱以刪除您的帳戶。",
-    "startingToday": "從今天開始",
-    "oneWeekFreeTrial": "一週免費試用",
     "paidSubscriptionStarts": "自 {startDate} 起",
     "cancelInSubscriptionSettings": "• 可在訂閱設定中隨時取消",
-    "cancelToAvoidCharges": "• 在 {trialEnds} 前取消以避免收費",
     "downloadGboard": "下載 Gboard",
     "autocorrectNotAvailable": "很抱歉，您的平台目前不支援此功能。請持續關注後續開發！",
     "pleaseUpdateApp": "請更新應用程式以繼續使用。",
@@ -3587,17 +3274,12 @@
     "knockSpaceSuccess": "你已申請加入此課程！管理員收到後會回覆你的請求 😄",
     "chooseWordAudioInstructionsBody": "聽完整個訊息。然後將音訊與詞語配對。",
     "chooseMorphsInstructionsBody": "點擊拼圖碎片回答語法問題！",
-    "pleaseEnterInt": "請輸入一個數字",
     "home": "首頁",
     "join": "加入",
     "resetInstructionTooltipsTitle": "重置指示提示",
     "resetInstructionTooltipsDesc": "點擊顯示像新用戶一樣的指示提示。",
-    "randomize": "隨機",
     "clear": "清除",
-    "featuredActivities": "精選",
     "save": "儲存",
-    "startChat": "開始聊天",
-    "translationProblem": "翻譯問題",
     "askToJoin": "請求加入",
     "emptyChatWarningTitle": "聊天是空的",
     "emptyChatWarningDesc": "你還沒有邀請任何人加入你的聊天。前往聊天設置邀請你的聯絡人或機器人。你也可以稍後再做。",
@@ -3627,17 +3309,13 @@
     "timesUsedIndependently": "独立使用次数",
     "timesUsedWithAssistance": "协助使用次数",
     "shareInviteCode": "分享邀请代码：{code}",
-    "leaderboard": "排行榜",
     "skipForNow": "暫時跳過",
     "permissions": "權限",
     "spaceChildPermission": "誰可以向此課程添加新聊天",
-    "addEnvironmentOverride": "新增環境覆蓋",
     "defaultOption": "預設",
     "deleteChatDesc": "你確定要刪除此聊天嗎？所有參與者的聊天內容將被刪除，且所有訊息將不再供練習或學習分析使用。",
     "deleteSpaceDesc": "此課程及所有選擇的聊天將被刪除，所有訊息將不再供練習或學習分析使用。此操作無法還原。",
     "launch": "啟動",
-    "searchChats": "搜尋聊天",
-    "maxFifty": "最多50個",
     "configureSpace": "設定課程",
     "pinMessages": "置頂訊息",
     "setJoinRules": "設定加入規則",
@@ -3671,9 +3349,6 @@
     "failedToFetchTranscription": "獲取轉錄失敗",
     "deleteEmptySpaceDesc": "該課程將被刪除，所有參與者都將失去訪問權限。此操作無法撤銷。",
     "regenerate": "重新生成",
-    "mySavedActivities": "我的已保存活動",
-    "noSavedActivities": "沒有已保存的活動",
-    "saveActivity": "保存此活動",
     "failedToPlayVideo": "播放視頻失敗",
     "done": "完成",
     "inThisSpace": "在此課程中",
@@ -3684,13 +3359,9 @@
     "numInvited": "{count} 已邀請",
     "saved": "已保存",
     "reset": "重置",
-    "errorFetchingActivitiesMessage": "獲取活動失敗",
     "errorFetchingDefinition": "獲取定義失敗",
     "errorProcessAnalytics": "處理分析失敗",
     "errorDownloading": "下載失敗",
-    "errorLoadingSpaceChildren": "載入此課程中的聊天失敗",
-    "unexpectedError": "發生未預期的錯誤。",
-    "pleaseReload": "請重新載入並重試。",
     "translationError": "翻譯錯誤",
     "check": "檢查",
     "unableToFindRoom": "找不到該代碼的聊天或課程。請再試一次。",
@@ -3699,19 +3370,14 @@
     "request": "請求",
     "requestAll": "全部請求",
     "confirmMessageUnpin": "您確定要取消釘選此訊息嗎？",
-    "saveAndLaunch": "保存並啟動",
-    "launchToSpace": "發布到課程",
     "pending": "待處理",
     "inactive": "未激活",
-    "confirmRole": "確認角色",
     "openRoleLabel": "開放",
     "finishedTheActivity": "🎯 {username} 完成了此活動",
     "activitySummaryError": "無法取得活動摘要",
     "requestSummaries": "請求摘要",
-    "generatingNewActivities": "你是此語言對的第一位用戶！請稍候，我們正在為你準備活動。",
     "requestAccessTitle": "請求分析訪問權限？",
     "requestAccessDesc": "你是否想請求查看參與者分析的權限？\n\n如果參與者同意，該課程的管理員將能夠查看他們的：\n    • 總詞彙量\n    • 總語法概念\n    • 完成的活動會話總數\n    • 使用的具體語法概念，正確與錯誤\n\n他們將無法查看他們的：\n    • 課程外的聊天訊息\n    • 詞彙清單",
-    "requestAccess": "請求存取 ({count})",
     "analyticsInactiveTitle": "無法向非活躍用戶發送請求",
     "analyticsInactiveDesc": "自此功能推出以來未登入的非活躍用戶將看不到您的請求。\n\n當他們回來時，請求按鈕將會出現。您可以稍後再次點擊他們名字下的請求按鈕來重新發送請求。",
     "accessRequestedTitle": "分析存取請求",
@@ -3734,8 +3400,6 @@
     "accessDesc": "您可以讓您的課程向全世界開放！或者，將您的課程設為私有且安全。",
     "createGroupChatDesc": "活動會話開始和結束，而群聊將保持開放以進行日常交流。",
     "deleteDesc": "只有管理員可以刪除課程。這是一個破壞性操作，會刪除所有用戶並刪除課程內所有選擇的聊天。請謹慎操作。",
-    "noCourseFound": "哦，這個課程需要一個計劃！\n\n課程計劃是一系列主題和對話活動。",
-    "additionalParticipants": "+ {num} 其他人",
     "whatNow": "接下來怎麼辦？",
     "chooseNextActivity": "選擇您的下一個活動！",
     "letsGo": "我們走吧",
@@ -3747,13 +3411,11 @@
     "waitNotDone": "等一下，我還沒完成！",
     "waitingForOthersToFinish": "等待其他人完成...",
     "generatingSummary": "分析聊天並生成結果",
-    "findCourse": "尋找課程",
     "pingParticipantsNotification": "{user} 正在尋找用戶加入 {room} 的活動會議",
     "course": "課程",
     "courses": "課程",
     "goToCourse": "前往課程：{course}",
     "activityComplete": "此活動已完成。活動摘要應在下方提供。",
-    "startNewSession": "開始新會話",
     "joinOpenSession": "加入公開會話",
     "activityNotFound": "未找到活動",
     "myActivities": "我的活動",
@@ -3797,7 +3459,6 @@
     "inviteYourFriends": "邀请你的朋友",
     "playWithAI": "暂时与AI玩玩",
     "courseStartDesc": "Pangea机器人随时准备开始！\n\n……但和朋友一起学习更好！",
-    "activityDropdownDesc": "完成此活動後，請點擊下方",
     "languageMismatchTitle": "語言不匹配",
     "languageMismatchDesc": "您的目標語言與此活動的語言不符。是否要更新您的目標語言？",
     "reportWordIssueTooltip": "舉報單詞資訊問題",
@@ -3872,10 +3533,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@interactiveTranslatorRequired": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@waTooltip": {
         "type": "String",
         "placeholders": {}
@@ -3885,10 +3542,6 @@
         "placeholders": {}
     },
     "@noIdenticalLanguages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchBy": {
         "type": "String",
         "placeholders": {}
     },
@@ -3976,14 +3629,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorDisableIT": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorDisableIGC": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorDisableITUserDesc": {
         "type": "String",
         "placeholders": {}
@@ -4000,10 +3645,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error405Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error405Desc": {
         "type": "String",
         "placeholders": {}
@@ -4016,15 +3657,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@error502504Title": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@error502504Desc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error404Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -4176,14 +3809,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@downloadTxtFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadCSVFile": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@promotionalSubscriptionDesc": {
         "type": "String",
         "placeholders": {}
@@ -4197,14 +3822,6 @@
         }
     },
     "@oneWeekTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadXLSXFile": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unkDisplayName": {
         "type": "String",
         "placeholders": {}
     },
@@ -5427,10 +5044,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@tooManyRequest": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enterNumber": {
         "type": "String",
         "placeholders": {}
@@ -5471,10 +5084,6 @@
         "placeholders": {}
     },
     "@manageSubscription": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@error520Title": {
         "type": "String",
         "placeholders": {}
     },
@@ -5547,10 +5156,6 @@
         }
     },
     "@noCapacityLimit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@downloadGroupText": {
         "type": "String",
         "placeholders": {}
     },
@@ -5820,47 +5425,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pangeaBotIsFallible": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@whatIsMeaning": {
-        "type": "String",
-        "placeholders": {
-            "lemma": {
-                "type": "String"
-            }
-        }
-    },
     "@chooseLemmaMeaningInstructionsBody": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@doubleClickToEdit": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@topicPlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@modePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectiveLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@learningObjectivePlaceholder": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@targetLanguageLabel": {
         "type": "String",
         "placeholders": {}
     },
@@ -5880,19 +5445,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@addVocabulary": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@instructions": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@numberOfLearners": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@mustBeInteger": {
         "type": "String",
         "placeholders": {}
     },
@@ -5956,10 +5509,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@exitWithoutSaving": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@enableAutocorrectPopupTitle": {
         "type": "String",
         "placeholders": {}
@@ -6000,14 +5549,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@startingToday": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@oneWeekFreeTrial": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@paidSubscriptionStarts": {
         "type": "String",
         "placeholders": {
@@ -6019,14 +5560,6 @@
     "@cancelInSubscriptionSettings": {
         "type": "String",
         "placeholders": {}
-    },
-    "@cancelToAvoidCharges": {
-        "type": "String",
-        "placeholders": {
-            "trialEnds": {
-                "type": "String"
-            }
-        }
     },
     "@downloadGboard": {
         "type": "String",
@@ -6064,10 +5597,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@pleaseEnterInt": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@home": {
         "type": "String",
         "placeholders": {}
@@ -6084,27 +5613,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@randomize": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@clear": {
         "type": "String",
         "placeholders": {}
     },
-    "@featuredActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@save": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startChat": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@translationProblem": {
         "type": "String",
         "placeholders": {}
     },
@@ -6228,10 +5741,6 @@
             }
         }
     },
-    "@leaderboard": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@skipForNow": {
         "type": "String",
         "placeholders": {}
@@ -6241,10 +5750,6 @@
         "placeholders": {}
     },
     "@spaceChildPermission": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@addEnvironmentOverride": {
         "type": "String",
         "placeholders": {}
     },
@@ -6261,14 +5766,6 @@
         "placeholders": {}
     },
     "@launch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@searchChats": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@maxFifty": {
         "type": "String",
         "placeholders": {}
     },
@@ -6408,18 +5905,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@mySavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@noSavedActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@saveActivity": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@failedToPlayVideo": {
         "type": "String",
         "placeholders": {}
@@ -6468,10 +5953,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@errorFetchingActivitiesMessage": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@errorFetchingDefinition": {
         "type": "String",
         "placeholders": {}
@@ -6481,18 +5962,6 @@
         "placeholders": {}
     },
     "@errorDownloading": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@errorLoadingSpaceChildren": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@unexpectedError": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@pleaseReload": {
         "type": "String",
         "placeholders": {}
     },
@@ -6535,23 +6004,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "@saveAndLaunch": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@launchToSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pending": {
         "type": "String",
         "placeholders": {}
     },
     "@inactive": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@confirmRole": {
         "type": "String",
         "placeholders": {}
     },
@@ -6575,10 +6032,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@generatingNewActivities": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@requestAccessTitle": {
         "type": "String",
         "placeholders": {}
@@ -6586,14 +6039,6 @@
     "@requestAccessDesc": {
         "type": "String",
         "placeholders": {}
-    },
-    "@requestAccess": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
     },
     "@analyticsInactiveTitle": {
         "type": "String",
@@ -6698,18 +6143,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@noCourseFound": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@additionalParticipants": {
-        "type": "int",
-        "placeholders": {
-            "num": {
-                "type": "int"
-            }
-        }
-    },
     "@whatNow": {
         "type": "String",
         "placeholders": {}
@@ -6758,10 +6191,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@findCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@pingParticipantsNotification": {
         "type": "String",
         "placeholders": {
@@ -6788,10 +6217,6 @@
         }
     },
     "@activityComplete": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@startNewSession": {
         "type": "String",
         "placeholders": {}
     },
@@ -6975,10 +6400,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@activityDropdownDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@languageMismatchTitle": {
         "type": "String",
         "placeholders": {}
@@ -7024,17 +6445,11 @@
         "placeholders": {}
     },
     "startOwn": "開始我的課程",
-    "joinCourseDesc": "每門課程包含8-10個有序的主題，並配有各種基於任務的語言學習活動。",
     "newMessageInPangeaChat": "📩 Pangea 聊天中有新訊息",
     "shareCourse": "分享課程",
     "addCourse": "添加課程",
-    "joinPublicCourse": "加入公開課程",
     "vocabLevelsDesc": "這是你升級後詞彙將會放置的地方！",
     "@startOwn": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -7047,10 +6462,6 @@
         "placeholders": {}
     },
     "@addCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinPublicCourse": {
         "type": "String",
         "placeholders": {}
     },
@@ -7069,7 +6480,6 @@
     "emojiView": "表情符號視圖",
     "feedbackDialogDesc": "我也會犯錯！有什麼可以幫助我改進的嗎？",
     "contactHasBeenInvitedToTheCourse": "聯絡人已被邀請參加課程",
-    "activityStatsButtonTooltip": "活動資訊",
     "allow": "允許",
     "deny": "拒絕",
     "enabledRenewal": "啟用訂閱續訂",
@@ -7337,10 +6747,6 @@
         "placeholders": {}
     },
     "@contactHasBeenInvitedToTheCourse": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityStatsButtonTooltip": {
         "type": "String",
         "placeholders": {}
     },
@@ -8396,16 +7802,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activitiesToUnlockTopicTitle": "解鎖下一主題的活動",
-    "activitiesToUnlockTopicDesc": "設定解鎖下一課程主題所需的活動數量",
-    "@activitiesToUnlockTopicTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activitiesToUnlockTopicDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "constructUseCorLMDesc": "正確的詞彙定義練習",
     "constructUseIncLMDesc": "不正確的詞彙定義練習",
     "constructUseCorLADesc": "正確的詞彙音頻練習",
@@ -8413,7 +7809,6 @@
     "constructUseBonus": "詞彙練習期間的獎勵",
     "practiceVocab": "練習詞彙",
     "selectMeaning": "選擇意思",
-    "selectAudio": "選擇匹配的音頻",
     "anotherRound": "再來一輪",
     "activitySettingsOverrideWarning": "語言和語言級別由活動計劃決定",
     "voice": "聲音",
@@ -8445,10 +7840,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@selectAudio": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@anotherRound": {
         "type": "String",
         "placeholders": {}
@@ -8466,12 +7857,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "downloadInitiated": "下載已啟動",
     "webDownloadPermissionMessage": "如果您的瀏覽器阻止下載，請為此網站啟用下載。",
-    "@downloadInitiated": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@webDownloadPermissionMessage": {
         "type": "String",
         "placeholders": {}
@@ -8566,11 +7952,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "courseLoadingError": "發生了一些問題，我們正在努力修復。稍後再檢查。",
-    "@courseLoadingError": {
-        "type": "String",
-        "placeholders": {}
-    },
     "autoIGCToolName": "啟用寫作輔助",
     "autoIGCToolDescription": "自動運行 Pangea Chat 工具以將發送的消息更正為目標語言。",
     "@autoIGCToolName": {
@@ -8626,24 +8007,13 @@
         "type": "String",
         "placeholders": {}
     },
-    "spanTypeGrammar": "文法",
-    "spanTypeWordChoice": "用詞選擇",
     "spanTypeSpelling": "拼寫",
     "spanTypePunctuation": "標點符號",
     "spanTypeStyle": "風格",
     "spanTypeFluency": "流暢度",
     "spanTypeAccents": "重音",
     "spanTypeCapitalization": "大寫",
-    "spanTypeCorrection": "修正",
     "spanFeedbackTitle": "報告修正問題",
-    "@spanTypeGrammar": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@spanTypeWordChoice": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanTypeSpelling": {
         "type": "String",
         "placeholders": {}
@@ -8668,10 +8038,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@spanTypeCorrection": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@spanFeedbackTitle": {
         "type": "String",
         "placeholders": {}
@@ -8684,13 +8050,7 @@
     "longPressToRecordVoiceMessage": "長按以錄製語音消息。",
     "pause": "暫停",
     "resume": "繼續",
-    "newSubSpace": "新的子空間",
-    "moveToDifferentSpace": "移動到不同的空間",
-    "removeFromSpaceDescription": "聊天將從空間中移除，但仍會出現在您的聊天列表中。",
     "countChats": "{chats} 條聊天",
-    "spaceMemberOf": "{spaces} 的空間成員",
-    "spaceMemberOfCanKnock": "{spaces} 的空間成員可以敲門",
-    "donate": "捐贈",
     "startedAPoll": "{username} 發起了一個投票。",
     "poll": "投票",
     "startPoll": "開始投票",
@@ -8714,23 +8074,15 @@
     "newStickerPack": "新貼圖包",
     "stickerPackName": "貼圖包名稱",
     "attribution": "歸屬",
-    "skipChatBackup": "跳過聊天備份",
-    "skipChatBackupWarning": "您確定嗎？如果不啟用聊天備份，您可能會在更換設備時失去訪問消息的權限。",
-    "loadingMessages": "正在加載消息",
-    "setupChatBackup": "設置聊天備份",
     "noMoreResultsFound": "未找到更多結果",
     "chatSearchedUntil": "聊天搜索至 {time}",
     "federationBaseUrl": "聯邦基本 URL",
     "clientWellKnownInformation": "客戶端已知信息：",
     "baseUrl": "基本 URL",
     "identityServer": "身份伺服器：",
-    "versionWithNumber": "版本：{version}",
     "logs": "日誌",
-    "advancedConfigs": "進階設定",
     "advancedConfigurations": "進階配置",
-    "signInWithLabel": "使用以下方式登入：",
     "selectAllWords": "選擇您在音頻中聽到的所有單詞",
-    "joinCourseForActivities": "加入課程以嘗試活動。",
     "@changedTheChatDescription": {
         "type": "String",
         "placeholders": {
@@ -8767,18 +8119,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@newSubSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@moveToDifferentSpace": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@removeFromSpaceDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@countChats": {
         "type": "String",
         "placeholders": {
@@ -8786,26 +8126,6 @@
                 "type": "int"
             }
         }
-    },
-    "@spaceMemberOf": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@spaceMemberOfCanKnock": {
-        "type": "String",
-        "placeholders": {
-            "spaces": {
-                "type": "String"
-            }
-        }
-    },
-    "@donate": {
-        "type": "String",
-        "placeholders": {}
     },
     "@startedAPoll": {
         "type": "String",
@@ -8911,22 +8231,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@skipChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipChatBackupWarning": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@loadingMessages": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@setupChatBackup": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@noMoreResultsFound": {
         "type": "String",
         "placeholders": {}
@@ -8955,19 +8259,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@versionWithNumber": {
-        "type": "String",
-        "placeholders": {
-            "version": {
-                "type": "String"
-            }
-        }
-    },
     "@logs": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@advancedConfigs": {
         "type": "String",
         "placeholders": {}
     },
@@ -8975,15 +8267,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "@signInWithLabel": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@selectAllWords": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@joinCourseForActivities": {
         "type": "String",
         "placeholders": {}
     },
@@ -9189,11 +8473,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinSpaceOnboardingDesc": "在課堂上？將您的加入代碼放在這裡。",
-    "@joinSpaceOnboardingDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
     "selectAudioMessagesOnPlayToolName": "自動突出顯示音訊消息",
     "selectAudioMessagesOnPlayDescription": "播放時自動突出顯示音訊消息",
     "@selectAudioMessagesOnPlayToolName": {
@@ -9237,18 +8516,6 @@
     "@clickToAddEmail": {
         "type": "String",
         "placeholders": {}
-    },
-    "minActivitiesPerTopicWarning": "這門課程有主題的活動數少於 {input}。請輸入一個小於或等於 {minValue} 的數字。",
-    "@minActivitiesPerTopicWarning": {
-        "type": "integer",
-        "placeholders": {
-            "input": {
-                "type": "int"
-            },
-            "minValue": {
-                "type": "int"
-            }
-        }
     },
     "clickToLogin": "點擊這裡重新登入。",
     "@clickToLogin": {
@@ -9665,17 +8932,11 @@
         "type": "String",
         "placeholders": {}
     },
-    "bearImageDescription": "一隻卡通風格的黃色熊，興奮地舉起雙臂。",
-    "@bearImageDescription": {
-        "type": "String",
-        "placeholders": {}
-    },
     "readingAssistanceTutorialCollectToken": "選擇單詞以了解更多信息",
     "requireAnalyticsAccessTitle": "需要分析訪問權限才能加入",
     "requireAnalyticsAccessDesc": "參與者必須授予訪問其學習分析的權限才能加入此課程",
     "analyticsAccessNoticeTitle": "需要分析訪問權限",
     "analyticsAccessNoticeDesc": "通過加入此課程，您同意授予管理員訪問您的學習分析的權限。",
-    "skipOnboardingClassCodeDesc": "獨立學習？別擔心，您可以：",
     "@readingAssistanceTutorialCollectToken": {
         "type": "String",
         "placeholders": {}
@@ -9693,10 +8954,6 @@
         "placeholders": {}
     },
     "@analyticsAccessNoticeDesc": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@skipOnboardingClassCodeDesc": {
         "type": "String",
         "placeholders": {}
     },
@@ -9725,7 +8982,6 @@
     "pickCefrLevelTeacherStepTitle": "你教什麼級別？",
     "pickCefrLevelStudentStepTitle": "你是什麼級別？",
     "customCourseStepTitle": "填寫此表單以獲得自訂課程",
-    "aboutYourClass": "關於您的課程",
     "courseCodeStepErrorMessage": "請檢查您的代碼並重試",
     "institution": "機構",
     "courseGoals": "課程目標",
@@ -9768,10 +9024,6 @@
         "placeholders": {}
     },
     "@customCourseStepTitle": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@aboutYourClass": {
         "type": "String",
         "placeholders": {}
     },
@@ -9888,12 +9140,7 @@
         "type": "String",
         "placeholders": {}
     },
-    "pangeaChatLogo": "Pangea 聊天標誌",
     "introChatDetails": "打聲招呼！向你的課程參與者介紹自己，尋找朋友，並在活動之外聊天。",
-    "@pangeaChatLogo": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@introChatDetails": {
         "type": "String",
         "placeholders": {}
@@ -9937,11 +9184,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "activityActions": "活動操作",
-    "@activityActions": {
-        "type": "String",
-        "placeholders": {}
-    },
     "pronunciationTools": "發音工具",
     "audioTranscription": "AI 音頻轉錄",
     "visualLearnerSupport": "視覺學習者支持",
@@ -9982,7 +9224,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "joinTheCourseToPlay": "加入包含此活動的課程以進行遊玩。",
     "resizeCoursePanel": "調整課程面板大小",
     "undo": "撤銷",
     "unlock": "解鎖",
@@ -9996,7 +9237,6 @@
     "addCourseBrowsePublic": "瀏覽公共課程",
     "browsePublicCourses": "瀏覽公共課程",
     "editProfile": "編輯個人資料",
-    "numObjectives": "{count} 個目標",
     "mapSearchHint": "搜尋活動",
     "mapSearchNoResults": "視圖中沒有匹配項",
     "mapFilterAllLanguages": "所有語言",
@@ -10005,7 +9245,6 @@
     "mapFilterCompleted": "完成",
     "mapFilterReset": "重置",
     "activityTypeConversation": "對話",
-    "lockedMissionRequirement": "完成前一個任務以解鎖",
     "playAgain": "再玩一次",
     "reviewActivity": "檢視",
     "mapEmptyInView": "在您的等級或語言中沒有任何內容。擴大您的篩選條件或縮小視圖。",
@@ -10020,14 +9259,9 @@
     "scrollToBottom": "滾動到底部",
     "courseImage": "課程圖片",
     "avatarPreview": "頭像預覽",
-    "activityPhoto": "活動照片",
     "emotePreview": "表情預覽: {name}",
     "activityLabel": "活動: {title}",
     "resetMapView": "重置地圖視圖",
-    "@joinTheCourseToPlay": {
-        "type": "String",
-        "placeholders": {}
-    },
     "@resizeCoursePanel": {
         "type": "String",
         "placeholders": {}
@@ -10080,14 +9314,6 @@
         "type": "String",
         "placeholders": {}
     },
-    "@numObjectives": {
-        "type": "String",
-        "placeholders": {
-            "count": {
-                "type": "int"
-            }
-        }
-    },
     "@mapSearchHint": {
         "type": "String",
         "placeholders": {}
@@ -10117,10 +9343,6 @@
         "placeholders": {}
     },
     "@activityTypeConversation": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@lockedMissionRequirement": {
         "type": "String",
         "placeholders": {}
     },
@@ -10177,10 +9399,6 @@
         "placeholders": {}
     },
     "@avatarPreview": {
-        "type": "String",
-        "placeholders": {}
-    },
-    "@activityPhoto": {
         "type": "String",
         "placeholders": {}
     },


### PR DESCRIPTION
## What

Removes 169 unused translation keys (with their `@` metadata) from all 55 `intl_*.arb` files — FluffyChat base keys for features Pangea doesn't expose (chat backup, recovery keys, multi-account, space admin, public-room encryption, guest access). ~45k lines deleted; `intl_en.arb` drops 2152 → 1983 keys.

## Why

Addresses #7699. Prerequisite for the L1 translation backfill in that issue — no point translating dead copy into ~80 new locales. Each key was confirmed unreferenced via `git grep -w` across the whole tree (excluding `lib/l10n`, `*.arb`, `scripts`), the same method as `scripts/find_unused_intl_keys.py`.

Note: three removed keys (`videoCall`, `voiceCall`, `videoCallsBetaWarning`) relate to calls, which are on the roadmap (voice-video-calls scoping). They're currently unused and trivially re-addable from upstream if calls ship; flagging in case you'd rather keep them.

## Testing

- `git grep -w` confirmed zero references to all 169 keys outside the l10n files.
- `flutter gen-l10n` regenerates cleanly (no errors) with the trimmed arb files.
- Diff is pure removal (`intl_en.arb`: 4 insertions / 464 deletions — the 4 are trailing-comma/whitespace fixes).

**TO TEST**
- [ ] Open the app, navigate through chat, course, and settings screens — all labels render normally with no blank or missing text
- [ ] Switch UI language to a non-English locale (e.g. Spanish) and confirm the same screens still render correctly

## Deploy Notes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Refreshed translations across many supported languages.
  * Updated chat, security, backup, notification, account, and room-management messages.
  * Expanded localized text for learning tools, courses, activities, analytics, subscriptions, onboarding, translation, and grammar assistance.
  * Improved support for dynamic labels, counts, and other formatted messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->