### PR TITLE
feat(chat): let any member download the transcript; restore completed-session menu

### DIFF
--- a/.github/instructions/activities.instructions.md
+++ b/.github/instructions/activities.instructions.md
@@ -25,6 +25,15 @@ The activity's start page doesn't store its own state; it reads it from the room
 
 When a session counts as "ended" is the org doc's call. The client's part is firing the summary once that happens, and keeping a short-lived local cache of the room's analytics so the page doesn't re-fetch on every visit.
 
+## Downloading the transcript
+
+The session's app bar carries a "More" (⋮) menu ([`ActivitySessionPopupMenu`](../../lib/routes/chat/activity_sessions/activity_session_popup_menu.dart)). A **live** session offers Invite, Leave, and Download; a **completed** session — the learner's own role archived (`hasArchivedActivity`) — keeps the menu but offers **Download only**, since Invite and Leave no longer apply once the session is over. Completing a session must not strip the menu: a learner returning to a finished session still needs to export it. (Regular, non-activity chats expose the same export from the chat-details button row, not this menu.)
+
+Download exports the full message history — sender, timestamp, original and sent message, and use type — as TXT / CSV / XLSX ([`lib/features/download/`](../../lib/features/download/)). Two decisions govern who sees it and where:
+
+- **Any room member can export.** The download only surfaces content the member can already read in the chat, so it grants no new visibility. Do not gate it behind power level. The one real cost is that it puts an off-platform copy of a whole room's messages — everyone's, in a group or multi-learner session — in one member's hands; for research-study or minor-heavy rooms that off-platform copy is a genuinely different exposure from in-app reading, and is the open question to revisit if the studies need tighter control.
+- **Web and desktop only, for now.** The download is `kIsWeb`-gated because the native mobile write path (`download_file_util.dart`, storage-permission + Downloads dir) has never shipped and is unvalidated. Enabling mobile is deliberately deferred until that path is tested — until then a completed session on native shows no ⋮ menu at all (Download would be its only item).
+
 ## When the activity can't be fetched
 
 Some session rooms reference an activity that no longer exists on the backend. The fallback ladder and the view-only contract are the org doc's ([Removed or unresolvable activities](../../../.github/.github/instructions/activities.instructions.md#editing-semantics)); what the client shows on each rung:

--- a/lib/routes/chat/activity_sessions/activity_session_popup_menu.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_popup_menu.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:matrix/matrix.dart';
@@ -5,7 +6,6 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/utils/chat_download_provider.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
-import 'package:fluffychat/widgets/matrix.dart';
 
 enum ActivityPopupMenuActions { invite, leave, download }
 
@@ -13,7 +13,16 @@ class ActivitySessionPopupMenu extends StatefulWidget {
   final Room room;
   final VoidCallback onLeave;
 
-  const ActivitySessionPopupMenu(this.room, {required this.onLeave, super.key});
+  /// A completed session (own role archived): only Download applies; leave and
+  /// invite are hidden.
+  final bool isCompleted;
+
+  const ActivitySessionPopupMenu(
+    this.room, {
+    required this.onLeave,
+    this.isCompleted = false,
+    super.key,
+  });
 
   @override
   ActivitySessionPopupMenuState createState() =>
@@ -40,17 +49,20 @@ class ActivitySessionPopupMenuState extends State<ActivitySessionPopupMenu>
         }
       },
       itemBuilder: (BuildContext context) => [
-        PopupMenuItem<ActivityPopupMenuActions>(
-          value: ActivityPopupMenuActions.invite,
-          child: Row(
-            children: [
-              const Icon(Icons.person_add_outlined),
-              const SizedBox(width: 12),
-              Text(L10n.of(context).invite),
-            ],
+        if (!widget.isCompleted)
+          PopupMenuItem<ActivityPopupMenuActions>(
+            value: ActivityPopupMenuActions.invite,
+            child: Row(
+              children: [
+                const Icon(Icons.person_add_outlined),
+                const SizedBox(width: 12),
+                Text(L10n.of(context).invite),
+              ],
+            ),
           ),
-        ),
-        if (MatrixState.pangeaController.userController.showDeveloperOptions)
+        // Any room member can download the transcript; web/desktop only for now
+        // (the native mobile download path is unvalidated).
+        if (kIsWeb)
           PopupMenuItem<ActivityPopupMenuActions>(
             value: ActivityPopupMenuActions.download,
             child: Row(
@@ -61,16 +73,17 @@ class ActivitySessionPopupMenuState extends State<ActivitySessionPopupMenu>
               ],
             ),
           ),
-        PopupMenuItem<ActivityPopupMenuActions>(
-          value: ActivityPopupMenuActions.leave,
-          child: Row(
-            children: [
-              const Icon(Icons.logout_outlined),
-              const SizedBox(width: 12),
-              Text(L10n.of(context).leave),
-            ],
+        if (!widget.isCompleted)
+          PopupMenuItem<ActivityPopupMenuActions>(
+            value: ActivityPopupMenuActions.leave,
+            child: Row(
+              children: [
+                const Icon(Icons.logout_outlined),
+                const SizedBox(width: 12),
+                Text(L10n.of(context).leave),
+              ],
+            ),
           ),
-        ),
       ],
     );
   }

--- a/lib/routes/chat/chat_details/chat_details_button_row.dart
+++ b/lib/routes/chat/chat_details/chat_details_button_row.dart
@@ -119,10 +119,10 @@ class ChatDetailsButtonRowState extends State<ChatDetailsButtonRow> {
         title: l10n.download,
         icon: const Icon(Icons.download_outlined, size: 30.0),
         onPressed: () => widget.controller.downloadChatAction(room.id, context),
-        visible:
-            kIsWeb &&
-            MatrixState.pangeaController.userController.showDeveloperOptions,
-        enabled: room.ownPowerLevel >= 50,
+        // Any room member can export the transcript — it only surfaces content
+        // they can already read in the chat. Web/desktop only for now; the
+        // native mobile download path is unvalidated, so mobile is deferred.
+        visible: kIsWeb,
         showInMainView: false,
       ),
       // ButtonDetails(

--- a/lib/routes/chat/chat_view.dart
+++ b/lib/routes/chat/chat_view.dart
@@ -1,5 +1,6 @@
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:badges/badges.dart';
@@ -156,7 +157,7 @@ class ChatView extends StatelessWidget {
     //   ];
     // }
     // return [];
-    if (controller.room.isArchived || controller.room.hasArchivedActivity) {
+    if (controller.room.isArchived) {
       return [];
     }
 
@@ -169,8 +170,18 @@ class ChatView extends StatelessWidget {
         : const AnalyticsHeaderAvatar();
 
     if (controller.room.showActivityChatUI) {
+      // A completed session (own role archived) keeps its "More" menu, but only
+      // to download the transcript — leave/invite no longer apply. Download is
+      // web/desktop only for now, so on native a completed session has no menu
+      // items; omit the button entirely there.
+      final bool isCompleted = controller.room.hasArchivedActivity;
       return [
-        ActivitySessionPopupMenu(controller.room, onLeave: controller.onLeave),
+        if (!isCompleted || kIsWeb)
+          ActivitySessionPopupMenu(
+            controller.room,
+            onLeave: controller.onLeave,
+            isCompleted: isCompleted,
+          ),
         ?analyticsAvatar,
       ];
     }

--- a/test/pangea/activity_session_popup_menu_test.dart
+++ b/test/pangea/activity_session_popup_menu_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_session_popup_menu.dart';
+import 'get_test_client.dart';
+
+/// The activity-session "More" (⋮) menu is shared between a live session and a
+/// completed one (own role archived). A live session offers Invite / Leave /
+/// Download; a completed session only offers Download — Invite and Leave no
+/// longer apply once the session is over.
+///
+/// Download itself is web/desktop only for now (`kIsWeb`), so it never renders
+/// in the VM test host; these tests pin the Invite/Leave visibility, which is
+/// the behaviour the `isCompleted` flag controls.
+void main() {
+  late Client client;
+  late Room room;
+  late L10n l10n;
+
+  setUp(() async {
+    client = await getTestClient();
+    room = Room(id: '!session:fakeServer.notExisting', client: client);
+  });
+
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  Future<void> pumpMenu(
+    WidgetTester tester, {
+    required bool isCompleted,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            l10n = L10n.of(context);
+            return Scaffold(
+              body: ActivitySessionPopupMenu(
+                room,
+                onLeave: () {},
+                isCompleted: isCompleted,
+              ),
+            );
+          },
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(ActivitySessionPopupMenu));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('live session menu offers Invite and Leave', (tester) async {
+    await pumpMenu(tester, isCompleted: false);
+    expect(find.text(l10n.invite), findsOneWidget);
+    expect(find.text(l10n.leave), findsOneWidget);
+  });
+
+  testWidgets('completed session menu hides Invite and Leave', (tester) async {
+    await pumpMenu(tester, isCompleted: true);
+    expect(find.text(l10n.invite), findsNothing);
+    expect(find.text(l10n.leave), findsNothing);
+  });
+}


### PR DESCRIPTION
## What

Expose the conversation-transcript download to any room member, and bring back the "More" (⋮) menu on completed activity sessions (Download only).

## Why

Closes #7722. The transcript export was gated behind Developer Options + moderator power level, and completed sessions rendered no app-bar actions at all, so participants couldn't export their own chats. Design + the who/where/platform decisions live in client `activities.instructions.md` → **Downloading the transcript** (added here).

Changes:
- Regular chats: drop the `showDeveloperOptions` + `ownPowerLevel >= 50` gates on the chat-details Download button (web/desktop, any member).
- Completed activity sessions: `chat_view` no longer blanks the app bar for `hasArchivedActivity`; the ⋮ menu returns with Download only (Invite/Leave dropped) via a new `isCompleted` flag on `ActivitySessionPopupMenu`.
- Web/desktop only for now (`kIsWeb`) — the native mobile write path is unvalidated and deliberately out of scope; on native a completed session still shows no menu.

## Testing

- `dart analyze` + `dart format` clean on all changed files.
- New widget test `test/pangea/activity_session_popup_menu_test.dart` — live menu shows Invite/Leave, completed menu hides them. Passes.
- Client-app TO TEST steps on the linked issue (#7722).

## Deploy Notes

None.