### PR TITLE
fix(settings): actionable message on change-password session error

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1524,6 +1524,11 @@
         "type": "String",
         "placeholders": {}
     },
+    "changePasswordSessionExpired": "Your session has expired. Please log in again.",
+    "@changePasswordSessionExpired": {
+        "type": "String",
+        "placeholders": {}
+    },
     "overview": "Overview",
     "@overview": {},
     "passwordRecoverySettings": "Password recovery settings",

--- a/lib/utils/localized_exception_extension.dart
+++ b/lib/utils/localized_exception_extension.dart
@@ -106,6 +106,16 @@ extension LocalizedExceptionExtension on Object {
           )) {
             return L10n.of(context).unableToJoinChat;
           }
+          // Changing a password logs the user out of their other sessions
+          // (logout_devices defaults to true server-side). On refresh-token
+          // sessions Synapse can also tear down the current session's token,
+          // so a follow-up request returns a raw 404 "No row found
+          // (access_tokens)" (M_UNKNOWN, not M_UNKNOWN_TOKEN, so soft-logout
+          // never catches it). Surface an actionable message instead of the
+          // internal DB string. See ansible#191 / client#7670.
+          if (exceptionContext == ExceptionContext.changePassword) {
+            return L10n.of(context).changePasswordSessionExpired;
+          }
           // Pangea#
           return (this as MatrixException).errorMessage;
       }


### PR DESCRIPTION
## Problem

On Settings > Security > Change password, changing the password and then immediately changing it again showed a raw server error inside the password field: `No row found (access_tokens)` (HTTP 404, `M_UNKNOWN`). Reported in #7670 and pangeachat/ansible#191.

## Root cause

The client logs in with refresh tokens (`enableSoftLogout` defaults to true). `POST /_matrix/client/v3/account/password` defaults to `logout_devices: true`, which is the behavior we want: changing your password should sign out your other sessions. Synapse is supposed to keep the current session alive (`except_device_id` / `except_access_token_id`), but on a refresh-token session in the deployed Synapse (v1.124.0) it tears down the current session's token too. The follow-up request then presents a dead token, and Synapse returns an internal `404 M_UNKNOWN "No row found (access_tokens)"` instead of a clean `401 M_UNKNOWN_TOKEN`, so the SDK's soft-logout path never catches it and the raw string reaches the UI.

## Change

Map any otherwise-unhandled `MatrixException` in the change-password context to an actionable message ("Your session has expired. Please log in again.") instead of surfacing the internal database string. Wrong-password (`M_FORBIDDEN`) and rate-limit cases keep their existing specific messages.

This is the client-side mitigation only. The full server fix (keep the current session valid under `logout_devices: true`) is tracked in pangeachat/ansible#191 and needs a Synapse upgrade. We are deliberately keeping `logout_devices: true`.

## TO TEST
- [ ] Open Settings > Security > Change password
- [ ] Change password to itself
- [ ] Reopen Settings > Security > Change password
- [ ] Change password again
- [ ] Instead of a raw `No row found (access_tokens)` error, an actionable "Your session has expired. Please log in again." message is shown

Closes #7670
Refs pangeachat/ansible#191
