### PR TITLE
fix(courses): re-attach home server_name to public-course preview room id before join/knock (#7717)

### DIFF
--- a/lib/routes/courses/preview/public_course_preview.dart
+++ b/lib/routes/courses/preview/public_course_preview.dart
@@ -196,17 +196,21 @@ class PublicCoursePreviewController extends State<PublicCoursePreview> {
 
     final knock = roomSummary?.joinRule == JoinRules.knock;
     if (knock) {
-      await showFutureLoadingDialog(
+      final knockResult = await showFutureLoadingDialog(
         context: context,
         future: () async {
           try {
-            await client.knockAndRecordRoom(widget.roomID!);
+            return await client.knockAndRecordRoom(widget.roomID!);
           } catch (e, s) {
             ErrorHandler.logError(e: e, s: s, data: {'roomID': widget.roomID});
             rethrow;
           }
         },
       );
+      // Only confirm the knock when it actually reached the server. On failure
+      // the loading dialog has already surfaced the error; show "You have
+      // knocked" only on success so it can't report a knock that never landed.
+      if (knockResult.result == null) return;
       await showOkAlertDialog(
         context: context,
         title: L10n.of(context).youHaveKnocked,

--- a/lib/routes/world/left_panel/left_panel_add_course_subpage.dart
+++ b/lib/routes/world/left_panel/left_panel_add_course_subpage.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/features/course_plans/new_course_page.dart';
+import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/token_params/add_course_token.dart';
 import 'package:fluffychat/routes/courses/find_course_page.dart';
 import 'package:fluffychat/routes/courses/own/invite/course_invite_page.dart';
@@ -45,7 +46,14 @@ class LeftPanelAddCourseSubpage extends StatelessWidget {
       case AddCourseSubpageEnum.browse:
         final roomId = param.previewRoomId;
         if (roomId != null) {
-          return PublicCoursePreview(roomID: roomId, closeButton: closeButton);
+          // previewRoomId rides the URL token as a bare localpart (shortRoomId
+          // on encode); re-attach the home server_name at this read-back
+          // boundary so join/knock get a legal room id — mirrors routes.dart's
+          // `preview/:courseroomid` builder. See room_id_url.dart.
+          return PublicCoursePreview(
+            roomID: fullRoomId(roomId),
+            closeButton: closeButton,
+          );
         }
         return FindCoursePage(
           closeButton: closeButton,


### PR DESCRIPTION
Closes #7717

## Problem

Joining a course from the **public courses** browser threw `!UjUBPaKalhHnGAnIXC was not legal room ID or room alias`, and courses could not be joined (web + Android). On knock-rule courses the user then also saw a "You have knocked" popup even though the knock never reached the server.

## Root cause

World_v2 URLs carry room ids as **bare localparts** (`!abc`, no `:home.server`) — `shortRoomId` strips the home `server_name` on encode. Every read-back site must re-attach it with `fullRoomId()` before any `getRoomById` / join / knock (see `lib/features/navigation/room_id_url.dart`).

`PublicCoursePreview` has two builders:
- `lib/config/routes.dart` (`preview/:courseroomid`) — **wraps** with `fullRoomId`. ✅
- `lib/routes/world/left_panel/left_panel_add_course_subpage.dart` (the world_v2 browse panel — the path in the report) — passed `param.previewRoomId` **raw**. ❌

So `widget.roomID` was a bare localpart. `_loadSummary()` defended itself with `fullRoomId()` (which is why the preview still rendered), but `joinCourse()` passed the raw id to `knockAndRecordRoom` / `joinRoomWithAccessCheck`, which the matrix SDK rejects as an illegal room id.

The "You have knocked" popup appeared anyway because the knock branch showed the success dialog unconditionally after the loading dialog — so a knock that had actually failed still reported success.

## Fix

Two changes, both in the public-course preview join flow:

1. **Re-attach the home `server_name` at the panel read-back boundary**, mirroring the `routes.dart` builder:

   ```dart
   return PublicCoursePreview(
     roomID: fullRoomId(roomId),
     closeButton: closeButton,
   );
   ```

   `fullRoomId` is idempotent and federation-safe (no-op on an id that already carries a `:domain`), so both entry paths now hand `PublicCoursePreview` a legal room id and join/knock succeed.

2. **Guard the "You have knocked" dialog on actual success** — only show it when the knock returned; on failure the loading dialog already surfaces the error, so it can no longer report a knock that never landed.

## Testing

- `flutter analyze` on both changed files — clean.
- `flutter test test/pangea/navigation/` — 282 passing, no regression. The `fullRoomId`/`shortRoomId` contract this relies on is already covered in `route_facts_test.dart`.
- The end-to-end join/knock exercises a live Synapse, so final confirmation is on staging.

**TO TEST**
- [ ] From the world map, open **add course → browse public courses**, open a public course, and confirm **Join** works (no "not legal room ID" popup).
- [ ] For a knock-rule course, tap **Knock** and confirm the knock actually registers (admin sees the pending knock) and the "You have knocked" popup only shows on success.
- [ ] Confirm on both web and Android.
