### PR TITLE
fix(activities): cap suggestion-card title to 2 lines so participant count isn't clipped

### DIFF
--- a/lib/routes/chat/chat_details/activity_suggestion_card.dart
+++ b/lib/routes/chat/chat_details/activity_suggestion_card.dart
@@ -87,11 +87,17 @@ class ActivitySuggestionCard extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text(
-                        activity.title,
-                        style: TextStyle(fontSize: fontSize),
-                        maxLines: 3,
-                        overflow: TextOverflow.ellipsis,
+                      // Fixed-height card: cap the title and let it yield space
+                      // (Flexible) so the star row and participant/mode row below
+                      // can't be pushed past the card's bottom edge and clipped by
+                      // the ClipRRect when a long title wraps (#7675).
+                      Flexible(
+                        child: Text(
+                          activity.title,
+                          style: TextStyle(fontSize: fontSize),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
                       if (_starsTotal > 0)
                         ActivityStarRow(


### PR DESCRIPTION
## What

Cap the `ActivitySuggestionCard` title at 2 lines and let it yield space, so a long title can no longer push the star row and participant/mode row off the fixed-height card.

## Why

Closes #7675.

The card is a fixed-height box (`cardHeight` 200/280 from `course_objectives_view.dart`) whose inner column holds title → stars → participant/mode row. The title already ellipsized, but at `maxLines: 3` a fully-wrapped title overflowed the height budget and the bottom row (participant count) got clipped by the card's `ClipRRect`. This is the narrow-card / 3-line-title case in the issue. Wrapping the title in `Flexible` also keeps it from clipping the rows below under the text-scaling work in #7719.

## Testing

- Static: `dart format` parses/validates the file clean. Full `flutter analyze`/widget test not run here — local SDK is 3.38.9 vs the repo's pinned 3.41.4, and no existing tests cover this widget.
- Change is layout-only (wrap existing `Text` in `Flexible`, `maxLines` 3 → 2); no logic change.
- Visual confirmation (long title on a narrow course activity card no longer clips the participant count) to be verified on staging via the linked issue's web QA label.

## Deploy Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity suggestion cards with better title wrapping and truncation.
  * Prevented star ratings and participant details from being clipped when titles are long.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->