### PR TITLE
fix(activities): highlight & count spoken target vocab in voice messages (#7659)

### DIFF
--- a/lib/features/activity_sessions/activity_plan_model.dart
+++ b/lib/features/activity_sessions/activity_plan_model.dart
@@ -279,6 +279,13 @@ class ActivityPlanModel {
     };
   }
 
+  /// Target vocab lemmas, lower-cased, as a set for membership tests — used
+  /// to highlight target words in messages and to track which target vocab
+  /// has been used in a session. Callers in hot render loops should read this
+  /// once and reuse it rather than per token (issue #7659).
+  Set<String> get vocabLemmas =>
+      vocab.map((v) => v.lemma.toLowerCase()).toSet();
+
   String get vocabString {
     final List<String> vocabList = [];
     String vocabString = "";

--- a/lib/routes/chat/activity_sessions/activity_chat_controller.dart
+++ b/lib/routes/chat/activity_sessions/activity_chat_controller.dart
@@ -150,33 +150,61 @@ class ActivityChatController {
     }
   }
 
+  bool _updatingUsedVocab = false;
+  bool _usedVocabDirty = false;
+
   Future<void> _updateUsedVocab() async {
-    final vocab = room.activityPlan?.vocab;
-    if (vocab == null || _disposed) return;
+    if (room.activityPlan == null || _disposed) return;
 
-    final vocabLemmas = vocab.map((v) => v.lemma.toLowerCase()).toSet();
-    final used = <String>{};
-
-    final timeline = await room.getTimeline();
-    await timeline.requestHistory();
-
-    for (final event in timeline.events) {
-      if (event.type != EventTypes.Message) continue;
-      final uses = PangeaMessageEvent(
-        event: event,
-        timeline: timeline,
-        ownMessage: event.senderId == userID,
-      ).originalSent?.vocabAndMorphUses;
-      if (uses == null) continue;
-      for (final use in uses) {
-        if (use.identifier.type == ConstructTypeEnum.vocab) {
-          final lemma = use.identifier.lemma.toLowerCase();
-          if (vocabLemmas.contains(lemma)) used.add(lemma);
-        }
-      }
+    // Coalesce bursts of construct updates: while one timeline scan is in
+    // flight, later triggers just mark the result dirty and let the running
+    // pass re-run once at the end. Avoids launching concurrent
+    // room.getTimeline() calls (documented as unsafe) and redundant full
+    // re-scans of the timeline on every analytics tick.
+    if (_updatingUsedVocab) {
+      _usedVocabDirty = true;
+      return;
     }
+    _updatingUsedVocab = true;
 
-    usedVocab.value = used;
+    try {
+      final timeline = await room.getTimeline();
+      // requestHistory loads *older* events; new messages arrive via sync and
+      // mutate timeline.events in place, so this only needs to run once per
+      // burst, not per re-scan.
+      await timeline.requestHistory();
+
+      do {
+        _usedVocabDirty = false;
+
+        final vocabLemmas = room.activityPlan?.vocabLemmas;
+        if (vocabLemmas == null) return;
+        final used = <String>{};
+
+        for (final event in timeline.events) {
+          if (event.type != EventTypes.Message) continue;
+          final uses = PangeaMessageEvent(
+            event: event,
+            timeline: timeline,
+            ownMessage: event.senderId == userID,
+          ).constructUses;
+          if (uses == null) continue;
+          for (final use in uses) {
+            if (use.identifier.type == ConstructTypeEnum.vocab) {
+              final lemma = use.identifier.lemma.toLowerCase();
+              if (vocabLemmas.contains(lemma)) used.add(lemma);
+            }
+          }
+          // Every target word already seen — no need to scan further back.
+          if (used.length == vocabLemmas.length) break;
+        }
+
+        if (_disposed) return;
+        usedVocab.value = used;
+      } while (_usedVocabDirty && !_disposed);
+    } finally {
+      _updatingUsedVocab = false;
+    }
   }
 
   Future<ActivitySummaryAnalyticsModel> getActivityAnalytics() async {

--- a/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
+++ b/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
@@ -9,6 +9,7 @@ import 'package:collection/collection.dart';
 import 'package:matrix/matrix.dart' hide Result;
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import 'package:fluffychat/features/analytics/constructs_model.dart';
 import 'package:fluffychat/pangea/common/constants/model_keys.dart';
 import 'package:fluffychat/pangea/common/models/llm_feedback_model.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
@@ -232,6 +233,16 @@ class PangeaMessageEvent {
   RepresentationEvent? get originalSent => representations.firstWhereOrNull(
     (element) => element.content.originalSent,
   );
+
+  /// Vocab + morph construct uses the sender actually produced in this
+  /// message — the single source for analytics and used-vocab tracking.
+  /// Typed messages read the sent representation's tokens; voice messages
+  /// read the embedded STT transcript. Both yield the same [OneConstructUse]
+  /// shape (spoken words score as `pvm`), so callers don't special-case audio
+  /// (issue #7659).
+  List<OneConstructUse>? get constructUses => isAudioMessage
+      ? getSpeechToTextLocal()?.constructs(room.id, eventId)
+      : originalSent?.vocabAndMorphUses;
 
   RepresentationEvent? get originalWritten => representations.firstWhereOrNull(
     (element) => element.content.originalWritten,

--- a/lib/routes/chat/events/tokens/stt_transcript_tokens.dart
+++ b/lib/routes/chat/events/tokens/stt_transcript_tokens.dart
@@ -15,6 +15,11 @@ class SttTranscriptTokens extends StatelessWidget {
   final void Function(PangeaToken)? onClick;
   final bool Function(PangeaToken)? isSelected;
 
+  /// Lower-cased target vocab lemmas for the room's activity, or null when
+  /// the room has no activity plan. Spoken words whose lemma is in this set
+  /// get the gold highlight, matching typed messages (issue #7659).
+  final Set<String>? vocabLemmas;
+
   const SttTranscriptTokens({
     super.key,
     required this.eventId,
@@ -22,6 +27,7 @@ class SttTranscriptTokens extends StatelessWidget {
     this.onClick,
     this.isSelected,
     this.style,
+    this.vocabLemmas,
   });
 
   List<PangeaToken> get tokens =>
@@ -65,6 +71,10 @@ class SttTranscriptTokens extends StatelessWidget {
 
               final token = tokenPosition.token!;
               final selected = isSelected?.call(token) ?? false;
+              final isVocabHighlight = TokenRenderingUtil.isVocabHighlight(
+                token.lemma.text,
+                vocabLemmas,
+              );
 
               return WidgetSpan(
                 child: HoverBuilder(
@@ -75,14 +85,19 @@ class SttTranscriptTokens extends StatelessWidget {
                       onTap: onClick != null
                           ? () => onClick?.call(token)
                           : null,
-                      child: UnderlineText(
-                        text: text,
-                        style: style ?? DefaultTextStyle.of(context).style,
-                        underlineColor: TokenRenderingUtil.underlineColor(
-                          Theme.of(context).colorScheme.primary.withAlpha(200),
-                          selected: selected,
-                          hovered: hovered,
-                          isNew: newTokens.any((t) => t == token.text),
+                      child: TokenRenderingUtil.vocabHighlight(
+                        highlight: isVocabHighlight,
+                        child: UnderlineText(
+                          text: text,
+                          style: style ?? DefaultTextStyle.of(context).style,
+                          underlineColor: TokenRenderingUtil.underlineColor(
+                            Theme.of(
+                              context,
+                            ).colorScheme.primary.withAlpha(200),
+                            selected: selected,
+                            hovered: hovered,
+                            isNew: newTokens.any((t) => t == token.text),
+                          ),
                         ),
                       ),
                     ),

--- a/lib/routes/chat/events/tokens/token_rendering_util.dart
+++ b/lib/routes/chat/events/tokens/token_rendering_util.dart
@@ -45,4 +45,32 @@ class TokenRenderingUtil {
     if (hovered) return underlineColor.withAlpha(100);
     return Colors.white.withAlpha(0);
   }
+
+  /// Whether a token whose lemma is [lemmaText] is one of the activity's
+  /// target vocab words. [vocabLemmas] must already be lower-cased; pass
+  /// null when the room has no activity plan. Shared by the typed-message
+  /// renderer and the STT transcript renderer so spoken and typed target
+  /// vocab highlight identically (issue #7659).
+  static bool isVocabHighlight(String lemmaText, Set<String>? vocabLemmas) =>
+      vocabLemmas != null && vocabLemmas.contains(lemmaText.toLowerCase());
+
+  /// Wraps [child] in the gold target-vocab highlight when [highlight] is
+  /// true, otherwise returns [child] unchanged. Keeps the typed and spoken
+  /// highlights visually identical.
+  static Widget vocabHighlight({
+    required bool highlight,
+    required Widget child,
+  }) {
+    if (!highlight) return child;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: AppConfig.gold.withAlpha(50),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: child,
+      ),
+    );
+  }
 }

--- a/lib/routes/chat/html_message.dart
+++ b/lib/routes/chat/html_message.dart
@@ -474,9 +474,8 @@ class HtmlMessage extends StatelessWidget {
             .map((v) => v.lemma.toLowerCase())
             .toSet();
         final isVocabHighlight =
-            vocabLemmas != null &&
             token != null &&
-            vocabLemmas.contains(token.lemma.text.toLowerCase());
+            TokenRenderingUtil.isVocabHighlight(token.lemma.text, vocabLemmas);
 
         final tokenWidth = renderer.tokenTextWidthForContainer(
           node.text,
@@ -552,20 +551,10 @@ class HtmlMessage extends StatelessWidget {
                             return ShimmerBackground(
                               enabled: showShimmer,
                               borderRadius: BorderRadius.circular(4.0),
-                              child: isVocabHighlight
-                                  ? DecoratedBox(
-                                      decoration: BoxDecoration(
-                                        color: AppConfig.gold.withAlpha(50),
-                                        borderRadius: BorderRadius.circular(12),
-                                      ),
-                                      child: Padding(
-                                        padding: const EdgeInsets.symmetric(
-                                          horizontal: 4,
-                                        ),
-                                        child: underlineTextWidget,
-                                      ),
-                                    )
-                                  : underlineTextWidget,
+                              child: TokenRenderingUtil.vocabHighlight(
+                                highlight: isVocabHighlight,
+                                child: underlineTextWidget,
+                              ),
                             );
                           },
                         ),

--- a/lib/routes/chat/html_message.dart
+++ b/lib/routes/chat/html_message.dart
@@ -53,9 +53,15 @@ class HtmlMessage extends StatelessWidget {
   final bool isTransitionAnimation;
   final bool isPracticeMode;
   final void Function(PangeaToken)? onClick;
+
+  /// Target vocab lemmas for the room's activity, computed once per build so
+  /// the per-token render loop doesn't rebuild the set for every token
+  /// (issue #7659). Null when the room has no activity plan.
+  late final Set<String>? _activityVocabLemmas =
+      controller.room.activityPlan?.vocabLemmas;
   // Pangea#
 
-  const HtmlMessage({
+  HtmlMessage({
     super.key,
     required this.html,
     required this.room,
@@ -470,12 +476,12 @@ class HtmlMessage extends StatelessWidget {
             !isPracticeMode &&
             isFirstNewToken;
 
-        final vocabLemmas = controller.room.activityPlan?.vocab
-            .map((v) => v.lemma.toLowerCase())
-            .toSet();
         final isVocabHighlight =
             token != null &&
-            TokenRenderingUtil.isVocabHighlight(token.lemma.text, vocabLemmas);
+            TokenRenderingUtil.isVocabHighlight(
+              token.lemma.text,
+              _activityVocabLemmas,
+            );
 
         final tokenWidth = renderer.tokenTextWidthForContainer(
           node.text,

--- a/lib/routes/chat/toolbar/layout/overlay_message.dart
+++ b/lib/routes/chat/toolbar/layout/overlay_message.dart
@@ -6,6 +6,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/features/subscription/widgets/subscription_paywall.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/async_state.dart';
@@ -146,6 +147,13 @@ class OverlayMessage extends StatelessWidget {
     final selectModeController = overlayController.selectModeController;
     final inReplyTo = event.inReplyToEventId(includingFallback: false);
 
+    // Target vocab lemmas for the room's activity, so a spoken word gets the
+    // same gold highlight in the transcript as a typed one does inline
+    // (issue #7659). Null in non-activity rooms — then nothing highlights.
+    final vocabLemmas = controller.room.activityPlan?.vocab
+        .map((v) => v.lemma.toLowerCase())
+        .toSet();
+
     final content = Container(
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(AppConfig.borderRadius),
@@ -285,6 +293,7 @@ class OverlayMessage extends StatelessWidget {
                 eventId: event.eventId,
                 onTokenSelected: overlayController.onClickOverlayMessageToken,
                 isTokenSelected: overlayController.isTokenSelected,
+                vocabLemmas: vocabLemmas,
               ),
               sizeAnimation != null
                   ? AnimatedBuilder(
@@ -450,6 +459,8 @@ class _MessageBubbleTranscription extends StatelessWidget {
   final Function(PangeaToken) onTokenSelected;
   final bool Function(PangeaToken) isTokenSelected;
 
+  final Set<String>? vocabLemmas;
+
   const _MessageBubbleTranscription({
     required this.controller,
     required this.enabled,
@@ -458,6 +469,7 @@ class _MessageBubbleTranscription extends StatelessWidget {
     required this.eventId,
     required this.onTokenSelected,
     required this.isTokenSelected,
+    this.vocabLemmas,
   });
 
   @override
@@ -512,6 +524,7 @@ class _MessageBubbleTranscription extends StatelessWidget {
                         style: style.copyWith(fontStyle: FontStyle.italic),
                         onClick: onTokenSelected,
                         isSelected: isTokenSelected,
+                        vocabLemmas: vocabLemmas,
                       ),
                       // if (MatrixState
                       //     .pangeaController.userController.showTranscription)

--- a/lib/routes/chat/toolbar/layout/overlay_message.dart
+++ b/lib/routes/chat/toolbar/layout/overlay_message.dart
@@ -150,9 +150,7 @@ class OverlayMessage extends StatelessWidget {
     // Target vocab lemmas for the room's activity, so a spoken word gets the
     // same gold highlight in the transcript as a typed one does inline
     // (issue #7659). Null in non-activity rooms — then nothing highlights.
-    final vocabLemmas = controller.room.activityPlan?.vocab
-        .map((v) => v.lemma.toLowerCase())
-        .toSet();
+    final vocabLemmas = controller.room.activityPlan?.vocabLemmas;
 
     final content = Container(
       decoration: BoxDecoration(

--- a/test/pangea/activity_plan_vocab_lemmas_test.dart
+++ b/test/pangea/activity_plan_vocab_lemmas_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_media_enum.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_request.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+
+/// `ActivityPlanModel.vocabLemmas` is the single source of the lower-cased
+/// target-vocab lemma set used by the message highlight and the used-vocab
+/// tracker (issue #7659). Membership tests there compare against lower-cased
+/// token lemmas, so this getter must lower-case and dedupe.
+void main() {
+  ActivityPlanModel plan(List<Vocab> vocab) => ActivityPlanModel(
+    req: ActivityPlanRequest(
+      topic: 'jobs',
+      mode: 'Roleplay',
+      objective: 'introduce yourself',
+      media: MediaEnum.nan,
+      cefrLevel: LanguageLevelTypeEnum.a1,
+      languageOfInstructions: 'en',
+      targetLanguage: 'es',
+      numberOfParticipants: 2,
+    ),
+    title: 't',
+    learningObjective: 'lo',
+    instructions: 'i',
+    vocab: vocab,
+    activityId: 'act-1',
+  );
+
+  test('lower-cases and dedupes lemmas across differing case/pos', () {
+    final p = plan([
+      Vocab(lemma: 'Hola', pos: 'INTJ'),
+      Vocab(lemma: 'hola', pos: 'NOUN'),
+      Vocab(lemma: 'Gracias', pos: 'INTJ'),
+    ]);
+
+    expect(p.vocabLemmas, {'hola', 'gracias'});
+  });
+
+  test('empty vocab yields an empty set', () {
+    expect(plan(const []).vocabLemmas, isEmpty);
+  });
+}

--- a/test/pangea/speech_to_text_constructs_test.dart
+++ b/test/pangea/speech_to_text_constructs_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/analytics/construct_type_enum.dart';
+import 'package:fluffychat/features/analytics/construct_use_type_enum.dart';
+import 'package:fluffychat/pangea/lemmas/lemma.dart';
+import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
+import 'package:fluffychat/routes/chat/events/models/pangea_token_text_model.dart';
+import 'package:fluffychat/routes/chat/events/speech_to_text/speech_to_text_response_model.dart';
+
+/// Voice (STT) messages must yield the same vocab construct uses that typed
+/// messages do, so spoken target vocab is counted as "used" (issue #7659).
+/// This pins `SpeechToTextResponseModel.constructs()` — the audio branch of
+/// `PangeaMessageEvent.constructUses`, which `_updateUsedVocab` intersects
+/// with the activity's target vocab to drive the used-vocab checklist and the
+/// gold highlight.
+PangeaToken _token(String content, {bool saveVocab = true}) => PangeaToken(
+  text: PangeaTokenText.fromJson({'content': content, 'offset': 0}),
+  lemma: Lemma(text: content, saveVocab: saveVocab, form: content),
+  pos: 'NOUN',
+  morph: const {},
+);
+
+SpeechToTextResponseModel _stt(List<PangeaToken> tokens) =>
+    SpeechToTextResponseModel(
+      results: [
+        SpeechToTextResult(
+          transcripts: [
+            Transcript(
+              text: tokens.map((t) => t.text.content).join(' '),
+              confidence: 100,
+              sttTokens: [for (final t in tokens) STTToken(token: t)],
+              langCode: 'es',
+              wordsPerHr: null,
+            ),
+          ],
+        ),
+      ],
+    );
+
+void main() {
+  test('spoken vocab tokens produce vocab construct uses scored as pvm', () {
+    final uses = _stt([_token('hola'), _token('gracias')]).constructs(
+      '!room:test',
+      r'$event',
+    );
+
+    final vocabUses = uses
+        .where((u) => u.identifier.type == ConstructTypeEnum.vocab)
+        .toList();
+
+    expect(
+      vocabUses.map((u) => u.identifier.lemma).toSet(),
+      {'hola', 'gracias'},
+    );
+    // Spoken production scores as pvm (parity with the send-path voice
+    // analytics), not the typed `wa`.
+    expect(
+      vocabUses.every((u) => u.useType == ConstructUseTypeEnum.pvm),
+      isTrue,
+    );
+  });
+
+  test('tokens flagged not to save vocab produce no uses (saveVocab gate)', () {
+    final uses = _stt([_token('the', saveVocab: false)]).constructs(
+      '!room:test',
+      r'$event',
+    );
+    expect(uses, isEmpty);
+  });
+
+  test('uses carry the room and event ids they were built with', () {
+    final uses = _stt([_token('hola')]).constructs('!room:test', r'$evt');
+    expect(uses, isNotEmpty);
+    expect(uses.first.metadata.roomId, '!room:test');
+    expect(uses.first.metadata.eventId, r'$evt');
+  });
+}

--- a/test/pangea/speech_to_text_constructs_test.dart
+++ b/test/pangea/speech_to_text_constructs_test.dart
@@ -39,19 +39,19 @@ SpeechToTextResponseModel _stt(List<PangeaToken> tokens) =>
 
 void main() {
   test('spoken vocab tokens produce vocab construct uses scored as pvm', () {
-    final uses = _stt([_token('hola'), _token('gracias')]).constructs(
-      '!room:test',
-      r'$event',
-    );
+    final uses = _stt([
+      _token('hola'),
+      _token('gracias'),
+    ]).constructs('!room:test', r'$event');
 
     final vocabUses = uses
         .where((u) => u.identifier.type == ConstructTypeEnum.vocab)
         .toList();
 
-    expect(
-      vocabUses.map((u) => u.identifier.lemma).toSet(),
-      {'hola', 'gracias'},
-    );
+    expect(vocabUses.map((u) => u.identifier.lemma).toSet(), {
+      'hola',
+      'gracias',
+    });
     // Spoken production scores as pvm (parity with the send-path voice
     // analytics), not the typed `wa`.
     expect(
@@ -61,10 +61,9 @@ void main() {
   });
 
   test('tokens flagged not to save vocab produce no uses (saveVocab gate)', () {
-    final uses = _stt([_token('the', saveVocab: false)]).constructs(
-      '!room:test',
-      r'$event',
-    );
+    final uses = _stt([
+      _token('the', saveVocab: false),
+    ]).constructs('!room:test', r'$event');
     expect(uses, isEmpty);
   });
 

--- a/test/pangea/token_rendering_util_vocab_highlight_test.dart
+++ b/test/pangea/token_rendering_util_vocab_highlight_test.dart
@@ -36,17 +36,11 @@ void main() {
 
     test('case-insensitive — spoken casing must not defeat the match', () {
       // vocabLemmas is pre-lower-cased by callers; the token lemma may not be.
-      expect(
-        TokenRenderingUtil.isVocabHighlight('Hola', {'hola'}),
-        isTrue,
-      );
+      expect(TokenRenderingUtil.isVocabHighlight('Hola', {'hola'}), isTrue);
     });
 
     test('false for empty lemma even against a non-empty set', () {
-      expect(
-        TokenRenderingUtil.isVocabHighlight('', {'hola'}),
-        isFalse,
-      );
+      expect(TokenRenderingUtil.isVocabHighlight('', {'hola'}), isFalse);
     });
   });
 
@@ -63,31 +57,34 @@ void main() {
       expect(identical(result, child), isTrue);
     });
 
-    testWidgets('wraps the child in the gold highlight when highlight is true', (
-      tester,
-    ) async {
-      final result = TokenRenderingUtil.vocabHighlight(
-        highlight: true,
-        child: const Text('hola'),
-      );
+    testWidgets(
+      'wraps the child in the gold highlight when highlight is true',
+      (tester) async {
+        final result = TokenRenderingUtil.vocabHighlight(
+          highlight: true,
+          child: const Text('hola'),
+        );
 
-      await tester.pumpWidget(
-        MaterialApp(home: Scaffold(body: Center(child: result))),
-      );
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(body: Center(child: result)),
+          ),
+        );
 
-      // The spoken word is still shown...
-      expect(find.text('hola'), findsOneWidget);
+        // The spoken word is still shown...
+        expect(find.text('hola'), findsOneWidget);
 
-      // ...inside a DecoratedBox tinted with the gold vocab colour, matching
-      // the typed-message highlight in html_message.dart.
-      final decoratedBox = tester.widget<DecoratedBox>(
-        find.ancestor(
-          of: find.text('hola'),
-          matching: find.byType(DecoratedBox),
-        ),
-      );
-      final decoration = decoratedBox.decoration as BoxDecoration;
-      expect(decoration.color, AppConfig.gold.withAlpha(50));
-    });
+        // ...inside a DecoratedBox tinted with the gold vocab colour, matching
+        // the typed-message highlight in html_message.dart.
+        final decoratedBox = tester.widget<DecoratedBox>(
+          find.ancestor(
+            of: find.text('hola'),
+            matching: find.byType(DecoratedBox),
+          ),
+        );
+        final decoration = decoratedBox.decoration as BoxDecoration;
+        expect(decoration.color, AppConfig.gold.withAlpha(50));
+      },
+    );
   });
 }

--- a/test/pangea/token_rendering_util_vocab_highlight_test.dart
+++ b/test/pangea/token_rendering_util_vocab_highlight_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/routes/chat/events/tokens/token_rendering_util.dart';
+
+/// Coverage for the shared target-vocab highlight helpers used by BOTH the
+/// typed-message renderer (`html_message.dart`) and the STT transcript
+/// renderer (`stt_transcript_tokens.dart`). These are the load-bearing
+/// decision + gold-wrapping behind issue #7659: spoken target vocab must
+/// highlight the same way typed target vocab does. The widgets themselves
+/// render tokens through `TokensUtil.getNewTokens`, which reads a process-
+/// global `MatrixState` singleton not available under `flutter test` (see
+/// stt_transcript_tokens_test.dart) — so the reusable logic is verified
+/// here, and the end-to-end render stays in the issue's TO TEST steps.
+void main() {
+  group('TokenRenderingUtil.isVocabHighlight', () {
+    test('false when the room has no activity plan (null lemma set)', () {
+      expect(TokenRenderingUtil.isVocabHighlight('hola', null), isFalse);
+    });
+
+    test('true when the lemma is a target vocab word', () {
+      expect(
+        TokenRenderingUtil.isVocabHighlight('hola', {'hola', 'gracias'}),
+        isTrue,
+      );
+    });
+
+    test('false when the lemma is not a target vocab word', () {
+      expect(
+        TokenRenderingUtil.isVocabHighlight('adios', {'hola', 'gracias'}),
+        isFalse,
+      );
+    });
+
+    test('case-insensitive — spoken casing must not defeat the match', () {
+      // vocabLemmas is pre-lower-cased by callers; the token lemma may not be.
+      expect(
+        TokenRenderingUtil.isVocabHighlight('Hola', {'hola'}),
+        isTrue,
+      );
+    });
+
+    test('false for empty lemma even against a non-empty set', () {
+      expect(
+        TokenRenderingUtil.isVocabHighlight('', {'hola'}),
+        isFalse,
+      );
+    });
+  });
+
+  group('TokenRenderingUtil.vocabHighlight', () {
+    testWidgets('returns the child unchanged when highlight is false', (
+      tester,
+    ) async {
+      const child = Text('hola');
+      final result = TokenRenderingUtil.vocabHighlight(
+        highlight: false,
+        child: child,
+      );
+
+      expect(identical(result, child), isTrue);
+    });
+
+    testWidgets('wraps the child in the gold highlight when highlight is true', (
+      tester,
+    ) async {
+      final result = TokenRenderingUtil.vocabHighlight(
+        highlight: true,
+        child: const Text('hola'),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: Center(child: result))),
+      );
+
+      // The spoken word is still shown...
+      expect(find.text('hola'), findsOneWidget);
+
+      // ...inside a DecoratedBox tinted with the gold vocab colour, matching
+      // the typed-message highlight in html_message.dart.
+      final decoratedBox = tester.widget<DecoratedBox>(
+        find.ancestor(
+          of: find.text('hola'),
+          matching: find.byType(DecoratedBox),
+        ),
+      );
+      final decoration = decoratedBox.decoration as BoxDecoration;
+      expect(decoration.color, AppConfig.gold.withAlpha(50));
+    });
+  });
+}


### PR DESCRIPTION
## Why

Closes #7659.

In conversation activities, target vocab words highlight gold when the learner **types** them, but not when they **speak** them via voice (STT). Two surfaces were affected by one root cause:

1. The gold **word highlight** in a voice message's transcript.
2. The activity **"used vocab" checklist** (`ActivityVocabWidget`), which never ticked off spoken words.

## Root cause

Voice messages already carry fully-lemmatized tokens (`STTToken.token` is a `PangeaToken`), but two consumers only ever looked at the typed path:

- The gold highlight lived only in the typed-message renderer (`html_message.dart`); the STT transcript renderer (`SttTranscriptTokens`) drew underlines but never checked the activity vocab.
- `_updateUsedVocab` read `originalSent?.vocabAndMorphUses`, which is null for audio events (no `tokens_sent`), so spoken vocab was never counted.

Nothing new had to be generated — the lemmas were there; the highlight/used-vocab logic just wasn't consulting them.

## What changed

**The fix**
- **`SttTranscriptTokens`** — wraps spoken tokens whose lemma is a target word in the same gold highlight as typed messages.
- **`PangeaMessageEvent.constructUses`** — one accessor returning the sender's vocab+morph uses for a message, from the sent representation (typed) or the embedded STT transcript (voice, scored `pvm`). `_updateUsedVocab` now uses it, so spoken target vocab ticks off the checklist.

**DRY / performance audit of the used-vocab path**
- **`ActivityPlanModel.vocabLemmas`** — the lower-cased target-lemma set was computed inline in three places (typed highlight, STT highlight, used-vocab scan). Now one getter.
- **`html_message.dart`** — that set was being rebuilt **for every token** in the per-token render loop; hoisted to a build-scoped field so it's computed once per message.
- **`_updateUsedVocab`** — now **coalesces** bursts of construct-update triggers (a full timeline scan in flight defers later triggers and re-runs once), which removes the documented-unsafe concurrent `room.getTimeline()` calls and the redundant `requestHistory()`/re-scan per analytics tick; and **early-exits** once every target word has been seen.
- **`TokenRenderingUtil.isVocabHighlight` / `vocabHighlight`** — the highlight decision + gold-box wrap are shared by the typed and STT renderers, so the two highlight *identically*.

## Deliberately out of scope

The activity **summary** analytics (`ActivitySummaryAnalyticsModel.addMessageConstructs`) has the same typed-only pattern, but its message-gathering (`getPangeaMessageEvents`) is Text-only and feeds summary **generation** — counting voice there changes what's sent to the summary LLM. That's a separate change with its own test surface; left for a follow-up rather than widening this PR.

## Testing

- `flutter analyze` — clean on all changed files.
- New tests: `speech_to_text_constructs_test.dart` (spoken tokens → vocab uses, `pvm`, `saveVocab` gate — the audio branch of `constructUses`), `activity_plan_vocab_lemmas_test.dart` (lower-case + dedupe), `token_rendering_util_vocab_highlight_test.dart` (decision + gold wrap). Existing `stt_transcript_tokens`, `tokens_util`, `vocab_and_morph_uses` still green.
- The full STT transcript render and the live checklist depend on a `MatrixState` singleton unavailable under `flutter test` (per the existing STT test's note), so the reusable logic is unit-tested and the end-to-end render stays in TO TEST.

TO TEST
- [ ] Open a conversation activity that has target vocabulary. The target words appear as chips in the activity's vocab list (the used-vocab panel).
- [ ] **Typed (existing behavior — should still work):** Send a text message that includes one of the target vocab words. Confirm the word is highlighted **gold/yellow** in your sent message, and its chip in the activity vocab list becomes highlighted (marked used).
- [ ] **Spoken (the fix):** Record and send a voice message saying a *different* target vocab word. Wait for it to finish transcribing, then tap the voice message to open it and view its transcript. Confirm the spoken target word is highlighted **gold/yellow** in the transcript, and its chip in the activity vocab list becomes highlighted (marked used).
- [ ] **No regression outside activities:** In a normal 1:1 chat that is *not* an activity, send a voice message and open its transcript. Confirm **no** gold/yellow vocab highlighting appears.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity vocabulary is now highlighted in gold across typed messages and speech-to-text transcripts.
  * Spoken vocabulary usage is detected more reliably, including audio messages.
  * Vocabulary matching is case-insensitive and removes duplicates.

* **Bug Fixes**
  * Prevented overlapping vocabulary scans during rapid activity updates.

* **Tests**
  * Added coverage for vocabulary matching, highlighting, and speech-to-text vocabulary detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->