### PR TITLE
fix(practice): draw morph distractors only from display-eligible tags

### DIFF
--- a/lib/pangea/morphs/grammar_constructs_provider.dart
+++ b/lib/pangea/morphs/grammar_constructs_provider.dart
@@ -50,15 +50,27 @@ class GrammarConstructsProvider {
     return morphs.getTag(feature, tag);
   }
 
-  static List<GrammarTag> getTags({required String feature}) {
-    final morphs = getFeaturesAndTags();
-    return morphs.getFeature(feature)?.tags ?? [];
-  }
+  static List<GrammarTag> getTags({required String feature}) =>
+      getFeaturesAndTags().getTags(feature);
 
-  static Future<List<GrammarTag>> fetchTags({required String feature}) async {
-    final morphs = await fetchFeaturesAndTags();
-    return morphs.getFeature(feature)?.tags ?? [];
-  }
+  static Future<List<GrammarTag>> fetchTags({required String feature}) async =>
+      (await fetchFeaturesAndTags()).getTags(feature);
+
+  /// Eligible distractor tag values for a morph practice question on
+  /// [feature] with correct answer [answerTag]. Single source of truth for
+  /// both practice generators — display-filtered, answer-excluded, and with
+  /// non-lemma POS categories removed. See
+  /// [MorphFeaturesAndTags.distractorTagValues].
+  static List<String> distractorTagValues({
+    required String feature,
+    required String answerTag,
+  }) => getFeaturesAndTags().distractorTagValues(feature, answerTag);
+
+  static Future<List<String>> fetchDistractorTagValues({
+    required String feature,
+    required String answerTag,
+  }) async =>
+      (await fetchFeaturesAndTags()).distractorTagValues(feature, answerTag);
 
   static GrammarFeature? getFeature({required String feature}) {
     final morphs = getFeaturesAndTags();

--- a/lib/pangea/morphs/morph_features_and_tags.dart
+++ b/lib/pangea/morphs/morph_features_and_tags.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 
 import 'package:fluffychat/pangea/morphs/default_grammar_constructs_response.dart';
 import 'package:fluffychat/pangea/morphs/grammar_constructs_response.dart';
+import 'package:fluffychat/pangea/morphs/parts_of_speech_enum.dart';
 
 class MorphFeaturesAndTags {
   final String _targetLanguage;
@@ -94,6 +95,32 @@ class MorphFeaturesAndTags {
     _tagLookup[_langKey]![feature]![tag] = match;
     return match;
   }
+
+  /// The display-eligible tags for [feature] — only those whose
+  /// (feature, value) actually manifests in the target language
+  /// (`display: true`), the same set surfaced in grammar analytics.
+  ///
+  /// Distinct from `getFeature(feature)?.tags`, which exposes the raw
+  /// `GrammarFeature` carrying the full unfiltered UD inventory. Grammar
+  /// practice must draw from this filtered set so typological labels that
+  /// don't apply to the language (e.g. jussive mood in French) never
+  /// surface as answer options.
+  List<GrammarTag> getTags(String feature) => _getFeature(feature)?.tags ?? [];
+
+  /// Candidate distractor tag *values* for a morph practice question on
+  /// [feature] whose correct answer is [answerTag]. Drawn only from the
+  /// display-eligible set ([getTags]), minus the answer (case-insensitive)
+  /// and any non-lemma POS category (punctuation/symbol/space/affix/x —
+  /// never a real word a learner could produce).
+  List<String> distractorTagValues(String feature, String answerTag) =>
+      getTags(feature)
+          .map((t) => t.value)
+          .where(
+            (value) =>
+                value.toLowerCase() != answerTag.toLowerCase() &&
+                PartOfSpeechEnum.isEligibleLemmaTag(value),
+          )
+          .toList();
 
   String guessMorphCategory(String morphLemma) {
     final cached = _morphCategoriesCache[morphLemma];

--- a/lib/routes/analytics/construct_analytics/practice/morph_category_practice_exercise_generator.dart
+++ b/lib/routes/analytics/construct_analytics/practice/morph_category_practice_exercise_generator.dart
@@ -1,5 +1,4 @@
 import 'package:fluffychat/pangea/morphs/grammar_constructs_provider.dart';
-import 'package:fluffychat/pangea/morphs/parts_of_speech_enum.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/practice/analytics_practice_session_model.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/practice/analytics_practice_session_repo.dart';
 import 'package:fluffychat/routes/chat/toolbar/practice_exercises/message_practice_exercise_request.dart';
@@ -22,17 +21,11 @@ class MorphCategoryPracticeExerciseGenerator {
       throw ArgumentError("Token does not have the specified morph feature");
     }
 
-    final tags = await GrammarConstructsProvider.fetchTags(
-      feature: feature.name,
-    );
-    final allTags = tags.map((t) => t.value);
-    final List<String> possibleDistractors = allTags
-        .where(
-          (tag) =>
-              tag.toLowerCase() != morphTag.toLowerCase() &&
-              PartOfSpeechEnum.isEligibleLemmaTag(tag),
-        )
-        .toList();
+    final List<String> possibleDistractors =
+        await GrammarConstructsProvider.fetchDistractorTagValues(
+          feature: feature.name,
+          answerTag: morphTag,
+        );
 
     if (possibleDistractors.isEmpty) {
       throw InsufficientDataException();

--- a/lib/routes/chat/toolbar/practice_exercises/morph_practice_exercise_generator.dart
+++ b/lib/routes/chat/toolbar/practice_exercises/morph_practice_exercise_generator.dart
@@ -4,7 +4,6 @@ import 'package:flutter/foundation.dart';
 
 import 'package:fluffychat/pangea/morphs/grammar_constructs_provider.dart';
 import 'package:fluffychat/pangea/morphs/morph_features_enum.dart';
-import 'package:fluffychat/pangea/morphs/parts_of_speech_enum.dart';
 import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
 import 'package:fluffychat/routes/chat/toolbar/message_practice/message_morph_choice.dart';
 import 'package:fluffychat/routes/chat/toolbar/practice_exercises/message_practice_exercise_request.dart';
@@ -30,15 +29,11 @@ class MorphPracticeExerciseGenerator {
       throw "No morph tag found for morph feature";
     }
 
-    final tags = GrammarConstructsProvider.getTags(feature: morphFeature.name);
-    final allTags = tags.map((t) => t.value);
-    final List<String> possibleDistractors = allTags
-        .where(
-          (tag) =>
-              tag.toLowerCase() != morphTag.toLowerCase() &&
-              PartOfSpeechEnum.isEligibleLemmaTag(tag),
-        )
-        .toList();
+    final List<String> possibleDistractors =
+        GrammarConstructsProvider.distractorTagValues(
+          feature: morphFeature.name,
+          answerTag: morphTag,
+        );
 
     possibleDistractors.shuffle();
     final distractors = possibleDistractors
@@ -48,7 +43,11 @@ class MorphPracticeExerciseGenerator {
     distractors.add(morphTag);
     final choices = distractors.toList()..shuffle();
 
-    debugger(when: kDebugMode && distractors.length < 3);
+    // A feature with only the answer as a display-eligible tag should have
+    // been filtered out at selection time (see practice_selection_repo).
+    // Fewer real values than that means either that gate or the language's
+    // grammar-constructs data is wrong.
+    debugger(when: kDebugMode && distractors.length < 2);
 
     return MessagePracticeExerciseResponse(
       exercise: MorphMatchPracticeExerciseModel(

--- a/lib/routes/chat/toolbar/practice_exercises/practice_selection_repo.dart
+++ b/lib/routes/chat/toolbar/practice_exercises/practice_selection_repo.dart
@@ -2,6 +2,7 @@ import 'package:get_storage/get_storage.dart';
 
 import 'package:fluffychat/pangea/common/constants/model_keys.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/pangea/morphs/grammar_constructs_provider.dart';
 import 'package:fluffychat/pangea/morphs/morph_features_enum.dart';
 import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
 import 'package:fluffychat/routes/chat/toolbar/practice_exercises/practice_exercise_type_enum.dart';
@@ -163,6 +164,15 @@ class PracticeSelectionRepo {
 
   static List<PracticeTarget> _tokenToMorphTargets(PangeaToken t) {
     return t.morphsBasicallyEligibleForPracticeByPriority
+        // Only offer a question when at least one real (display-eligible)
+        // distractor exists for this feature+answer in the current language;
+        // otherwise the exercise would have no valid wrong answers.
+        .where(
+          (m) => GrammarConstructsProvider.distractorTagValues(
+            feature: m.category,
+            answerTag: m.lemma,
+          ).isNotEmpty,
+        )
         .map(
           (m) => PracticeTarget(
             tokens: [t],

--- a/test/pangea/morphs/morph_features_and_tags_test.dart
+++ b/test/pangea/morphs/morph_features_and_tags_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/morphs/grammar_constructs_response.dart';
+import 'package:fluffychat/pangea/morphs/morph_features_and_tags.dart';
+
+/// Regression coverage for #7715: grammar practice must draw answer options
+/// only from the display-eligible tag set (the values that actually manifest
+/// in the target language), never from the full unfiltered UD inventory.
+void main() {
+  Map<String, dynamic> tag(
+    String value, {
+    required bool display,
+    String? title,
+  }) => {
+    "value": value,
+    "display": display,
+    "example": "",
+    "sequence_position": 3.5,
+    "title": title ?? value,
+    "description": "",
+  };
+
+  MorphFeaturesAndTags build(List<Map<String, dynamic>> features) =>
+      MorphFeaturesAndTags.fromGrammarConstructsResponse(
+        response: GrammarConstructsResponse.fromJson({
+          "user_l1": "en",
+          "source_l1": "en",
+          "target_language": "fr",
+          "features": features,
+        }),
+      );
+
+  setUp(MorphFeaturesAndTags.clearLookupCache);
+
+  group('MorphFeaturesAndTags.getTags', () {
+    test('returns only display-eligible tags', () {
+      final morphs = build([
+        {
+          "feature": "Mood",
+          "feature_title": "Mood",
+          "values": [
+            tag("Ind", display: true, title: "Indicative"),
+            tag("Sub", display: true, title: "Subjunctive"),
+            tag("Jus", display: false, title: "Jussive"),
+            tag("Prp", display: false, title: "Purposive"),
+          ],
+        },
+      ]);
+
+      expect(
+        morphs.getTags("Mood").map((t) => t.value),
+        ["Ind", "Sub"],
+        reason: 'display:false typological labels must be filtered out',
+      );
+    });
+
+    test('does not mutate the unfiltered inventory on getFeature', () {
+      final morphs = build([
+        {
+          "feature": "Mood",
+          "feature_title": "Mood",
+          "values": [
+            tag("Ind", display: true),
+            tag("Jus", display: false),
+          ],
+        },
+      ]);
+
+      // getFeature still exposes the raw GrammarFeature (full inventory);
+      // only getTags applies the display filter. This documents where the
+      // fix lives so a future refactor doesn't silently reintroduce the leak.
+      expect(morphs.getFeature("Mood")?.tags.map((t) => t.value), [
+        "Ind",
+        "Jus",
+      ]);
+      expect(morphs.getTags("Mood").map((t) => t.value), ["Ind"]);
+    });
+  });
+
+  group('MorphFeaturesAndTags.distractorTagValues', () {
+    test('excludes display:false values and the answer (case-insensitive)', () {
+      final morphs = build([
+        {
+          "feature": "Mood",
+          "feature_title": "Mood",
+          "values": [
+            tag("Ind", display: true),
+            tag("Sub", display: true),
+            tag("Cnd", display: true),
+            tag("Jus", display: false),
+            tag("Adm", display: false),
+          ],
+        },
+      ]);
+
+      expect(morphs.distractorTagValues("Mood", "ind"), ["Sub", "Cnd"]);
+    });
+
+    test('excludes non-lemma POS categories even when display:true', () {
+      final morphs = build([
+        {
+          "feature": "Pos",
+          "feature_title": "Part of speech",
+          "values": [
+            tag("NOUN", display: true),
+            // A non-lemma category that is (incorrectly) display:true must
+            // still never be offered as a distractor — the #7601 guard.
+            tag("PUNCT", display: true),
+            tag("AFFIX", display: false),
+          ],
+        },
+      ]);
+
+      expect(morphs.distractorTagValues("Pos", "NOUN"), isEmpty);
+    });
+
+    test('returns empty when the answer is the only display-eligible tag', () {
+      final morphs = build([
+        {
+          "feature": "Poss",
+          "feature_title": "Possessive",
+          "values": [
+            tag("Yes", display: true),
+            tag("No", display: false),
+          ],
+        },
+      ]);
+
+      expect(morphs.distractorTagValues("Poss", "Yes"), isEmpty);
+    });
+  });
+}

--- a/test/pangea/morphs/morph_features_and_tags_test.dart
+++ b/test/pangea/morphs/morph_features_and_tags_test.dart
@@ -59,10 +59,7 @@ void main() {
         {
           "feature": "Mood",
           "feature_title": "Mood",
-          "values": [
-            tag("Ind", display: true),
-            tag("Jus", display: false),
-          ],
+          "values": [tag("Ind", display: true), tag("Jus", display: false)],
         },
       ]);
 
@@ -119,10 +116,7 @@ void main() {
         {
           "feature": "Poss",
           "feature_title": "Possessive",
-          "values": [
-            tag("Yes", display: true),
-            tag("No", display: false),
-          ],
+          "values": [tag("Yes", display: true), tag("No", display: false)],
         },
       ]);
 


### PR DESCRIPTION
## What

Grammar practice (toolbar and analytics) no longer offers abbreviated, non-applicable morphology values as wrong answers — e.g. `Jus`, `Prp`, `Adm`, `Com`, `Neut`, `Inv`, `Conv`, and `PHRASALV` where the language doesn't use them.

## Why

Closes #7715.

Root cause: the distractor pool was drawn from `MorphFeaturesAndTags.getFeature(feature).tags` — the raw `GrammarFeature` carrying the **full unfiltered UD inventory** — so `display: false` values (typological labels that don't manifest in the target language) leaked in. The `.where((t) => t.display)` filter is applied only to the sibling `MorphFeatureTags.tags` field, which grammar analytics reads (so names render correctly there) but the two practice generators didn't. They then rendered as raw UD codes because a leaked `display: false` tag has no title in the filtered lookup. #7601 patched only the POS symptom via `isEligibleLemmaTag`; every other feature still leaked.

## What changed

- `MorphFeaturesAndTags.getTags` / `distractorTagValues` — one display-filtered source of truth for the distractor pool (answer-excluded case-insensitively, non-lemma POS categories removed). Both practice generators now call it through `GrammarConstructsProvider`, replacing the duplicated inline filters.
- Toolbar feature selection (`_tokenToMorphTargets`) skips a feature with no display-eligible distractor, so filtering can't produce a 0-distractor question (analytics already gated on `tags.length > 1`).

## Testing

- `flutter analyze` on the touched dirs — no issues.
- `flutter test test/pangea/morphs/` — new `morph_features_and_tags_test.dart` (display filter, answer/case exclusion, non-lemma POS guard even when `display: true`, single-eligible-tag → empty pool) plus the existing POS test — all pass.
- Runtime QA on staging per the issue's TO TEST checklist (high CEFR, several L2s).

## Deploy Notes

None.
