### PR TITLE
fix(chat): round the Close chat hover highlight in an open chat (#7656)

### DIFF
--- a/lib/routes/chat/chat_view.dart
+++ b/lib/routes/chat/chat_view.dart
@@ -315,7 +315,14 @@ class ChatView extends StatelessWidget {
                       )
                     // #Pangea
                     : controller.widget.backButton != null
-                    ? controller.widget.backButton!
+                    // Center so the injected close/back control keeps its
+                    // natural square size instead of being stretched to the
+                    // leading slot's tight height (72 in column mode, per
+                    // appBarTheme.toolbarHeight). A stretched M3 IconButton's
+                    // StadiumBorder hover overlay renders as a tall pill rather
+                    // than a circle (#7656). Mirrors the default BackButton
+                    // branch below, which is likewise Center-wrapped.
+                    ? Center(child: controller.widget.backButton!)
                     // : FluffyThemes.isColumnMode(context)
                     // ? null
                     // Pangea#


### PR DESCRIPTION
## What
The close (X) button in an open chat's header showed an oversized, vertically stretched hover highlight (a tall pill) instead of the round highlight every other panel close button uses.

## Why
The chat `AppBar`'s `leading` slot stretches its child to fill the column-mode toolbar (56 wide by 72 tall, from `appBarTheme.toolbarHeight`). The injected close/back control (`backButton`) was placed there raw, so the Material 3 `IconButton` filled the 56x72 slot and its `StadiumBorder` hover overlay drew as a tall pill. The chat-list X and the analytics/settings X's stay round because they sit in a centered `PanelHeader` row at their natural 48x48 size.

## Fix
Wrap the injected leading in `Center`, so it keeps its natural square size (48x48, round hover), matching the default back-button branch right below it (also `Center`-wrapped) and the other panel close buttons. One-line widget change.

Verified against staging: the live "Close chat" button measures 56x72 (the pill). A raw `IconButton` in a tight 56x72 box reproduces the pill; wrapping it in `Center` yields a 48x48 circle.

Closes #7656

## TO TEST
- [ ] Open a chat in the web client (wide / column layout).
- [ ] Hover the X (Close chat) in the chat header.
- [ ] The hover highlight is a round circle, matching the "Close chat list" X and the other panel close buttons (not a tall oval/pill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
