### PR TITLE
feat(activities): autosave completed sessions and bank stars on save

### DIFF
--- a/.github/instructions/activities.instructions.md
+++ b/.github/instructions/activities.instructions.md
@@ -25,6 +25,12 @@ The activity's start page doesn't store its own state; it reads it from the room
 
 When a session counts as "ended" is the org doc's call. The client's part is firing the summary once that happens, and keeping a short-lived local cache of the room's analytics so the page doesn't re-fetch on every visit.
 
+## Completion saves itself
+
+Saving a completed session is automatic — the design (what saving means, when it happens, and how stars bank on it) is the org doc's ([Saving and stars](../../../.github/.github/instructions/activities.instructions.md#saving-and-stars)); what the client owns is where the save runs. [`ActivityAutoSaveService`](../../lib/features/activity_sessions/activity_auto_save_service.dart) watches activity-role state changes across **all** rooms, not just the open chat, so a session that completes while the learner is elsewhere — or that completed before this login — still saves on the next sync. The save is idempotent, so a second device observing the same completion is harmless. A room whose plan is still hydrating is retried once the plan lands; a room whose plan is gone entirely (the archived-view rung in [When the activity can't be fetched](#when-the-activity-cant-be-fetched)) cannot resolve a target language and is skipped.
+
+The profile star counter ([`totalStarsEarned`](../../lib/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart)) counts saved sessions only. In-session star displays and per-activity progress on cards stay live — only the profile total waits for the save.
+
 ## Downloading the transcript
 
 The session's app bar carries a "More" (⋮) menu ([`ActivitySessionPopupMenu`](../../lib/routes/chat/activity_sessions/activity_session_popup_menu.dart)). A **live** session offers Invite, Leave, and Download; a **completed** session — the learner's own role archived (`hasArchivedActivity`) — keeps the menu but offers **Download only**, since Invite and Leave no longer apply once the session is over. Completing a session must not strip the menu: a learner returning to a finished session still needs to export it. (Regular, non-activity chats expose the same export from the chat-details button row, not this menu.)

--- a/lib/features/activity_sessions/activity_auto_save_service.dart
+++ b/lib/features/activity_sessions/activity_auto_save_service.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/features/analytics_data/analytics_data_service.dart';
+import 'package:fluffychat/features/languages/p_language_store.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+
+/// Whether a session is due for an automatic save: the session ended, this
+/// user finished their own role, and they haven't saved it yet. A user who
+/// left without finishing never saves (their stars never bank — the incentive
+/// to finish).
+@visibleForTesting
+bool activityAutoSaveGate({
+  required bool isActivityFinished,
+  required bool hasCompletedRole,
+  required bool hasArchivedActivity,
+}) => isActivityFinished && hasCompletedRole && !hasArchivedActivity;
+
+/// Saves completed activity sessions automatically — records the session to
+/// the learner's analytics room and archives their role — so a session that
+/// completes while the learner is elsewhere still saves on the next sync.
+/// See activities.instructions.md → "Completion saves itself".
+class ActivityAutoSaveService {
+  final Client client;
+  final AnalyticsDataService analyticsService;
+
+  ActivityAutoSaveService({
+    required this.client,
+    required this.analyticsService,
+  });
+
+  StreamSubscription? _roleStateSub;
+  final Set<String> _saving = {};
+  bool _disposed = false;
+
+  Future<void> start() async {
+    if (!client.isLogged()) {
+      await client.onLoginStateChanged.stream.firstWhere(
+        (state) => state == LoginState.loggedIn,
+      );
+    }
+    if (client.prevBatch == null) {
+      await client.onSync.stream.first;
+    }
+    if (_disposed) return;
+
+    _roleStateSub = client.onRoomState.stream
+        .where((event) => event.state.type == PangeaEventTypes.activityRole)
+        .listen((event) => _maybeSave(client.getRoomById(event.roomId)));
+
+    // Reference plans hydrate asynchronously; a room skipped because its plan
+    // hadn't resolved yet is retried when the repo notifies.
+    ActivityPlanRepo.instance.addListener(_sweep);
+    _sweep();
+  }
+
+  void dispose() {
+    _disposed = true;
+    _roleStateSub?.cancel();
+    ActivityPlanRepo.instance.removeListener(_sweep);
+  }
+
+  void _sweep() {
+    for (final room in client.rooms) {
+      _maybeSave(room);
+    }
+  }
+
+  Future<void> _maybeSave(Room? room) async {
+    if (_disposed || room == null || !room.isActivitySession) return;
+    if (!activityAutoSaveGate(
+      isActivityFinished: room.isActivityFinished,
+      hasCompletedRole: room.hasCompletedRole,
+      hasArchivedActivity: room.hasArchivedActivity,
+    )) {
+      return;
+    }
+
+    // Reading the plan triggers hydration for reference rooms; a null here is
+    // retried via the repo listener. A room with no resolvable plan at all
+    // can't determine its target language and is skipped.
+    final plan = room.activityPlan;
+    if (plan == null) return;
+
+    final lang = PLanguageStore.byLangCode(
+      plan.req.targetLanguage.split("-").first,
+    );
+    if (lang == null) return;
+
+    if (!_saving.add(room.id)) return;
+    try {
+      // Analytics room first: if this write fails, archived_at stays unset and
+      // the save retries on the next role-state event or sweep.
+      await analyticsService.updateService.sendActivityAnalytics(
+        room.id,
+        lang,
+      );
+      await room.archiveActivity();
+
+      GoogleAnalytics.completeActivity(
+        plan.activityId,
+        room.id,
+        versionPinHonored: !plan.usedFallbackVersion,
+        fallbackCause: plan.fallbackCause,
+      );
+    } catch (e, s) {
+      ErrorHandler.logError(e: e, s: s, data: {'roomId': room.id});
+    } finally {
+      _saving.remove(room.id);
+    }
+  }
+}

--- a/lib/features/activity_sessions/activity_plan_model.dart
+++ b/lib/features/activity_sessions/activity_plan_model.dart
@@ -419,7 +419,9 @@ class ActivityRole {
     return {
       'id': id,
       'name': name,
-      'goal': goal,
+      // Omit when null: the choreographer's Role schema defaults a missing
+      // `goal` but 422s on an explicit null (v2 roles carry `goals` instead).
+      if (goal != null) 'goal': goal,
       'avatar_url': avatarUrl,
       "goals": goals.map((g) => g.toJson()).toList(),
     };

--- a/lib/features/activity_sessions/activity_role_model.dart
+++ b/lib/features/activity_sessions/activity_role_model.dart
@@ -21,7 +21,10 @@ class ActivityRoleModel {
   bool get isArchived => archivedAt != null;
 
   String? stateEventMessage(String displayName, L10n l10n) {
-    if (isFinished) {
+    // Only the transition into finished gets a timeline row. The automatic
+    // save re-writes the same role state (adding archived_at), and rendering
+    // that write too would repeat the row on every completed session.
+    if (isFinished && !isArchived) {
       return l10n.finishedTheActivity(displayName);
     } else {
       return null;

--- a/lib/routes/chat/activity_sessions/activity_finished_status_message.dart
+++ b/lib/routes/chat/activity_sessions/activity_finished_status_message.dart
@@ -1,75 +1,23 @@
 import 'package:flutter/material.dart';
 
-import 'package:go_router/go_router.dart';
-
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
-import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_summary_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_summary_room_extension.dart';
-import 'package:fluffychat/features/languages/p_language_store.dart';
-import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/features/subscription/widgets/subscription_paywall.dart';
 import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/pangea/common/utils/error_handler.dart';
-import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
 import 'package:fluffychat/pangea/common/widgets/error_indicator.dart';
 import 'package:fluffychat/routes/chat/chat.dart';
-import 'package:fluffychat/routes/chat/chat_details/space_details_content.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
+/// Bottom status bar for a session the user has finished: shows the waiting
+/// state while others are still going, then the summary's loading/error
+/// states. Saving is automatic (ActivityAutoSaveService) — there is no manual
+/// save step here.
 class ActivityFinishedStatusMessage extends StatelessWidget {
   final ChatController controller;
 
   const ActivityFinishedStatusMessage({super.key, required this.controller});
-
-  void _onArchive(BuildContext context) {
-    _archiveToAnalytics();
-    // A standalone activity has no course to return to — go home instead.
-    final course = controller.room.courseParent;
-    context.go(
-      course != null
-          ? WorkspaceNav.openCourse(
-              GoRouterState.of(context).uri,
-              course.id,
-              tab: SpaceSettingsTabs.course,
-            )
-          : "/",
-    );
-  }
-
-  Future<void> _archiveToAnalytics() async {
-    try {
-      final activityPlan = controller.room.activityPlan;
-      if (activityPlan == null) {
-        throw Exception("No activity plan found for room");
-      }
-
-      GoogleAnalytics.completeActivity(
-        activityPlan.activityId,
-        controller.room.id,
-        versionPinHonored: !activityPlan.usedFallbackVersion,
-        fallbackCause: activityPlan.fallbackCause,
-      );
-
-      final lang = activityPlan.req.targetLanguage.split("-").first;
-      final langModel = PLanguageStore.byLangCode(lang)!;
-      await controller.room.archiveActivity();
-      await MatrixState
-          .pangeaController
-          .matrixState
-          .analyticsDataService
-          .updateService
-          .sendActivityAnalytics(controller.room.id, langModel);
-    } catch (e, s) {
-      ErrorHandler.logError(e: e, s: s, data: {'roomId': controller.room.id});
-    }
-  }
-
-  ActivitySummaryModel? get summary => controller.room.activitySummaryByL1;
-
-  bool get _enableArchive =>
-      summary?.summary != null || summary?.hasError == true;
 
   @override
   Widget build(BuildContext context) {
@@ -82,11 +30,9 @@ class ActivityFinishedStatusMessage extends StatelessWidget {
     final l1 = MatrixState.pangeaController.userController.userL1Code;
 
     final finished = controller.room.isActivityFinished;
-    final archived = controller.room.hasArchivedActivity;
     final summary = controller.room.activitySummaryByL1;
 
-    final hasContent =
-        !finished || !archived || (summary != null && summary.summary == null);
+    final hasContent = !finished || (summary != null && summary.summary == null);
 
     return AnimatedSize(
       alignment: Alignment.bottomCenter,
@@ -113,11 +59,6 @@ class ActivityFinishedStatusMessage extends StatelessWidget {
                             fetchSummaries: l1 != null
                                 ? () => controller.room.fetchSummaries(l1)
                                 : null,
-                          ),
-                        if (!archived)
-                          _ArchiveSection(
-                            enabled: _enableArchive,
-                            onArchive: () => _onArchive(context),
                           ),
                       ] else
                         _WaitSection(
@@ -204,48 +145,6 @@ class _SummarySection extends StatelessWidget {
     }
 
     return const SizedBox.shrink();
-  }
-}
-
-class _ArchiveSection extends StatelessWidget {
-  final bool enabled;
-  final VoidCallback onArchive;
-
-  const _ArchiveSection({required this.enabled, required this.onArchive});
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return Column(
-      spacing: 12,
-      children: [
-        Text(
-          L10n.of(context).saveActivityDesc,
-          style: const TextStyle(fontStyle: FontStyle.italic),
-          textAlign: TextAlign.center,
-        ),
-        ElevatedButton(
-          onPressed: enabled ? onArchive : null,
-          style: ElevatedButton.styleFrom(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            foregroundColor: theme.colorScheme.onPrimaryContainer,
-            backgroundColor: theme.colorScheme.primaryContainer,
-          ),
-          child: Row(
-            spacing: 12,
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Icon(Icons.radar, size: 20),
-              Text(
-                L10n.of(context).saveActivityTitle,
-                style: const TextStyle(fontSize: 12),
-              ),
-            ],
-          ),
-        ),
-      ],
-    );
   }
 }
 

--- a/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart
+++ b/lib/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
@@ -33,8 +35,11 @@ extension OrchestratorClientExtension on Client {
     return completed;
   }
 
+  /// Profile star total: counts saved sessions only. Stars earned in a
+  /// session bank into this total when the session is auto-saved on
+  /// completion — see activities.instructions.md → "Completion saves itself".
   int totalStarsEarned(LanguageModel lang) {
-    final byActivity = <String, int>{};
+    final sessions = <SessionStars>[];
     for (final room in rooms) {
       final activityId = room.activityId;
       final activityLang = room.activityPlan?.req.targetLanguage;
@@ -45,11 +50,28 @@ extension OrchestratorClientExtension on Client {
 
       if (lang.langCodeShort != activityLang.split('-').first) continue;
 
-      final earned = room.orchestratorAwardedGoals.awards[roleId]?.length ?? 0;
-      if (earned > (byActivity[activityId] ?? 0)) {
-        byActivity[activityId] = earned;
-      }
+      sessions.add((
+        activityId: activityId,
+        earned: room.orchestratorAwardedGoals.awards[roleId]?.length ?? 0,
+        saved: room.hasArchivedActivity,
+      ));
     }
-    return byActivity.values.fold<int>(0, (a, b) => a + b);
+    return totalBankedStars(sessions);
   }
+}
+
+typedef SessionStars = ({String activityId, int earned, bool saved});
+
+/// Sums banked stars: saved sessions only, deduped to the best run per
+/// activity so replays don't double-count.
+@visibleForTesting
+int totalBankedStars(Iterable<SessionStars> sessions) {
+  final byActivity = <String, int>{};
+  for (final session in sessions) {
+    if (!session.saved) continue;
+    if (session.earned > (byActivity[session.activityId] ?? 0)) {
+      byActivity[session.activityId] = session.earned;
+    }
+  }
+  return byActivity.values.fold<int>(0, (a, b) => a + b);
 }

--- a/lib/routes/world/user_cluster_view_model.dart
+++ b/lib/routes/world/user_cluster_view_model.dart
@@ -110,7 +110,11 @@ class WorldUserClusterViewModel implements UserClusterViewModel {
 
   @override
   Stream<void> get starsUpdateStream => client.onRoomState.stream.where(
-    (e) => e.state.type == PangeaEventTypes.orchestratorAwardedGoals,
+    // Stars bank when the session saves (archived_at on the role state), so
+    // the counter listens for role-state changes as well as live awards.
+    (e) =>
+        e.state.type == PangeaEventTypes.orchestratorAwardedGoals ||
+        e.state.type == PangeaEventTypes.activityRole,
   );
 
   @override

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -19,6 +19,7 @@ import 'package:universal_html/html.dart' as html;
 import 'package:url_launcher/url_launcher_string.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/activity_sessions/activity_auto_save_service.dart';
 import 'package:fluffychat/features/analytics_data/analytics_data_service.dart';
 import 'package:fluffychat/features/join_codes/space_code_repo.dart';
 import 'package:fluffychat/features/languages/locale_provider.dart';
@@ -83,6 +84,7 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
   late StreamSubscription? _uriListener;
 
   final Map<String, AnalyticsDataService> _analyticsServices = {};
+  final Map<String, ActivityAutoSaveService> _activityAutoSaveServices = {};
   // Pangea#
   SharedPreferences get store => widget.store;
 
@@ -517,6 +519,13 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
     }
     // #Pangea
     _analyticsServices[name] ??= AnalyticsDataService(c);
+    if (_activityAutoSaveServices[name] == null) {
+      _activityAutoSaveServices[name] = ActivityAutoSaveService(
+        client: c,
+        analyticsService: _analyticsServices[name]!,
+      );
+      _activityAutoSaveServices[name]!.start();
+    }
     // Pangea#
   }
 
@@ -532,6 +541,8 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
     // #Pangea
     onUiaRequest[name]?.cancel();
     onUiaRequest.remove(name);
+    _activityAutoSaveServices[name]?.dispose();
+    _activityAutoSaveServices.remove(name);
     _analyticsServices[name]?.dispose();
     _analyticsServices.remove(name);
     // Pangea#

--- a/test/pangea/activity_auto_save_gate_test.dart
+++ b/test/pangea/activity_auto_save_gate_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_auto_save_service.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_client_extension.dart';
+
+/// The gate ActivityAutoSaveService uses to decide whether a session is due
+/// for its automatic save (pangeachat/client#7648): the session ended, the
+/// user finished their own role, and it isn't saved yet. Saving is what banks
+/// the session's stars into the profile total, so a user who left without
+/// finishing must never pass this gate.
+void main() {
+  group('activityAutoSaveGate', () {
+    test('completed session with own role finished and not yet saved '
+        'is due for save', () {
+      expect(
+        activityAutoSaveGate(
+          isActivityFinished: true,
+          hasCompletedRole: true,
+          hasArchivedActivity: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('already-saved session never re-saves', () {
+      expect(
+        activityAutoSaveGate(
+          isActivityFinished: true,
+          hasCompletedRole: true,
+          hasArchivedActivity: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('session still in progress does not save', () {
+      expect(
+        activityAutoSaveGate(
+          isActivityFinished: false,
+          hasCompletedRole: true,
+          hasArchivedActivity: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('session ended but own role never finished (user abandoned) '
+        'does not save — abandoned stars never bank', () {
+      expect(
+        activityAutoSaveGate(
+          isActivityFinished: true,
+          hasCompletedRole: false,
+          hasArchivedActivity: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('totalBankedStars', () {
+    test('unsaved sessions contribute nothing to the profile total', () {
+      expect(
+        totalBankedStars([
+          (activityId: 'a', earned: 3, saved: false),
+          (activityId: 'b', earned: 2, saved: false),
+        ]),
+        0,
+      );
+    });
+
+    test('saved sessions bank their stars', () {
+      expect(
+        totalBankedStars([
+          (activityId: 'a', earned: 3, saved: true),
+          (activityId: 'b', earned: 2, saved: true),
+        ]),
+        5,
+      );
+    });
+
+    test('replays of the same activity dedupe to the best saved run', () {
+      expect(
+        totalBankedStars([
+          (activityId: 'a', earned: 1, saved: true),
+          (activityId: 'a', earned: 3, saved: true),
+        ]),
+        3,
+      );
+    });
+
+    test('an unsaved run with more stars than the saved run of the same '
+        'activity does not raise the total', () {
+      expect(
+        totalBankedStars([
+          (activityId: 'a', earned: 2, saved: true),
+          (activityId: 'a', earned: 4, saved: false),
+        ]),
+        2,
+      );
+    });
+  });
+}

--- a/test/pangea/activity_role_serialization_test.dart
+++ b/test/pangea/activity_role_serialization_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+
+/// The choreographer's Role schema defaults a missing legacy `goal` but 422s
+/// on an explicit null (Pydantic string_type). v2 roles carry the `goals`
+/// pool and no legacy goal string, so serializing `'goal': null` broke every
+/// v2 activity-summary request. The key must be omitted when null.
+void main() {
+  group('ActivityRole.toJson', () {
+    test('omits the legacy goal key when null (v2 role with goals pool)', () {
+      final role = ActivityRole(
+        id: 'estudiante_a',
+        name: 'Estudiante A',
+        goal: null,
+        goals: [ActivityRoleGoal(id: 'g1', description: 'Describe a person')],
+      );
+      expect(role.toJson().containsKey('goal'), isFalse);
+    });
+
+    test('keeps the legacy goal string when set (v1 role)', () {
+      final role = ActivityRole(
+        id: 'estudiante_a',
+        name: 'Estudiante A',
+        goal: 'Describe a person',
+        goals: const [],
+      );
+      expect(role.toJson()['goal'], 'Describe a person');
+    });
+  });
+}


### PR DESCRIPTION
## What
Autosave replaces the manual 'Save activity' button; profile star total counts saved sessions only. Also fixes the v2 activity-summary 422.

## Why
Closes #7648 (per wcjord's comment: autosave on completion; stars shouldn't count toward the profile total until saved).

Design: org activities doc → 'Saving and stars' (pangeachat/.github PR opened alongside) and client activities doc → 'Completion saves itself' (in this PR).

- New `ActivityAutoSaveService`: watches activity-role state across all rooms + startup sweep, so completion observed while away still saves on next sync. Analytics-room write lands before `archived_at`, so a failed save retries; idempotent across devices.
- `ActivityFinishedStatusMessage`: save button removed; summary loading/error states unchanged.
- `totalStarsEarned`: counts saved (archived) sessions only; stars counter stream also listens to role-state events so the total updates when the save lands.
- Fix (pre-existing, surfaced in testing): `ActivityRole.toJson` sent `goal: null` for v2 roles — choreo's `Role.goal` defaults when missing but 422s on explicit null, breaking summaries for every v2 activity. Key now omitted when null.
- Fix: 'wrapped up this activity' timeline row rendered again on the autosave's role-state write; now renders only the finish transition.

## Testing
- Unit: `flutter test test/pangea/` — 1158 pass locally (fvm 3.41.4). New: `activity_auto_save_gate_test.dart` (save gate + star banking/dedupe), `activity_role_serialization_test.dart` (goal-key omission). Live choreo/synapse endpoint suites fail locally on env credentials — pre-existing, unrelated.
- Manual smoke (local build on :8090 against staging backends): completed a bot activity end-to-end — no save button; session auto-archived ~2s after finish (role state + analytics room verified); saved-activities list gained the session; profile star counter went 0 → 1 on save; summary request now returns 200 and renders the feedback carousel (was 422 before the fix).

## Deploy Notes
None
