### PR TITLE
fix(wa): compute IGC start button segments in didChangeDependencies

### DIFF
--- a/lib/routes/chat/choreographer/igc/start_igc_button.dart
+++ b/lib/routes/chat/choreographer/igc/start_igc_button.dart
@@ -43,6 +43,7 @@ class _StartIGCButtonState extends State<StartIGCButton>
 
   AssistanceStateEnum? _prevState;
   bool _shouldStop = false;
+  bool _didInitSegments = false;
 
   List<Segment> _prevSegments = [];
   List<Segment> _currentSegments = [];
@@ -80,15 +81,6 @@ class _StartIGCButtonState extends State<StartIGCButton>
     final igc = choreographer.igcController;
     final orchestator = choreographer.orchestratorController;
 
-    _currentSegments = _segmentsForState(
-      widget.initialState,
-      igc.activeMatch.value,
-      overrideColor: widget.initialForegroundColor,
-    );
-
-    _prevSegments = List.from(_currentSegments);
-    _segmentController.forward(from: 0.0);
-
     _prevState = widget.initialState;
 
     choreographer.addListener(_handleStateChange);
@@ -97,6 +89,24 @@ class _StartIGCButtonState extends State<StartIGCButton>
       igc.matchUpdateStream.stream,
       orchestator.suggestionStream.stream,
     ]).listen((_) => _updateSegments());
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Initial segments must be computed here, not in initState:
+    // _segmentsForState reads Theme.of(context) via stateColor(), which is
+    // unavailable until dependencies are ready. Run only once.
+    if (_didInitSegments) return;
+    _didInitSegments = true;
+
+    _currentSegments = _segmentsForState(
+      widget.initialState,
+      widget.choreographer.igcController.activeMatch.value,
+      overrideColor: widget.initialForegroundColor,
+    );
+    _prevSegments = List.from(_currentSegments);
+    _segmentController.forward(from: 0.0);
   }
 
   @override


### PR DESCRIPTION
## What

Move the IGC start button's initial progress-ring segment computation out of `initState` into `didChangeDependencies`, so it no longer reads `Theme.of(context)` before the widget's dependencies are ready.

## Why

Closes #7738.

`_StartIGCButtonState.initState()` called `_segmentsForState(...)`, which resolves segment colors via `AssistanceStateEnum.stateColor()` → `Theme.of(context)`. For the `suggesting` state that read is unconditional, so entering a new activity session room threw `dependOnInheritedWidgetOfExactType<_InheritedTheme>() ... called before initState() completed` and the chat view rendered as a red error screen. The `BOTTOM OVERFLOWED BY 99408 PIXELS` banner was a cascade: the thrown widget is replaced by a `RenderErrorBox` inside the fixed-height chat input row.

The initial-segment work now runs in `didChangeDependencies` (guarded by a `_didInitSegments` flag so it runs once), which is the correct lifecycle point for inherited-widget access. Listener registration and controller setup stay in `initState`. Compute-once behavior is unchanged.

## Testing

- `flutter analyze lib/routes/chat/choreographer/igc/start_igc_button.dart` — clean, no issues.
- No regression widget test added: constructing a `Choreographer` in a test pulls in `MatrixState` and Pangea global singletons that the base `prepareTestClient` fixture doesn't set up, and there is no existing scaffolding for it. Flagging as a real coverage gap rather than dressing it as covered.
- Live activity-session reproduction not driven from this session (needs staging login + join course + start activity + pick role). Smoke deferred to staging QA via the TO TEST on #7738.

## Deploy Notes

None.