### PR TITLE
feat(settings): L2 immersion toggle for app UI language

### DIFF
--- a/.github/instructions/localization.instructions.md
+++ b/.github/instructions/localization.instructions.md
@@ -14,6 +14,10 @@ How the Flutter client's UI strings are stored, translated, and kept in sync. Fo
 - **Only the template carries `@`-metadata** (placeholder types, plural definitions). Locale files hold just `@@locale`, `@@last_modified`, and the translated key→value strings — gen-l10n reads placeholder metadata from the template.
 - Locale selection falls back to English for any key (or whole locale) not translated, so a missing translation degrades gracefully rather than breaking the UI.
 
+## Which language the app UI uses
+
+By default the app UI is shown in the user's **source/native language (L1)**. A learner can opt into **immersion** — showing the UI in their **target language (L2)** — via the `appLanguageIsTarget` flag in `UserSettings` (toggle on the learning settings page). [`MatrixState._setAppLanguage`](../../lib/widgets/matrix.dart) resolves the locale from that flag, falling back to L1 (then system) when L2 isn't set. Because it's a non-language setting, the change propagates on `settingsUpdateStream`, which `_setAppLanguage` also listens to so the toggle takes effect immediately. Untranslated L2 keys fall back to English like any other locale.
+
 ## L1 coverage principle
 
 Every L1 — every language in the CMS `languages` collection — should get a UI translation. A language is offered as an L1 only if an LLM we route to supports it (the L1 gate in the language-list doc), so offering it while showing English UI is the mismatch we're closing. Until a locale is translated it falls back to English; the backfill tooling below exists to drive that gap to zero.

--- a/lib/features/user/user_model.dart
+++ b/lib/features/user/user_model.dart
@@ -17,6 +17,11 @@ class UserSettings {
   final bool? publicProfile;
   final String? targetLanguage;
   final String? sourceLanguage;
+
+  /// When true, the app UI (menus, buttons, labels) is shown in the user's
+  /// target language for immersion instead of their source/native language.
+  /// Untranslated keys fall back to English.
+  final bool appLanguageIsTarget;
   final GenderEnum gender;
   final String? country;
   final String? about;
@@ -29,6 +34,7 @@ class UserSettings {
     this.publicProfile,
     this.targetLanguage,
     this.sourceLanguage,
+    this.appLanguageIsTarget = false,
     this.gender = GenderEnum.unselected,
     this.country,
     this.about,
@@ -46,6 +52,7 @@ class UserSettings {
     publicProfile: json[UserConstants.publicProfile],
     targetLanguage: json[ModelKey.targetLanguage],
     sourceLanguage: json[ModelKey.sourceLanguage],
+    appLanguageIsTarget: json[ModelKey.appLanguageIsTarget] as bool? ?? false,
     gender: json[UserConstants.userGender] is String
         ? GenderEnumExtension.fromString(json[UserConstants.userGender])
         : GenderEnum.unselected,
@@ -64,6 +71,7 @@ class UserSettings {
     data[UserConstants.publicProfile] = publicProfile;
     data[ModelKey.targetLanguage] = targetLanguage;
     data[ModelKey.sourceLanguage] = sourceLanguage;
+    data[ModelKey.appLanguageIsTarget] = appLanguageIsTarget;
     data[UserConstants.userGender] = gender.string;
     data[UserConstants.userCountry] = country;
     data[UserConstants.userAbout] = about;
@@ -130,6 +138,7 @@ class UserSettings {
     bool? publicProfile,
     String? targetLanguage,
     String? sourceLanguage,
+    bool? appLanguageIsTarget,
     GenderEnum? gender,
     String? country,
     String? about,
@@ -143,6 +152,7 @@ class UserSettings {
       publicProfile: publicProfile ?? this.publicProfile,
       targetLanguage: targetLanguage ?? this.targetLanguage,
       sourceLanguage: sourceLanguage ?? this.sourceLanguage,
+      appLanguageIsTarget: appLanguageIsTarget ?? this.appLanguageIsTarget,
       gender: gender ?? this.gender,
       country: country ?? this.country,
       about: about ?? this.about,
@@ -161,6 +171,7 @@ class UserSettings {
         (other.publicProfile ?? false) == (publicProfile ?? false) &&
         other.targetLanguage == targetLanguage &&
         other.sourceLanguage == sourceLanguage &&
+        other.appLanguageIsTarget == appLanguageIsTarget &&
         other.gender == gender &&
         other.country == country &&
         other.about == about &&
@@ -175,6 +186,7 @@ class UserSettings {
     (publicProfile ?? false).hashCode,
     targetLanguage.hashCode,
     sourceLanguage.hashCode,
+    appLanguageIsTarget.hashCode,
     gender.hashCode,
     country.hashCode,
     about.hashCode,

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -158,6 +158,16 @@
         "type": "String",
         "placeholders": {}
     },
+    "appInTargetLanguageTitle": "Show the app in the language I'm learning",
+    "@appInTargetLanguageTitle": {
+        "type": "String",
+        "placeholders": {}
+    },
+    "appInTargetLanguageDesc": "Menus, buttons, and labels appear in your target language for immersion. Untranslated text falls back to English.",
+    "@appInTargetLanguageDesc": {
+        "type": "String",
+        "placeholders": {}
+    },
     "appLock": "App lock",
     "@appLock": {
         "type": "String",

--- a/lib/pangea/common/constants/model_keys.dart
+++ b/lib/pangea/common/constants/model_keys.dart
@@ -2,6 +2,7 @@ class ModelKey {
   static const String userId = 'user_id';
   static const String targetLanguage = 'target_language';
   static const String sourceLanguage = 'source_language';
+  static const String appLanguageIsTarget = 'app_language_is_target';
   static const String userL1 = 'user_l1';
   static const String userL2 = 'user_l2';
   static const String langCode = 'lang_code';

--- a/lib/routes/settings/settings_learning/learning_settings_tiles.dart
+++ b/lib/routes/settings/settings_learning/learning_settings_tiles.dart
@@ -150,6 +150,13 @@ class LearningSettingsTiles extends StatelessWidget {
                     );
                   },
                 ),
+                SwitchListTile.adaptive(
+                  value: viewModel.appLanguageIsTarget,
+                  title: Text(L10n.of(context).appInTargetLanguageTitle),
+                  subtitle: Text(L10n.of(context).appInTargetLanguageDesc),
+                  activeThumbColor: AppConfig.activeToggleColor,
+                  onChanged: viewModel.setAppLanguageIsTarget,
+                ),
                 ListTile(
                   leading: const Icon(Icons.lightbulb),
                   title: Text(L10n.of(context).resetInstructionTooltipsTitle),

--- a/lib/routes/settings/settings_learning/learning_settings_view_model.dart
+++ b/lib/routes/settings/settings_learning/learning_settings_view_model.dart
@@ -153,6 +153,18 @@ class LearningSettingsViewModel extends ChangeNotifier {
     _updateProfile(updated);
   }
 
+  bool get appLanguageIsTarget =>
+      _updatedProfile.userSettings.appLanguageIsTarget;
+
+  void setAppLanguageIsTarget(bool value) {
+    final updated = _updatedProfile.copyWith(
+      userSettings: _updatedProfile.userSettings.copyWith(
+        appLanguageIsTarget: value,
+      ),
+    );
+    _updateProfile(updated);
+  }
+
   void resetInstructionTooltips() {
     final updated = _updatedProfile.copyWith(
       instructionSettings: InstructionSettings(),

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -395,6 +395,7 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
   }
 
   StreamSubscription? _languageListener;
+  StreamSubscription? _appLanguageSettingsListener;
   Future<void> _setLanguageListener() async {
     await pangeaController.userController.initialize();
     GrammarConstructsProvider.fetchFeaturesAndTags();
@@ -406,13 +407,31 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
           analyticsDataService.updateService.onUpdateLanguages(update);
           GrammarConstructsProvider.fetchFeaturesAndTags();
         });
+
+    // Non-language settings changes (e.g. the app-copy-language immersion
+    // toggle) emit here, not on languageStream — re-apply the locale so the
+    // toggle takes effect.
+    _appLanguageSettingsListener?.cancel();
+    _appLanguageSettingsListener = pangeaController
+        .userController
+        .settingsUpdateStream
+        .stream
+        .listen((_) => _setAppLanguage());
   }
 
   void _setAppLanguage() {
     try {
-      Provider.of<LocaleProvider>(context, listen: false).setLocale(
-        pangeaController.userController.profile.userSettings.sourceLanguage,
-      );
+      final settings = pangeaController.userController.profile.userSettings;
+      // Immersion: show the app in the target language when the user opts in,
+      // otherwise their source/native language. Falls back to source (then
+      // system) if the target isn't set.
+      final appLanguage = settings.appLanguageIsTarget
+          ? (settings.targetLanguage ?? settings.sourceLanguage)
+          : settings.sourceLanguage;
+      Provider.of<LocaleProvider>(
+        context,
+        listen: false,
+      ).setLocale(appLanguage);
     } catch (e, s) {
       Logs().e('Error setting app language', e);
       ErrorHandler.logError(e: e, s: s, data: {});
@@ -616,6 +635,7 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
     linuxNotifications?.close();
     // #Pangea
     _languageListener?.cancel();
+    _appLanguageSettingsListener?.cancel();
     _uriListener?.cancel();
     notifPermissionNotifier.dispose();
     // Pangea#

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -293,10 +293,10 @@ packages:
     dependency: "direct main"
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -1496,18 +1496,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   material_symbols_icons:
     dependency: "direct main"
     description:
@@ -2438,26 +2438,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   timezone:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -293,10 +293,10 @@ packages:
     dependency: "direct main"
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -1496,18 +1496,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   material_symbols_icons:
     dependency: "direct main"
     description:
@@ -2438,26 +2438,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.12"
   timezone:
     dependency: transitive
     description:

--- a/test/features/user/user_settings_app_language_test.dart
+++ b/test/features/user/user_settings_app_language_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/user/user_model.dart';
+
+void main() {
+  group('UserSettings.appLanguageIsTarget', () {
+    test('defaults to false', () {
+      expect(UserSettings().appLanguageIsTarget, isFalse);
+    });
+
+    test('round-trips through toJson/fromJson', () {
+      final settings = UserSettings(
+        sourceLanguage: 'en',
+        targetLanguage: 'es',
+        appLanguageIsTarget: true,
+      );
+      final restored = UserSettings.fromJson(settings.toJson());
+      expect(restored.appLanguageIsTarget, isTrue);
+    });
+
+    test('absent key defaults to false when hydrating legacy data', () {
+      final restored = UserSettings.fromJson({'source_language': 'en'});
+      expect(restored.appLanguageIsTarget, isFalse);
+    });
+
+    test('copyWith updates the flag', () {
+      expect(
+        UserSettings().copyWith(appLanguageIsTarget: true).appLanguageIsTarget,
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds a learning-settings toggle — **"Show the app in the language I'm learning"** — that switches the app UI copy from the user's native language (L1) to their target language (L2) for immersion.

- New `appLanguageIsTarget` flag on `UserSettings` (default off), synced via Matrix account data like the other language settings.
- `MatrixState._setAppLanguage` resolves the app locale from the flag (target when on, else source), falling back to source/system when the target isn't set.
- Because it's a non-language setting, the change emits on `settingsUpdateStream` — `_setAppLanguage` now also listens there, so toggling applies immediately.
- Toggle UI on the learning settings page; two new `intl_en.arb` keys.

## Why

Closes #7734. Viable now that the #7699 backfill gave every L2 a UI translation (L2s ⊂ L1s); untranslated keys fall back to English. Design captured in `localization.instructions.md` ("Which language the app UI uses").

## Testing

- New unit test (`user_settings_app_language_test.dart`) covers the flag's default, toJson/fromJson round-trip, legacy-absent fallback, and copyWith — 4 tests pass.
- `flutter analyze` clean, `dart format` clean, `flutter gen-l10n` clean.
- The 2 new en keys will be flagged by the l10n sync-check for translation into the other locales (English fallback until then).

TO TEST steps are on #7734.

## Deploy Notes

None
