### PR TITLE
chore(l10n): restore CI sync-check gate that missed the #7730 merge

### DIFF
--- a/.github/instructions/localization.instructions.md
+++ b/.github/instructions/localization.instructions.md
@@ -28,6 +28,7 @@ Every L1 — every language in the CMS `languages` collection — should get a U
   - **ICU safety is a hard gate.** Placeholders (`{count}`) and plural/select syntax must survive verbatim — the model is instructed to preserve them, and every value is then validated (placeholder set matches English, plural/select structure intact). The script **refuses to write** an arb if any value fails. AI-translated locales are recorded in `ai-translated-keys.json` so native-speaker corrections can layer on later.
   - **Vertex, not AI Studio.** Auth is the service account / ADC on the org's Cloud Billing. The AI Studio API-key path is deprecated — its prepaid credit pool depletes silently.
 - **[`backfill_l10n.py`](../../scripts/translate/backfill_l10n.py)** fetches the L1 list from the CMS, diffs it against existing locales, and runs the translator for every missing one in parallel. Resumable (skips existing locales); one language failing doesn't abort the batch.
+- **[`audit_fix_translations.py`](../../scripts/translate/audit_fix_translations.py)** reviews an *existing* locale against English with Gemini 2.5 Pro and proposes fixes for mistranslations, untranslated strings, and broken placeholders — keeping correct copy verbatim. **Review-assisted, not blind-apply**: an LLM reviewer has a persistent bias toward restyling even when told not to. Run it with `--dry`, have a human vet the proposed diff, and apply selectively — do not auto-run it across community (human-translated) locales.
 
 Always run `flutter gen-l10n` after translating, and commit the regenerated locale set.
 
@@ -37,4 +38,6 @@ Always run `flutter gen-l10n` after translating, and commit the regenerated loca
 
 ## Keeping copy in sync
 
-When `intl_en.arb` changes, every locale falls behind. `gen-l10n` surfaces the gap in `needed-translations.txt`; re-run the translator to close it. A CI guard that fails when a PR leaves `needed-translations.txt` non-empty is the intended backstop against drift.
+When `intl_en.arb` changes, every locale falls behind — and `gen-l10n` only catches *added* keys (missing from a locale), never *updated* ones (a key whose English value changed while the stale translation stays present).
+
+[`check_l10n_sync.py`](../../scripts/translate/check_l10n_sync.py) closes both gaps. On a PR it diffs `intl_en.arb` against the base branch, finds every key added or value-changed, and lists the locales that weren't re-translated for those keys. The [`l10n_sync_check`](../../.github/workflows/l10n_sync_check.yaml) workflow runs it and posts the result as a **non-blocking warning annotation** — it notifies, it does not fail the build. The remediation the annotation names is to run the translator for the changed keys before merging.

--- a/.github/workflows/l10n_sync_check.yaml
+++ b/.github/workflows/l10n_sync_check.yaml
@@ -1,0 +1,25 @@
+name: l10n sync check
+
+# Notify (non-blocking) when a PR changes English UI copy without updating
+# translations. See scripts/translate/check_l10n_sync.py and
+# .github/instructions/localization.instructions.md.
+
+on:
+  pull_request:
+    paths:
+      - "lib/l10n/intl_en.arb"
+
+jobs:
+  l10n-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }} --depth=1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Check translation sync
+        run: python scripts/translate/check_l10n_sync.py --base origin/${{ github.base_ref }}

--- a/scripts/translate/audit_fix_translations.py
+++ b/scripts/translate/audit_fix_translations.py
@@ -1,0 +1,184 @@
+"""Audit and fix an existing locale's `intl_<lang>.arb` with Gemini 2.5 Pro.
+
+Unlike `translate_gemini.py` (which translates from scratch), this REVIEWS each
+existing translation against the English source and changes it only when it is
+genuinely wrong — mistranslated, incomplete, left untranslated, or with broken
+ICU placeholders. Correct, idiomatic, and legitimately-shared translations are
+kept verbatim, so high-quality community (Weblate) translations are preserved.
+
+Use it to catch drift/quality issues in existing locales without the downgrade
+risk of blind re-translation. Design: client/.github/instructions/localization.instructions.md.
+
+Auth: Vertex AI, same as translate_gemini.py (GOOGLE_APPLICATION_CREDENTIALS,
+VERTEX_PROJECT, VERTEX_LOCATION).
+
+Usage:
+  python scripts/translate/audit_fix_translations.py --lang de --name German
+  # --dry reports proposed changes without writing; --limit N reviews first N keys
+"""
+
+import argparse
+import json
+import os
+import re
+import time
+from datetime import datetime
+from pathlib import Path
+
+from google import genai
+from google.genai import errors as genai_errors
+from google.genai import types
+
+MODEL = "gemini-2.5-pro"
+BATCH = 50
+VAR_RE = re.compile(r"\{(\w+)\}")
+PIVOT_RE = re.compile(r"\{(\w+),\s*(?:plural|select)")
+
+
+def refs(s: str) -> set:
+    """Placeholder names referenced, as {name} or as an ICU pivot `name, plural`."""
+    if not isinstance(s, str):
+        return set()
+    return set(VAR_RE.findall(s)) | set(PIVOT_RE.findall(s))
+
+
+def validate(en_val: str, tr_val: str) -> str | None:
+    if not isinstance(tr_val, str) or not tr_val.strip():
+        return "empty"
+    dropped = refs(en_val) - refs(tr_val)
+    invented = refs(tr_val) - refs(en_val)
+    if dropped:
+        return f"dropped placeholder(s) {sorted(dropped)}"
+    if invented:
+        return f"invented placeholder(s) {sorted(invented)}"
+    if "```" in tr_val:
+        return "markdown fence leaked into value"
+    return None
+
+
+PROMPT = """You are auditing existing UI translations into {name} for a language-learning chat app. Each entry gives the key, the English source, and the current {name} translation (or null if missing).
+
+Return the correct FINAL {name} translation for every key as a JSON object (key → value), nothing else.
+
+Most of this copy is human community translation. Your job is to catch genuine errors, NOT to improve or restyle it. Return every value UNCHANGED unless it meets one of the four Fix Conditions below.
+
+Fix Conditions — change a value ONLY if it is:
+1. A mistranslation — the current translation means something different from the English.
+2. Untranslated — still in English (or another wrong language) when it should be translated. Legitimately-shared terms and brand names (e.g. "Chat", "Homeserver", "FluffyChat", "Matrix", "Emoji", proper nouns) do NOT count as untranslated — keep them.
+3. Incomplete — missing part of the meaning.
+4. Broken placeholder/ICU — a `{{placeholder}}` is missing, extra, renamed, or the plural/select structure is malformed.
+
+DO NOT change a value for any other reason. Specifically, NEVER change:
+- punctuation, spacing, capitalization, or whitespace (e.g. "…" vs "...", a space before an ellipsis);
+- one word for a synonym when the current word is correct (e.g. do not swap "Analytik"→"Analyse");
+- formality or register (e.g. formal vs informal address, imperative vs infinitive);
+- an already-understandable borrowed or playful term into a more "native" one.
+
+When in doubt, KEEP the existing copy. Preserve ICU plural/select structure; translate only human-readable text; never drop or invent placeholders.
+
+Entries:
+{payload}"""
+
+
+def vertex_client() -> genai.Client:
+    import google.auth
+
+    creds, default_project = google.auth.default(
+        scopes=["https://www.googleapis.com/auth/cloud-platform"]
+    )
+    project = os.environ.get("VERTEX_PROJECT") or default_project
+    location = os.environ.get("VERTEX_LOCATION", "global")
+    print(f"Vertex: project={project} location={location} model={MODEL}")
+    return genai.Client(vertexai=True, project=project, location=location, credentials=creds)
+
+
+def review_batch(client, name, items: dict) -> dict:
+    prompt = PROMPT.format(name=name, payload=json.dumps(items, ensure_ascii=False, indent=2))
+    for attempt in range(6):
+        try:
+            resp = client.models.generate_content(
+                model=MODEL,
+                contents=prompt,
+                config=types.GenerateContentConfig(
+                    temperature=0.1,
+                    response_mime_type="application/json",
+                    thinking_config=types.ThinkingConfig(thinking_budget=128),
+                ),
+            )
+        except genai_errors.APIError as e:
+            if getattr(e, "code", None) in (429, 500, 503) and attempt < 5:
+                time.sleep(2 ** attempt)
+                continue
+            raise
+        text = (resp.text or "").strip()
+        if text.startswith("```"):
+            text = re.sub(r"^```\w*\n?|\n?```$", "", text).strip()
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            time.sleep(2)
+    raise RuntimeError("batch failed to parse after retries")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--lang", required=True)
+    ap.add_argument("--name", required=True)
+    ap.add_argument("--l10n", default="lib/l10n")
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--dry", action="store_true", help="report proposed changes, don't write")
+    args = ap.parse_args()
+
+    l10n = Path(args.l10n)
+    en = json.loads((l10n / "intl_en.arb").read_text(encoding="utf-8"))
+    cur = json.loads((l10n / f"intl_{args.lang}.arb").read_text(encoding="utf-8"))
+    keys = [k for k in en if not k.startswith("@")]
+    if args.limit:
+        keys = keys[: args.limit]
+
+    client = vertex_client()
+    final: dict[str, str] = {}
+    errors: list[str] = []
+    for i in range(0, len(keys), BATCH):
+        chunk = keys[i : i + BATCH]
+        items = {k: {"english": en[k], "current": cur.get(k)} for k in chunk}
+        out = review_batch(client, args.name, items)
+        for k in chunk:
+            v = out.get(k)
+            err = validate(en[k], v)
+            if err:
+                errors.append(f"{k}: {err} | value={v!r}")
+            final[k] = v if v is not None else cur.get(k, en[k])
+        print(f"  reviewed {min(i + BATCH, len(keys))}/{len(keys)}")
+
+    changed = {k: (cur.get(k), final[k]) for k in keys if cur.get(k) != final[k]}
+    print(f"\n{args.lang}: {len(changed)} keys changed, {len(errors)} validation errors")
+    for k, (old, new) in list(changed.items())[:30]:
+        print(f"  ~ {k}\n      old: {old!r}\n      new: {new!r}")
+    for e in errors[:20]:
+        print("  ERR", e)
+
+    if args.dry:
+        print("(dry run — not writing)")
+        return
+    if errors:
+        print("Refusing to write with validation errors. Fix and retry.")
+        return
+
+    out_doc = {k: v for k, v in cur.items() if k.startswith("@")}
+    out_doc["@@locale"] = args.lang
+    out_doc["@@last_modified"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+    for k in keys:
+        out_doc[k] = final[k]
+    # keep any non-en keys that already existed (don't silently drop), except metadata rewritten above
+    for k, v in cur.items():
+        if k not in out_doc and not k.startswith("@"):
+            out_doc[k] = v
+    (l10n / f"intl_{args.lang}.arb").write_text(
+        json.dumps(out_doc, indent=4, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(f"wrote intl_{args.lang}.arb ({len(changed)} keys changed)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/translate/check_l10n_sync.py
+++ b/scripts/translate/check_l10n_sync.py
@@ -1,0 +1,72 @@
+"""CI check: notify when English UI copy changes without translations catching up.
+
+Compares `intl_en.arb` against a base git ref. Any key added or whose English
+value changed is stale in every locale that wasn't also updated for it in the
+same change. Emits GitHub Actions warning annotations listing the stale locales
+so the PR author can re-translate (scripts/translate/translate_gemini.py or the
+backfill-l10n skill). Notify-only — it does not fail the build.
+
+Usage (CI): python scripts/translate/check_l10n_sync.py --base origin/main
+"""
+
+import argparse
+import glob
+import json
+import os
+import subprocess
+
+
+def git_show_json(ref: str, path: str) -> dict:
+    r = subprocess.run(["git", "show", f"{ref}:{path}"], capture_output=True, text=True)
+    if r.returncode != 0 or not r.stdout.strip():
+        return {}
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return {}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="origin/main")
+    ap.add_argument("--l10n", default="lib/l10n")
+    args = ap.parse_args()
+
+    en_now = json.load(open(f"{args.l10n}/intl_en.arb", encoding="utf-8"))
+    en_base = git_show_json(args.base, f"{args.l10n}/intl_en.arb")
+    keys = [k for k in en_now if not k.startswith("@")]
+    changed = [k for k in keys if en_now[k] != en_base.get(k)]  # added or value-changed
+
+    if not changed:
+        print("l10n sync: no English UI copy changed in this PR.")
+        return
+
+    stale: dict[str, list[str]] = {}
+    for p in sorted(glob.glob(f"{args.l10n}/intl_*.arb")):
+        loc = os.path.basename(p)[len("intl_"):-len(".arb")]
+        if loc == "en":
+            continue
+        now = json.load(open(p, encoding="utf-8"))
+        base = git_show_json(args.base, p)
+        # stale = English changed but this locale's value for the key did not
+        s = [k for k in changed if now.get(k) == base.get(k)]
+        if s:
+            stale[loc] = s
+
+    print(f"{len(changed)} English key(s) changed or added: {sorted(changed)}")
+    if not stale:
+        print("All locales were updated for these keys — translations in sync.")
+        return
+
+    total = sum(len(v) for v in stale.values())
+    print(
+        f"::warning title=Translations out of sync::{len(stale)} locale(s) are stale "
+        f"for {len(changed)} changed English key(s) ({total} locale-key pairs). "
+        f"Re-translate with scripts/translate/translate_gemini.py or the backfill-l10n skill."
+    )
+    for loc, ks in sorted(stale.items()):
+        print(f"  {loc}: {len(ks)} key(s) not updated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Restores the l10n CI sync-check gate + audit-fix tool that **never reached main**: the commit adding them was pushed to #7730's branch after that PR had already squash-merged, so they orphaned on the deleted branch. `translate_gemini.py` (an earlier commit) made it, which masked the gap.

- `scripts/translate/check_l10n_sync.py` — diffs `intl_en.arb` against the base branch, lists locales stale for added/changed keys.
- `.github/workflows/l10n_sync_check.yaml` — runs it on PRs touching `intl_en.arb`, posts a **non-blocking warning annotation** (notify-only, per the agreed design).
- `scripts/translate/audit_fix_translations.py` — the review-assisted audit-fix tool.
- Updates `localization.instructions.md` (keep-in-sync + audit-fix sections) to match.

## Why

Without this, nothing flags a PR that adds English copy without translating it — which is exactly what happened on #7740 (the immersion toggle shipped English-only keys until caught by eye). This closes that hole for future PRs.

## Testing

`python -m py_compile` on both scripts; `check_l10n_sync.py --base HEAD` runs clean.

No client testing needed, CI tooling + instructions doc; no runtime surface.

## Deploy Notes

None
