### PR TITLE
chore(l10n): block CI on untranslated new keys (warn on value-changes)

### DIFF
--- a/.github/instructions/localization.instructions.md
+++ b/.github/instructions/localization.instructions.md
@@ -40,4 +40,7 @@ Always run `flutter gen-l10n` after translating, and commit the regenerated loca
 
 When `intl_en.arb` changes, every locale falls behind — and `gen-l10n` only catches *added* keys (missing from a locale), never *updated* ones (a key whose English value changed while the stale translation stays present).
 
-[`check_l10n_sync.py`](../../scripts/translate/check_l10n_sync.py) closes both gaps. On a PR it diffs `intl_en.arb` against the base branch, finds every key added or value-changed, and lists the locales that weren't re-translated for those keys. The [`l10n_sync_check`](../../.github/workflows/l10n_sync_check.yaml) workflow runs it and posts the result as a **non-blocking warning annotation** — it notifies, it does not fail the build. The remediation the annotation names is to run the translator for the changed keys before merging.
+[`check_l10n_sync.py`](../../scripts/translate/check_l10n_sync.py) closes both gaps. On a PR it diffs `intl_en.arb` against the base branch and splits what changed into two tiers, run by the [`l10n_sync_check`](../../.github/workflows/l10n_sync_check.yaml) workflow:
+
+- **Added keys → blocking.** A newly-added English key that isn't translated into every locale ships English-only (the gap that let the immersion toggle merge untranslated). Any locale missing an added key **fails the check** — translate them (`backfill_l10n.py`, or `translate_gemini.py` per locale) and commit before merging.
+- **Value-changed keys → warning.** When an existing key's English text changes but a locale keeps its old translation, the locale still renders (just slightly stale), so this only **warns** — a copy tweak isn't blocked on re-translating every locale.

--- a/scripts/translate/check_l10n_sync.py
+++ b/scripts/translate/check_l10n_sync.py
@@ -14,6 +14,7 @@ import glob
 import json
 import os
 import subprocess
+import sys
 
 
 def git_show_json(ref: str, path: str) -> dict:
@@ -35,37 +36,59 @@ def main() -> None:
     en_now = json.load(open(f"{args.l10n}/intl_en.arb", encoding="utf-8"))
     en_base = git_show_json(args.base, f"{args.l10n}/intl_en.arb")
     keys = [k for k in en_now if not k.startswith("@")]
-    changed = [k for k in keys if en_now[k] != en_base.get(k)]  # added or value-changed
+    added = [k for k in keys if k not in en_base]
+    value_changed = [k for k in keys if k in en_base and en_now[k] != en_base[k]]
 
-    if not changed:
+    if not added and not value_changed:
         print("l10n sync: no English UI copy changed in this PR.")
         return
 
-    stale: dict[str, list[str]] = {}
+    # Two tiers. ADDED keys are new copy that ships English-only until every
+    # locale has them — this is the gap that lets a feature merge untranslated,
+    # so a locale missing an added key BLOCKS. VALUE-CHANGED keys only WARN: the
+    # existing translation still renders (just slightly stale), so a copy tweak
+    # isn't blocked on re-translating every locale.
+    untranslated: dict[str, list[str]] = {}  # added keys missing from a locale -> block
+    stale: dict[str, list[str]] = {}  # changed keys the locale didn't update -> warn
     for p in sorted(glob.glob(f"{args.l10n}/intl_*.arb")):
         loc = os.path.basename(p)[len("intl_"):-len(".arb")]
         if loc == "en":
             continue
         now = json.load(open(p, encoding="utf-8"))
         base = git_show_json(args.base, p)
-        # stale = English changed but this locale's value for the key did not
-        s = [k for k in changed if now.get(k) == base.get(k)]
+        u = [k for k in added if k not in now]
+        s = [k for k in value_changed if now.get(k) == base.get(k)]
+        if u:
+            untranslated[loc] = u
         if s:
             stale[loc] = s
 
-    print(f"{len(changed)} English key(s) changed or added: {sorted(changed)}")
-    if not stale:
-        print("All locales were updated for these keys — translations in sync.")
-        return
+    if added:
+        print(f"{len(added)} English key(s) added: {sorted(added)}")
+    if value_changed:
+        print(f"{len(value_changed)} English key(s) value-changed: {sorted(value_changed)}")
 
-    total = sum(len(v) for v in stale.values())
-    print(
-        f"::warning title=Translations out of sync::{len(stale)} locale(s) are stale "
-        f"for {len(changed)} changed English key(s) ({total} locale-key pairs). "
-        f"Re-translate with scripts/translate/translate_gemini.py or the backfill-l10n skill."
-    )
-    for loc, ks in sorted(stale.items()):
-        print(f"  {loc}: {len(ks)} key(s) not updated")
+    if stale:
+        pairs = sum(len(v) for v in stale.values())
+        print(
+            f"::warning title=Translations may be stale::{len(stale)} locale(s) still hold "
+            f"the previous translation for {len(value_changed)} changed key(s) ({pairs} pairs). "
+            f"Consider re-translating with scripts/translate/translate_gemini.py."
+        )
+
+    if untranslated:
+        pairs = sum(len(v) for v in untranslated.values())
+        print(
+            f"::error title=New strings are untranslated::{len(untranslated)} locale(s) are "
+            f"missing {len(added)} newly-added key(s) ({pairs} pairs). Translate them "
+            f"(scripts/translate/backfill_l10n.py, or translate_gemini.py per locale) and "
+            f"commit before merging."
+        )
+        for loc, ks in sorted(untranslated.items())[:20]:
+            print(f"  {loc}: missing {len(ks)}")
+        sys.exit(1)
+
+    print("New keys are translated across all locales. In sync.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Makes the l10n sync-check gate (restored in #7745) actually **block** on the failure mode that let the immersion toggle ship English-only — while staying low-friction for routine copy edits. Two tiers:

- **Added English keys → blocking.** If a new key isn't translated into every locale, the check **fails** (exit 1) — new copy can't merge English-only.
- **Value-changed keys → warning.** If an existing key's English changes but a locale keeps its old translation, it only **warns** (the old translation still renders). A copy tweak isn't blocked on re-translating 115 locales.

Also updates `localization.instructions.md` to describe the two tiers.

## Why

Follow-up to #7745 (which restored the gate as notify-only). #7734's toggle merged with untranslated keys precisely because new-key coverage wasn't enforced; this closes that. Remediation is one command (`backfill_l10n.py`), which fills all missing locales.

## Testing

Verified locally against the real arb set:
- No English change → passes (exit 0).
- Synthetic **added** key untranslated → **fails** (exit 1), lists the missing locales.
- Synthetic **value-change** only → warns, passes (exit 0).

No client testing needed, CI tooling + instructions doc; no runtime surface.

## Deploy Notes

None
