### PR TITLE
fix(navigation): add close control to 'no longer participating' empty state (#7746)

### DIFF
--- a/lib/routes/world/left_panel/left_panel_room_subpage.dart
+++ b/lib/routes/world/left_panel/left_panel_room_subpage.dart
@@ -11,6 +11,7 @@ import 'package:fluffychat/routes/chat/chat_details/chat_details.dart';
 import 'package:fluffychat/routes/chat/chat_details/invite/pangea_invitation_selection.dart';
 import 'package:fluffychat/routes/chat/chat_search/chat_search_page.dart';
 import 'package:fluffychat/routes/world/left_panel/left_panel_room_details_subpage.dart';
+import 'package:fluffychat/routes/world/panel_header.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/share_scaffold_dialog.dart';
 
@@ -28,14 +29,24 @@ class LeftPanelRoomSubpage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final emptyPage = Center(
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Text(
-          L10n.of(context).youAreNoLongerParticipatingInThisChat,
-          textAlign: TextAlign.center,
+    // Give the empty state the panel's close control (#7746): without a header
+    // the "no longer participating" message stranded the user with no way to
+    // dismiss the panel back to the map. Mirrors the chrome of sibling subpages.
+    final emptyPage = Column(
+      children: [
+        PanelHeader(leading: closeButton, title: ''),
+        Expanded(
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Text(
+                L10n.of(context).youAreNoLongerParticipatingInThisChat,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
         ),
-      ),
+      ],
     );
 
     final id = param?.id;

--- a/test/pangea/navigation/left_panel_room_subpage_empty_state_test.dart
+++ b/test/pangea/navigation/left_panel_room_subpage_empty_state_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/left_panel/left_panel_room_subpage.dart';
+import 'package:fluffychat/routes/world/panel_header.dart';
+
+void main() {
+  testWidgets(
+    'empty "no longer participating" state renders the panel close control (#7746)',
+    (tester) async {
+      // A null param drops LeftPanelRoomSubpage to its empty state before it
+      // ever touches Matrix.of — the same state reached when the room is left,
+      // is a space, or is unknown. Before #7746 that state was bare centered
+      // text with no way to dismiss the panel.
+      const closeKey = Key('the-close-button');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          supportedLocales: L10n.supportedLocales,
+          home: const Scaffold(
+            body: LeftPanelRoomSubpage(
+              param: null,
+              shareItems: null,
+              closeButton: IconButton(
+                key: closeKey,
+                icon: Icon(Icons.close),
+                onPressed: null,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Read the localized string from the live element tree rather than
+      // awaiting L10n.delegate.load — awaiting that future stalls the
+      // testWidgets fake-async clock.
+      final l10n = L10n.of(
+        tester.element(find.byType(LeftPanelRoomSubpage)),
+      );
+      expect(
+        find.text(l10n.youAreNoLongerParticipatingInThisChat),
+        findsOneWidget,
+      );
+      // The empty state now carries the panel header + the injected close
+      // control, so the user can dismiss it back to the map.
+      expect(find.byType(PanelHeader), findsOneWidget);
+      expect(find.byKey(closeKey), findsOneWidget);
+    },
+  );
+}


### PR DESCRIPTION
Fixes #7746.

## Problem

When a session panel points at a room the user has left (or a space, or an unknown room), `LeftPanelRoomSubpage` dropped to an empty state that was bare centered text — "You are no longer participating in this chat" — with **no close control**. The user was stranded with no way to dismiss the panel back to the map (see the issue screenshot).

Every other subpage in this panel renders the workspace `closeButton`; this empty state was the one path that dropped it.

## Fix

Wrap the empty state in a `PanelHeader(leading: closeButton)` — the same chrome sibling subpages (`LeftPanelChatListSubpage`, `CoursesHubPanel`, …) already use — so the panel's `X`/`←` control is present and the user can close it.

## Changes

- `lib/routes/world/left_panel/left_panel_room_subpage.dart` — empty state now renders a `PanelHeader` with the injected `closeButton` above the message.
- `test/pangea/navigation/left_panel_room_subpage_empty_state_test.dart` — new widget test asserting the empty state renders both the message and the close control.

## Testing

- [x] `flutter analyze` clean on changed files
- [x] New widget test passes
- [x] Ensure that 'No Longer participating in this chat' window can be closed
