### PR TITLE
refactor(panels): three named width families so same-slot navigation never resizes

### DIFF
--- a/.github/instructions/routing.instructions.md
+++ b/.github/instructions/routing.instructions.md
@@ -321,6 +321,18 @@ One vocabulary covers how content opens:
   chat opened in a course folds the course card behind it, and closing the chat
   reveals the card as it was left (#7332).
 
+**Panel widths come in three named families, not per-panel numbers (#7572).**
+Panels that can replace each other in a slot share one min/comfort/ideal
+triple (`PanelWidths` in the registry), so navigating between them never
+resizes the column — the width-jump QA kept catching. The families: **list**
+(the thin index columns — the chat list, the DM-create picker), **wide** (the
+live/content surfaces — a chat, a session, an activity or course card, and the
+course flow pages, which host forms and media and earn the same room), and
+**tool** (the entire right column — settings, analytics and its details,
+practice — one width for every tool panel). The only remaining width step is
+the deliberate list↔wide difference. A new panel type joins a family; it does
+not invent its own widths.
+
 **Opening is a fit test, not a depth count.** A surface opens a new panel when
 the column is under its two-panel budget *and* the budget can grant the newcomer
 its minimum width; otherwise the page **pushes** onto the panel it came from.

--- a/lib/features/navigation/panel_registry.dart
+++ b/lib/features/navigation/panel_registry.dart
@@ -3,6 +3,32 @@ import 'package:fluffychat/features/navigation/panel_types_enum.dart';
 /// Which column a panel belongs to, which fixes its role and its justification.
 enum PanelColumn { left, right }
 
+/// The three width families every panel draws from (#7572). Panels that can
+/// replace each other in a slot share a family, so navigating between them
+/// never changes the column's width — the only width step left is the
+/// deliberate list↔wide difference. Defined once here (not per-def literals)
+/// so the families can't drift apart.
+///
+///  - **list** — the thin index columns (the chat list, the DM-create picker).
+///  - **wide** — the live/content surfaces: a chat, a session, an activity or
+///    course card, and the course flow pages (details / invite / edit / add),
+///    which host forms and media and want the same room.
+///  - **tool** — the entire right column (settings, analytics + its details,
+///    practice), one width for every tool panel.
+abstract class PanelWidths {
+  static const double listMin = 300;
+  static const double listComfort = 340;
+  static const double listIdeal = 380;
+
+  static const double wideMin = 360;
+  static const double wideComfort = 480;
+  static const double wideIdeal = 720;
+
+  static const double toolMin = 360;
+  static const double toolComfort = 440;
+  static const double toolIdeal = 520;
+}
+
 /// Static layout metadata for a panel type. Pure data (no widgets), so the URL
 /// parser in `route_facts.dart` and the width allocator can read it without a
 /// widget binding; the widget builder is resolved separately by the shell.
@@ -115,18 +141,18 @@ sealed class PanelDef {
 
 class ChatsPanelDef extends PanelDef {
   const ChatsPanelDef({
-    super.minWidth = 300,
-    super.reasonableMinWidth = 340,
-    super.idealWidth = 380,
+    super.minWidth = PanelWidths.listMin,
+    super.reasonableMinWidth = PanelWidths.listComfort,
+    super.idealWidth = PanelWidths.listIdeal,
     super.priority = 30,
   }) : super(type: PanelTypesEnum.chats, column: PanelColumn.left);
 }
 
 class RoomPanelDef extends PanelDef {
   const RoomPanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 480,
-    super.idealWidth = 720,
+    super.minWidth = PanelWidths.wideMin,
+    super.reasonableMinWidth = PanelWidths.wideComfort,
+    super.idealWidth = PanelWidths.wideIdeal,
     super.priority = 80,
   }) : super(
          type: PanelTypesEnum.room,
@@ -139,9 +165,9 @@ class RoomPanelDef extends PanelDef {
 
 class SessionPanelDef extends PanelDef {
   const SessionPanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 480,
-    super.idealWidth = 720,
+    super.minWidth = PanelWidths.wideMin,
+    super.reasonableMinWidth = PanelWidths.wideComfort,
+    super.idealWidth = PanelWidths.wideIdeal,
   }) : super(
          type: PanelTypesEnum.session,
          column: PanelColumn.left,
@@ -155,9 +181,9 @@ class SessionPanelDef extends PanelDef {
 
 class ActivityPanelDef extends PanelDef {
   const ActivityPanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 480,
-    super.idealWidth = 720,
+    super.minWidth = PanelWidths.wideMin,
+    super.reasonableMinWidth = PanelWidths.wideComfort,
+    super.idealWidth = PanelWidths.wideIdeal,
   }) : super(
          type: PanelTypesEnum.activity,
          column: PanelColumn.left,
@@ -168,22 +194,24 @@ class ActivityPanelDef extends PanelDef {
 }
 
 class CoursePanelDef extends PanelDef {
-  const CoursePanelDef({super.minWidth = 360, super.reasonableMinWidth = 480})
-    : super(
-        idealWidth: 720,
-        type: PanelTypesEnum.course,
-        column: PanelColumn.left,
-        priority: 60,
-        mapContent:
-            true, // selecting a course scopes the map (mobile: bottom sheet)
-      );
+  const CoursePanelDef({
+    super.minWidth = PanelWidths.wideMin,
+    super.reasonableMinWidth = PanelWidths.wideComfort,
+  }) : super(
+         idealWidth: PanelWidths.wideIdeal,
+         type: PanelTypesEnum.course,
+         column: PanelColumn.left,
+         priority: 60,
+         mapContent:
+             true, // selecting a course scopes the map (mobile: bottom sheet)
+       );
 }
 
 class CoursePagePanelDef extends PanelDef {
   const CoursePagePanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 440,
-    super.idealWidth = 600,
+    super.minWidth = PanelWidths.wideMin,
+    super.reasonableMinWidth = PanelWidths.wideComfort,
+    super.idealWidth = PanelWidths.wideIdeal,
   }) : super(
          type: PanelTypesEnum.coursepage,
          column: PanelColumn.left,
@@ -196,9 +224,9 @@ class CoursePagePanelDef extends PanelDef {
 
 class AddCoursePanelDef extends PanelDef {
   const AddCoursePanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 440,
-    super.idealWidth = 600,
+    super.minWidth = PanelWidths.wideMin,
+    super.reasonableMinWidth = PanelWidths.wideComfort,
+    super.idealWidth = PanelWidths.wideIdeal,
   }) : super(
          type: PanelTypesEnum.addcourse,
          column: PanelColumn.left,
@@ -210,9 +238,9 @@ class AddCoursePanelDef extends PanelDef {
 
 class AddCoursePagePanelDef extends PanelDef {
   const AddCoursePagePanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 440,
-    super.idealWidth = 600,
+    super.minWidth = PanelWidths.wideMin,
+    super.reasonableMinWidth = PanelWidths.wideComfort,
+    super.idealWidth = PanelWidths.wideIdeal,
   }) : super(
          type: PanelTypesEnum.addcoursepage,
          column: PanelColumn.left,
@@ -226,9 +254,9 @@ class AddCoursePagePanelDef extends PanelDef {
 
 class SettingsPanelDef extends PanelDef {
   const SettingsPanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 440,
-    super.idealWidth = 520,
+    super.minWidth = PanelWidths.toolMin,
+    super.reasonableMinWidth = PanelWidths.toolComfort,
+    super.idealWidth = PanelWidths.toolIdeal,
   }) : super(
          type: PanelTypesEnum.settings,
          column: PanelColumn.right,
@@ -238,12 +266,12 @@ class SettingsPanelDef extends PanelDef {
 
 class SettingsPagePanelDef extends PanelDef {
   const SettingsPagePanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 440,
-    // Match the `settings` menu width so a page folded into the menu's slot
-    // (under width pressure) doesn't resize and jump the close/back icon
-    // when drilling in or out (#7146).
-    super.idealWidth = 520,
+    super.minWidth = PanelWidths.toolMin,
+    super.reasonableMinWidth = PanelWidths.toolComfort,
+    // Same tool family as the `settings` menu so a page folded into the menu's
+    // slot (under width pressure) doesn't resize and jump the close/back icon
+    // when drilling in or out (#7146) — now guaranteed by the shared family.
+    super.idealWidth = PanelWidths.toolIdeal,
   }) : super(
          type: PanelTypesEnum.settingspage,
          column: PanelColumn.right,
@@ -256,9 +284,9 @@ class SettingsPagePanelDef extends PanelDef {
 
 class AnalyticsPanelDef extends PanelDef {
   const AnalyticsPanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 420,
-    super.idealWidth = 488,
+    super.minWidth = PanelWidths.toolMin,
+    super.reasonableMinWidth = PanelWidths.toolComfort,
+    super.idealWidth = PanelWidths.toolIdeal,
   }) : super(
          type: PanelTypesEnum.analytics,
          column: PanelColumn.right,
@@ -268,9 +296,9 @@ class AnalyticsPanelDef extends PanelDef {
 
 class VocabPanelDef extends PanelDef {
   const VocabPanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 420,
-    super.idealWidth = 488,
+    super.minWidth = PanelWidths.toolMin,
+    super.reasonableMinWidth = PanelWidths.toolComfort,
+    super.idealWidth = PanelWidths.toolIdeal,
   }) : super(
          type: PanelTypesEnum.vocab,
          column: PanelColumn.right,
@@ -282,9 +310,9 @@ class VocabPanelDef extends PanelDef {
 
 class GrammarPanelDef extends PanelDef {
   const GrammarPanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 420,
-    super.idealWidth = 488,
+    super.minWidth = PanelWidths.toolMin,
+    super.reasonableMinWidth = PanelWidths.toolComfort,
+    super.idealWidth = PanelWidths.toolIdeal,
   }) : super(
          type: PanelTypesEnum.grammar,
          column: PanelColumn.right,
@@ -296,9 +324,9 @@ class GrammarPanelDef extends PanelDef {
 
 class ReviewPanelDef extends PanelDef {
   const ReviewPanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 420,
-    super.idealWidth = 488,
+    super.minWidth = PanelWidths.toolMin,
+    super.reasonableMinWidth = PanelWidths.toolComfort,
+    super.idealWidth = PanelWidths.toolIdeal,
   }) : super(
          type: PanelTypesEnum.review,
          column: PanelColumn.right,
@@ -308,9 +336,9 @@ class ReviewPanelDef extends PanelDef {
 
 class PracticePanelDef extends PanelDef {
   const PracticePanelDef({
-    super.minWidth = 360,
-    super.reasonableMinWidth = 420,
-    super.idealWidth = 520,
+    super.minWidth = PanelWidths.toolMin,
+    super.reasonableMinWidth = PanelWidths.toolComfort,
+    super.idealWidth = PanelWidths.toolIdeal,
   }) : super(
          type: PanelTypesEnum.practice,
          column: PanelColumn.right,
@@ -321,9 +349,9 @@ class PracticePanelDef extends PanelDef {
 
 class NewPrivateChatPanelDef extends PanelDef {
   const NewPrivateChatPanelDef({
-    super.minWidth = 300,
-    super.reasonableMinWidth = 380,
-    super.idealWidth = 400,
+    super.minWidth = PanelWidths.listMin,
+    super.reasonableMinWidth = PanelWidths.listComfort,
+    super.idealWidth = PanelWidths.listIdeal,
   }) : super(
          type: PanelTypesEnum.newprivatechat,
          column: PanelColumn.left,

--- a/test/pangea/navigation/panel_allocator_test.dart
+++ b/test/pangea/navigation/panel_allocator_test.dart
@@ -38,9 +38,11 @@ void main() {
       'a single right summary docks at the right edge behind the gutter',
       () {
         final l = run(right: [PanelTypesEnum.analytics]);
-        expect(l.right.single.width, 488);
-        expect(l.right.single.left, 1600 - 88 - 488); // 1024
-        expect(l.mapRightOverlay, 576); // 488 + gutter 88
+        // The tool-family ideal (#7572) — one width for the whole right column.
+        const w = PanelWidths.toolIdeal;
+        expect(l.right.single.width, w);
+        expect(l.right.single.left, 1600 - 88 - w);
+        expect(l.mapRightOverlay, w + 88); // card + gutter
         expect(l.mapLeftOverlay, 73); // rail only, no left panel
         expect(l.clusterVisible, isTrue);
       },
@@ -61,12 +63,13 @@ void main() {
       final l = run(
         right: [PanelTypesEnum.analytics, PanelTypesEnum.vocab],
       ); // master-first [summary, detail]
-      expect(l.right[0].width, 488);
-      expect(l.right[1].width, 488);
-      expect(l.right[0].left, 1600 - 88 - 488); // summary (master) at the edge
-      expect(l.right[1].left, 1600 - 88 - 488 - 16 - 488); // detail to its left
+      const w = PanelWidths.toolIdeal;
+      expect(l.right[0].width, w);
+      expect(l.right[1].width, w);
+      expect(l.right[0].left, 1600 - 88 - w); // summary (master) at the edge
+      expect(l.right[1].left, 1600 - 88 - w - 16 - w); // detail to its left
       expectNoOverlap(l);
-      expect(l.mapRightOverlay, 488 * 2 + 16 + 88); // both cards + gap + gutter
+      expect(l.mapRightOverlay, w * 2 + 16 + 88); // both cards + gap + gutter
     });
   });
 


### PR DESCRIPTION
**What**

Collapses the six per-panel width triples into **three named families** (`PanelWidths` in the panel registry) so panels that can replace each other in a slot always share min/comfort/ideal — same-slot navigation never resizes the column:

- **list** (300/340/380): chats, newprivatechat — the DM-create picker now matches the chat list exactly (the 380→400 jump in TigToggle's follow-up video is gone).
- **wide** (360/480/720): room, session, activity, course, **and the course flow pages** (coursepage / addcourse / addcoursepage — previously 600). Course → edit/invite transitions are now width-stable.
- **tool** (360/440/520): the entire right column — settings, settingspage, analytics, vocab, grammar, review, practice. Analytics widens 488→520 to match settings.

The families are constants referenced by every def (no per-def literals), so drift can't quietly return. routing.instructions.md records the scheme; allocator tests now assert against the family constants.

**Why**

#7572: differing min/max widths made panels visibly jump when switching surfaces. Decision (Will): course pages join the wide family; the right column unifies at 520. The only remaining width step is the deliberate list↔wide difference the ticket endorses.

**Testing**

- Full `test/pangea/` suite green (1183); analyze / format / import_sorter clean.
- Local profile build verified at 1250×800.
- Side effect to watch: course pages at ideal 720 (was 600) reach fold pressure slightly earlier when paired with another left panel at ~1100–1300px widths — fold semantics themselves are allocator-unit-tested.

**TO TEST**

- [ ] Wide screen: open All Chats, tap the new-chat (+) button — the panel does not change width when the DM picker replaces the list, or back.
- [ ] Open a course card, then its edit/invite/details page — the column stays one width through the whole flow, and matches a chat/activity window's width.
- [ ] Right column: open Settings, then Analytics (and a vocab/grammar detail) — no width jump between any of them.
- [ ] ~1200px window: open a chat beside All Chats, then a course page beside a course card — panels compress/fold rather than overlap, nothing slides under the top-right cluster.

Closes #7572.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized panel sizing across list, wide, and tool panel types.
  * Panel navigation now maintains consistent column widths within each sizing family.
  * Preserved the intentional width difference between list and wide panels.
  * Updated layout validation to reflect the new shared sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->