### PR TITLE
feat(hooks): surface backfill-l10n skill at l10n moments via repo-local pointer tables

### DIFF
--- a/.github/hooks/on-domain-command.md
+++ b/.github/hooks/on-domain-command.md
@@ -1,0 +1,8 @@
+<!-- consumed by: the shared pretooluse-reminders.sh (pangeachat/.github), which reads this -->
+<!-- repo-local table after the org table — harness-sync.instructions.md § Repo-specific hooks. -->
+<!-- format: blank-line-separated pairs — line 1 an extended-regex pattern matched against the -->
+<!-- about-to-run command, remaining lines the message. Every matching row fires, once per -->
+<!-- session per pattern (` [always]` suffix repeats every time). -->
+
+scripts/translate/|flutter gen-l10n
+Client l10n tooling — if the backfill-l10n skill isn't already in context, read .github/skills/backfill-l10n/SKILL.md first: which script fits (new keys vs new locale vs one locale), the `uv run` invocations, and the required post-run steps. localization.instructions.md governs.

--- a/.github/hooks/on-edit-path.md
+++ b/.github/hooks/on-edit-path.md
@@ -1,0 +1,8 @@
+<!-- consumed by: the shared pretooluse-edit-path.sh (pangeachat/.github), which checks this -->
+<!-- repo-local table BEFORE the org table — harness-sync.instructions.md § Repo-specific hooks. -->
+<!-- format: blank-line-separated pairs — line 1 an extended-regex pattern matched against the -->
+<!-- FILE PATH being edited, remaining lines the message. First match wins; rows fire once per -->
+<!-- session per pattern (` [always]` suffix repeats every time). -->
+
+lib/l10n/intl_en\.arb$
+Adding UI string keys? Every new key in intl_en.arb must be translated into ALL locales before merge — the l10n-sync CI gate blocks otherwise. Remediation is the backfill-l10n skill: `uv run scripts/translate/translate_new_keys.py`, then `flutter gen-l10n`. localization.instructions.md governs.


### PR DESCRIPTION
## What

Repo-local hook pointer rows: editing `lib/l10n/intl_en.arb` or running the translate scripts / `flutter gen-l10n` now surfaces the `backfill-l10n` skill and localization doc at that moment.

## Why

Addresses pangeachat/.github#265 — companion to pangeachat/.github#266, which adds the repo-local-table mechanism these files feed. Inert until that PR merges (unread files); no ordering hazard.

## Testing

Smoke-tested against the #266 scripts: both rows fire with the expected messages, per-session suppression holds, and non-matching client files still fall through to the shared org table.

No client testing needed, agent-harness pointer rows; no runtime user surface.

## Deploy Notes

None.
