### PR TITLE
fix(settings): restore shared panel header on settings detail pages

### DIFF
--- a/.github/instructions/routing.instructions.md
+++ b/.github/instructions/routing.instructions.md
@@ -274,6 +274,20 @@ user came from:
 the other.** If a panel shows the wrong affordance, its tree placement or the
 context handling is wrong — fix that, not the button.
 
+**Every panel shows exactly one header, and the shared chrome is the default.**
+A panel is wrapped in the shared header (the close/back control plus its title)
+unless it explicitly opts out and renders its own — which a page may do when it
+needs chrome the shared header can't express: a leaf-specific title the token
+doesn't carry, or a trailing action. An opting-out page takes the panel's close
+control and places it in its own header, so the affordance rule above still
+holds. Two failure modes this rule exists to prevent, one on each side:
+**no header** (a page that renders none while the wrapper was dropped — the
+learner has no title and no way out, #7763) and **two headers** (a page that
+draws its own *and* gets wrapped). Because "renders its own chrome" is invisible
+to the wrapper, the opt-out is declared per page (settings:
+`SettingsPageEnum.addHeader`) and pinned by tests — a new page that forgets to
+declare gets the default, which is the safe direction.
+
 ### The navigation tree: parent, child, sibling
 
 Every surface declares where it sits in one explicit tree, in the

--- a/lib/routes/world/right_panel/workspace_right_panel.dart
+++ b/lib/routes/world/right_panel/workspace_right_panel.dart
@@ -124,16 +124,35 @@ class WorkspaceRightPanel extends StatelessWidget {
           ),
         );
       case SettingsPagePanelToken(param: final param):
-        return PanelCard(
-          child: RightPanelSettingsSubpage(
-            param: param,
-            closeButton: IconButton(
-              tooltip: leadingTooltip,
-              icon: Icon(leadingIcon),
-              onPressed: onLeading,
-            ),
-          ),
+        final settingsPage = SettingsPageEnum.fromString(param?.subpage);
+        final settingsCloseButton = IconButton(
+          tooltip: leadingTooltip,
+          icon: Icon(leadingIcon),
+          onPressed: onLeading,
         );
+
+        // The shared header is the DEFAULT for a settings detail; only a page
+        // that draws its own chrome opts out (SettingsPageEnum.addHeader).
+        // Dropping the wrapper wholesale left every classic page (learning,
+        // style, notifications, devices, chat, security, password, profile)
+        // with no title and no way out (#7763).
+        return settingsPage.addHeader
+            ? PanelCardWithHeader(
+                title: settingsPage.title(l10n),
+                icon: leadingIcon,
+                onLeading: onLeading,
+                tooltip: leadingTooltip,
+                child: RightPanelSettingsSubpage(
+                  param: param,
+                  closeButton: settingsCloseButton,
+                ),
+              )
+            : PanelCard(
+                child: RightPanelSettingsSubpage(
+                  param: param,
+                  closeButton: settingsCloseButton,
+                ),
+              );
       case VocabAnalyticsPanelToken(param: final param):
         return PanelCard(
           child: ConstructAnalyticsView(

--- a/lib/routes/world/settings_page_enum.dart
+++ b/lib/routes/world/settings_page_enum.dart
@@ -18,6 +18,14 @@ enum SettingsPageEnum {
     if (path != null && path.contains('security/ignorelist')) {
       return SettingsPageEnum.ignore;
     }
+    // The subscription family is one page family with several leaves
+    // (`subscription/history`, `/discount`, `/selected`); they all render their
+    // own app bar, so every leaf must resolve here rather than falling through
+    // to `menu` — a leaf that resolved to `menu` would take the shared header
+    // AND draw its own (double header).
+    if (path != null && path.startsWith('subscription')) {
+      return SettingsPageEnum.subscription;
+    }
     switch (path) {
       case 'learning':
         return SettingsPageEnum.learning;
@@ -74,8 +82,18 @@ enum SettingsPageEnum {
     }
   }
 
+  /// Whether the panel wraps this page in the shared [PanelCardWithHeader]
+  /// chrome (X/back + title). **The wrapper is the default**: a settings view
+  /// that renders no chrome of its own would otherwise have no title and no way
+  /// out. Opt out ONLY for a page that renders its own header and takes the
+  /// panel's `closeButton` — otherwise it draws two. See
+  /// routing.instructions.md § Closing a panel.
   bool get addHeader => switch (this) {
+    // Own PanelHeader with a trailing add-email action.
     SettingsPageEnum.email => false,
+    // The subscription family: each leaf builds its own AppBar so it can carry
+    // a leaf-specific title (e.g. the selected plan) the token can't express.
+    SettingsPageEnum.subscription => false,
     _ => true,
   };
 }

--- a/test/pangea/navigation/settings_panel_header_test.dart
+++ b/test/pangea/navigation/settings_panel_header_test.dart
@@ -71,8 +71,14 @@ void main() {
     });
 
     test('classic pages resolve to themselves', () {
-      expect(SettingsPageEnum.fromString('learning'), SettingsPageEnum.learning);
-      expect(SettingsPageEnum.fromString('security'), SettingsPageEnum.security);
+      expect(
+        SettingsPageEnum.fromString('learning'),
+        SettingsPageEnum.learning,
+      );
+      expect(
+        SettingsPageEnum.fromString('security'),
+        SettingsPageEnum.security,
+      );
       expect(
         SettingsPageEnum.fromString('security/password'),
         SettingsPageEnum.password,

--- a/test/pangea/navigation/settings_panel_header_test.dart
+++ b/test/pangea/navigation/settings_panel_header_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/world/settings_page_enum.dart';
+
+/// Every settings detail must end up with exactly ONE header: the shared
+/// PanelCardHeader by default, or its own chrome when it opts out via
+/// `addHeader == false`. #7763 flattened the wrapper away for every page,
+/// leaving the classic pages with no title and no way out; these tests pin
+/// both halves of the contract.
+void main() {
+  group('SettingsPageEnum.addHeader', () {
+    // Pages whose views render NO chrome of their own — dropping the shared
+    // header strands the user with no title and no close control.
+    const needsSharedHeader = {
+      SettingsPageEnum.learning,
+      SettingsPageEnum.style,
+      SettingsPageEnum.notifications,
+      SettingsPageEnum.devices,
+      SettingsPageEnum.chat,
+      SettingsPageEnum.security,
+      SettingsPageEnum.password,
+      SettingsPageEnum.ignore,
+      SettingsPageEnum.profile,
+      SettingsPageEnum.menu,
+    };
+
+    // Pages that build their own header AND take the panel's closeButton —
+    // wrapping them too would draw two headers.
+    const rendersOwnHeader = {
+      SettingsPageEnum.email, // own PanelHeader (+ add-email action)
+      SettingsPageEnum.subscription, // own AppBar per leaf
+    };
+
+    for (final page in needsSharedHeader) {
+      test('${page.name} takes the shared header', () {
+        expect(page.addHeader, isTrue);
+      });
+    }
+
+    for (final page in rendersOwnHeader) {
+      test('${page.name} opts out (renders its own)', () {
+        expect(page.addHeader, isFalse);
+      });
+    }
+
+    test('every enum value is classified by these tests', () {
+      expect(
+        {...needsSharedHeader, ...rendersOwnHeader},
+        containsAll(SettingsPageEnum.values),
+        reason: 'a new SettingsPageEnum needs a header decision here',
+      );
+    });
+  });
+
+  group('SettingsPageEnum.fromString', () {
+    test('subscription leaves all resolve to subscription, not menu', () {
+      // A leaf falling through to `menu` (addHeader true) would take the shared
+      // header on top of the AppBar it draws itself.
+      for (final sub in [
+        'subscription',
+        'subscription/history',
+        'subscription/discount',
+        'subscription/selected',
+      ]) {
+        expect(
+          SettingsPageEnum.fromString(sub),
+          SettingsPageEnum.subscription,
+          reason: '$sub must not fall through to menu',
+        );
+      }
+    });
+
+    test('classic pages resolve to themselves', () {
+      expect(SettingsPageEnum.fromString('learning'), SettingsPageEnum.learning);
+      expect(SettingsPageEnum.fromString('security'), SettingsPageEnum.security);
+      expect(
+        SettingsPageEnum.fromString('security/password'),
+        SettingsPageEnum.password,
+      );
+      expect(
+        SettingsPageEnum.fromString('security/3pid'),
+        SettingsPageEnum.email,
+      );
+      expect(
+        SettingsPageEnum.fromString('security/ignorelist/@a:b.com'),
+        SettingsPageEnum.ignore,
+      );
+    });
+
+    test('null and unknown degrade to the menu', () {
+      expect(SettingsPageEnum.fromString(null), SettingsPageEnum.menu);
+      expect(SettingsPageEnum.fromString('nope'), SettingsPageEnum.menu);
+    });
+  });
+}


### PR DESCRIPTION
## What

Settings detail pages get their header back. The shared `PanelCardWithHeader` is once again the default for `SettingsPagePanelToken`; pages that render their own chrome opt out via `SettingsPageEnum.addHeader`.

## Why

Closes #7764. #7655 replaced the wrapper with a bare `PanelCard` + a `closeButton` passed into the subpage — right for the subscription family and `security/3pid` (they build their own headers), but every other settings view renders no chrome and doesn't accept a `closeButton`, so learning / style / notifications / devices / chat / security / password / blocked-users / profile-edit shipped with no title and no way out. `addHeader` was left dead.

Design: routing.instructions.md § Closing a panel (rule added in this PR — the wrapper is the default; a page opts out only if it draws its own header, so every panel has exactly one).

## What changed

- `workspace_right_panel.dart`: restore the `addHeader` branch; both arms still pass `closeButton`, so opt-out pages keep their close control.
- `settings_page_enum.dart`: `subscription` joins `email` in the opt-out set; `fromString` resolves subscription **leaves** (`/history`, `/discount`, `/selected`) to `subscription` — they previously fell through to `menu`, which post-fix would have double-headered them. Documented why the default is the wrapper.
- New `test/pangea/navigation/settings_panel_header_test.dart`: pins which pages take the shared header vs render their own, fails if a new enum value is added without a header decision, and pins the subscription-leaf resolution.

## Testing

- `flutter test test/pangea/navigation/` — 299 pass (16 new).
- `flutter analyze` — clean on `lib/routes/world` + `lib/routes/settings`.
- **Not visually verified.** I built and served this branch but couldn't reach a logged-in state to photograph the panels: the profile build's origin has no session and `?devlogin=1` is debug-only, while the debug run's DWDS never connected (the known external-Chrome flake) — and it was competing for CPU with an in-flight QA session, so I stopped rather than keep retrying. The TO TEST checklist on #7764 covers every affected page, including the opt-out pages that must not double-header.

## Deploy Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings panels now consistently display a shared title and close/back control where applicable.
  * Subscription pages retain their own app bars and titles without duplicate panel headers.
  * Settings subpages can use customized header behavior when needed.

* **Bug Fixes**
  * Prevented settings panels from appearing without an exit control or with duplicate headers.
  * Improved routing so subscription subpages open in the correct settings section.

* **Documentation**
  * Clarified header behavior and page-level customization rules.

* **Tests**
  * Added coverage for header selection and settings route parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->