### PR TITLE
docs: drop retired choreo api-key from auth doc and local-run skill

### DIFF
--- a/.github/instructions/matrix-auth.instructions.md
+++ b/.github/instructions/matrix-auth.instructions.md
@@ -67,12 +67,11 @@ echo "$MATRIX_TOKEN"
 
 ### Choreo API
 
-Choreo requires **both** the Matrix token and the API key (from `CHOREO_API_KEY` in `client/.env`):
+Choreo gates on the Matrix token alone — it validates the bearer via Synapse `whoami` plus the RevenueCat entitlement check, and reads no API-key header:
 
 ```sh
 curl -s 'https://api.staging.pangea.chat/choreo/<endpoint>' \
-  -H "Authorization: Bearer $MATRIX_TOKEN" \
-  -H 'api-key: <CHOREO_API_KEY>'
+  -H "Authorization: Bearer $MATRIX_TOKEN"
 ```
 
 ### Synapse Client-Server API

--- a/.github/instructions/matrix-auth.instructions.md
+++ b/.github/instructions/matrix-auth.instructions.md
@@ -91,5 +91,5 @@ The test account is **not** a server admin. For admin endpoints, use the bot acc
 |-------|-------|-----|
 | `M_FORBIDDEN` | Token expired or invalidated | Re-run the login curl to get a fresh token |
 | `M_UNKNOWN_TOKEN` | Token from a different homeserver or old session | Confirm you're hitting `matrix.staging.pangea.chat` |
-| `Could not validate Matrix token` from choreo | Missing `api-key` header | Add both `Authorization` and `api-key` headers |
+| `Could not validate Matrix token` from choreo | Choreo's homeserver rejected the bearer — wrong environment's token, or expired | Confirm the token's homeserver matches the choreo you're calling, then re-run the login curl |
 | `M_USER_DEACTIVATED` | Test account was deactivated | Re-register or use a different test account |

--- a/.github/skills/run-flutter-web-local/SKILL.md
+++ b/.github/skills/run-flutter-web-local/SKILL.md
@@ -214,7 +214,7 @@ scripts/use-env.sh local      # or: staging
 
 **MUST READ** [matrix-auth.instructions.md](../../instructions/matrix-auth.instructions.md) for the profile rules (why `.env` is never edited in place, and the credentials each profile must carry).
 
-Profile contents: `CHOREO_API_KEY` is identical in both. **`CMS_API` must match the `SYNAPSE_URL` environment**: the client sends the Matrix access token as the CMS bearer and the CMS validates it against *its own* homeserver — a mismatched pair (local `@learner` token against staging CMS, or vice-versa) returns **403** and content silently fails to load.
+Profile contents: **`CMS_API` must match the `SYNAPSE_URL` environment**: the client sends the Matrix access token as the CMS bearer and the CMS validates it against *its own* homeserver — a mismatched pair (local `@learner` token against staging CMS, or vice-versa) returns **403** and content silently fails to load.
 
 | Key | `.env.local` | `.env.staging` |
 |---|---|---|


### PR DESCRIPTION
## What

Remove the retired choreo `api-key` header from the client's auth doc and local-run skill.

## Why

No issue — docs-only, no client-app surface to test ([issues.instructions.md](.github/instructions/issues.instructions.md) exception).

Choreo gates on Matrix auth (bearer → Synapse `whoami` → RevenueCat entitlement). It reads no inbound `api-key` header, and no infra provisions the secret, so both docs were instructing readers to send a credential that validates nothing. Part of the cross-repo removal: [2-step-choreographer#2814](https://github.com/pangeachat/2-step-choreographer/pull/2814), [admin-dash-api#59](https://github.com/pangeachat/admin-dash-api/pull/59).

## Changes

- `matrix-auth.instructions.md` — the Choreo API section said Choreo requires **both** the Matrix token and the API key. Now states the bearer alone, and the curl drops the `api-key` header.
- `run-flutter-web-local/SKILL.md` — drop the stale "`CHOREO_API_KEY` is identical in both" profile note. The env table below it never listed the key, so nothing else changes.

Design intent for this removal was resolved with Will directly before these edits, not in this PR.

## Testing

No client testing needed, docs-only removal of a credential the service does not read; no runtime surface.

Verified no `CHOREO_API_KEY` or choreo `api-key` reference remains anywhere in `client/.github/` or `client/lib/`.

## Deploy Notes

None.