### PR TITLE
chore: register doc-coverage hook on Bash so scripted edits are covered

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 \"$HOME/PangeaChat/.github/scripts/intent-gate.py\""
+          },
+          {
+            "type": "command",
             "command": "bash \"$HOME/PangeaChat/.github/scripts/pretooluse-reminders.sh\""
           }
         ]


### PR DESCRIPTION
## What

Track the `Bash` registration of the doc-coverage hook in this repo's `.claude/settings.json`.

## Why

No issue — harness config, no client surface ([issues.instructions.md](.github/instructions/issues.instructions.md) exception).

Follows pangeachat/.github#267, which added the hook's topic tier and registered it on `Bash` so a scripted bulk edit (a `python`/`sed` pass) is covered — previously the matcher was `Edit|Write|NotebookEdit` only, so a sweep through Bash bypassed it entirely.

This repo is one of only two that **track** `.claude/settings.json` rather than gitignore it, and per [harness-sync](https://github.com/pangeachat/.github/blob/main/.github/instructions/harness-sync.instructions.md) it is tracked so a fresh clone has hooks before its first session. The file is generated by `sync-copilot-to-claude.py` from the base in `pangeachat/.github`; this commit is that regenerated output, not a hand edit.

## Testing

No client testing needed, generated harness config; no runtime surface — no Dart, asset, or build change.

Confirmed the only diff is the added `intent-gate.py` entry on the existing `Bash` matcher.

## Deploy Notes

None.