### PR TITLE
fix(practice): body-width progress/timer and single-shape cluster badge with hover/press feedback

### DIFF
--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_view.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_view.dart
@@ -13,8 +13,9 @@ import 'package:fluffychat/routes/analytics/construct_analytics/practice/unsubsc
 import 'package:fluffychat/widgets/animated_progress_bar.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
 
-/// The practice panel's ONE header row: close (silent leave) + progress +
-/// wall-clock timer + feedback flag + explicit End control. See
+/// The practice panel: a nav header (close = silent leave, title, feedback
+/// flag, explicit End control) with the session's progress bar + wall-clock
+/// timer riding at the top of the BODY — session state, not navigation. See
 /// routing.instructions.md § Practice is a persistent background session.
 class AnalyticsPracticeView extends StatelessWidget {
   final AnalyticsPracticeState controller;
@@ -64,13 +65,6 @@ class AnalyticsPracticeView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    const loading = Center(
-      child: SizedBox(
-        width: 24,
-        height: 24,
-        child: CircularProgressIndicator.adaptive(),
-      ),
-    );
     return Scaffold(
       appBar: AppBar(
         leading: IconButton(
@@ -79,81 +73,108 @@ class AnalyticsPracticeView extends StatelessWidget {
           // Silent leave: the session stays alive in the holder.
           onPressed: controller.widget.close,
         ),
-        title: Row(
-          spacing: 8.0,
-          children: [
-            Expanded(
-              child: ValueListenableBuilder(
-                valueListenable: controller.progress,
-                builder: (context, progress, _) => AnimatedProgressBar(
-                  height: 20.0,
-                  widthPercent: progress,
-                  barColor: Theme.of(context).colorScheme.primary,
-                ),
-              ),
-            ),
-            ValueListenableBuilder(
-              valueListenable: controller.practiceExerciseState,
-              builder: (context, state, _) {
-                final session = controller.session.session;
-                return PracticeTimerWidget(
-                  key: ValueKey(session?.startedAt ?? DateTime(0)),
-                  startedAt: session?.startedAt,
-                  frozenSeconds: session?.state.elapsedSeconds ?? 0,
-                  onTimeUpdate: controller.session.updateElapsedTime,
-                  isRunning:
-                      session != null &&
-                      !session.isComplete &&
-                      controller.session.sessionError == null,
-                );
-              },
-            ),
-          ],
-        ),
+        title: Text(L10n.of(context).practice),
         actions: [_headerActions(context)],
       ),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 8.0),
-        child: MaxWidthBody(
-          withScrolling: false,
-          showBorder: false,
-          padding: EdgeInsets.only(left: 32.0, right: 32.0),
-          addVerticalPadding: false,
-          // Rebuild on every session-flow transition: a load left in flight by
-          // a closed panel lands through this notifier, so a reopened panel
-          // renders it without this State's setState.
+      body: _body(context),
+    );
+  }
+
+  /// Progress + timer are session state, not navigation — they ride at the
+  /// top of the body, inside the same width constraints as the page content.
+  Widget _progressAndTimer(BuildContext context) => Padding(
+    padding: const EdgeInsets.only(top: 8.0, bottom: 4.0),
+    child: Row(
+      spacing: 8.0,
+      children: [
+        Expanded(
           child: ValueListenableBuilder(
-            valueListenable: controller.practiceExerciseState,
-            builder: (context, _, _) {
-              final error = controller.session.sessionError;
-              if (error != null) {
-                if (error is InsufficientDataException) {
-                  return InsufficientDataIndicator();
-                }
-
-                return error is UnsubscribedException
-                    ? const UnsubscribedPracticePage()
-                    : AnalyticsInitErrorIndicator(
-                        reinitialize: controller.startSession,
-                      );
-              }
-
-              final session = controller.session.session;
-              if (session != null) {
-                return session.isComplete && !session.loadFailed
-                    ? CompletedAnalyticsPracticeExercisesView(
-                        session: session,
-                        launchSession: controller.startSession,
-                        levelProgress: controller.levelProgress,
-                      )
-                    : OngoingAnalyticsPracticeSessionView(controller);
-              }
-
-              return loading;
-            },
+            valueListenable: controller.progress,
+            builder: (context, progress, _) => AnimatedProgressBar(
+              height: 20.0,
+              widthPercent: progress,
+              barColor: Theme.of(context).colorScheme.primary,
+            ),
           ),
         ),
+        ValueListenableBuilder(
+          valueListenable: controller.practiceExerciseState,
+          builder: (context, state, _) {
+            final session = controller.session.session;
+            return PracticeTimerWidget(
+              key: ValueKey(session?.startedAt ?? DateTime(0)),
+              startedAt: session?.startedAt,
+              frozenSeconds: session?.state.elapsedSeconds ?? 0,
+              onTimeUpdate: controller.session.updateElapsedTime,
+              isRunning:
+                  session != null &&
+                  !session.isComplete &&
+                  controller.session.sessionError == null,
+            );
+          },
+        ),
+      ],
+    ),
+  );
+
+  Widget _body(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      child: MaxWidthBody(
+        withScrolling: false,
+        showBorder: false,
+        padding: EdgeInsets.only(left: 32.0, right: 32.0),
+        addVerticalPadding: false,
+        child: Column(
+          children: [
+            _progressAndTimer(context),
+            Expanded(child: _content(context)),
+          ],
+        ),
       ),
+    );
+  }
+
+  Widget _content(BuildContext context) {
+    const loading = Center(
+      child: SizedBox(
+        width: 24,
+        height: 24,
+        child: CircularProgressIndicator.adaptive(),
+      ),
+    );
+    // Rebuild on every session-flow transition: a load left in flight by
+    // a closed panel lands through this notifier, so a reopened panel
+    // renders it without this State's setState.
+    return ValueListenableBuilder(
+      valueListenable: controller.practiceExerciseState,
+      builder: (context, _, _) {
+        final error = controller.session.sessionError;
+        if (error != null) {
+          if (error is InsufficientDataException) {
+            return InsufficientDataIndicator();
+          }
+
+          return error is UnsubscribedException
+              ? const UnsubscribedPracticePage()
+              : AnalyticsInitErrorIndicator(
+                  reinitialize: controller.startSession,
+                );
+        }
+
+        final session = controller.session.session;
+        if (session != null) {
+          return session.isComplete && !session.loadFailed
+              ? CompletedAnalyticsPracticeExercisesView(
+                  session: session,
+                  launchSession: controller.startSession,
+                  levelProgress: controller.levelProgress,
+                )
+              : OngoingAnalyticsPracticeSessionView(controller);
+        }
+
+        return loading;
+      },
     );
   }
 }

--- a/lib/routes/analytics/construct_analytics/practice/practice_session_badge.dart
+++ b/lib/routes/analytics/construct_analytics/practice/practice_session_badge.dart
@@ -6,14 +6,26 @@ import 'package:material_symbols_icons/symbols.dart';
 
 import 'package:fluffychat/routes/analytics/construct_analytics/practice/practice_timer_widget.dart';
 
-/// The live-practice label stacked on a section's cluster tracker: the
-/// practice icon + the session's running wall-clock timer. Signals the
-/// background session and marks the tracker as its resume tap-target. See
-/// routing.instructions.md § Practice is a persistent background session.
+/// The live-practice rendering of a cluster tracker: the practice icon above
+/// the session's running wall-clock timer, sized to the tracker's own
+/// icon/count metrics so it fully takes the button's place while a session is
+/// live. The tracker supplies the stadium background (its hover shape); this
+/// widget is just the ticking content. See routing.instructions.md § Practice
+/// is a persistent background session.
 class PracticeSessionBadge extends StatefulWidget {
   final DateTime startedAt;
 
-  const PracticeSessionBadge({required this.startedAt, super.key});
+  /// Match the host tracker's icon/count sizing so the swap doesn't change
+  /// the button's footprint.
+  final double iconSize;
+  final double fontSize;
+
+  const PracticeSessionBadge({
+    required this.startedAt,
+    this.iconSize = 24,
+    this.fontSize = 16,
+    super.key,
+  });
 
   @override
   State<PracticeSessionBadge> createState() => _PracticeSessionBadgeState();
@@ -37,33 +49,28 @@ class _PracticeSessionBadgeState extends State<PracticeSessionBadge> {
   @override
   Widget build(BuildContext context) {
     final elapsed = DateTime.now().difference(widget.startedAt).inSeconds;
-    final colorScheme = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 1.0),
-      decoration: BoxDecoration(
-        color: colorScheme.primary,
-        borderRadius: BorderRadius.circular(8.0),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Symbols.fitness_center,
-            size: 10.0,
-            color: colorScheme.onPrimary,
+    final onPrimary = Theme.of(context).colorScheme.onPrimary;
+    // Content only — the host tracker paints the single stadium fill over its
+    // own hover geometry, so the badge never introduces a second shape.
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(
+          Symbols.fitness_center,
+          size: widget.iconSize * 0.85,
+          color: onPrimary,
+        ),
+        const SizedBox(height: 2),
+        Text(
+          PracticeTimerWidget.formatTime(elapsed),
+          style: TextStyle(
+            fontSize: widget.fontSize * 0.65,
+            height: 1.1,
+            fontWeight: FontWeight.w600,
+            color: onPrimary,
           ),
-          const SizedBox(width: 2.0),
-          Text(
-            PracticeTimerWidget.formatTime(elapsed),
-            style: TextStyle(
-              fontSize: 9.0,
-              height: 1.0,
-              fontWeight: FontWeight.w600,
-              color: colorScheme.onPrimary,
-            ),
-          ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -287,7 +287,7 @@ class _PowerupsPill extends StatelessWidget {
 /// The displayed count abbreviates above 999 ([compactCount]) so the pill
 /// never outgrows the allocator's fixed cluster gutter; the semantics label
 /// carries the exact count.
-class ClusterTrackerButton extends StatelessWidget {
+class ClusterTrackerButton extends StatefulWidget {
   final ProgressIndicatorEnum indicator;
   final int count;
   final VoidCallback onTap;
@@ -307,6 +307,23 @@ class ClusterTrackerButton extends StatelessWidget {
     this.fontSize = 16,
     super.key,
   });
+
+  @override
+  State<ClusterTrackerButton> createState() => _ClusterTrackerButtonState();
+}
+
+class _ClusterTrackerButtonState extends State<ClusterTrackerButton> {
+  ProgressIndicatorEnum get indicator => widget.indicator;
+  int get count => widget.count;
+  VoidCallback get onTap => widget.onTap;
+  double get horizontalPadding => widget.horizontalPadding;
+  double get iconSize => widget.iconSize;
+  double get fontSize => widget.fontSize;
+
+  /// Hover feedback for the live-practice badge: the fill brightens to full
+  /// opacity (the gold ink highlight is suppressed there — a translucent gold
+  /// wash over solid primary read as no feedback at all).
+  bool _hovered = false;
 
   @override
   Widget build(BuildContext context) {
@@ -340,7 +357,10 @@ class ClusterTrackerButton extends StatelessWidget {
           excludeFromSemantics: true,
           child: InkWell(
             onTap: onTap,
-            hoverColor: AppConfig.goldByTheme(context).withAlpha(50),
+            onHover: (h) => setState(() => _hovered = h),
+            hoverColor: liveSessionStart != null
+                ? Colors.transparent
+                : AppConfig.goldByTheme(context).withAlpha(50),
             borderRadius: BorderRadius.circular(100),
             child: Semantics(
               button: true,
@@ -348,39 +368,46 @@ class ClusterTrackerButton extends StatelessWidget {
               // abbreviation.
               label: semanticsLabel,
               excludeSemantics: true,
-              child: Padding(
+              // While a session is live the badge takes the button's place:
+              // ONE stadium fill on exactly the hover-highlight geometry
+              // (same radius, same padded bounds), practice icon over the
+              // running timer inside it. Painted as INK (not a Container) so
+              // Material's press splash renders on top of the fill — the same
+              // white flash the sibling trackers give.
+              child: Ink(
+                decoration: liveSessionStart != null
+                    ? BoxDecoration(
+                        color: Theme.of(context).colorScheme.primary.withValues(
+                          alpha: _hovered ? 1.0 : 0.75,
+                        ),
+                        borderRadius: BorderRadius.circular(100),
+                      )
+                    : null,
                 padding: EdgeInsets.symmetric(
                   horizontal: horizontalPadding,
                   vertical: 9,
                 ),
-                child: Stack(
-                  clipBehavior: Clip.none,
-                  alignment: Alignment.topCenter,
-                  children: [
-                    Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(indicator.icon, size: iconSize),
-                        const SizedBox(height: 3),
-                        Text(
-                          compactCount(count),
-                          style: TextStyle(
-                            fontSize: fontSize,
-                            height: 1.1,
-                            fontWeight: FontWeight.w600,
+                child: liveSessionStart != null
+                    ? PracticeSessionBadge(
+                        startedAt: liveSessionStart,
+                        iconSize: iconSize,
+                        fontSize: fontSize,
+                      )
+                    : Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(indicator.icon, size: iconSize),
+                          const SizedBox(height: 3),
+                          Text(
+                            compactCount(count),
+                            style: TextStyle(
+                              fontSize: fontSize,
+                              height: 1.1,
+                              fontWeight: FontWeight.w600,
+                            ),
                           ),
-                        ),
-                      ],
-                    ),
-                    if (liveSessionStart != null)
-                      Positioned(
-                        top: 0,
-                        child: PracticeSessionBadge(
-                          startedAt: liveSessionStart,
-                        ),
+                        ],
                       ),
-                  ],
-                ),
               ),
             ),
           ),


### PR DESCRIPTION
## What

Practice UI polish from staging QA: progress/timer back in the body at content width, and the cluster badge fully replaces the tracker with a single-shape fill plus hover/press feedback.

## Why

Closes #7767. Follow-up polish to the practice background-session redesign (#7743 / #7744), from Will's staging QA.

## What changed

- `AnalyticsPracticeView`: nav header carries only X / "Practice" / flag / End; the progress bar + wall-clock timer moved inside the body's `MaxWidthBody`, so their edges align with the exercise content.
- `ClusterTrackerButton`: while a session is live, the practice badge (icon over running timer) replaces the whole button — ONE stadium fill painted on the hover-highlight geometry, as `Ink` so Material's press splash renders on top; fill at 75% primary opacity, 100% on hover (gold ink tint suppressed for the live state). Exact count stays in the semantics label.
- `PracticeSessionBadge`: content-only column sized off the host tracker's icon/count metrics.

## Testing

- Full `flutter test`: 1241 passed; the only 2 failures were local env-profile artifacts (scheme-less `SYNAPSE_URL` in a freshly seeded `.env.staging`), unrelated to the diff — fixed locally, both endpoint tests pass.
- Verified live against staging in the local web client: header layout, badge replacement, hover brighten, press splash, resume-on-tap.

## Deploy Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session progress and elapsed time now appear prominently at the top of the practice page.
  * Practice session badges support adaptable icon and text sizing.
  * Live-session tracker buttons provide improved hover feedback and display.

* **Bug Fixes**
  * Improved practice session state handling, including loading, errors, insufficient data, and completed sessions.
  * Preserved session recovery through the existing retry flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->