### PR TITLE
fix(browse): let the catalog decide course eligibility and show its results

### DIFF
--- a/.github/instructions/events-and-tokens.instructions.md
+++ b/.github/instructions/events-and-tokens.instructions.md
@@ -47,7 +47,7 @@ Defined in `lib/pangea/events/constants/pangea_event_types.dart`:
 |---|---|---|
 | `pangea.bot_options` | `botOptions` | Bot behavior configuration |
 | `pangea.capacity` | `capacity` | Room capacity limit |
-| `pangea.course_plan` | `coursePlan` | Course plan reference (v1 event type, under v3 review — a quest reference may replace it) |
+| `pangea.course_plan` | `coursePlan` | The quest a course space runs (`uuid`) and the course's target language (`l2`). The public course catalog's eligibility and language filtering read this event — see [public-courses.instructions.md](../../../synapse-pangea-chat/.github/instructions/public-courses.instructions.md). Write it through [`CoursePlanEvent`](../../lib/features/course_plans/courses/course_plan_event.dart), never as a raw map. |
 | `pangea.teacher_mode` | `teacherMode` | Teacher mode toggle |
 | `pangea.course_chat_list` | `courseChatList` | Course chat list default chat settings |
 

--- a/lib/features/course_plans/courses/course_plan_event.dart
+++ b/lib/features/course_plans/courses/course_plan_event.dart
@@ -1,13 +1,42 @@
+/// The `pangea.course_plan` room state event: which quest a course space is
+/// running, and the target language the public course catalog filters on.
+///
+/// See `public-courses.instructions.md` in synapse-pangea-chat for the rule
+/// this event feeds — a room is a course if, and only if, it is published and
+/// carries one of these with a usable plan id.
 class CoursePlanEvent {
   final String uuid;
 
-  CoursePlanEvent({required this.uuid});
+  /// Target language of the course. Null on spaces created before the language
+  /// was recorded in room state; the catalog returns those unfiltered but
+  /// excludes them when a language filter is applied.
+  final String? l2;
 
-  Map<String, dynamic> toJson() {
-    return {'uuid': uuid};
+  CoursePlanEvent({required this.uuid, this.l2});
+
+  Map<String, dynamic> toJson() => {'uuid': uuid, if (l2 != null) 'l2': l2};
+
+  /// Returns null when the event carries no usable plan id, so a malformed or
+  /// blanked event reads as "this room has no course plan" — the same answer a
+  /// room with no event at all gives — instead of throwing at the call site.
+  ///
+  /// Spaces created server-side write the id as `course_plan_id` rather than
+  /// `uuid`; both are accepted, matching the catalog query.
+  static CoursePlanEvent? tryParse(Map<String, dynamic> json) {
+    final id = _planId(json);
+    if (id == null) return null;
+    final l2 = json['l2'];
+    return CoursePlanEvent(
+      uuid: id,
+      l2: l2 is String && l2.isNotEmpty ? l2 : null,
+    );
   }
 
-  factory CoursePlanEvent.fromJson(Map<String, dynamic> json) {
-    return CoursePlanEvent(uuid: json['uuid'] as String);
+  static String? _planId(Map<String, dynamic> json) {
+    for (final key in const ['uuid', 'course_plan_id']) {
+      final value = json[key];
+      if (value is String && value.isNotEmpty) return value;
+    }
+    return null;
   }
 }

--- a/lib/features/course_plans/courses/course_plan_room_extension.dart
+++ b/lib/features/course_plans/courses/course_plan_room_extension.dart
@@ -13,7 +13,7 @@ extension CoursePlanRoomExtension on Room {
   CoursePlanEvent? get coursePlan {
     final event = getState(PangeaEventTypes.coursePlan);
     if (event == null) return null;
-    return CoursePlanEvent.fromJson(event.content);
+    return CoursePlanEvent.tryParse(event.content);
   }
 
   String? activeActivityRoomId(String activityId) {
@@ -30,7 +30,13 @@ extension CoursePlanRoomExtension on Room {
     return null;
   }
 
-  Future<void> addCourseToSpace(String courseId) async {
+  /// [targetLanguage] is required because the public course catalog filters on
+  /// it: a course space whose plan event carries no `l2` is excluded from every
+  /// language-filtered browse, so attaching a quest without it hides the course.
+  Future<void> addCourseToSpace(
+    String courseId, {
+    required String targetLanguage,
+  }) async {
     // Ensure students in course can launch activity rooms
     final powerLevels = Map<String, dynamic>.from(
       getState(EventTypes.RoomPowerLevels)?.content ?? {},
@@ -48,11 +54,18 @@ extension CoursePlanRoomExtension on Room {
       );
     }
 
-    if (coursePlan?.uuid == courseId) return;
+    final desired = CoursePlanEvent(uuid: courseId, l2: targetLanguage);
+    final current = coursePlan;
+    // Rewrite when the language is missing or stale as well as when the quest
+    // changes, so a space attached before `l2` was recorded is repaired here.
+    if (current?.uuid == courseId && current?.l2 == desired.l2) return;
     final future = waitForRoomInSync();
-    await client.setRoomStateWithKey(id, PangeaEventTypes.coursePlan, "", {
-      "uuid": courseId,
-    });
+    await client.setRoomStateWithKey(
+      id,
+      PangeaEventTypes.coursePlan,
+      "",
+      desired.toJson(),
+    );
     if (coursePlan?.uuid != courseId) {
       await future;
     }

--- a/lib/features/quests/repo/quest_plans_repo.dart
+++ b/lib/features/quests/repo/quest_plans_repo.dart
@@ -101,10 +101,41 @@ class QuestPlansRepo {
     }
   }
 
+  /// Resolve a page of quest ids in one request, keyed by id.
+  ///
+  /// The catalog hands back a page of course ids at a time; fetching them one
+  /// by one costs a round trip per card, which is felt directly as browse
+  /// latency. Ids that do not resolve are simply absent from the result.
+  ///
+  /// [requireMissions] defaults to true to preserve the creation picker's rule
+  /// (#7700); catalog callers pass false.
+  static Future<Map<String, CoursePlanModel>> getMany(
+    List<String> questIds, {
+    bool requireMissions = true,
+  }) async {
+    if (questIds.isEmpty) return const {};
+    final resp = await _client().find<CoursePlanModel?>(
+      _collection,
+      (json) => _fromQuestPlanJson(json, requireMissions: requireMissions),
+      limit: questIds.length,
+      where: {
+        'id': {'in': questIds},
+      },
+      depth: 0,
+    );
+    return {
+      for (final plan in resp.docs.whereType<CoursePlanModel>())
+        plan.uuid: plan,
+    };
+  }
+
   /// JSON → synthesized [CoursePlanModel]. Returns ``null`` on a missing /
   /// malformed quest-plans row so the caller can filter it out cleanly
   /// instead of inserting a broken card.
-  static CoursePlanModel? _fromQuestPlanJson(Map<String, dynamic> json) {
+  static CoursePlanModel? _fromQuestPlanJson(
+    Map<String, dynamic> json, {
+    bool requireMissions = true,
+  }) {
     final id = json['id'] as String?;
     final req = json['req'] as Map<String, dynamic>?;
     final res = json['res'] as Map<String, dynamic>?;
@@ -126,11 +157,15 @@ class QuestPlansRepo {
     final sequence = res['learning_objective_sequence'] as List<dynamic>?;
     final missionCount = sequence?.length ?? 0;
     // A quest-plan with no missions has no content to build a course from — it
-    // would show as a "0 modules" card the learner can't actually create. Drop
-    // it here (the same null-to-filter contract as the missing-field guards
-    // above) so it never reaches the creation picker or the repo's other
-    // consumers (find-course, course-plan provider, onboarding). #7700
-    if (missionCount == 0) return null;
+    // would show as a "0 modules" card the learner can't actually create, so
+    // the creation picker drops it (#7700).
+    //
+    // Browsing is the other way round: whether a published course space appears
+    // in the catalog is decided by the catalog endpoint, from room state alone,
+    // and never by the contents of the quest behind it. A course whose quest is
+    // empty is still a real, joinable course. Callers reading the catalog pass
+    // requireMissions: false. See public-courses.instructions.md.
+    if (requireMissions && missionCount == 0) return null;
     // Placeholder strings carry the *count* so the "N modules" chip reads
     // correctly. They are never resolved against the v1 ``course-plan-topics``
     // collection — no v3 surface walks ``topicIds`` on a synthesized model.

--- a/lib/features/room_summaries/room_summary_extension.dart
+++ b/lib/features/room_summaries/room_summary_extension.dart
@@ -255,7 +255,7 @@ class RoomSummaryResponse {
         json[PangeaEventTypes.coursePlan]?["default"]?["content"];
     CoursePlanEvent? coursePlan;
     if (coursePlanEntry != null && coursePlanEntry is Map<String, dynamic>) {
-      coursePlan = CoursePlanEvent.fromJson(coursePlanEntry);
+      coursePlan = CoursePlanEvent.tryParse(coursePlanEntry);
     }
 
     final powerLevelsEntry =

--- a/lib/pangea/spaces/public_course_extension.dart
+++ b/lib/pangea/spaces/public_course_extension.dart
@@ -5,15 +5,12 @@ import 'package:matrix/matrix.dart';
 import 'package:matrix/matrix_api_lite/generated/api.dart';
 
 import 'package:fluffychat/pangea/common/constants/model_keys.dart';
-import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
 
 extension PublicCourseExtension on Api {
   Future<PublicCoursesResponse> getPublicCourses({
     int limit = 10,
     String? since,
     String? targetLanguage,
-    String? languageOfInstructions,
-    LanguageLevelTypeEnum? cefrLevel,
   }) async {
     final requestUri = Uri(
       path: '/_synapse/client/unstable/org.pangea/public_courses',
@@ -21,8 +18,6 @@ extension PublicCourseExtension on Api {
         'limit': limit.toString(),
         'since': ?since,
         ModelKey.targetLanguage: ?targetLanguage,
-        'language_of_instructions': ?languageOfInstructions,
-        if (cefrLevel != null) 'cefr_level': cefrLevel.string,
       },
     );
     final request = Request('GET', baseUri!.resolveUri(requestUri));
@@ -46,20 +41,15 @@ extension PublicCoursesRequest on Client {
     int limit = 10,
     String? since,
     String? targetLanguage,
-    String? languageOfInstructions,
-    LanguageLevelTypeEnum? cefrLevel,
   }) => getPublicCourses(
     limit: limit,
     since: since,
     targetLanguage: targetLanguage,
-    languageOfInstructions: languageOfInstructions,
-    cefrLevel: cefrLevel,
   );
 }
 
 class PublicCoursesResponse extends GetPublicRoomsResponse {
   final List<PublicCoursesChunk> courses;
-  final String? filteringWarning;
 
   PublicCoursesResponse({
     required super.chunk,
@@ -67,7 +57,6 @@ class PublicCoursesResponse extends GetPublicRoomsResponse {
     required super.prevBatch,
     required super.totalRoomCountEstimate,
     required this.courses,
-    this.filteringWarning,
   });
 
   @override
@@ -75,16 +64,19 @@ class PublicCoursesResponse extends GetPublicRoomsResponse {
     return {
       ...super.toJson(),
       'chunk': courses.map((e) => e.toJson()).toList(),
-      'filtering_warning': filteringWarning,
     };
   }
 
+  /// Entries without a usable course id are dropped rather than surfaced as
+  /// broken cards. The catalog should never send one — a room with no plan id
+  /// is not a course — but during a rollout an older homeserver still can, and
+  /// one bad entry must not fail the whole page.
   @override
   PublicCoursesResponse.fromJson(super.json)
     : courses = (json['chunk'] as List)
-          .map((e) => PublicCoursesChunk.fromJson(e))
+          .map((e) => PublicCoursesChunk.tryParse(e))
+          .nonNulls
           .toList(),
-      filteringWarning = json['filtering_warning'] as String?,
       super.fromJson();
 
   PublicCoursesResponse copyWith({
@@ -93,7 +85,6 @@ class PublicCoursesResponse extends GetPublicRoomsResponse {
     String? prevBatch,
     int? totalRoomCountEstimate,
     List<PublicCoursesChunk>? courses,
-    String? filteringWarning,
   }) {
     return PublicCoursesResponse(
       chunk: chunk ?? this.chunk,
@@ -102,7 +93,6 @@ class PublicCoursesResponse extends GetPublicRoomsResponse {
       totalRoomCountEstimate:
           totalRoomCountEstimate ?? this.totalRoomCountEstimate,
       courses: courses ?? this.courses,
-      filteringWarning: filteringWarning ?? this.filteringWarning,
     );
   }
 }
@@ -111,26 +101,21 @@ class PublicCoursesChunk {
   final PublishedRoomsChunk room;
   final String courseId;
   final String? targetLanguage;
-  final String? languageOfInstructions;
-  final LanguageLevelTypeEnum? cefrLevel;
 
   PublicCoursesChunk({
     required this.room,
     required this.courseId,
     this.targetLanguage,
-    this.languageOfInstructions,
-    this.cefrLevel,
   });
 
-  factory PublicCoursesChunk.fromJson(Map<String, dynamic> json) {
+  /// Returns null when the entry carries no course id.
+  static PublicCoursesChunk? tryParse(Map<String, dynamic> json) {
+    final courseId = json['course_id'];
+    if (courseId is! String || courseId.isEmpty) return null;
     return PublicCoursesChunk(
       room: PublishedRoomsChunk.fromJson(json),
-      courseId: json['course_id'] as String,
+      courseId: courseId,
       targetLanguage: json[ModelKey.targetLanguage] as String?,
-      languageOfInstructions: json['language_of_instructions'] as String?,
-      cefrLevel: json['cefr_level'] != null
-          ? LanguageLevelTypeEnum.fromString(json['cefr_level'] as String)
-          : null,
     );
   }
 
@@ -139,9 +124,6 @@ class PublicCoursesChunk {
       'room': room.toJson(),
       'course_id': courseId,
       if (targetLanguage != null) ModelKey.targetLanguage: targetLanguage,
-      if (languageOfInstructions != null)
-        'language_of_instructions': languageOfInstructions,
-      if (cefrLevel != null) 'cefr_level': cefrLevel!.toString(),
     };
   }
 }

--- a/lib/routes/courses/find_course_page.dart
+++ b/lib/routes/courses/find_course_page.dart
@@ -93,10 +93,24 @@ class FindCoursePageState extends State<FindCoursePage> {
     super.dispose();
   }
 
+  /// Clears the state that belongs to the previous catalog query.
+  ///
+  /// The language filter is a server-side query parameter, so cached results
+  /// and the pagination cursor are scoped to the language they were fetched
+  /// for. Carrying them across a filter change would re-show courses in the
+  /// old language and resume paging with a cursor from a different query.
+  void _resetQueryState() {
+    _resultsCache.clear();
+    coursePlans.clear();
+    nextBatch = null;
+    fullyLoaded = false;
+  }
+
   void setTargetLanguageFilter(LanguageModel? language) {
     if (targetLanguageFilter.value == language) return;
     targetLanguageFilter.value = language;
     visibleCourses.value = [];
+    _resetQueryState();
     loading.value = false;
     _loadGeneration++;
     if (scrollController.hasClients) {
@@ -127,9 +141,9 @@ class FindCoursePageState extends State<FindCoursePage> {
   /// Get a sorted list of cached courses that:
   /// 1) Are not already in the list of visible courses
   /// 2) Are not a course that the user is already in
-  /// 2) Have a course plan that matches the language filter
-  /// 3) Match the search term, if any exists
-  List<PublicCoursesChunk> _filterCourses(String targetLanguage) {
+  /// 3) Have a resolved plan, so a card can be rendered for them
+  /// 4) Match the search term, if any exists
+  List<PublicCoursesChunk> _filterCourses() {
     final courses = List<PublicCoursesChunk>.from(_resultsCache);
 
     // filter out already visible courses
@@ -144,21 +158,17 @@ class FindCoursePageState extends State<FindCoursePage> {
       ),
     );
 
-    // filter out rooms with 0 members
-    final nonEmptyCourses = unjoinedCourses.where(
-      (c) => c.room.numJoinedMembers > 0,
+    // Eligibility — which rooms are courses, and which language they are in —
+    // belongs to the catalog endpoint, which filters before it paginates. The
+    // only reason a returned course is dropped here is that its plan did not
+    // resolve, so there is no title to render a card with.
+    // See public-courses.instructions.md in synapse-pangea-chat.
+    final renderableCourses = unjoinedCourses.where(
+      (c) => coursePlans[c.courseId] != null,
     );
 
-    // filter out courses without relevant plans
-    final targetLanguageCourses = nonEmptyCourses.where((chunk) {
-      final course = coursePlans[chunk.courseId];
-      if (course == null) return false;
-      if (targetLanguage == "") return true;
-      return course.targetLanguage.split('-').first == targetLanguage;
-    });
-
     // filter by search term
-    List<PublicCoursesChunk> filtered = targetLanguageCourses.toList();
+    List<PublicCoursesChunk> filtered = renderableCourses.toList();
     final searchText = searchController.text.trim().toLowerCase();
     if (searchText.isNotEmpty) {
       filtered = filtered.where((chunk) {
@@ -204,33 +214,39 @@ class FindCoursePageState extends State<FindCoursePage> {
     return filtered;
   }
 
-  Future<void> loadMore({bool loadMore = false}) async {
+  /// How many courses one load should try to add before it stops.
+  static const int _pageTarget = 5;
+
+  /// Safety bound on network round trips per load. This is a guard against a
+  /// pathological catalog, not the stopping condition — stopping on a batch
+  /// count is what made "load more" give up while courses were still available
+  /// (#7542).
+  static const int _maxBatchesPerLoad = 10;
+
+  Future<void> loadMore() async {
     if (loading.value) return;
     loading.value = true;
 
     final int generation = _loadGeneration;
-    final targetLanguage = targetLanguageFilter.value?.langCodeShort ?? "";
+
+    // Measured before anything is shown, so courses surfaced from the cache
+    // count as progress for this load rather than triggering further round
+    // trips for results the user can already see.
+    final int startingCount = visibleCourses.value.length;
 
     // First, get any courses from the cache that should be visible and show
-    visibleCourses.value = [
-      ...visibleCourses.value,
-      ..._filterCourses(targetLanguage),
-    ];
+    visibleCourses.value = [...visibleCourses.value, ..._filterCourses()];
 
-    // Then, load until at least 5 courses are visible, or all courses have been loaded
-    int timesLoaded = 0;
+    int batches = 0;
     while (_loadGeneration == generation &&
         loading.value &&
-        (visibleCourses.value.length < 5 || loadMore) &&
-        timesLoaded < 4 &&
-        !fullyLoaded) {
+        !fullyLoaded &&
+        batches < _maxBatchesPerLoad &&
+        visibleCourses.value.length - startingCount < _pageTarget) {
       await _loadNextBatch();
       if (!mounted || _loadGeneration != generation) return;
-      visibleCourses.value = [
-        ...visibleCourses.value,
-        ..._filterCourses(targetLanguage),
-      ];
-      timesLoaded++;
+      visibleCourses.value = [...visibleCourses.value, ..._filterCourses()];
+      batches++;
     }
 
     // Only update loading state if this load is still the current one.
@@ -280,9 +296,13 @@ class FindCoursePageState extends State<FindCoursePage> {
 
   Future<Result<PublicCoursesResponse>> _requestPublicCourses() async {
     try {
-      final resp = await Matrix.of(
-        context,
-      ).client.requestPublicCourses(since: nextBatch);
+      final targetLanguage = targetLanguageFilter.value?.langCodeShort;
+      final resp = await Matrix.of(context).client.requestPublicCourses(
+        since: nextBatch,
+        targetLanguage: targetLanguage?.isNotEmpty == true
+            ? targetLanguage
+            : null,
+      );
       return Result.value(resp);
     } catch (e, s) {
       ErrorHandler.logError(e: e, s: s, data: {'nextBatch': nextBatch});
@@ -294,12 +314,14 @@ class FindCoursePageState extends State<FindCoursePage> {
     List<String> courseIds,
   ) async {
     try {
-      // world_v2: resolve each public-course id from the v3 quest-plans layer.
-      final plans = <String, CoursePlanModel>{};
-      for (final id in courseIds) {
-        final quest = await QuestPlansRepo.get(id);
-        if (quest != null) plans[id] = quest;
-      }
+      // world_v2: resolve the page's public-course ids from the v3 quest-plans
+      // layer in one request. requireMissions is false because a course whose
+      // quest has no missions is still a real course in the catalog — only the
+      // creation picker refuses those (public-courses.instructions.md, #7700).
+      final plans = await QuestPlansRepo.getMany(
+        courseIds,
+        requireMissions: false,
+      );
       return Result.value(plans);
     } catch (e, s) {
       ErrorHandler.logError(e: e, s: s, data: {'courseIds': courseIds});
@@ -430,35 +452,39 @@ class FindCoursePageView extends StatelessWidget {
                                   ? CircularProgressIndicator.adaptive()
                                   : !controller.fullyLoaded
                                   ? TextButton(
-                                      onPressed: () =>
-                                          controller.loadMore(loadMore: true),
+                                      onPressed: () => controller.loadMore(),
                                       child: Text(L10n.of(context).loadMore),
                                     )
                                   : SizedBox(),
                             );
                           }
                           final space = courses[index];
-                          if (controller.coursePlans[space.courseId] != null) {
-                            return AddCourseTile(
-                              chunk: space,
-                              coursePlan:
-                                  controller.coursePlans[space.courseId]!,
-                              onTap: () => context.go(
-                                WorkspaceNav.openAddCoursePage(
-                                  GoRouterState.of(context).uri,
-                                  AddCourseSubpageEnum.browse,
-                                  previewRoomId: space.room.roomId,
-                                  initialLanguageFilter: controller
-                                      .targetLanguageFilter
-                                      .value
-                                      ?.langCode,
-                                ),
-                              ),
-                              isKnock:
-                                  space.room.joinRule == JoinRules.knock.name,
-                            );
+                          final coursePlan =
+                              controller.coursePlans[space.courseId];
+                          // Only courses with a resolved plan reach this list,
+                          // so this is a defensive guard, not an expected
+                          // branch — an unrenderable course must never occupy a
+                          // row, or "load more" appears to do nothing.
+                          if (coursePlan == null) {
+                            return const SizedBox.shrink();
                           }
-                          return SizedBox();
+                          return AddCourseTile(
+                            chunk: space,
+                            coursePlan: coursePlan,
+                            onTap: () => context.go(
+                              WorkspaceNav.openAddCoursePage(
+                                GoRouterState.of(context).uri,
+                                AddCourseSubpageEnum.browse,
+                                previewRoomId: space.room.roomId,
+                                initialLanguageFilter: controller
+                                    .targetLanguageFilter
+                                    .value
+                                    ?.langCode,
+                              ),
+                            ),
+                            isKnock:
+                                space.room.joinRule == JoinRules.knock.name,
+                          );
                         },
                       ),
                     );

--- a/lib/routes/courses/own/selected_course_page.dart
+++ b/lib/routes/courses/own/selected_course_page.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart' as sdk;
 
 import 'package:fluffychat/features/analytics_access/course_settings_model.dart';
+import 'package:fluffychat/features/course_plans/courses/course_plan_event.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
 import 'package:fluffychat/features/navigation/token_params/add_course_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
@@ -109,7 +110,10 @@ class SelectedCourseController extends State<SelectedCourse> {
           initialState: [
             sdk.StateEvent(
               type: PangeaEventTypes.coursePlan,
-              content: {"uuid": courseId},
+              content: CoursePlanEvent(
+                uuid: courseId,
+                l2: course.targetLanguage,
+              ).toJson(),
             ),
             sdk.StateEvent(
               type: PangeaEventTypes.courseSettings,
@@ -145,7 +149,10 @@ class SelectedCourseController extends State<SelectedCourse> {
       throw Exception("Space not found");
     }
 
-    await space.addCourseToSpace(widget.courseId);
+    await space.addCourseToSpace(
+      widget.courseId,
+      targetLanguage: course.targetLanguage,
+    );
 
     if (space.name.isEmpty) {
       await space.setName(course.name);

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -14,6 +14,7 @@ import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/panel_types_enum.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/token_params/activity_token.dart';
+import 'package:fluffychat/features/navigation/token_params/add_course_token.dart';
 import 'package:fluffychat/features/navigation/token_params/room_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
@@ -543,11 +544,21 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
           .length;
       preferredCavityHeight =
           _chatsSheetHeaderAllowance + visibleChats * _chatsSheetRowEstimate;
-    } else if (cavityToken?.type == PanelTypesEnum.addcourse) {
+    } else if (cavityToken?.type == PanelTypesEnum.addcourse &&
+        cavityToken?.param is! AddCoursePageTokenParam) {
       // The Courses hub opens tall enough to show all joined courses (or the
       // add-course buttons when there are none), capped by maxHeightFraction —
       // no longer defaulting to half (#7692). Same joined-course predicate as
       // the hub list, so the estimate counts exactly what renders.
+      //
+      // Content-fit is the HUB's rule only. Its subpages (browse public
+      // courses, start my own, enter a code) show unrelated content that
+      // arrives asynchronously, so a height derived from the joined-course
+      // count leaves their lists too short to build a single row — browse then
+      // reads as "no courses" until the learner drags the sheet up (#7542).
+      // They fall through to the default (roughly half the screen), which is
+      // what routing.instructions.md specifies for sections other than the
+      // chats sheet and the Courses hub.
       final courseCount = joinedCourses(client, l10n).length;
       preferredCavityHeight =
           _chatsSheetHeaderAllowance +

--- a/test/pangea/courses/course_catalog_parsing_test.dart
+++ b/test/pangea/courses/course_catalog_parsing_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/course_plans/courses/course_plan_event.dart';
+import 'package:fluffychat/pangea/spaces/public_course_extension.dart';
+
+/// Parsing rules for the public course catalog.
+///
+/// Both parsers answer the same question — "is this a course?" — at the point
+/// of reading, so a malformed record reads as "not a course" instead of
+/// throwing out at a call site. See public-courses.instructions.md.
+void main() {
+  group('CoursePlanEvent.tryParse', () {
+    test('reads the plan id from uuid', () {
+      final event = CoursePlanEvent.tryParse({'uuid': 'quest-1'});
+      expect(event?.uuid, 'quest-1');
+    });
+
+    test('falls back to course_plan_id, which server-created spaces write', () {
+      final event = CoursePlanEvent.tryParse({'course_plan_id': 'quest-2'});
+      expect(event?.uuid, 'quest-2');
+    });
+
+    test('prefers uuid when both keys are present', () {
+      final event = CoursePlanEvent.tryParse({
+        'uuid': 'quest-1',
+        'course_plan_id': 'quest-2',
+      });
+      expect(event?.uuid, 'quest-1');
+    });
+
+    test('reads the target language', () {
+      final event = CoursePlanEvent.tryParse({'uuid': 'q', 'l2': 'es'});
+      expect(event?.l2, 'es');
+    });
+
+    test('a course with no recorded language parses, without one', () {
+      final event = CoursePlanEvent.tryParse({'uuid': 'q'});
+      expect(event, isNotNull);
+      expect(event?.l2, isNull);
+    });
+
+    test('an event with no plan id is not a course', () {
+      expect(CoursePlanEvent.tryParse({}), isNull);
+      expect(CoursePlanEvent.tryParse({'l2': 'es'}), isNull);
+    });
+
+    test('a blanked plan id is not a course', () {
+      // Matrix has no true state deletion, so removing a course plan means
+      // blanking the event content.
+      expect(CoursePlanEvent.tryParse({'uuid': ''}), isNull);
+      expect(
+        CoursePlanEvent.tryParse({'uuid': '', 'course_plan_id': ''}),
+        isNull,
+      );
+    });
+
+    test('a non-string plan id does not throw', () {
+      expect(CoursePlanEvent.tryParse({'uuid': 42}), isNull);
+    });
+
+    test('round-trips through toJson, omitting an absent language', () {
+      expect(CoursePlanEvent(uuid: 'q', l2: 'de').toJson(), {
+        'uuid': 'q',
+        'l2': 'de',
+      });
+      expect(CoursePlanEvent(uuid: 'q').toJson(), {'uuid': 'q'});
+    });
+  });
+
+  group('PublicCoursesResponse.fromJson', () {
+    Map<String, dynamic> room(String id, {String? courseId}) => {
+      'room_id': id,
+      'num_joined_members': 3,
+      'world_readable': true,
+      'guest_can_join': false,
+      if (courseId != null) 'course_id': courseId,
+    };
+
+    test('parses entries that carry a course id', () {
+      final resp = PublicCoursesResponse.fromJson({
+        'chunk': [room('!a:server', courseId: 'quest-1')],
+        'next_batch': '!a:server',
+        'total_room_count_estimate': 1,
+      });
+      expect(resp.courses, hasLength(1));
+      expect(resp.courses.single.courseId, 'quest-1');
+    });
+
+    test('drops an entry with no course id instead of failing the page', () {
+      // A homeserver that predates the catalog eligibility rule can still send
+      // one of these. Previously it threw and took the whole page down (#7542).
+      final resp = PublicCoursesResponse.fromJson({
+        'chunk': [
+          room('!a:server', courseId: 'quest-1'),
+          room('!b:server'),
+          room('!c:server', courseId: 'quest-3'),
+        ],
+        'next_batch': '!c:server',
+        'total_room_count_estimate': 3,
+      });
+      expect(resp.courses.map((c) => c.courseId), ['quest-1', 'quest-3']);
+    });
+
+    test('carries the pagination cursor through', () {
+      final resp = PublicCoursesResponse.fromJson({
+        'chunk': [room('!a:server', courseId: 'q')],
+        'next_batch': '!a:server',
+        'total_room_count_estimate': 9,
+      });
+      expect(resp.nextBatch, '!a:server');
+      expect(resp.totalRoomCountEstimate, 9);
+    });
+  });
+}


### PR DESCRIPTION
## What

Browse asks the catalog for courses in the learner's language and renders what comes back, instead of over-fetching unvetted rooms and re-deciding eligibility locally. Also records a course's target language in room state so the catalog can filter on it.

## Why

Closes #7542

Browse showed roughly one course per "Load more". Three independent causes: the client discarded most of each page after already paying a CMS round trip per room; "Load more" ran a fixed four batches with no success condition; and the add-course sheet opened too short to build a single list row, so results that *were* fetched rendered into a zero-height viewport and read as "no courses".

Contract for what appears and how it is filtered: [public-courses.instructions.md](https://github.com/pangeachat/synapse-pangea-chat/blob/7542-browse-eligibility-and-language/.github/instructions/public-courses.instructions.md) in `synapse-pangea-chat`.

## Testing

- `flutter test` — **1286 passed**
- `flutter analyze lib/` — no new issues. (7 pre-existing `L10n` undefined-getter errors from #7749 exist on `origin/main` too; verified byte-identical by stashing.)
- Driven end-to-end through the real UI (profile build, local Synapse + CMS, `@learner`, single-column layout):
  - request is now `?limit=10&target_language=es` — previously only `since`
  - one batched `quest-plans?where[id][in][…]` per page instead of one request per course
  - list renders at the default sheet height with no dragging
  - `es-MX` course appears under an `es` filter (base-language matching, #53)
  - switching the filter issues a fresh query with **no stale cursor**, then pages on a keyset cursor
  - joined courses excluded client-side; German, unpublished, and blank-plan rooms excluded server-side

## Deploy Notes

pangeachat/.github#272 — ship this **after** the `synapse-pangea-chat` module and the one-time `l2` backfill. Until the backfill runs, a language-filtered Browse only returns courses created after the module deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added target-language support when associating courses with spaces.
  * Improved course catalog loading, filtering, pagination, and bulk plan resolution.
  * Added safer handling for incomplete or invalid course catalog entries.

* **Bug Fixes**
  * Corrected course-space metadata when language information was previously missing.
  * Prevented malformed course data from causing parsing failures.
  * Refined mobile course panel sizing behavior.

* **Documentation**
  * Updated course event documentation for the v3 format.

* **Tests**
  * Added coverage for course plan parsing, language data, invalid entries, and pagination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->