### PR TITLE
fix(tests): use a null-aware element so flutter analyze is clean again

### DIFF
--- a/test/pangea/courses/course_catalog_parsing_test.dart
+++ b/test/pangea/courses/course_catalog_parsing_test.dart
@@ -73,7 +73,7 @@ void main() {
       'num_joined_members': 3,
       'world_readable': true,
       'guest_can_join': false,
-      if (courseId != null) 'course_id': courseId,
+      'course_id': ?courseId,
     };
 
     test('parses entries that carry a course id', () {


### PR DESCRIPTION
## What

One line in a test file. `main` has been red on `code_tests` since #7770; this makes it green.

```
info • Use the null-aware marker '?' rather than a null check via an 'if'
     • test/pangea/courses/course_catalog_parsing_test.dart:76:7 • use_null_aware_elements
```

`if (courseId != null) 'course_id': courseId` → `'course_id': ?courseId`.

## Why it went unnoticed

The failure is **mine**, from #7770, and it is not a test failure — all 1278 tests pass. `code_tests` runs six gates before the tests, and `flutter analyze` exits non-zero on **any** issue including `info`. So a single info-level lint in a new test file took the whole job down, and the job name pointed at tests.

Worth noting how the safety net missed it: the git-layer pre-push gate exists precisely to catch `dart format` / analyze drift in seconds rather than minutes-later in CI, but it preferred the `fvm` wrapper, which shells out to a `dart` that agent sessions do not have on PATH — so it failed open silently. pangeachat/.github#270 fixed that yesterday by preferring the repo-pinned SDK. This is the class of bug that fix exists to stop.

## Testing

Against `origin/main` in a clean worktree, before and after:

- `flutter analyze` — was `1 issue found`, now `No issues found!`
- `flutter test` — 1278 pass, exit 0 (unchanged; the tests were never the problem)
- `dart format lib/ test/ --set-exit-if-changed` — clean
- `dart run import_sorter:main --exit-if-changed` — clean
- `./scripts/generate-locale-config.sh && git diff --exit-code` — no drift

## TO TEST

Nothing to tap through — this changes a test file's map literal only, with no client surface. The verification is CI going green.

## Deploy Notes

None.