### PR TITLE
feat(release): automated iOS TestFlight lane with fastlane match signing

### DIFF
--- a/.github/instructions/deployment.instructions.md
+++ b/.github/instructions/deployment.instructions.md
@@ -20,7 +20,7 @@ Production is periodically synced from `main` via merge PRs. Between syncs, the 
 ## Deploy Mechanism
 
 - Flutter web build → S3 upload via GitHub Actions
-- Mobile builds: manual app store builds and releases
+- Mobile builds: Android — release builds an APK attached to the GitHub release; Play Store upload is a manual [`manual.yml`](../../.github/workflows/manual.yml) dispatch. iOS — every production release builds a signed IPA and uploads it to TestFlight via [`ios-testflight.yml`](../../.github/workflows/ios-testflight.yml) (fastlane match signing; certs live encrypted in the private `pangeachat/ios-certificates` repo); App Store submission from TestFlight stays a human step. The same workflow is manually dispatchable for staging TestFlight builds, replacing laptop fastlane builds — this matters because the checked-in Firebase config files are the staging ones, so only env-secret-driven CI builds are guaranteed to carry the right Firebase project (FCM tokens are project-scoped; a mismatch kills push).
 - Staging: app.staging.pangea.chat (S3 + CloudFront)
 - Production: app.pangea.chat (S3 + CloudFront)
 

--- a/.github/workflows/ios-certs-bootstrap.yml
+++ b/.github/workflows/ios-certs-bootstrap.yml
@@ -1,0 +1,37 @@
+name: Bootstrap iOS signing certs (one-time)
+# Mints the Apple Distribution certificate + App Store provisioning profile via
+# fastlane match and stores them encrypted in pangeachat/ios-certificates.
+# Run once (and again only to rotate). Requires secrets: MATCH_PASSWORD,
+# MATCH_GIT_SSH_KEY (write deploy key on ios-certificates), and the
+# APP_STORE_CONNECT_API_KEY_* set.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap_certs:
+    runs-on: macos-15
+    environment: production
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
+        with:
+          ruby-version: "3.3"
+      - name: Install Fastlane
+        run: gem install fastlane -NV
+      - name: Load match repo deploy key
+        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.MATCH_GIT_SSH_KEY }}
+      - name: Mint certs into match repo
+        working-directory: ios
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+          APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64 }}
+        run: fastlane ios bootstrap_certs

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,0 +1,79 @@
+name: Build iOS and upload to TestFlight
+# Signed iOS build via fastlane match, uploaded to TestFlight.
+# - Called from release.yaml with environment=production on every release.
+# - Manually dispatchable for staging (or production) test builds — replaces
+#   the laptop fastlane beta flow. The selected GitHub Environment supplies
+#   GOOGLE_SERVICES_PLIST and WEB_APP_ENV, so the Firebase project always
+#   matches the target environment (see deployment.instructions.md).
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: choice
+        description: Select the environment
+        options:
+          - staging
+          - production
+        default: "staging"
+
+permissions:
+  contents: read
+
+jobs:
+  build_ios_testflight:
+    runs-on: macos-15
+    environment: ${{ inputs.environment }}
+    env:
+      WEB_APP_ENV: ${{ vars.WEB_APP_ENV }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - run: cat .github/workflows/versions.env >> $GITHUB_ENV
+      - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
+      - name: Use Xcode 16.4
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - run: brew install sqlcipher
+      - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
+        with:
+          ruby-version: "3.3"
+      - name: Install Fastlane
+        run: gem install fastlane -NV
+      - name: Add Firebase Messaging
+        env:
+          GOOGLE_SERVICES_PLIST: ${{ secrets.GOOGLE_SERVICES_PLIST }}
+        run: ./scripts/configure-firebase-messaging.sh
+      - name: Update env files to selected environment
+        run: |
+          rm -f .env
+          echo "$WEB_APP_ENV" > .env
+      - name: Apply .env patch
+        run: git apply ./scripts/enable_mobile_env.patch
+      - name: Remove Emoji Font
+        run: |
+          rm -rf fonts/NotoEmoji
+          yq -i 'del( .flutter.fonts[] | select(.family == "NotoEmoji") )' pubspec.yaml
+      - run: flutter pub get
+      - name: Build iOS (unsigned)
+        run: flutter build ios --release --no-codesign
+      - name: Load match repo deploy key
+        uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.MATCH_GIT_SSH_KEY }}
+      - name: Sign and upload to TestFlight
+        working-directory: ios
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+          APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64 }}
+        run: fastlane ios release_candidate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,6 +151,13 @@ jobs:
           asset_name: pangeachat.apk
           asset_content_type: application/vnd.android.package-archive
 
+  build_ios:
+    needs: create_release
+    uses: ./.github/workflows/ios-testflight.yml
+    with:
+      environment: production
+    secrets: inherit
+
   build_linux:
     strategy:
       matrix:

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -44,6 +44,59 @@ platform :ios do
       changelog: "This is a release candidate for Pangea Chat. Please test if the app is overall in a good condition before we push this to production.",
     )
   end
+
+  desc "One-time: mint the App Store distribution cert + profile into the match repo"
+  lane :bootstrap_certs do
+    api_key = app_store_connect_api_key(
+      key_id: ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"],
+      issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
+      key_content: ENV["APP_STORE_CONNECT_API_KEY_KEY"],
+      is_key_content_base64: ENV["APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64"],
+      duration: 500,
+      in_house: false
+    )
+    setup_ci if ENV["CI"]
+    match(type: "appstore", api_key: api_key, readonly: false)
+  end
+
+  desc "CI release: sign with match, build IPA, upload to TestFlight"
+  lane :release_candidate do
+    api_key = app_store_connect_api_key(
+      key_id: ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"],
+      issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
+      key_content: ENV["APP_STORE_CONNECT_API_KEY_KEY"],
+      is_key_content_base64: ENV["APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64"],
+      duration: 500,
+      in_house: false
+    )
+    setup_ci if ENV["CI"]
+    match(type: "appstore", api_key: api_key, readonly: true)
+    increment_build_number(
+      xcodeproj: "Runner.xcodeproj",
+      build_number: latest_testflight_build_number(api_key: api_key) + 1
+    )
+    re = /version:\s([0-9]*\.[0-9]*\.[0-9]*)\+[0-9]*/i
+    config = File.read("../../pubspec.yaml")
+    version_name = config.match(re).captures[0]
+    increment_version_number(version_number: version_name)
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: "Runner.xcodeproj",
+      code_sign_identity: "Apple Distribution",
+      profile_name: "match AppStore com.talktolearn.chat"
+    )
+    build_app(
+      workspace: "Runner.xcworkspace",
+      scheme: "Runner",
+      export_method: "app-store"
+    )
+    upload_to_testflight(
+      api_key: api_key,
+      distribute_external: true,
+      groups: "App Store Connect Users",
+      changelog: "Automated release candidate build. Verify overall app condition before promoting to the App Store.",
+    )
+  end
 end
 
 lane :release do

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -1,0 +1,5 @@
+git_url("git@github.com:pangeachat/ios-certificates.git")
+storage_mode("git")
+type("appstore")
+app_identifier(["com.talktolearn.chat"])
+username("wcjord@email.wm.edu")


### PR DESCRIPTION
Closes #7780. Adds the iOS half of the release pipeline so production iOS builds stop depending on a laptop with the right plist swapped in.

## What

- `ios-testflight.yml` — reusable + manually dispatchable workflow: production-or-staging environment, plist swap via `GOOGLE_SERVICES_PLIST`, unsigned `flutter build ios`, then fastlane `release_candidate` (match signing, IPA, TestFlight upload).
- `release.yaml` — new `build_ios` job calls it with `environment: production` on every release.
- `ios-certs-bootstrap.yml` — one-time dispatch that mints the Apple Distribution cert + App Store profile via the existing App Store Connect API key and stores them encrypted in `pangeachat/ios-certificates` (fastlane match).
- Fastfile: `bootstrap_certs` and `release_candidate` lanes; Matchfile. The old `beta` lane is untouched.
- deployment.instructions.md: mobile-builds line updated to match (discussed with Will in chat).

## Prereqs before merge (Will)

1. Create private repo `pangeachat/ios-certificates`.
2. Add a write deploy key to it; store the private key as client repo secret `MATCH_GIT_SSH_KEY`.
3. Set client repo secret `MATCH_PASSWORD` (random passphrase; keep a copy in Secrets Manager).

## Validation plan (post-merge)

1. Dispatch `ios-certs-bootstrap` once — should populate the certs repo.
2. Dispatch `ios-testflight` with `staging` — signed build appears in TestFlight.
3. Next production release exercises `build_ios` for real.

Note the dual-branch model: this must be synced (or cherry-picked) to `production` before the next release, or the release runs without the iOS job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated iOS release builds and TestFlight uploads for staging and production.
  * Added automated Android release APK attachment to GitHub releases.
  * Added a manual workflow for uploading Android builds to the Play Store.
  * Added iOS signing certificate setup for release automation.

* **Documentation**
  * Updated deployment documentation with mobile build and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->