### PR TITLE
fix(release): sign share and notification-service extension targets via match

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -79,12 +79,19 @@ platform :ios do
     config = File.read("../../pubspec.yaml")
     version_name = config.match(re).captures[0]
     increment_version_number(version_number: version_name)
-    update_code_signing_settings(
-      use_automatic_signing: false,
-      path: "Runner.xcodeproj",
-      code_sign_identity: "Apple Distribution",
-      profile_name: "match AppStore com.talktolearn.chat"
-    )
+    {
+      "Runner" => "com.talktolearn.chat",
+      "FluffyChat Share" => "com.talktolearn.chat.FluffyChatShare",
+      "Notification Service Extension" => "com.talktolearn.chat.Notification-Service-Extension",
+    }.each do |target, bundle_id|
+      update_code_signing_settings(
+        use_automatic_signing: false,
+        path: "Runner.xcodeproj",
+        targets: [target],
+        code_sign_identity: "Apple Distribution",
+        profile_name: "match AppStore #{bundle_id}"
+      )
+    end
     build_app(
       workspace: "Runner.xcworkspace",
       scheme: "Runner",

--- a/ios/fastlane/Matchfile
+++ b/ios/fastlane/Matchfile
@@ -1,5 +1,9 @@
 git_url("git@github.com:pangeachat/ios-certificates.git")
 storage_mode("git")
 type("appstore")
-app_identifier(["com.talktolearn.chat"])
+app_identifier([
+  "com.talktolearn.chat",
+  "com.talktolearn.chat.FluffyChatShare",
+  "com.talktolearn.chat.Notification-Service-Extension",
+])
 username("wcjord@email.wm.edu")


### PR DESCRIPTION
Part of #7780. The first staging dispatch of the iOS lane failed in xcodebuild: the project has two extension targets (FluffyChat Share, Notification Service Extension) that were left on automatic signing with no matching profile.

- Matchfile now covers all three bundle IDs, so bootstrap mints three profiles
- release_candidate pins each target to its own match profile

Validation: re-dispatch ios-certs-bootstrap, then ios-testflight (staging) — build should reach TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)