### PR TITLE
fix: carry all languages filter while navigating between add course p…

### DIFF
--- a/lib/features/course_plans/new_course_page.dart
+++ b/lib/features/course_plans/new_course_page.dart
@@ -192,12 +192,14 @@ class NewCoursePageState extends State<NewCoursePage> {
     }
 
     if (existingRoom == null) {
+      final lang = _targetLanguageFilter.value?.langCode;
       context.go(
         WorkspaceNav.openAddCoursePage(
           GoRouterState.of(context).uri,
           AddCourseSubpageEnum.own,
           createCourseId: course.uuid,
-          initialLanguageFilter: _targetLanguageFilter.value?.langCode,
+          initialLanguageFilter: lang,
+          allLanguagesFilter: lang == null,
         ),
       );
       return;
@@ -239,12 +241,14 @@ class NewCoursePageState extends State<NewCoursePage> {
     );
 
     if (action == 0) {
+      final lang = _targetLanguageFilter.value?.langCode;
       context.go(
         WorkspaceNav.openAddCoursePage(
           GoRouterState.of(context).uri,
           AddCourseSubpageEnum.own,
           createCourseId: course.uuid,
-          initialLanguageFilter: _targetLanguageFilter.value?.langCode,
+          initialLanguageFilter: lang,
+          allLanguagesFilter: lang == null,
         ),
       );
     } else if (action == 1) {

--- a/lib/features/navigation/token_params/add_course_token.dart
+++ b/lib/features/navigation/token_params/add_course_token.dart
@@ -17,9 +17,11 @@ enum AddCourseSubpageEnum {
 class AddCoursePageTokenParam extends TokenParam {
   final AddCourseSubpageEnum subpage;
 
-  // used by browse and own add course subpages to set initial language filter
-  // and to maintain language filters across navigation
+  // Used by browse and own add course subpages to set initial language
+  // filter and to maintain language filters across navigation. String filter
+  // supercedes boolean all languages flag
   final String? initialLanguageFilter;
+  final bool allLanguagesFilter;
 
   // public browsing options
   final String? previewRoomId;
@@ -34,6 +36,7 @@ class AddCoursePageTokenParam extends TokenParam {
   const AddCoursePageTokenParam({
     required this.subpage,
     this.initialLanguageFilter,
+    this.allLanguagesFilter = false,
     this.previewRoomId,
     this.createCourseId,
     this.privateCourseJoinCode,
@@ -60,6 +63,7 @@ class AddCoursePageTokenParam extends TokenParam {
         return AddCoursePageTokenParam(
           subpage: subpage,
           initialLanguageFilter: initialLanguageFilter,
+          allLanguagesFilter: allLanguagesFilter,
         );
       case AddCourseSubpageEnum.private:
         return null;
@@ -70,11 +74,13 @@ class AddCoursePageTokenParam extends TokenParam {
             subpage: subpage,
             createCourseId: createCourseId,
             initialLanguageFilter: initialLanguageFilter,
+            allLanguagesFilter: allLanguagesFilter,
           );
         }
         return AddCoursePageTokenParam(
           subpage: subpage,
           initialLanguageFilter: initialLanguageFilter,
+          allLanguagesFilter: allLanguagesFilter,
         );
     }
   }
@@ -88,29 +94,37 @@ class AddCoursePageTokenParam extends TokenParam {
     final privateCourseJoinCode = this.privateCourseJoinCode;
 
     final encodedSubpage = TokenFields.encode(subpage.name);
+
     final encodedLanguage =
         initialLanguageFilter != null && initialLanguageFilter.isNotEmpty
         ? 'l${TokenFields.encode(initialLanguageFilter)}'
         : null;
 
+    final encodedJoinCode =
+        privateCourseJoinCode != null && privateCourseJoinCode.isNotEmpty
+        ? "j${TokenFields.encode(privateCourseJoinCode)}"
+        : null;
+
+    final encodedAllLanguagesFilter = allLanguagesFilter ? 'a' : null;
+
     switch (subpage) {
       case AddCourseSubpageEnum.browse:
-        final encodedRoomId = previewRoomId != null && previewRoomId.isNotEmpty
+        final encodedPreviewRoomId =
+            previewRoomId != null && previewRoomId.isNotEmpty
             ? TokenFields.encode(shortRoomId(previewRoomId))
             : null;
 
+        final route = encodedPreviewRoomId != null
+            ? '$encodedSubpage/$encodedPreviewRoomId'
+            : encodedSubpage;
+
         return TokenFields.join([
-          encodedRoomId != null
-              ? '$encodedSubpage/$encodedRoomId'
-              : encodedSubpage,
+          route,
           ?encodedLanguage,
+          ?encodedAllLanguagesFilter,
         ]);
       case AddCourseSubpageEnum.private:
-        return TokenFields.join([
-          encodedSubpage,
-          if (privateCourseJoinCode != null && privateCourseJoinCode.isNotEmpty)
-            'j${TokenFields.encode(privateCourseJoinCode)}',
-        ]);
+        return TokenFields.join([encodedSubpage, ?encodedJoinCode]);
       case AddCourseSubpageEnum.own:
         if (createCourseId != null) {
           final encodedCourseId = TokenFields.encode(createCourseId);
@@ -120,64 +134,69 @@ class AddCoursePageTokenParam extends TokenParam {
           return TokenFields.join([
             '$encodedSubpage/$encodedCourseId',
             ?encodedLanguage,
+            ?encodedAllLanguagesFilter,
           ]);
         }
-        return TokenFields.join([encodedSubpage, ?encodedLanguage]);
+        return TokenFields.join([
+          encodedSubpage,
+          ?encodedLanguage,
+          ?encodedAllLanguagesFilter,
+        ]);
     }
   }
 
   factory AddCoursePageTokenParam.parse(String param) {
     final parts = param.split('/');
-    final chunks = TokenFields.split(parts.first);
+    final routeChunks = TokenFields.split(parts.first);
     final subpage = AddCourseSubpageEnum.fromString(
-      TokenFields.decode(chunks.first),
+      TokenFields.decode(routeChunks.first),
     );
+
+    final paramChunks = TokenFields.split(parts.last);
+    final params = paramChunks.skip(1);
+
+    final encodedLanguageEntry = params
+        .firstWhereOrNull((p) => p.startsWith('l'))
+        ?.substring(1);
+
+    final languageFilter =
+        encodedLanguageEntry != null && encodedLanguageEntry.isNotEmpty
+        ? TokenFields.decode(encodedLanguageEntry)
+        : null;
+
+    final encodedJoinCodeEntry = params
+        .firstWhereOrNull((p) => p.startsWith('j'))
+        ?.substring(1);
+
+    final joinCode =
+        encodedJoinCodeEntry != null && encodedJoinCodeEntry.isNotEmpty
+        ? TokenFields.decode(encodedJoinCodeEntry)
+        : null;
+
+    final allLanguagesFilter = params.any((p) => p == 'a');
 
     switch (subpage) {
       case AddCourseSubpageEnum.browse:
         if (parts.length > 1) {
           final roomIdChunks = TokenFields.split(parts[1]);
           final previewRoomId = TokenFields.decode(roomIdChunks.first);
-
-          final languageEntry = roomIdChunks
-              .skip(1)
-              .firstWhereOrNull((c) => c.startsWith('l'))
-              ?.substring(1);
-
           return AddCoursePageTokenParam(
             subpage: subpage,
             previewRoomId: previewRoomId,
-            initialLanguageFilter:
-                languageEntry != null && languageEntry.isNotEmpty
-                ? TokenFields.decode(languageEntry)
-                : null,
+            initialLanguageFilter: languageFilter,
+            allLanguagesFilter: allLanguagesFilter,
           );
         }
 
-        final languageEntry = chunks
-            .skip(1)
-            .firstWhereOrNull((c) => c.startsWith('l'))
-            ?.substring(1);
-
         return AddCoursePageTokenParam(
           subpage: subpage,
-          initialLanguageFilter:
-              languageEntry != null && languageEntry.isNotEmpty
-              ? TokenFields.decode(languageEntry)
-              : null,
+          initialLanguageFilter: languageFilter,
+          allLanguagesFilter: allLanguagesFilter,
         );
       case AddCourseSubpageEnum.private:
-        final privateCourseJoinCode = chunks
-            .skip(1)
-            .firstWhereOrNull((c) => c.startsWith('j'))
-            ?.substring(1);
-
         return AddCoursePageTokenParam(
           subpage: subpage,
-          privateCourseJoinCode:
-              privateCourseJoinCode != null && privateCourseJoinCode.isNotEmpty
-              ? TokenFields.decode(privateCourseJoinCode)
-              : null,
+          privateCourseJoinCode: joinCode,
         );
       case AddCourseSubpageEnum.own:
         if (parts.length > 2 && parts[2] == 'invite') {
@@ -192,33 +211,18 @@ class AddCoursePageTokenParam extends TokenParam {
         if (parts.length > 1) {
           final courseIdChunks = TokenFields.split(parts[1]);
           final createCourseId = TokenFields.decode(courseIdChunks.first);
-
-          final languageEntry = courseIdChunks
-              .skip(1)
-              .firstWhereOrNull((c) => c.startsWith('l'))
-              ?.substring(1);
-
           return AddCoursePageTokenParam(
             subpage: subpage,
             createCourseId: createCourseId,
-            initialLanguageFilter:
-                languageEntry != null && languageEntry.isNotEmpty
-                ? TokenFields.decode(languageEntry)
-                : null,
+            initialLanguageFilter: languageFilter,
+            allLanguagesFilter: allLanguagesFilter,
           );
         }
 
-        final languageEntry = chunks
-            .skip(1)
-            .firstWhereOrNull((c) => c.startsWith('l'))
-            ?.substring(1);
-
         return AddCoursePageTokenParam(
           subpage: subpage,
-          initialLanguageFilter:
-              languageEntry != null && languageEntry.isNotEmpty
-              ? TokenFields.decode(languageEntry)
-              : null,
+          initialLanguageFilter: languageFilter,
+          allLanguagesFilter: allLanguagesFilter,
         );
     }
   }

--- a/lib/features/navigation/workspace_nav.dart
+++ b/lib/features/navigation/workspace_nav.dart
@@ -742,6 +742,7 @@ abstract class WorkspaceNav {
     Uri current,
     AddCourseSubpageEnum page, {
     String? initialLanguageFilter,
+    bool? allLanguagesFilter,
     String? previewRoomId,
     String? createCourseId,
     bool showNewCourseInvitePage = false,
@@ -754,6 +755,9 @@ abstract class WorkspaceNav {
     final carriedLanguageFilter =
         matchingTypePanel.firstOrNull?.param?.initialLanguageFilter;
 
+    final carriedAllLanguagesFilter =
+        matchingTypePanel.firstOrNull?.param?.allLanguagesFilter;
+
     return _mutate(
       current,
       'left',
@@ -764,6 +768,8 @@ abstract class WorkspaceNav {
             subpage: page,
             initialLanguageFilter:
                 initialLanguageFilter ?? carriedLanguageFilter,
+            allLanguagesFilter:
+                allLanguagesFilter ?? carriedAllLanguagesFilter ?? false,
             previewRoomId: previewRoomId,
             createCourseId: createCourseId,
             showNewCourseInvitePage: showNewCourseInvitePage,

--- a/lib/routes/courses/find_course_page.dart
+++ b/lib/routes/courses/find_course_page.dart
@@ -26,10 +26,12 @@ import 'package:fluffychat/widgets/matrix.dart';
 class FindCoursePage extends StatefulWidget {
   final Widget closeButton;
   final String? initialLanguageCode;
+  final bool showAll;
   const FindCoursePage({
     super.key,
     required this.closeButton,
     this.initialLanguageCode,
+    this.showAll = false,
   });
 
   @override
@@ -68,7 +70,9 @@ class FindCoursePageState extends State<FindCoursePage> {
         ? PLanguageStore.byLangCode(initialLangCode)
         : null;
 
-    final targetLang = availableLanguages.contains(initialLang)
+    final targetLang = (initialLang == null && widget.showAll)
+        ? null
+        : availableLanguages.contains(initialLang)
         ? initialLang
         : availableLanguages.contains(initialLang?.unlocalized)
         ? initialLang?.unlocalized
@@ -340,6 +344,7 @@ class FindCoursePageState extends State<FindCoursePage> {
         GoRouterState.of(context).uri,
         AddCourseSubpageEnum.own,
         initialLanguageFilter: targetLanguage,
+        allLanguagesFilter: targetLanguage == null,
       ),
     );
   }
@@ -468,6 +473,9 @@ class FindCoursePageView extends StatelessWidget {
                           if (coursePlan == null) {
                             return const SizedBox.shrink();
                           }
+
+                          final lang =
+                              controller.targetLanguageFilter.value?.langCode;
                           return AddCourseTile(
                             chunk: space,
                             coursePlan: coursePlan,
@@ -476,10 +484,8 @@ class FindCoursePageView extends StatelessWidget {
                                 GoRouterState.of(context).uri,
                                 AddCourseSubpageEnum.browse,
                                 previewRoomId: space.room.roomId,
-                                initialLanguageFilter: controller
-                                    .targetLanguageFilter
-                                    .value
-                                    ?.langCode,
+                                initialLanguageFilter: lang,
+                                allLanguagesFilter: lang == null,
                               ),
                             ),
                             isKnock:

--- a/lib/routes/world/left_panel/left_panel_add_course_subpage.dart
+++ b/lib/routes/world/left_panel/left_panel_add_course_subpage.dart
@@ -58,6 +58,7 @@ class LeftPanelAddCourseSubpage extends StatelessWidget {
         return FindCoursePage(
           closeButton: closeButton,
           initialLanguageCode: param.initialLanguageFilter,
+          showAll: param.allLanguagesFilter,
         );
       case AddCourseSubpageEnum.private:
         return CourseCodePage(
@@ -82,7 +83,7 @@ class LeftPanelAddCourseSubpage extends StatelessWidget {
         return NewCoursePage(
           route: 'rooms',
           initialLanguageCode: param.initialLanguageFilter,
-          showAll: param.initialLanguageFilter == 'all',
+          showAll: param.allLanguagesFilter,
           closeButton: closeButton,
         );
     }


### PR DESCRIPTION
…ages

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
