### PR TITLE
fix(quests): exclude activity-less Missions from the quest star total

### DIFF
--- a/lib/features/quests/quest_objectives_loader.dart
+++ b/lib/features/quests/quest_objectives_loader.dart
@@ -48,13 +48,14 @@ class QuestObjectivesLoader {
   QuestLoader get questLoader => _questLoader;
   ValueNotifier<ProgressionResolution> get progression => _progression;
 
-  QuestStarSummary get questStars {
-    final List<String> objectiveIds = switch (_questLoader.value) {
-      AsyncLoaded(value: final value) => value.quest.learningObjectiveIds,
-      _ => const [],
-    };
-    return progression.value.questStars(_courseId, objectiveIds);
-  }
+  /// The header's star summary, or null before this course's progress resolves
+  /// (the bar then renders its muted empty state).
+  ///
+  /// Deliberately supplies no Mission list: the resolver owns which Missions
+  /// count. Passing `quest.learningObjectiveIds` here used to disagree with the
+  /// panel — which drops activity-less Missions (#7114) — so each hidden
+  /// Mission silently added a default threshold to the denominator (#7663).
+  QuestStarSummary? get questStars => progression.value.questStars(_courseId);
 
   /// This course's resolved quest, or null until the shared resolution lands
   /// (or when the course isn't joined) — the panel then shows no star display,

--- a/lib/features/quests/quest_progression_resolver.dart
+++ b/lib/features/quests/quest_progression_resolver.dart
@@ -82,6 +82,12 @@ class QuestProgress {
   /// effective threshold against another course's content and credit its stars
   /// (#7771). Where two courses genuinely list the SAME activity, each still
   /// counts it — that case needs no union, since both outlines carry it.
+  ///
+  /// Holds only the quest's **scored** Missions — those the outline gives at
+  /// least one activity. A Mission with no activities offers no stars and the
+  /// panel doesn't render it at all (#7114), so counting it would break the
+  /// doc's denominator invariant (#7663). [orderedMissionIds] still carries the
+  /// full sequence, so gradient distances are unaffected.
   final Map<String, MissionProgress> rollup;
 
   const QuestProgress({
@@ -91,6 +97,25 @@ class QuestProgress {
     required this.indexByMission,
     required this.rollup,
   });
+
+  /// This quest's star summary: each scored Mission's stars capped at its
+  /// threshold, over the summed thresholds.
+  ///
+  /// Computed here, from [rollup], on purpose — callers do NOT pass a Mission
+  /// list. When they did, the course panel filtered to Missions with activities
+  /// while the header summed every LO in the quest, so hidden activity-less
+  /// Missions each added the default threshold to the denominator: one 4-star
+  /// activity displayed as 44 (#7663). One owner for "which Missions count"
+  /// means a caller can no longer disagree with the panel.
+  QuestStarSummary get starSummary {
+    var earned = 0;
+    var total = 0;
+    for (final progress in rollup.values) {
+      earned += progress.cappedStars;
+      total += progress.threshold;
+    }
+    return QuestStarSummary(earned: earned, total: total);
+  }
 }
 
 /// The shared resolution: one [QuestProgress] per in-scope quest, each with its
@@ -121,24 +146,12 @@ class ProgressionResolution {
     return null;
   }
 
-  /// The star summary for [courseId] given its ordered [missionIds]:
-  /// per-Mission stars capped at each threshold, summed, over the summed
-  /// thresholds. Read from that course's own rollup — never a cross-course
-  /// blend. A Mission its rollup doesn't know (course not in scope, or the
-  /// resolution hasn't landed) contributes its default threshold and zero
-  /// stars, so a partially-resolved panel still shows a stable denominator.
-  QuestStarSummary questStars(String? courseId, Iterable<String> missionIds) {
-    final scoped =
-        forCourse(courseId)?.rollup ?? const <String, MissionProgress>{};
-    var earned = 0;
-    var total = 0;
-    for (final id in missionIds) {
-      final progress = scoped[id];
-      earned += progress?.cappedStars ?? 0;
-      total += progress?.threshold ?? kDefaultStarsToUnlockObjective;
-    }
-    return QuestStarSummary(earned: earned, total: total);
-  }
+  /// [courseId]'s star summary, from that course's own rollup — never a
+  /// cross-course blend. Null when the course isn't in scope (a preview, or
+  /// before the resolution lands); the header then renders its muted empty bar
+  /// rather than a denominator invented from default thresholds.
+  QuestStarSummary? questStars(String? courseId) =>
+      forCourse(courseId)?.starSummary;
 
   /// The next-Mission gradient (0..[kBandCeiling]) for an activity carrying
   /// [objectiveRefs]: 1.0 at a quest's anchor Mission, decaying linearly to 0
@@ -220,10 +233,18 @@ ProgressionResolution resolveProgression({
 
     final rollup = <String, MissionProgress>{};
     for (final missionId in seq) {
+      final activities = outline.activityIdsByLo[missionId] ?? const <String>{};
+      // A Mission the outline gives NO activities offers no stars, and the
+      // panel doesn't render it (#7114). Leave it out of the rollup entirely
+      // rather than scoring it: counting it would add a full threshold to a
+      // denominator no content backs, which is how one 4-star activity came to
+      // display as 44 (#7663). Distinct from the zero-CEILING case below, where
+      // the Mission has activities whose plans carry no goal data.
+      if (activities.isEmpty) continue;
+
       var stars = 0;
       var earnableCeiling = 0;
-      for (final activityId
-          in outline.activityIdsByLo[missionId] ?? const <String>{}) {
+      for (final activityId in activities) {
         stars += starsByActivity[activityId] ?? 0;
         earnableCeiling += outline.earnableByActivity[activityId] ?? 0;
       }
@@ -260,17 +281,25 @@ ProgressionResolution resolveProgression({
 /// whose rollup is below threshold; once all are satisfied, the lowest-star
 /// Mission, tie-broken by earliest quest order (deterministic, so the anchor
 /// does not flicker between equal-star frames).
+///
+/// Missions absent from [rollup] are unscored — the outline gives them no
+/// activities — so they are skipped. Anchoring one would point the learner at a
+/// Mission with nothing to play and, being unsatisfiable, would pin the anchor
+/// there permanently. Null when the quest has no scored Mission at all.
 String? _anchorFor(List<String> seq, Map<String, MissionProgress> rollup) {
   for (final missionId in seq) {
-    if (!(rollup[missionId]?.satisfied ?? false)) return missionId;
+    final progress = rollup[missionId];
+    if (progress == null) continue;
+    if (!progress.satisfied) return missionId;
   }
   String? lowest;
   int? lowestStars;
   for (final missionId in seq) {
-    final stars = rollup[missionId]?.stars ?? 0;
-    if (lowestStars == null || stars < lowestStars) {
+    final progress = rollup[missionId];
+    if (progress == null) continue;
+    if (lowestStars == null || progress.stars < lowestStars) {
       lowest = missionId;
-      lowestStars = stars;
+      lowestStars = progress.stars;
     }
   }
   return lowest;

--- a/test/pangea/quest_star_summary_test.dart
+++ b/test/pangea/quest_star_summary_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:fluffychat/features/quests/lo_progression.dart';
 import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
 
 /// Star display math (quests.instructions.md, "Star display on the course
@@ -40,10 +39,7 @@ void main() {
         'getting-around': const MissionProgress(stars: 4, threshold: 7),
         'introductions': const MissionProgress(stars: 1, threshold: 7),
       });
-      final summary = resolution.questStars('c1', [
-        'getting-around',
-        'introductions',
-      ]);
+      final summary = resolution.questStars('c1')!;
       expect(summary.earned, 5);
       expect(summary.total, 14);
       expect(summary.fraction, closeTo(5 / 14, 1e-9));
@@ -54,26 +50,38 @@ void main() {
         'a': const MissionProgress(stars: 12, threshold: 7),
         'b': const MissionProgress(stars: 0, threshold: 7),
       });
-      final summary = resolution.questStars('c1', ['a', 'b']);
+      final summary = resolution.questStars('c1')!;
       expect(summary.earned, 7);
       expect(summary.total, 14);
     });
 
-    test('a Mission missing from the rollup keeps a stable denominator '
-        '(default threshold, zero stars)', () {
+    test('a Mission outside the rollup adds nothing to the denominator', () {
+      // #7663: the rollup holds only Missions with activities. An activity-less
+      // Mission is hidden from the panel and offers no stars, so it must not
+      // contribute a threshold — the summary counts what the rollup holds and
+      // nothing else. The old shape took a Mission list and defaulted unknown
+      // ids to the standard threshold, which is how one 4-star activity
+      // displayed as 44.
       final resolution = resolutionWith({
         'known': const MissionProgress(stars: 3, threshold: 7),
       });
-      final summary = resolution.questStars('c1', ['known', 'unknown']);
+      final summary = resolution.questStars('c1')!;
       expect(summary.earned, 3);
-      expect(summary.total, 7 + kDefaultStarsToUnlockObjective);
+      expect(summary.total, 7);
     });
 
     test('empty quest yields zero with a safe fraction', () {
-      final summary = resolutionWith({}).questStars('c1', const []);
+      final summary = resolutionWith({}).questStars('c1')!;
       expect(summary.earned, 0);
       expect(summary.total, 0);
       expect(summary.fraction, 0);
+    });
+
+    test('an unresolved course is null, not an invented denominator', () {
+      // The header renders its muted empty bar on null (ProgressBarRow).
+      expect(ProgressionResolution.empty.questStars('c1'), isNull);
+      expect(resolutionWith({}).questStars('other-course'), isNull);
+      expect(resolutionWith({}).questStars(null), isNull);
     });
   });
 }

--- a/test/pangea/quests/per_course_mission_rollup_test.dart
+++ b/test/pangea/quests/per_course_mission_rollup_test.dart
@@ -143,20 +143,99 @@ void main() {
         starsByActivity: const {'b1': 4},
       );
 
-      final a = r.questStars('A', ['m1']);
+      final a = r.questStars('A')!;
       expect(a.earned, 0);
       expect(a.total, 4, reason: "clamped to course A's own content");
 
-      final b = r.questStars('B', ['m1']);
+      final b = r.questStars('B')!;
       expect(b.earned, 4);
       expect(b.total, 4);
     });
 
-    test('an unresolved course falls back to the default denominator', () {
-      // Preview / pre-resolve: a stable denominator, never another course's.
-      final summary = ProgressionResolution.empty.questStars('A', ['m1', 'm2']);
+    test('an unresolved course is null, not an invented denominator', () {
+      expect(ProgressionResolution.empty.questStars('A'), isNull);
+    });
+  });
+
+  group('activity-less Missions (#7663)', () {
+    /// TigToggle's report: a quest whose sequence carries five Missions but
+    /// where only one has an activity (worth 4 stars). The panel renders that
+    /// one Mission; the header used to sum all five and add the default
+    /// threshold for each hidden one — displaying 44.
+    ProgressionResolution oneRealMissionOfFive() => resolveProgression(
+      outlines: [
+        outline(
+          'A',
+          ['m1', 'm2', 'm3', 'm4', 'm5'],
+          {
+            'm1': {'a1'},
+          },
+          earnable: {'a1': 4},
+        ),
+      ],
+      starsByActivity: const {},
+    );
+
+    test('do not inflate the quest denominator (was 44, must be 4)', () {
+      final summary = oneRealMissionOfFive().questStars('A')!;
+      expect(summary.total, 4);
       expect(summary.earned, 0);
-      expect(summary.total, kDefaultStarsToUnlockObjective * 2);
+    });
+
+    test('are absent from the rollup, so the panel has nothing to render', () {
+      final quest = oneRealMissionOfFive().forCourse('A')!;
+      expect(quest.rollup.keys, ['m1']);
+      expect(quest.rollup['m2'], isNull);
+    });
+
+    test('never become the anchor — there is nothing to play there', () {
+      // m1 is unsatisfied, so it anchors. Once it IS satisfied, the anchor must
+      // not fall through to an unplayable Mission.
+      final satisfied = resolveProgression(
+        outlines: [
+          outline(
+            'A',
+            ['m1', 'm2'],
+            {
+              'm1': {'a1'},
+            },
+            earnable: {'a1': 4},
+          ),
+        ],
+        starsByActivity: const {'a1': 4},
+      );
+      expect(satisfied.forCourse('A')!.anchorMissionId, 'm1');
+    });
+
+    test('a quest with no playable Mission has no anchor at all', () {
+      final none = resolveProgression(
+        outlines: [
+          outline('A', ['m1', 'm2'], const {}),
+        ],
+        starsByActivity: const {},
+      );
+      expect(none.forCourse('A')!.anchorMissionId, isNull);
+      expect(none.questStars('A')!.total, 0);
+    });
+
+    test('a Mission WITH activities but no goal data keeps its threshold', () {
+      // Distinct from the activity-less case: degraded/legacy plans report 0
+      // earnable, and must NOT read satisfied-at-zero.
+      final degraded = resolveProgression(
+        outlines: [
+          outline(
+            'A',
+            ['m1'],
+            {
+              'm1': {'a1'},
+            },
+          ),
+        ],
+        starsByActivity: const {},
+      );
+      final m1 = degraded.forCourse('A')!.rollup['m1']!;
+      expect(m1.threshold, kDefaultStarsToUnlockObjective);
+      expect(m1.satisfied, isFalse);
     });
   });
 


### PR DESCRIPTION
## What

A Mission the outline gives no activities no longer contributes a threshold to the quest star total, and can no longer become the next-Mission anchor.

## Why

Closes #7663

Reported by @TigToggle: a course with **1 activity worth 4 stars displayed a total of 44**, and another with 15 earnable showed 35.

The panel hides activity-less Missions (#7114) via `objectiveGroupsWithActivities`, but the header summed `quest.learningObjectiveIds` — *every* LO. An activity-less Mission has an earnable ceiling of 0, and the clamp deliberately keeps the configured threshold at ceiling 0 (so degraded plans don't read satisfied-at-zero), so each hidden Mission silently added 10:

- 4 + (4 hidden × 10) = **44**
- 15 + (2 hidden × 10) = **35**

This is the invariant [quests.instructions.md](.github/instructions/quests.instructions.md) already states for the quest bar — the denominator "can never exceed the stars the course's activities actually offer." The code was violating it, so no doc change: this is compliance, not new design.

## The DRY fix

The root cause was **two places independently deciding which Missions count** — the panel filtered to those with activities, the loader passed the full LO list. So the caller no longer decides:

- `QuestStarSummary` is computed by `QuestProgress.starSummary` from its own rollup. `questStars` takes **no Mission list** — the shape that allowed the disagreement is gone.
- `resolveProgression` skips Missions with an empty activity set, so the rollup holds only *scored* Missions. One owner for "which Missions count."
- `questStars` returns `QuestStarSummary?` — null for an unresolved course. `ProgressBarRow` already renders a muted empty bar on null, which beats inventing a denominator from default thresholds.

Two behaviors preserved deliberately:

- **Zero ceiling ≠ no activities.** A Mission *with* activities whose plans carry no goal data keeps its configured threshold (degraded/legacy plans must not read satisfied-at-zero). Only the no-activities case is excluded. Covered by a test.
- `orderedMissionIds` still carries the full sequence, so `missionGradient` distances are unchanged.

Also fixed in passing: `_anchorFor` skipped over unscored Missions. Previously an activity-less Mission was permanently unsatisfiable, so once the anchor reached it, it pinned there — pointing the learner at a Mission with nothing to play.

## Testing

On the pinned SDK (Flutter 3.41.4 via fvm, matching CI):

- `fvm flutter test` — full suite, **1337 passed**.
- `fvm flutter analyze` — **No issues found**, exit 0.
- `fvm dart format lib/ test/` — clean. `pubspec.lock` unchanged.
- New group in `per_course_mission_rollup_test.dart` reproduces the report directly: 5 Missions, 1 activity worth 4 → total is **4, not 44**; hidden Missions absent from the rollup; anchor never lands on one; a quest with no playable Mission has no anchor; and the zero-ceiling case keeps its threshold.
- `quest_star_summary_test.dart` — the test asserting `7 + kDefaultStarsToUnlockObjective` for an unknown Mission **encoded this bug**; replaced with the correct expectation plus null-on-unresolved coverage.
- Not verified in a running client — staging smoke after deploy, per the issue's TO TEST.

## Deploy Notes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quest star totals now count only playable Missions with earnable activities.
  * Star totals are correctly scoped to the selected course.
  * Unresolved courses now show an empty or muted state instead of an invented denominator.
  * Quest anchors no longer select unplayable or unscored Missions.
  * Missions with activities but missing goal data retain their expected thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->