### PR TITLE
fix(analytics): strip identity from addcoursepage screen names, drop duplicate '/' screen

### DIFF
--- a/.github/instructions/google-analytics.instructions.md
+++ b/.github/instructions/google-analytics.instructions.md
@@ -28,6 +28,30 @@ and rationale live in the
 Event names, params, and screen names are still a cross-service contract: the
 measurement mirror must stay joinable by name with those first-party facts.
 
+## What GA answers (the product questions)
+
+GA exists to answer a short list of named product questions, each mapped to
+its instrument — a report that cannot answer its question is a bug, and a
+new product event must state which question it serves or it doesn't ship:
+
+1. **Are new users activating?** — the Activation funnel
+   (`sign_up → sent_message → start_activity`).
+2. **Which panels do learners actually use, per platform?** — Pages and
+   screens by "Page title and screen name" (see Screen tracking below).
+3. **Does anyone reach and convert on the subscription page?** — screen
+   `settingspage:subscription` plus the Subscription conversion funnel
+   (`begin_checkout → purchase`).
+4. **Do learners come back?** — GA4 retention cohorts keyed on the
+   pseudonymous user id.
+5. **Are practice and teacher surfaces adopted?** — screen-based funnels,
+   once title data accrues.
+
+Canonical funnel definitions are SQL over the BigQuery export in the devops
+repo (`analytics/funnels/` — see its ga-analytics-sync doc); GA UI
+explorations are non-canonical convenience views. At current MAU these
+reads are directional, not statistical; per-learner truth stays first-party
+per the engagement-analytics contract above.
+
 ## Screen tracking
 
 - **A screen name is the focused panel's token with identity stripped — token
@@ -66,6 +90,16 @@ measurement mirror must stay joinable by name with those first-party facts.
   is a real screen view even though it replaces the history entry.
 - **Event vocabulary matches the token grammar**: `vocab` / `grammar`, never
   `morph`.
+- **On web, the page title mirrors the screen name — exactly, no prefix.**
+  GA's web layer reports by page title, and the web SDK's `screen_name`
+  param is invisible to GA's built-in dimensions (verified empirically: with
+  a Platform=web comparison, every screen-name row reads zero). So
+  `MaterialApp.title` follows the workspace screen name, making web rows
+  merge with app rows under "Page title and screen name". Off the workspace
+  (page routes) and on mobile, the title stays the application name. The
+  registered `screen_name` custom dimension ("Screen name web", declared in
+  the devops `analytics/ga-config.yaml` spec for both properties) remains
+  the event-grain key for Explorations and BigQuery.
 
 ## Event shape
 

--- a/.github/instructions/google-analytics.instructions.md
+++ b/.github/instructions/google-analytics.instructions.md
@@ -34,15 +34,19 @@ GA exists to answer a short list of named product questions, each mapped to
 its instrument — a report that cannot answer its question is a bug, and a
 new product event must state which question it serves or it doesn't ship:
 
-1. **Are new users activating?** — the Activation funnel
+1. **Are new users activating?** — the Activation funnel:
+   [activation.sql](https://github.com/pangeachat/devops/blob/main/analytics/funnels/activation.sql)
    (`sign_up → sent_message → start_activity`).
-2. **Which panels do learners actually use, per platform?** — Pages and
-   screens by "Page title and screen name" (see Screen tracking below).
+2. **Which panels do learners actually use, per platform?** —
+   [Pages and screens by "Page title and screen name"](https://analytics.google.com/analytics/web/#/p323613034/reports/explorer?params=_r.explorerCard..seldim%3D%5B%22unifiedScreenName%22%5D&r=all-pages-and-screens)
+   (prod; swap the property id for staging, see Screen tracking below).
 3. **Does anyone reach and convert on the subscription page?** — screen
-   `settingspage:subscription` plus the Subscription conversion funnel
+   `settingspage:subscription` plus the Subscription conversion funnel:
+   [subscription_conversion.sql](https://github.com/pangeachat/devops/blob/main/analytics/funnels/subscription_conversion.sql)
    (`begin_checkout → purchase`).
-4. **Do learners come back?** — GA4 retention cohorts keyed on the
-   pseudonymous user id.
+4. **Do learners come back?** — GA4
+   [retention cohorts](https://analytics.google.com/analytics/web/#/p323613034/reports/reportinghub)
+   keyed on the pseudonymous user id.
 5. **Are practice and teacher surfaces adopted?** — screen-based funnels,
    once title data accrues.
 

--- a/lib/features/navigation/panel_token.dart
+++ b/lib/features/navigation/panel_token.dart
@@ -234,11 +234,12 @@ class AddCoursePagePanelToken extends PanelToken<AddCoursePageTokenParam> {
       AddCourseSubpageEnum.browse =>
         param.previewRoomId != null ? 'browse/preview' : 'browse',
       AddCourseSubpageEnum.private => 'private',
-      AddCourseSubpageEnum.own => param.createCourseId == null
-          ? 'own'
-          : param.showNewCourseInvitePage
-          ? 'own/invite'
-          : 'own/preview',
+      AddCourseSubpageEnum.own =>
+        param.createCourseId == null
+            ? 'own'
+            : param.showNewCourseInvitePage
+            ? 'own/invite'
+            : 'own/preview',
     };
     return '${type.name}:$leaf';
   }

--- a/lib/features/navigation/panel_token.dart
+++ b/lib/features/navigation/panel_token.dart
@@ -225,6 +225,25 @@ class AddCoursePagePanelToken extends PanelToken<AddCoursePageTokenParam> {
     : super(PanelTypesEnum.addcoursepage, param);
 
   @override
+  String get screenName {
+    final param = this.param;
+    if (param is! AddCoursePageTokenParam) return type.name;
+    // Identity (course id, room id, join code) and filters stay out of the
+    // name; only the subpage and the pushed leaf are navigational.
+    final leaf = switch (param.subpage) {
+      AddCourseSubpageEnum.browse =>
+        param.previewRoomId != null ? 'browse/preview' : 'browse',
+      AddCourseSubpageEnum.private => 'private',
+      AddCourseSubpageEnum.own => param.createCourseId == null
+          ? 'own'
+          : param.showNewCourseInvitePage
+          ? 'own/invite'
+          : 'own/preview',
+    };
+    return '${type.name}:$leaf';
+  }
+
+  @override
   AddCoursePagePanelToken? get popped {
     final param = this.param;
     if (param == null || !param.isPushed) return null;

--- a/lib/features/navigation/workspace_screen_tracker.dart
+++ b/lib/features/navigation/workspace_screen_tracker.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:go_router/go_router.dart';
 
 import 'package:fluffychat/features/navigation/screen_names.dart';
@@ -15,6 +17,15 @@ import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
 abstract class WorkspaceScreenTracker {
   static String? _lastScreenName;
 
+  /// On web, the current workspace screen name, for `MaterialApp.title` to
+  /// mirror into `document.title`. GA's web layer reports by page title (the
+  /// web SDK's screen_name param is invisible to built-in reports); mirroring
+  /// the screen name — exactly, no prefix — makes web rows merge with app rows
+  /// under GA's "Page title and screen name" dimension. Null off the
+  /// workspace (page routes keep the app name). Always null on mobile, where
+  /// the title labels the OS task switcher instead.
+  static final ValueNotifier<String?> webTitle = ValueNotifier(null);
+
   /// Listen to [router] for the app's lifetime, emitting on each real change.
   static void attach(GoRouter router) {
     final provider = router.routeInformationProvider;
@@ -27,6 +38,7 @@ abstract class WorkspaceScreenTracker {
     final name = ScreenNames.forWorkspace(uri);
     if (name == _lastScreenName) return;
     _lastScreenName = name;
+    if (kIsWeb) webTitle.value = name;
     GoogleAnalytics.logScreenView(name);
   }
 }

--- a/lib/features/subscription/controllers/subscription_controller.dart
+++ b/lib/features/subscription/controllers/subscription_controller.dart
@@ -96,7 +96,9 @@ class SubscriptionController with ChangeNotifier {
       final isSubscribed = _state is SubscriptionActive;
       final beganPayment = SubscriptionManagementRepo.getBeganPayment();
       if (beganPayment && isSubscribed) {
+        final planId = SubscriptionManagementRepo.getBeganPaymentPlanId();
         await SubscriptionManagementRepo.removeBeganPayment();
+        GoogleAnalytics.purchaseSubscription(planId);
         _onSubscribe();
       }
     } catch (e, s) {

--- a/lib/features/subscription/repo_v2/subscription_management_repo.dart
+++ b/lib/features/subscription/repo_v2/subscription_management_repo.dart
@@ -9,12 +9,22 @@ class SubscriptionManagementRepo {
     return _cache.read(PLocalKey.beganPayment) ?? false;
   }
 
-  static Future<void> setBeganPayment() async {
+  /// [planId] rides along so the purchase event on the post-checkout return
+  /// can name the plan (the Stripe redirect loses all client state).
+  static Future<void> setBeganPayment([String? planId]) async {
     await _cache.write(PLocalKey.beganPayment, true);
+    if (planId != null) {
+      await _cache.write(PLocalKey.beganPaymentPlanId, planId);
+    }
+  }
+
+  static String? getBeganPaymentPlanId() {
+    return _cache.read(PLocalKey.beganPaymentPlanId);
   }
 
   static Future<void> removeBeganPayment() async {
     await _cache.remove(PLocalKey.beganPayment);
+    await _cache.remove(PLocalKey.beganPaymentPlanId);
   }
 
   static bool getDismissedPaywall() {

--- a/lib/pangea/common/constants/local.key.dart
+++ b/lib/pangea/common/constants/local.key.dart
@@ -2,6 +2,7 @@ class PLocalKey {
   static const String cachedSpaceCodeToJoin = "cachedclasscodetojoin";
   static const String cachedSpaceCodeToJoinAt = "cachedclasscodetojoinat";
   static const String beganPayment = "beganWebPayment";
+  static const String beganPaymentPlanId = "beganWebPaymentPlanId";
   static const String dismissedPaywall = 'dismissedPaywall';
   static const String paywallBackoff = 'paywallBackoff';
   static const String clickedCancelSubscription = 'clickedCancelSubscription';

--- a/lib/pangea/common/utils/firebase_analytics.dart
+++ b/lib/pangea/common/utils/firebase_analytics.dart
@@ -225,6 +225,21 @@ class GoogleAnalytics {
     );
   }
 
+  /// Checkout completed: the subscription turned active after a begun payment
+  /// (detected on return from Stripe). Closes the begin_checkout funnel with
+  /// GA4's recommended `purchase` event.
+  static void purchaseSubscription(String? planId) {
+    logEvent(
+      'purchase',
+      parameters: {
+        'currency': 'USD',
+        'item_id': ?planId,
+        'item_category': 'subscription',
+        'quantity': 1,
+      },
+    );
+  }
+
   static void startActivity(
     String activityId,
     String roomId, {

--- a/lib/pangea/common/utils/firebase_analytics.dart
+++ b/lib/pangea/common/utils/firebase_analytics.dart
@@ -325,6 +325,12 @@ class GoogleAnalytics {
           return false;
         }
 
+        // The workspace route ('/') is tracked by WorkspaceScreenTracker with
+        // token-derived names; logging it here would double-count it as '/'.
+        if (name == '/') {
+          return false;
+        }
+
         debugPrint("navigating to route: $name");
         return true;
       },

--- a/lib/routes/settings/settings_subscription/payment_page_mixin.dart
+++ b/lib/routes/settings/settings_subscription/payment_page_mixin.dart
@@ -14,7 +14,7 @@ mixin PaymentPageMixin<T extends StatefulWidget> on State<T> {
     _recordBeganPayment(request.planId, request.promoCode);
     final paymentLink = await _requestPaymentLink(request);
     if (paymentLink == null) return;
-    await _launchPaymentLink(paymentLink);
+    await _launchPaymentLink(paymentLink, request.planId);
   }
 
   void _recordBeganPayment(String planId, [String? promoCode]) {
@@ -49,8 +49,8 @@ mixin PaymentPageMixin<T extends StatefulWidget> on State<T> {
     return checkoutResult.result;
   }
 
-  Future<void> _launchPaymentLink(String paymentLink) async {
-    await SubscriptionManagementRepo.setBeganPayment();
+  Future<void> _launchPaymentLink(String paymentLink, String planId) async {
+    await SubscriptionManagementRepo.setBeganPayment(planId);
     final success = await launchUrlString(
       paymentLink,
       webOnlyWindowName: "_self",

--- a/lib/widgets/fluffy_chat_app.dart
+++ b/lib/widgets/fluffy_chat_app.dart
@@ -75,44 +75,48 @@ class FluffyChatApp extends StatelessWidget {
           // workspace (and on mobile) it is null and the app name applies.
           title: webTitle ?? AppSettings.applicationName.value,
           // Pangea#
-        themeMode: themeMode,
-        theme: FluffyThemes.buildTheme(context, Brightness.light, primaryColor),
-        darkTheme: FluffyThemes.buildTheme(
-          context,
-          Brightness.dark,
-          primaryColor,
-        ),
-        scrollBehavior: CustomScrollBehavior(),
-        // #Pangea
-        locale: Provider.of<LocaleProvider>(context).locale,
-        // localizationsDelegates: L10n.localizationsDelegates,
-        localizationsDelegates: const [
-          L10n.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          CountryLocalizations.delegate,
-        ],
-        // Pangea#
-        supportedLocales: L10n.supportedLocales,
-        routerConfig: router,
-        // #Pangea
-        // builder: (context, child) => AppLockWidget(
-        builder: (context, child) => Directionality(
-          textDirection: TextDirection.ltr,
-          child: AppLockWidget(
-            pincode: pincode,
-            clients: clients,
-            // Need a navigator above the Matrix widget for
-            // displaying dialogs
-            child: Matrix(
+          themeMode: themeMode,
+          theme: FluffyThemes.buildTheme(
+            context,
+            Brightness.light,
+            primaryColor,
+          ),
+          darkTheme: FluffyThemes.buildTheme(
+            context,
+            Brightness.dark,
+            primaryColor,
+          ),
+          scrollBehavior: CustomScrollBehavior(),
+          // #Pangea
+          locale: Provider.of<LocaleProvider>(context).locale,
+          // localizationsDelegates: L10n.localizationsDelegates,
+          localizationsDelegates: const [
+            L10n.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            CountryLocalizations.delegate,
+          ],
+          // Pangea#
+          supportedLocales: L10n.supportedLocales,
+          routerConfig: router,
+          // #Pangea
+          // builder: (context, child) => AppLockWidget(
+          builder: (context, child) => Directionality(
+            textDirection: TextDirection.ltr,
+            child: AppLockWidget(
+              pincode: pincode,
               clients: clients,
-              store: store,
-              child: testWidget ?? child,
+              // Need a navigator above the Matrix widget for
+              // displaying dialogs
+              child: Matrix(
+                clients: clients,
+                store: store,
+                child: testWidget ?? child,
+              ),
             ),
           ),
-        ),
-        // Pangea#
+          // Pangea#
         ),
       ),
     );

--- a/lib/widgets/fluffy_chat_app.dart
+++ b/lib/widgets/fluffy_chat_app.dart
@@ -13,6 +13,7 @@ import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/languages/locale_provider.dart';
 import 'package:fluffychat/features/navigation/legacy_redirects.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
+import 'package:fluffychat/features/navigation/workspace_screen_tracker.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
 import 'package:fluffychat/widgets/app_lock.dart';
@@ -63,8 +64,17 @@ class FluffyChatApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ThemeBuilder(
-      builder: (context, themeMode, primaryColor) => MaterialApp.router(
-        title: AppSettings.applicationName.value,
+      // #Pangea
+      // builder: (context, themeMode, primaryColor) => MaterialApp.router(
+      //   title: AppSettings.applicationName.value,
+      builder: (context, themeMode, primaryColor) => ValueListenableBuilder(
+        valueListenable: WorkspaceScreenTracker.webTitle,
+        builder: (context, webTitle, _) => MaterialApp.router(
+          // On web the GA screen name doubles as document.title so panel
+          // screens report by title (workspace_screen_tracker.dart); off the
+          // workspace (and on mobile) it is null and the app name applies.
+          title: webTitle ?? AppSettings.applicationName.value,
+          // Pangea#
         themeMode: themeMode,
         theme: FluffyThemes.buildTheme(context, Brightness.light, primaryColor),
         darkTheme: FluffyThemes.buildTheme(
@@ -103,6 +113,7 @@ class FluffyChatApp extends StatelessWidget {
           ),
         ),
         // Pangea#
+        ),
       ),
     );
   }

--- a/test/pangea/navigation/screen_names_test.dart
+++ b/test/pangea/navigation/screen_names_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/screen_names.dart';
 import 'package:fluffychat/features/navigation/token_params/activity_token.dart';
+import 'package:fluffychat/features/navigation/token_params/add_course_token.dart';
 import 'package:fluffychat/features/navigation/token_params/analytics_practice_token.dart';
 import 'package:fluffychat/features/navigation/token_params/analytics_token.dart';
 import 'package:fluffychat/features/navigation/token_params/course_details_token.dart';
@@ -55,6 +56,59 @@ void main() {
           AnalyticsPracticeTokenParam.parse('grammar'),
         ).screenName,
         'practice:grammar',
+      );
+    });
+
+    test('addcoursepage keeps subpage and leaf, drops ids and filters', () {
+      expect(
+        AddCoursePagePanelToken(
+          AddCoursePageTokenParam.parse('own'),
+        ).screenName,
+        'addcoursepage:own',
+      );
+      // Language filter and all-languages flag are dropped.
+      expect(
+        AddCoursePagePanelToken(
+          AddCoursePageTokenParam.parse('own.les-ES.a'),
+        ).screenName,
+        'addcoursepage:own',
+      );
+      // The created course's id is identity; the pushed page keeps its leaf.
+      expect(
+        AddCoursePagePanelToken(
+          AddCoursePageTokenParam.parse(
+            'own/30dbdcfc-0f8c-4b7f-bdf8-f15d86c8cb24.les',
+          ),
+        ).screenName,
+        'addcoursepage:own/preview',
+      );
+      expect(
+        AddCoursePagePanelToken(
+          AddCoursePageTokenParam.parse(
+            'own/30dbdcfc-0f8c-4b7f-bdf8-f15d86c8cb24/invite',
+          ),
+        ).screenName,
+        'addcoursepage:own/invite',
+      );
+      expect(
+        AddCoursePagePanelToken(
+          AddCoursePageTokenParam.parse('browse'),
+        ).screenName,
+        'addcoursepage:browse',
+      );
+      // The previewed room's id is identity.
+      expect(
+        AddCoursePagePanelToken(
+          AddCoursePageTokenParam.parse('browse/!abc.les'),
+        ).screenName,
+        'addcoursepage:browse/preview',
+      );
+      // The private join code is identity (and secret) — never in a name.
+      expect(
+        AddCoursePagePanelToken(
+          AddCoursePageTokenParam.parse('private.jABC123'),
+        ).screenName,
+        'addcoursepage:private',
       );
     });
 


### PR DESCRIPTION
## What
Stop identity leaking into GA screen names, stop the duplicate `/` screen, mirror the workspace screen name into the web page title, and close the subscription funnel with a `purchase` event.

## Why
Closes #7816. Staging GA4 export shows `addcoursepage:own/<uuid>`, `addcoursepage:browse/<room-id>`, `.j<join-code>` etc. as screen names — google-analytics.instructions.md requires identity stripped, navigational leaf kept. `/` duplicates WorkspaceScreenTracker's token-derived workspace names. GA's built-in dimensions ignore the web SDK's `screen_name` param (verified: with a Platform=web comparison all screen-name rows read 0), so web panel views were invisible. And the checkout funnel logged `begin_checkout` but never a completion, so conversion was unanswerable in GA.

## Changes
- `AddCoursePagePanelToken.screenName` override: `addcoursepage:own`, `own/preview`, `own/invite`, `browse`, `browse/preview`, `private`
- `FirebaseAnalyticsObserver` routeFilter skips the `/` route
- `WorkspaceScreenTracker.webTitle` (web only): `MaterialApp.title` follows the workspace screen name exactly, so web rows merge with app rows under GA's "Page title and screen name" dimension; off-workspace and mobile keep the app name
- GA4 `purchase` event on the post-checkout return: `setBeganPayment` now persists the planId across the Stripe redirect; when the subscription turns active with a begun payment, `purchaseSubscription(planId)` fires alongside the existing subscribed user property (one writer per product moment)

Doc note: the client subscriptions docs don't yet mention analytics events; coverage gap flagged rather than edited (instructions-doc invariant).

## Testing
- Full `flutter test` suite passes (1250+ tests), including new addcoursepage screen-name cases built from real leaked names in the staging GA4 BigQuery export
- Live-verified on a local web build against staging: document.title tracked world → chats → room across navigations and held through login-driven MaterialApp rebuilds
- Purchase event: unit-level analyzer/tests only — the full path needs a live Stripe checkout, deferred to staging QA (TO TEST on the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Improved subscription purchase tracking, including the selected plan.
  * Improved screen and page-title reporting across web navigation.
  * Reduced duplicate analytics events for workspace pages.

* **User Experience**
  * Web browser titles now reflect the current workspace or page.
  * Add-course navigation screens now provide more accurate names for previews, invitations, and subpages.

* **Tests**
  * Added coverage for add-course screen-name behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->