### PR TITLE
chore: sort imports in main.dart and join-code bounce test

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,10 +3,10 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_web_plugins/url_strategy.dart';
 
 import 'package:collection/collection.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:get_storage/get_storage.dart';
 import 'package:matrix/matrix.dart';
 import 'package:provider/provider.dart';

--- a/test/pangea/join_code_login_bounce_test.dart
+++ b/test/pangea/join_code_login_bounce_test.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart';
 
+import 'package:flutter_test/flutter_test.dart';
 import 'package:get_storage/get_storage.dart';
 
 import 'package:fluffychat/features/join_codes/space_code_repo.dart';


### PR DESCRIPTION
## What
Import ordering in `lib/main.dart` + `test/pangea/join_code_login_bounce_test.dart` (2 lines).

## Why
Addresses #7819. #7820 merged before its import-sort fixup commit, leaving main's `code_tests` import check red.

## Testing
`dart run import_sorter:main --no-comments --exit-if-changed` passes locally; no behavior change.

## Deploy Notes
None.