### PR TITLE
fix: don't use root navigator in member action popup

### DIFF
--- a/lib/widgets/users/member_actions_popup_menu_button.dart
+++ b/lib/widgets/users/member_actions_popup_menu_button.dart
@@ -34,13 +34,7 @@ void showMemberActionsPopupMenu({
   final dmRoomId = user.room.client.getDirectChatFromUserId(user.id);
   // Pangea#
 
-  // #Pangea
-  // final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
-  final overlay =
-      Overlay.of(context, rootOverlay: true).context.findRenderObject()
-          as RenderBox;
-  // Pangea#
-
+  final overlay = Overlay.of(context).context.findRenderObject() as RenderBox;
   final button = context.findRenderObject() as RenderBox;
 
   final position = RelativeRect.fromRect(
@@ -58,9 +52,6 @@ void showMemberActionsPopupMenu({
       user.id == BotName.byEnvironment && room?.showActivityChatUI == true;
 
   final action = await showMenu<_MemberActions>(
-    // #Pangea
-    useRootNavigator: true,
-    // Pangea#
     context: context,
     position: position,
     items: <PopupMenuEntry<_MemberActions>>[


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
