### PR TITLE
fix(join-codes): mobile-web fallback keeps shared-link payloads

### DIFF
--- a/.github/instructions/joining-courses.instructions.md
+++ b/.github/instructions/joining-courses.instructions.md
@@ -124,7 +124,13 @@ Every case where `room.join()` is called without explicit user confirmation:
 
 ## Deep Linking — Mobile & Web
 
-A class link must reach the app on mobile. iOS Universal Links and Android App Links are configured so the OS intercepts `app.pangea.chat` and opens the installed app directly; the bare `/<code>` path reaches the incoming-URI listener, which passes it straight to the router (Route 1 — no per-shape rewrite). When the app is not installed, the web app loads and processes the same path — there is no deferred deep-linking service (Branch.io, etc.).
+A shared link (`/<code>` course join, `/<uuid>` activity) must reach the app on mobile. Three legs, in the order a tap resolves:
+
+1. **App installed, normal tap** — iOS Universal Links / Android App Links intercept `app.pangea.chat` at the OS level, before any web page loads. Both platforms claim the whole host (Android intent filters have no path restriction; the iOS AASA declares `paths: ["*"]`), so every link shape is covered. The OS hands the full URL to the running app's incoming-URI listener, which passes the path straight to the router (Route 1 — no per-shape rewrite; the mapping is unit-tested).
+2. **App not installed** — the tap opens the mobile browser; the webapp CloudFront serves the SPA for any path, and the web app processes the link exactly as on desktop, including the logged-out login-bounce ferry. There is no deferred deep-linking service (Branch.io, etc.) — a store install cannot carry the link, so the web IS the fallback.
+3. **In-app browsers** (Instagram, Gmail webview, …) — Universal/App Links often don't fire there; the user stays on the web fallback, which works.
+
+The store steer in [`web/index.html`](../../web/index.html) exists for plain visitors, and fires ONLY on a bare-root mobile load: a deep path is an inbound link, and bouncing it to the store (or the pathless `pangea://` scheme) would drop the payload — the failure that silently broke mobile-web links in the past.
 
 ### Infrastructure touchpoints
 

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -668,26 +668,29 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
   }
 
   // #Pangea
+  /// The in-app location an OS-delivered link maps to — pure and unit-tested
+  /// (incoming_uri_path_test.dart): a bare `/<code>` course join link and the
+  /// `/<uuid>` activity link flow straight through to the router's
+  /// LegacyRedirects, which folds them into their tokens — no per-shape
+  /// rewrite here.
+  static String incomingUriToPath(Uri uri) {
+    if (uri.fragment.isNotEmpty) {
+      return uri.fragment.startsWith('/') ? uri.fragment : '/${uri.fragment}';
+    }
+    final query = uri.queryParameters;
+    final queryString = query.entries
+        .map((e) => '${e.key}=${e.value}')
+        .join('&');
+    var path = '/${uri.pathSegments.join('/')}';
+    if (queryString.isNotEmpty) {
+      path = '$path?$queryString';
+    }
+    return path;
+  }
+
   Future<void> _processIncomingUris(Uri? uri) async {
     if (uri == null) return;
-
-    String path;
-    if (uri.fragment.isNotEmpty) {
-      path = uri.fragment.startsWith('/') ? uri.fragment : '/${uri.fragment}';
-    } else {
-      final query = uri.queryParameters;
-      final queryString = query.entries
-          .map((e) => '${e.key}=${e.value}')
-          .join('&');
-      path = '/${uri.pathSegments.join('/')}';
-      if (queryString.isNotEmpty) {
-        path = '$path?$queryString';
-      }
-    }
-
-    // A bare `/<code>` course join link (and the `/<uuid>` activity link) flow
-    // straight through to the router's LegacyRedirects, which folds them into
-    // their tokens — no per-shape rewrite here.
+    final path = incomingUriToPath(uri);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       FluffyChatApp.router.go(path);
     });

--- a/test/pangea/incoming_uri_path_test.dart
+++ b/test/pangea/incoming_uri_path_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/navigation/legacy_redirects.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+
+/// The installed-app deep-link leg: iOS Universal Links / Android App Links
+/// deliver the full `app.pangea.chat` URL to the running app, and
+/// [MatrixState.incomingUriToPath] maps it to the in-app location the router
+/// resolves. The mapped path must be exactly what `LegacyRedirects` folds —
+/// a bare `/<code>` course join link and a `/<uuid>` activity link reach
+/// their token flows with no per-shape rewrite in between
+/// (joining-courses.instructions.md, Deep Linking).
+void main() {
+  group('MatrixState.incomingUriToPath', () {
+    test('a bare course-code link maps to its path and folds', () {
+      final path = MatrixState.incomingUriToPath(
+        Uri.parse('https://app.pangea.chat/vj3pc8b'),
+      );
+      expect(path, '/vj3pc8b');
+      expect(
+        LegacyRedirects.resolve(Uri.parse(path)),
+        contains('addcoursepage:private'),
+      );
+    });
+
+    test('an activity uuid link maps to its path and folds', () {
+      const uuid = 'a1aed3f6-1ef7-4ed0-bc46-4a393aaf880b';
+      final path = MatrixState.incomingUriToPath(
+        Uri.parse('https://app.pangea.chat/$uuid'),
+      );
+      expect(path, '/$uuid');
+      expect(LegacyRedirects.resolve(Uri.parse(path)), contains(uuid));
+    });
+
+    test('activity link params ride along', () {
+      const uuid = 'a1aed3f6-1ef7-4ed0-bc46-4a393aaf880b';
+      final path = MatrixState.incomingUriToPath(
+        Uri.parse('https://app.pangea.chat/$uuid?launch=true'),
+      );
+      expect(path, '/$uuid?launch=true');
+      final folded = LegacyRedirects.resolve(Uri.parse(path));
+      expect(folded, contains(uuid));
+    });
+
+    test('a root link maps to the world', () {
+      expect(
+        MatrixState.incomingUriToPath(Uri.parse('https://app.pangea.chat/')),
+        '/',
+      );
+    });
+
+    test('a legacy fragment link maps to the fragment path', () {
+      expect(
+        MatrixState.incomingUriToPath(
+          Uri.parse('https://app.pangea.chat/#/world'),
+        ),
+        '/world',
+      );
+    });
+  });
+}

--- a/web/index.html
+++ b/web/index.html
@@ -222,6 +222,15 @@
 
       if (!isMobile) return; // Exit if not a mobile device
 
+      // A deep path is an inbound link (`/<code>` course join, `/<uuid>`
+      // activity — joining-courses.instructions.md). The web app is the
+      // documented fallback for those: when the app is installed the OS
+      // intercepts the link BEFORE this page loads (Universal/App Links), so
+      // reaching here means no app or an in-app browser — the store bounce
+      // would drop the link payload, and there is no deferred deep-linking
+      // service to recover it. Only bare-root visits steer to the store.
+      if (window.location.pathname !== '/') return;
+
       const appScheme = 'pangea://'; // Replace with your app's scheme
       const fallbackURL = isIOS
         ? 'https://apps.apple.com/app/pangea-chat/id1445118630'


### PR DESCRIPTION
## What

The mobile store steer in `web/index.html` fires only on bare-root loads — deep paths (course `/<code>`, activity `/<uuid>`) stay on the web fallback. The OS-link → in-app path mapping is extracted (`MatrixState.incomingUriToPath`) and unit-tested against `LegacyRedirects` folding.

## Why

Closes #7830. Web-as-fallback is the documented design (joining-courses.instructions.md, Deep Linking — section updated here to document all three legs, per chat); the unconditional store bounce dropped link payloads for no-app and in-app-browser opens. Installed-app interception (host-wide filters, AASA `*`) is unchanged.

## Testing

- New `incoming_uri_path_test.dart` (bare code, uuid, params, root, legacy fragment → folded tokens); 311 pass across touched suites; analyze/format/import-sort clean
- Served `index.html` verified to carry the deep-path guard; device tap-throughs are the issue's TO TEST (store steer is UA-gated, not drivable from desktop)

## Deploy Notes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of shared course and activity links across mobile and web.
  * Deep links now preserve their destination, including activity identifiers and query parameters.
  * Added support for legacy fragment-based links.

* **Bug Fixes**
  * Prevented deep links from being redirected to the app store or losing their destination.
  * App-store fallback now applies only when opening the mobile site root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->