### PR TITLE
fix: remove translucent hit test behavior

### DIFF
--- a/lib/features/tutorials/tutorial_overlay_widget.dart
+++ b/lib/features/tutorials/tutorial_overlay_widget.dart
@@ -260,7 +260,6 @@ class _TutorialOverlayWidgetState extends State<TutorialOverlayWidget> {
           ? SystemMouseCursors.click
           : SystemMouseCursors.basic,
       child: GestureDetector(
-        behavior: HitTestBehavior.translucent,
         onTap: step != null && _visible ? () => _next(step) : null,
         child: Stack(
           children: [


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
