### PR TITLE
feat(join-codes): iOS Smart App Banner carries shared-link URLs into the app

### DIFF
--- a/.github/instructions/joining-courses.instructions.md
+++ b/.github/instructions/joining-courses.instructions.md
@@ -130,7 +130,7 @@ A shared link (`/<code>` course join, `/<uuid>` activity) must reach the app on 
 2. **App not installed** — the tap opens the mobile browser; the webapp CloudFront serves the SPA for any path, and the web app processes the link exactly as on desktop, including the logged-out login-bounce ferry. There is no deferred deep-linking service (Branch.io, etc.) — a store install cannot carry the link, so the web IS the fallback.
 3. **In-app browsers** (Instagram, Gmail webview, …) — Universal/App Links often don't fire there; the user stays on the web fallback, which works.
 
-The store steer in [`web/index.html`](../../web/index.html) exists for plain visitors, and fires ONLY on a bare-root mobile load: a deep path is an inbound link, and bouncing it to the store (or the pathless `pangea://` scheme) would drop the payload — the failure that silently broke mobile-web links in the past.
+The store steer in [`web/index.html`](../../web/index.html) exists for plain visitors, and fires ONLY on a bare-root mobile load: a deep path is an inbound link, and bouncing it to the store (or the pathless `pangea://` scheme) would drop the payload — the failure that silently broke mobile-web links in the past. On iOS, a Smart App Banner (`apple-itunes-app`, `app-argument` = the live URL) additionally offers installed-app users in Safari or an in-app browser a native "Open in app" hop that keeps the link intact.
 
 ### Infrastructure touchpoints
 

--- a/web/index.html
+++ b/web/index.html
@@ -2,6 +2,23 @@
 <html>
 
 <head>
+  <!-- #Pangea -->
+  <!-- iOS Smart App Banner: Safari renders a native "Open in app" strip.
+       app-argument carries the CURRENT URL, so a shared link (`/<code>`
+       course join, `/<uuid>` activity) opened in Safari or an in-app browser
+       hops into the installed app with the link intact; "View" goes to the
+       App Store. Injected via script because the argument must be the live
+       URL (joining-courses.instructions.md, Deep Linking). -->
+  <script>
+    (function () {
+      const meta = document.createElement('meta');
+      meta.name = 'apple-itunes-app';
+      meta.content =
+        'app-id=1445118630, app-argument=' + window.location.href;
+      document.head.appendChild(meta);
+    })();
+  </script>
+  <!-- Pangea# -->
   <!--
     If you are serving your web app in a path other than the root, change the
     href value below to reflect the base path you are serving from.


### PR DESCRIPTION
## What

`web/index.html` injects the `apple-itunes-app` meta with `app-argument` set to the live URL — iOS Safari renders the native "Open in app" banner; opening hops into the installed app with the shared link (`/<code>`, `/<uuid>`) intact, "View" goes to the App Store. One doc sentence added to the Deep Linking section.

## Why

Follow-up to #7830 (merged in #7831), per chat: web-as-fallback stays the design, and the banner is the industry-convention upgrade for installed-app users who land on the web (Safari taps, in-app browsers where Universal Links don't fire).

## Testing

- Served page verified in-browser: the meta is present with `app-id=1445118630, app-argument=<current deep-link URL>`
- Banner rendering is iOS-Safari-only — covered by the device tap-throughs already on #7830's TO TEST

## Deploy Notes

None.