### PR TITLE
fix: don't forward tutorial if next step cannot be shown

### DIFF
--- a/lib/features/tutorials/tutorial_overlay_controller.dart
+++ b/lib/features/tutorials/tutorial_overlay_controller.dart
@@ -266,6 +266,7 @@ class TutorialOverlayController {
   }) {
     if (!isFocused) {
       Logs().w("Tutorial ${tutorial.tutorialType} is not locally enabled");
+      _closeOverlay();
       return;
     }
 
@@ -273,6 +274,7 @@ class TutorialOverlayController {
       Logs().w(
         "Tutorial ${tutorial.tutorialType} is not queued to launch next",
       );
+      _closeOverlay();
       return;
     }
 
@@ -280,6 +282,7 @@ class TutorialOverlayController {
       Logs().w(
         "Another tutorial is already active: ${_state.model.activeTutorial!.tutorialType}",
       );
+      _closeOverlay();
       return;
     }
 
@@ -287,11 +290,13 @@ class TutorialOverlayController {
       Logs().w(
         "Tutorial ${tutorial.tutorialType} blocked because another route/dialog is on top.",
       );
+      _closeOverlay();
       return;
     }
 
     final opened = _openTutorialOverlay(context);
     if (!opened) {
+      _closeOverlay();
       return;
     }
 

--- a/lib/features/tutorials/tutorial_overlay_widget.dart
+++ b/lib/features/tutorials/tutorial_overlay_widget.dart
@@ -213,11 +213,14 @@ class _TutorialOverlayWidgetState extends State<TutorialOverlayWidget> {
       widget.setTutorialTransitioning(true);
 
       final onTap = step.data.onTap;
+      final canShowNextStep = step.data.canShowNextStep;
       if (onTap != null) {
         await Future.wait([onTap.call(), Future.delayed(_duration)]);
       } else {
         await Future.delayed(_duration);
       }
+
+      if (!canShowNextStep()) return false;
     } catch (e, s) {
       ErrorHandler.logError(
         e: "Error executing tutorial step callback",

--- a/lib/features/tutorials/tutorial_step_model.dart
+++ b/lib/features/tutorials/tutorial_step_model.dart
@@ -19,8 +19,13 @@ class TutorialStep {
 class TutorialStepData {
   final String targetKey;
   final Future<void> Function()? onTap;
+  final bool Function() canShowNextStep;
 
-  TutorialStepData({required this.targetKey, this.onTap});
+  TutorialStepData({
+    required this.targetKey,
+    this.onTap,
+    required this.canShowNextStep,
+  });
 }
 
 class TutorialStepStyle {

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -762,6 +762,7 @@ class ChatController extends State<ChatPageWithRoom>
             onTap: () async {
               showToolbar(event, bypassBlockingOverlays: true);
             },
+            canShowNextStep: () => isToolbarOpen,
           ),
         ],
       ),
@@ -777,6 +778,7 @@ class ChatController extends State<ChatPageWithRoom>
           TutorialStepData(
             targetKey: ChoreoConstants.inputTransformTargetKey,
             onTap: () async => inputFocus.requestFocus(),
+            canShowNextStep: () => true,
           ),
         ],
       ),

--- a/lib/routes/chat/toolbar/reading_assistance/select_mode_buttons.dart
+++ b/lib/routes/chat/toolbar/reading_assistance/select_mode_buttons.dart
@@ -256,6 +256,8 @@ class SelectModeButtonsState extends State<SelectModeButtons> {
               widget.overlayController.updateSelectedSpan(null);
               _shimmerTranslateButton.value = true;
             },
+            canShowNextStep: () =>
+                mounted && controller.selectedMode.value == null,
           ),
           TutorialStepData(
             targetKey: translateTarget,
@@ -263,6 +265,9 @@ class SelectModeButtonsState extends State<SelectModeButtons> {
               await updateMode(SelectMode.translate);
               await Future.delayed(Duration(milliseconds: 4000));
             },
+            canShowNextStep: () =>
+                mounted &&
+                controller.selectedMode.value == SelectMode.translate,
           ),
           TutorialStepData(
             targetKey: audioTarget,
@@ -270,10 +275,13 @@ class SelectModeButtonsState extends State<SelectModeButtons> {
               await updateMode(SelectMode.audio);
               await Future.delayed(Duration(milliseconds: 1000));
             },
+            canShowNextStep: () =>
+                mounted && controller.selectedMode.value == SelectMode.audio,
           ),
           TutorialStepData(
             targetKey: msgTarget,
             onTap: () async => widget.controller.clearSelectedEvents(),
+            canShowNextStep: () => true,
           ),
         ],
       ),

--- a/test/pangea/tutorial_state_test.dart
+++ b/test/pangea/tutorial_state_test.dart
@@ -16,7 +16,8 @@ const _full = [
   TutorialEnum.writingAssistance,
 ];
 
-TutorialStepData _stepData() => TutorialStepData(targetKey: 'test_key');
+TutorialStepData _stepData() =>
+    TutorialStepData(targetKey: 'test_key', canShowNextStep: () => true);
 
 ReadingAssistantTutorialModel _readingModel() =>
     ReadingAssistantTutorialModel(data: [_stepData()]);


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
