### PR TITLE
Use option text size for vocab practice example messages

### DIFF
--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_message_widget.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_message_widget.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'package:fluffychat/config/app_config.dart';
-import 'package:fluffychat/config/setting_keys.dart';
+import 'package:fluffychat/config/themes.dart';
 
 class AnalyticsPracticeExerciseExampleMessage extends StatelessWidget {
   final Future<List<InlineSpan>?> future;
@@ -10,6 +9,10 @@ class AnalyticsPracticeExerciseExampleMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textStyle = FluffyThemes.isColumnMode(context)
+        ? Theme.of(context).textTheme.titleMedium
+        : Theme.of(context).textTheme.titleSmall;
+
     return FutureBuilder<List<InlineSpan>?>(
       future: future,
       builder: (context, snapshot) {
@@ -25,11 +28,8 @@ class AnalyticsPracticeExerciseExampleMessage extends StatelessWidget {
           ),
           child: RichText(
             text: TextSpan(
-              style: TextStyle(
+              style: textStyle?.copyWith(
                 color: Theme.of(context).colorScheme.onPrimary,
-                fontSize:
-                    AppSettings.fontSizeFactor.value *
-                    AppConfig.messageFontSize,
               ),
               children: snapshot.data!,
             ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated analytics practice message text to use the app’s theme-based typography.
  * Improved consistency of text sizing and coloring across different layout modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->