### PR TITLE
Fix Android Play Store workflow: add required Java distribution

### DIFF
--- a/.github/workflows/android-playstore.yml
+++ b/.github/workflows/android-playstore.yml
@@ -44,6 +44,7 @@ jobs:
       - run: cat .github/workflows/versions.env >> $GITHUB_ENV
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
+          distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2
         with:
@@ -56,7 +57,6 @@ jobs:
         uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
         with:
           ruby-version: '3.3'
-          distribution: 'zulu'
       - name: Add Firebase Messaging
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}


### PR DESCRIPTION
## Problem

The first manual run of the Android Play Store internal-track workflow ([run 29867135982](https://github.com/pangeachat/client/actions/runs/29867135982)) failed after 14s at the **Set up Java** step:

> Input required and not supplied: distribution

`actions/setup-java@v4` requires a `distribution` input; the step only passed `java-version`, so GitHub aborted the step before any build work ran.

## Fix

- Add `distribution: 'temurin'` to the `setup-java` step (Java 17 per `versions.env` resolves fine under Temurin).
- Remove a stray `distribution: 'zulu'` from the `ruby/setup-ruby` step, which has no such input and silently ignored it — it looks like the distribution line originally landed on the wrong step during setup.

## To test

CI verification, not a client-app flow:
1. From Actions → **Build Android and upload to Play Store internal track** → Run workflow on this branch (or after merge).
2. Confirm the **Set up Java** step now succeeds and the run proceeds past it.

Note: a full run uploads a signed appbundle to the Play Store internal track, so I did not auto-trigger it — re-dispatch it deliberately when you want the actual upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Java runtime distribution used during Android Play Store internal-track deployments.
  * Improved compatibility and consistency for Flutter builds and automated deployment tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->