### PR TITLE
Fix Android version code: use max internal track code, not versions[0]

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -24,7 +24,7 @@ platform :android do
         track: "internal",
         json_key: "./keys.json"
       )
-    last_version = versions[0].to_i
+    last_version = versions.map(&:to_i).max
     Dir.chdir("../..") do
       re = /version:\s([0-9]*\.[0-9]*\.[0-9]*)\+[0-9]*/i
       config = File.read("./pubspec.yaml")
@@ -43,7 +43,7 @@ platform :android do
         track: "internal",
         json_key: "./keys.json"
       )
-    last_version = versions[0].to_i
+    last_version = versions.map(&:to_i).max
     upload_to_play_store(
       track: 'internal',
       aab: '../build/app/outputs/bundle/release/app-release.aab',


### PR DESCRIPTION
## Problem

With the setup-java fix (#7845) in place, the Play Store workflow now builds the appbundle and authenticates with Google Play, but the upload fails ([run 29925556204](https://github.com/pangeachat/client/actions/runs/29925556204)):

> Google Api Error: Invalid request - Version code 3825 has already been used.

## Root cause

`prepare-android-release.sh` runs the `set_build_code_internal` lane before the build, which rewrites `pubspec.yaml` to `version: X.Y.Z+{last_version+1}` so the aab is built with the next version code. Both that lane and `deploy_internal_test` compute:

```ruby
last_version = versions[0].to_i
```

`google_play_track_version_codes` returns the track's codes in **no guaranteed order**, so `versions[0]` is not necessarily the highest. The internal track already held both 3825 and 3826, but at prepare time `versions[0]` returned an older 3824, so the build got `3824 + 1 = 3825` — a code already in use. Collision.

## Fix

Take the actual maximum in both lanes:

```ruby
last_version = versions.map(&:to_i).max
```

Now the build number is always `highest_existing_internal_code + 1`, which is unique.

## To test

CI verification, not a client-app flow:
1. Actions → **Build Android and upload to Play Store internal track** → Run workflow on `main`.
2. Confirm the **Deploy Android Release** step uploads to the internal track without a "version code already used" error.

Note: a full run uploads a signed appbundle to the Play Store internal track (a real side effect).