### PR TITLE
fix(auth): root-absolute web SSO callback and .env fetch under path URLs

### DIFF
--- a/lib/pangea/common/config/env_loader.dart
+++ b/lib/pangea/common/config/env_loader.dart
@@ -26,7 +26,10 @@ class EnvLoader {
   static Future<bool> tryLoadFromWebRoot({http.Client? client}) async {
     final httpClient = client ?? http.Client();
     try {
-      final response = await httpClient.get(Uri.base.resolve('.env'));
+      // Root-absolute: with path URLs the app can boot on any nested path
+      // (`/home/login`), and a RELATIVE resolve fetched `/home/.env` — which
+      // the SPA fallback answers with index.html, silently failing the load.
+      final response = await httpClient.get(Uri.base.resolve('/.env'));
       if (response.statusCode != 200 || !looksLikeEnvFile(response.body)) {
         return false;
       }

--- a/lib/routes/home/p_sso_button.dart
+++ b/lib/routes/home/p_sso_button.dart
@@ -16,6 +16,16 @@ import 'package:fluffychat/routes/home/store_login_method_repo.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
+/// The web SSO callback URL — the static `auth.html` shipped at the WEB
+/// ROOT, resolved from the page's origin. Never resolve it relative to the
+/// current page URL: with path URLs the login page lives at `/home/login`,
+/// so a relative resolve produced `/home/auth.html` — no such file, the SPA
+/// fallback boots the app there, and the homeserver's `loginToken` dies on
+/// a routerless page (the post-path-strategy SSO breakage). Pure —
+/// unit-tested (sso_redirect_url_test.dart).
+String webSsoRedirectUrl(String href) =>
+    Uri.parse(href).resolve('/auth.html').toString();
+
 class PangeaSsoButton extends StatelessWidget {
   final SSOProvider provider;
   final String? title;
@@ -64,9 +74,7 @@ class PangeaSsoButton extends StatelessWidget {
         PlatformInfos.isWeb ||
         PlatformInfos.isMacOS);
     final redirectUrl = kIsWeb
-        ? Uri.parse(
-            html.window.location.href,
-          ).resolveUri(Uri(pathSegments: ['auth.html'])).toString()
+        ? webSsoRedirectUrl(html.window.location.href)
         : isDefaultPlatform
         ? '${AppConfig.appOpenUrlScheme.toLowerCase()}://login'
         : 'http://localhost:3001//login';

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -25,6 +25,7 @@ import flutter_tts
 import flutter_web_auth_2
 import flutter_webrtc
 import geolocator_apple
+import in_app_purchase_storekit
 import just_audio
 import open_file_mac
 import package_info_plus
@@ -67,6 +68,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterWebAuth2Plugin.register(with: registry.registrar(forPlugin: "FlutterWebAuth2Plugin"))
   FlutterWebRTCPlugin.register(with: registry.registrar(forPlugin: "FlutterWebRTCPlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
+  InAppPurchasePlugin.register(with: registry.registrar(forPlugin: "InAppPurchasePlugin"))
   JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   OpenFilePlugin.register(with: registry.registrar(forPlugin: "OpenFilePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1271,6 +1271,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.6.0"
+  in_app_purchase:
+    dependency: "direct main"
+    description:
+      name: in_app_purchase
+      sha256: "0e9510b80b0074e89ab0a8e0fc901439b779dc9ae575ab8d419253c6e1627716"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.0"
+  in_app_purchase_android:
+    dependency: transitive
+    description:
+      name: in_app_purchase_android
+      sha256: b8af1b6f0e57076b5da5ede71e3af2d727017c0416ad2a41017c6ed2b102381d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
+  in_app_purchase_platform_interface:
+    dependency: transitive
+    description:
+      name: in_app_purchase_platform_interface
+      sha256: "0b0076cac8ce4fa7048f01e76af8b123aeb6a7c4e0dea2a5206d6664454f3e36"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.1"
+  in_app_purchase_storekit:
+    dependency: transitive
+    description:
+      name: in_app_purchase_storekit
+      sha256: "47d63717270133fcfa1ff8e144f6aaf9d498fa3884de43e24909737da55aedd8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.10+1"
   injector:
     dependency: transitive
     description:

--- a/test/pangea/sso_redirect_url_test.dart
+++ b/test/pangea/sso_redirect_url_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/home/p_sso_button.dart';
+
+/// The web SSO callback must always be the static `auth.html` at the WEB
+/// ROOT. With path URLs the login page lives at a nested path, and resolving
+/// the callback RELATIVE to the page produced `/home/auth.html` — a
+/// non-file the SPA fallback boots the app on, stranding the homeserver's
+/// `loginToken` on a routerless Page Not Found (the post-#7820 SSO
+/// breakage).
+void main() {
+  group('webSsoRedirectUrl', () {
+    test('resolves to root auth.html from the nested login page', () {
+      expect(
+        webSsoRedirectUrl('https://app.staging.pangea.chat/home/login'),
+        'https://app.staging.pangea.chat/auth.html',
+      );
+    });
+
+    test('resolves to root auth.html from the root', () {
+      expect(
+        webSsoRedirectUrl('https://app.pangea.chat/'),
+        'https://app.pangea.chat/auth.html',
+      );
+    });
+
+    test('drops query and fragment state from the page URL', () {
+      expect(
+        webSsoRedirectUrl('http://localhost:8090/home/login?devlogin=1#x'),
+        'http://localhost:8090/auth.html',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

`webSsoRedirectUrl` resolves the SSO callback to the web root's `auth.html` from the page origin (pure helper, unit-tested); `EnvLoader` fetches `/.env` root-absolute.

## Why

Closes #7849 — staging-breaking SSO regression from the path URL strategy (#7820): both URLs were resolved relative to the current page, which only worked while the hash strategy pinned every page to `/`.

## Testing

- New `sso_redirect_url_test.dart` (nested login page, root, query/fragment stripping); `env_loader_test.dart` 9 pass; navigation + ferry suites 306 pass; analyze/format/sort clean
- SSO completion needs a real Google login — staging tap-through on the issue TO TEST after deploy

## Deploy Notes

None.