### PR TITLE
Make courses list content/behavior match nav rail courses list

### DIFF
--- a/lib/routes/courses/add_course_tile.dart
+++ b/lib/routes/courses/add_course_tile.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
 
+import 'package:badges/badges.dart' as b;
+
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/courses/add_course_tile_content.dart';
 import 'package:fluffychat/routes/courses/course_info_chip_widget.dart';
 import 'package:fluffychat/widgets/avatar.dart';
+import 'package:fluffychat/widgets/invited_course_badge.dart';
 import 'package:fluffychat/widgets/url_image_widget.dart';
 
 class AddCourseTile extends StatelessWidget {
@@ -23,6 +26,7 @@ class AddCourseTile extends StatelessWidget {
     final theme = Theme.of(context);
     final courseId = content.courseId;
     final members = content.members;
+    final invited = content.invited ?? false;
     final title = content.title(L10n.of(context));
     final expandedContent = content.expandedContent;
 
@@ -59,11 +63,23 @@ class AddCourseTile extends StatelessWidget {
                           imageUrl: content.imageUrl,
                           width: 48.0,
                           borderRadius: BorderRadius.circular(10.0),
-                          replacement: Avatar(
-                            name: title,
-                            borderRadius: BorderRadius.circular(10.0),
-                            size: 48.0,
-                          ),
+                          replacement: invited
+                              ? InvitedCourseBadge(
+                                  position: b.BadgePosition.topEnd(
+                                    top: -5,
+                                    end: -7,
+                                  ),
+                                  child: Avatar(
+                                    name: title,
+                                    borderRadius: BorderRadius.circular(10.0),
+                                    size: 48.0,
+                                  ),
+                                )
+                              : Avatar(
+                                  name: title,
+                                  borderRadius: BorderRadius.circular(10.0),
+                                  size: 48.0,
+                                ),
                         ),
                       ),
                     ),
@@ -101,14 +117,14 @@ class AddCourseTile extends StatelessWidget {
                             runSpacing: 8.0,
                             crossAxisAlignment: WrapCrossAlignment.center,
                             children: [
-                              if (members != null)
+                              if (members != null && !invited)
                                 CourseInfoChip(
                                   icon: Icons.group,
                                   text: '$members',
                                   fontSize: 12.0,
                                   iconSize: 12.0,
                                 ),
-                              if (courseId != null)
+                              if (courseId != null && !invited)
                                 CourseInfoChips(
                                   courseId,
                                   fontSize: 12.0,

--- a/lib/routes/courses/add_course_tile_content.dart
+++ b/lib/routes/courses/add_course_tile_content.dart
@@ -16,6 +16,8 @@ abstract class AddCourseTileContent {
 
   bool get isKnock => false;
 
+  bool? get invited => null;
+
   String? get expandedContent => null;
 }
 
@@ -31,6 +33,9 @@ class RoomAddCourseTileContent extends AddCourseTileContent {
 
   @override
   int? get members => space.summary.mJoinedMemberCount ?? 1;
+
+  @override
+  bool get invited => space.membership == Membership.invite;
 
   @override
   String? get courseId => space.coursePlan?.uuid;

--- a/lib/routes/world/left_panel/left_panel_courses_list_view.dart
+++ b/lib/routes/world/left_panel/left_panel_courses_list_view.dart
@@ -3,37 +3,42 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
-import 'package:fluffychat/features/course_plans/courses/course_plan_room_extension.dart';
+import 'package:fluffychat/features/analytics_access/join_room_analytics_consent_handler.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/courses/add_course_options.dart';
 import 'package:fluffychat/routes/courses/add_course_tile_content.dart';
 import 'package:fluffychat/routes/courses/add_course_tile_list.dart';
 import 'package:fluffychat/routes/world/panel_header.dart';
+import 'package:fluffychat/utils/chat_list_handle_space_tap.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
-/// The courses the learner is in — spaces they've joined that carry a course
-/// plan — sorted by localized display name. Shared so the panel body and the
-/// shell's content-fit height estimate count exactly the same rooms.
-List<Room> joinedCourses(Client client, L10n l10n) =>
+/// Sort invited courses to the top of the course list
+/// Courses within categories are sorted by localized display name.
+List<Room> sortedCourses(Client client, L10n l10n) =>
     client.rooms
         .where(
           (r) =>
-              r.isSpace &&
-              r.membership == Membership.join &&
-              r.coursePlan != null,
+              r.isSpace &
+              (r.membership == Membership.join ||
+                  r.membership == Membership.invite),
         )
         .toList()
-      ..sort(
-        (a, b) => a
+      ..sort((a, b) {
+        if (priority(a) != priority(b)) {
+          return priority(a).compareTo(priority(b));
+        }
+        return a
             .getLocalizedDisplayname(MatrixLocals(l10n))
             .toLowerCase()
             .compareTo(
               b.getLocalizedDisplayname(MatrixLocals(l10n)).toLowerCase(),
-            ),
-      );
+            );
+      });
+
+int priority(Room room) => room.membership == Membership.invite ? 1 : 2;
 
 /// The **Courses** left-column panel (world_v2): the "Courses" header plus the
 /// scrollable list of joined courses.
@@ -59,7 +64,7 @@ class CoursesHubPanel extends StatelessWidget {
           .where((s) => s.hasRoomUpdate)
           .rateLimit(const Duration(seconds: 1)),
       builder: (context, _) {
-        final courses = joinedCourses(client, l10n);
+        final courses = sortedCourses(client, l10n);
         return Column(
           children: [
             PanelHeader(
@@ -78,57 +83,52 @@ class CoursesHubPanel extends StatelessWidget {
   }
 }
 
-/// The scrollable body of [CoursesHubPanel]: a tile per joined course, and —
-/// only when the learner has none yet — the "Add new course" divider and the
-/// full-width add-course buttons as the empty state (#7172: an empty list isn't
-/// a plan-less course, so no "needs a plan" message here).
+/// The scrollable body of [CoursesHubPanel],
+/// containing a tile for each invited or joined course.
+/// Matches nav rail course behavior on course selection.
 class LeftPanelCoursesListView extends StatelessWidget {
   final List<Room> courses;
 
   const LeftPanelCoursesListView({super.key, required this.courses});
 
+  // Open joined courses, or open popup for invited courses
+  Future<void> _onTapCourse(BuildContext context, Room course) async {
+    final uri = GoRouterState.of(context).uri;
+    final client = Matrix.of(context).client;
+    final membership = course.membership;
+
+    if (!{Membership.invite, Membership.leave}.contains(membership)) {
+      context.go(
+        WorkspaceNav.openCourseSection(uri, course.id, keepRoom: false),
+      );
+      return;
+    }
+
+    final joinResp = course.membership == Membership.invite
+        ? await SpaceTapUtil.onInviteTap(context, course)
+        : await SpaceTapUtil.autoJoin(context, course);
+
+    if (joinResp == null) return;
+    final joinedRoom = client.getRoomById(joinResp.roomId);
+    if (joinedRoom == null) return;
+
+    final handler = JoinRoomAnalyticsConsentHandler(joinResp, joinedRoom);
+    final joinedRoomId = await handler.handle(context);
+    if (joinedRoomId == null) return;
+
+    context.go(
+      WorkspaceNav.openCourseSection(uri, joinedRoomId, keepRoom: false),
+    );
+    return;
+  }
+
   @override
   Widget build(BuildContext context) {
-    final l10n = L10n.of(context);
-    final theme = Theme.of(context);
-
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12.0),
       child: AddCourseTileList(
         content: courses.map((c) => RoomAddCourseTileContent(c)).toList(),
-        onTap: (index) => context.go(
-          WorkspaceNav.openCourse(
-            GoRouterState.of(context).uri,
-            courses[index].id,
-          ),
-        ),
-        extraContent: courses.isEmpty
-            ? [
-                const SizedBox(height: 4.0),
-                // "Add new course" section divider + the full add-course buttons.
-                Row(
-                  children: [
-                    Expanded(
-                      child: Divider(color: theme.colorScheme.outlineVariant),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 12.0),
-                      child: Text(
-                        l10n.addNewCourse,
-                        style: theme.textTheme.labelLarge?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                    ),
-                    Expanded(
-                      child: Divider(color: theme.colorScheme.outlineVariant),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 12.0),
-                const AddCourseOptions(),
-              ]
-            : null,
+        onTap: (index) => _onTapCourse(context, courses[index]),
       ),
     );
   }

--- a/lib/routes/world/left_panel/left_panel_courses_list_view.dart
+++ b/lib/routes/world/left_panel/left_panel_courses_list_view.dart
@@ -21,14 +21,14 @@ List<Room> sortedCourses(Client client, L10n l10n) =>
     client.rooms
         .where(
           (r) =>
-              r.isSpace &
+              r.isSpace &&
               (r.membership == Membership.join ||
                   r.membership == Membership.invite),
         )
         .toList()
       ..sort((a, b) {
-        if (priority(a) != priority(b)) {
-          return priority(a).compareTo(priority(b));
+        if (_priority(a) != _priority(b)) {
+          return _priority(a).compareTo(_priority(b));
         }
         return a
             .getLocalizedDisplayname(MatrixLocals(l10n))
@@ -38,7 +38,7 @@ List<Room> sortedCourses(Client client, L10n l10n) =>
             );
       });
 
-int priority(Room room) => room.membership == Membership.invite ? 1 : 2;
+int _priority(Room room) => room.membership == Membership.invite ? 1 : 2;
 
 /// The **Courses** left-column panel (world_v2): the "Courses" header plus the
 /// scrollable list of joined courses.
@@ -83,9 +83,10 @@ class CoursesHubPanel extends StatelessWidget {
   }
 }
 
-/// The scrollable body of [CoursesHubPanel],
-/// containing a tile for each invited or joined course.
-/// Matches nav rail course behavior on course selection.
+/// The scrollable body of [CoursesHubPanel]: a tile per invited or joined
+/// course (matching nav rail behavior on course selection), and — only when the
+/// learner has none yet — the "Add new course" divider and the full-width
+/// add-course buttons as the empty state (#7172).
 class LeftPanelCoursesListView extends StatelessWidget {
   final List<Room> courses;
 
@@ -124,11 +125,44 @@ class LeftPanelCoursesListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final l10n = L10n.of(context);
+    final theme = Theme.of(context);
+
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12.0),
       child: AddCourseTileList(
         content: courses.map((c) => RoomAddCourseTileContent(c)).toList(),
         onTap: (index) => _onTapCourse(context, courses[index]),
+        // Only when the learner is in no courses yet (none joined, none
+        // invited): the "Add new course" divider + the full-width add-course
+        // buttons as the empty state (#7172). With at least one course, the
+        // add-course actions ride the header instead (see [CoursesHubPanel]).
+        extraContent: courses.isEmpty
+            ? [
+                const SizedBox(height: 4.0),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Divider(color: theme.colorScheme.outlineVariant),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+                      child: Text(
+                        l10n.addNewCourse,
+                        style: theme.textTheme.labelLarge?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: Divider(color: theme.colorScheme.outlineVariant),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12.0),
+                const AddCourseOptions(),
+              ]
+            : null,
       ),
     );
   }

--- a/lib/widgets/invited_course_badge.dart
+++ b/lib/widgets/invited_course_badge.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+import 'package:badges/badges.dart' as b;
+
+class InvitedCourseBadge extends StatelessWidget {
+  final b.BadgePosition? position;
+  final Widget? child;
+
+  const InvitedCourseBadge({super.key, this.position, this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return b.Badge(
+      badgeStyle: b.BadgeStyle(
+        badgeColor: Theme.of(context).colorScheme.error,
+        elevation: 4,
+        borderSide: BorderSide.none,
+        padding: const EdgeInsetsGeometry.all(0),
+      ),
+      badgeContent: Icon(
+        Icons.error_outline,
+        color: Theme.of(context).colorScheme.onPrimary,
+        size: 16,
+      ),
+      position: position,
+      child: child,
+    );
+  }
+}

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -560,7 +560,7 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
       // They fall through to the default (roughly half the screen), which is
       // what routing.instructions.md specifies for sections other than the
       // chats sheet and the Courses hub.
-      final courseCount = joinedCourses(client, l10n).length;
+      final courseCount = sortedCourses(client, l10n).length;
       preferredCavityHeight =
           _chatsSheetHeaderAllowance +
           (courseCount == 0

--- a/lib/widgets/navigation_rail.dart
+++ b/lib/widgets/navigation_rail.dart
@@ -20,6 +20,7 @@ import 'package:fluffychat/utils/chat_list_handle_space_tap.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
 import 'package:fluffychat/widgets/avatar.dart';
+import 'package:fluffychat/widgets/invited_course_badge.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/navi_rail_item.dart';
 
@@ -312,21 +313,7 @@ class _SpaceItem extends StatelessWidget {
           );
 
           if (space.membership == Membership.invite) {
-            return b.Badge(
-              badgeStyle: b.BadgeStyle(
-                badgeColor: Theme.of(context).colorScheme.error,
-                elevation: 4,
-                borderSide: BorderSide.none,
-                padding: const EdgeInsetsGeometry.all(0),
-              ),
-              badgeContent: Icon(
-                Icons.error_outline,
-                color: Theme.of(context).colorScheme.onPrimary,
-                size: 16,
-              ),
-              position: position,
-              child: child,
-            );
+            return InvitedCourseBadge(position: position, child: child);
           }
 
           return FutureBuilder(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Invited courses now appear in the Courses list, prioritized ahead of joined courses.
  - Invited courses are clearly marked with an invitation badge.
  - Selecting an invitation guides you through joining before opening the course.

- **Bug Fixes**
  - Course navigation and mobile layout sizing now account for invited courses.
  - Participant counts are hidden on course tiles until an invitation is accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->