### PR TITLE
Add padding to invite page share button on narrow screen

### DIFF
--- a/lib/routes/chat/chat_details/invite/pangea_invitation_selection_view.dart
+++ b/lib/routes/chat/chat_details/invite/pangea_invitation_selection_view.dart
@@ -59,7 +59,13 @@ class PangeaInvitationSelectionView extends StatelessWidget {
         ),
         centerTitle: false,
         actions: [
-          ShareRoomButton(room: room, child: const Icon(Icons.share_outlined)),
+          Padding(
+            padding: .only(right: FluffyThemes.isColumnMode(context) ? 0 : 16),
+            child: ShareRoomButton(
+              room: room,
+              child: const Icon(Icons.share_outlined),
+            ),
+          ),
         ],
       ),
       body: MaxWidthBody(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
