### PR TITLE
Announce mobile builds to Release Announcements Matrix room

### DIFF
--- a/.github/workflows/android-playstore.yml
+++ b/.github/workflows/android-playstore.yml
@@ -33,8 +33,10 @@ permissions:
 
 jobs:
   deploy_playstore_internal:
-    environment: 
+    environment:
       name: ${{ inputs.environment }}
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     env:
       WEB_APP_ENV: ${{ vars.WEB_APP_ENV }}
       ENV_OVERRIDES: ${{ vars.ENV_OVERRIDES }}
@@ -84,6 +86,11 @@ jobs:
           PLAY_STORE_KEYSTORE_KEY_PASSWORD: ${{ secrets.PLAY_STORE_KEYSTORE_KEY_PASSWORD }}
           PLAY_STORE_CONFIG_JSON: ${{ secrets.PLAY_STORE_CONFIG_JSON }}
         run: ./scripts/prepare-android-release.sh
+      - name: Capture build version
+        id: version
+        # prepare-android-release.sh (set_build_code_internal) rewrites pubspec
+        # with the Play Store build code, so this reads e.g. "5.0.0+3828".
+        run: echo "version=$(grep -m1 '^version:' pubspec.yaml | awk '{print $2}')" >> $GITHUB_OUTPUT
       - name: Build Android Release
         run: flutter build appbundle --target-platform android-arm,android-arm64,android-x64
       - name: Deploy Android Release
@@ -97,3 +104,16 @@ jobs:
           bundle update fastlane
           bundle exec fastlane deploy_internal_test
           cd ..
+
+  notify:
+    needs: deploy_playstore_internal
+    permissions:
+      id-token: write
+      contents: read
+    uses: pangeachat/.github/.github/workflows/notify-matrix-deploy.yaml@9aca4dce4faf90cf72371d1bd6618b87eecde409 # main
+    with:
+      service_name: "Pangea Chat Android"
+      version: ${{ needs.deploy_playstore_internal.outputs.version }}
+      headline: "(${{ inputs.environment }}) is on the Play Store internal track — internal testers get it automatically"
+    secrets:
+      aws_role_arn: ${{ secrets.AWS_ROLE_ARN_PROD }}

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -28,11 +28,18 @@ jobs:
   build_ios_testflight:
     runs-on: macos-15
     environment: ${{ inputs.environment }}
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     env:
       WEB_APP_ENV: ${{ vars.WEB_APP_ENV }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - run: cat .github/workflows/versions.env >> $GITHUB_ENV
+      - name: Capture build version
+        id: version
+        # Semantic version only — fastlane assigns the iOS build number itself
+        # (latest TestFlight build + 1), so pubspec's +N is not meaningful here.
+        run: echo "version=$(grep -m1 '^version:' pubspec.yaml | awk '{print $2}' | cut -d+ -f1)" >> $GITHUB_OUTPUT
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
@@ -79,3 +86,16 @@ jobs:
           APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
           APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_IS_KEY_CONTENT_BASE64 }}
         run: fastlane ios release_candidate
+
+  notify:
+    needs: build_ios_testflight
+    permissions:
+      id-token: write
+      contents: read
+    uses: pangeachat/.github/.github/workflows/notify-matrix-deploy.yaml@9aca4dce4faf90cf72371d1bd6618b87eecde409 # main
+    with:
+      service_name: "Pangea Chat iOS"
+      version: ${{ needs.build_ios_testflight.outputs.version }}
+      headline: "(${{ inputs.environment }}) is on TestFlight — internal testers get it automatically"
+    secrets:
+      aws_role_arn: ${{ secrets.AWS_ROLE_ARN_PROD }}


### PR DESCRIPTION
## Summary

Adds a `notify` job to both mobile store workflows so the team hears about every new build in the **Release Announcements** Matrix room, using the existing `notify-matrix-deploy.yaml` reusable workflow (with the new `headline` input from pangeachat/.github#285, pinned by SHA):

- **Android** (`android-playstore.yml`): posts e.g. "🚀 **Pangea Chat Android 5.0.0+3828** (staging) is on the Play Store internal track — internal testers get it automatically". The version is captured after the Fastlane lane assigns the Play build code.
- **iOS** (`ios-testflight.yml`): posts e.g. "🚀 **Pangea Chat iOS 5.0.0** (staging) is on TestFlight — internal testers get it automatically". Semantic version only, since fastlane assigns the TestFlight build number itself.

The notify job runs only when the upload succeeds, for both manual dispatches and release-driven production builds (`release.yaml` passes `secrets: inherit`). Auth is the existing OIDC → `github-deploy-prod` role → Secrets Manager path; `pangeachat/client` is already in the role's allowed repos and the repo already has `AWS_ROLE_ARN_PROD`.

## To Test

CI verification, not a client-app flow:
1. Actions → **Build Android and upload to Play Store internal track** → Run workflow (staging).
2. After the run completes, confirm a message from `@pangea-chat-system-status:matrix.org` appears in Release Announcements with the correct version+build code.
3. iOS path gets exercised on the next TestFlight build the same way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated notifications after successful Android Play Store internal deployments.
  * Added automated notifications after successful iOS TestFlight builds.
  * Notifications now include the released app version and deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->