### PR TITLE
fix(l10n): filter regional dialects from L1 picker + resolve dialect codes to their translation

### DIFF
--- a/.github/instructions/language-list.instructions.md
+++ b/.github/instructions/language-list.instructions.md
@@ -18,7 +18,7 @@ For the cross-service language list architecture, L1/L2 definitions, and CMS sch
 
 | Getter | Filter | Used for |
 |---|---|---|
-| `baseOptions` | All languages (no filter) | L1 / source / native language selection |
+| `baseOptions` | All languages minus same-script **regional** variants — English (US/UK), Spanish (Mexico), etc. are dropped; a genuinely different **writing system** (Traditional Chinese, Jawi Malay, Shahmukhi Punjabi) is kept | L1 / source / native language selection |
 | `targetOptions` | `element.l2` (i.e., `l2Support != L2SupportEnum.na`) | L2 / target / learning language selection |
 | `unlocalizedTargetOptions` | L2 filter + excludes regional variants (e.g., keeps "Portuguese" but not "Portuguese (Brazil)") | Course creation language filter |
 

--- a/.github/instructions/localization.instructions.md
+++ b/.github/instructions/localization.instructions.md
@@ -18,6 +18,8 @@ How the Flutter client's UI strings are stored, translated, and kept in sync. Fo
 
 By default the app UI is shown in the user's **source/native language (L1)**. A learner can opt into **immersion** — showing the UI in their **target language (L2)** — via the `appLanguageIsTarget` flag in `UserSettings` (toggle on the learning settings page). [`MatrixState._setAppLanguage`](../../lib/widgets/matrix.dart) resolves the locale from that flag, falling back to L1 (then system) when L2 isn't set. Because it's a non-language setting, the change propagates on `settingsUpdateStream`, which `_setAppLanguage` also listens to so the toggle takes effect immediately. Untranslated L2 keys fall back to English like any other locale.
 
+CMS language codes are BCP-47 with `-` (`es-MX`, `zh-TW`). [`LocaleProvider.setLocale`](../../lib/features/languages/locale_provider.dart) resolves them to a translation by **language** (dropping region, which doesn't change the UI copy), with one exception: Traditional Chinese (`zh-TW`/`zh-HK`/`zh-Hant`) maps to the separate `intl_zh_Hant` translation. So a regional dialect renders its base language's translation rather than falling back to English.
+
 ## L1 coverage principle
 
 Every L1 — every language in the CMS `languages` collection — should get a UI translation. A language is offered as an L1 only if an LLM we route to supports it (the L1 gate in the language-list doc), so offering it while showing English UI is the mismatch we're closing. Until a locale is translated it falls back to English; the backfill tooling below exists to drive that gap to zero.

--- a/lib/features/languages/locale_provider.dart
+++ b/lib/features/languages/locale_provider.dart
@@ -8,16 +8,40 @@ class LocaleProvider extends ChangeNotifier {
   Locale? get locale => _locale;
 
   void setLocale(String? value) {
-    final split = value?.split('_');
-    if (split == null ||
-        split.isEmpty ||
-        !intl.DateFormat.localeExists(split[0])) {
+    if (value == null || value.isEmpty) {
       _locale = null;
       notifyListeners();
       return;
     }
 
-    _locale = Locale(split[0], split.length > 1 ? split[1] : null);
+    // Language codes come from the CMS as BCP-47 with '-' (e.g. `es-MX`,
+    // `zh-TW`). The app UI is translated by language (and, for Chinese, by
+    // script) — not by region — so resolve to the language and drop the
+    // region, which Flutter then matches against the base translation. The
+    // previous code split on '_' only, so a hyphenated code became a malformed
+    // `Locale('es-MX')` that matched nothing and fell back to English.
+    final parts = value.replaceAll('_', '-').split('-');
+    final lang = parts.first.toLowerCase();
+    if (!intl.DateFormat.localeExists(lang)) {
+      _locale = null;
+      notifyListeners();
+      return;
+    }
+
+    final suffix = parts.length > 1 ? parts[1].toLowerCase() : null;
+    // Traditional Chinese ships as its own translation (`intl_zh_Hant`); map
+    // its script/region codes to it. Simplified and every other variant use
+    // the base language.
+    if (lang == 'zh' &&
+        suffix != null &&
+        const {'hant', 'tw', 'hk', 'mo'}.contains(suffix)) {
+      _locale = const Locale.fromSubtags(
+        languageCode: 'zh',
+        scriptCode: 'Hant',
+      );
+    } else {
+      _locale = Locale(lang);
+    }
     notifyListeners();
   }
 }

--- a/lib/features/languages/p_language_store.dart
+++ b/lib/features/languages/p_language_store.dart
@@ -23,7 +23,36 @@ class PLanguageStore {
   List<LanguageModel> get targetOptions =>
       _langList.where((element) => element.l2).toList();
 
-  List<LanguageModel> get baseOptions => _langList.toList();
+  /// L1 (native language) options. Shows one entry per language plus genuinely
+  /// distinct writing systems (Traditional Chinese, Jawi Malay, Shahmukhi
+  /// Punjabi). Regional variants that write the same way as their base language
+  /// — English (US/UK), Spanish (Mexico), Cantonese (HK), etc. — are dropped:
+  /// they don't belong in native-language selection and the app UI is
+  /// translated by language + script, not by region.
+  List<LanguageModel> get baseOptions {
+    // Collapse near-identical scripts so a variant isn't kept for a trivial
+    // difference (generic Han `Hani` vs Simplified `Hans`; Arabic `Arab` vs
+    // Nastaliq `Aran`).
+    String scriptClass(String s) {
+      if (s == 'Hans' || s == 'Hani') return 'Hans';
+      if (s == 'Arab' || s == 'Aran') return 'Arab';
+      return s;
+    }
+
+    final baseScript = <String, String>{};
+    for (final lang in _langList) {
+      if (lang.langCode == lang.langCodeShort) {
+        baseScript[lang.langCodeShort] = scriptClass(lang.script);
+      }
+    }
+
+    return _langList.where((lang) {
+      if (lang.langCode == lang.langCodeShort) return true; // base language
+      final base = baseScript[lang.langCodeShort];
+      if (base == null) return true; // no base row — don't drop the language
+      return scriptClass(lang.script) != base; // keep only a distinct script
+    }).toList();
+  }
 
   List<LanguageModel> get unlocalizedTargetOptions {
     final unlocalized = _langList

--- a/test/features/languages/locale_provider_test.dart
+++ b/test/features/languages/locale_provider_test.dart
@@ -1,0 +1,59 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:intl/date_symbol_data_local.dart';
+
+import 'package:fluffychat/features/languages/locale_provider.dart';
+
+void main() {
+  group('LocaleProvider.setLocale', () {
+    late LocaleProvider provider;
+    // setLocale validates the language via intl's date-locale data, which the
+    // app loads at startup; load it here too so the unit test mirrors runtime.
+    setUpAll(() async => initializeDateFormatting());
+    setUp(() => provider = LocaleProvider());
+
+    test('base language resolves to itself', () {
+      provider.setLocale('es');
+      expect(provider.locale, const Locale('es'));
+    });
+
+    test('hyphenated regional variant resolves to the base language', () {
+      provider.setLocale('es-MX');
+      expect(provider.locale, const Locale('es'));
+    });
+
+    test('underscore form also resolves to the base language', () {
+      provider.setLocale('en_US');
+      expect(provider.locale, const Locale('en'));
+    });
+
+    test('Simplified Chinese resolves to base zh', () {
+      provider.setLocale('zh-CN');
+      expect(provider.locale, const Locale('zh'));
+    });
+
+    test('Traditional Chinese maps to the zh_Hant translation', () {
+      const hant = Locale.fromSubtags(languageCode: 'zh', scriptCode: 'Hant');
+      provider.setLocale('zh-TW');
+      expect(provider.locale, hant);
+      provider.setLocale('zh-HK');
+      expect(provider.locale, hant);
+      provider.setLocale('zh-Hant');
+      expect(provider.locale, hant);
+    });
+
+    test('null / empty / unknown code clears the locale', () {
+      provider.setLocale('es');
+      provider.setLocale(null);
+      expect(provider.locale, isNull);
+      provider.setLocale('es');
+      provider.setLocale('');
+      expect(provider.locale, isNull);
+      provider.setLocale('es');
+      provider.setLocale('zzz');
+      expect(provider.locale, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## What

Fixes dialects appearing as L1 (native-language) options and rendering untranslated.

- **L1 picker filter** (`PLanguageStore.baseOptions`): drops same-script *regional* variants — English (US/UK/AU/India), Spanish (Spain/Mexico), Cantonese (HK), Flemish, Moldovan, Montenegrin, etc. (25 → 3 kept). Keeps genuinely different *writing systems*: Traditional Chinese, Jawi Malay, Shahmukhi Punjabi. Uses the CMS `script` field, collapsing near-identical scripts (Hani≈Hans, Arab≈Aran).
- **Locale resolution fix** (`LocaleProvider.setLocale`): the root cause of "untranslated dialects." It split codes on `_`, but CMS codes use `-` (`es-MX`, `zh-TW`), so a hyphenated code became a malformed `Locale('es-MX')` that matched nothing and fell back to English. Now it resolves to the language (dropping region), with Traditional Chinese (`zh-TW`/`zh-HK`/`zh-Hant`) mapped to the `intl_zh_Hant` translation.

Why both: filtering hides dialects from *new* selections, but the resolution fix is what repairs users who already picked one — and it fixes Chinese, where `zh-CN`/`zh-TW` also rendered English despite shipping `intl_zh` and `intl_zh_Hant`.

## Why

Closes #7809. Design captured in `language-list.instructions.md` (baseOptions row) and `localization.instructions.md` (resolution).

## Testing

- New `locale_provider_test.dart`: 6 tests — base language, hyphen/underscore regional → base, Simplified → `zh`, Traditional → `zh_Hant`, null/empty/unknown → cleared. All pass.
- Filter verified against the live CMS L1 set: 135 → 113, dropping exactly the 22 regional variants, keeping ms-Arab / pa-Arab / zh-TW.
- `flutter analyze` clean, `dart format` clean.

**TO TEST**
- [ ] Open the native-language (L1) picker — no "(US)", "(Mexico)", "(Brazil)" style dialect entries; one entry per language
- [ ] "Chinese (Traditional)", "Malay (Jawi)", "Punjabi (Shahmukhi)" still appear (distinct writing systems)
- [ ] Set L1 to a language and confirm the app UI shows in it (not English) — including Chinese Simplified and Traditional

## Deploy Notes

None
