### PR TITLE
fix(analytics): keep tab title constant, report screen name via GA page_title override

### DIFF
--- a/.github/instructions/google-analytics.instructions.md
+++ b/.github/instructions/google-analytics.instructions.md
@@ -94,16 +94,18 @@ per the engagement-analytics contract above.
   is a real screen view even though it replaces the history entry.
 - **Event vocabulary matches the token grammar**: `vocab` / `grammar`, never
   `morph`.
-- **On web, the page title mirrors the screen name — exactly, no prefix.**
-  GA's web layer reports by page title, and the web SDK's `screen_name`
-  param is invisible to GA's built-in dimensions (verified empirically: with
-  a Platform=web comparison, every screen-name row reads zero). So
-  `MaterialApp.title` follows the workspace screen name, making web rows
-  merge with app rows under "Page title and screen name". Off the workspace
-  (page routes) and on mobile, the title stays the application name. The
-  registered `screen_name` custom dimension ("Screen name web", declared in
-  the devops `analytics/ga-config.yaml` spec for both properties) remains
-  the event-grain key for Explorations and BigQuery.
+- **On web, GA's page_title field mirrors the screen name — exactly, no
+  prefix — while the visible tab title stays the application name.** GA's
+  web layer reports by page title, and the web SDK's `screen_name` param is
+  invisible to GA's built-in dimensions (verified empirically: with a
+  Platform=web comparison, every screen-name row reads zero). So the tracker
+  overrides the GA tag's `page_title` via `gtag('set')` on each screen
+  change, making web rows merge with app rows under "Page title and screen
+  name" — but `document.title` is never touched: the browser tab reads
+  "Pangea Chat" throughout. The registered `screen_name` custom dimension
+  ("Screen name web", declared in the devops `analytics/ga-config.yaml`
+  spec for both properties) remains the event-grain key for Explorations
+  and BigQuery.
 
 ## Event shape
 

--- a/lib/features/navigation/ga_page_title/ga_page_title_stub.dart
+++ b/lib/features/navigation/ga_page_title/ga_page_title_stub.dart
@@ -1,0 +1,4 @@
+/// No-op off web — GA app streams report screens natively via
+/// firebase_screen; only the web layer needs the page_title override.
+/// Web implementation: ga_page_title_web.dart.
+void setGaPageTitle(String name) {}

--- a/lib/features/navigation/ga_page_title/ga_page_title_web.dart
+++ b/lib/features/navigation/ga_page_title/ga_page_title_web.dart
@@ -1,0 +1,18 @@
+import 'dart:js_interop';
+
+@JS('gtag')
+external JSFunction? get _gtag;
+
+/// Point GA's page_title field at the current workspace screen name WITHOUT
+/// touching the visible document.title, which stays "Pangea Chat"
+/// (google-analytics.instructions.md). gtag('set') applies to all subsequent
+/// hits on the page, so page_views and screen_views report the token screen
+/// name while the browser tab keeps the app name.
+///
+/// gtag is absent when Firebase analytics init was skipped (no env config,
+/// e.g. local dev) — no-op in that case.
+void setGaPageTitle(String name) {
+  final gtag = _gtag;
+  if (gtag == null) return;
+  gtag.callAsFunction(null, 'set'.toJS, {'page_title': name}.jsify());
+}

--- a/lib/features/navigation/workspace_screen_tracker.dart
+++ b/lib/features/navigation/workspace_screen_tracker.dart
@@ -1,7 +1,7 @@
-import 'package:flutter/foundation.dart';
-
 import 'package:go_router/go_router.dart';
 
+import 'package:fluffychat/features/navigation/ga_page_title/ga_page_title_stub.dart'
+    if (dart.library.js_interop) 'package:fluffychat/features/navigation/ga_page_title/ga_page_title_web.dart';
 import 'package:fluffychat/features/navigation/screen_names.dart';
 import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
 
@@ -17,15 +17,6 @@ import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
 abstract class WorkspaceScreenTracker {
   static String? _lastScreenName;
 
-  /// On web, the current workspace screen name, for `MaterialApp.title` to
-  /// mirror into `document.title`. GA's web layer reports by page title (the
-  /// web SDK's screen_name param is invisible to built-in reports); mirroring
-  /// the screen name — exactly, no prefix — makes web rows merge with app rows
-  /// under GA's "Page title and screen name" dimension. Null off the
-  /// workspace (page routes keep the app name). Always null on mobile, where
-  /// the title labels the OS task switcher instead.
-  static final ValueNotifier<String?> webTitle = ValueNotifier(null);
-
   /// Listen to [router] for the app's lifetime, emitting on each real change.
   static void attach(GoRouter router) {
     final provider = router.routeInformationProvider;
@@ -38,7 +29,10 @@ abstract class WorkspaceScreenTracker {
     final name = ScreenNames.forWorkspace(uri);
     if (name == _lastScreenName) return;
     _lastScreenName = name;
-    if (kIsWeb) webTitle.value = name;
+    // On web, GA's page_title field follows the screen name so built-in
+    // reports show panels — but the visible document.title stays the app
+    // name (google-analytics.instructions.md). No-op off web.
+    setGaPageTitle(name);
     GoogleAnalytics.logScreenView(name);
   }
 }

--- a/lib/features/navigation/workspace_screen_tracker.dart
+++ b/lib/features/navigation/workspace_screen_tracker.dart
@@ -1,9 +1,10 @@
 import 'package:go_router/go_router.dart';
 
-import 'package:fluffychat/features/navigation/ga_page_title/ga_page_title_stub.dart'
-    if (dart.library.js_interop) 'package:fluffychat/features/navigation/ga_page_title/ga_page_title_web.dart';
 import 'package:fluffychat/features/navigation/screen_names.dart';
 import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
+
+import 'package:fluffychat/features/navigation/ga_page_title/ga_page_title_stub.dart'
+    if (dart.library.js_interop) 'package:fluffychat/features/navigation/ga_page_title/ga_page_title_web.dart';
 
 /// Emits a GA4 screen view whenever the workspace screen changes, keyed on the
 /// token-derived name from [ScreenNames] (google-analytics.instructions.md).

--- a/lib/widgets/fluffy_chat_app.dart
+++ b/lib/widgets/fluffy_chat_app.dart
@@ -13,7 +13,6 @@ import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/languages/locale_provider.dart';
 import 'package:fluffychat/features/navigation/legacy_redirects.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
-import 'package:fluffychat/features/navigation/workspace_screen_tracker.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
 import 'package:fluffychat/widgets/app_lock.dart';
@@ -64,60 +63,46 @@ class FluffyChatApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ThemeBuilder(
-      // #Pangea
-      // builder: (context, themeMode, primaryColor) => MaterialApp.router(
-      //   title: AppSettings.applicationName.value,
-      builder: (context, themeMode, primaryColor) => ValueListenableBuilder(
-        valueListenable: WorkspaceScreenTracker.webTitle,
-        builder: (context, webTitle, _) => MaterialApp.router(
-          // On web the GA screen name doubles as document.title so panel
-          // screens report by title (workspace_screen_tracker.dart); off the
-          // workspace (and on mobile) it is null and the app name applies.
-          title: webTitle ?? AppSettings.applicationName.value,
-          // Pangea#
-          themeMode: themeMode,
-          theme: FluffyThemes.buildTheme(
-            context,
-            Brightness.light,
-            primaryColor,
-          ),
-          darkTheme: FluffyThemes.buildTheme(
-            context,
-            Brightness.dark,
-            primaryColor,
-          ),
-          scrollBehavior: CustomScrollBehavior(),
-          // #Pangea
-          locale: Provider.of<LocaleProvider>(context).locale,
-          // localizationsDelegates: L10n.localizationsDelegates,
-          localizationsDelegates: const [
-            L10n.delegate,
-            GlobalMaterialLocalizations.delegate,
-            GlobalCupertinoLocalizations.delegate,
-            GlobalWidgetsLocalizations.delegate,
-            CountryLocalizations.delegate,
-          ],
-          // Pangea#
-          supportedLocales: L10n.supportedLocales,
-          routerConfig: router,
-          // #Pangea
-          // builder: (context, child) => AppLockWidget(
-          builder: (context, child) => Directionality(
-            textDirection: TextDirection.ltr,
-            child: AppLockWidget(
-              pincode: pincode,
+      builder: (context, themeMode, primaryColor) => MaterialApp.router(
+        title: AppSettings.applicationName.value,
+        themeMode: themeMode,
+        theme: FluffyThemes.buildTheme(context, Brightness.light, primaryColor),
+        darkTheme: FluffyThemes.buildTheme(
+          context,
+          Brightness.dark,
+          primaryColor,
+        ),
+        scrollBehavior: CustomScrollBehavior(),
+        // #Pangea
+        locale: Provider.of<LocaleProvider>(context).locale,
+        // localizationsDelegates: L10n.localizationsDelegates,
+        localizationsDelegates: const [
+          L10n.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          CountryLocalizations.delegate,
+        ],
+        // Pangea#
+        supportedLocales: L10n.supportedLocales,
+        routerConfig: router,
+        // #Pangea
+        // builder: (context, child) => AppLockWidget(
+        builder: (context, child) => Directionality(
+          textDirection: TextDirection.ltr,
+          child: AppLockWidget(
+            pincode: pincode,
+            clients: clients,
+            // Need a navigator above the Matrix widget for
+            // displaying dialogs
+            child: Matrix(
               clients: clients,
-              // Need a navigator above the Matrix widget for
-              // displaying dialogs
-              child: Matrix(
-                clients: clients,
-                store: store,
-                child: testWidget ?? child,
-              ),
+              store: store,
+              child: testWidget ?? child,
             ),
           ),
-          // Pangea#
         ),
+        // Pangea#
       ),
     );
   }


### PR DESCRIPTION
## What
The browser tab reads "Pangea Chat" everywhere again; GA still receives the token screen name as page_title.

## Why
Closes #7855. #7817 mirrored the workspace screen name into document.title so GA's web reports show panels — side effect: the visible tab title changed per panel ("world", "chats"). Requirement per Will: the visible title stays "Pangea Chat" throughout.

## Changes
- Revert the MaterialApp title plumbing — title is the app name again, unconditionally
- `setGaPageTitle` (web-only via conditional import, dart:js_interop): on each workspace screen change, `gtag('set', {page_title: <screen name>})` — GA's page_title field follows the screen name while document.title is never touched; no-op when gtag is absent (local dev) and off web
- google-analytics.instructions.md bullet updated to record the resolved design (discussed in chat)

## Testing
- `flutter test test/pangea/navigation/` passes; analyzer clean on changed files
- Local web run against staging: tab title stays "Pangea Chat" from load onward (previously flipped to "world" seconds after load); gtag path no-ops cleanly without analytics config
- Deferred: the gtag('set') page_title behavior needs a configured build — will verify on staging immediately post-deploy (collect requests should carry the screen name as page title while the tab shows "Pangea Chat")

🤖 Generated with [Claude Code](https://claude.com/claude-code)