### PR TITLE
Only default to peek on main selected course page

### DIFF
--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -668,7 +668,7 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
         // A course card opens at peek (the map leads); sections and the
         // activity plan open at half (the plan keeps its pin visible above —
         // the Google Maps UX).
-        cavityDefaultsToPeek: isCourseCavity,
+        cavityDefaultsToPeek: cavityToken?.type == PanelTypesEnum.course,
         // Dismissing the activity plan sheet (drag down, or its own back/X)
         // CLOSES the plan — dropping its token clears the map's activity
         // focus (#7614; world-map.instructions.md). Map taps do NOT dismiss:


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
