### PR TITLE
Remove odd gap at bottom of onboarding language selection list

### DIFF
--- a/lib/routes/onboarding/onboarding_step_views/pick_language_step_view.dart
+++ b/lib/routes/onboarding/onboarding_step_views/pick_language_step_view.dart
@@ -185,7 +185,6 @@ class PickLanguageStepViewState extends State<PickLanguageStepView> {
                               padding: const EdgeInsets.only(
                                 left: 16.0,
                                 right: 16.0,
-                                bottom: 60.0,
                               ),
                               sliver: ValueListenableBuilder(
                                 valueListenable: _selectedTargetLanguage,


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
