### PR TITLE
Mobile build announcements: drop testers phrase, use dispatch notes as Summary

### DIFF
--- a/.github/workflows/android-playstore.yml
+++ b/.github/workflows/android-playstore.yml
@@ -26,7 +26,7 @@ on:
      new_release_notes:
         required: true
         type: string
-        description: "The release notes for the new release (Unused atm)"
+        description: "Posted to Release Announcements as the build's Summary (plain text; or paste '## Summary' / '## To Test' markdown sections)"
 
 permissions:
   contents: read
@@ -116,6 +116,7 @@ jobs:
     with:
       service_name: "Pangea Chat Android"
       version: ${{ needs.deploy_playstore_internal.outputs.version }}
-      headline: "(${{ inputs.environment }}) is on the Play Store internal track — internal testers get it automatically"
+      headline: "(${{ inputs.environment }}) is on the Play Store internal track"
+      release_body: ${{ inputs.new_release_notes }}
     secrets:
       aws_role_arn: ${{ secrets.AWS_ROLE_ARN_PROD }}

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -11,6 +11,10 @@ on:
       environment:
         required: true
         type: string
+      new_release_notes:
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       environment:
@@ -20,6 +24,11 @@ on:
           - staging
           - production
         default: "staging"
+      new_release_notes:
+        required: false
+        type: string
+        default: ""
+        description: "Posted to Release Announcements as the build's Summary (plain text; or paste '## Summary' / '## To Test' markdown sections)"
 
 permissions:
   contents: read
@@ -98,6 +107,7 @@ jobs:
     with:
       service_name: "Pangea Chat iOS"
       version: ${{ needs.build_ios_testflight.outputs.version }}
-      headline: "(${{ inputs.environment }}) is on TestFlight — internal testers get it automatically"
+      headline: "(${{ inputs.environment }}) is on TestFlight"
+      release_body: ${{ inputs.new_release_notes }}
     secrets:
       aws_role_arn: ${{ secrets.AWS_ROLE_ARN_PROD }}

--- a/.github/workflows/notify-matrix-build.yml
+++ b/.github/workflows/notify-matrix-build.yml
@@ -3,7 +3,8 @@ name: Notify Matrix — Build/Deploy
 # public, and GitHub does not allow public repos to call reusable workflows
 # from private repos, so the org workflow can't be referenced here (same
 # constraint as sygnal, which inlines these steps). Keep in sync with the org
-# workflow when it changes.
+# workflow when it changes. One deliberate divergence: a release_body with no
+# template sections is treated entirely as the Summary (see parse step).
 
 on:
   workflow_call:
@@ -92,6 +93,12 @@ jobs:
 
           summary = extract_section(body, "Summary")
           to_test = extract_section(body, "To Test")
+
+          # Local divergence from the org workflow: a non-empty body with no
+          # template sections (e.g. the free-text notes field on manual
+          # mobile-build dispatches) is treated as the Summary.
+          if body.strip() and not summary and not to_test:
+              summary = body.strip()
 
           # Plain text (markdown) — fallback for clients without HTML support
           plain = f"\U0001f680 **{service} {version}** {headline}"


### PR DESCRIPTION
## Summary

Refines the mobile build announcements per feedback on the first live message:

- Drops "— internal testers get it automatically" from both headlines.
- The `new_release_notes` dispatch field (previously labeled "Unused atm") now flows into the announcement: plain text renders as the **Summary**; pasting `## Summary` / `## To Test` markdown sections renders both, matching other services' release notes. iOS gains the same (optional) field.
- Local notifier divergence (documented in its header): a body with no template sections is treated entirely as the Summary.

Production mobile builds ride release.yaml, whose auto-generated release bodies have no template sections, so they stay headline-only for now — adopting authored release notes for client releases is a separate process decision.

## To Test

1. Actions → **Build Android and upload to Play Store internal track** → Run workflow (staging) with a sentence in the notes field.
2. Confirm the Release Announcements message shows that sentence under **Summary** and no longer contains the testers phrase.

(Message formatting for plain/template/empty notes verified locally against the parse script; the Matrix posting path was verified live on run 29936186853.)