### PR TITLE
ci: post-deploy smoke for deep-link files and served scripts

### DIFF
--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -178,7 +178,41 @@ jobs:
           done
       - name: Invalidate CloudFront cache
         run: |
-          aws cloudfront create-invalidation --distribution-id $CF_DISTRIBUTION_ID --paths "/*"
+          INVALIDATION_ID=$(aws cloudfront create-invalidation \
+            --distribution-id $CF_DISTRIBUTION_ID --paths "/*" \
+            --query 'Invalidation.Id' --output text)
+          echo "INVALIDATION_ID=$INVALIDATION_ID" >> "$GITHUB_ENV"
+      - name: Post-deploy smoke — deep-link files and served scripts
+        # The SPA index fallback serves index.html with a 200 for ANY missing
+        # path (deep-link design, joining-courses.instructions.md), which
+        # turns two loud failures silent: a dropped .well-known file breaks
+        # installed-app links invisibly, and a missing build artifact
+        # presents as a white screen instead of a 404. This step makes them
+        # loud again at deploy time (#7862).
+        run: |
+          set -e
+          BASE="https://app.staging.pangea.chat"
+          aws cloudfront wait invalidation-completed \
+            --distribution-id $CF_DISTRIBUTION_ID --id "$INVALIDATION_ID"
+
+          # 1. .well-known files are real JSON carrying the app id — not the
+          #    SPA fallback's HTML.
+          for f in apple-app-site-association assetlinks.json; do
+            curl -sf "$BASE/.well-known/$f" \
+              | python3 -c "import sys,json; assert 'com.talktolearn.chat' in json.dumps(json.load(sys.stdin))" \
+              || { echo "::error::.well-known/$f is missing, invalid JSON, or lacks the app id (SPA fallback?)"; exit 1; }
+          done
+
+          # 2. Runtime entry scripts serve as JavaScript, not the SPA shell.
+          for f in flutter.js main.dart.js; do
+            head=$(curl -sf "$BASE/$f" | head -c 1)
+            [ "$head" != "<" ] && [ -n "$head" ] \
+              || { echo "::error::$f served HTML or empty — partial deploy?"; exit 1; }
+          done
+
+          # 3. A deep path serves the SPA shell (the fallback is alive).
+          curl -sf "$BASE/zz9smoke" | grep -qi "<html\|<base\|flutter" \
+            || { echo "::error::deep path did not serve the SPA shell — fallback broken?"; exit 1; }
 
   update_sentry:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -282,7 +282,41 @@ jobs:
           done
       - name: Invalidate CloudFront cache
         run: |
-          aws cloudfront create-invalidation --distribution-id $CF_DISTRIBUTION_ID --paths "/*"
+          INVALIDATION_ID=$(aws cloudfront create-invalidation \
+            --distribution-id $CF_DISTRIBUTION_ID --paths "/*" \
+            --query 'Invalidation.Id' --output text)
+          echo "INVALIDATION_ID=$INVALIDATION_ID" >> "$GITHUB_ENV"
+      - name: Post-deploy smoke — deep-link files and served scripts
+        # The SPA index fallback serves index.html with a 200 for ANY missing
+        # path (deep-link design, joining-courses.instructions.md), which
+        # turns two loud failures silent: a dropped .well-known file breaks
+        # installed-app links invisibly, and a missing build artifact
+        # presents as a white screen instead of a 404. This step makes them
+        # loud again at deploy time (#7862).
+        run: |
+          set -e
+          BASE="https://app.pangea.chat"
+          aws cloudfront wait invalidation-completed \
+            --distribution-id $CF_DISTRIBUTION_ID --id "$INVALIDATION_ID"
+
+          # 1. .well-known files are real JSON carrying the app id — not the
+          #    SPA fallback's HTML.
+          for f in apple-app-site-association assetlinks.json; do
+            curl -sf "$BASE/.well-known/$f" \
+              | python3 -c "import sys,json; assert 'com.talktolearn.chat' in json.dumps(json.load(sys.stdin))" \
+              || { echo "::error::.well-known/$f is missing, invalid JSON, or lacks the app id (SPA fallback?)"; exit 1; }
+          done
+
+          # 2. Runtime entry scripts serve as JavaScript, not the SPA shell.
+          for f in flutter.js main.dart.js; do
+            head=$(curl -sf "$BASE/$f" | head -c 1)
+            [ "$head" != "<" ] && [ -n "$head" ] \
+              || { echo "::error::$f served HTML or empty — partial deploy?"; exit 1; }
+          done
+
+          # 3. A deep path serves the SPA shell (the fallback is alive).
+          curl -sf "$BASE/zz9smoke" | grep -qi "<html\|<base\|flutter" \
+            || { echo "::error::deep path did not serve the SPA shell — fallback broken?"; exit 1; }
 
   update_sentry:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

After the CloudFront invalidation completes, staging and prod deploys assert: `.well-known/apple-app-site-association` + `assetlinks.json` are real JSON carrying the app id; `flutter.js` + `main.dart.js` serve as JavaScript (not the SPA shell); and a deep path serves the SPA shell. The invalidation step now captures its id so the smoke can wait on it.

## Why

Closes #7862 — the SPA index fallback (devops#234) turns dropped `.well-known` files and partial-sync artifacts into silent HTML-200s; this makes them fail the deploy loudly instead.

## Testing

- All five assertions run green against live staging right now; YAML validated
- The real proof is the staging deploy this PR triggers on merge — its own smoke step runs

## Deploy Notes

None.