### PR TITLE
style: sort imports in locale_provider_test to unbreak CI on main

### DIFF
--- a/test/features/languages/locale_provider_test.dart
+++ b/test/features/languages/locale_provider_test.dart
@@ -1,7 +1,6 @@
 import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:intl/date_symbol_data_local.dart';
 
 import 'package:fluffychat/features/languages/locale_provider.dart';


### PR DESCRIPTION
## What
One-line import sort in `test/features/languages/locale_provider_test.dart`.

## Why
Addresses #7855's CI noise / unbreaks main. #7854 merged while its CI run was cancelled, landing an unsorted import on main — since PR CI runs on the merge ref, every open PR now fails the `import_sorter` gate regardless of its own content (verified by reproducing CI's exact toolchain via fvm 3.41.4: clean branch passes, merge-with-main fails on this file).

## Testing
- `fvm dart run import_sorter:main --no-comments --exit-if-changed` clean after the fix (Flutter 3.41.4, CI's pin)
- `fvm flutter test test/features/languages/locale_provider_test.dart` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)