### PR TITLE
Add background to left chat page

### DIFF
--- a/lib/routes/world/left_panel/left_panel_room_subpage.dart
+++ b/lib/routes/world/left_panel/left_panel_room_subpage.dart
@@ -35,7 +35,10 @@ class LeftPanelRoomSubpage extends StatelessWidget {
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: Text(L10n.of(context).youAreNoLongerParticipatingInThisChat),
+          child: Text(
+            L10n.of(context).youAreNoLongerParticipatingInThisChat,
+            textAlign: TextAlign.center,
+          ),
         ),
       ),
     );

--- a/lib/routes/world/left_panel/left_panel_room_subpage.dart
+++ b/lib/routes/world/left_panel/left_panel_room_subpage.dart
@@ -11,7 +11,6 @@ import 'package:fluffychat/routes/chat/chat_details/chat_details.dart';
 import 'package:fluffychat/routes/chat/chat_details/invite/pangea_invitation_selection.dart';
 import 'package:fluffychat/routes/chat/chat_search/chat_search_page.dart';
 import 'package:fluffychat/routes/world/left_panel/left_panel_room_details_subpage.dart';
-import 'package:fluffychat/routes/world/panel_header.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/share_scaffold_dialog.dart';
 
@@ -29,24 +28,16 @@ class LeftPanelRoomSubpage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Give the empty state the panel's close control (#7746): without a header
-    // the "no longer participating" message stranded the user with no way to
-    // dismiss the panel back to the map. Mirrors the chrome of sibling subpages.
-    final emptyPage = Column(
-      children: [
-        PanelHeader(leading: closeButton, title: ''),
-        Expanded(
-          child: Center(
-            child: Padding(
-              padding: const EdgeInsets.all(24),
-              child: Text(
-                L10n.of(context).youAreNoLongerParticipatingInThisChat,
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ),
+    // Give the empty state the panel's close control (#7746)
+    // to avoid stranding the user
+    final emptyPage = Scaffold(
+      appBar: AppBar(leading: closeButton),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Text(L10n.of(context).youAreNoLongerParticipatingInThisChat),
         ),
-      ],
+      ),
     );
 
     final id = param?.id;

--- a/test/pangea/navigation/left_panel_room_subpage_empty_state_test.dart
+++ b/test/pangea/navigation/left_panel_room_subpage_empty_state_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/world/left_panel/left_panel_room_subpage.dart';
-import 'package:fluffychat/routes/world/panel_header.dart';
 
 void main() {
   testWidgets(
@@ -43,9 +42,8 @@ void main() {
         find.text(l10n.youAreNoLongerParticipatingInThisChat),
         findsOneWidget,
       );
-      // The empty state now carries the panel header + the injected close
+      // The empty state now carries the injected close
       // control, so the user can dismiss it back to the map.
-      expect(find.byType(PanelHeader), findsOneWidget);
       expect(find.byKey(closeKey), findsOneWidget);
     },
   );


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the unavailable or invalid room screen with a standard app bar and close control.
  * Simplified the empty-state layout and spacing for a more consistent presentation.

* **Tests**
  * Updated coverage to verify that the close control appears in the room’s empty state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->