### PR TITLE
Start chat analytics xp ring at level badge

### DIFF
--- a/lib/routes/world/circular_xp_ring_painter.dart
+++ b/lib/routes/world/circular_xp_ring_painter.dart
@@ -41,7 +41,7 @@ class CircularXpRingPainter extends CustomPainter {
     if (p <= 0) return;
     canvas.drawArc(
       rect,
-      -math.pi / 2,
+      -2 * math.pi / 3,
       2 * math.pi * p,
       false,
       Paint()

--- a/lib/routes/world/circular_xp_ring_painter.dart
+++ b/lib/routes/world/circular_xp_ring_painter.dart
@@ -3,7 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 
 /// Paints the collapsed avatar's XP ring: a full gray circular track with a
-/// gold arc filling clockwise from the top for [progress] (0-1) of the way to
+/// gold arc filling clockwise from the level badge for [progress] (0-1) of the way to
 /// the next level. The cluster's `XpBorderPainter` traces the powerups pill's
 /// rounded-rect outline instead, so the circular avatar needs this simpler
 /// circular counterpart rather than reusing it as-is.


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the XP progress ring so the gold arc begins near the level badge and fills clockwise.
  * Clarified the progress ring’s visual behavior in its documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->