### PR TITLE
Don't reserve space for empty about me

### DIFF
--- a/lib/widgets/users/about_me_display.dart
+++ b/lib/widgets/users/about_me_display.dart
@@ -24,7 +24,7 @@ class AboutMeDisplay extends StatelessWidget {
         ),
         builder: (context, snapshot) {
           final about = snapshot.data?.about;
-          return about == null
+          return about == null || about.trim().isEmpty
               ? const SizedBox.shrink()
               : AboutMeText(about: about, textSize: textSize);
         },


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile display handling so blank “About” sections are hidden instead of showing empty space.
  * Existing “About” content continues to display normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->