### PR TITLE
fix: wrap tutorial overlay to block semantics passing clicks to lower…

### DIFF
--- a/lib/features/tutorials/tutorial_overlay_widget.dart
+++ b/lib/features/tutorials/tutorial_overlay_widget.dart
@@ -258,92 +258,96 @@ class _TutorialOverlayWidgetState extends State<TutorialOverlayWidget> {
     final hasTargetPosition =
         _lastTargetOffset != null && _lastTargetSize != null;
 
-    return MouseRegion(
-      cursor: step != null && _visible
-          ? SystemMouseCursors.click
-          : SystemMouseCursors.basic,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: step != null && _visible ? () => _next(step) : null,
-        child: Stack(
-          children: [
-            AnimatedOpacity(
-              opacity: _visible && step != null && hasTargetPosition
-                  ? 1.0
-                  : 0.0,
-              duration: _duration,
-              child: step != null
-                  ? ColorFiltered(
-                      colorFilter: const ColorFilter.mode(
-                        Colors.black,
-                        BlendMode.srcOut,
-                      ),
-                      child: Stack(
-                        children: [
-                          /// Overlay + layer
-                          Container(
-                            decoration: BoxDecoration(
-                              color: Colors.black.withAlpha(100),
-                            ),
+    return BlockSemantics(
+      child: MouseRegion(
+        cursor: step != null && _visible
+            ? SystemMouseCursors.click
+            : SystemMouseCursors.basic,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: step != null && _visible ? () => _next(step) : null,
+          child: Stack(
+            children: [
+              AnimatedOpacity(
+                opacity: _visible && step != null && hasTargetPosition
+                    ? 1.0
+                    : 0.0,
+                duration: _duration,
+                child: step != null
+                    ? ExcludeSemantics(
+                        child: ColorFiltered(
+                          colorFilter: const ColorFilter.mode(
+                            Colors.black,
+                            BlendMode.srcOut,
                           ),
-
-                          /// The "hole"
-                          CompositedTransformFollower(
-                            link: MatrixState.pAnyState
-                                .layerLinkAndKey(step.data.targetKey)
-                                .link,
-                            showWhenUnlinked: false,
-                            targetAnchor: Alignment.center,
-                            followerAnchor: Alignment.center,
-                            child: Container(
-                              width: holeWidth,
-                              height: holeHeight,
-                              decoration: BoxDecoration(
-                                color: Colors.white,
-                                borderRadius: BorderRadius.circular(
-                                  step.style.borderRadius ?? 16,
+                          child: Stack(
+                            children: [
+                              /// Overlay + layer
+                              Container(
+                                decoration: BoxDecoration(
+                                  color: Colors.black.withAlpha(100),
                                 ),
                               ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    )
-                  : const SizedBox.shrink(),
-            ),
 
-            if (_visible && step != null && hasTargetPosition)
-              CompositedTransformFollower(
-                link: MatrixState.pAnyState
-                    .layerLinkAndKey(step.data.targetKey)
-                    .link,
-                showWhenUnlinked: false,
-                targetAnchor: showAbove
-                    ? Alignment.topCenter
-                    : Alignment.bottomCenter,
-                followerAnchor: showAbove
-                    ? Alignment.bottomCenter
-                    : Alignment.topCenter,
-                offset: Offset(
-                  _tooltipHorizontalOffset(stepSize) ?? 0,
-                  showAbove
-                      ? -_tooltipPadding
-                      : _tooltipPadding, // gap between target and tooltip
-                ),
-                child: TutorialTooltipContainerWidget(
-                  width: step.style.tooltipSize.width,
-                  height: step.style.tooltipSize.height,
-                  padding: _tooltipPadding,
-                  onNext: () => _next(step),
-                  onPrevious: _previous,
-                  showNext: showNavigation && widget.enabledForward,
-                  showPrevious: showNavigation && widget.enabledBack,
-                  currentStep: widget.completedSteps,
-                  totalSteps: widget.totalSteps,
-                  text: step.style.tooltip,
-                ),
+                              /// The "hole"
+                              CompositedTransformFollower(
+                                link: MatrixState.pAnyState
+                                    .layerLinkAndKey(step.data.targetKey)
+                                    .link,
+                                showWhenUnlinked: false,
+                                targetAnchor: Alignment.center,
+                                followerAnchor: Alignment.center,
+                                child: Container(
+                                  width: holeWidth,
+                                  height: holeHeight,
+                                  decoration: BoxDecoration(
+                                    color: Colors.white,
+                                    borderRadius: BorderRadius.circular(
+                                      step.style.borderRadius ?? 16,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      )
+                    : const SizedBox.shrink(),
               ),
-          ],
+
+              if (_visible && step != null && hasTargetPosition)
+                CompositedTransformFollower(
+                  link: MatrixState.pAnyState
+                      .layerLinkAndKey(step.data.targetKey)
+                      .link,
+                  showWhenUnlinked: false,
+                  targetAnchor: showAbove
+                      ? Alignment.topCenter
+                      : Alignment.bottomCenter,
+                  followerAnchor: showAbove
+                      ? Alignment.bottomCenter
+                      : Alignment.topCenter,
+                  offset: Offset(
+                    _tooltipHorizontalOffset(stepSize) ?? 0,
+                    showAbove
+                        ? -_tooltipPadding
+                        : _tooltipPadding, // gap between target and tooltip
+                  ),
+                  child: TutorialTooltipContainerWidget(
+                    width: step.style.tooltipSize.width,
+                    height: step.style.tooltipSize.height,
+                    padding: _tooltipPadding,
+                    onNext: () => _next(step),
+                    onPrevious: _previous,
+                    showNext: showNavigation && widget.enabledForward,
+                    showPrevious: showNavigation && widget.enabledBack,
+                    currentStep: widget.completedSteps,
+                    totalSteps: widget.totalSteps,
+                    text: step.style.tooltip,
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
… overlay

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
