### PR TITLE
Fix links blending into own-message bubble in light mode (#7874)

### DIFF
--- a/lib/routes/chat/message.dart
+++ b/lib/routes/chat/message.dart
@@ -234,10 +234,10 @@ class Message extends StatelessWidget {
     //           ? theme.colorScheme.primaryFixed
     //           : theme.colorScheme.onTertiaryContainer
     //     : theme.colorScheme.primary;
-    final linkColor = theme.brightness == Brightness.light
-        ? theme.colorScheme.primary
-        : ownMessage
+    final linkColor = ownMessage
         ? theme.colorScheme.onPrimary
+        : theme.brightness == Brightness.light
+        ? theme.colorScheme.primary
         : theme.colorScheme.onSurface;
     // Pangea#
 

--- a/lib/routes/chat/toolbar/layout/overlay_message.dart
+++ b/lib/routes/chat/toolbar/layout/overlay_message.dart
@@ -98,10 +98,10 @@ class OverlayMessage extends StatelessWidget {
         ? theme.colorScheme.onPrimary
         : theme.colorScheme.onSurface;
 
-    final linkColor = theme.brightness == Brightness.light
-        ? theme.colorScheme.primary
-        : ownMessage
+    final linkColor = ownMessage
         ? theme.colorScheme.onPrimary
+        : theme.brightness == Brightness.light
+        ? theme.colorScheme.primary
         : theme.colorScheme.onSurface;
 
     final displayEvent = event.getDisplayEvent(timeline);


### PR DESCRIPTION
Fixes #7874

## Problem
Own messages now use a primary-colored bubble. In light mode `linkColor` was always `colorScheme.primary`, so links inside your own message rendered primary-on-primary and blended into the bubble background.

## Fix
Select link color by ownership first: own-message links use `onPrimary` (in both light and dark), matching the message text color; other messages are unchanged (`primary` in light, `onSurface` in dark). Applied in both the timeline bubble (`message.dart`) and the toolbar overlay's enlarged copy of the same bubble (`overlay_message.dart`).

| context | mode | before | after |
|---|---|---|---|
| own message | light | primary (blended) | onPrimary |
| own message | dark | onPrimary | onPrimary |
| other message | light | primary | primary |
| other message | dark | onSurface | onSurface |

## TO TEST
- [ ] In light mode, send a message containing a link in a chat — the link is clearly visible against your own (primary) message bubble
- [ ] In dark mode, send a message containing a link — the link is still visible
- [ ] Links in messages from others remain visible in both light and dark modes
- [ ] Open the message toolbar/overlay on a link message and confirm the link is visible there too
