### PR TITLE
fix: 'Requires analytics to join' toggle errors on course invite page (#7799)

### DIFF
--- a/lib/routes/courses/own/invite/course_invite_page.dart
+++ b/lib/routes/courses/own/invite/course_invite_page.dart
@@ -80,7 +80,12 @@ class CourseInvitePageController extends State<CourseInvitePage>
               e.roomId == spaceId &&
               e.state.type == PangeaEventTypes.coursePlan,
         ),
-      if (room?.requireAnalyticsAccess != true)
+      // Wait for the courseSettings state event to be PRESENT, not for its
+      // value to be true. Keying on requireAnalyticsAccess conflates "state
+      // synced" with "analytics enabled": once the user toggles analytics off,
+      // every getSpaceId() call would otherwise hang 10s waiting for a
+      // courseSettings event that never comes, then throw (#7799).
+      if (room?.getState(PangeaEventTypes.courseSettings) == null)
         roomStateStream.firstWhere(
           (e) =>
               e.roomId == spaceId &&


### PR DESCRIPTION
Fixes #7799.

## Problem
On the post-creation course invite page, toggling **Requires analytics to join** off loads for ~10s, then shows an error and resets the **Allow others to search for your course** toggle. Afterwards every toggle on the page exhibits the same loading/error behavior.

## Root cause
`getSpaceId()` (run before every toggle write and by both toggles' `FutureBuilder`s) waits for the `courseSettings` state event to sync. The wait added in #7642 was keyed on `room?.requireAnalyticsAccess != true`, which conflates *"the courseSettings state has synced"* with *"analytics is enabled"*.

At creation, analytics defaults to `true`, so the condition correctly waits for the state to arrive. But once the user toggles analytics **off**, `requireAnalyticsAccess` is `false`, so every subsequent `getSpaceId()` waits 10s for a `courseSettings` event that never comes, then throws. The `_isPublic` / `_requireAnalyticsAccess` `FutureBuilder`s catch that and fall back to `true` — the "error + visibility reset" the reporter saw — and it poisons every other toggle too.

## Fix
Wait for the `courseSettings` state event to be **present** (`getState(...) == null`), not for its value to be `true`. Same intent as #7642 (don't render the toggle until state has loaded), without hanging when analytics is off.

## Changes
- `lib/routes/courses/own/invite/course_invite_page.dart` — `getSpaceId()` gates the courseSettings sync-wait on state-event presence rather than on `requireAnalyticsAccess != true`.

## TO TEST
- [ ] Create a course
- [ ] Toggle **Requires analytics to join** off — no loading hang, no error
- [ ] Confirm **Allow others to search for your course** does not reset when toggling analytics
- [ ] Toggle **Allow others to search for your course** on/off — behaves as expected
- [ ] Toggle both back and forth a few times — each responds immediately
- [ ] Proceed with **Invite your friends** / **Play with AI for now** — course opens fine