### PR TITLE
fix(analytics): stamp GA user_id before slow sync awaits

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -147,6 +147,20 @@ Future<void> startGui(List<Client> clients, SharedPreferences store) async {
 
   // Preload first client
   final firstClient = clients.firstOrNull;
+
+  // #Pangea
+  // Stamp the GA user id as early as possible — before the rooms/account-data
+  // sync awaits below, which can be slow on a cold start. Otherwise
+  // early-session events (session_start, first screen views) fire with only
+  // the pseudonymous device id, which GA4 surfaces as a bare number (#7789).
+  // userID is restored from local storage by getClients(), so it is already
+  // known here. The post-sync call further down re-affirms it and clears it if
+  // the staging/prod mismatch check logs the client out.
+  await GoogleAnalytics.analyticsUserUpdate(
+    clients.firstWhereOrNull((c) => c.isLogged())?.userID,
+  );
+  // Pangea#
+
   await firstClient?.roomsLoading;
   await firstClient?.accountDataLoading;
 


### PR DESCRIPTION
## What
Move the boot-time `GoogleAnalytics.analyticsUserUpdate` call ahead of the `roomsLoading` / `accountDataLoading` awaits in `startGui`, so the GA4 `user_id` is set as early as the GUI path allows. The existing post-sync call is kept as the authoritative correction (it clears the id if the staging/prod mismatch check logs the client out).

## Why
Addresses #7789 (users showing as bare numbers in GA). `user_id` was previously stamped only *after* the cold-start sync awaits, so early-session events (`session_start`, first screen views) fired with only the pseudonymous device id — which GA4 surfaces as `1116834636.1768936784`-style numbers. `userID` is restored from local storage by `getClients()` and is already known before those awaits.

Serves the existing intent in `google-analytics.instructions.md` ("the learner rides every event as the GA4 user id") — no design change.

Scope note: this raises `user_id` coverage; it is not the whole issue. Verified in prod BigQuery that Reporting Identity is already **Blended** (uses user_id first), so that setting is not the cause. Fully-anonymous lifecycle events before any client loads remain inherently unattributed, and reports keyed on the **User pseudo ID** dimension will always show numbers regardless — use the **User ID** dimension.

## Testing
- `dart analyze lib/main.dart` → No issues found.
- Runtime attribution is **not observable locally**: analytics init is deliberately skipped in local dev when no Firebase env config is present (`firebase_analytics.dart` `initialize()`), so `setUserId` is a no-op off a deploy build.
- Post-deploy verification (staging): re-run the GA4 BigQuery coverage query and confirm `session_start` / early `screen_view` events for a returning logged-in user now carry `user_id`.

## Deploy Notes
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Improved analytics initialization so user identity is available earlier during app startup.
  * User identity continues to be refreshed after workspace initialization completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->