### PR TITLE
chore: remove references to deprecated message reporting flow

### DIFF
--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -116,7 +116,6 @@ import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/utils/other_party_can_receive.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/show_scaffold_dialog.dart';
-import 'package:fluffychat/widgets/adaptive_dialogs/show_modal_action_popup.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_text_input_dialog.dart';
 import 'package:fluffychat/widgets/announcing_snackbar.dart';
@@ -1815,55 +1814,6 @@ class ChatController extends State<ChatPageWithRoom>
     //   selectedEvents.clear();
     // });
     clearSelectedEvents();
-    // Pangea#
-  }
-
-  void reportEventAction() async {
-    final event = selectedEvents.single;
-    final score = await showModalActionPopup<int>(
-      context: context,
-      title: L10n.of(context).reportMessage,
-      message: L10n.of(context).howOffensiveIsThisContent,
-      cancelLabel: L10n.of(context).cancel,
-      actions: [
-        AdaptiveModalAction(
-          value: -100,
-          label: L10n.of(context).extremeOffensive,
-        ),
-        AdaptiveModalAction(value: -50, label: L10n.of(context).offensive),
-        AdaptiveModalAction(value: 0, label: L10n.of(context).inoffensive),
-      ],
-    );
-    if (score == null) return;
-    final reason = await showTextInputDialog(
-      context: context,
-      title: L10n.of(context).whyDoYouWantToReportThis,
-      okLabel: L10n.of(context).ok,
-      cancelLabel: L10n.of(context).cancel,
-      hintText: L10n.of(context).reason,
-    );
-    if (reason == null || reason.isEmpty) return;
-    final result = await showFutureLoadingDialog(
-      context: context,
-      future: () => Matrix.of(context).client.reportEvent(
-        event.roomId!,
-        event.eventId,
-        reason: reason,
-        score: score,
-      ),
-    );
-    if (result.error != null) return;
-    // #Pangea
-    // setState(() {
-    //   showEmojiPicker = false;
-    //   selectedEvents.clear();
-    // });
-    clearSelectedEvents();
-    // Pangea#
-    // #Pangea
-    ScaffoldMessenger.of(context).showSnackBarAnnounced(
-      SnackBar(content: Text(L10n.of(context).contentHasBeenReported)),
-    );
     // Pangea#
   }
 

--- a/lib/routes/chat/chat_view.dart
+++ b/lib/routes/chat/chat_view.dart
@@ -35,128 +35,12 @@ import 'package:fluffychat/widgets/mxc_image.dart';
 import 'package:fluffychat/widgets/unread_rooms_badge.dart';
 import '../../utils/stream_extension.dart';
 
-// #Pangea
-// enum _EventContextAction { info, report }
-// Pangea#
-
 class ChatView extends StatelessWidget {
   final ChatController controller;
 
   const ChatView(this.controller, {super.key});
 
   List<Widget> _appBarActions(BuildContext context) {
-    // #Pangea
-    // if (controller.selectMode) {
-    //   return [
-    //     if (controller.canEditSelectedEvents)
-    //       IconButton(
-    //         icon: const Icon(Icons.edit_outlined),
-    //         tooltip: L10n.of(context).edit,
-    //         onPressed: controller.editSelectedEventAction,
-    //       ),
-    //     if (controller.selectedEvents.length == 1 &&
-    //         controller.activeThreadId == null &&
-    //         controller.room.canSendDefaultMessages)
-    //       IconButton(
-    //         icon: const Icon(Icons.message_outlined),
-    //         tooltip: L10n.of(context).replyInThread,
-    //         onPressed: () => controller.enterThread(
-    //           controller.selectedEvents.single.eventId,
-    //         ),
-    //       ),
-    //     IconButton(
-    //       icon: const Icon(Icons.copy_outlined),
-    //       tooltip: L10n.of(context).copyToClipboard,
-    //       onPressed: controller.copyEventsAction,
-    //     ),
-    //     if (controller.canRedactSelectedEvents)
-    //       IconButton(
-    //         icon: const Icon(Icons.delete_outlined),
-    //         tooltip: L10n.of(context).redactMessage,
-    //         onPressed: controller.redactEventsAction,
-    //       ),
-    //     if (controller.selectedEvents.length == 1)
-    //       PopupMenuButton<_EventContextAction>(
-    //         useRootNavigator: true,
-    //         onSelected: (action) {
-    //           switch (action) {
-    //             case _EventContextAction.info:
-    //               controller.showEventInfo();
-    //               controller.clearSelectedEvents();
-    //               break;
-    //             case _EventContextAction.report:
-    //               controller.reportEventAction();
-    //               break;
-    //           }
-    //         },
-    //         itemBuilder: (context) => [
-    //           if (controller.canPinSelectedEvents)
-    //             PopupMenuItem(
-    //               onTap: controller.pinEvent,
-    //               value: null,
-    //               child: Row(
-    //                 mainAxisSize: .min,
-    //                 children: [
-    //                   const Icon(Icons.push_pin_outlined),
-    //                   const SizedBox(width: 12),
-    //                   Text(L10n.of(context).pinMessage),
-    //                 ],
-    //               ),
-    //             ),
-    //           if (controller.canSaveSelectedEvent)
-    //             PopupMenuItem(
-    //               onTap: () => controller.saveSelectedEvent(context),
-    //               value: null,
-    //               child: Row(
-    //                 mainAxisSize: .min,
-    //                 children: [
-    //                   const Icon(Icons.download_outlined),
-    //                   const SizedBox(width: 12),
-    //                   Text(L10n.of(context).downloadFile),
-    //                 ],
-    //               ),
-    //             ),
-    //           PopupMenuItem(
-    //             value: _EventContextAction.info,
-    //             child: Row(
-    //               mainAxisSize: .min,
-    //               children: [
-    //                 const Icon(Icons.info_outlined),
-    //                 const SizedBox(width: 12),
-    //                 Text(L10n.of(context).messageInfo),
-    //               ],
-    //             ),
-    //           ),
-    //           if (controller.selectedEvents.single.status.isSent)
-    //             PopupMenuItem(
-    //               value: _EventContextAction.report,
-    //               child: Row(
-    //                 mainAxisSize: .min,
-    //                 children: [
-    //                   const Icon(Icons.shield_outlined, color: Colors.red),
-    //                   const SizedBox(width: 12),
-    //                   Text(L10n.of(context).reportMessage),
-    //                 ],
-    //               ),
-    //             ),
-    //         ],
-    //       ),
-    //   ];
-    // } else if (!controller.room.isArchived) {
-    //   return [
-    //     if (AppSettings.experimentalVoip.value &&
-    //         Matrix.of(context).voipPlugin != null &&
-    //         controller.room.isDirectChat)
-    //       IconButton(
-    //         onPressed: controller.onPhoneButtonTap,
-    //         icon: const Icon(Icons.call_outlined),
-    //         tooltip: L10n.of(context).placeCall,
-    //       ),
-    //     EncryptionButton(controller.room),
-    //     ChatSettingsPopupMenu(controller.room, true),
-    //   ];
-    // }
-    // return [];
     if (controller.room.isArchived) {
       return [];
     }
@@ -214,7 +98,6 @@ class ChatView extends StatelessWidget {
       ),
       ?analyticsAvatar,
     ];
-    // Pangea#
   }
 
   @override


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
