### PR TITLE
fix(grammar): refresh meaning card when feedback regenerates copy (#7676)

### DIFF
--- a/lib/pangea/morphs/morph_meaning_widget.dart
+++ b/lib/pangea/morphs/morph_meaning_widget.dart
@@ -15,12 +15,20 @@ class MorphMeaningWidget extends StatefulWidget {
   final TextStyle? style;
   final bool blankErrorFeedback;
 
+  /// Bumped by an ancestor when the cached meaning for this (feature, tag) is
+  /// regenerated in place — e.g. after grammar-meaning feedback is applied
+  /// (#7676). The (feature, tag) identity is unchanged, so `didUpdateWidget`'s
+  /// identity check can't catch it; listening to this notifier re-fetches the
+  /// now-updated copy. Mirrors LemmaMeaningBuilder / PhoneticTranscriptionBuilder.
+  final ValueNotifier<int>? reloadNotifier;
+
   const MorphMeaningWidget({
     super.key,
     required this.feature,
     required this.tag,
     this.style,
     this.blankErrorFeedback = false,
+    this.reloadNotifier,
   });
 
   @override
@@ -38,18 +46,24 @@ class MorphMeaningWidgetState extends State<MorphMeaningWidget> {
   void initState() {
     super.initState();
     _loadMorphMeaning();
+    widget.reloadNotifier?.addListener(_loadMorphMeaning);
   }
 
   @override
   void didUpdateWidget(covariant MorphMeaningWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.reloadNotifier != widget.reloadNotifier) {
+      oldWidget.reloadNotifier?.removeListener(_loadMorphMeaning);
+      widget.reloadNotifier?.addListener(_loadMorphMeaning);
+    }
     if (oldWidget.tag != widget.tag || oldWidget.feature != widget.feature) {
       _loadMorphMeaning();
     }
-    super.didUpdateWidget(oldWidget);
   }
 
   @override
   void dispose() {
+    widget.reloadNotifier?.removeListener(_loadMorphMeaning);
     _loader.dispose();
     super.dispose();
   }
@@ -86,18 +100,21 @@ class MorphMeaningWidgetState extends State<MorphMeaningWidget> {
 
   @override
   Widget build(BuildContext context) {
-    return switch (_loader.value) {
-      AsyncLoading() || AsyncIdle() => const TextLoadingShimmer(),
-      AsyncError() => Text(
-        textAlign: TextAlign.center,
-        L10n.of(context).meaningNotFound,
-        style: widget.style,
-      ),
-      AsyncLoaded(value: final tag) => Text(
-        textAlign: TextAlign.center,
-        tag.description,
-        style: widget.style,
-      ),
-    };
+    return ValueListenableBuilder(
+      valueListenable: _loader,
+      builder: (context, loaderState, _) => switch (loaderState) {
+        AsyncLoading() || AsyncIdle() => const TextLoadingShimmer(),
+        AsyncError() => Text(
+          textAlign: TextAlign.center,
+          L10n.of(context).meaningNotFound,
+          style: widget.style,
+        ),
+        AsyncLoaded(value: final tag) => Text(
+          textAlign: TextAlign.center,
+          tag.description,
+          style: widget.style,
+        ),
+      },
+    );
   }
 }

--- a/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
+++ b/lib/routes/analytics/construct_analytics/analytics_details_popup.dart
@@ -304,9 +304,14 @@ class ConstructAnalyticsViewState extends State<ConstructAnalyticsView> {
           );
           if (!mounted || result.isError) return;
           final response = result.result;
-          // Only remount when the gate actually regenerated the copy;
-          // a declined feedback leaves the card untouched (#7676).
-          if (response?.appliedEdits ?? true) setState(() {});
+          // Only refresh when the gate actually regenerated the copy; a
+          // declined feedback leaves the card untouched (#7676). setState
+          // refreshes the synchronously-read titles; the notifier bump makes
+          // the async meaning widget re-fetch the merged description.
+          if (response?.appliedEdits ?? true) {
+            reloadNotifier.value++;
+            setState(() {});
+          }
           await showDialog(
             context: context,
             builder: (context) => FeedbackResponseDialog(
@@ -374,7 +379,10 @@ class ConstructAnalyticsViewState extends State<ConstructAnalyticsView> {
                   : widget.view == ConstructTypeEnum.morph
                   ? widget.construct == null
                         ? MorphAnalyticsListView(controller: this)
-                        : MorphDetailsView(constructId: widget.construct!)
+                        : MorphDetailsView(
+                            constructId: widget.construct!,
+                            reloadNotifier: reloadNotifier,
+                          )
                   : widget.construct == null
                   ? VocabAnalyticsListView(controller: this)
                   : VocabDetailsView(

--- a/lib/routes/analytics/construct_analytics/construct_analytics_details/morph_details_view.dart
+++ b/lib/routes/analytics/construct_analytics/construct_analytics_details/morph_details_view.dart
@@ -15,7 +15,16 @@ import 'package:fluffychat/widgets/matrix.dart';
 
 class MorphDetailsView extends StatelessWidget {
   final ConstructIdentifier constructId;
-  const MorphDetailsView({required this.constructId, super.key});
+
+  /// Bumped when the meaning copy is regenerated in place (grammar feedback,
+  /// #7676) so the meaning widget re-fetches without a construct change.
+  final ValueNotifier<int>? reloadNotifier;
+
+  const MorphDetailsView({
+    required this.constructId,
+    this.reloadNotifier,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -101,6 +110,7 @@ class MorphDetailsView extends StatelessWidget {
                 feature: feature,
                 tag: tag,
                 style: Theme.of(context).textTheme.bodyLarge,
+                reloadNotifier: reloadNotifier,
               ),
               if (localizedTag != null)
                 GrammarConstructExample(tag: localizedTag),


### PR DESCRIPTION
### What
Refresh the grammar meaning card's description after feedback regenerates the copy in place.

### Why
`Closes #7676`. Applied feedback merged the regenerated bundle into the constructs cache (`submitTagFeedback`) and the parent called `setState`, but `MorphMeaningWidget` cached its fetched description in State and only re-fetched on a feature/tag change. With identity unchanged and no key, Flutter reused the State, so the displayed description stayed stale (the sync-read titles updated, the async description did not). Design intent lives in `grammar-analytics.instructions.md` (In-app feedback on grammar info).

### What changed
- Thread an optional `reloadNotifier` from `analytics_details_popup` through `MorphDetailsView` into `MorphMeaningWidget`, mirroring the `LemmaMeaningBuilder` / `PhoneticTranscriptionBuilder` reload idiom the vocab flag path already uses.
- `MorphMeaningWidget` listens to the notifier and re-fetches; `build` now uses `ValueListenableBuilder` so a reload repaints (it previously read the notifier value directly).
- On applied edits, bump the notifier (refreshes the async description) alongside the existing `setState` (refreshes the sync-read titles). Declined feedback still leaves the card untouched.

### Testing
- `flutter analyze` clean on the three changed files.
- Existing `test/pangea/grammar_meaning_feedback_response_test.dart` passes.
- Runtime render is verified via the issue's TO TEST on staging. The widget reads the process-global `MatrixState` singleton, which is not available under `flutter test` (repo convention: pure logic is unit-tested, end-to-end render is QA'd on staging).

### Deploy Notes
None.
