### PR TITLE
chore: display when reset instruction tooltips has been selected

### DIFF
--- a/lib/routes/settings/settings_learning/learning_settings_tiles.dart
+++ b/lib/routes/settings/settings_learning/learning_settings_tiles.dart
@@ -161,7 +161,10 @@ class LearningSettingsTiles extends StatelessWidget {
                   leading: const Icon(Icons.lightbulb),
                   title: Text(L10n.of(context).resetInstructionTooltipsTitle),
                   subtitle: Text(L10n.of(context).resetInstructionTooltipsDesc),
-                  onTap: viewModel.resetInstructionTooltips,
+                  selected: viewModel.hasResetTooltips,
+                  onTap: viewModel.hasResetTooltips
+                      ? null
+                      : viewModel.resetInstructionTooltips,
                 ),
               ],
             ),

--- a/lib/routes/settings/settings_learning/learning_settings_view_model.dart
+++ b/lib/routes/settings/settings_learning/learning_settings_view_model.dart
@@ -23,12 +23,15 @@ class LearningSettingsViewModel extends ChangeNotifier {
   }
 
   Timer? _textDebounce;
+  bool _hasResetTooltips = false;
 
   @override
   void dispose() {
     _textDebounce?.cancel();
     super.dispose();
   }
+
+  bool get hasResetTooltips => _hasResetTooltips;
 
   bool get haveSettingsChanged {
     final originalProfile = MatrixState.pangeaController.userController.profile;
@@ -169,6 +172,7 @@ class LearningSettingsViewModel extends ChangeNotifier {
     final updated = _updatedProfile.copyWith(
       instructionSettings: InstructionSettings(),
     );
+    _hasResetTooltips = true;
     _updateProfile(updated);
   }
 


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
