### PR TITLE
Move header inside new dm page scaffold, remove extra panel

### DIFF
--- a/lib/routes/new_private_chat/new_private_chat.dart
+++ b/lib/routes/new_private_chat/new_private_chat.dart
@@ -18,7 +18,9 @@ import '../../widgets/adaptive_dialogs/user_dialog.dart';
 // Pangea#
 
 class NewPrivateChat extends StatefulWidget {
-  const NewPrivateChat({super.key});
+  final Widget closeButton;
+
+  const NewPrivateChat({super.key, required this.closeButton});
 
   @override
   NewPrivateChatController createState() => NewPrivateChatController();
@@ -92,5 +94,6 @@ class NewPrivateChatController extends State<NewPrivateChat> {
   );
 
   @override
-  Widget build(BuildContext context) => NewPrivateChatView(this);
+  Widget build(BuildContext context) =>
+      NewPrivateChatView(this, closeButton: widget.closeButton);
 }

--- a/lib/routes/new_private_chat/new_private_chat.dart
+++ b/lib/routes/new_private_chat/new_private_chat.dart
@@ -18,9 +18,9 @@ import '../../widgets/adaptive_dialogs/user_dialog.dart';
 // Pangea#
 
 class NewPrivateChat extends StatefulWidget {
-  final Widget closeButton;
+  final Widget? closeButton;
 
-  const NewPrivateChat({super.key, required this.closeButton});
+  const NewPrivateChat({super.key, this.closeButton});
 
   @override
   NewPrivateChatController createState() => NewPrivateChatController();

--- a/lib/routes/new_private_chat/new_private_chat_view.dart
+++ b/lib/routes/new_private_chat/new_private_chat_view.dart
@@ -13,13 +13,9 @@ import 'package:fluffychat/widgets/pangea_search_bar.dart';
 
 class NewPrivateChatView extends StatelessWidget {
   final NewPrivateChatController controller;
-  final Widget closeButton;
+  final Widget? closeButton;
 
-  const NewPrivateChatView(
-    this.controller, {
-    super.key,
-    required this.closeButton,
-  });
+  const NewPrivateChatView(this.controller, {super.key, this.closeButton});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/new_private_chat/new_private_chat_view.dart
+++ b/lib/routes/new_private_chat/new_private_chat_view.dart
@@ -13,8 +13,13 @@ import 'package:fluffychat/widgets/pangea_search_bar.dart';
 
 class NewPrivateChatView extends StatelessWidget {
   final NewPrivateChatController controller;
+  final Widget closeButton;
 
-  const NewPrivateChatView(this.controller, {super.key});
+  const NewPrivateChatView(
+    this.controller, {
+    super.key,
+    required this.closeButton,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -22,6 +27,19 @@ class NewPrivateChatView extends StatelessWidget {
 
     final searchResponse = controller.searchResponse;
     return Scaffold(
+      appBar: AppBar(
+        leading: closeButton,
+        titleSpacing: 0,
+        title: Text(
+          L10n.of(context).newDirectMessage,
+          style: FluffyThemes.isColumnMode(context)
+              ? theme.textTheme.titleLarge
+              : theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+        ),
+        centerTitle: false,
+      ),
       body: MaxWidthBody(
         withScrolling: false,
         innerPadding: const EdgeInsets.symmetric(vertical: 8),

--- a/lib/routes/world/left_panel/workspace_left_panel.dart
+++ b/lib/routes/world/left_panel/workspace_left_panel.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
-import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/new_private_chat/new_private_chat.dart';
 import 'package:fluffychat/routes/world/activity_detail_panel.dart';
 import 'package:fluffychat/routes/world/left_panel/left_panel_add_course_subpage.dart';
@@ -16,7 +15,6 @@ import 'package:fluffychat/routes/world/left_panel/left_panel_courses_list_view.
 import 'package:fluffychat/routes/world/left_panel/left_panel_room_details_subpage.dart';
 import 'package:fluffychat/routes/world/left_panel/left_panel_room_subpage.dart';
 import 'package:fluffychat/routes/world/panel_card.dart';
-import 'package:fluffychat/routes/world/panel_header.dart';
 import 'package:fluffychat/widgets/share_scaffold_dialog.dart';
 
 /// Renders one left-column panel token (the chat list, a live room, a course,
@@ -120,17 +118,7 @@ class WorkspaceLeftPanel extends StatelessWidget {
           closeButton: closeButton,
         );
       }(),
-      NewPrivateChatPanelToken() => PanelCard(
-        child: Column(
-          children: [
-            PanelHeader(
-              leading: closeButton,
-              title: L10n.of(context).newDirectMessage,
-            ),
-            Expanded(child: NewPrivateChat()),
-          ],
-        ),
-      ),
+      NewPrivateChatPanelToken() => NewPrivateChat(closeButton: closeButton),
       _ => const SizedBox.shrink(),
     };
 


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [x] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional close button to the private chat screen, allowing the app to supply custom leading controls.

* **UI Improvements**
  * Improved private chat navigation title styling for better consistency across layouts.
  * Updated the private chat panel to use the shared workspace panel chrome, removing redundant nested panel/header elements for a cleaner look.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->