### PR TITLE
fix: ensure subscription options view always depends on purchase pres…

### DIFF
--- a/lib/routes/settings/settings_subscription/settings_subscription_view.dart
+++ b/lib/routes/settings/settings_subscription/settings_subscription_view.dart
@@ -165,20 +165,15 @@ class SettingsSubscriptionView extends StatelessWidget {
                                 onEnterDiscountCode: onEnterDiscountCode,
                                 showSubscriptionOptions: subscriptionStatus
                                     .onlyActiveEntitlementIsTrial,
+                                purchasePresentation: purchasePresentation,
                               )
-                            : switch (purchasePresentation) {
-                                PurchasePresentation.full =>
-                                  SubscriptionOptions(
-                                    onEnterDiscountCode: onEnterDiscountCode,
-                                    onTapSubscription: onTapSubscription,
-                                    productsState: productsState,
-                                    selectedSubscription: selectedSubscription,
-                                  ),
-                                PurchasePresentation.webInfo =>
-                                  const _WebPurchaseNotice(),
-                                PurchasePresentation.hidden =>
-                                  const _PurchaseUnavailableNotice(),
-                              },
+                            : _SubscriptionOptionsByPurchasePresentation(
+                                purchasePresentation,
+                                onEnterDiscountCode: onEnterDiscountCode,
+                                onTapSubscription: onTapSubscription,
+                                productsState: productsState,
+                                selectedSubscription: selectedSubscription,
+                              ),
                       ],
                     );
                   }(),
@@ -209,6 +204,8 @@ class FullAccessContent extends StatelessWidget {
   final AsyncState<List<ProductPlan>> productsState;
   final ValueNotifier<ProductPlan?> selectedSubscription;
 
+  final PurchasePresentation purchasePresentation;
+
   const FullAccessContent({
     super.key,
     this.showTrialInfo = false,
@@ -223,6 +220,7 @@ class FullAccessContent extends StatelessWidget {
     required this.onTapSubscription,
     required this.productsState,
     required this.selectedSubscription,
+    required this.purchasePresentation,
   });
 
   @override
@@ -283,7 +281,8 @@ class FullAccessContent extends StatelessWidget {
             ),
           ),
         if (showSubscriptionOptions)
-          SubscriptionOptions(
+          _SubscriptionOptionsByPurchasePresentation(
+            purchasePresentation,
             onEnterDiscountCode: onEnterDiscountCode,
             onTapSubscription: onTapSubscription,
             productsState: productsState,
@@ -320,5 +319,37 @@ class _PurchaseUnavailableNotice extends StatelessWidget {
       textAlign: TextAlign.center,
       style: Theme.of(context).textTheme.bodyLarge,
     );
+  }
+}
+
+class _SubscriptionOptionsByPurchasePresentation extends StatelessWidget {
+  final PurchasePresentation purchasePresentation;
+
+  final Future<void> Function() onEnterDiscountCode;
+  final Future<void> Function(ProductPlan) onTapSubscription;
+
+  final AsyncState<List<ProductPlan>> productsState;
+  final ValueNotifier<ProductPlan?> selectedSubscription;
+
+  const _SubscriptionOptionsByPurchasePresentation(
+    this.purchasePresentation, {
+    required this.onEnterDiscountCode,
+    required this.onTapSubscription,
+    required this.productsState,
+    required this.selectedSubscription,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return switch (purchasePresentation) {
+      PurchasePresentation.full => SubscriptionOptions(
+        onEnterDiscountCode: onEnterDiscountCode,
+        onTapSubscription: onTapSubscription,
+        productsState: productsState,
+        selectedSubscription: selectedSubscription,
+      ),
+      PurchasePresentation.webInfo => const _WebPurchaseNotice(),
+      PurchasePresentation.hidden => const _PurchaseUnavailableNotice(),
+    };
   }
 }


### PR DESCRIPTION
…entation value

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
