### PR TITLE
docs(grammar): clarify sync_eval caps at 7, publication needs async_eval 8

### DIFF
--- a/.github/instructions/grammar-analytics.instructions.md
+++ b/.github/instructions/grammar-analytics.instructions.md
@@ -52,7 +52,7 @@ L1-language titles and descriptions come from the server, not from client-side l
 - per-value `title` in user_l1 (e.g. "현재 시제" for Pres)
 - per-value `description` in user_l1 (2–3 sentence pedagogical explanation)
 
-Cache-miss translation rows are generated on demand via the panel-eval cascade (canonical doc score gates publication at ≥ 8; translation score gates per-L1 visibility independently — low-score Korean falls back to source_l1 text). The legacy `get_grammar_copy.dart` hardcoded copy and matching `grammarCopy*` L10n keys are obsolete under the new model and slated for removal (Phase 3 of #6660).
+Cache-miss translation rows are generated on demand via the panel-eval cascade (canonical doc score gates publication at ≥ 8; translation score gates per-L1 visibility independently — low-score Korean falls back to source_l1 text). That ≥ 8 publication bar is an **async_eval** rubric score. The structural `synchronous_eval` gate tops out at 7 ("Clean") and never publishes on its own; a server-side change that lets sync_eval emit 8 would silently publish structurally-valid but un-reviewed content. See the choreo audit scale in [`llm-base-handler-audit-collection.instructions.md`](https://github.com/pangeachat/2-step-choreographer/blob/main/.github/instructions/llm-base-handler-audit-collection.instructions.md). The legacy `get_grammar_copy.dart` hardcoded copy and matching `grammarCopy*` L10n keys are obsolete under the new model and slated for removal (Phase 3 of #6660).
 
 ## UI Structure
 


### PR DESCRIPTION
### What
Clarify in `grammar-analytics.instructions.md` that the canonical `≥ 8` publication bar is an **async_eval** rubric score, and that the structural `synchronous_eval` gate caps at 7.

### Why
`Addresses #2838` (client-doc half; the choreo code fix is pangeachat/2-step-choreographer#2841). The doc already gated publication at `≥ 8` via the "LLM panel", but did not distinguish that 8 from the structural gate. The choreo bug was exactly sync_eval emitting 8, which let a structural pass publish without the panel. This adds the missing distinction so the intent is regression-proof. Reconciliation agreed in chat with Will (Option 2).

### Testing
N/A (documentation).

### Deploy Notes
None.
