### PR TITLE
Anchor world-map pan direction to the focused pin so it stays on screen (#7880)

### DIFF
--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -634,6 +634,7 @@ class WorldMapController extends State<WorldMap>
               padding: _exposedCanvasPadding,
               maxZoom: mapController.camera.zoom,
             ),
+            anchor: point,
           );
           return;
         }
@@ -677,6 +678,7 @@ class WorldMapController extends State<WorldMap>
                 ? mapController.camera.zoom
                 : WorldMapConstants.focusZoom,
           ),
+          anchor: point,
         );
         return;
       }
@@ -698,17 +700,24 @@ class WorldMapController extends State<WorldMap>
 
   /// Glide the camera to where [fit] would place it (instead of snapping via
   /// `fitCamera`). [CameraFit.fit] resolves the target center+zoom without
-  /// moving; we tween to it.
-  void _animateFit(CameraFit fit) {
+  /// moving; we tween to it. [anchor] is the pin the fit is centering (if any);
+  /// it steers the pan's east/west direction so the pin stays on screen for
+  /// the whole glide (#7880, [WorldMapConstants.panTargetLongitude]).
+  void _animateFit(CameraFit fit, {LatLng? anchor}) {
     final target = fit.fit(mapController.camera);
-    _animateCameraTo(target.center, target.zoom);
+    _animateCameraTo(target.center, target.zoom, anchor: anchor);
   }
 
   /// Tween the camera center + zoom to the target. The glide length scales with
   /// the zoom distance ([WorldMapConstants.glideDurationFor]) and pan/zoom are
   /// staggered so the pan runs at the wider zoom (#7239). Re-targets cleanly if
   /// called mid-flight (the glide restarts from the current position).
-  void _animateCameraTo(LatLng center, double zoom) {
+  ///
+  /// [anchor]: the pin being brought into view, if the move is about one. The
+  /// stored target longitude is UNWRAPPED so the tween's direction carries the
+  /// anchor's on-screen copy directly to its resting spot instead of taking a
+  /// path that throws it off screen (#7880).
+  void _animateCameraTo(LatLng center, double zoom, {LatLng? anchor}) {
     final anim = _cameraAnimationController;
     if (!mounted) {
       try {
@@ -716,9 +725,17 @@ class WorldMapController extends State<WorldMap>
       } catch (_) {}
       return;
     }
-    _camStart = mapController.camera.center;
+    final start = mapController.camera.center;
+    _camStart = start;
     _camStartZoom = mapController.camera.zoom;
-    _camTarget = center;
+    _camTarget = LatLng(
+      center.latitude,
+      WorldMapConstants.panTargetLongitude(
+        start: start.longitude,
+        target: center.longitude,
+        anchor: anchor?.longitude,
+      ),
+    );
     _camTargetZoom = zoom;
     anim
       ..duration = WorldMapConstants.glideDurationFor(_camStartZoom, zoom)
@@ -738,13 +755,11 @@ class WorldMapController extends State<WorldMap>
       _camTargetZoom,
     );
     final lat = start.latitude + (end.latitude - start.latitude) * p.pan;
-    // Pan longitude along the shortest angular direction so a pin near the
-    // antimeridian glides toward its visible on-screen position (#7880).
-    final lng = WorldMapConstants.lerpLongitude(
-      start.longitude,
-      end.longitude,
-      p.pan,
-    );
+    // A plain linear tween: the direction decision (which world-copy of the
+    // target to fly to, so the focused pin stays on screen) was already baked
+    // into the UNWRAPPED target longitude by [_animateCameraTo] (#7880).
+    // Mid-tween values may exceed +-180; `move` re-normalizes each frame.
+    final lng = start.longitude + (end.longitude - start.longitude) * p.pan;
     final zoom = _camStartZoom + (_camTargetZoom - _camStartZoom) * p.zoom;
     try {
       mapController.move(LatLng(lat, lng), zoom);

--- a/lib/routes/world/world_map_constants.dart
+++ b/lib/routes/world/world_map_constants.dart
@@ -100,19 +100,46 @@ class WorldMapConstants {
     curve: Curves.easeInOut,
   );
 
-  /// Interpolate longitude from [start] to [end] at pan progress [t] along the
-  /// SHORTEST angular direction (#7880). A raw linear tween of longitude values
-  /// sweeps the long way around whenever start/end straddle the antimeridian
-  /// numerically (e.g. 175 -> -179 tweens down through 0, a 354deg spin), even
-  /// though the target pin is only a few degrees away on screen. Wrapping the
-  /// delta into (-180, 180] pans toward the pin's visible on-screen direction.
-  /// The returned value may fall slightly outside [-180, 180] mid-tween (e.g.
-  /// 181, i.e. -179); flutter_map's `move` normalizes it, and the tile layer
-  /// wraps, so the sweep stays continuous across the seam.
-  static double lerpLongitude(double start, double end, double t) {
-    var delta = (end - start) % 360;
-    if (delta > 180) delta -= 360;
-    return start + delta * t;
+  /// Wrap an angular delta into (-180, 180] degrees.
+  static double _wrapDelta(double degrees) {
+    final m = degrees % 360; // Dart % is non-negative for a positive divisor.
+    return m > 180 ? m - 360 : m;
+  }
+
+  /// The UNWRAPPED longitude a camera glide should tween to, so the glide's
+  /// direction keeps the focused pin on screen the whole flight (#7880). The
+  /// returned value is `start + delta` with delta possibly beyond +-180; the
+  /// tick tweens to it linearly, and flutter_map's `move` re-normalizes each
+  /// frame (its seamless-scrolling adjustment), so the sweep is continuous
+  /// across the antimeridian.
+  ///
+  /// Choosing the direction is a choice of which world-copy of [target] to fly
+  /// to, and neither naive rule is right:
+  /// - RAW linear (`target - start`) sweeps the long way whenever the two
+  ///   values straddle the antimeridian numerically (175 -> -179 spins -354deg
+  ///   through 0) — the issue's original video.
+  /// - SHORTEST center-to-center path breaks when a wide side panel pushes the
+  ///   target CENTER far past the pin: pin near the left edge, panel covering
+  ///   the left half, resting spot right-of-center -> the correct camera sweep
+  ///   exceeds 180deg, so "shortest" flips direction and throws the pin off
+  ///   screen — the QA reopen.
+  ///
+  /// The rule that matches the issue ("keep the spot on screen the whole
+  /// time") anchors the direction to the PIN, not the center: the pin's
+  /// on-screen offset must travel directly from where it is now
+  /// (`wrap(anchor - start)`) to where it rests (`wrap(anchor - target)`), so
+  /// the camera delta is the difference of the two — monotonic pin motion by
+  /// construction, wherever the centers sit. Without an [anchor] (world reset,
+  /// zoom steps, course-bounds fits) it falls back to the shortest path.
+  static double panTargetLongitude({
+    required double start,
+    required double target,
+    double? anchor,
+  }) {
+    if (anchor == null) return start + _wrapDelta(target - start);
+    final offsetNow = _wrapDelta(anchor - start);
+    final offsetDest = _wrapDelta(anchor - target);
+    return start + (offsetNow - offsetDest);
   }
 
   /// The (pan, zoom) progress at raw glide value [t] for a move from [startZoom]

--- a/test/pangea/world_map_glide_test.dart
+++ b/test/pangea/world_map_glide_test.dart
@@ -62,38 +62,69 @@ void main() {
     });
   });
 
-  group('lerpLongitude — shortest angular pan (#7880)', () {
-    double lerp(double a, double b, double t) =>
-        WorldMapConstants.lerpLongitude(a, b, t);
+  group('panTargetLongitude — pin-anchored pan direction (#7880)', () {
+    double to(double start, double target, [double? anchor]) =>
+        WorldMapConstants.panTargetLongitude(
+          start: start,
+          target: target,
+          anchor: anchor,
+        );
 
-    test('endpoints are exact at t=0 and t=1', () {
-      expect(lerp(175, -179, 0), moreOrLessEquals(175));
-      // t=1 lands on the target modulo a full turn (181 == -179).
-      expect(lerp(175, -179, 1) % 360, moreOrLessEquals(181 % 360));
+    test('the result is always the target modulo a full turn', () {
+      for (final (s, t, a) in <(double, double, double?)>[
+        (145, -81, 10),
+        (175, -170, -179),
+        (10, 40, 12),
+        (163, 30, null),
+        (-150, 170, null),
+      ]) {
+        expect(
+          (to(s, t, a) - t) % 360,
+          moreOrLessEquals(0),
+          reason: 'start=$s target=$t anchor=$a',
+        );
+      }
     });
 
-    test('crossing the antimeridian eastward takes the short way (+6deg)', () {
-      // 175 -> -179 is +6deg across the seam, NOT -354deg through 0.
-      expect(lerp(175, -179, 0.5), moreOrLessEquals(178));
+    test('QA reopen geometry: a wide left panel demands a >180deg westward '
+        'sweep, and the anchor keeps it westward', () {
+      // Camera over the Pacific (~145E), pin at ~10E visible near the LEFT
+      // edge (offset -135). The activity panel covers the left half, so the
+      // pin's resting spot is right-of-center: target center ~ -81 (91deg
+      // WEST of the pin). Correct sweep: 226deg west, pin slides left-edge ->
+      // right-of-center, on screen throughout. Shortest center-to-center
+      // wraps that to +134 EAST and hurls the pin off the left edge.
+      final unwrapped = to(145, -81, 10);
+      expect(unwrapped, moreOrLessEquals(-81)); // west: 145 -> -81, no wrap
+      expect(unwrapped - 145, moreOrLessEquals(-226)); // > 180, deliberately
     });
 
-    test('crossing the antimeridian westward takes the short way (-6deg)', () {
-      // -179 -> 175 is -6deg across the seam, NOT +354deg through 0.
-      expect(lerp(-179, 175, 0.5), moreOrLessEquals(-182));
+    test('original-video geometry: seam-straddling values take the short way '
+        'toward the visible pin', () {
+      // Camera at 175, pin at -179 visible +6 east across the seam, panel
+      // shift puts the target center at -170. RAW linear would sweep -345
+      // through 0; the anchor unwraps the target to 190 (= -170), a short
+      // +15 eastward glide past the seam.
+      expect(to(175, -170, -179), moreOrLessEquals(190));
     });
 
-    test('an ordinary move away from the seam interpolates linearly', () {
-      expect(lerp(10, 40, 0.5), moreOrLessEquals(25));
-      expect(lerp(-20, -50, 0.25), moreOrLessEquals(-27.5));
+    test('an anchored ordinary move (no seam, no wide panel) is linear', () {
+      expect(to(10, 40, 12), moreOrLessEquals(40));
+      expect(to(-20, -50, -22), moreOrLessEquals(-50));
     });
 
-    test('a half-turn keeps its sign rather than flipping', () {
-      // Exactly 180deg is the boundary: (-180, 180] keeps +180 as +180.
-      expect(lerp(0, 180, 1), moreOrLessEquals(180));
+    test('without an anchor, falls back to the shortest angular path', () {
+      // 175 -> -179 is +6 across the seam (unwrapped 181), not -354.
+      expect(to(175, -179), moreOrLessEquals(181));
+      // -179 -> 175 is -6 across the seam (unwrapped -185), not +354.
+      expect(to(-179, 175), moreOrLessEquals(-185));
+      // Ordinary moves stay put.
+      expect(to(10, 40), moreOrLessEquals(40));
     });
 
-    test('a no-op move stays put', () {
-      expect(lerp(42, 42, 0.5), moreOrLessEquals(42));
+    test('a no-op move stays put, anchored or not', () {
+      expect(to(42, 42, 42), moreOrLessEquals(42));
+      expect(to(42, 42), moreOrLessEquals(42));
     });
   });
 }


### PR DESCRIPTION
Fixes #7880 (reopened). Supersedes the approach in #7884.

## What QA saw
On web (2-column layout), clicking a pin near the left edge panned the map the long way around: the pin flew off the left edge, the world wrapped, and it re-entered from the right — instead of sliding directly to its resting spot.

## Why the first fix (#7884) wasn't enough
#7884 made the glide take the **shortest angular path between camera centers**. That fixed the original seam-straddling case, but it's the wrong quantity: the requirement is about the **pin**, not the center.

Reconstructing QA's screenshots: camera over the Pacific (~145°E), pin at ~10°E visible near the left edge. Clicking opens the activity panel over the **left half** of the screen, so the pin's resting spot is right-of-center — putting the target camera center ~90° **west of the pin** (~-80°). The correct sweep is 226° west (pin slides left-edge → right-of-center, on screen throughout). Because that exceeds 180°, "shortest center path" flips it to 134° **east** — throwing the pin off screen. So the wide side panel is exactly what breaks the center-based rule, which is why it reproduced in the 2-column layout.

## The fix
Anchor the pan direction to the pin. `WorldMapConstants.panTargetLongitude(start, target, anchor)` unwraps the target center longitude so the pin's on-screen offset travels **directly** from where it is now (`wrap(pin − start)`) to where it rests (`wrap(pin − target)`) — monotonic pin motion by construction, wherever the centers sit, with sweeps beyond ±180° allowed when the geometry demands it. The glide tick tweens linearly to the unwrapped value; flutter_map re-normalizes each frame, so crossing the antimeridian stays seamless.

Anchored call sites: the selection pan (`_runFitToContext`) and the focus button (`_onCameraFocusRequest`), each passing its pin. Anchor-less moves (world reset, zoom steps, course-bounds fit) fall back to the shortest center path.

## Changes to look over
- `lib/routes/world/world_map_constants.dart` — `panTargetLongitude` replaces `lerpLongitude`; the doc comment records why both naive rules (raw linear, shortest-center) fail.
- `lib/routes/world/world_map.dart` — `_animateCameraTo`/`_animateFit` take an `anchor`; the tick is a plain linear tween of the pre-unwrapped target.
- `test/pangea/world_map_glide_test.dart` — regression tests reconstructing both real failure geometries (QA's wide-panel web repro and the original seam video), plus mod-360 correctness, fallback, and no-op cases.

## TO TEST
- [ ] Web, 2-column layout (QA's repro): zoom out to the whole world, pan so a pin sits very close to the left edge, then click it. The map should pan left-to-right — the pin slides from the edge to its spot beside the opened panel, staying on screen the whole time.
- [ ] Same with a pin near the right edge (pan should run right-to-left, pin on screen throughout).
- [ ] Repeat at a narrower screen size (bottom-sheet layout) with a pin near a side edge.
- [ ] Click an ordinary pin mid-screen — normal short pan, unchanged.
- [ ] Activity plan page → focus button: the zoom-in glide keeps the pin on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
