### PR TITLE
fix(android): declare POST_NOTIFICATIONS so the permission prompt can appear

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
Closes #7912.

## Summary

One-line manifest fix for Android notifications being silently dropped on current builds (reported in #6717 (comment)).

Push infra is fully healthy (Sygnal logs show every FCM send accepted in both envs), but Android 13+ with targetSdk >= 33 requires `POST_NOTIFICATIONS` to be declared in the manifest before the runtime permission can even be requested. Pangea's existing permission flow (`EnableNotificationsDialog` -> `Permission.notification.request()`) is correctly designed and wired, but without the declaration the request returns denied immediately and the OS prompt never shows. Older builds targeted SDK < 33 where the permission didn't exist — the Flutter 3.41 store-CI builds activated the requirement.

No Dart changes; the existing dialog flow becomes functional.

## To Test

See #7912 — Android 13+ device, fresh install of the next internal-track build: enable-notifications dialog → OS permission prompt → grant → backgrounded app receives a DM notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Android notification permissions, enabling the app to request permission to send notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->