### PR TITLE
fix(grammar): match feature case-insensitively when merging meaning feedback (#7676)

### DIFF
--- a/lib/pangea/morphs/grammar_constructs_provider.dart
+++ b/lib/pangea/morphs/grammar_constructs_provider.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:matrix/matrix_api_lite/utils/logs.dart';
 
 import 'package:fluffychat/features/languages/language_constants.dart';
@@ -127,17 +129,48 @@ class GrammarConstructsProvider {
       return regen;
     }
 
-    final features = constructs.features;
-    final featureIndex = features.indexWhere((f) => f.value == feature);
-    if (featureIndex == -1) {
+    final updatedConstructs = mergeFeedbackIntoConstructs(
+      constructs,
+      feature,
+      regen,
+    );
+    if (updatedConstructs == null) {
       Logs().w("Feature $feature not found in submitTagFeedback");
       return regen;
     }
 
+    await GrammarConstructsRepo.instance.setCached(request, updatedConstructs);
+    MorphFeaturesAndTags.clearLookupCache();
+    return regen;
+  }
+
+  /// Merge a regenerated meaning bundle [regen] into the cached joined
+  /// [constructs], matching by feature and tag value. Matching is
+  /// case-insensitive: the feedback [feature] is the analytics construct
+  /// category (a lowercase UD key, e.g. "aspect"), while the cached feature
+  /// and tag values are canonical-cased ("Aspect", "Perf"). A case-sensitive
+  /// match silently no-ops the merge, leaving the card showing the old copy
+  /// even though the reload fires — the bug behind #7676. Canonical-only
+  /// fields (display, example, sequence) are untouched. Returns null when the
+  /// feature isn't present, so the caller leaves the cache untouched.
+  @visibleForTesting
+  static GrammarConstructsResponse? mergeFeedbackIntoConstructs(
+    GrammarConstructsResponse constructs,
+    String feature,
+    GrammarMeaningFeedbackResponse regen,
+  ) {
+    final features = constructs.features;
+    final featureIndex = features.indexWhere(
+      (f) => f.value.toLowerCase() == feature.toLowerCase(),
+    );
+    if (featureIndex == -1) return null;
+
     final currentFeature = features[featureIndex];
-    final updatesByValue = {for (final v in regen.values) v.value: v};
+    final updatesByValue = {
+      for (final v in regen.values) v.value.toLowerCase(): v,
+    };
     final updatedTags = currentFeature.tags.map((tag) {
-      final update = updatesByValue[tag.value];
+      final update = updatesByValue[tag.value.toLowerCase()];
       if (update == null) return tag;
       return tag.copyWith(title: update.title, description: update.description);
     }).toList();
@@ -147,10 +180,6 @@ class GrammarConstructsProvider {
       title: regen.featureTitle,
       tags: updatedTags,
     );
-
-    final updatedConstructs = constructs.copyWith(features: updatedFeatures);
-    await GrammarConstructsRepo.instance.setCached(request, updatedConstructs);
-    MorphFeaturesAndTags.clearLookupCache();
-    return regen;
+    return constructs.copyWith(features: updatedFeatures);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -293,10 +293,10 @@ packages:
     dependency: "direct main"
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -1488,18 +1488,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   material_symbols_icons:
     dependency: "direct main"
     description:
@@ -2422,26 +2422,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   timezone:
     dependency: transitive
     description:

--- a/test/pangea/morphs/grammar_constructs_feedback_merge_test.dart
+++ b/test/pangea/morphs/grammar_constructs_feedback_merge_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/morphs/grammar_constructs_provider.dart';
+import 'package:fluffychat/pangea/morphs/grammar_constructs_response.dart';
+import 'package:fluffychat/pangea/morphs/grammar_meaning_feedback_repo.dart';
+
+/// Regression coverage for #7676: a grammar-meaning feedback response echoes
+/// the feature in canonical case ("Aspect"), but the flag is raised from the
+/// analytics construct category in lowercase ("aspect"). The merge must match
+/// case-insensitively — as the display path (MorphFeaturesAndTags.getTag)
+/// already does — or the regenerated copy never lands in the cache and the
+/// card keeps showing the old definition even after the reload fires.
+void main() {
+  GrammarConstructsResponse constructs() => GrammarConstructsResponse.fromJson({
+    "user_l1": "en",
+    "source_l1": "en",
+    "target_language": "de",
+    "features": [
+      {
+        "feature": "Aspect",
+        "feature_title": "Aspect",
+        "values": [
+          {
+            "value": "Perf",
+            "display": true,
+            "example": "Ich habe gelesen",
+            "sequence_position": 1.0,
+            "title": "Perfect",
+            "description": "OLD long definition",
+          },
+        ],
+      },
+    ],
+  });
+
+  GrammarMeaningFeedbackResponse regen({
+    String feature = "Aspect",
+    String value = "Perf",
+  }) => GrammarMeaningFeedbackResponse(
+    feature: feature,
+    featureTitle: "Aspect",
+    values: [
+      GrammarMeaningValueUpdate(
+        value: value,
+        title: "Perfect Aspect",
+        description: "NEW short definition",
+      ),
+    ],
+    editsApplied: true,
+  );
+
+  test('merges when the flagged feature is lowercase (#7676)', () {
+    final merged = GrammarConstructsProvider.mergeFeedbackIntoConstructs(
+      constructs(),
+      "aspect", // analytics construct category — lowercase UD key
+      regen(),
+    );
+
+    expect(merged, isNotNull);
+    final tag = merged!.features.single.tags.single;
+    expect(tag.description, "NEW short definition");
+    expect(tag.title, "Perfect Aspect");
+  });
+
+  test('merges tag values case-insensitively', () {
+    final merged = GrammarConstructsProvider.mergeFeedbackIntoConstructs(
+      constructs(),
+      "aspect",
+      regen(value: "perf"), // lowercased tag value
+    );
+    expect(
+      merged!.features.single.tags.single.description,
+      "NEW short definition",
+    );
+  });
+
+  test('returns null when the feature is absent (cache left untouched)', () {
+    final merged = GrammarConstructsProvider.mergeFeedbackIntoConstructs(
+      constructs(),
+      "tense",
+      regen(),
+    );
+    expect(merged, isNull);
+  });
+
+  test(
+    'leaves canonical-only fields (display, example, sequence) untouched',
+    () {
+      final merged = GrammarConstructsProvider.mergeFeedbackIntoConstructs(
+        constructs(),
+        "aspect",
+        regen(),
+      );
+      final tag = merged!.features.single.tags.single;
+      expect(tag.display, isTrue);
+      expect(tag.example, "Ich habe gelesen");
+      expect(tag.sequencePosition, 1.0);
+    },
+  );
+}


### PR DESCRIPTION
### What
Match the feature name case-insensitively when merging a regenerated grammar-meaning bundle into the cached constructs, so the flagged card actually updates.

### Why
Closes #7676 (reopened). #7894 wired the card to reload after feedback, but the reload had nothing new to read: the merge in `submitTagFeedback` matched the feature with a case-sensitive `features.indexWhere((f) => f.value == feature)`. The `feature` passed in is the analytics construct category (a lowercase UD key, e.g. `aspect`, `pos`), while the cached `GrammarFeature.value` is canonical-cased (`Aspect`, `Pos`). The match returned -1, so the merge early-returned without writing, and the display kept showing the old copy (it matches case-insensitively via `MorphFeaturesAndTags.getTag`). Reproduced from Kelrap's report: response returns new copy with `edits_applied: true`, but neither reload nor reenter updates the card.

Fix: the merge logic is extracted into a testable `mergeFeedbackIntoConstructs` helper that matches feature and tag values case-insensitively, mirroring the display path. Canonical-only fields (display, example, sequence) stay untouched.

### Testing
`flutter test test/pangea/morphs/` — 12 pass, including 4 new cases in `grammar_constructs_feedback_merge_test.dart` (lowercase feature merges, case-insensitive tag values, absent-feature returns null, canonical fields preserved). `flutter analyze` clean on the changed files.

### Deploy Notes
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved grammar feedback merging to match feature categories and tag values regardless of capitalization.
  * Preserved existing canonical grammar details while applying updated feedback.
  * Prevented cache changes when feedback targets a feature that cannot be found.

* **Tests**
  * Added regression coverage for case-insensitive feedback merging and preservation of existing grammar fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->