### PR TITLE
fix: prevent semantics from passing activity list scroll arrow click …

### DIFF
--- a/lib/routes/courses/course_objectives/objective_section_scroll_arrow.dart
+++ b/lib/routes/courses/course_objectives/objective_section_scroll_arrow.dart
@@ -30,18 +30,20 @@ class ObjectiveSectionScrollArrow extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = L10n.of(context);
-    return Semantics(
-      button: true,
-      label: direction.label(l10n),
-      child: MouseRegion(
-        cursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: onTap,
-          child: Container(
-            padding: EdgeInsets.all(8.0),
-            decoration: BoxDecoration(color: theme.colorScheme.surface),
-            child: Center(child: Icon(direction.icon)),
+    return BlockSemantics(
+      child: Semantics(
+        button: true,
+        label: direction.label(l10n),
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: onTap,
+            child: Container(
+              padding: EdgeInsets.all(8.0),
+              decoration: BoxDecoration(color: theme.colorScheme.surface),
+              child: Center(child: Icon(direction.icon)),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
…to widget below

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
