### PR TITLE
fix: remove keys from map markers to prevent duplicate key error when…

### DIFF
--- a/lib/routes/world/dot_markers_layer.dart
+++ b/lib/routes/world/dot_markers_layer.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:flutter_map/flutter_map.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/routes/world/world_map_client_extension.dart';
+import 'package:fluffychat/routes/world/world_map_large_card.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_state_dot.dart';
+
+class DotMarkersLayer {
+  final List<QuestActivityCard> nonLargeCards;
+  final PinTier Function(String) tierOf;
+  final ActivityPinState Function(String) stateOf;
+  final ActivityStarLevel Function(String) starLevelOf;
+  final bool Function(String) nonStartableOf;
+  final bool Function(String) pingedOf;
+  final Room? Function(String)? activeActivityInstance;
+  final Size Function(ActivityPinState, PinTier) markerBox;
+  final Alignment Function(ActivityPinState, PinTier) markerAlignment;
+  final String? focusedId;
+  final void Function(QuestActivityCard) onTap;
+  final ({List<LargeCardParticipant> participants, int openSlots}) Function(
+    String,
+    ActivityPinState,
+  )
+  sessionParticipants;
+
+  const DotMarkersLayer({
+    required this.nonLargeCards,
+    required this.tierOf,
+    required this.stateOf,
+    required this.starLevelOf,
+    required this.nonStartableOf,
+    required this.pingedOf,
+    required this.activeActivityInstance,
+    required this.markerBox,
+    required this.markerAlignment,
+    required this.focusedId,
+    required this.onTap,
+    required this.sessionParticipants,
+  });
+
+  /// The mid-pin "num/num" participant counts for `joinable`/`ongoingPending`
+  /// (world-map.instructions.md, "Pin display") — derived from the shared
+  /// [_sessionParticipants] resolver so they match the large card's row.
+  /// Null/null for every other state, or when the counts aren't resolvable yet.
+  ({int? filled, int? total}) _participantCounts(
+    String activityId,
+    ActivityPinState state,
+  ) {
+    final (:participants, :openSlots) = sessionParticipants(activityId, state);
+    final filled = participants.length;
+    final total = filled + openSlots;
+    return total > 0
+        ? (filled: filled, total: total)
+        : (filled: null, total: null);
+  }
+
+  /// The learner's own live room for an `ongoingActive` pin (world-map.
+  /// instructions.md, "Pin state") — null (badge hidden) for every other
+  /// state.
+  Room? _unreadRoomFor(String activityId, ActivityPinState state) {
+    if (state != ActivityPinState.ongoingActive) return null;
+    return activeActivityInstance?.call(activityId);
+  }
+
+  /// The rendered small/mid pins, each an individual marker (no clustering).
+  /// Tapping any pin opens/focuses the activity in one step (no tap-to-peek).
+  /// Small dots are emitted before mid pins so mid always paints on top —
+  /// markers later in the list draw over earlier ones, and "small pins should
+  /// never show on top of mid pins" (world-map.instructions.md, "Pin display").
+  MarkerLayer layer() {
+    // Small dots first, then mid pins, each tier keeping its score order — a
+    // stable partition (Dart's List.sort is not guaranteed stable) so mid
+    // always paints over small without reshuffling same-tier pins frame to
+    // frame.
+    final cards = nonLargeCards;
+    final ordered = [
+      ...cards.where((c) => tierOf(c.activityId) == PinTier.small),
+      ...cards.where((c) => tierOf(c.activityId) != PinTier.small),
+    ];
+    return MarkerLayer(
+      markers: ordered.map((card) {
+        final state = stateOf(card.activityId);
+        final tier = tierOf(card.activityId);
+        final box = markerBox(state, tier);
+        final counts = _participantCounts(card.activityId, state);
+
+        return Marker(
+          point: card.point!,
+          width: box.width,
+          height: box.height,
+          alignment: markerAlignment(state, tier),
+          child: Opacity(
+            opacity: nonStartableOf(card.activityId) ? 0.5 : 1.0,
+            child: WorldMapDot(
+              card: card,
+              state: state,
+              tier: tier,
+              onTap: () => onTap(card),
+              pinged: pingedOf(card.activityId),
+              starLevel: starLevelOf(card.activityId),
+              unreadRoom: _unreadRoomFor(card.activityId, state),
+              participantsFilled: counts.filled,
+              participantsTotal: counts.total,
+              isFocused: card.activityId == focusedId,
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/routes/world/exiting_large_markers_layer.dart
+++ b/lib/routes/world/exiting_large_markers_layer.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:flutter_map/flutter_map.dart';
+
+import 'package:fluffychat/routes/world/world_map_large_card.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_view.dart';
+
+class ExitingLargeMarkersLayer {
+  final List<LargeCardSnapshot> exitingLarge;
+  final void Function(String) onExited;
+
+  const ExitingLargeMarkersLayer({
+    required this.exitingLarge,
+    required this.onExited,
+  });
+
+  MarkerLayer layer() {
+    final cards = exitingLarge.where((s) => s.card.point != null);
+    return MarkerLayer(
+      markers: cards.map((snap) {
+        const tier = PinTier.large;
+        return Marker(
+          point: snap.card.point!,
+          width: tier.dotWidth + WorldMapLargeCard.badgeOverhang * 2,
+          height:
+              tier.dotHeight(snap.state) +
+              WorldMapLargeCard.tailHeight +
+              WorldMapLargeCard.badgeOverhang,
+          alignment: Alignment.topCenter,
+          child: Align(
+            alignment: Alignment.bottomCenter,
+            child: WorldMapLargeCardAnimated(
+              dying: true,
+              onExited: () => onExited(snap.card.activityId),
+              child: WorldMapLargeCard(
+                card: snap.card,
+                state: snap.state,
+                pinged: snap.pinged,
+                plan: snap.plan,
+                liveRoom: snap.liveRoom,
+                starsEarned: snap.starsEarned,
+                participants: snap.participants,
+                openSlots: snap.openSlots,
+                starLevel: snap.starLevel,
+                // No interaction on a card that's on its way out.
+                onTap: () {},
+                onClose: null,
+              ),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/routes/world/exiting_markers_layer.dart
+++ b/lib/routes/world/exiting_markers_layer.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_map/flutter_map.dart';
+
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_state_dot.dart';
+import 'package:fluffychat/routes/world/world_map_view.dart';
+
+class ExitingMarkersLayer {
+  final List<PinSnapshot> exiting;
+  final Size Function(ActivityPinState, PinTier) markerBox;
+  final Alignment Function(ActivityPinState, PinTier) markerAlignment;
+  final void Function(String) onExited;
+
+  const ExitingMarkersLayer({
+    required this.exiting,
+    required this.markerBox,
+    required this.markerAlignment,
+    required this.onExited,
+  });
+
+  MarkerLayer layer() {
+    final cards = exiting.where((p) => p.card.point != null);
+    return MarkerLayer(
+      markers: cards.map((p) {
+        final box = markerBox(p.state, p.tier);
+        return Marker(
+          point: p.card.point!,
+          width: box.width,
+          height: box.height,
+          alignment: markerAlignment(p.state, p.tier),
+          child: WorldMapDot(
+            card: p.card,
+            state: p.state,
+            tier: p.tier,
+            onTap: () {},
+            pinged: p.pinged,
+            starLevel: p.starLevel,
+            dying: true,
+            onExited: () => onExited(p.card.activityId),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/routes/world/large_markers_layer.dart
+++ b/lib/routes/world/large_markers_layer.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_map/flutter_map.dart';
+
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/routes/world/world_map_large_card.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_view.dart';
+
+class LargeMarkersLayer {
+  final List<QuestActivityCard> largeCards;
+  final Map<String, LargeCardSnapshot> currentLarge;
+  final String? focusedId;
+  final void Function(QuestActivityCard) onTap;
+  final void Function(QuestActivityCard) onClose;
+
+  const LargeMarkersLayer({
+    required this.largeCards,
+    required this.currentLarge,
+    required this.focusedId,
+    required this.onTap,
+    required this.onClose,
+  });
+
+  MarkerLayer layer() {
+    const tier = PinTier.large;
+    return MarkerLayer(
+      markers: largeCards.map((card) {
+        final snap = currentLarge[card.activityId]!;
+        return Marker(
+          point: card.point!,
+          // Widen by the badge overhang on both sides; the card centres within
+          // and the pin stays at the box's horizontal centre, so the tail still
+          // lands on the dot while the top-right badge has room to peek.
+          width: tier.dotWidth + WorldMapLargeCard.badgeOverhang * 2,
+          // The inner Align lets the card hug its own content (each state is a
+          // different height: joinable/ongoingPending add the avatar row,
+          // ongoingActive adds the message preview + star row). Height here is
+          // only a ceiling so the tallest variant isn't clipped; shorter cards
+          // don't stretch to fill it. The extra tailHeight reserves room beneath
+          // the card for the pin tail; the badgeOverhang reserves room ABOVE
+          // (topCenter alignment anchors the box bottom to the pin, so slack
+          // lands at the top) for the peeking unread badge.
+          height:
+              tier.dotHeight(snap.state) +
+              WorldMapLargeCard.tailHeight +
+              WorldMapLargeCard.badgeOverhang,
+          alignment: Alignment.topCenter,
+          child: Align(
+            // Bottom-align so the card+tail hugs its pin (the tail tip lands on
+            // the dot) instead of floating with a gap above it (#7153).
+            alignment: Alignment.bottomCenter,
+            child: WorldMapLargeCardAnimated(
+              child: WorldMapLargeCard(
+                card: snap.card,
+                state: snap.state,
+                pinged: snap.pinged,
+                plan: snap.plan,
+                liveRoom: snap.liveRoom,
+                starsEarned: snap.starsEarned,
+                participants: snap.participants,
+                openSlots: snap.openSlots,
+                starLevel: snap.starLevel,
+                isFocused: card.activityId == focusedId,
+                onTap: () => onTap(card),
+                onClose: () => onClose(card),
+              ),
+            ),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/lib/routes/world/large_markers_layer.dart
+++ b/lib/routes/world/large_markers_layer.dart
@@ -25,50 +25,54 @@ class LargeMarkersLayer {
   MarkerLayer layer() {
     const tier = PinTier.large;
     return MarkerLayer(
-      markers: largeCards.map((card) {
-        final snap = currentLarge[card.activityId]!;
-        return Marker(
-          point: card.point!,
-          // Widen by the badge overhang on both sides; the card centres within
-          // and the pin stays at the box's horizontal centre, so the tail still
-          // lands on the dot while the top-right badge has room to peek.
-          width: tier.dotWidth + WorldMapLargeCard.badgeOverhang * 2,
-          // The inner Align lets the card hug its own content (each state is a
-          // different height: joinable/ongoingPending add the avatar row,
-          // ongoingActive adds the message preview + star row). Height here is
-          // only a ceiling so the tallest variant isn't clipped; shorter cards
-          // don't stretch to fill it. The extra tailHeight reserves room beneath
-          // the card for the pin tail; the badgeOverhang reserves room ABOVE
-          // (topCenter alignment anchors the box bottom to the pin, so slack
-          // lands at the top) for the peeking unread badge.
-          height:
-              tier.dotHeight(snap.state) +
-              WorldMapLargeCard.tailHeight +
-              WorldMapLargeCard.badgeOverhang,
-          alignment: Alignment.topCenter,
-          child: Align(
-            // Bottom-align so the card+tail hugs its pin (the tail tip lands on
-            // the dot) instead of floating with a gap above it (#7153).
-            alignment: Alignment.bottomCenter,
-            child: WorldMapLargeCardAnimated(
-              child: WorldMapLargeCard(
-                card: snap.card,
-                state: snap.state,
-                pinged: snap.pinged,
-                plan: snap.plan,
-                liveRoom: snap.liveRoom,
-                starsEarned: snap.starsEarned,
-                participants: snap.participants,
-                openSlots: snap.openSlots,
-                starLevel: snap.starLevel,
-                isFocused: card.activityId == focusedId,
-                onTap: () => onTap(card),
-                onClose: () => onClose(card),
+      markers: largeCards
+          .map((card) {
+            final snap = currentLarge[card.activityId];
+            if (snap == null || card.point == null) return null;
+            return Marker(
+              point: card.point!,
+              // Widen by the badge overhang on both sides; the card centres within
+              // and the pin stays at the box's horizontal centre, so the tail still
+              // lands on the dot while the top-right badge has room to peek.
+              width: tier.dotWidth + WorldMapLargeCard.badgeOverhang * 2,
+              // The inner Align lets the card hug its own content (each state is a
+              // different height: joinable/ongoingPending add the avatar row,
+              // ongoingActive adds the message preview + star row). Height here is
+              // only a ceiling so the tallest variant isn't clipped; shorter cards
+              // don't stretch to fill it. The extra tailHeight reserves room beneath
+              // the card for the pin tail; the badgeOverhang reserves room ABOVE
+              // (topCenter alignment anchors the box bottom to the pin, so slack
+              // lands at the top) for the peeking unread badge.
+              height:
+                  tier.dotHeight(snap.state) +
+                  WorldMapLargeCard.tailHeight +
+                  WorldMapLargeCard.badgeOverhang,
+              alignment: Alignment.topCenter,
+              child: Align(
+                // Bottom-align so the card+tail hugs its pin (the tail tip lands on
+                // the dot) instead of floating with a gap above it (#7153).
+                alignment: Alignment.bottomCenter,
+                child: WorldMapLargeCardAnimated(
+                  child: WorldMapLargeCard(
+                    card: snap.card,
+                    state: snap.state,
+                    pinged: snap.pinged,
+                    plan: snap.plan,
+                    liveRoom: snap.liveRoom,
+                    starsEarned: snap.starsEarned,
+                    participants: snap.participants,
+                    openSlots: snap.openSlots,
+                    starLevel: snap.starLevel,
+                    isFocused: card.activityId == focusedId,
+                    onTap: () => onTap(card),
+                    onClose: () => onClose(card),
+                  ),
+                ),
               ),
-            ),
-          ),
-        );
-      }).toList(),
+            );
+          })
+          .whereType<Marker>()
+          .toList(),
     );
   }
 }

--- a/lib/routes/world/mid_size_pin_labels_layer.dart
+++ b/lib/routes/world/mid_size_pin_labels_layer.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/widgets.dart';
+
+import 'package:flutter_map/flutter_map.dart';
+
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/routes/world/world_map_pin_budget.dart';
+import 'package:fluffychat/routes/world/world_map_pin_label.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+
+class MidSizePinLabelsLayer {
+  final List<QuestActivityCard> nonLargeCards;
+  final LabelSide? Function(String) sideOf;
+  final Size? Function(String) sizeOf;
+  final ActivityPinState Function(String) stateOf;
+  final bool Function(String) nonStartableOf;
+
+  const MidSizePinLabelsLayer({
+    required this.nonLargeCards,
+    required this.sideOf,
+    required this.sizeOf,
+    required this.stateOf,
+    required this.nonStartableOf,
+  });
+
+  /// The marker alignment that seats a label of [size] on [side] of a mid pin
+  /// whose tip is the marker's point — the render-side mirror of [pinLabelRect].
+  /// flutter_map's alignment is the pixel position of the point inside the box
+  /// ([Marker.computePixelAlignment]); values outside [-1,1] push the box fully
+  /// beside the head with no clamping.
+  Alignment _labelAlignment(LabelSide side, Size size) {
+    final headR = PinSize.midDiameter / 2;
+    final left = side == LabelSide.right
+        ? -(headR + kPinLabelGap)
+        : headR + kPinLabelGap + size.width;
+    final top = PinSize.midPointHeight + headR + size.height / 2;
+    return Marker.computePixelAlignment(
+      width: size.width,
+      height: size.height,
+      left: left,
+      top: top,
+    );
+  }
+
+  MarkerLayer layer() {
+    /// The activity-name labels for the mid pins the placement pass kept — each a
+    /// marker anchored at the pin's point, offset to its chosen side, and
+    /// non-interactive (an [IgnorePointer]) so the wide box never swallows a
+    /// pin/map tap.
+    final markers = nonLargeCards
+        .map((card) {
+          final id = card.activityId;
+          final side = sideOf(id);
+          final size = sizeOf(id);
+          if (side == null || size == null) return null;
+          return Marker(
+            point: card.point!,
+            width: size.width,
+            height: size.height,
+            alignment: _labelAlignment(side, size),
+            child: Opacity(
+              // Match the pin: a non-startable available pin's label dims too.
+              opacity: nonStartableOf(id) ? 0.5 : 1.0,
+              child: IgnorePointer(
+                child: WorldMapPinLabel(
+                  title: card.title,
+                  color: stateOf(id).labelColor,
+                ),
+              ),
+            ),
+          );
+        })
+        .whereType<Marker>()
+        .toList();
+    return MarkerLayer(markers: markers);
+  }
+}

--- a/lib/routes/world/world_map_ranking.dart
+++ b/lib/routes/world/world_map_ranking.dart
@@ -56,6 +56,12 @@ enum ActivityPinState {
 
   /// The accent used for a large card's border / foreground — the state hue.
   Color get accent => color;
+
+  /// The label text colour: the pin's state colour, except `available` — whose
+  /// light-purple fill is too low-contrast for light-purple text, so its label
+  /// uses dark purple instead (world-map.instructions.md, "Pin state").
+  Color get labelColor =>
+      this == ActivityPinState.available ? AppConfig.primaryColor : color;
 }
 
 /// The visual weight a pin renders at, filled from the top of the score. The

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -6,7 +6,6 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:matrix/matrix.dart';
 
-import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
@@ -15,16 +14,19 @@ import 'package:fluffychat/features/activity_sessions/discovered_sessions_cache.
 import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
+import 'package:fluffychat/routes/world/dot_markers_layer.dart';
+import 'package:fluffychat/routes/world/exiting_large_markers_layer.dart';
+import 'package:fluffychat/routes/world/exiting_markers_layer.dart';
+import 'package:fluffychat/routes/world/large_markers_layer.dart';
+import 'package:fluffychat/routes/world/mid_size_pin_labels_layer.dart';
 import 'package:fluffychat/routes/world/world_map.dart';
 import 'package:fluffychat/routes/world/world_map_client_extension.dart';
 import 'package:fluffychat/routes/world/world_map_constants.dart';
 import 'package:fluffychat/routes/world/world_map_large_card.dart';
 import 'package:fluffychat/routes/world/world_map_pin_budget.dart';
-import 'package:fluffychat/routes/world/world_map_pin_label.dart';
 import 'package:fluffychat/routes/world/world_map_ranking.dart';
 import 'package:fluffychat/routes/world/world_map_room_extension.dart';
 import 'package:fluffychat/routes/world/world_map_search_overlay.dart';
-import 'package:fluffychat/routes/world/world_map_state_dot.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/widgets/layouts/panel_allocator.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -112,14 +114,14 @@ class _PinRenderer {
 }
 
 /// Cached render snapshot for a pin that is animating out of the active set.
-class _PinSnapshot {
+class PinSnapshot {
   final QuestActivityCard card;
   final ActivityPinState state;
   final PinTier tier;
   final bool pinged;
   final ActivityStarLevel starLevel;
 
-  const _PinSnapshot({
+  const PinSnapshot({
     required this.card,
     required this.state,
     required this.tier,
@@ -131,7 +133,7 @@ class _PinSnapshot {
 /// Cached render snapshot for a large card that is animating out (demoted, or
 /// simply no longer fits) — everything [WorldMapLargeCard] needs, frozen at
 /// its last live frame so it renders identically while it shrinks away.
-class _LargeCardSnapshot {
+class LargeCardSnapshot {
   final QuestActivityCard card;
   final ActivityPinState state;
   final bool pinged;
@@ -142,7 +144,7 @@ class _LargeCardSnapshot {
   final int openSlots;
   final ActivityStarLevel starLevel;
 
-  const _LargeCardSnapshot({
+  const LargeCardSnapshot({
     required this.card,
     required this.state,
     required this.pinged,
@@ -179,21 +181,21 @@ class _WorldMapViewState extends State<WorldMapView> {
   static const double _narrowBottomChromeInset = 140.0;
 
   /// Pins that have left the active set and are animating to scale 0.
-  final Map<String, _PinSnapshot> _exiting = {};
+  final Map<String, PinSnapshot> _exiting = {};
 
   /// Last-known render snapshot of each active non-large pin, used to seed
   /// [_exiting] with the correct visual state when a pin leaves.
-  Map<String, _PinSnapshot> _lastActive = {};
+  Map<String, PinSnapshot> _lastActive = {};
 
   /// Large cards that have left the large tier (demoted, or the dot promoted
   /// past it out of view) and are animating to scale/opacity 0 — mirrors
   /// [_exiting]/[_lastActive] but for [WorldMapLargeCard] (world-map card
   /// pop-in/out; see [WorldMapLargeCardAnimated]).
-  final Map<String, _LargeCardSnapshot> _exitingLarge = {};
+  final Map<String, LargeCardSnapshot> _exitingLarge = {};
 
   /// Last-known render snapshot of each active large card, used to seed
   /// [_exitingLarge] with the correct content when a card leaves.
-  Map<String, _LargeCardSnapshot> _lastActiveLarge = {};
+  Map<String, LargeCardSnapshot> _lastActiveLarge = {};
 
   /// The last render model computed while the camera was settled. Reused
   /// as-is while [WorldMapController.isActivelyMoving] is true, instead of
@@ -259,33 +261,6 @@ class _WorldMapViewState extends State<WorldMapView> {
     return size;
   }
 
-  /// The label text colour: the pin's state colour, except `available` — whose
-  /// light-purple fill is too low-contrast for light-purple text, so its label
-  /// uses dark purple instead (world-map.instructions.md, "Pin state").
-  Color _labelColor(ActivityPinState state) =>
-      state == ActivityPinState.available
-      ? AppConfig.primaryColor
-      : state.color;
-
-  /// The marker alignment that seats a label of [size] on [side] of a mid pin
-  /// whose tip is the marker's point — the render-side mirror of [pinLabelRect].
-  /// flutter_map's alignment is the pixel position of the point inside the box
-  /// ([Marker.computePixelAlignment]); values outside [-1,1] push the box fully
-  /// beside the head with no clamping.
-  Alignment _labelAlignment(LabelSide side, Size size) {
-    final headR = PinSize.midDiameter / 2;
-    final left = side == LabelSide.right
-        ? -(headR + kPinLabelGap)
-        : headR + kPinLabelGap + size.width;
-    final top = PinSize.midPointHeight + headR + size.height / 2;
-    return Marker.computePixelAlignment(
-      width: size.width,
-      height: size.height,
-      left: left,
-      top: top,
-    );
-  }
-
   /// Choose each labelable mid pin's side via the live camera projection,
   /// mirroring [_placeLarge]: same safe area (viewport minus the side overlays),
   /// with the placed large cards as obstacles so a label never lands on a card.
@@ -343,40 +318,6 @@ class _WorldMapViewState extends State<WorldMapView> {
     }
   }
 
-  /// The activity-name labels for the mid pins the placement pass kept — each a
-  /// marker anchored at the pin's point, offset to its chosen side, and
-  /// non-interactive (an [IgnorePointer]) so the wide box never swallows a
-  /// pin/map tap.
-  List<Marker> _labelMarkers(_PinRenderer render) {
-    final markers = <Marker>[];
-    for (final card in render.nonLargeCards) {
-      final id = card.activityId;
-      final side = render.labels.sideOf(id);
-      final size = render.labelSizes[id];
-      if (side == null || size == null) continue;
-      markers.add(
-        Marker(
-          key: ValueKey('label_$id'),
-          point: card.point!,
-          width: size.width,
-          height: size.height,
-          alignment: _labelAlignment(side, size),
-          child: Opacity(
-            // Match the pin: a non-startable available pin's label dims too.
-            opacity: render.nonStartableOf(id) ? 0.5 : 1.0,
-            child: IgnorePointer(
-              child: WorldMapPinLabel(
-                title: card.title,
-                color: _labelColor(render.stateOf(id)),
-              ),
-            ),
-          ),
-        ),
-      );
-    }
-    return markers;
-  }
-
   /// Detects newly-gone non-large pins and adds them to [_exiting] using their
   /// last-known render state — **including** a pin promoted to large: its dot
   /// shrinks away in this layer while [WorldMapLargeCardAnimated] grows the new
@@ -404,7 +345,7 @@ class _WorldMapViewState extends State<WorldMapView> {
     // Refresh the snapshot for the next frame.
     _lastActive = {
       for (final card in render.nonLargeCards)
-        card.activityId: _PinSnapshot(
+        card.activityId: PinSnapshot(
           card: card,
           state: render.stateOf(card.activityId),
           tier: render.tierOf(card.activityId),
@@ -419,7 +360,7 @@ class _WorldMapViewState extends State<WorldMapView> {
   /// shrink-out in [_exitingLarge] instead of vanishing instantly. Its dot
   /// (mid, if eligible, else small) pops in fresh the same frame, the mirror
   /// image of a promotion.
-  void _updateExitingLarge(Map<String, _LargeCardSnapshot> currentLarge) {
+  void _updateExitingLarge(Map<String, LargeCardSnapshot> currentLarge) {
     final currentIds = currentLarge.keys.toSet();
 
     _exitingLarge.removeWhere((id, _) => currentIds.contains(id));
@@ -780,111 +721,13 @@ class _WorldMapViewState extends State<WorldMapView> {
     }
   }
 
-  /// The mid-pin "num/num" participant counts for `joinable`/`ongoingPending`
-  /// (world-map.instructions.md, "Pin display") — derived from the shared
-  /// [_sessionParticipants] resolver so they match the large card's row.
-  /// Null/null for every other state, or when the counts aren't resolvable yet.
-  ({int? filled, int? total}) _participantCounts(
-    String activityId,
-    ActivityPinState state,
-  ) {
-    final (:participants, :openSlots) = _sessionParticipants(activityId, state);
-    final filled = participants.length;
-    final total = filled + openSlots;
-    return total > 0
-        ? (filled: filled, total: total)
-        : (filled: null, total: null);
-  }
-
-  /// The learner's own live room for an `ongoingActive` pin (world-map.
-  /// instructions.md, "Pin state") — null (badge hidden) for every other
-  /// state.
-  Room? _unreadRoomFor(String activityId, ActivityPinState state) {
-    if (state != ActivityPinState.ongoingActive) return null;
-    return widget.controller.client?.activeActivityInstance(activityId);
-  }
-
-  /// The rendered small/mid pins, each an individual marker (no clustering).
-  /// Tapping any pin opens/focuses the activity in one step (no tap-to-peek).
-  /// Small dots are emitted before mid pins so mid always paints on top —
-  /// markers later in the list draw over earlier ones, and "small pins should
-  /// never show on top of mid pins" (world-map.instructions.md, "Pin display").
-  List<Marker> _dotMarkers(_PinRenderer render) {
-    // Small dots first, then mid pins, each tier keeping its score order — a
-    // stable partition (Dart's List.sort is not guaranteed stable) so mid
-    // always paints over small without reshuffling same-tier pins frame to
-    // frame.
-    final cards = render.nonLargeCards;
-    final ordered = [
-      ...cards.where((c) => render.tierOf(c.activityId) == PinTier.small),
-      ...cards.where((c) => render.tierOf(c.activityId) != PinTier.small),
-    ];
-    return ordered.map((card) {
-      final state = render.stateOf(card.activityId);
-      final tier = render.tierOf(card.activityId);
-      final box = _markerBox(state, tier);
-      final counts = _participantCounts(card.activityId, state);
-
-      return Marker(
-        key: ValueKey(card.activityId),
-        point: card.point!,
-        width: box.width,
-        height: box.height,
-        alignment: _markerAlignment(state, tier),
-        child: Opacity(
-          opacity: render.nonStartableOf(card.activityId) ? 0.5 : 1.0,
-          child: WorldMapDot(
-            key: ValueKey(card.activityId),
-            card: card,
-            state: state,
-            tier: tier,
-            onTap: () => widget.controller.openActivity(card),
-            pinged: render.pingedOf(card.activityId),
-            starLevel: render.starLevelOf(card.activityId),
-            unreadRoom: _unreadRoomFor(card.activityId, state),
-            participantsFilled: counts.filled,
-            participantsTotal: counts.total,
-            isFocused: card.activityId == render.focusedId,
-          ),
-        ),
-      );
-    }).toList();
-  }
-
-  /// Dying pins rendered in a separate layer so they animate out without
-  /// disturbing the live pins while shrinking.
-  List<Marker> _exitingMarkers() =>
-      _exiting.values.where((p) => p.card.point != null).map((p) {
-        final box = _markerBox(p.state, p.tier);
-        return Marker(
-          key: ValueKey('exiting_${p.card.activityId}'),
-          point: p.card.point!,
-          width: box.width,
-          height: box.height,
-          alignment: _markerAlignment(p.state, p.tier),
-          child: WorldMapDot(
-            key: ValueKey('exiting_${p.card.activityId}'),
-            card: p.card,
-            state: p.state,
-            tier: p.tier,
-            onTap: () {},
-            pinged: p.pinged,
-            starLevel: p.starLevel,
-            dying: true,
-            onExited: () {
-              if (mounted) setState(() => _exiting.remove(p.card.activityId));
-            },
-          ),
-        );
-      }).toList();
-
   /// Resolves everything [WorldMapLargeCard] needs for [card] — hydrates the
   /// plan, and sources participants/seats from the right place per state (a
   /// joinable session's room-preview/room, or the learner's own live room for
   /// Ongoing). Shared by [_largeMarkers] (the live layer) and
   /// [_updateExitingLarge] (freezing a snapshot for the card's exit
   /// animation), so both read identical data.
-  _LargeCardSnapshot _snapshotLargeCard(
+  LargeCardSnapshot _snapshotLargeCard(
     QuestActivityCard card,
     _PinRenderer render,
   ) {
@@ -913,7 +756,7 @@ class _WorldMapViewState extends State<WorldMapView> {
       liveRoom: liveRoom,
     );
 
-    return _LargeCardSnapshot(
+    return LargeCardSnapshot(
       card: card,
       state: state,
       pinged: render.pingedOf(card.activityId),
@@ -933,111 +776,6 @@ class _WorldMapViewState extends State<WorldMapView> {
     );
   }
 
-  /// The large featured cards the placement pass fit on screen, rendered
-  /// unclustered so they're always visible. Wrapped in
-  /// [WorldMapLargeCardAnimated] so a newly-placed card pops in (mirroring a
-  /// demoted card's shrink-out in [_exitingLargeMarkers]) instead of snapping
-  /// into existence. [currentLarge] is precomputed once per frame in [build]
-  /// (and reused by [_updateExitingLarge]) so every card's data is resolved
-  /// exactly once.
-  List<Marker> _largeMarkers(
-    _PinRenderer render,
-    Map<String, _LargeCardSnapshot> currentLarge,
-  ) {
-    const tier = PinTier.large;
-    return render.largeCards.map((card) {
-      final snap = currentLarge[card.activityId]!;
-      return Marker(
-        key: ValueKey(card.activityId),
-        point: card.point!,
-        // Widen by the badge overhang on both sides; the card centres within
-        // and the pin stays at the box's horizontal centre, so the tail still
-        // lands on the dot while the top-right badge has room to peek.
-        width: tier.dotWidth + WorldMapLargeCard.badgeOverhang * 2,
-        // The inner Align lets the card hug its own content (each state is a
-        // different height: joinable/ongoingPending add the avatar row,
-        // ongoingActive adds the message preview + star row). Height here is
-        // only a ceiling so the tallest variant isn't clipped; shorter cards
-        // don't stretch to fill it. The extra tailHeight reserves room beneath
-        // the card for the pin tail; the badgeOverhang reserves room ABOVE
-        // (topCenter alignment anchors the box bottom to the pin, so slack
-        // lands at the top) for the peeking unread badge.
-        height:
-            tier.dotHeight(snap.state) +
-            WorldMapLargeCard.tailHeight +
-            WorldMapLargeCard.badgeOverhang,
-        alignment: Alignment.topCenter,
-        child: Align(
-          // Bottom-align so the card+tail hugs its pin (the tail tip lands on
-          // the dot) instead of floating with a gap above it (#7153).
-          alignment: Alignment.bottomCenter,
-          child: WorldMapLargeCardAnimated(
-            key: ValueKey(card.activityId),
-            child: WorldMapLargeCard(
-              card: snap.card,
-              state: snap.state,
-              pinged: snap.pinged,
-              plan: snap.plan,
-              liveRoom: snap.liveRoom,
-              starsEarned: snap.starsEarned,
-              participants: snap.participants,
-              openSlots: snap.openSlots,
-              starLevel: snap.starLevel,
-              isFocused: card.activityId == render.focusedId,
-              onTap: () => widget.controller.openActivity(card),
-              onClose: () => widget.controller.dismissLargeCard(card),
-            ),
-          ),
-        ),
-      );
-    }).toList();
-  }
-
-  /// Large cards that have left the tier (X-dismissed, out-ranked, or bumped
-  /// by a zoom/placement change) rendered in a separate layer so they can
-  /// shrink away without disturbing the live cards — the mirror of
-  /// [_exitingMarkers] for the large tier.
-  List<Marker> _exitingLargeMarkers() =>
-      _exitingLarge.values.where((s) => s.card.point != null).map((snap) {
-        const tier = PinTier.large;
-        return Marker(
-          key: ValueKey('exiting_large_${snap.card.activityId}'),
-          point: snap.card.point!,
-          width: tier.dotWidth + WorldMapLargeCard.badgeOverhang * 2,
-          height:
-              tier.dotHeight(snap.state) +
-              WorldMapLargeCard.tailHeight +
-              WorldMapLargeCard.badgeOverhang,
-          alignment: Alignment.topCenter,
-          child: Align(
-            alignment: Alignment.bottomCenter,
-            child: WorldMapLargeCardAnimated(
-              key: ValueKey('exiting_large_${snap.card.activityId}'),
-              dying: true,
-              onExited: () {
-                if (mounted) {
-                  setState(() => _exitingLarge.remove(snap.card.activityId));
-                }
-              },
-              child: WorldMapLargeCard(
-                card: snap.card,
-                state: snap.state,
-                pinged: snap.pinged,
-                plan: snap.plan,
-                liveRoom: snap.liveRoom,
-                starsEarned: snap.starsEarned,
-                participants: snap.participants,
-                openSlots: snap.openSlots,
-                starLevel: snap.starLevel,
-                // No interaction on a card that's on its way out.
-                onTap: () {},
-                onClose: null,
-              ),
-            ),
-          ),
-        );
-      }).toList();
-
   /// #7813: a resize can raise the viewport-derived zoom-out floor above the
   /// camera's current zoom (window grown, phone rotated). Left below the floor,
   /// containLatitude rejects every camera move and panning freezes — so nudge
@@ -1054,6 +792,16 @@ class _WorldMapViewState extends State<WorldMapView> {
         }
       } catch (_) {}
     });
+  }
+
+  void _onExitedMarker(String activityId) {
+    if (mounted) setState(() => _exiting.remove(activityId));
+  }
+
+  void _onExitedLargeCardMarker(String activityId) {
+    if (mounted) {
+      setState(() => _exitingLarge.remove(activityId));
+    }
   }
 
   @override
@@ -1150,19 +898,53 @@ class _WorldMapViewState extends State<WorldMapView> {
                 // width-driven budget. Small/mid dots render individually (no
                 // clustering); the large featured cards render unclustered above so
                 // they're always visible.
-                MarkerLayer(markers: _dotMarkers(render)),
+                DotMarkersLayer(
+                  nonLargeCards: render.nonLargeCards,
+                  stateOf: render.stateOf,
+                  nonStartableOf: render.nonStartableOf,
+                  tierOf: render.tierOf,
+                  starLevelOf: render.starLevelOf,
+                  pingedOf: render.pingedOf,
+                  activeActivityInstance:
+                      widget.controller.client?.activeActivityInstance,
+                  markerBox: _markerBox,
+                  markerAlignment: _markerAlignment,
+                  sessionParticipants: (a, b) => _sessionParticipants(a, b),
+                  focusedId: render.focusedId,
+                  onTap: widget.controller.openActivity,
+                ).layer(),
                 // Activity-name labels for mid pins, above the dots but below the
                 // large cards (world-map.instructions.md, "Pin display"; z-order:
                 // small < mid < labels < large).
-                MarkerLayer(markers: _labelMarkers(render)),
+                MidSizePinLabelsLayer(
+                  nonLargeCards: render.nonLargeCards,
+                  sideOf: render.labels.sideOf,
+                  sizeOf: (id) => render.labelSizes[id],
+                  stateOf: render.stateOf,
+                  nonStartableOf: render.nonStartableOf,
+                ).layer(),
                 // Dying pins (a separate layer) so they don't disturb the live pins
                 // while animating out.
-                MarkerLayer(markers: _exitingMarkers()),
+                ExitingMarkersLayer(
+                  exiting: _exiting.values.toList(),
+                  markerBox: _markerBox,
+                  markerAlignment: _markerAlignment,
+                  onExited: _onExitedMarker,
+                ).layer(),
                 // Dying large cards (demoted, or bumped out) shrinking away beneath
                 // the live layer.
-                MarkerLayer(markers: _exitingLargeMarkers()),
+                ExitingLargeMarkersLayer(
+                  exitingLarge: _exitingLarge.values.toList(),
+                  onExited: _onExitedLargeCardMarker,
+                ).layer(),
                 // Large cards (always visible): the featured cards the width affords.
-                MarkerLayer(markers: _largeMarkers(render, currentLarge)),
+                LargeMarkersLayer(
+                  largeCards: render.largeCards,
+                  currentLarge: currentLarge,
+                  focusedId: render.focusedId,
+                  onTap: widget.controller.openActivity,
+                  onClose: widget.controller.dismissLargeCard,
+                ).layer(),
                 Positioned(
                   // On a narrow screen the bottom chrome (nav widget + the search bar
                   // riding above it) owns the bottom edge, so lift the attribution


### PR DESCRIPTION
… fully zoomed out

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved world map marker rendering for quest activities, including dot markers, large activity cards, labels, and animated exit states.
  * Added participant counts and activity status indicators to applicable map pins.
  * Improved marker layering so pins and labels appear in the correct visual order.
  * Updated available activity labels with improved color contrast.
* **Refactor**
  * Reorganized map marker rendering into dedicated components for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->