### PR TITLE
chore: change how activity list navigation arrow animations work

### DIFF
--- a/lib/routes/courses/course_objectives/objective_section.dart
+++ b/lib/routes/courses/course_objectives/objective_section.dart
@@ -291,14 +291,19 @@ class ObjectiveSectionState extends State<ObjectiveSection> {
                   left: 0,
                   top: 0,
                   bottom: 0,
-                  child: IgnorePointer(
-                    ignoring: !showArrow,
+                  child: AnimatedSize(
+                    duration: const Duration(milliseconds: 150),
                     child: AnimatedOpacity(
                       duration: const Duration(milliseconds: 150),
                       opacity: showArrow ? 1 : 0,
-                      child: ObjectiveSectionScrollArrow(
-                        direction: ArrowDirection.back,
-                        onTap: () => _scrollByArrow(ArrowDirection.back),
+                      child: ClipRect(
+                        child: SizedBox(
+                          width: showArrow ? 40.0 : 0.0,
+                          child: ObjectiveSectionScrollArrow(
+                            direction: ArrowDirection.back,
+                            onTap: () => _scrollByArrow(ArrowDirection.back),
+                          ),
+                        ),
                       ),
                     ),
                   ),
@@ -310,14 +315,19 @@ class ObjectiveSectionState extends State<ObjectiveSection> {
                   right: 0,
                   top: 0,
                   bottom: 0,
-                  child: IgnorePointer(
-                    ignoring: !showArrow,
+                  child: AnimatedSize(
+                    duration: const Duration(milliseconds: 150),
                     child: AnimatedOpacity(
                       duration: const Duration(milliseconds: 150),
                       opacity: showArrow ? 1 : 0,
-                      child: ObjectiveSectionScrollArrow(
-                        direction: ArrowDirection.forward,
-                        onTap: () => _scrollByArrow(ArrowDirection.forward),
+                      child: ClipRect(
+                        child: SizedBox(
+                          width: showArrow ? 40.0 : 0.0,
+                          child: ObjectiveSectionScrollArrow(
+                            direction: ArrowDirection.forward,
+                            onTap: () => _scrollByArrow(ArrowDirection.forward),
+                          ),
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
