### PR TITLE
chore: replace activity list stack with row as test

### DIFF
--- a/lib/routes/courses/course_objectives/objective_section.dart
+++ b/lib/routes/courses/course_objectives/objective_section.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_svg/svg.dart';
+import 'package:matrix/matrix_api_lite/utils/logs.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
@@ -193,127 +194,142 @@ class ObjectiveSectionState extends State<ObjectiveSection> {
         // The activities that satisfy this objective.
         SizedBox(
           height: _cardHeight,
-          child: Stack(
+          child: Row(
             children: [
-              NotificationListener<ScrollMetricsNotification>(
-                onNotification: (ScrollMetricsNotification notification) {
-                  _updateArrowVisibility();
-                  return true;
-                },
-                child: ListView.separated(
-                  controller: _scrollController,
-                  scrollDirection: Axis.horizontal,
-                  itemCount: activities.length,
-                  separatorBuilder: (_, _) => SizedBox(width: widget.spacing),
-                  padding: EdgeInsets.symmetric(vertical: widget.spacing / 2.0),
-                  itemBuilder: (context, i) {
-                    final ref = activities[i];
-                    final complete =
-                        (widget.hasCompletedActivity?.call(ref.activityId) ??
-                        false);
-                    final starsEarned = widget.userStarsByActivity(
-                      ref.activityId,
-                    );
-                    final liveState = widget.liveStateByActivity(
-                      ref.activityId,
-                    );
-                    // Dim activities that can't be started yet: the course lacks
-                    // enough members for their roles (tapping opens the start page's
-                    // Invite CTA). A live (ongoing/joinable) session already filled
-                    // its seats so it never dims
-                    final available = widget.availableParticipants;
-                    final canStart =
-                        available == null ||
-                        complete ||
-                        liveState.state != null ||
-                        ref.plan.req.numberOfParticipants <= available;
-                    return MouseRegion(
-                      cursor: SystemMouseCursors.click,
-                      child: GestureDetector(
-                        // In a preview (no room), open the activity as a standalone
-                        // world object (`/<activityId>`). In a joined course, open it
-                        // as the focused detail over the map: DROP the `left=course`
-                        // card (so it isn't left blank beside the activity) but KEEP
-                        // the `?m=course:` filter. That surviving course scope is what
-                        // marks this plan as the card's child: its close is a back-arrow
-                        // that reopens the card (a pin-opened plan drops the scope and so
-                        // closes with an X). The map stays course-scoped and zooms to
-                        // this activity (`mapFocusFor` → `ActivityFocus`). See
-                        // routing.instructions.md.
-                        onTap: () => widget.onTap(ref),
-                        child: Stack(
-                          // The card's state banner peeks past its top-left
-                          // corner, so this wrapping Stack must not clip it.
-                          clipBehavior: Clip.none,
-                          children: [
-                            Opacity(
-                              opacity: canStart ? 1.0 : 0.5,
-                              child: ActivitySuggestionCard(
-                                activity: ref.plan,
-                                width: _cardWidth,
-                                height: _cardHeight,
-                                fontSize: _isColumnMode ? 16.0 : 12.0,
-                                fontSizeSmall: _isColumnMode ? 12.0 : 8.0,
-                                iconSize: _isColumnMode ? 12.0 : 8.0,
-                                starsEarned: starsEarned,
-                                pinState: complete ? null : liveState.state,
-                                openSessions: liveState.openSessions,
-                              ),
-                            ),
-                            if (complete)
-                              Container(
-                                width: _cardWidth,
-                                height: _cardHeight,
-                                decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.circular(12.0),
-                                  color: theme.colorScheme.surface.withAlpha(
-                                    180,
-                                  ),
-                                ),
-                                child: Center(
-                                  child: SvgPicture.asset(
-                                    'assets/pangea/check.svg',
-                                    width: 48.0,
-                                    height: 48.0,
-                                  ),
-                                ),
-                              ),
-                          ],
-                        ),
+              ValueListenableBuilder(
+                valueListenable: _showBackArrowNotifier,
+                builder: (context, showArrow, _) => Positioned(
+                  left: 0,
+                  top: 0,
+                  bottom: 0,
+                  width: 40,
+                  child: IgnorePointer(
+                    ignoring: !showArrow,
+                    child: Opacity(
+                      opacity: showArrow ? 1 : 0,
+                      child: ObjectiveSectionScrollArrow(
+                        direction: ArrowDirection.back,
+                        onTap: () => _scrollByArrow(ArrowDirection.back),
                       ),
-                    );
+                    ),
+                  ),
+                ),
+              ),
+              Expanded(
+                child: NotificationListener<ScrollMetricsNotification>(
+                  onNotification: (ScrollMetricsNotification notification) {
+                    _updateArrowVisibility();
+                    return true;
                   },
+                  child: ListView.separated(
+                    controller: _scrollController,
+                    scrollDirection: Axis.horizontal,
+                    itemCount: activities.length,
+                    separatorBuilder: (_, _) => SizedBox(width: widget.spacing),
+                    padding: EdgeInsets.symmetric(
+                      vertical: widget.spacing / 2.0,
+                    ),
+                    itemBuilder: (context, i) {
+                      final ref = activities[i];
+                      final complete =
+                          (widget.hasCompletedActivity?.call(ref.activityId) ??
+                          false);
+                      final starsEarned = widget.userStarsByActivity(
+                        ref.activityId,
+                      );
+                      final liveState = widget.liveStateByActivity(
+                        ref.activityId,
+                      );
+                      // Dim activities that can't be started yet: the course lacks
+                      // enough members for their roles (tapping opens the start page's
+                      // Invite CTA). A live (ongoing/joinable) session already filled
+                      // its seats so it never dims
+                      final available = widget.availableParticipants;
+                      final canStart =
+                          available == null ||
+                          complete ||
+                          liveState.state != null ||
+                          ref.plan.req.numberOfParticipants <= available;
+                      return MouseRegion(
+                        cursor: SystemMouseCursors.click,
+                        child: Listener(
+                          behavior: HitTestBehavior.opaque,
+                          onPointerDown: (_) => Logs().w('CARD $i'),
+                          child: GestureDetector(
+                            // In a preview (no room), open the activity as a standalone
+                            // world object (`/<activityId>`). In a joined course, open it
+                            // as the focused detail over the map: DROP the `left=course`
+                            // card (so it isn't left blank beside the activity) but KEEP
+                            // the `?m=course:` filter. That surviving course scope is what
+                            // marks this plan as the card's child: its close is a back-arrow
+                            // that reopens the card (a pin-opened plan drops the scope and so
+                            // closes with an X). The map stays course-scoped and zooms to
+                            // this activity (`mapFocusFor` → `ActivityFocus`). See
+                            // routing.instructions.md.
+                            onTap: () => widget.onTap(ref),
+                            child: Stack(
+                              // The card's state banner peeks past its top-left
+                              // corner, so this wrapping Stack must not clip it.
+                              clipBehavior: Clip.hardEdge,
+                              children: [
+                                Opacity(
+                                  opacity: canStart ? 1.0 : 0.5,
+                                  child: ActivitySuggestionCard(
+                                    activity: ref.plan,
+                                    width: _cardWidth,
+                                    height: _cardHeight,
+                                    fontSize: _isColumnMode ? 16.0 : 12.0,
+                                    fontSizeSmall: _isColumnMode ? 12.0 : 8.0,
+                                    iconSize: _isColumnMode ? 12.0 : 8.0,
+                                    starsEarned: starsEarned,
+                                    pinState: complete ? null : liveState.state,
+                                    openSessions: liveState.openSessions,
+                                  ),
+                                ),
+                                if (complete)
+                                  Container(
+                                    width: _cardWidth,
+                                    height: _cardHeight,
+                                    decoration: BoxDecoration(
+                                      borderRadius: BorderRadius.circular(12.0),
+                                      color: theme.colorScheme.surface
+                                          .withAlpha(180),
+                                    ),
+                                    child: Center(
+                                      child: SvgPicture.asset(
+                                        'assets/pangea/check.svg',
+                                        width: 48.0,
+                                        height: 48.0,
+                                      ),
+                                    ),
+                                  ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
                 ),
               ),
               ValueListenableBuilder(
-                valueListenable: _showBackArrowNotifier,
-                builder: (context, showArrow, _) => showArrow
-                    ? Positioned(
-                        left: 0,
-                        top: 0,
-                        bottom: 0,
-                        width: 40,
-                        child: ObjectiveSectionScrollArrow(
-                          direction: ArrowDirection.back,
-                          onTap: () => _scrollByArrow(ArrowDirection.back),
-                        ),
-                      )
-                    : SizedBox(),
-              ),
-              ValueListenableBuilder(
                 valueListenable: _showForwardArrowNotifier,
-                builder: (context, showArrow, _) => showArrow
-                    ? Positioned(
-                        right: 0,
-                        top: 0,
-                        bottom: 0,
-                        width: 40,
-                        child: ObjectiveSectionScrollArrow(
-                          direction: ArrowDirection.forward,
-                          onTap: () => _scrollByArrow(ArrowDirection.forward),
-                        ),
-                      )
-                    : SizedBox(),
+                builder: (context, showArrow, _) => IgnorePointer(
+                  ignoring: !showArrow,
+                  child: Opacity(
+                    opacity: showArrow ? 1 : 0,
+                    child: Positioned(
+                      right: 0,
+                      top: 0,
+                      bottom: 0,
+                      width: 40,
+                      child: ObjectiveSectionScrollArrow(
+                        direction: ArrowDirection.forward,
+                        onTap: () => _scrollByArrow(ArrowDirection.forward),
+                      ),
+                    ),
+                  ),
+                ),
               ),
             ],
           ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
