### PR TITLE
chore: remove pretooluse-merge-gate.sh hook wire

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,10 +37,6 @@
           },
           {
             "type": "command",
-            "command": "bash \"$HOME/PangeaChat/.github/scripts/pretooluse-merge-gate.sh\""
-          },
-          {
-            "type": "command",
             "command": "python3 \"$HOME/PangeaChat/.github/scripts/intent-gate.py\""
           },
           {


### PR DESCRIPTION
## Summary
- Removes the `pretooluse-merge-gate.sh` hook wire from `.claude/settings.json`.

## Why
Local config cleanup, not client-testable — no issue linkage per copilot-instructions.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated command-line workflow checks to provide intent validation and reminders.
  * Retained existing issue-related checks while removing the previous merge-gate step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->