### PR TITLE
fix: default the course panel to the Course Plan tab

### DIFF
--- a/lib/routes/chat/chat_details/space_details_content.dart
+++ b/lib/routes/chat/chat_details/space_details_content.dart
@@ -55,7 +55,10 @@ class SpaceDetailsContent extends StatelessWidget {
   const SpaceDetailsContent(this.controller, this.room, {super.key});
 
   SpaceSettingsTabs tab(BuildContext context) {
-    final defaultTab = SpaceSettingsTabs.chat;
+    // Course Plan is the default tab: it's where a course's activities live,
+    // so a bare `course` token (opened fresh, or reopened by an activity's
+    // back-arrow, #7933) lands there rather than on Chat.
+    final defaultTab = SpaceSettingsTabs.course;
     final activeTab = controller.widget.activeTab;
     if (activeTab != null) {
       return activeTab;


### PR DESCRIPTION
## Summary
- The course panel's tab fallback now defaults to Course Plan instead of Chat.
- This is also what an activity's back-arrow falls through to when it reseats the course card (`WorkspaceNav.dropActivityOverlay(reopenCourseCard: true)` inserts a bare, tab-less `course` token), so going back from an activity now lands on Course Plan — where that activity lives — instead of Chat.

## Why
Closes #7933

## Test plan
- [ ] Open a course from the rail, a map pin, or a Courses-list tile — it opens on the Course Plan tab.
- [ ] From a course's Course Plan tab (or a map pin while a course is scoped), tap into an activity, then tap the back arrow — it returns to the course card on the Course Plan tab, not Chat.
- [ ] Switching tabs within the course card (Chat / Course Plan / Participants / More) still works normally.