### PR TITLE
fix: hide activity summary if present in non-finished activity, show …

### DIFF
--- a/lib/features/activity_sessions/activity_summary_room_extension.dart
+++ b/lib/features/activity_sessions/activity_summary_room_extension.dart
@@ -18,7 +18,7 @@ import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 extension ActivitySummaryRoomExtension on Room {
-  ActivitySummaryModel? activitySummary(String langCode) {
+  ActivitySummaryModel? _activitySummary(String langCode) {
     final stateEvent = getState(PangeaEventTypes.activitySummary, langCode);
     if (stateEvent == null) return null;
 
@@ -37,7 +37,16 @@ extension ActivitySummaryRoomExtension on Room {
   ActivitySummaryModel? get activitySummaryByL1 {
     final l1 = MatrixState.pangeaController.userController.userL1Code;
     if (l1 == null) return null;
-    return activitySummary(l1);
+    return _activitySummary(l1);
+  }
+
+  ActivitySummaryModel? get visibleActivitySummaryByL1 {
+    // account for edge case of activity summary in non-finished activity
+    if (!isActivityFinished) return null;
+
+    final l1 = MatrixState.pangeaController.userController.userL1Code;
+    if (l1 == null) return null;
+    return _activitySummary(l1);
   }
 
   Future<void> _setActivitySummary(
@@ -95,7 +104,7 @@ extension ActivitySummaryRoomExtension on Room {
 
     final List<ContentFeedbackModel> contentFeedback = [];
     if (feedback != null) {
-      final prevSummary = activitySummary(langCode);
+      final prevSummary = _activitySummary(langCode);
       if (prevSummary?.summary != null) {
         contentFeedback.add(
           ContentFeedbackModel(
@@ -120,7 +129,8 @@ extension ActivitySummaryRoomExtension on Room {
     String langCode,
   ) {
     final ActivitySummaryAnalyticsModel analytics =
-        activitySummary(langCode)?.analytics ?? ActivitySummaryAnalyticsModel();
+        _activitySummary(langCode)?.analytics ??
+        ActivitySummaryAnalyticsModel();
     for (final messageEvent in messageEvents) {
       analytics.addMessageConstructs(messageEvent);
     }
@@ -151,7 +161,7 @@ extension ActivitySummaryRoomExtension on Room {
   );
 
   Future<void> fetchSummaries(String langCode, {String? feedback}) async {
-    if (activitySummary(langCode)?.summary != null && feedback == null) return;
+    if (_activitySummary(langCode)?.summary != null && feedback == null) return;
     await _startRequestingActivitySummary(langCode);
 
     final events = await getAllEvents();
@@ -181,7 +191,7 @@ extension ActivitySummaryRoomExtension on Room {
 
     final result = await ActivitySummaryRepo.get(id, req);
     if (result.isError) {
-      if (activitySummary(langCode)?.summary == null) {
+      if (_activitySummary(langCode)?.summary == null) {
         await _stopRequestingActivitySummaryOnError(analytics, langCode);
       }
     } else {

--- a/lib/routes/chat/activity_sessions/activity_chat_controller.dart
+++ b/lib/routes/chat/activity_sessions/activity_chat_controller.dart
@@ -78,7 +78,7 @@ class ActivityChatController {
     await _onLeaveActivitySession();
   }
 
-  ActivitySummaryModel? get _summaryEvent => room.activitySummaryByL1;
+  ActivitySummaryModel? get _summaryEvent => room.visibleActivitySummaryByL1;
   ActivitySummaryResponseModel? get _summary => _summaryEvent?.summary;
 
   bool get hasSummary => _summary != null;

--- a/lib/routes/chat/activity_sessions/activity_finished_status_message.dart
+++ b/lib/routes/chat/activity_sessions/activity_finished_status_message.dart
@@ -32,7 +32,7 @@ class ActivityFinishedStatusMessage extends StatelessWidget {
     final l1 = MatrixState.pangeaController.userController.userL1Code;
 
     final finished = controller.room.isActivityFinished;
-    final summary = controller.room.activitySummaryByL1;
+    final summary = controller.room.visibleActivitySummaryByL1;
 
     final hasContent =
         !finished || (summary != null && summary.summary == null);

--- a/lib/routes/chat/activity_sessions/activity_user_summaries_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_user_summaries_widget.dart
@@ -26,7 +26,7 @@ class ActivityUserSummaries extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final summaryModel = room.activitySummaryByL1;
+    final summaryModel = room.visibleActivitySummaryByL1;
     if (summaryModel == null || summaryModel.hasError) {
       return const SizedBox();
     }

--- a/lib/routes/chat/chat_details/chat_context_menu_action.dart
+++ b/lib/routes/chat/chat_details/chat_context_menu_action.dart
@@ -30,8 +30,9 @@ extension on ChatContextAction {
       case ChatContextAction.mute:
         return room.membership == Membership.join;
       case ChatContextAction.leave:
-        return room.membership == Membership.join &&
-            (!room.isActivitySession || !room.isActivityStarted);
+        if (room.membership != Membership.join) return false;
+        if (!room.isActivitySession) return true;
+        return !room.isActivityStarted || !room.hasPickedRole;
       case ChatContextAction.delete:
         return room.isRoomAdmin && !room.isDirectChat;
       case ChatContextAction.endActivity:


### PR DESCRIPTION
…leave option in chat popup for user without role in started activity

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
