### PR TITLE
Order tab traversal for map filter

### DIFF
--- a/lib/routes/world/world_map_search_overlay.dart
+++ b/lib/routes/world/world_map_search_overlay.dart
@@ -95,147 +95,150 @@ class _WorldMapSearchOverlayState extends State<WorldMapSearchOverlay> {
       label: l10n.searchActivitiesLabel,
       container: true,
       child: SafeArea(
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            PangeaSearchBar(
-              controller: _controller,
-              onChanged: widget.updateQuery,
-              labelText: l10n.mapSearchHint,
-              suffixIcon: searching
-                  ? IconButton(
-                      icon: const Icon(Icons.close),
-                      tooltip: l10n.clearSearch,
-                      onPressed: () => widget.updateQuery(''),
-                    )
-                  : null,
-            ),
-            const SizedBox(height: 8),
-            Semantics(
-              label: l10n.activityFilterButtonsLabel,
-              container: true,
-              child: SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                child: Row(
-                  children: [
-                    if (widget.l2Label != null) ...[
-                      FilterChip(
-                        selected: widget.filter.l2Only,
-                        label: Text(
-                          widget.filter.l2Only
-                              ? widget.l2Label!
-                              : l10n.mapFilterAllLanguages,
-                        ),
-                        avatar: const Icon(Icons.translate, size: 16),
-                        onSelected: (_) => widget.onToggleL2(),
-                      ),
-                      const SizedBox(width: 6),
-                    ],
-                    for (final level in LanguageLevelTypeEnum.values) ...[
-                      FilterChip(
-                        selected: widget.filter.cefrFilter.contains(level),
-                        label: Text(level.title(context)),
-                        onSelected: (_) => widget.toggleCefr(level),
-                      ),
-                      const SizedBox(width: 6),
-                    ],
-                    for (final c in MapCompletionFilter.values) ...[
-                      FilterChip(
-                        selected: widget.filter.completionFilter.contains(c),
-                        label: Text(_completionLabel(l10n, c)),
-                        onSelected: (_) => widget.toggleCompletion(c),
-                      ),
-                      const SizedBox(width: 6),
-                    ],
-                    if (widget.filter.canReset)
-                      ActionChip(
-                        avatar: const Icon(Icons.restart_alt, size: 16),
-                        label: Text(l10n.mapFilterReset),
-                        onPressed: widget.onReset,
-                      ),
-                  ],
-                ),
+        child: FocusTraversalGroup(
+          policy: OrderedTraversalPolicy(),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              PangeaSearchBar(
+                controller: _controller,
+                onChanged: widget.updateQuery,
+                labelText: l10n.mapSearchHint,
+                suffixIcon: searching
+                    ? IconButton(
+                        icon: const Icon(Icons.close),
+                        tooltip: l10n.clearSearch,
+                        onPressed: () => widget.updateQuery(''),
+                      )
+                    : null,
               ),
-            ),
-            if (searching) ...[
               const SizedBox(height: 8),
-              Material(
-                elevation: 4,
-                borderRadius: BorderRadius.circular(12),
-                color: theme.colorScheme.surface,
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxHeight: 320),
-                  child: widget.results.isEmpty
-                      ? Padding(
-                          padding: const EdgeInsets.all(16),
-                          child: Text(
-                            l10n.mapSearchNoResults,
-                            style: theme.textTheme.bodyMedium,
-                          ),
-                        )
-                      : Semantics(
-                          label: l10n.filteredActivitiesLabel,
-                          container: true,
-                          child: ListView.builder(
-                            shrinkWrap: true,
-                            padding: EdgeInsets.zero,
-                            itemCount: widget.results.length > _maxResults
-                                ? _maxResults
-                                : widget.results.length,
-                            itemBuilder: (context, i) {
-                              final card = widget.results[i];
-                              return ListTile(
-                                dense: true,
-                                leading: const Icon(Icons.star, size: 18),
-                                title: Text(
-                                  card.title,
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                                subtitle: Text(
-                                  [card.l2, card.cefr]
-                                      .where((s) => s != null && s.isNotEmpty)
-                                      .join(' · '),
-                                  maxLines: 1,
-                                  overflow: TextOverflow.ellipsis,
-                                ),
-                                onTap: () => widget.onResultTap(card),
-                              );
-                            },
-                          ),
-                        ),
-                ),
-              ),
-            ] else if (widget.emptyInView) ...[
-              const SizedBox(height: 8),
-              Material(
-                elevation: 4,
-                borderRadius: BorderRadius.circular(12),
-                color: theme.colorScheme.surface,
-                child: Padding(
-                  padding: const EdgeInsets.all(12),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
+              Semantics(
+                label: l10n.activityFilterButtonsLabel,
+                container: true,
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
                     children: [
-                      Text(
-                        l10n.mapEmptyInView,
-                        style: theme.textTheme.bodyMedium,
-                      ),
-                      const SizedBox(height: 8),
-                      if (widget.filter.l2Only && widget.l2Label != null)
-                        FilledButton.tonalIcon(
-                          icon: const Icon(Icons.translate, size: 16),
-                          label: Text(l10n.widenSearch),
-                          onPressed: widget.onWidenSearch,
+                      if (widget.l2Label != null) ...[
+                        FilterChip(
+                          selected: widget.filter.l2Only,
+                          label: Text(
+                            widget.filter.l2Only
+                                ? widget.l2Label!
+                                : l10n.mapFilterAllLanguages,
+                          ),
+                          avatar: const Icon(Icons.translate, size: 16),
+                          onSelected: (_) => widget.onToggleL2(),
+                        ),
+                        const SizedBox(width: 6),
+                      ],
+                      for (final level in LanguageLevelTypeEnum.values) ...[
+                        FilterChip(
+                          selected: widget.filter.cefrFilter.contains(level),
+                          label: Text(level.title(context)),
+                          onSelected: (_) => widget.toggleCefr(level),
+                        ),
+                        const SizedBox(width: 6),
+                      ],
+                      for (final c in MapCompletionFilter.values) ...[
+                        FilterChip(
+                          selected: widget.filter.completionFilter.contains(c),
+                          label: Text(_completionLabel(l10n, c)),
+                          onSelected: (_) => widget.toggleCompletion(c),
+                        ),
+                        const SizedBox(width: 6),
+                      ],
+                      if (widget.filter.canReset)
+                        ActionChip(
+                          avatar: const Icon(Icons.restart_alt, size: 16),
+                          label: Text(l10n.mapFilterReset),
+                          onPressed: widget.onReset,
                         ),
                     ],
                   ),
                 ),
               ),
+              if (searching) ...[
+                const SizedBox(height: 8),
+                Material(
+                  elevation: 4,
+                  borderRadius: BorderRadius.circular(12),
+                  color: theme.colorScheme.surface,
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 320),
+                    child: widget.results.isEmpty
+                        ? Padding(
+                            padding: const EdgeInsets.all(16),
+                            child: Text(
+                              l10n.mapSearchNoResults,
+                              style: theme.textTheme.bodyMedium,
+                            ),
+                          )
+                        : Semantics(
+                            label: l10n.filteredActivitiesLabel,
+                            container: true,
+                            child: ListView.builder(
+                              shrinkWrap: true,
+                              padding: EdgeInsets.zero,
+                              itemCount: widget.results.length > _maxResults
+                                  ? _maxResults
+                                  : widget.results.length,
+                              itemBuilder: (context, i) {
+                                final card = widget.results[i];
+                                return ListTile(
+                                  dense: true,
+                                  leading: const Icon(Icons.star, size: 18),
+                                  title: Text(
+                                    card.title,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                  subtitle: Text(
+                                    [card.l2, card.cefr]
+                                        .where((s) => s != null && s.isNotEmpty)
+                                        .join(' · '),
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                  onTap: () => widget.onResultTap(card),
+                                );
+                              },
+                            ),
+                          ),
+                  ),
+                ),
+              ] else if (widget.emptyInView) ...[
+                const SizedBox(height: 8),
+                Material(
+                  elevation: 4,
+                  borderRadius: BorderRadius.circular(12),
+                  color: theme.colorScheme.surface,
+                  child: Padding(
+                    padding: const EdgeInsets.all(12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          l10n.mapEmptyInView,
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                        const SizedBox(height: 8),
+                        if (widget.filter.l2Only && widget.l2Label != null)
+                          FilledButton.tonalIcon(
+                            icon: const Icon(Icons.translate, size: 16),
+                            label: Text(l10n.widenSearch),
+                            onPressed: widget.onWidenSearch,
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard and assistive-navigation order across the world map search overlay, including the search bar, filters, and results or empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->