### PR TITLE
fix: make activity scroll arrows clickable on web (#7803)

### DIFF
--- a/lib/routes/courses/course_objectives/objective_section.dart
+++ b/lib/routes/courses/course_objectives/objective_section.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_svg/svg.dart';
-import 'package:matrix/matrix_api_lite/utils/logs.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
@@ -231,108 +230,98 @@ class ObjectiveSectionState extends State<ObjectiveSection> {
                         ref.plan.req.numberOfParticipants <= available;
                     return MouseRegion(
                       cursor: SystemMouseCursors.click,
-                      child: Listener(
-                        behavior: HitTestBehavior.opaque,
-                        onPointerDown: (_) => Logs().w('CARD $i'),
-                        child: GestureDetector(
-                          // In a preview (no room), open the activity as a standalone
-                          // world object (`/<activityId>`). In a joined course, open it
-                          // as the focused detail over the map: DROP the `left=course`
-                          // card (so it isn't left blank beside the activity) but KEEP
-                          // the `?m=course:` filter. That surviving course scope is what
-                          // marks this plan as the card's child: its close is a back-arrow
-                          // that reopens the card (a pin-opened plan drops the scope and so
-                          // closes with an X). The map stays course-scoped and zooms to
-                          // this activity (`mapFocusFor` → `ActivityFocus`). See
-                          // routing.instructions.md.
-                          onTap: () => widget.onTap(ref),
-                          child: Stack(
-                            // The card's state banner peeks past its top-left
-                            // corner, so this wrapping Stack must not clip it.
-                            clipBehavior: Clip.hardEdge,
-                            children: [
-                              Opacity(
-                                opacity: canStart ? 1.0 : 0.5,
-                                child: ActivitySuggestionCard(
-                                  activity: ref.plan,
-                                  width: _cardWidth,
-                                  height: _cardHeight,
-                                  fontSize: _isColumnMode ? 16.0 : 12.0,
-                                  fontSizeSmall: _isColumnMode ? 12.0 : 8.0,
-                                  iconSize: _isColumnMode ? 12.0 : 8.0,
-                                  starsEarned: starsEarned,
-                                  pinState: complete ? null : liveState.state,
-                                  openSessions: liveState.openSessions,
+                      child: GestureDetector(
+                        // In a preview (no room), open the activity as a standalone
+                        // world object (`/<activityId>`). In a joined course, open it
+                        // as the focused detail over the map: DROP the `left=course`
+                        // card (so it isn't left blank beside the activity) but KEEP
+                        // the `?m=course:` filter. That surviving course scope is what
+                        // marks this plan as the card's child: its close is a back-arrow
+                        // that reopens the card (a pin-opened plan drops the scope and so
+                        // closes with an X). The map stays course-scoped and zooms to
+                        // this activity (`mapFocusFor` → `ActivityFocus`). See
+                        // routing.instructions.md.
+                        onTap: () => widget.onTap(ref),
+                        child: Stack(
+                          // The card's state banner peeks past its top-left
+                          // corner, so this wrapping Stack must not clip it.
+                          clipBehavior: Clip.hardEdge,
+                          children: [
+                            Opacity(
+                              opacity: canStart ? 1.0 : 0.5,
+                              child: ActivitySuggestionCard(
+                                activity: ref.plan,
+                                width: _cardWidth,
+                                height: _cardHeight,
+                                fontSize: _isColumnMode ? 16.0 : 12.0,
+                                fontSizeSmall: _isColumnMode ? 12.0 : 8.0,
+                                iconSize: _isColumnMode ? 12.0 : 8.0,
+                                starsEarned: starsEarned,
+                                pinState: complete ? null : liveState.state,
+                                openSessions: liveState.openSessions,
+                              ),
+                            ),
+                            if (complete)
+                              Container(
+                                width: _cardWidth,
+                                height: _cardHeight,
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(12.0),
+                                  color: theme.colorScheme.surface.withAlpha(
+                                    180,
+                                  ),
+                                ),
+                                child: Center(
+                                  child: SvgPicture.asset(
+                                    'assets/pangea/check.svg',
+                                    width: 48.0,
+                                    height: 48.0,
+                                  ),
                                 ),
                               ),
-                              if (complete)
-                                Container(
-                                  width: _cardWidth,
-                                  height: _cardHeight,
-                                  decoration: BoxDecoration(
-                                    borderRadius: BorderRadius.circular(12.0),
-                                    color: theme.colorScheme.surface.withAlpha(
-                                      180,
-                                    ),
-                                  ),
-                                  child: Center(
-                                    child: SvgPicture.asset(
-                                      'assets/pangea/check.svg',
-                                      width: 48.0,
-                                      height: 48.0,
-                                    ),
-                                  ),
-                                ),
-                            ],
-                          ),
+                          ],
                         ),
                       ),
                     );
                   },
                 ),
               ),
+              // The scroll arrows overlay the ends of the ListView. Only mount
+              // the arrow that is currently usable — a hidden-but-present arrow
+              // (IgnorePointer / opacity 0) still leaves a semantics node at the
+              // edge that, on Flutter web, lets a tap fall through to the card
+              // beneath it. Wrapping the live arrow in BlockSemantics drops the
+              // card semantics underneath so the tap lands on the arrow (#7803).
               Positioned(
                 left: 0,
                 top: 0,
                 bottom: 0,
-                child: ValueListenableBuilder(
+                child: ValueListenableBuilder<bool>(
                   valueListenable: _showBackArrowNotifier,
-                  builder: (context, showArrow, _) => BlockSemantics(
-                    blocking: showArrow,
-                    child: IgnorePointer(
-                      ignoring: !showArrow,
-                      child: AnimatedOpacity(
-                        duration: Duration(milliseconds: 150),
-                        opacity: showArrow ? 1 : 0,
-                        child: ObjectiveSectionScrollArrow(
-                          direction: ArrowDirection.back,
-                          onTap: () => _scrollByArrow(ArrowDirection.back),
-                        ),
-                      ),
-                    ),
-                  ),
+                  builder: (context, showArrow, _) => showArrow
+                      ? BlockSemantics(
+                          child: ObjectiveSectionScrollArrow(
+                            direction: ArrowDirection.back,
+                            onTap: () => _scrollByArrow(ArrowDirection.back),
+                          ),
+                        )
+                      : const SizedBox.shrink(),
                 ),
               ),
               Positioned(
                 right: 0,
                 top: 0,
                 bottom: 0,
-                child: ValueListenableBuilder(
+                child: ValueListenableBuilder<bool>(
                   valueListenable: _showForwardArrowNotifier,
-                  builder: (context, showArrow, _) => BlockSemantics(
-                    blocking: showArrow,
-                    child: IgnorePointer(
-                      ignoring: !showArrow,
-                      child: AnimatedOpacity(
-                        duration: Duration(milliseconds: 150),
-                        opacity: showArrow ? 1 : 0,
-                        child: ObjectiveSectionScrollArrow(
-                          direction: ArrowDirection.forward,
-                          onTap: () => _scrollByArrow(ArrowDirection.forward),
-                        ),
-                      ),
-                    ),
-                  ),
+                  builder: (context, showArrow, _) => showArrow
+                      ? BlockSemantics(
+                          child: ObjectiveSectionScrollArrow(
+                            direction: ArrowDirection.forward,
+                            onTap: () => _scrollByArrow(ArrowDirection.forward),
+                          ),
+                        )
+                      : const SizedBox.shrink(),
                 ),
               ),
             ],

--- a/lib/routes/courses/course_objectives/objective_section_scroll_arrow.dart
+++ b/lib/routes/courses/course_objectives/objective_section_scroll_arrow.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'package:matrix/matrix_api_lite/utils/logs.dart';
-
 import 'package:fluffychat/l10n/l10n.dart';
 
 enum ArrowDirection {
@@ -31,17 +29,27 @@ class ObjectiveSectionScrollArrow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return GestureDetector(
-      onTap: () {
-        Logs().w('tap ${direction.name}');
-        onTap();
-      },
-      behavior: HitTestBehavior.opaque,
-      child: AbsorbPointer(
-        child: Container(
-          padding: EdgeInsets.all(8.0),
-          decoration: BoxDecoration(color: theme.colorScheme.surface),
-          child: Center(child: Icon(direction.icon)),
+    // Expose the arrow as an explicit button. On Flutter web, when the
+    // accessibility layer is active, pointer events are dispatched through the
+    // semantics DOM tree rather than the render tree, so the arrow needs its own
+    // tappable semantics node that sits on top of the activity cards beneath it.
+    // The caller wraps this in a BlockSemantics so the card nodes underneath
+    // can't intercept the tap (#7803). Do NOT wrap this in an AbsorbPointer /
+    // IgnorePointer: those strip this node's semantics and reintroduce the
+    // click-through.
+    return Semantics(
+      button: true,
+      label: direction.label(L10n.of(context)),
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: onTap,
+          child: Container(
+            padding: const EdgeInsets.all(8.0),
+            decoration: BoxDecoration(color: theme.colorScheme.surface),
+            child: Center(child: Icon(direction.icon)),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Fixes #7803

## Problem
The left/right activity scroll arrows couldn't be clicked on **deployed web** builds — taps fell through to the activity card beneath the arrow. It only happened when the ListView was at either scroll extreme (only one arrow showing), reproduced across browsers, but never on local builds of any type.

## Root cause
This is a Flutter-web **semantics hit-test** issue (same class as #7942). On web, when the accessibility layer is active, pointer events are dispatched through the semantics DOM tree rather than the render tree — which is why it never reproduced locally. The current state on `main` had regressed:

- The arrow was wrapped in `AbsorbPointer`, which strips the arrow's own tappable semantics node, so the card's node underneath won the hit test.
- The opposite (hidden) arrow stayed mounted via `IgnorePointer` + opacity 0, leaving a stale semantics node at the edge for taps to fall through. This explains the "only at the extremes" behavior — at an extreme only one arrow shows and its partner is that invisible ghost.

## Fix
**`objective_section_scroll_arrow.dart`**
- Added an explicit `Semantics(button: true, label: …)` node.
- Removed the `AbsorbPointer` wrapper that was stripping the arrow's semantics.
- Removed leftover debug `Logs()` and the matrix logs import.

**`objective_section.dart`**
- Each arrow is now **conditionally mounted** — only the usable arrow exists in the tree (no `IgnorePointer`/opacity-0 ghost).
- The live arrow is wrapped in `BlockSemantics` so the card nodes underneath can't intercept the tap.
- Removed the debug `Listener`/`Logs('CARD $i')` wrapper around the cards and the unused import.

`dart analyze` passes on both files. No existing widget tests reference these files.

## ⚠️ Needs web verification
This bug does **not reproduce locally on any build type**, so it could not be verified locally. The reasoning is sound and strictly more correct than current `main` (proper button semantics + no semantics-stripping `AbsorbPointer` + no ghost node), but it needs a deploy to confirm — specifically on the setups still failing in the issue thread (Opera/Windows and Firefox/Mac, left arrow).

Trade-off: `BlockSemantics` drops the ListView's semantics while an arrow is showing (screen readers won't reach the cards then). This is the same trade already in place on `main`, kept intentionally.

## TO TEST
- [ ] Open course plan
- [ ] Use side arrows to scroll through activities (on deployed web, at both scroll extremes, across browsers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)