### PR TITLE
fix: back scroll arrow scrolls forward when both arrows visible (#7803)

### DIFF
--- a/lib/routes/courses/course_objectives/objective_section.dart
+++ b/lib/routes/courses/course_objectives/objective_section.dart
@@ -286,12 +286,31 @@ class ObjectiveSectionState extends State<ObjectiveSection> {
                   },
                 ),
               ),
+              // Drop the card semantics beneath the arrows so a tap on an arrow
+              // can't fall through to a card on Flutter web (#7803). A single
+              // blocker painted after the ListView but before the arrows keeps
+              // the two arrows from clobbering each other's semantics: a
+              // per-arrow BlockSemantics would also drop the sibling arrow
+              // painted before it, routing its taps to the wrong arrow.
+              ListenableBuilder(
+                listenable: Listenable.merge([
+                  _showBackArrowNotifier,
+                  _showForwardArrowNotifier,
+                ]),
+                builder: (context, _) {
+                  final blocking =
+                      _showBackArrowNotifier.value ||
+                      _showForwardArrowNotifier.value;
+                  return blocking
+                      ? const BlockSemantics()
+                      : const SizedBox.shrink();
+                },
+              ),
               // The scroll arrows overlay the ends of the ListView. Only mount
               // the arrow that is currently usable — a hidden-but-present arrow
               // (IgnorePointer / opacity 0) still leaves a semantics node at the
               // edge that, on Flutter web, lets a tap fall through to the card
-              // beneath it. Wrapping the live arrow in BlockSemantics drops the
-              // card semantics underneath so the tap lands on the arrow (#7803).
+              // beneath it.
               Positioned(
                 left: 0,
                 top: 0,
@@ -299,11 +318,9 @@ class ObjectiveSectionState extends State<ObjectiveSection> {
                 child: ValueListenableBuilder<bool>(
                   valueListenable: _showBackArrowNotifier,
                   builder: (context, showArrow, _) => showArrow
-                      ? BlockSemantics(
-                          child: ObjectiveSectionScrollArrow(
-                            direction: ArrowDirection.back,
-                            onTap: () => _scrollByArrow(ArrowDirection.back),
-                          ),
+                      ? ObjectiveSectionScrollArrow(
+                          direction: ArrowDirection.back,
+                          onTap: () => _scrollByArrow(ArrowDirection.back),
                         )
                       : const SizedBox.shrink(),
                 ),
@@ -315,11 +332,9 @@ class ObjectiveSectionState extends State<ObjectiveSection> {
                 child: ValueListenableBuilder<bool>(
                   valueListenable: _showForwardArrowNotifier,
                   builder: (context, showArrow, _) => showArrow
-                      ? BlockSemantics(
-                          child: ObjectiveSectionScrollArrow(
-                            direction: ArrowDirection.forward,
-                            onTap: () => _scrollByArrow(ArrowDirection.forward),
-                          ),
+                      ? ObjectiveSectionScrollArrow(
+                          direction: ArrowDirection.forward,
+                          onTap: () => _scrollByArrow(ArrowDirection.forward),
                         )
                       : const SizedBox.shrink(),
                 ),

--- a/lib/routes/courses/course_objectives/objective_section_scroll_arrow.dart
+++ b/lib/routes/courses/course_objectives/objective_section_scroll_arrow.dart
@@ -33,10 +33,10 @@ class ObjectiveSectionScrollArrow extends StatelessWidget {
     // accessibility layer is active, pointer events are dispatched through the
     // semantics DOM tree rather than the render tree, so the arrow needs its own
     // tappable semantics node that sits on top of the activity cards beneath it.
-    // The caller wraps this in a BlockSemantics so the card nodes underneath
-    // can't intercept the tap (#7803). Do NOT wrap this in an AbsorbPointer /
-    // IgnorePointer: those strip this node's semantics and reintroduce the
-    // click-through.
+    // The caller drops the card semantics underneath (a sibling BlockSemantics)
+    // so the cards can't intercept the tap (#7803). Do NOT wrap this in an
+    // AbsorbPointer / IgnorePointer: those strip this node's semantics and
+    // reintroduce the click-through.
     return Semantics(
       button: true,
       label: direction.label(L10n.of(context)),


### PR DESCRIPTION
Follow-up to #7980 (already merged). Fixes a regression that fix surfaced.

## Problem
After #7980 fixed the web click-through, a new issue appeared: when **both** arrows are visible (list scrolled to the middle), tapping the **back** arrow scrolled the list **forward**.

## Root cause
Each arrow was wrapped in its own `BlockSemantics`. In the `Stack`, the forward arrow is painted last, so its `BlockSemantics` drops the semantics of everything painted before it — **including the back arrow**. With the back arrow's semantics node gone, Flutter web routed the tap to the only remaining button node (the forward arrow), scrolling forward.

## Fix
Replace the two per-arrow `BlockSemantics` with a **single** blocker painted after the ListView but before the arrows. It drops only the card semantics beneath the arrows, and the two arrows no longer clobber each other's nodes.

```
Stack
├─ ListView (cards)
├─ BlockSemantics        ← drops card semantics only, when any arrow is shown
├─ back arrow  (button semantics survive)
└─ forward arrow (button semantics survive)
```

`dart analyze` passes. Still needs deploy verification on web (both the extremes case from #7803 and the both-visible case), since this class of bug doesn't reproduce on local builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)