### PR TITLE
fix(nav): raise activity plan when its pull-up bar is tapped on web (#7927)

### DIFF
--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -715,7 +715,24 @@ class _NavCavity extends StatelessWidget {
         // Grab handle: drag to resize, tap to toggle half/full. Exposed to
         // assistive tech as a single named button that runs the toggle (the
         // drag is pointer-only) — mirrors `MobileCourseSheet`'s handle (#7128).
+        //
+        // `container: true` forces the handle into its OWN semantics node
+        // instead of merging into the cavity's node. It matters because the
+        // enclosing cavity GestureDetector carries the vertical-drag (scroll)
+        // actions but, for a non-peek cavity (the activity plan), NO tap of its
+        // own (`onBodyTap` is null unless it's a course at peek). Without this,
+        // the handle's tap action merged INTO that scrollable node, producing a
+        // single node that was both scrollable and tappable. On Flutter web
+        // with the accessibility layer active, pointer events dispatch through
+        // the semantics DOM, and a scrollable node does not reliably deliver a
+        // tap — so clicking the handle did nothing (only manual dragging
+        // worked), but only on browsers/OSes that turn the a11y layer on
+        // (#7927; the sibling web-semantics fall-through of #7803). A course at
+        // peek was unaffected only because its cavity node had its own
+        // `onBodyTap`, which kept the handle a separate child node. Forcing the
+        // container makes the handle that separate button in every cavity.
         Semantics(
+          container: true,
           button: true,
           label: l10n.resizeCoursePanel,
           onTap: onHandleTap,

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 
@@ -398,6 +399,78 @@ void main() {
           greaterThan(100.0),
           reason: 'reopening after a drag-to-zero must restore a real height',
         );
+      },
+    );
+
+    testWidgets(
+      'the handle is its own tappable semantics node, not merged into the '
+      'scrollable cavity (#7927)',
+      (tester) async {
+        // The activity-plan cavity (non-peek, dismiss-on-close): its outer
+        // cavity GestureDetector carries the vertical-drag (scroll) actions but
+        // no tap of its own. The handle must still surface as its OWN button
+        // node. If it merges into the scrollable cavity node — inheriting
+        // scrollUp/scrollDown — Flutter web's accessibility layer stops
+        // delivering the tap, so clicking the handle does nothing and the sheet
+        // can only be dragged (the #7927 report: reproduced on Opera/Windows,
+        // where the a11y layer is active, but not on Chrome, where it isn't).
+        final semantics = tester.ensureSemantics();
+        await pumpNav(
+          tester,
+          cavityChild: const Text('Activity plan'),
+          cavityKey: 'activity-a',
+          onDismissed: () {},
+        );
+
+        final l10n = L10n.of(tester.element(find.byType(MobileNavWidget)));
+
+        // Walk to the semantics root from any node, then collect every node
+        // carrying the handle label.
+        SemanticsNode root = tester.getSemantics(find.byType(MobileNavWidget));
+        while (root.parent != null) {
+          root = root.parent!;
+        }
+
+        final labelled = <SemanticsData>[];
+        void collect(SemanticsNode node) {
+          final data = node.getSemanticsData();
+          if (data.label.contains(l10n.resizeCoursePanel)) labelled.add(data);
+          node.visitChildren((child) {
+            collect(child);
+            return true;
+          });
+        }
+
+        collect(root);
+
+        expect(
+          labelled,
+          hasLength(1),
+          reason: 'the handle must surface as exactly one semantics node',
+        );
+        final handle = labelled.single;
+
+        expect(
+          handle.hasAction(SemanticsAction.tap),
+          isTrue,
+          reason: 'the handle node must run the resize toggle on tap',
+        );
+        // The crux of #7927: a handle merged into the scrollable cavity node
+        // would inherit its scroll actions (and the hosted content's label),
+        // and that scrollable+tappable node drops the tap on Flutter web.
+        expect(
+          handle.hasAction(SemanticsAction.scrollUp),
+          isFalse,
+          reason: 'the handle must be its own node, not the scrollable cavity',
+        );
+        expect(handle.hasAction(SemanticsAction.scrollDown), isFalse);
+        expect(
+          handle.label,
+          l10n.resizeCoursePanel,
+          reason: 'a merged node would also carry the cavity content label',
+        );
+
+        semantics.dispose();
       },
     );
   });


### PR DESCRIPTION
### What

Make the single-column nav cavity's pull-up bar raise an **activity plan** from half to full on tap, not just via drag — matching how a course card already behaves.

### Why

Closes #7927.

The pull-up bar is a labeled toggle button (routing.instructions.md → "Expanded to full height": *"The handle is also a labeled button — a tap toggles half ↔ full"*). Tapping it raised a course but did nothing on an activity plan, which could only be dragged. It reproduced on Opera/Windows but not on Chrome/iPhone.

Root cause is the Flutter-web semantics layer — the same class of bug as #7803. For a non-peek cavity (the activity plan) the enclosing cavity `GestureDetector` carries only the vertical-drag (scroll) actions and no tap of its own (`onBodyTap` is null unless it's a course at peek), so the handle's tap action **merged into that scrollable semantics node** — one node that was both scrollable and tappable. When the accessibility layer is active (on by default on some browser/OS combos, e.g. Opera on Windows), pointer events dispatch through the semantics DOM, and a scrollable node does not reliably deliver a tap, so the click was swallowed. A course at peek was unaffected because its cavity node had its own `onBodyTap`, which kept the handle a separate child node.

Fix: `container: true` on the handle's `Semantics` forces it into its own standalone button node in every cavity, structurally identical to the working course handle.

### Testing

- **New regression test** (`mobile_nav_widget_test.dart`): with the accessibility layer enabled, asserts the activity-plan handle surfaces as its own tap-only semantics node and is never merged with the cavity's `scrollUp`/`scrollDown` actions. Verified it **fails without** the one-line fix and **passes with** it.
- Full navigation suite green: `fvm flutter test test/pangea/navigation/` → **308 passing**.
- `fvm flutter analyze` on the changed files → no issues.
- **Not** manually reproduced on Opera/Windows (that combo isn't available to me). The evidence is that the fixed activity handle's semantics tree is now identical to the course handle's, which is confirmed working on that combo. Worth a quick confirm from @TigToggle on staging.

### Deploy Notes

None.

### Accessibility

- [x] New or changed controls have an accessible name. The handle keeps its `resizeCoursePanel` label; this change makes it a discrete, correctly-exposed button node (previously it was folded into the scrollable cavity node).
