### PR TITLE
fix(activities): paginate + cache course activity-session discovery

### DIFF
--- a/lib/features/activity_sessions/activity_session_discovery.dart
+++ b/lib/features/activity_sessions/activity_session_discovery.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
@@ -35,38 +37,174 @@ extension ActivitySessionDiscovery on Client {
   /// Room ids of activity-session children across [joinedCourseSpaces], read from
   /// the server hierarchy so a coursemate's session (absent from `client.rooms`)
   /// is included. Optionally scoped to a single [activityId] by room type.
-  /// Best-effort per course; a failed hierarchy read is logged and skipped.
+  ///
+  /// Each course space's hierarchy is **fully paginated** (the same `from`/
+  /// `nextBatch` walk the course chats page uses), so a session past the first
+  /// 100 rooms in a large course is still found — the #7982 miss. Because this
+  /// runs on the world map's hot discovery loop (~every 3s, across *all* joined
+  /// courses), the paginated scan of each space is cached for
+  /// [_CourseSessionScanCache.ttl]; the per-cycle freshness that must stay live
+  /// (seats/presence) comes from the caller's `room_preview` step, not from this
+  /// id enumeration, so caching the id set here does not stale the map. The
+  /// cache holds the **unscoped** set, so the map (unscoped) and the start page
+  /// (scoped to one activity) share a single scan.
+  ///
+  /// Best-effort per course; a failed hierarchy read is logged and skipped
+  /// (its cache entry is left untouched so the next cycle retries).
   Future<Set<String>> courseActivitySessionRoomIds({String? activityId}) async {
-    final exactType = activityId != null
-        ? '${PangeaRoomTypes.activitySession}:$activityId'
-        : null;
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
     final ids = <String>{};
     for (final space in joinedCourseSpaces) {
-      try {
-        final hierarchy = await getSpaceHierarchy(
-          space.id,
-          maxDepth: 1,
-          limit: 100,
+      var sessions = _CourseSessionScanCache.instance.fresh(space.id, nowMs);
+      if (sessions == null) {
+        sessions = await paginateActivitySessionRooms(
+          spaceId: space.id,
+          fetchPage: (from) => getSpaceHierarchy(
+            space.id,
+            maxDepth: 1,
+            from: from,
+            limit: 100,
+          ),
         );
-        for (final child in hierarchy.rooms) {
-          if (child.roomId == space.id) continue; // the space root itself
-          final type = child.roomType;
-          if (type == null ||
-              !type.startsWith(PangeaRoomTypes.activitySession)) {
-            continue; // only activity-session rooms
-          }
-          if (exactType != null && type != exactType) continue;
-          ids.add(child.roomId);
-        }
-      } catch (e, s) {
-        ErrorHandler.logError(
-          e: e,
-          s: s,
-          m: 'course space hierarchy fetch failed',
-          data: {'spaceId': space.id},
-        );
+        if (sessions == null) continue; // failed read — retry next cycle
+        _CourseSessionScanCache.instance.store(space.id, sessions, nowMs);
       }
+      ids.addAll(activitySessionIdsMatching(sessions, activityId: activityId));
     }
     return ids;
   }
 }
+
+/// Room ids from a scanned `{roomId: roomType}` map, optionally scoped to a
+/// single [activityId] via the exact `p.activity.session:$activityId` type — so
+/// the map (unscoped) and the start page (scoped) filter the one shared,
+/// unscoped cached scan differently.
+@visibleForTesting
+Set<String> activitySessionIdsMatching(
+  Map<String, String> sessions, {
+  String? activityId,
+}) {
+  if (activityId == null) return sessions.keys.toSet();
+  final exactType = '${PangeaRoomTypes.activitySession}:$activityId';
+  return sessions.entries
+      .where((e) => e.value == exactType)
+      .map((e) => e.key)
+      .toSet();
+}
+
+/// A generous safety bound on the paginated scan of one course space's
+/// hierarchy (~[_maxHierarchyPagesPerSpace] * 100 rooms). Hitting it is logged
+/// rather than silently truncating — a course this large is beyond what
+/// client-side discovery can cover and wants the deferred choreographer
+/// cross-course endpoint (world-map.instructions.md "Future Work").
+const int _maxHierarchyPagesPerSpace = 20;
+
+/// Walk one space's hierarchy to completion, returning its activity-session
+/// rooms as `{roomId: roomType}` (unscoped). [fetchPage] is the paginated
+/// hierarchy read — injected so the pagination/cap/error logic is testable
+/// without a live client. Returns `null` on a failed read (logged) so the
+/// caller leaves any cached entry in place and retries; a successful scan of a
+/// space with no sessions returns an empty map.
+@visibleForTesting
+Future<Map<String, String>?> paginateActivitySessionRooms({
+  required String spaceId,
+  required Future<GetSpaceHierarchyResponse> Function(String? from) fetchPage,
+  int maxCalls = _maxHierarchyPagesPerSpace,
+}) async {
+  final found = <String, String>{};
+  String? from;
+  var calls = 0;
+  try {
+    do {
+      final page = await fetchPage(from);
+      for (final child in page.rooms) {
+        if (child.roomId == spaceId) continue; // the space root itself
+        final type = child.roomType;
+        if (type == null ||
+            !type.startsWith(PangeaRoomTypes.activitySession)) {
+          continue; // only activity-session rooms
+        }
+        found[child.roomId] = type;
+      }
+      from = page.nextBatch;
+      calls++;
+    } while (from != null && calls < maxCalls);
+    if (from != null) {
+      // More pages remain but we've hit the cap — log so a pathologically large
+      // course is visible rather than a silent partial scan.
+      ErrorHandler.logError(
+        e: Exception('activity-session hierarchy scan hit page cap'),
+        m: 'activity-session discovery truncated for large course space',
+        data: {'spaceId': spaceId, 'calls': calls},
+      );
+    }
+    return found;
+  } catch (e, s) {
+    ErrorHandler.logError(
+      e: e,
+      s: s,
+      m: 'course space hierarchy fetch failed',
+      data: {'spaceId': spaceId},
+    );
+    return null;
+  }
+}
+
+/// Per-space cache of the fully-paginated activity-session room scan, so the
+/// world map's ~3s discovery loop reuses one hierarchy walk per course for
+/// [ttl] instead of re-paging every cycle. Freshness of seats/presence is the
+/// caller's per-cycle `room_preview` job, not this id set (which only changes
+/// when a session opens/closes), so a short TTL keeps the map current while
+/// bounding request volume. Process-wide singleton, like DiscoveredSessionsCache.
+class _CourseSessionScanCache {
+  _CourseSessionScanCache._();
+  static final _CourseSessionScanCache instance = _CourseSessionScanCache._();
+
+  /// Well inside #7982's "after 1-2 minutes" expectation given the ~3s loop.
+  static const Duration ttl = Duration(seconds: 30);
+
+  final Map<String, _ScanEntry> _bySpace = {};
+
+  /// The cached scan for [spaceId] (`{roomId: roomType}`) if it is still within
+  /// [ttl] at [nowMs], else null (the caller re-scans).
+  Map<String, String>? fresh(String spaceId, int nowMs) {
+    final entry = _bySpace[spaceId];
+    if (entry == null) return null;
+    if (nowMs - entry.scannedAtMs > ttl.inMilliseconds) return null;
+    return entry.sessions;
+  }
+
+  void store(String spaceId, Map<String, String> sessions, int nowMs) {
+    _bySpace[spaceId] = _ScanEntry(sessions, nowMs);
+  }
+
+  void clear() => _bySpace.clear();
+}
+
+class _ScanEntry {
+  _ScanEntry(this.sessions, this.scannedAtMs);
+  final Map<String, String> sessions;
+  final int scannedAtMs;
+}
+
+/// Test seams onto the process-wide scan cache. The singleton persists across
+/// tests, so a suite resets it in `setUp`; the store/fresh wrappers exercise the
+/// TTL logic deterministically with an injected `nowMs` (no real clock).
+@visibleForTesting
+void debugResetActivitySessionScanCache() =>
+    _CourseSessionScanCache.instance.clear();
+
+@visibleForTesting
+Map<String, String>? debugFreshActivitySessionScan(String spaceId, int nowMs) =>
+    _CourseSessionScanCache.instance.fresh(spaceId, nowMs);
+
+@visibleForTesting
+void debugStoreActivitySessionScan(
+  String spaceId,
+  Map<String, String> sessions,
+  int nowMs,
+) =>
+    _CourseSessionScanCache.instance.store(spaceId, sessions, nowMs);
+
+@visibleForTesting
+Duration get debugActivitySessionScanTtl => _CourseSessionScanCache.ttl;

--- a/test/pangea/activity_session_discovery_test.dart
+++ b/test/pangea/activity_session_discovery_test.dart
@@ -1,0 +1,157 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_session_discovery.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_room_types.dart';
+
+/// #7982: the world map and activity start page missed coursemate sessions in
+/// courses with >100 rooms because the shared discovery read only fetched the
+/// first hierarchy page. The fix fully paginates that read and caches the scan
+/// per space (so the map's ~3s loop doesn't re-page every cycle).
+///
+/// These exercise the fix's three seams directly — pagination, the scoped
+/// filter, and the scan cache — which is where the bug lived and where the
+/// regression risk is; the extension method that wires them together is thin
+/// glue over these.
+void main() {
+  const spaceId = '!course:fakeServer.notExisting';
+  const act = 'activity-abc';
+  final sessionType = '${PangeaRoomTypes.activitySession}:$act';
+
+  // A minimal valid space-hierarchy room chunk. Only room_id / room_type carry
+  // the signal we test; the rest are the response's required fields.
+  SpaceRoomsChunk$2 chunk(String roomId, {String? roomType}) =>
+      SpaceRoomsChunk$2.fromJson({
+        'room_id': roomId,
+        'room_type': ?roomType,
+        'num_joined_members': 1,
+        'guest_can_join': false,
+        'world_readable': false,
+        'children_state': <Map<String, Object?>>[],
+      });
+
+  GetSpaceHierarchyResponse page(
+    List<SpaceRoomsChunk$2> rooms, {
+    String? nextBatch,
+  }) =>
+      GetSpaceHierarchyResponse(rooms: rooms, nextBatch: nextBatch);
+
+  group('paginateActivitySessionRooms', () {
+    test('finds a session on page 2 (the #7982 regression)', () async {
+      // Page 1 is all non-session rooms (analytics + the space root) with a
+      // continuation token; the session room only appears on page 2. The old
+      // single-page read stopped at page 1 and never saw it.
+      final pages = <GetSpaceHierarchyResponse>[
+        page(
+          [
+            chunk(spaceId), // the space root itself — skipped
+            chunk('!analytics:fakeServer.notExisting',
+                roomType: PangeaRoomTypes.analytics),
+            chunk('!chat:fakeServer.notExisting'),
+          ],
+          nextBatch: 'token-1',
+        ),
+        page([chunk('!session:fakeServer.notExisting', roomType: sessionType)]),
+      ];
+
+      var calls = 0;
+      final result = await paginateActivitySessionRooms(
+        spaceId: spaceId,
+        fetchPage: (from) async {
+          // Page 1 requested with from==null, page 2 with the returned token.
+          expect(from, calls == 0 ? isNull : 'token-1');
+          return pages[calls++];
+        },
+      );
+
+      expect(calls, 2, reason: 'should keep paging until nextBatch is null');
+      expect(result, {'!session:fakeServer.notExisting': sessionType});
+    });
+
+    test('keeps only activity-session rooms, dropping others and the root',
+        () async {
+      final result = await paginateActivitySessionRooms(
+        spaceId: spaceId,
+        fetchPage: (from) async => page([
+          chunk(spaceId, roomType: 'm.space'),
+          chunk('!analytics:x', roomType: PangeaRoomTypes.analytics),
+          chunk('!plainchat:x'), // no room type
+          chunk('!s1:x', roomType: sessionType),
+          chunk('!s2:x', roomType: '${PangeaRoomTypes.activitySession}:other'),
+        ]),
+      );
+      expect(result, {
+        '!s1:x': sessionType,
+        '!s2:x': '${PangeaRoomTypes.activitySession}:other',
+      });
+    });
+
+    test('stops at the page cap and logs rather than looping forever',
+        () async {
+      // A pathological server that always returns another page. The cap must
+      // bound the number of reads; we assert it stopped at maxCalls.
+      var calls = 0;
+      final result = await paginateActivitySessionRooms(
+        spaceId: spaceId,
+        maxCalls: 3,
+        fetchPage: (from) async {
+          calls++;
+          return page(
+            [chunk('!s$calls:x', roomType: sessionType)],
+            nextBatch: 'always-more',
+          );
+        },
+      );
+      expect(calls, 3);
+      expect(result, hasLength(3));
+    });
+
+    test('returns null on a failed read so the caller retries', () async {
+      final result = await paginateActivitySessionRooms(
+        spaceId: spaceId,
+        fetchPage: (from) async => throw Exception('network down'),
+      );
+      expect(result, isNull);
+    });
+  });
+
+  group('activitySessionIdsMatching', () {
+    final scan = {
+      '!a:x': sessionType,
+      '!b:x': '${PangeaRoomTypes.activitySession}:other',
+    };
+
+    test('unscoped returns every room id', () {
+      expect(activitySessionIdsMatching(scan), {'!a:x', '!b:x'});
+    });
+
+    test('scoped keeps only the matching activity id', () {
+      expect(activitySessionIdsMatching(scan, activityId: act), {'!a:x'});
+    });
+  });
+
+  group('scan cache TTL', () {
+    setUp(debugResetActivitySessionScanCache);
+    tearDown(debugResetActivitySessionScanCache);
+
+    test('a fresh entry is reused; an expired one is not', () {
+      const t0 = 1000000;
+      final ttlMs = debugActivitySessionScanTtl.inMilliseconds;
+      debugStoreActivitySessionScan(spaceId, {'!a:x': sessionType}, t0);
+
+      // Within the TTL: reused (so the ~3s loop skips a re-scan).
+      expect(
+        debugFreshActivitySessionScan(spaceId, t0 + ttlMs),
+        {'!a:x': sessionType},
+      );
+      // Past the TTL: a miss, so the caller re-paginates.
+      expect(debugFreshActivitySessionScan(spaceId, t0 + ttlMs + 1), isNull);
+    });
+
+    test('a reset clears the cache', () {
+      debugStoreActivitySessionScan(spaceId, {'!a:x': sessionType}, 0);
+      debugResetActivitySessionScanCache();
+      expect(debugFreshActivitySessionScan(spaceId, 0), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## What
Fully paginate (and cache) the shared course activity-session discovery read, so a coursemate's open session in a course with >100 rooms surfaces as joinable on the map pin, the course-plan card's OPEN banner, and the activity start page.

## Why
Closes #7982

`courseActivitySessionRoomIds` — the one read the world map's joinable-pin signals and the start page's join list share — fetched each joined course space's hierarchy **once** (`limit: 100`, no `from`/`nextBatch`). In a course whose space holds >100 child rooms (analytics rooms, chats, sessions), an activity-session room past the first page was silently dropped, so the session never became a joinable candidate on any of those surfaces. The course chats list was unaffected because it already paginates.

## Changes
- `courseActivitySessionRoomIds` now walks each space's hierarchy to completion via `from`/`nextBatch` (the same pattern `course_chats_page` uses).
- Because this runs on the map's ~3s discovery loop across **all** joined courses, the paginated scan is cached per space with a 30s TTL, so the loop reuses one hierarchy walk instead of re-paging every cycle. Live seat/presence freshness stays the caller's per-cycle `room_preview` step — unchanged.
- The scan is bounded by a page cap that **logs** on hit rather than truncating silently.
- Callers are untouched (same `Set<String>` contract).

Discovery design (what feeds each surface, the throttled reads) is owned by [world-map.instructions.md → "Discovering joinable sessions"] and unchanged by this PR; this is a read-completeness fix, not a design change. Remains best-effort: courses beyond the page cap, and sessions in courses the learner hasn't joined, still await the choreographer's deferred cross-course discovery endpoint (tracked in that doc's Future Work).

## Testing
- **Unit** (new `test/pangea/activity_session_discovery_test.dart`, 8 tests, all pass locally): page-2 discovery (the regression), room-type/space-root filtering, page-cap bound, failed-read → null retry, scoped `activityId` filter, and scan-cache TTL reuse/expiry.
- `flutter analyze` on the changed files: no issues.
- Full multi-account end-to-end (issue's TO TEST — UserA starts a session, UserB finds it on map/card/chats/start page) is a staging-QA step; local reproduction of the >100-room case is impractical (a quick local proxy is to temporarily lower `limit` so a normal course spans pages).

## Deploy Notes
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity-session discovery across paginated course hierarchies.
  * Ensured activity sessions appearing on later pages are detected correctly.
  * Excluded invalid, non-session, and root rooms from discovery.
  * Added safeguards for incomplete scans and failed page requests, allowing retries.
  * Improved filtering when searching for sessions associated with a specific activity.

* **Performance**
  * Added short-lived caching to reduce repeated hierarchy scans during discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->