### PR TITLE
fix(world): open the activity you tap on overlapping map pins

### DIFF
--- a/lib/features/activity_sessions/activity_session_discovery.dart
+++ b/lib/features/activity_sessions/activity_session_discovery.dart
@@ -59,12 +59,8 @@ extension ActivitySessionDiscovery on Client {
       if (sessions == null) {
         sessions = await paginateActivitySessionRooms(
           spaceId: space.id,
-          fetchPage: (from) => getSpaceHierarchy(
-            space.id,
-            maxDepth: 1,
-            from: from,
-            limit: 100,
-          ),
+          fetchPage: (from) =>
+              getSpaceHierarchy(space.id, maxDepth: 1, from: from, limit: 100),
         );
         if (sessions == null) continue; // failed read — retry next cycle
         _CourseSessionScanCache.instance.store(space.id, sessions, nowMs);
@@ -120,8 +116,7 @@ Future<Map<String, String>?> paginateActivitySessionRooms({
       for (final child in page.rooms) {
         if (child.roomId == spaceId) continue; // the space root itself
         final type = child.roomType;
-        if (type == null ||
-            !type.startsWith(PangeaRoomTypes.activitySession)) {
+        if (type == null || !type.startsWith(PangeaRoomTypes.activitySession)) {
           continue; // only activity-session rooms
         }
         found[child.roomId] = type;
@@ -203,8 +198,7 @@ void debugStoreActivitySessionScan(
   String spaceId,
   Map<String, String> sessions,
   int nowMs,
-) =>
-    _CourseSessionScanCache.instance.store(spaceId, sessions, nowMs);
+) => _CourseSessionScanCache.instance.store(spaceId, sessions, nowMs);
 
 @visibleForTesting
 Duration get debugActivitySessionScanTtl => _CourseSessionScanCache.ttl;

--- a/lib/routes/world/mid_size_pin_labels_layer.dart
+++ b/lib/routes/world/mid_size_pin_labels_layer.dart
@@ -13,6 +13,7 @@ class MidSizePinLabelsLayer {
   final Size? Function(String) sizeOf;
   final ActivityPinState Function(String) stateOf;
   final bool Function(String) nonStartableOf;
+  final void Function(QuestActivityCard) onTap;
 
   const MidSizePinLabelsLayer({
     required this.nonLargeCards,
@@ -20,6 +21,7 @@ class MidSizePinLabelsLayer {
     required this.sizeOf,
     required this.stateOf,
     required this.nonStartableOf,
+    required this.onTap,
   });
 
   /// The marker alignment that seats a label of [size] on [side] of a mid pin
@@ -43,9 +45,10 @@ class MidSizePinLabelsLayer {
 
   MarkerLayer layer() {
     /// The activity-name labels for the mid pins the placement pass kept — each a
-    /// marker anchored at the pin's point, offset to its chosen side, and
-    /// non-interactive (an [IgnorePointer]) so the wide box never swallows a
-    /// pin/map tap.
+    /// marker anchored at the pin's point, offset to its chosen side. The label
+    /// box is measured tight to its text, so it opens ITS OWN activity on tap
+    /// (not the neighbour pin it may sit over — #7920); it paints above the dot
+    /// layer, so this tap wins over any pin beneath.
     final markers = nonLargeCards
         .map((card) {
           final id = card.activityId;
@@ -60,10 +63,19 @@ class MidSizePinLabelsLayer {
             child: Opacity(
               // Match the pin: a non-startable available pin's label dims too.
               opacity: nonStartableOf(id) ? 0.5 : 1.0,
-              child: IgnorePointer(
-                child: WorldMapPinLabel(
-                  title: card.title,
-                  color: stateOf(id).labelColor,
+              // ExcludeSemantics: the pin's own Semantics(button) node stays the
+              // single a11y activation target, so the label adds no duplicate
+              // node. Opaque so the whole (text-tight) box is tappable, not just
+              // painted glyph pixels; the tap-only recognizer still yields to
+              // the map's drag recognizer, so panning from a label is unaffected.
+              child: ExcludeSemantics(
+                child: GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onTap: () => onTap(card),
+                  child: WorldMapPinLabel(
+                    title: card.title,
+                    color: stateOf(id).labelColor,
+                  ),
                 ),
               ),
             ),

--- a/lib/routes/world/world_map_pin_label.dart
+++ b/lib/routes/world/world_map_pin_label.dart
@@ -8,8 +8,9 @@ import 'package:fluffychat/routes/world/world_map_ranking.dart';
 /// chosen by the [placePinLabels] geometry pass; this widget is pure
 /// presentation. It's sized by its enclosing marker box (measured to match
 /// [kPinLabelTextStyle]), so the text already fits — [kPinLabelMaxWidth] caps
-/// it upstream and it ellipsizes if ever over. Non-interactive: the caller
-/// wraps it in an [IgnorePointer] so the wide box never intercepts pin/map taps.
+/// it upstream and it ellipsizes if ever over. The caller wraps it in a
+/// tap target that opens the label's own activity (the box is measured tight to
+/// the text, so the tappable area matches the visible label — #7920).
 class WorldMapPinLabel extends StatelessWidget {
   final String title;
   final Color color;

--- a/lib/routes/world/world_map_pin_shape.dart
+++ b/lib/routes/world/world_map_pin_shape.dart
@@ -63,6 +63,20 @@ class TeardropPainter extends CustomPainter {
     return path;
   }
 
+  /// Absorb taps only within the visible teardrop silhouette, not the whole
+  /// rectangular box — otherwise the transparent corners/gutters steal taps
+  /// meant for an overlapping neighbour pin or its name label (#7920). Mirrors
+  /// how a small dot's [BoxDecoration] already clips its tap area to the circle.
+  ///
+  /// [_shapePath] is built around `x=0` and [paint] draws it after translating
+  /// by `size.width / 2`; the marker box width equals [headDiameter], so shift
+  /// the incoming local position back by `headDiameter / 2` into path space
+  /// before testing. Reuses the exact painted path, so the hit region is
+  /// pixel-identical to the silhouette.
+  @override
+  bool? hitTest(Offset position) =>
+      _shapePath().contains(position.translate(-headDiameter / 2, 0));
+
   @override
   void paint(Canvas canvas, Size size) {
     // Center the shape (built around x=0) in the painter's width.

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -922,6 +922,7 @@ class _WorldMapViewState extends State<WorldMapView> {
                   sizeOf: (id) => render.labelSizes[id],
                   stateOf: render.stateOf,
                   nonStartableOf: render.nonStartableOf,
+                  onTap: widget.controller.openActivity,
                 ).layer(),
                 // Dying pins (a separate layer) so they don't disturb the live pins
                 // while animating out.

--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -551,7 +551,8 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
                               // collapsing sheet squeezes its content into a
                               // few pixels mid-animation and the inner
                               // RenderFlex overflows.
-                              final showContent = baseCavityPx > 0 && visible > 0;
+                              final showContent =
+                                  baseCavityPx > 0 && visible > 0;
                               return SizedBox(
                                 key: _cavityBoxKey,
                                 height: visible,

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -268,7 +268,9 @@ class WorkspaceShell extends StatelessWidget {
                             // `viewInsets` is still intact (#7754).
                             keyboardInset:
                                 (MediaQuery.viewInsetsOf(context).bottom -
-                                        MediaQuery.viewPaddingOf(context).bottom)
+                                        MediaQuery.viewPaddingOf(
+                                          context,
+                                        ).bottom)
                                     .clamp(0.0, double.infinity),
                           ),
                         ),

--- a/test/pangea/activity_session_discovery_test.dart
+++ b/test/pangea/activity_session_discovery_test.dart
@@ -33,8 +33,7 @@ void main() {
   GetSpaceHierarchyResponse page(
     List<SpaceRoomsChunk$2> rooms, {
     String? nextBatch,
-  }) =>
-      GetSpaceHierarchyResponse(rooms: rooms, nextBatch: nextBatch);
+  }) => GetSpaceHierarchyResponse(rooms: rooms, nextBatch: nextBatch);
 
   group('paginateActivitySessionRooms', () {
     test('finds a session on page 2 (the #7982 regression)', () async {
@@ -42,15 +41,14 @@ void main() {
       // continuation token; the session room only appears on page 2. The old
       // single-page read stopped at page 1 and never saw it.
       final pages = <GetSpaceHierarchyResponse>[
-        page(
-          [
-            chunk(spaceId), // the space root itself — skipped
-            chunk('!analytics:fakeServer.notExisting',
-                roomType: PangeaRoomTypes.analytics),
-            chunk('!chat:fakeServer.notExisting'),
-          ],
-          nextBatch: 'token-1',
-        ),
+        page([
+          chunk(spaceId), // the space root itself — skipped
+          chunk(
+            '!analytics:fakeServer.notExisting',
+            roomType: PangeaRoomTypes.analytics,
+          ),
+          chunk('!chat:fakeServer.notExisting'),
+        ], nextBatch: 'token-1'),
         page([chunk('!session:fakeServer.notExisting', roomType: sessionType)]),
       ];
 
@@ -68,43 +66,49 @@ void main() {
       expect(result, {'!session:fakeServer.notExisting': sessionType});
     });
 
-    test('keeps only activity-session rooms, dropping others and the root',
-        () async {
-      final result = await paginateActivitySessionRooms(
-        spaceId: spaceId,
-        fetchPage: (from) async => page([
-          chunk(spaceId, roomType: 'm.space'),
-          chunk('!analytics:x', roomType: PangeaRoomTypes.analytics),
-          chunk('!plainchat:x'), // no room type
-          chunk('!s1:x', roomType: sessionType),
-          chunk('!s2:x', roomType: '${PangeaRoomTypes.activitySession}:other'),
-        ]),
-      );
-      expect(result, {
-        '!s1:x': sessionType,
-        '!s2:x': '${PangeaRoomTypes.activitySession}:other',
-      });
-    });
+    test(
+      'keeps only activity-session rooms, dropping others and the root',
+      () async {
+        final result = await paginateActivitySessionRooms(
+          spaceId: spaceId,
+          fetchPage: (from) async => page([
+            chunk(spaceId, roomType: 'm.space'),
+            chunk('!analytics:x', roomType: PangeaRoomTypes.analytics),
+            chunk('!plainchat:x'), // no room type
+            chunk('!s1:x', roomType: sessionType),
+            chunk(
+              '!s2:x',
+              roomType: '${PangeaRoomTypes.activitySession}:other',
+            ),
+          ]),
+        );
+        expect(result, {
+          '!s1:x': sessionType,
+          '!s2:x': '${PangeaRoomTypes.activitySession}:other',
+        });
+      },
+    );
 
-    test('stops at the page cap and logs rather than looping forever',
-        () async {
-      // A pathological server that always returns another page. The cap must
-      // bound the number of reads; we assert it stopped at maxCalls.
-      var calls = 0;
-      final result = await paginateActivitySessionRooms(
-        spaceId: spaceId,
-        maxCalls: 3,
-        fetchPage: (from) async {
-          calls++;
-          return page(
-            [chunk('!s$calls:x', roomType: sessionType)],
-            nextBatch: 'always-more',
-          );
-        },
-      );
-      expect(calls, 3);
-      expect(result, hasLength(3));
-    });
+    test(
+      'stops at the page cap and logs rather than looping forever',
+      () async {
+        // A pathological server that always returns another page. The cap must
+        // bound the number of reads; we assert it stopped at maxCalls.
+        var calls = 0;
+        final result = await paginateActivitySessionRooms(
+          spaceId: spaceId,
+          maxCalls: 3,
+          fetchPage: (from) async {
+            calls++;
+            return page([
+              chunk('!s$calls:x', roomType: sessionType),
+            ], nextBatch: 'always-more');
+          },
+        );
+        expect(calls, 3);
+        expect(result, hasLength(3));
+      },
+    );
 
     test('returns null on a failed read so the caller retries', () async {
       final result = await paginateActivitySessionRooms(
@@ -140,10 +144,9 @@ void main() {
       debugStoreActivitySessionScan(spaceId, {'!a:x': sessionType}, t0);
 
       // Within the TTL: reused (so the ~3s loop skips a re-scan).
-      expect(
-        debugFreshActivitySessionScan(spaceId, t0 + ttlMs),
-        {'!a:x': sessionType},
-      );
+      expect(debugFreshActivitySessionScan(spaceId, t0 + ttlMs), {
+        '!a:x': sessionType,
+      });
       // Past the TTL: a miss, so the caller re-paginates.
       expect(debugFreshActivitySessionScan(spaceId, t0 + ttlMs + 1), isNull);
     });

--- a/test/pangea/world/world_map_hit_test.dart
+++ b/test/pangea/world/world_map_hit_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/world_map_pin_budget.dart';
+import 'package:fluffychat/routes/world/world_map_pin_label.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_state_dot.dart';
+
+/// Covers #7920: on the map, a tap must open exactly the activity the user
+/// sees. Two guards:
+///   - a mid pin absorbs taps only within its visible teardrop silhouette, not
+///     the transparent corners of its bounding box (so an overlapping neighbour
+///     can't steal the tap through empty space);
+///   - a mid pin's name label opens ITS OWN activity when tapped.
+void main() {
+  const card = QuestActivityCard(
+    activityId: 'a1',
+    title: 'Test Activity',
+    l2: 'es',
+    coordinates: [0, 0],
+    learningObjectiveRefs: [],
+  );
+
+  Future<void> pump(WidgetTester tester, Widget child) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(body: Center(child: child)),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  group('mid-pin glyph-accurate hit-testing (#7920)', () {
+    testWidgets('a tap in the transparent box corner does NOT open the '
+        'activity', (tester) async {
+      var tapped = false;
+      await pump(
+        tester,
+        WorldMapDot(
+          card: card,
+          state: ActivityPinState.available,
+          tier: PinTier.mid,
+          onTap: () => tapped = true,
+          pinged: false,
+        ),
+      );
+
+      // The mid box is midDiameter wide × (midDiameter + midPointHeight) tall;
+      // its top-left corner is well outside the head circle (centre at
+      // (midDiameter/2, midDiameter/2), radius midDiameter/2).
+      final topLeft = tester.getTopLeft(find.byType(WorldMapDot));
+      await tester.tapAt(topLeft + const Offset(2, 2));
+      await tester.pump();
+
+      expect(
+        tapped,
+        isFalse,
+        reason:
+            'a tap on the pin box\'s transparent corner must fall through, not '
+            'open the activity — the corner belongs to whatever is beneath (#7920)',
+      );
+    });
+
+    testWidgets('a tap on the pin head DOES open the activity', (tester) async {
+      var tapped = false;
+      await pump(
+        tester,
+        WorldMapDot(
+          card: card,
+          state: ActivityPinState.available,
+          tier: PinTier.mid,
+          onTap: () => tapped = true,
+          pinged: false,
+        ),
+      );
+
+      final topLeft = tester.getTopLeft(find.byType(WorldMapDot));
+      const headCentre = Offset(
+        PinSize.midDiameter / 2,
+        PinSize.midDiameter / 2,
+      );
+      await tester.tapAt(topLeft + headCentre);
+      await tester.pump();
+
+      expect(
+        tapped,
+        isTrue,
+        reason: 'a tap on the visible pin head must open its activity',
+      );
+    });
+  });
+
+  testWidgets('a mid-pin label opens its own activity when tapped (#7920)', (
+    tester,
+  ) async {
+    var tapped = false;
+    // The exact composition MidSizePinLabelsLayer wraps each label in.
+    await pump(
+      tester,
+      ExcludeSemantics(
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () => tapped = true,
+          child: const WorldMapPinLabel(
+            title: 'Test Activity',
+            color: Colors.black,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(WorldMapPinLabel));
+    await tester.pump();
+
+    expect(
+      tapped,
+      isTrue,
+      reason:
+          'clicking a label\'s visible text must open the NAMED activity, not '
+          'fall through to a neighbouring pin beneath it (#7920)',
+    );
+  });
+}


### PR DESCRIPTION
### What
On the world map, tapping an overlapping activity pin or its name label could open a **different** activity than the one shown. Two fixes make what-you-see what-you-tap.

### Why
Closes #7920

Root cause (both in `lib/routes/world/`):
- Mid-pin name labels were wrapped in `IgnorePointer`, so a tap on the visible label text fell **through** to whatever pin sat beneath it — and labels de-conflict visually against mid pins but not against small dots, so they routinely sit over a neighbour's hit box.
- A mid pin absorbed taps across its whole rectangular box (transparent teardrop corners/gutters included — `TeardropPainter` had no `hitTest`, and `RenderCustomPaint.hitTestSelf` defaults to `?? true`), so an overlapping neighbour's invisible box could steal the tap.

Fix:
- **Labels open their own activity** — `MidSizePinLabelsLayer` wraps each label in an opaque, text-tight `GestureDetector` routing to its own `openActivity`; `ExcludeSemantics` keeps the pin's own `Semantics` node the single a11y activation target. The label layer paints above the dots, so it wins over any pin beneath.
- **Glyph-accurate pin hit-testing** — `TeardropPainter.hitTest` clips a mid pin's tap area to the visible teardrop silhouette, mirroring how a small dot's `BoxDecoration` already clips to its circle. The topmost *visible* glyph wins, not an invisible bounding box.

Design intent is unchanged (labels/pins correspond to their activity) — see [world-map.instructions.md](.github/instructions/world-map.instructions.md) ("Pin display", "Tap any pin to Focus"). No instructions-doc change.

### Testing
- **Unit/widget (bucket the change touches): `flutter test test/pangea/world/` → 61 passing**, including a new `world_map_hit_test.dart` asserting the fixed behavior: a tap in the pin box's transparent corner does **not** open the activity, a tap on the pin head **does**, and a label tap opens its own activity.
- `flutter analyze lib/routes/world/ test/pangea/world/` → clean.
- Manual (web, staging backend): confirmed the map renders the exact overlapping cluster from the issue and taps open activities; reporter (issue author is assignee) also eyeballed it as fixed. Note: pixel-precise automated overlap clicks weren't reliably reproducible through the in-app browser pane (unstable canvas click coordinates) — the deterministic widget tests are the authoritative check.

### Deploy Notes
None.