### PR TITLE
fix(routing): ignore the app_links boot-URL replay on web

### DIFF
--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -767,8 +767,22 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
     return path;
   }
 
+  /// Whether an `app_links` emission should be navigated to.
+  ///
+  /// Only OS-delivered links are real inbound navigations. On **web** the
+  /// plugin has no OS channel: its stream is a single value captured at
+  /// construction — the URL the page was LOADED with — so every emission is a
+  /// replay of the boot location the router already consumed (path URL
+  /// strategy, see main.dart). Acting on that replay re-navigates the user
+  /// back to the link they may already have moved on from: it arrives one
+  /// post-frame AFTER the app's first frame, so closing a deep-linked
+  /// activity or course in that window snapped straight back into it — the
+  /// "uncloseable activity" trap (#7821). Pure, so it is unit-tested.
+  static bool shouldNavigateToIncomingUri({required bool isWeb}) => !isWeb;
+
   Future<void> _processIncomingUris(Uri? uri) async {
     if (uri == null) return;
+    if (!shouldNavigateToIncomingUri(isWeb: kIsWeb)) return;
     final path = incomingUriToPath(uri);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       FluffyChatApp.router.go(path);

--- a/test/pangea/incoming_uri_path_test.dart
+++ b/test/pangea/incoming_uri_path_test.dart
@@ -58,6 +58,16 @@ void main() {
       );
     });
 
+    test('web replays are never navigated to; native links are', () {
+      // app_links has no OS channel on web: its stream is a single value
+      // captured at construction — the URL the page was loaded with — which
+      // the router already consumed via the path URL strategy. Acting on that
+      // replay yanked users back into a deep-linked activity they had just
+      // closed (#7821). Native genuinely delivers inbound links here.
+      expect(MatrixState.shouldNavigateToIncomingUri(isWeb: true), isFalse);
+      expect(MatrixState.shouldNavigateToIncomingUri(isWeb: false), isTrue);
+    });
+
     test('an invite_user fragment link maps to the fragment path with its '
         'percent-encoding intact (single-decoded by the router, not here)', () {
       expect(

--- a/test/pangea/navigation/token_grammar_test.dart
+++ b/test/pangea/navigation/token_grammar_test.dart
@@ -327,6 +327,17 @@ void main() {
       ]);
     });
 
+    test('closing a link-opened activity lands on the bare world', () {
+      // The shape a shared `/<uuid>` link folds to: an activity token, no
+      // course context. Closing must yield the plain world — any surviving
+      // activity token (or a re-navigation to the original link, #7821) is
+      // what made the activity uncloseable.
+      final open = u('/?left=activity:act-1');
+      final closed = WorkspaceNav.dropActivityOverlay(open);
+      expect(closed, '/');
+      expect(parseOpenPanels(u(closed)).left, isEmpty);
+    });
+
     test('dropActivityOverlay keeps the context; reopenCourseCard reseats the '
         'card', () {
       final open = u('/?c=!s&left=activity:act-1.r!sess');


### PR DESCRIPTION
## What

`MatrixState` no longer navigates on `app_links` emissions on web. Also formats `grammar_error_blank_length_test.dart`, which landed unformatted on main and fails the format gate for everyone.

## Why

Addresses #7821 (TigToggle: an activity link-invite traps users in an uncloseable activity; #7885 did not fix it).

`app_links_web` has no OS channel — its stream is literally `Stream.value(window.location.href)` captured at plugin construction, i.e. a replay of the URL the page was **loaded** with. Since `usePathUrlStrategy()` (#7830) the router already consumes that boot location, so the listener re-navigates to it **one post-frame after the app's first frame** — seconds into a cold boot. Anything the user did in that window is undone: close a deep-linked activity and you land straight back in it. The base app's `gotInitialLink` flag exists for exactly this case and was dead code.

Native still delivers genuinely new inbound links through this stream (the app launches at `/` there and the OS link only arrives via app_links), so only web skips.

## Testing

- `shouldNavigateToIncomingUri` unit-tested both ways; new guard that closing a link-opened activity yields the bare world; 334 tests pass across the navigation / incoming-uri / login-bounce suites; analyze, format, import-sort clean
- Local browser on `origin/main`: a `/<uuid>` deep link left the raw path in the address bar, then flipped to the token URL when the replay landed. With this fix it folds once at boot and stays put.
- Caveat for review: I could not reproduce Tig's full close→reopen loop in the local harness (canvas clicks on the panel's close control did not dispatch), so the device retest on #7821 is the real confirmation.

## Deploy Notes

None.