### PR TITLE
fix(nav): restore unread badge on the All-chats rail icon

### DIFF
--- a/lib/widgets/navi_rail_item.dart
+++ b/lib/widgets/navi_rail_item.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 
+import 'package:badges/badges.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/widgets/hover_builder.dart';
+import 'package:fluffychat/widgets/unread_rooms_badge.dart';
 import '../config/themes.dart';
 
 class NaviRailItem extends StatelessWidget {
@@ -76,30 +78,37 @@ class NaviRailItem extends StatelessWidget {
                       duration: FluffyThemes.animationDuration,
                       curve: FluffyThemes.animationCurve,
                       child: MergeSemantics(
-                        child: Container(
-                          alignment: Alignment.center,
-                          margin: EdgeInsets.symmetric(
-                            horizontal: isColumnMode ? 16.0 : 12.0,
-                            vertical: isColumnMode ? 8.0 : 6.0,
+                        child: UnreadRoomsBadge(
+                          filter: unreadBadgeFilter ?? (_) => false,
+                          badgePosition: BadgePosition.topEnd(
+                            top: 1,
+                            end: isColumnMode ? 8 : 4,
                           ),
-                          // Material + InkWell give the item real Material
-                          // interaction states — hover overlay, pressed
-                          // ripple, focus. The InkWell's own borderRadius
-                          // bounds the ripple; no Material clip, so angular
-                          // icons (e.g. the Pangea mark) aren't cut.
-                          child: Material(
-                            color:
-                                backgroundColor ??
-                                (isSelected
-                                    ? theme.colorScheme.primaryContainer
-                                    : theme.colorScheme.surfaceContainerHigh),
-                            borderRadius: borderRadius,
-                            child: Tooltip(
-                              message: toolTip,
-                              child: InkWell(
-                                borderRadius: borderRadius,
-                                onTap: onTap,
-                                child: icon,
+                          child: Container(
+                            alignment: Alignment.center,
+                            margin: EdgeInsets.symmetric(
+                              horizontal: isColumnMode ? 16.0 : 12.0,
+                              vertical: isColumnMode ? 8.0 : 6.0,
+                            ),
+                            // Material + InkWell give the item real Material
+                            // interaction states — hover overlay, pressed
+                            // ripple, focus. The InkWell's own borderRadius
+                            // bounds the ripple; no Material clip, so angular
+                            // icons (e.g. the Pangea mark) aren't cut.
+                            child: Material(
+                              color:
+                                  backgroundColor ??
+                                  (isSelected
+                                      ? theme.colorScheme.primaryContainer
+                                      : theme.colorScheme.surfaceContainerHigh),
+                              borderRadius: borderRadius,
+                              child: Tooltip(
+                                message: toolTip,
+                                child: InkWell(
+                                  borderRadius: borderRadius,
+                                  onTap: onTap,
+                                  child: icon,
+                                ),
                               ),
                             ),
                           ),


### PR DESCRIPTION
### What
Restore the unread-message badge on the **All chats** icon in the side navigation rail.

### Why
Closes #7996.

Regression from #7972 ("Make course list behavior and appearance consistent"), merged 2026-07-29. That refactor of `NaviRailItem` removed the `UnreadRoomsBadge` wrapper (and its `badges/badges.dart` + `unread_rooms_badge.dart` imports) but left `unreadBadgeFilter` still declared on the widget and still passed by `SpacesNavigationRail` for the Chats item — so the filter was wired to nothing and no badge rendered. Course-space badges were unaffected (they render via `CourseAvatar`); only the All-chats icon lost its count.

### What changed
- `lib/widgets/navi_rail_item.dart`: re-add the two imports and re-wrap the icon `Container` in `UnreadRoomsBadge(filter: unreadBadgeFilter ?? (_) => false, badgePosition: BadgePosition.topEnd(...))` — an exact restore of the pre-#7972 structure.
- No change needed to `navigation_rail.dart` (still passes `unreadBadgeFilter: (room) => room.firstSpaceParent == null`) or to `unread_rooms_badge.dart` (count logic intact).
- Scope: the `?? (_) => false` fallback keeps World/Courses rail icons unbadged (no filter → count 0 → `showBadge: false`); only the Chats icon shows a count. No double-badging of course spaces.

### Testing
- `flutter analyze lib/widgets/navi_rail_item.dart lib/widgets/navigation_rail.dart` → **No issues found** (confirms both restored imports are genuinely used again).
- Unit/widget bucket: no tests cover the nav rail (`NaviRailItem` / `SpacesNavigationRail`), so nothing in that bucket exercises this surface.
- Visual verification per #7996's TO TEST (unread count appears on the All-chats icon, reflects total, clears on read) deferred to staging QA — the badge count requires a live two-user unread state.

### Accessibility
- [x] No new/changed controls. `UnreadRoomsBadge` already supplies a `semanticsLabel` for the count; the icon's tooltip is unchanged.

### Deploy Notes
None.
