### PR TITLE
fix(nav): give the narrow course shortcut its own semantics node

### DIFF
--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -680,6 +680,20 @@ class _CourseShortcutButton extends StatelessWidget {
       child: Semantics(
         // Announce the active-course state — the border alone is visual-only.
         selected: selected,
+        // `container: true` forces the shortcut into its OWN standalone
+        // semantics node instead of merging its tap + selected state up into
+        // the rail's "Navigation options" node. The other three rail items are
+        // IconButtons, which already stand alone; this custom InkWell did not,
+        // so on Flutter web with the accessibility layer active (Firefox, and
+        // release web builds generally) its tap dispatched to the merged rail
+        // node and fell through to the live map behind — the course could be
+        // collapsed but never re-expanded by tapping the shortcut (#7944; the
+        // sibling web-semantics tap loss of #7927 / #7803). `label` gives the
+        // now-standalone node its accessible name (the course), which it
+        // previously borrowed from the merged rail node.
+        container: true,
+        button: true,
+        label: label,
         child: InkWell(
           borderRadius: BorderRadius.circular(99),
           onTap: onTap,

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -577,6 +577,84 @@ void main() {
     );
   });
 
+  group('course shortcut is its own semantics node (#7944)', () {
+    testWidgets(
+      'the course shortcut surfaces as a standalone tappable node, not merged '
+      'into the rail container',
+      (tester) async {
+        // The other three rail items are IconButtons, which stand alone. The
+        // course shortcut is a custom InkWell; without `container: true` its
+        // tap + selected state merged UP into the rail's "Navigation options"
+        // node, leaving it with no node of its own. On Flutter web with the
+        // accessibility layer active (Firefox / release builds), a tap on that
+        // merged rail node dispatched to the live map behind and fell through —
+        // so a collapsed course could never be re-expanded by the shortcut
+        // (#7944; the sibling web-semantics tap loss of #7927 / #7803). Forcing
+        // the shortcut into its own container node fixes it.
+        final semantics = tester.ensureSemantics();
+        await pumpNav(
+          tester,
+          activeSection: AppSection.courses,
+          cavitySection: null,
+          courseShortcutHostsCavity: true,
+          cavityChild: const Text('Course card'),
+          cavityKey: 'course-a',
+          cavityDefaultsToPeek: true,
+        );
+
+        final l10n = L10n.of(tester.element(find.byType(MobileNavWidget)));
+
+        SemanticsNode root = tester.getSemantics(find.byType(MobileNavWidget));
+        while (root.parent != null) {
+          root = root.parent!;
+        }
+
+        SemanticsData? shortcut;
+        SemanticsData? railContainer;
+        void collect(SemanticsNode node) {
+          final data = node.getSemanticsData();
+          if (data.label == 'Add a course') shortcut = data;
+          if (data.label == l10n.navOptionsLabel) railContainer = data;
+          node.visitChildren((child) {
+            collect(child);
+            return true;
+          });
+        }
+
+        collect(root);
+
+        expect(
+          shortcut,
+          isNotNull,
+          reason:
+              'the course shortcut must surface as its own labelled node, not '
+              'be absorbed into the rail container',
+        );
+        expect(
+          shortcut!.hasAction(SemanticsAction.tap),
+          isTrue,
+          reason: 'the standalone shortcut node must carry its own tap action',
+        );
+
+        // The crux of #7944: the rail container must NOT carry the shortcut's
+        // tap — a merged tap on the wide rail node is what Firefox dropped to
+        // the map.
+        expect(
+          railContainer,
+          isNotNull,
+          reason: 'the rail container node should still exist',
+        );
+        expect(
+          railContainer!.hasAction(SemanticsAction.tap),
+          isFalse,
+          reason: 'the rail container must not absorb the shortcut tap',
+        );
+
+        semantics.dispose();
+      },
+    );
+  });
+
   group('tap-outside collapse', () {
     testWidgets(
       'tapping outside collapses (ephemeral — no navigation), and the rail '


### PR DESCRIPTION
### What
Fix the narrow-screen bottom-nav **course shortcut** so tapping it re-expands a collapsed course (peek) instead of doing nothing on Firefox / deployed web.

### Why
Closes #7944.

The shortcut was the one rail item built as a custom `InkWell` without `container: true`, so its tap + selected state merged **up into the wide "Navigation options" rail node** — it had no semantics node of its own (the other three items are `IconButton`s, which do). On Flutter web with the accessibility layer active (Firefox, and deployed builds generally), pointer events dispatch through the semantics DOM, and a tap on that merged node **fell through to the live map behind the collapsed nav** (`mapStaysLive`, no tap-barrier) — confirmed by the map zooming on a double-tap. Same class as #7927 / #7803.

Collapse-is-not-close / tap-to-re-expand behavior is owned by `routing.instructions.md` → Single-column bottom nav.

### Changes to look over
- `_CourseShortcutButton` (`lib/widgets/layouts/mobile_nav_widget.dart`): add `container: true` + `button: true` + `label` so the shortcut is its own standalone tappable node, like the other rail items.
- New semantics regression test (`test/pangea/navigation/mobile_nav_widget_test.dart`): asserts the shortcut surfaces as its own tappable node **and** the rail container no longer absorbs its tap.

### Testing
- **Unit**: `flutter test test/pangea/navigation/mobile_nav_widget_test.dart` — 32/32 pass (incl. the new test). `flutter analyze` clean on the touched files. A semantics-tree diagnostic confirmed the merge before / standalone node after.
- **Behavior**: this bug only reproduces on **deployed web** (semantics-DOM pointer dispatch; it does not reproduce on local debug or local release builds — see #7803's "never on local builds"). Verify on **staging in Firefox** after deploy: narrow view → open a course → collapse it to the rail → tap the course shortcut → it re-expands to peek.

### Deploy Notes
None.

### Accessibility
- [x] New/changed controls have an accessible name — the shortcut now carries its own `label` (the course name) and `button` role (previously borrowed from the merged rail node).
