### PR TITLE
fix(courses): render add-course tiles without a room (#8001)

### DIFF
--- a/lib/pangea/common/widgets/course_avatar.dart
+++ b/lib/pangea/common/widgets/course_avatar.dart
@@ -12,8 +12,13 @@ class CourseAvatar extends StatelessWidget {
   final Uri? avatar;
   final String displayname;
   final double size;
-  final Future<Event?> unreadCoursePingEvent;
-  final Set<String?> courseChildrenIds;
+
+  /// The unread course-ping future and the course's child-room ids drive the
+  /// notification badge. They are only available for real course rooms (nav
+  /// rail, joined-courses list); for add-course previews and course-plan
+  /// suggestions there is no room yet, so both are null and no badge shows.
+  final Future<Event?>? unreadCoursePingEvent;
+  final Set<String?>? courseChildrenIds;
   final bool invite;
 
   final Widget? child;
@@ -23,8 +28,8 @@ class CourseAvatar extends StatelessWidget {
     this.avatar,
     required this.displayname,
     required this.size,
-    required this.unreadCoursePingEvent,
-    required this.courseChildrenIds,
+    this.unreadCoursePingEvent,
+    this.courseChildrenIds,
     this.invite = false,
     this.child,
   });
@@ -47,6 +52,14 @@ class CourseAvatar extends StatelessWidget {
 
     if (invite) {
       return InvitedCourseBadge(position: position, child: child);
+    }
+
+    // No underlying room (add-course preview or course-plan suggestion): show
+    // the plain avatar without the unread-notification badge.
+    final unreadCoursePingEvent = this.unreadCoursePingEvent;
+    final courseChildrenIds = this.courseChildrenIds;
+    if (unreadCoursePingEvent == null || courseChildrenIds == null) {
+      return child;
     }
 
     return UnreadRoomsBadge(

--- a/lib/routes/courses/add_course_tile.dart
+++ b/lib/routes/courses/add_course_tile.dart
@@ -59,8 +59,8 @@ class AddCourseTile extends StatelessWidget {
                       avatar: content.imageUrl,
                       displayname: title,
                       size: 48.0,
-                      unreadCoursePingEvent: unreadCoursePingEvent!,
-                      courseChildrenIds: courseChildrenIds!,
+                      unreadCoursePingEvent: unreadCoursePingEvent,
+                      courseChildrenIds: courseChildrenIds,
                       invite: invited,
                     ),
                     Expanded(

--- a/test/pangea/courses/add_course_tile_grey_box_test.dart
+++ b/test/pangea/courses/add_course_tile_grey_box_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/courses/add_course_tile.dart';
+import 'package:fluffychat/routes/courses/add_course_tile_content.dart';
+
+void main() {
+  // Avatar reads Environment.botName (dotenv) while building; load a stub env
+  // so the widget under test builds the same way it does in the app.
+  TestWidgetsFlutterBinding.ensureInitialized();
+  setUpAll(() => dotenv.testLoad(mergeWith: {'BOT_NAME': 'Pangea Bot'}));
+
+  Widget wrap(Widget child) => MaterialApp(
+    localizationsDelegates: L10n.localizationsDelegates,
+    supportedLocales: L10n.supportedLocales,
+    home: Scaffold(
+      body: SizedBox(width: 400, child: Center(child: child)),
+    ),
+  );
+
+  group('AddCourseTile (#8001)', () {
+    // "Start My Own" and "Browse Public Courses" tiles are backed by content
+    // types (CoursePlan / Preview) with no underlying room, so their
+    // unreadCoursePingEvent and courseChildrenIds are null. #7972 force-
+    // unwrapped both, throwing a null-check error that rendered as a grey box.
+    testWidgets('renders content with no room without throwing', (
+      tester,
+    ) async {
+      final content = CombinedAddCourseTileContent(title: 'Intro Spanish');
+      expect(content.unreadCoursePingEvent, isNull);
+      expect(content.courseChildrenIds, isNull);
+
+      await tester.pumpWidget(wrap(AddCourseTile(content: content)));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('Intro Spanish'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Closes #8001

## Problem

**Start My Own** and **Browse Public Courses** rendered a grey box instead of the course list.

<img width="300" alt="grey box" src="https://github.com/user-attachments/assets/9ac75d39-744a-4dbf-a2b6-820d8e018136" />

## Root cause

Introduced by #7972. That PR swapped `AddCourseTile`'s avatar for the shared `CourseAvatar` and force-unwrapped two fields:

```dart
unreadCoursePingEvent: unreadCoursePingEvent!,
courseChildrenIds: courseChildrenIds!,
```

Those fields are only populated for real course rooms (nav rail, joined-courses list). The content types backing the two add-course pages — `CoursePlanAddCourseTileContent` (Start My Own) and `PreviewAddCourseTileContent` (Browse Public Courses) — leave both null, so the `!` threw a null-check error at build time and Flutter rendered the failed subtree as a grey error box.

## Fix

- `CourseAvatar`: make `unreadCoursePingEvent` and `courseChildrenIds` nullable; when there is no underlying room, fall back to the plain avatar with no unread-notification badge.
- `AddCourseTile`: drop the two `!` null-assertions.
- Nav rail and joined-courses list always pass both non-null, so their notification badges are unchanged.

## Changes

- `lib/pangea/common/widgets/course_avatar.dart`
- `lib/routes/courses/add_course_tile.dart`
- `test/pangea/courses/add_course_tile_grey_box_test.dart` (new regression test)

## Testing

- `flutter analyze` clean on changed + dependent files.
- New widget test renders a roomless add-course tile; verified it **fails on the pre-fix code** (reproduces the crash) and **passes with the fix**.

---

**TO TEST**
- [ ] Open the Courses panel as a user with no courses joined
- [ ] Tap **Start My Own** — the course-plan list renders (tiles with title, no grey box)
- [ ] Tap **Browse Public Courses** — the public course list renders (tiles with title/avatar, no grey box)
- [ ] In the nav rail and joined-courses list, confirm course avatars and their unread-notification badges still appear as before