### PR TITLE
fix(courses): make invited courses read as an invitation, not an error

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -78,6 +78,15 @@ abstract class AppConfig {
   static Color goldByTheme(BuildContext context) =>
       Theme.of(context).brightness == Brightness.light ? gold : goldLight;
 
+  /// Readable ink on top of [goldByTheme], which is a light fill in both
+  /// brightnesses — so both branches resolve to a dark tone.
+  static Color onGoldByTheme(BuildContext context) {
+    final theme = Theme.of(context);
+    return theme.brightness == Brightness.light
+        ? theme.colorScheme.onSurface
+        : theme.colorScheme.surface;
+  }
+
   static String goldHexByTheme(BuildContext context) =>
       Theme.of(context).brightness == Brightness.light
       ? goldHexCode

--- a/lib/pangea/common/widgets/invited_course_badge.dart
+++ b/lib/pangea/common/widgets/invited_course_badge.dart
@@ -2,6 +2,13 @@ import 'package:flutter/material.dart';
 
 import 'package:badges/badges.dart' as b;
 
+import 'package:fluffychat/config/app_config.dart';
+
+/// The badge on the avatar of a course the learner has been invited to but
+/// hasn't joined yet. Gold rather than error-colored, and an envelope rather
+/// than a warning glyph: an invitation is an opportunity, not a problem
+/// (#7636). Sized to match the unread-ping badge in `CourseAvatar` so the
+/// avatar doesn't shift as a course moves between states.
 class InvitedCourseBadge extends StatelessWidget {
   final b.BadgePosition? position;
   final Widget? child;
@@ -12,15 +19,15 @@ class InvitedCourseBadge extends StatelessWidget {
   Widget build(BuildContext context) {
     return b.Badge(
       badgeStyle: b.BadgeStyle(
-        badgeColor: Theme.of(context).colorScheme.error,
+        badgeColor: AppConfig.goldByTheme(context),
         elevation: 4,
         borderSide: BorderSide.none,
-        padding: const EdgeInsetsGeometry.all(0),
+        padding: const EdgeInsetsGeometry.all(2),
       ),
       badgeContent: Icon(
-        Icons.error_outline,
-        color: Theme.of(context).colorScheme.onPrimary,
-        size: 16,
+        Icons.mail,
+        color: AppConfig.onGoldByTheme(context),
+        size: 12,
       ),
       position: position,
       child: child,

--- a/lib/routes/courses/add_course_tile.dart
+++ b/lib/routes/courses/add_course_tile.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/widgets/course_avatar.dart';
 import 'package:fluffychat/routes/courses/add_course_tile_content.dart';
@@ -28,7 +29,11 @@ class AddCourseTile extends StatelessWidget {
     final title = content.title(L10n.of(context));
     final expandedContent = content.expandedContent;
 
-    final label = members != null
+    // An invited course hides its member/level chips, so the participant count
+    // would announce detail that isn't on screen — lead with the state instead.
+    final label = invited
+        ? '$title, ${L10n.of(context).invited}'
+        : members != null
         ? '$title, ${L10n.of(context).countParticipants(members)}'
         : title;
 
@@ -97,6 +102,19 @@ class AddCourseTile extends StatelessWidget {
                             runSpacing: 8.0,
                             crossAxisAlignment: WrapCrossAlignment.center,
                             children: [
+                              if (invited)
+                                CourseInfoChip(
+                                  icon: Icons.mail,
+                                  text: L10n.of(context).invited,
+                                  fontSize: 12.0,
+                                  iconSize: 12.0,
+                                  highlightColor: AppConfig.goldByTheme(
+                                    context,
+                                  ),
+                                  foregroundColor: AppConfig.onGoldByTheme(
+                                    context,
+                                  ),
+                                ),
                               if (members != null && !invited)
                                 CourseInfoChip(
                                   icon: Icons.group,

--- a/lib/routes/courses/course_info_chip_widget.dart
+++ b/lib/routes/courses/course_info_chip_widget.dart
@@ -12,6 +12,10 @@ class CourseInfoChip extends StatelessWidget {
   final EdgeInsets? padding;
   final Color? highlightColor;
 
+  /// Ink for the icon and text. Needed when [highlightColor] is dark or
+  /// saturated enough that the ambient text color stops being legible on it.
+  final Color? foregroundColor;
+
   const CourseInfoChip({
     super.key,
     required this.icon,
@@ -20,6 +24,7 @@ class CourseInfoChip extends StatelessWidget {
     required this.iconSize,
     this.padding,
     this.highlightColor,
+    this.foregroundColor,
   });
 
   @override
@@ -28,8 +33,11 @@ class CourseInfoChip extends StatelessWidget {
       spacing: 4.0,
       mainAxisSize: MainAxisSize.min,
       children: [
-        Icon(icon, size: iconSize),
-        Text(text, style: TextStyle(fontSize: fontSize)),
+        Icon(icon, size: iconSize, color: foregroundColor),
+        Text(
+          text,
+          style: TextStyle(fontSize: fontSize, color: foregroundColor),
+        ),
       ],
     );
 

--- a/test/pangea/courses/invited_course_tile_test.dart
+++ b/test/pangea/courses/invited_course_tile_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/widgets/invited_course_badge.dart';
+import 'package:fluffychat/routes/courses/add_course_tile.dart';
+import 'package:fluffychat/routes/courses/add_course_tile_content.dart';
+import 'package:fluffychat/routes/courses/course_info_chip_widget.dart';
+
+/// Coverage for #7636: a course the learner has been *invited* to must read as
+/// an invitation, not as an error. In the courses list that means a gold
+/// "Invited" chip and an envelope glyph — never the error-colored warning badge
+/// the state used to borrow.
+class _StubCourseTileContent extends AddCourseTileContent {
+  @override
+  final bool invited;
+
+  final int? memberCount;
+
+  _StubCourseTileContent({required this.invited, this.memberCount = 12});
+
+  @override
+  String title(L10n l10n) => 'Elementary German I';
+
+  @override
+  int? get members => memberCount;
+
+  @override
+  Future<Event?>? get unreadCoursePingEvent => Future.value(null);
+
+  @override
+  Set<String?> get courseChildrenIds => const {};
+}
+
+void main() {
+  setUpAll(() {
+    // `Avatar` inside `CourseAvatar` resolves the bot name from the environment
+    // at build time; initialize dotenv inline so no real `.env` is needed.
+    dotenv.testLoad(fileInput: 'BOT_NAME=@bot:example.org');
+  });
+
+  Future<void> pumpTile(WidgetTester tester, {required bool invited}) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              width: 360,
+              child: AddCourseTile(
+                content: _StubCourseTileContent(invited: invited),
+                onTap: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    // L10n's delegate resolves from a deferred library, so the tile isn't in
+    // the tree until localizations finish loading.
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('invited course shows a gold Invited chip', (tester) async {
+    await pumpTile(tester, invited: true);
+
+    final context = tester.element(find.byType(AddCourseTile));
+    final l10n = L10n.of(context);
+
+    final chip = tester.widget<CourseInfoChip>(
+      find.byWidgetPredicate(
+        (w) => w is CourseInfoChip && w.text == l10n.invited,
+      ),
+    );
+
+    expect(chip.icon, Icons.mail);
+    expect(chip.highlightColor, AppConfig.goldByTheme(context));
+    expect(
+      chip.foregroundColor,
+      AppConfig.onGoldByTheme(context),
+      reason: 'gold is a light fill; the label needs dark ink to stay legible',
+    );
+  });
+
+  testWidgets('invited course badge is gold and envelope-shaped, not an error', (
+    tester,
+  ) async {
+    await pumpTile(tester, invited: true);
+
+    expect(find.byType(InvitedCourseBadge), findsOneWidget);
+
+    final context = tester.element(find.byType(AddCourseTile));
+    final icon = tester.widget<Icon>(
+      find.descendant(
+        of: find.byType(InvitedCourseBadge),
+        matching: find.byType(Icon),
+      ),
+    );
+
+    expect(icon.icon, Icons.mail);
+    expect(icon.icon, isNot(Icons.error_outline));
+    expect(icon.color, AppConfig.onGoldByTheme(context));
+    expect(
+      icon.color,
+      isNot(Theme.of(context).colorScheme.error),
+      reason: 'an invitation is an opportunity, not a problem (#7636)',
+    );
+  });
+
+  testWidgets('invited state is announced instead of the participant count', (
+    tester,
+  ) async {
+    await pumpTile(tester, invited: true);
+
+    final context = tester.element(find.byType(AddCourseTile));
+    final l10n = L10n.of(context);
+
+    final semantics = tester.widget<Semantics>(
+      find
+          .descendant(
+            of: find.byType(AddCourseTile),
+            matching: find.byType(Semantics),
+          )
+          .first,
+    );
+
+    expect(semantics.properties.label, contains(l10n.invited));
+    expect(
+      semantics.properties.label,
+      isNot(contains(l10n.countParticipants(12))),
+      reason: 'the member chip is hidden while invited, so do not announce it',
+    );
+  });
+
+  // The joined branch of the tile renders `UnreadRoomsBadge`, which needs a
+  // `Provider<MatrixState>` this change doesn't touch — so the chip's own
+  // contract is covered directly instead of through a fully-mounted tile.
+  testWidgets('chip paints icon and text with the given foreground', (
+    tester,
+  ) async {
+    const ink = Color(0xFF123456);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: CourseInfoChip(
+            icon: Icons.mail,
+            text: 'Invited',
+            fontSize: 12.0,
+            iconSize: 12.0,
+            highlightColor: AppConfig.gold,
+            foregroundColor: ink,
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.widget<Icon>(find.byIcon(Icons.mail)).color, ink);
+    expect(tester.widget<Text>(find.text('Invited')).style?.color, ink);
+  });
+}

--- a/test/pangea/courses/invited_course_tile_test.dart
+++ b/test/pangea/courses/invited_course_tile_test.dart
@@ -19,15 +19,13 @@ class _StubCourseTileContent extends AddCourseTileContent {
   @override
   final bool invited;
 
-  final int? memberCount;
-
-  _StubCourseTileContent({required this.invited, this.memberCount = 12});
+  _StubCourseTileContent({required this.invited});
 
   @override
   String title(L10n l10n) => 'Elementary German I';
 
   @override
-  int? get members => memberCount;
+  int? get members => 12;
 
   @override
   Future<Event?>? get unreadCoursePingEvent => Future.value(null);
@@ -88,30 +86,31 @@ void main() {
     );
   });
 
-  testWidgets('invited course badge is gold and envelope-shaped, not an error', (
-    tester,
-  ) async {
-    await pumpTile(tester, invited: true);
+  testWidgets(
+    'invited course badge is gold and envelope-shaped, not an error',
+    (tester) async {
+      await pumpTile(tester, invited: true);
 
-    expect(find.byType(InvitedCourseBadge), findsOneWidget);
+      expect(find.byType(InvitedCourseBadge), findsOneWidget);
 
-    final context = tester.element(find.byType(AddCourseTile));
-    final icon = tester.widget<Icon>(
-      find.descendant(
-        of: find.byType(InvitedCourseBadge),
-        matching: find.byType(Icon),
-      ),
-    );
+      final context = tester.element(find.byType(AddCourseTile));
+      final icon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byType(InvitedCourseBadge),
+          matching: find.byType(Icon),
+        ),
+      );
 
-    expect(icon.icon, Icons.mail);
-    expect(icon.icon, isNot(Icons.error_outline));
-    expect(icon.color, AppConfig.onGoldByTheme(context));
-    expect(
-      icon.color,
-      isNot(Theme.of(context).colorScheme.error),
-      reason: 'an invitation is an opportunity, not a problem (#7636)',
-    );
-  });
+      expect(icon.icon, Icons.mail);
+      expect(icon.icon, isNot(Icons.error_outline));
+      expect(icon.color, AppConfig.onGoldByTheme(context));
+      expect(
+        icon.color,
+        isNot(Theme.of(context).colorScheme.error),
+        reason: 'an invitation is an opportunity, not a problem (#7636)',
+      );
+    },
+  );
 
   testWidgets('invited state is announced instead of the participant count', (
     tester,


### PR DESCRIPTION
### What

An invited course now reads as an invitation instead of an error: a gold envelope badge on the course avatar, plus an "Invited" chip in the courses list.

### Why

`Addresses #7636` — the invited state borrowed a red `error_outline` badge, which signals "something is wrong" for what is actually an opportunity. Invited courses also appeared in the courses list with no indication of *why* they looked different from joined ones.

Not a full close: the notification-center entry point raised on the issue is still open. Pulsing was explicitly declined.

### Changes

- `InvitedCourseBadge` — `Icons.error_outline` on `colorScheme.error` → `Icons.mail` on `AppConfig.goldByTheme`. Resized to 12px icon / 2px padding so its 16px outer box matches the unread-ping badge; the avatar no longer shifts as a course moves between states. One shared widget covers both the nav rail and the courses list.
- `AddCourseTile` — gold "Invited" chip in the row where member/level chips sit when joined. Reuses the existing `invited` l10n key, so no new string and no translation pass.
- `AppConfig.onGoldByTheme` — dark ink for gold fills, matching the existing pattern in `selected_subscription_view.dart`.
- `CourseInfoChip.foregroundColor` — `highlightColor` existed with no call sites and no way to keep text legible on a saturated fill.
- Screen-reader label leads with "Invited" instead of the participant count, since the member chip is hidden in that state.

### Testing

Run locally against the repo-pinned Flutter (3.41.4 via fvm):

- `flutter analyze` — clean.
- `dart format --set-exit-if-changed lib/ test/` — clean.
- 4 new widget tests in `test/pangea/courses/invited_course_tile_test.dart` — pass.
- Full suite: 1588 pass / 3 skip / 8 fail. Those 8 (navigation, world-map, semantics-activation) fail identically on clean `origin/main` at a68a5aa — pre-existing, untouched by this change.
- Contrast checked against the app's real seeded theme: badge 10.3:1 light / 14.1:1 dark, chip 11.5:1 / 7.8:1 — all above WCAG AAA.

Not verified in a running client: reaching the invited state needs a live account with a pending course invite. Worth an eyeball on staging.

### Accessibility

- [x] New or changed controls have an accessible name. The chip is inside the tile's existing `Semantics(button: true, label: ...)`, whose label now announces the invited state; the badge is decorative and sits under the avatar's `ExcludeSemantics`.

### Deploy Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved visual treatment for invited courses with gold-themed invitation badges and mail icons.
  * Added clearer accessibility labels that identify invited courses without announcing participant counts.
  * Improved contrast for course information chips with customizable text and icon colors.

* **Bug Fixes**
  * Corrected invited course styling so it no longer appears as an error or warning state.

* **Tests**
  * Added coverage for invited-course visuals, accessibility labels, icons, and color contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->