### PR TITLE
fix(activities): require a session before the archived 'no longer supported' view

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_session_start_page.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_start_page.dart
@@ -40,11 +40,28 @@ enum SessionState {
   /// The user has confirmed their role.
   confirmedRole,
 
-  /// The backend confirmed the activity no longer exists (404). The page is
-  /// read-only: it renders the plan recovered from legacy room state when one
-  /// exists, else the archived fallback body — never role selection.
+  /// The backend confirmed the activity no longer exists (404) AND there is a
+  /// session to review. The page is read-only: it renders the plan recovered
+  /// from legacy room state when one exists, else the archived fallback body —
+  /// never role selection.
   archived,
 }
+
+/// Whether a confirmed-removed activity renders the read-only archived view
+/// and its "no longer supported" notice.
+///
+/// The removed-activity ladder is scoped to session ROOMS: every rung renders
+/// what the room itself holds — roles, stars, timeline — so a learner or their
+/// teacher can always reopen an old session and review the work done there
+/// (activities.instructions.md, "Removed or unresolvable activities"). Reached
+/// WITHOUT a session, as a bare world-map pin is, there is no such thing to
+/// review: the archived body would render empty and the notice would tell the
+/// learner an activity they never ran is out of date (#7918). That case is a
+/// plain not-found instead.
+bool archivedSessionGate({
+  required bool activityRemoved,
+  required bool hasSessionRoom,
+}) => activityRemoved && hasSessionRoom;
 
 class ActivitySessionStartPage extends StatefulWidget {
   final String activityId;
@@ -324,8 +341,15 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
     );
   }
 
+  /// See [archivedSessionGate]. Also read by the view, which picks the
+  /// archived body over the not-found error on the same condition.
+  bool get isArchived => archivedSessionGate(
+    activityRemoved: activityRemoved,
+    hasSessionRoom: widget.roomId != null,
+  );
+
   SessionState get _sessionState {
-    if (activityRemoved) return SessionState.archived;
+    if (isArchived) return SessionState.archived;
 
     final roomExists = widget.roomId != null;
     final userIsCreatingRoom = widget.launch;

--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -43,7 +43,7 @@ class ActivitySessionStartView extends StatelessWidget {
   });
 
   String? _archivedRoomName(BuildContext context) {
-    if (!controller.activityRemoved) return null;
+    if (!controller.isArchived) return null;
     return controller.activityRoom?.getLocalizedDisplayname(
       MatrixLocals(L10n.of(context)),
     );
@@ -184,9 +184,11 @@ class ActivitySessionStartView extends StatelessWidget {
                     ),
                   ),
                 )
-              // Confirmed removed with no plan recoverable from room state:
-              // archived body from role/goal state alone.
-              : activity == null && controller.activityRemoved
+              // Confirmed removed, with a session and no plan recoverable from
+              // its room state: archived body from role/goal state alone.
+              // Without a session there is nothing to build it from, so a
+              // removed activity falls through to not-found (#7918).
+              : activity == null && controller.isArchived
               ? _ArchivedSessionFallbackBody(controller)
               : activity == null
               ? Center(

--- a/test/pangea/activity_archived_session_gate_test.dart
+++ b/test/pangea/activity_archived_session_gate_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
+
+/// The gate deciding whether a confirmed-removed activity renders the
+/// read-only archived view and its "no longer supported" notice.
+///
+/// The removed-activity ladder is scoped to session ROOMS — every rung renders
+/// what the room itself holds (roles, stars, timeline) so past work stays
+/// reviewable (activities.instructions.md, "Removed or unresolvable
+/// activities"). The regression this locks (#7918): the gate was `removed`
+/// alone, so a removed activity opened from a bare world-map pin — no session,
+/// nothing to review — rendered an all-but-empty archived page telling the
+/// learner their activity "ran on an older version". Without a session that
+/// notice is simply wrong, and the map dead-ends.
+void main() {
+  group('archivedSessionGate', () {
+    test('removed activity WITH a session is archived — the session is the '
+        'thing being reviewed', () {
+      expect(
+        archivedSessionGate(activityRemoved: true, hasSessionRoom: true),
+        isTrue,
+      );
+    });
+
+    test('removed activity with NO session is not archived — a bare map pin '
+        'has nothing to review', () {
+      expect(
+        archivedSessionGate(activityRemoved: true, hasSessionRoom: false),
+        isFalse,
+      );
+    });
+
+    test('a healthy activity is never archived, session or not', () {
+      expect(
+        archivedSessionGate(activityRemoved: false, hasSessionRoom: true),
+        isFalse,
+      );
+      expect(
+        archivedSessionGate(activityRemoved: false, hasSessionRoom: false),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

A removed activity only renders the archived "no longer supported" view when there is a session to review.

## Why

Closes #7918

The gate was `activityRemoved` alone, evaluated before anything checked for a session room. A map pin carries no room, so a removed activity opened from the map rendered the archived fallback body with nothing in it — an icon and a notice telling the learner an activity they never ran is out of date, and a dead end. That is the screenshot on the issue: no role tiles under the text, because there was no room to build them from.

The removed-activity ladder is scoped to session rooms — see [activities.instructions.md](https://github.com/pangeachat/.github/blob/main/.github/instructions/activities.instructions.md) ("Removed or unresolvable activities"): every rung renders what the room holds so past work stays reviewable. With no session there is nothing to review, so the page now falls through to the existing not-found error.

The condition was also derived twice — once in `_sessionState`, once in the view's body switch — so fixing only the former would have left the same empty page reachable via `notStarted`. Both now read one named gate, `archivedSessionGate`.

Cross-repo: the other half of what Tig saw is choreo turning a CMS outage into a 404, which the client faithfully reads as "removed" — pangeachat/2-step-choreographer#2882. Independent of this PR; either can ship first.

## Testing

- New `test/pangea/activity_archived_session_gate_test.dart` — 3 cases, pass. Locks removed+session → archived, removed+no-session → not archived, healthy → never archived.
- Full `fvm flutter test test/pangea/` run: 1590 pass. 8 failures, all pre-existing on `origin/main` and unrelated (navigation, world-map, and popup-menu widget tests) — verified by stashing this change and re-running the same files.
- `fvm flutter analyze` on the touched files and the new test: clean. No `pubspec.lock` churn.
- Playwright browser specs not run locally — that bucket runs against staging post-deploy and nightly, per testing.instructions.md.

## Deploy Notes

None.
