### PR TITLE
fix(courses): keep activity card semantics when a scroll arrow shows

### DIFF
--- a/lib/routes/courses/course_objectives/objective_section.dart
+++ b/lib/routes/courses/course_objectives/objective_section.dart
@@ -286,31 +286,21 @@ class ObjectiveSectionState extends State<ObjectiveSection> {
                   },
                 ),
               ),
-              // Drop the card semantics beneath the arrows so a tap on an arrow
-              // can't fall through to a card on Flutter web (#7803). A single
-              // blocker painted after the ListView but before the arrows keeps
-              // the two arrows from clobbering each other's semantics: a
-              // per-arrow BlockSemantics would also drop the sibling arrow
-              // painted before it, routing its taps to the wrong arrow.
-              ListenableBuilder(
-                listenable: Listenable.merge([
-                  _showBackArrowNotifier,
-                  _showForwardArrowNotifier,
-                ]),
-                builder: (context, _) {
-                  final blocking =
-                      _showBackArrowNotifier.value ||
-                      _showForwardArrowNotifier.value;
-                  return blocking
-                      ? const BlockSemantics()
-                      : const SizedBox.shrink();
-                },
-              ),
               // The scroll arrows overlay the ends of the ListView. Only mount
               // the arrow that is currently usable — a hidden-but-present arrow
               // (IgnorePointer / opacity 0) still leaves a semantics node at the
               // edge that, on Flutter web, lets a tap fall through to the card
               // beneath it.
+              //
+              // Do NOT add a BlockSemantics here to keep an arrow tap off the
+              // card beneath it. Blocking is not geometric: it drops EVERY
+              // previously-painted sibling in this Stack, which is the whole
+              // ListView — so every card in an overflowing row loses its
+              // semantics node, and with it (on web, where the accessibility
+              // layer dispatches pointer events through the semantics DOM) any
+              // way to be clicked at all (#8011). The arrows are painted after
+              // the ListView, so their own button nodes already sit above the
+              // cards and win the tap without blocking anything.
               Positioned(
                 left: 0,
                 top: 0,

--- a/lib/routes/courses/course_objectives/objective_section_scroll_arrow.dart
+++ b/lib/routes/courses/course_objectives/objective_section_scroll_arrow.dart
@@ -33,10 +33,10 @@ class ObjectiveSectionScrollArrow extends StatelessWidget {
     // accessibility layer is active, pointer events are dispatched through the
     // semantics DOM tree rather than the render tree, so the arrow needs its own
     // tappable semantics node that sits on top of the activity cards beneath it.
-    // The caller drops the card semantics underneath (a sibling BlockSemantics)
-    // so the cards can't intercept the tap (#7803). Do NOT wrap this in an
-    // AbsorbPointer / IgnorePointer: those strip this node's semantics and
-    // reintroduce the click-through.
+    // The caller paints the arrows after the card ListView, which is what puts
+    // this node above the cards (#7803). Do NOT wrap this in an AbsorbPointer /
+    // IgnorePointer: those strip this node's semantics and reintroduce the
+    // click-through.
     return Semantics(
       button: true,
       label: direction.label(L10n.of(context)),

--- a/test/pangea/courses/objective_section_semantics_test.dart
+++ b/test/pangea/courses/objective_section_semantics_test.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_media_enum.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_request.dart';
+import 'package:fluffychat/features/quests/models/learning_objective_model.dart';
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/courses/course_objectives/objective_section.dart';
+import 'package:fluffychat/routes/courses/course_objectives/objective_section_scroll_arrow.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+
+/// Semantics contract for the activity strip in a Mission row.
+///
+/// On Flutter web, when the accessibility layer is active, pointer events are
+/// dispatched through the semantics DOM tree rather than the render tree. That
+/// makes "does this widget have a semantics node" equivalent to "can this widget
+/// be clicked at all" on web — which is why these are semantics assertions and
+/// not `tester.tap` assertions. A widget-test tap goes through the render tree
+/// and passes either way, so it cannot see this class of bug.
+///
+/// Two directions are pinned here, one per historical regression:
+///  - #8011 — a `BlockSemantics` added beside the arrows dropped EVERY card's
+///    semantics node in any overflowing row (blocking is not geometric), so no
+///    activity card could be opened on web while a chevron was showing.
+///  - #7803 — the arrows must still out-rank the cards they overlap, which they
+///    do by being painted after the ListView. Pinned as node order.
+void main() {
+  // The card's image widget reads Environment.cmsApi before it decides whether
+  // to fetch anything, so dotenv has to be loaded even though these tests never
+  // want a real image.
+  setUp(() {
+    dotenv.testLoad(mergeWith: {'CMS_API': 'https://cms.test.invalid'});
+  });
+
+  ActivityPlanModel plan(
+    String id,
+    String title,
+    int participants,
+  ) => ActivityPlanModel(
+    req: ActivityPlanRequest(
+      topic: '',
+      mode: '',
+      objective: '',
+      media: MediaEnum.nan,
+      cefrLevel: LanguageLevelTypeEnum.a2,
+      languageOfInstructions: 'en',
+      targetLanguage: 'es',
+      numberOfParticipants: participants,
+    ),
+    title: title,
+    learningObjective: '',
+    instructions: '',
+    vocab: const [],
+    activityId: id,
+    // A host outside AppConfig's image allowlist, so the card renders its
+    // no-image fallback instead of reaching for the network. Without this the
+    // model falls back to a real placeholder URL on the assets host.
+    imageURL: 'https://images.test.invalid/$id.png',
+  );
+
+  // Ascending participant counts so the widget's own sort keeps this order.
+  const titles = ['Alpha Activity', 'Beta Activity', 'Gamma Activity'];
+  const objectiveText = 'Can introduce self.';
+
+  QuestObjectiveGroup objectiveGroup() => QuestObjectiveGroup(
+    objective: LearningObjective(id: 'lo-1', objective: objectiveText),
+    activities: [
+      for (var i = 0; i < titles.length; i++)
+        QuestActivity(activityId: 'a-$i', plan: plan('a-$i', titles[i], 2 + i)),
+    ],
+  );
+
+  const cardWidth = 160.0;
+
+  Widget wrap({required double width, void Function(QuestActivity)? onTap}) =>
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(
+            width: width,
+            child: ObjectiveSection(
+              index: 0,
+              group: objectiveGroup(),
+              onTap: onTap ?? (_) {},
+              userStarsByActivity: (_) => 0,
+              hasCompletedActivity: (_) => false,
+              liveStateByActivity: (_) => (state: null, openSessions: 0),
+              availableParticipants: 10,
+              progress: null,
+              // No vertical padding, so each card gets the height it asks for.
+              spacing: 0.0,
+              cardWidth: cardWidth,
+              cardHeight: 220.0,
+            ),
+          ),
+        ),
+      );
+
+  /// Every non-empty semantics label in the live tree, in semantic child order.
+  /// Order matters: Flutter web builds its semantics DOM in this order, so a
+  /// node listed later sits above an overlapping node listed earlier.
+  ///
+  /// Anchored on the objective header, which sits outside the activity Stack and
+  /// so always has a node, then walked up to the root — the header is the one
+  /// node guaranteed to survive whatever the strip below it is doing.
+  List<String> labelsInOrder(WidgetTester tester) {
+    var root = tester.semantics.find(find.text(objectiveText));
+    while (root.parent != null) {
+      root = root.parent!;
+    }
+
+    final labels = <String>[];
+    void visit(SemanticsNode node) {
+      if (node.label.isNotEmpty) labels.add(node.label);
+      node.visitChildren((child) {
+        visit(child);
+        return true;
+      });
+    }
+
+    visit(root);
+    return labels;
+  }
+
+  /// Position of the first node whose label contains [needle], or -1. Cards merge
+  /// their title with the participant count into one node ('Alpha Activity\n2'),
+  /// so these lookups must be substring matches — an exact `indexOf` silently
+  /// returns -1 for every card and makes the ordering assertion below pass
+  /// without testing anything.
+  int indexOfLabelContaining(List<String> labels, String needle) =>
+      labels.indexWhere((label) => label.contains(needle));
+
+  group('ObjectiveSection activity strip semantics', () {
+    testWidgets('cards keep their semantics nodes while a scroll arrow is '
+        'showing (#8011)', (tester) async {
+      final handle = tester.ensureSemantics();
+      // 3 x 160 overflows a 360 viewport, so the forward arrow mounts.
+      await tester.pumpWidget(wrap(width: 360.0));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(ObjectiveSectionScrollArrow),
+        findsOneWidget,
+        reason: 'the overflowing strip should mount its forward arrow',
+      );
+
+      final labels = labelsInOrder(tester);
+      for (final title in titles) {
+        expect(
+          indexOfLabelContaining(labels, title),
+          isNonNegative,
+          reason:
+              '$title lost its semantics node while an arrow was showing — on '
+              'web that makes the card unclickable. Labels: $labels',
+        );
+      }
+      handle.dispose();
+    });
+
+    testWidgets('the arrow node is ordered after the cards it overlaps '
+        '(#7803)', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(wrap(width: 360.0));
+      await tester.pumpAndSettle();
+
+      final labels = labelsInOrder(tester);
+      final arrowIndex = indexOfLabelContaining(labels, 'Forward');
+      expect(
+        arrowIndex,
+        isNonNegative,
+        reason: 'the forward arrow needs its own node. Labels: $labels',
+      );
+
+      final lastCardIndex = titles
+          .map((t) => indexOfLabelContaining(labels, t))
+          .reduce((a, b) => a > b ? a : b);
+      // Guard the comparison below against passing on a not-found (-1) card.
+      expect(
+        lastCardIndex,
+        isNonNegative,
+        reason: 'the cards need nodes for this ordering check to mean anything',
+      );
+      expect(
+        arrowIndex,
+        greaterThan(lastCardIndex),
+        reason:
+            'the arrow must be painted after the cards so its node sits above '
+            'them and takes the tap instead of the card beneath it',
+      );
+      handle.dispose();
+    });
+
+    testWidgets('no arrow mounts when the strip fits, and the cards still '
+        'carry semantics', (tester) async {
+      final handle = tester.ensureSemantics();
+      // 3 x 160 = 480 fits a 600 viewport.
+      await tester.pumpWidget(wrap(width: 600.0));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ObjectiveSectionScrollArrow), findsNothing);
+      final labels = labelsInOrder(tester);
+      for (final title in titles) {
+        expect(
+          indexOfLabelContaining(labels, title),
+          isNonNegative,
+          reason: '$title has no semantics node. Labels: $labels',
+        );
+      }
+      handle.dispose();
+    });
+
+    testWidgets('tapping a card opens that activity', (tester) async {
+      final tapped = <String>[];
+      await tester.pumpWidget(
+        wrap(width: 360.0, onTap: (a) => tapped.add(a.activityId)),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(titles.first));
+      await tester.pumpAndSettle();
+      expect(tapped, ['a-0']);
+    });
+  });
+}


### PR DESCRIPTION
## What

Remove the `BlockSemantics` sitting beside the course-plan scroll arrows, which was deleting every activity card's semantics node in any overflowing Mission row.

## Why

Closes #8011

Regression from #7980 / #7981. Blocking is not geometric: it drops every previously-painted sibling in the Stack, which is the whole card `ListView`. On Flutter web the accessibility layer dispatches pointer events through the semantics DOM rather than the render tree, so a card with no node cannot be clicked at all — hence "cards dead, map pins fine" for anyone whose browser has that layer active.

The blocker was never load-bearing. The arrows are painted after the `ListView`, so their own `Semantics(button:)` nodes already sit above the cards. What actually fixed #7803 was dropping the `AbsorbPointer` that had been stripping the arrow's own node, plus no longer keeping the hidden arrow mounted — both of which stay.

Fixes the screen-reader half too: the cards were invisible to assistive tech, and the strip unscrollable by it, on every platform whenever a chevron showed.

## Testing

- `flutter test` — full suite, 1647 passed.
- New `test/pangea/courses/objective_section_semantics_test.dart`, 4 cases. Confirmed it is a real regression test rather than a tautology: with the `BlockSemantics` stashed back in, the two regression cases fail (cards lose their nodes; the ordering guard trips) and the other two still pass.
- `flutter analyze` on the touched paths and `dart format` — both clean.

**Browser verification not done — needs the TO TEST pass on staging.** These are deliberately semantics-tree assertions: a widget-test `tap` goes through the render tree and passes with or without this bug, so it cannot see this class of defect. That means the unit tests prove the cards get their nodes back, but they cannot prove that a real web click now lands on a card, nor that arrow clicks don't regress to #7803. Both only exist in a browser, and there is no E2E coverage for this panel today (`lib/routes/courses/**` is in no `e2e/trigger-map.json` glob), so the linked issue's TO TEST is the gate for those two.

## Deploy Notes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility and interaction for horizontally scrolling activity sections on Flutter web.
  * Activity cards remain individually accessible and clickable when scroll arrows are displayed.
  * Scroll arrows now reliably receive focus, pointer input, and activation priority when overlapping cards.
  * Preserved card accessibility and activation when all activities fit without scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->