### PR TITLE
fix(chat-list): make mark-as-read work on chats with an unread count

### DIFF
--- a/lib/routes/chat/chat_details/chat_context_menu_action.dart
+++ b/lib/routes/chat/chat_details/chat_context_menu_action.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:matrix/matrix.dart';
 
+import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/features/navigation/room_close_location.dart';
@@ -40,6 +41,33 @@ extension on ChatContextAction {
       default:
         return false;
     }
+  }
+}
+
+extension RoomUnreadContextActions on Room {
+  /// Whether the chat list is currently showing an unread indicator for this
+  /// room — the same predicate `UnreadBubble` draws from. Note this is wider
+  /// than [markedUnread] (the explicit `m.marked_unread` flag): a room with
+  /// real unread messages, or a muted room with new ones, is unread without
+  /// that flag ever being set.
+  bool get showsUnreadIndicator => isUnread || hasNewMessages;
+
+  /// Clears the unread indicator: sends a read receipt for the latest event
+  /// (what actually drops `notificationCount`, and with it the badge count)
+  /// and clears the explicit unread flag. [markUnread] alone does **not** set
+  /// a read marker, so on its own it leaves the count untouched.
+  Future<void> clearUnread() async {
+    final lastEventId = lastEvent?.eventId;
+    // A pending local echo carries a transaction id, not an event id; sending
+    // a receipt for one would fail server-side.
+    if (lastEventId != null && lastEventId.isValidMatrixId) {
+      await setReadMarker(
+        lastEventId,
+        mRead: lastEventId,
+        public: AppSettings.sendPublicReadReceipts.value,
+      );
+    }
+    if (markedUnread) await markUnread(false);
   }
 }
 
@@ -148,12 +176,14 @@ void chatContextMenuAction(
             mainAxisSize: MainAxisSize.min,
             children: [
               Icon(
-                room.markedUnread
+                room.showsUnreadIndicator
                     ? Icons.mark_as_unread
                     : Icons.mark_as_unread_outlined,
               ),
               const SizedBox(width: 12),
-              Text(room.markedUnread ? l10n.markAsRead : l10n.markAsUnread),
+              Text(
+                room.showsUnreadIndicator ? l10n.markAsRead : l10n.markAsUnread,
+              ),
             ],
           ),
         ),
@@ -240,9 +270,12 @@ void chatContextMenuAction(
       );
       return;
     case ChatContextAction.markUnread:
+      // Re-read the predicate rather than reusing the value the menu was built
+      // from — a message can arrive while the menu is open.
+      final markRead = room.showsUnreadIndicator;
       await showFutureLoadingDialog(
         context: context,
-        future: () => room.markUnread(!room.markedUnread),
+        future: () => markRead ? room.clearUnread() : room.markUnread(true),
       );
       return;
     case ChatContextAction.mute:

--- a/lib/routes/chat/chat_details/chat_context_menu_action.dart
+++ b/lib/routes/chat/chat_details/chat_context_menu_action.dart
@@ -52,20 +52,24 @@ extension RoomUnreadContextActions on Room {
   /// that flag ever being set.
   bool get showsUnreadIndicator => isUnread || hasNewMessages;
 
-  /// Clears the unread indicator: sends a read receipt for the latest event
-  /// (what actually drops `notificationCount`, and with it the badge count)
-  /// and clears the explicit unread flag. [markUnread] alone does **not** set
-  /// a read marker, so on its own it leaves the count untouched.
+  /// Clears the unread indicator: sends a read receipt (what actually drops
+  /// `notificationCount`, and with it the badge count) and clears the explicit
+  /// unread flag. [markUnread] alone does **not** set a read marker, so on its
+  /// own it leaves the count untouched.
+  ///
+  /// Receipt targeting is delegated to the timeline, which picks the newest
+  /// *synced* event. That skips an unsent local echo — whose id is a
+  /// transaction id the server would reject a receipt for — and still marks
+  /// the confirmed messages beneath it read. Same path the chat view takes on
+  /// open.
   Future<void> clearUnread() async {
-    final lastEventId = lastEvent?.eventId;
-    // A pending local echo carries a transaction id, not an event id; sending
-    // a receipt for one would fail server-side.
-    if (lastEventId != null && lastEventId.isValidMatrixId) {
-      await setReadMarker(
-        lastEventId,
-        mRead: lastEventId,
+    final timeline = await getTimeline();
+    try {
+      await timeline.setReadMarker(
         public: AppSettings.sendPublicReadReceipts.value,
       );
+    } finally {
+      timeline.cancelSubscriptions();
     }
     if (markedUnread) await markUnread(false);
   }

--- a/test/pangea/chat_context_mark_read_test.dart
+++ b/test/pangea/chat_context_mark_read_test.dart
@@ -1,0 +1,155 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:fluffychat/routes/chat/chat_details/chat_context_menu_action.dart';
+import 'get_test_client.dart';
+
+/// Regression coverage for #8009 — the chat-list "more options" menu offered
+/// "Mark as unread" on a chat that already had an unread count, and its read
+/// branch left the count untouched.
+///
+/// The bug was that both the label and the action keyed off `markedUnread` (the
+/// explicit `m.marked_unread` flag) rather than whether the room actually reads
+/// as unread.
+void main() {
+  sqfliteFfiInit();
+
+  late Client client;
+
+  setUpAll(() async {
+    client = await getTestClient();
+    // Lets the fake API answer the room-scoped account_data PUT that clearing
+    // the unread flag performs.
+    FakeMatrixApi.client = client;
+  });
+
+  setUp(() => FakeMatrixApi.calledEndpoints.clear());
+
+  Room room({
+    int notificationCount = 0,
+    bool markedUnread = false,
+    Event? lastEvent,
+  }) => Room(
+    id: '!1234:example.com',
+    client: client,
+    notificationCount: notificationCount,
+    lastEvent: lastEvent,
+    roomAccountData: markedUnread
+        ? {
+            'm.marked_unread': BasicEvent(
+              type: 'm.marked_unread',
+              content: {'unread': true},
+            ),
+          }
+        : {},
+  );
+
+  group('showsUnreadIndicator', () {
+    test('is true for a room with an unread notification count', () {
+      // The #8009 case: unread count, no explicit flag. Keying off
+      // markedUnread here is what produced the wrong "Mark as unread" label.
+      final r = room(notificationCount: 3);
+
+      expect(r.markedUnread, isFalse);
+      expect(r.showsUnreadIndicator, isTrue);
+    });
+
+    test('is true for a room flagged unread with no notification count', () {
+      final r = room(markedUnread: true);
+
+      expect(r.notificationCount, 0);
+      expect(r.showsUnreadIndicator, isTrue);
+    });
+
+    test('is true when both the count and the flag are set', () {
+      expect(
+        room(notificationCount: 1, markedUnread: true).showsUnreadIndicator,
+        isTrue,
+      );
+    });
+
+    test('is false for a room with no count, no flag and no new messages', () {
+      final r = room();
+
+      expect(r.hasNewMessages, isFalse);
+      expect(r.showsUnreadIndicator, isFalse);
+    });
+  });
+
+  group('clearUnread', () {
+    Event message({required String eventId, String? senderId}) => Event(
+      eventId: eventId,
+      type: EventTypes.Message,
+      content: {'msgtype': 'm.text', 'body': 'hi'},
+      senderId: senderId ?? '@other:example.com',
+      originServerTs: DateTime.now(),
+      room: Room(id: '!1234:example.com', client: client),
+    );
+
+    bool calledMatching(String fragment) =>
+        FakeMatrixApi.calledEndpoints.keys.any((e) => e.contains(fragment));
+
+    test('sends a read receipt for the latest event', () async {
+      // markUnread() alone never sets a read marker, which is why the badge
+      // count survived a mark-unread/mark-read round trip before the fix. The
+      // receipt is what actually zeroes notificationCount on the server.
+      final r = room(
+        notificationCount: 2,
+        lastEvent: message(eventId: '\$1234:example.com'),
+      );
+
+      await r.clearUnread();
+
+      expect(calledMatching('read_markers'), isTrue);
+    });
+
+    test('also clears the explicit unread flag when it is set', () async {
+      final r = room(
+        markedUnread: true,
+        lastEvent: message(eventId: '\$1234:example.com'),
+      );
+
+      await r.clearUnread();
+
+      expect(calledMatching('read_markers'), isTrue);
+      expect(calledMatching('m.marked_unread'), isTrue);
+    });
+
+    test('does not touch the unread flag when it was never set', () async {
+      final r = room(
+        notificationCount: 1,
+        lastEvent: message(eventId: '\$1234:example.com'),
+      );
+
+      await r.clearUnread();
+
+      expect(calledMatching('m.marked_unread'), isFalse);
+    });
+
+    test(
+      'skips the receipt when the last event is a pending local echo',
+      () async {
+        // A pending event carries a transaction id, not a valid event id, so
+        // sending a receipt for it would fail server-side.
+        final r = room(
+          notificationCount: 1,
+          lastEvent: message(
+            eventId: 'web1700000000000',
+            senderId: client.userID!,
+          ),
+        );
+
+        await r.clearUnread();
+
+        expect(calledMatching('read_markers'), isFalse);
+      },
+    );
+
+    test('is a no-op on a room with nothing to clear', () async {
+      await room().clearUnread();
+
+      expect(FakeMatrixApi.calledEndpoints, isEmpty);
+    });
+  });
+}

--- a/test/pangea/chat_context_mark_read_test.dart
+++ b/test/pangea/chat_context_mark_read_test.dart
@@ -15,141 +15,191 @@ import 'get_test_client.dart';
 void main() {
   sqfliteFfiInit();
 
-  late Client client;
+  // read_markers is only stubbed for a handful of room ids in FakeMatrixApi.
+  const roomId = '!1234:example.com';
 
-  setUpAll(() async {
+  late Client client;
+  late String confirmedEventId;
+  late String pendingTxId;
+
+  // sqflite's ':memory:' database is shared process-wide, so room and event
+  // rows outlive a client. Fresh event ids per test keep handleSync from
+  // deduping against an earlier test's copy and keeping its sender.
+  var testCounter = 0;
+
+  setUp(() async {
     client = await getTestClient();
-    // Lets the fake API answer the room-scoped account_data PUT that clearing
-    // the unread flag performs.
     FakeMatrixApi.client = client;
+    testCounter++;
+    confirmedEventId = '\$confirmed$testCounter:example.com';
+    pendingTxId = 'web170000000000$testCounter';
   });
 
-  setUp(() => FakeMatrixApi.calledEndpoints.clear());
-
-  Room room({
+  /// Builds the room through a sync so it has a real timeline, which is what
+  /// receipt targeting reads from.
+  Future<Room> syncRoom({
     int notificationCount = 0,
     bool markedUnread = false,
-    Event? lastEvent,
-  }) => Room(
-    id: '!1234:example.com',
-    client: client,
-    notificationCount: notificationCount,
-    lastEvent: lastEvent,
-    roomAccountData: markedUnread
-        ? {
-            'm.marked_unread': BasicEvent(
-              type: 'm.marked_unread',
-              content: {'unread': true},
+    bool lastMessageFromSelf = false,
+  }) async {
+    await client.handleSync(
+      SyncUpdate(
+        nextBatch: 'batch1',
+        rooms: RoomsUpdate(
+          join: {
+            roomId: JoinedRoomUpdate(
+              unreadNotifications: UnreadNotificationCounts(
+                notificationCount: notificationCount,
+                highlightCount: 0,
+              ),
+              // Always sent, so a leaked flag from an earlier test can't
+              // linger as an implicit true.
+              accountData: [
+                BasicEvent(
+                  type: 'm.marked_unread',
+                  content: {'unread': markedUnread},
+                ),
+              ],
+              timeline: TimelineUpdate(
+                prevBatch: 'prev1',
+                events: [
+                  MatrixEvent(
+                    eventId: confirmedEventId,
+                    type: EventTypes.Message,
+                    content: {'msgtype': 'm.text', 'body': 'a message'},
+                    senderId: lastMessageFromSelf
+                        ? client.userID!
+                        : '@other:example.com',
+                    originServerTs: DateTime.now(),
+                  ),
+                ],
+              ),
             ),
-          }
-        : {},
-  );
+          },
+        ),
+      ),
+    );
+    return client.getRoomById(roomId)!;
+  }
+
+  /// Stacks an unsent local echo on top, mirroring the fake sync the SDK emits
+  /// from `sendEvent`. Its id is a transaction id, not an event id.
+  Future<Room> addPendingEcho() async {
+    await client.handleSync(
+      SyncUpdate(
+        nextBatch: 'batch2',
+        rooms: RoomsUpdate(
+          join: {
+            roomId: JoinedRoomUpdate(
+              timeline: TimelineUpdate(
+                events: [
+                  MatrixEvent(
+                    eventId: pendingTxId,
+                    type: EventTypes.Message,
+                    content: {'msgtype': 'm.text', 'body': 'my pending reply'},
+                    senderId: client.userID!,
+                    originServerTs: DateTime.now(),
+                    unsigned: {
+                      messageSendingStatusKey: EventStatus.sending.intValue,
+                      'transaction_id': pendingTxId,
+                    },
+                  ),
+                ],
+              ),
+            ),
+          },
+        ),
+      ),
+    );
+    return client.getRoomById(roomId)!;
+  }
+
+  Iterable<String> callsMatching(String fragment) => FakeMatrixApi
+      .calledEndpoints
+      .entries
+      .where((e) => e.key.contains(fragment))
+      .expand((e) => e.value)
+      .map((body) => body.toString());
 
   group('showsUnreadIndicator', () {
-    test('is true for a room with an unread notification count', () {
+    test('is true for a room with an unread notification count', () async {
       // The #8009 case: unread count, no explicit flag. Keying off
       // markedUnread here is what produced the wrong "Mark as unread" label.
-      final r = room(notificationCount: 3);
+      final room = await syncRoom(notificationCount: 3);
 
-      expect(r.markedUnread, isFalse);
-      expect(r.showsUnreadIndicator, isTrue);
+      expect(room.markedUnread, isFalse);
+      expect(room.showsUnreadIndicator, isTrue);
     });
 
-    test('is true for a room flagged unread with no notification count', () {
-      final r = room(markedUnread: true);
+    test('is true for a room flagged unread with no count', () async {
+      final room = await syncRoom(markedUnread: true);
 
-      expect(r.notificationCount, 0);
-      expect(r.showsUnreadIndicator, isTrue);
+      expect(room.notificationCount, 0);
+      expect(room.showsUnreadIndicator, isTrue);
     });
 
-    test('is true when both the count and the flag are set', () {
-      expect(
-        room(notificationCount: 1, markedUnread: true).showsUnreadIndicator,
-        isTrue,
-      );
+    test('is true when both the count and the flag are set', () async {
+      final room = await syncRoom(notificationCount: 1, markedUnread: true);
+
+      expect(room.showsUnreadIndicator, isTrue);
     });
 
-    test('is false for a room with no count, no flag and no new messages', () {
-      final r = room();
+    test('is false for a read chat whose newest message is your own', () async {
+      final room = await syncRoom(lastMessageFromSelf: true);
 
-      expect(r.hasNewMessages, isFalse);
-      expect(r.showsUnreadIndicator, isFalse);
+      expect(room.hasNewMessages, isFalse);
+      expect(room.showsUnreadIndicator, isFalse);
     });
   });
 
   group('clearUnread', () {
-    Event message({required String eventId, String? senderId}) => Event(
-      eventId: eventId,
-      type: EventTypes.Message,
-      content: {'msgtype': 'm.text', 'body': 'hi'},
-      senderId: senderId ?? '@other:example.com',
-      originServerTs: DateTime.now(),
-      room: Room(id: '!1234:example.com', client: client),
-    );
-
-    bool calledMatching(String fragment) =>
-        FakeMatrixApi.calledEndpoints.keys.any((e) => e.contains(fragment));
-
     test('sends a read receipt for the latest event', () async {
       // markUnread() alone never sets a read marker, which is why the badge
       // count survived a mark-unread/mark-read round trip before the fix. The
       // receipt is what actually zeroes notificationCount on the server.
-      final r = room(
-        notificationCount: 2,
-        lastEvent: message(eventId: '\$1234:example.com'),
-      );
+      final room = await syncRoom(notificationCount: 2);
+      FakeMatrixApi.calledEndpoints.clear();
 
-      await r.clearUnread();
+      await room.clearUnread();
 
-      expect(calledMatching('read_markers'), isTrue);
+      expect(callsMatching('read_markers').single, contains(confirmedEventId));
     });
 
     test('also clears the explicit unread flag when it is set', () async {
-      final r = room(
-        markedUnread: true,
-        lastEvent: message(eventId: '\$1234:example.com'),
-      );
+      final room = await syncRoom(notificationCount: 1, markedUnread: true);
+      FakeMatrixApi.calledEndpoints.clear();
 
-      await r.clearUnread();
+      await room.clearUnread();
 
-      expect(calledMatching('read_markers'), isTrue);
-      expect(calledMatching('m.marked_unread'), isTrue);
+      expect(callsMatching('read_markers'), isNotEmpty);
+      expect(callsMatching('m.marked_unread'), isNotEmpty);
     });
 
     test('does not touch the unread flag when it was never set', () async {
-      final r = room(
-        notificationCount: 1,
-        lastEvent: message(eventId: '\$1234:example.com'),
-      );
+      final room = await syncRoom(notificationCount: 1);
+      FakeMatrixApi.calledEndpoints.clear();
 
-      await r.clearUnread();
+      await room.clearUnread();
 
-      expect(calledMatching('m.marked_unread'), isFalse);
+      expect(callsMatching('m.marked_unread'), isEmpty);
     });
 
-    test(
-      'skips the receipt when the last event is a pending local echo',
-      () async {
-        // A pending event carries a transaction id, not a valid event id, so
-        // sending a receipt for it would fail server-side.
-        final r = room(
-          notificationCount: 1,
-          lastEvent: message(
-            eventId: 'web1700000000000',
-            senderId: client.userID!,
-          ),
-        );
+    test('still marks read when an unsent echo is the newest event', () async {
+      // Reachable by replying from a notification, or when a send is queued
+      // offline. The echo's id is a transaction id, so a receipt aimed at it
+      // would be rejected — but the confirmed messages beneath it must still
+      // be marked read rather than the whole action silently no-opping.
+      await syncRoom(notificationCount: 2);
+      final room = await addPendingEcho();
+      expect(room.lastEvent?.eventId, pendingTxId);
+      expect(room.lastEvent!.eventId.isValidMatrixId, isFalse);
+      FakeMatrixApi.calledEndpoints.clear();
 
-        await r.clearUnread();
+      await room.clearUnread();
 
-        expect(calledMatching('read_markers'), isFalse);
-      },
-    );
-
-    test('is a no-op on a room with nothing to clear', () async {
-      await room().clearUnread();
-
-      expect(FakeMatrixApi.calledEndpoints, isEmpty);
+      final receipt = callsMatching('read_markers').single;
+      expect(receipt, contains(confirmedEventId));
+      expect(receipt, isNot(contains(pendingTxId)));
     });
   });
 }


### PR DESCRIPTION
### What

Make the chat-list "more options" menu offer **Mark as read** on a chat that actually has unread messages, and make it clear the unread count.

### Why

Closes #8009.

Both symptoms came from one mistake: the menu keyed its label, icon, and action off `room.markedUnread` — the explicit `m.marked_unread` account-data flag — rather than whether the room reads as unread. In the SDK, `isUnread` is `notificationCount > 0 || markedUnread`, so a chat with real unread messages has `markedUnread == false`:

- **Wrong label** — a chat showing an unread badge offered "Mark as unread".
- **Count never moved** — the read branch called `markUnread(false)`, which only clears the flag. The SDK is explicit that it "does **not** set a read marker", and the badge number is `notificationCount` (`unread_bubble.dart`) while the All-chats badge counts rooms where `isUnread` (`unread_rooms_badge.dart`). Neither moves without a read receipt, so marking unread then read was a visible no-op.

Not a regression from the world-nav work — the same logic is in the commented-out pre-refactor menu in `chat_list.dart`, and upstream FluffyChat `main` still has it verbatim (`lib/pages/chat_list/chat_list.dart`).

### What changed

`lib/routes/chat/chat_details/chat_context_menu_action.dart` only, plus a test:

- New `RoomUnreadContextActions` extension with `showsUnreadIndicator` (`isUnread || hasNewMessages` — the same predicate `UnreadBubble` draws from, so the menu can't disagree with the badge the user is looking at) and `clearUnread()`.
- Label and icon now use `showsUnreadIndicator` instead of `markedUnread`.
- `clearUnread()` sends a read receipt — which is what actually drops `notificationCount` — then clears the explicit flag if it was set.
- Receipt targeting is delegated to `Timeline.setReadMarker`, which picks the newest **synced** event. That is the same path the chat view uses on open, and it handles the case where the newest event is an unsent local echo: the echo's id is a transaction id the server would reject, so the receipt targets the confirmed messages beneath it instead. Reachable by replying from a notification, or when a send is queued offline.
- The action re-reads the predicate at tap time rather than reusing what the menu was built from, since a message can arrive while the menu is open.

Because `showsUnreadIndicator` includes `hasNewMessages`, this also fixes the muted-chat case — a muted chat with new messages shows a dot and previously also offered the wrong label.

**Behavior note for review:** marking read from the chat list sends a read receipt for messages the user never opened, visible to the other party when `sendPublicReadReceipts` is on (default true). That's standard messenger behavior and matches what the notification "Mark as read" action already does, but it is a real behavior change rather than a pure display fix.

### Testing

- **Unit/widget** (the bucket this change touches): new `test/pangea/chat_context_mark_read_test.dart`, 8 tests — 4 pinning `showsUnreadIndicator` across count-only / flag-only / both / read-chat, and 4 on `clearUnread` asserting the receipt targets the newest synced event, that the flag is cleared only when set, and that a chat topped by an unsent local echo still gets a receipt aimed at the confirmed event beneath it (asserted on the request body, so it would catch a regression to targeting the transaction id). All pass.
- Full local suite: `fvm flutter test` → **1637 passed, 3 skipped**, no regressions.
- `fvm flutter analyze lib/ test/` → **No issues found**. `fvm dart format` and `import_sorter` clean.
- No other bucket applies: this is client-only with no choreo/CMS call, so there is no smoke/eval/load surface. No Playwright spec covers the chat-list context menu.
- **Not verified against a live homeserver.** The assertion that the badge count actually reaches zero needs a real server and a second user to generate unread state; `FakeMatrixApi` can only confirm the receipt is sent and what it targets. That check belongs to staging QA via the issue's TO TEST.

### Accessibility

- [x] No new or changed controls — the existing menu item's text label changes value (`markAsRead` / `markAsUnread`, both already localized), which is what a screen reader announces. No new icon-only affordance.

### Deploy Notes

None.
