### PR TITLE
fix: filter out modules with 0 activities from module count

### DIFF
--- a/lib/features/quests/models/quest_plan_model.dart
+++ b/lib/features/quests/models/quest_plan_model.dart
@@ -1,4 +1,6 @@
+import 'package:fluffychat/features/languages/p_language_store.dart';
 import 'package:fluffychat/features/quests/models/learning_objective_model.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
 
 /// A v3 Quest, read from the CMS `quest-plans` collection: an ordered sequence
 /// of Learning Objectives (Missions) a learner advances through.
@@ -29,6 +31,16 @@ class QuestPlan {
 
   List<String> get learningObjectiveIds =>
       sequence.map((step) => step.objective.id).toList();
+
+  /// Display forms of the quest's two header fields, mirroring
+  /// `CoursePlanModel.targetLanguageDisplay` and `CoursePlanModel.cefrLevel` —
+  /// the same chips render off either model, so they must read identically.
+  String get targetLanguageDisplay =>
+      PLanguageStore.byLangCode(targetLanguage)?.langCode.toUpperCase() ??
+      targetLanguage.toUpperCase();
+
+  LanguageLevelTypeEnum get cefrLevel =>
+      LanguageLevelTypeEnum.fromString(targetCefr);
 
   factory QuestPlan.fromJson(Map<String, dynamic> json) {
     final res = (json['res'] as Map?)?.cast<String, dynamic>() ?? const {};

--- a/lib/features/quests/quest_objectives_loader.dart
+++ b/lib/features/quests/quest_objectives_loader.dart
@@ -15,7 +15,10 @@ typedef QuestLoader = ValueNotifier<AsyncState<QuestOutline>>;
 /// An activity-less objective would otherwise show a header over a fixed-height
 /// activity-card row that is all empty space, so it is dropped (#7114). Null
 /// (still loading / no data) maps to an empty list.
-@visibleForTesting
+///
+/// The single home of "which Missions does the learner actually see": the
+/// course panel's list and the "N modules" chip both count through it, so a
+/// hidden Mission can never be listed by one and counted by the other (#7976).
 List<QuestObjectiveGroup> objectiveGroupsWithActivities(
   List<QuestObjectiveGroup>? groups,
 ) => (groups ?? const <QuestObjectiveGroup>[])

--- a/lib/routes/chat/chat_details/space_details_content.dart
+++ b/lib/routes/chat/chat_details/space_details_content.dart
@@ -511,6 +511,7 @@ class SpaceDetailsContent extends StatelessWidget {
                                   ),
                                   child: CourseInfoChips(
                                     room.coursePlan!.uuid,
+                                    courseRoomId: room.id,
                                     fontSize: 12.0,
                                     iconSize: 12.0,
                                   ),

--- a/lib/routes/courses/add_course_tile.dart
+++ b/lib/routes/courses/add_course_tile.dart
@@ -125,6 +125,7 @@ class AddCourseTile extends StatelessWidget {
                               if (courseId != null && !invited)
                                 CourseInfoChips(
                                   courseId,
+                                  courseRoomId: content.courseRoomId,
                                   fontSize: 12.0,
                                   iconSize: 12.0,
                                 ),

--- a/lib/routes/courses/add_course_tile_content.dart
+++ b/lib/routes/courses/add_course_tile_content.dart
@@ -15,6 +15,10 @@ abstract class AddCourseTileContent {
 
   String? get courseId => null;
 
+  /// The joined/previewed course space, where the tile has one — lets the info
+  /// chips read the same quest outline the course itself does.
+  String? get courseRoomId => null;
+
   bool get isKnock => false;
 
   bool? get invited => null;
@@ -51,6 +55,9 @@ class RoomAddCourseTileContent extends AddCourseTileContent {
 
   @override
   String? get courseId => space.coursePlan?.uuid;
+
+  @override
+  String? get courseRoomId => space.id;
 }
 
 class PreviewAddCourseTileContent extends AddCourseTileContent {

--- a/lib/routes/courses/course_info_chip_widget.dart
+++ b/lib/routes/courses/course_info_chip_widget.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 
-import 'package:fluffychat/features/course_plans/courses/course_plan_builder.dart';
+import 'package:fluffychat/features/quests/quest_objectives_loader.dart';
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/widgets/future_loading_dialog.dart';
 
 class CourseInfoChip extends StatelessWidget {
   final IconData icon;
@@ -60,8 +62,24 @@ class CourseInfoChip extends StatelessWidget {
   }
 }
 
+/// The course's language / level / module chips, read from the quest outline.
+///
+/// The module count is the Missions the learner will actually *see* — the same
+/// `objectiveGroupsWithActivities` filter the course panel lists through — so a
+/// Mission with no activities can no longer be counted here while being hidden
+/// there (#7976). That rules out the plan-level count
+/// (`CoursePlanModel.topicIds.length`), which is the quest's whole Mission
+/// sequence, activity-less ones included.
 class CourseInfoChips extends StatefulWidget {
   final String courseId;
+
+  /// The course space this quest is being shown in, where there is one. Admits
+  /// the owner's private activities (membership verified server-side) and keys
+  /// into the same outline-cache row the course panel and the joined-course
+  /// progression cache already built — so the chips normally cost no round trip
+  /// and can't count a different activity set than the panel renders.
+  final String? courseRoomId;
+
   final double? fontSize;
   final double? iconSize;
   final EdgeInsets? padding;
@@ -69,6 +87,7 @@ class CourseInfoChips extends StatefulWidget {
   const CourseInfoChips(
     this.courseId, {
     super.key,
+    this.courseRoomId,
     this.fontSize,
     this.iconSize,
     this.padding,
@@ -78,27 +97,54 @@ class CourseInfoChips extends StatefulWidget {
   State<CourseInfoChips> createState() => CourseInfoChipsState();
 }
 
-class CourseInfoChipsState extends State<CourseInfoChips>
-    with CoursePlanProvider {
+class CourseInfoChipsState extends State<CourseInfoChips> {
+  QuestOutline? _outline;
+
+  /// Guards against a superseded load landing last when the widget is recycled
+  /// onto another course mid-flight.
+  int _loadGeneration = 0;
+
   @override
   void initState() {
     super.initState();
-    loadCourse(widget.courseId);
+    _loadOutline();
   }
 
   @override
   void didUpdateWidget(covariant CourseInfoChips oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (oldWidget.courseId != widget.courseId) {
-      loadCourse(widget.courseId);
+    if (oldWidget.courseId != widget.courseId ||
+        oldWidget.courseRoomId != widget.courseRoomId) {
+      _loadOutline();
     }
+  }
+
+  Future<void> _loadOutline() async {
+    _loadGeneration++;
+    final loadGen = _loadGeneration;
+    // Clear stale chips when recycled onto another course; on first load there
+    // is nothing to clear and setState would be premature.
+    if (_outline != null) setState(() => _outline = null);
+
+    final result = await QuestRepo.outline(
+      widget.courseId,
+      courseRoomId: widget.courseRoomId,
+    );
+    if (!mounted || loadGen != _loadGeneration) return;
+    // A failed read is already logged by the repo; the chips just stay hidden.
+    setState(() => _outline = result.result);
   }
 
   @override
   Widget build(BuildContext context) {
-    if (course == null) {
+    final outline = _outline;
+    if (outline == null) {
       return const SizedBox.shrink();
     }
+
+    // Deliberately unpinned: pinning fails open (`effectivePinnedActivityIds`),
+    // so it can never empty a Mission and never changes this count.
+    final moduleCount = objectiveGroupsWithActivities(outline.groups).length;
 
     return Wrap(
       spacing: 8.0,
@@ -106,21 +152,21 @@ class CourseInfoChipsState extends State<CourseInfoChips>
       children: [
         CourseInfoChip(
           icon: Icons.language,
-          text: course!.targetLanguageDisplay,
+          text: outline.quest.targetLanguageDisplay,
           fontSize: widget.fontSize,
           iconSize: widget.iconSize,
           padding: widget.padding,
         ),
         CourseInfoChip(
           icon: Icons.school,
-          text: course!.cefrLevel.title(context),
+          text: outline.quest.cefrLevel.title(context),
           fontSize: widget.fontSize,
           iconSize: widget.iconSize,
           padding: widget.padding,
         ),
         CourseInfoChip(
           icon: Icons.location_on,
-          text: L10n.of(context).numModules(course!.topicIds.length),
+          text: L10n.of(context).numModules(moduleCount),
           fontSize: widget.fontSize,
           iconSize: widget.iconSize,
           padding: widget.padding,

--- a/lib/routes/courses/own/invite/course_invite_page.dart
+++ b/lib/routes/courses/own/invite/course_invite_page.dart
@@ -227,6 +227,9 @@ class CourseInvitePageController extends State<CourseInvitePage>
                             ),
                             CourseInfoChips(
                               widget.courseId,
+                              courseRoomId: Matrix.of(
+                                context,
+                              ).client.getRoomByCourseId(widget.courseId)?.id,
                               fontSize: 12.0,
                               iconSize: 12.0,
                             ),

--- a/test/pangea/quests/quest_plan_display_fields_test.dart
+++ b/test/pangea/quests/quest_plan_display_fields_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/quests/models/quest_plan_model.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+
+/// The quest-plan display fields the course info chips read (#7976). They moved
+/// off `CoursePlanModel` — whose plan-level `topicIds.length` counted Missions
+/// the learner never sees — so the language and level chips now render from the
+/// quest itself and must keep reading identically.
+void main() {
+  Map<String, dynamic> questJson({String? cefr, String language = 'ko'}) => {
+    'id': 'quest-1',
+    'req': {
+      'target_language': language,
+      'target_l1': 'en',
+      'target_cefr': ?cefr,
+    },
+    'res': {
+      'name': 'Plan it like a pro',
+      'description': 'Plan a trip.',
+      'learning_objective_sequence': const [],
+    },
+  };
+
+  group('QuestPlan.cefrLevel', () {
+    test('parses the quest-plan CEFR string', () {
+      expect(
+        QuestPlan.fromJson(questJson(cefr: 'B1')).cefrLevel,
+        LanguageLevelTypeEnum.b1,
+      );
+    });
+
+    test(
+      'a missing CEFR falls back to the enum default rather than throwing',
+      () {
+        expect(
+          QuestPlan.fromJson(questJson()).cefrLevel,
+          LanguageLevelTypeEnum.a1,
+        );
+      },
+    );
+  });
+
+  group('QuestPlan.targetLanguageDisplay', () {
+    test('uppercases the raw code when the language store has no entry', () {
+      expect(
+        QuestPlan.fromJson(questJson(language: 'ko')).targetLanguageDisplay,
+        'KO',
+      );
+    });
+
+    test(
+      'an absent target language degrades to an empty chip, not a crash',
+      () {
+        expect(
+          QuestPlan.fromJson(questJson(language: '')).targetLanguageDisplay,
+          '',
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
