### PR TITLE
fix(world-map): stop the map's semantics node blanketing DOM video embeds

### DIFF
--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -829,170 +829,190 @@ class _WorldMapViewState extends State<WorldMapView> {
     final map = Semantics(
       label: L10n.of(context).activities,
       container: true,
-      // Any pointer-down on the map drops text-input focus, so tapping or
-      // panning the map closes the search bar's keyboard — on a narrow screen
-      // an open keyboard pins most of the viewport (#7635). Listener observes
-      // without consuming, so pin taps and map gestures are unaffected. (Pin
-      // FOCUS is separate and deliberately not cleared by map taps — see the
-      // note on MapOptions below.)
-      child: Listener(
-        onPointerDown: (_) => FocusManager.instance.primaryFocus?.unfocus(),
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            // The zoom-out floor is viewport-derived (#7813): out to where one
-            // world copy would become smaller than the map's height or width,
-            // whichever binds first. The height term is also what keeps
-            // containLatitude from rejecting every move (freezing all panning)
-            // when the ±90 band is shorter than the viewport — the old fixed
-            // floor of 3 guarded that for desktop but left phones unable to
-            // pull back to the world. A resize can raise the floor above the
-            // current zoom (window grown, rotation); re-clamp the camera then,
-            // or panning freezes exactly as above.
-            final minZoom = WorldMapConstants.minZoomFor(constraints.biggest);
-            _reclampCameraIfBelow(minZoom);
-            return FlutterMap(
-              mapController: widget.controller.mapController,
-              options: MapOptions(
-                // The persistent instance keeps its own camera across
-                // navigation, so no external camera-state restore is needed.
-                initialCenter:
-                    widget.controller.widget.initialCenter ??
-                    const LatLng(20, 0),
-                initialZoom: widget.controller.widget.initialZoom ?? 3,
-                minZoom: minZoom,
-                maxZoom: WorldMapConstants.maxZoom,
-                // Clamp latitude only — leaving longitude free so the user can pan
-                // east-west and the world wraps seamlessly ("rotate the world
-                // around"). Epsg3857 replicates longitude, so tiles and markers
-                // repeat across world copies automatically. A longitude-bounded
-                // `contain`/`containCenter` pins the camera when zoomed out and hides
-                // content behind the left column with no way to pan it out.
-                cameraConstraint: const CameraConstraint.containLatitude(
-                  90,
-                  -90,
+      // ExcludeSemantics (#8013): flutter_map taps the map through a plain
+      // `GestureDetector` (PositionedTapDetector2) that never sets
+      // `excludeFromSemantics`, so it publishes a tap action over the map's
+      // whole hit area — the entire viewport. Flutter web renders a tappable
+      // semantics node as `role=button` with `pointer-events: all`, so with the
+      // semantics tree on (staging forces it via ENABLE_SEMANTICS; Flutter also
+      // enables it for assistive tech) that one node blankets every DOM
+      // platform view layered over the map — the activity plan's YouTube
+      // `<iframe>`, an uploaded `<video>` — and swallows the mouse events those
+      // embeds need, leaving their own controls dead.
+      //
+      // COST, accepted deliberately: this drops the pins' own
+      // Semantics(button) nodes too, so map pins are not reachable by a screen
+      // reader until the upstream fix lands. Narrower cuts were tried and do
+      // NOT clear it (excluding just the attribution, unmerging this container)
+      // — the offending node is flutter_map's own map-level tap detector.
+      // Upstream fix filed against fleaflet/flutter_map; revert this to a
+      // narrower scope once a released version carries it.
+      child: ExcludeSemantics(
+        // Any pointer-down on the map drops text-input focus, so tapping or
+        // panning the map closes the search bar's keyboard — on a narrow screen
+        // an open keyboard pins most of the viewport (#7635). Listener observes
+        // without consuming, so pin taps and map gestures are unaffected. (Pin
+        // FOCUS is separate and deliberately not cleared by map taps — see the
+        // note on MapOptions below.)
+        child: Listener(
+          onPointerDown: (_) => FocusManager.instance.primaryFocus?.unfocus(),
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              // The zoom-out floor is viewport-derived (#7813): out to where one
+              // world copy would become smaller than the map's height or width,
+              // whichever binds first. The height term is also what keeps
+              // containLatitude from rejecting every move (freezing all panning)
+              // when the ±90 band is shorter than the viewport — the old fixed
+              // floor of 3 guarded that for desktop but left phones unable to
+              // pull back to the world. A resize can raise the floor above the
+              // current zoom (window grown, rotation); re-clamp the camera then,
+              // or panning freezes exactly as above.
+              final minZoom = WorldMapConstants.minZoomFor(constraints.biggest);
+              _reclampCameraIfBelow(minZoom);
+              return FlutterMap(
+                mapController: widget.controller.mapController,
+                options: MapOptions(
+                  // The persistent instance keeps its own camera across
+                  // navigation, so no external camera-state restore is needed.
+                  initialCenter:
+                      widget.controller.widget.initialCenter ??
+                      const LatLng(20, 0),
+                  initialZoom: widget.controller.widget.initialZoom ?? 3,
+                  minZoom: minZoom,
+                  maxZoom: WorldMapConstants.maxZoom,
+                  // Clamp latitude only — leaving longitude free so the user can pan
+                  // east-west and the world wraps seamlessly ("rotate the world
+                  // around"). Epsg3857 replicates longitude, so tiles and markers
+                  // repeat across world copies automatically. A longitude-bounded
+                  // `contain`/`containCenter` pins the camera when zoomed out and hides
+                  // content behind the left column with no way to pan it out.
+                  cameraConstraint: const CameraConstraint.containLatitude(
+                    90,
+                    -90,
+                  ),
+                  interactionOptions: const InteractionOptions(
+                    flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
+                  ),
+                  // Tapping empty map does not clear focus — a focus is cleared only by
+                  // closing its panel or focusing another (world-map.instructions.md).
+                  // World pins are viewport-bounded: load once the camera is ready, then
+                  // re-load (debounced) as the user pans/zooms. Course pins are
+                  // context-bound and unaffected.
+                  onMapReady: widget.controller.loadWorldPins,
+                  onPositionChanged: (_, hasGesture) =>
+                      widget.controller.onMapPositionChanged(hasGesture),
                 ),
-                interactionOptions: const InteractionOptions(
-                  flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
-                ),
-                // Tapping empty map does not clear focus — a focus is cleared only by
-                // closing its panel or focusing another (world-map.instructions.md).
-                // World pins are viewport-bounded: load once the camera is ready, then
-                // re-load (debounced) as the user pans/zooms. Course pins are
-                // context-bound and unaffected.
-                onMapReady: widget.controller.loadWorldPins,
-                onPositionChanged: (_, hasGesture) =>
-                    widget.controller.onMapPositionChanged(hasGesture),
-              ),
-              children: [
-                // Base tiles, switched by app theme: OpenStreetMap (light) / CartoDB
-                // Dark Matter (dark). Retina (@2x) keeps the dark basemap's small
-                // labels sharp; CartoDB serves @2x, light (OSM) stays 1x.
-                TileLayer(
-                  urlTemplate: dark
-                      ? 'https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
-                      : 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-                  retinaMode: retina,
-                  userAgentPackageName: 'com.talktolearn.chat',
-                ),
-                // world_v2: activity pins by relevance tier + state, capped by the
-                // width-driven budget. Small/mid dots render individually (no
-                // clustering); the large featured cards render unclustered above so
-                // they're always visible.
-                DotMarkersLayer(
-                  nonLargeCards: render.nonLargeCards,
-                  stateOf: render.stateOf,
-                  nonStartableOf: render.nonStartableOf,
-                  tierOf: render.tierOf,
-                  starLevelOf: render.starLevelOf,
-                  pingedOf: render.pingedOf,
-                  activeActivityInstance:
-                      widget.controller.client?.activeActivityInstance,
-                  markerBox: _markerBox,
-                  markerAlignment: _markerAlignment,
-                  sessionParticipants: (a, b) => _sessionParticipants(a, b),
-                  focusedId: render.focusedId,
-                  onTap: widget.controller.openActivity,
-                ).layer(),
-                // Activity-name labels for mid pins, above the dots but below the
-                // large cards (world-map.instructions.md, "Pin display"; z-order:
-                // small < mid < labels < large).
-                MidSizePinLabelsLayer(
-                  nonLargeCards: render.nonLargeCards,
-                  sideOf: render.labels.sideOf,
-                  sizeOf: (id) => render.labelSizes[id],
-                  stateOf: render.stateOf,
-                  nonStartableOf: render.nonStartableOf,
-                  onTap: widget.controller.openActivity,
-                ).layer(),
-                // Dying pins (a separate layer) so they don't disturb the live pins
-                // while animating out.
-                ExitingMarkersLayer(
-                  exiting: _exiting.values.toList(),
-                  markerBox: _markerBox,
-                  markerAlignment: _markerAlignment,
-                  onExited: _onExitedMarker,
-                ).layer(),
-                // Dying large cards (demoted, or bumped out) shrinking away beneath
-                // the live layer.
-                ExitingLargeMarkersLayer(
-                  exitingLarge: _exitingLarge.values.toList(),
-                  onExited: _onExitedLargeCardMarker,
-                ).layer(),
-                // Large cards (always visible): the featured cards the width affords.
-                LargeMarkersLayer(
-                  largeCards: render.largeCards,
-                  currentLarge: currentLarge,
-                  focusedId: render.focusedId,
-                  onTap: widget.controller.openActivity,
-                  onClose: widget.controller.dismissLargeCard,
-                ).layer(),
-                Positioned(
-                  // On a narrow screen the bottom chrome (nav widget + the search bar
-                  // riding above it) owns the bottom edge, so lift the attribution
-                  // above it — otherwise it sits unreadable UNDER the floating rail
-                  // (#7218 on narrow).
-                  left: 0,
-                  bottom: FluffyThemes.isColumnMode(context)
-                      ? 0.0
-                      : _narrowBottomChromeInset,
-                  child: SafeArea(
-                    child: Stack(
-                      children: [
-                        // Background so attributions button
-                        // is visible in dark mode
-                        Positioned(
-                          left: PlatformInfos.isMobile ? 12 : 8,
-                          bottom: PlatformInfos.isMobile ? 12 : 8,
-                          child: Container(
-                            height: 32,
-                            width: 32,
-                            decoration: BoxDecoration(
-                              color: const Color.fromARGB(130, 135, 135, 135),
-                              shape: BoxShape.circle,
+                children: [
+                  // Base tiles, switched by app theme: OpenStreetMap (light) / CartoDB
+                  // Dark Matter (dark). Retina (@2x) keeps the dark basemap's small
+                  // labels sharp; CartoDB serves @2x, light (OSM) stays 1x.
+                  TileLayer(
+                    urlTemplate: dark
+                        ? 'https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
+                        : 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                    retinaMode: retina,
+                    userAgentPackageName: 'com.talktolearn.chat',
+                  ),
+                  // world_v2: activity pins by relevance tier + state, capped by the
+                  // width-driven budget. Small/mid dots render individually (no
+                  // clustering); the large featured cards render unclustered above so
+                  // they're always visible.
+                  DotMarkersLayer(
+                    nonLargeCards: render.nonLargeCards,
+                    stateOf: render.stateOf,
+                    nonStartableOf: render.nonStartableOf,
+                    tierOf: render.tierOf,
+                    starLevelOf: render.starLevelOf,
+                    pingedOf: render.pingedOf,
+                    activeActivityInstance:
+                        widget.controller.client?.activeActivityInstance,
+                    markerBox: _markerBox,
+                    markerAlignment: _markerAlignment,
+                    sessionParticipants: (a, b) => _sessionParticipants(a, b),
+                    focusedId: render.focusedId,
+                    onTap: widget.controller.openActivity,
+                  ).layer(),
+                  // Activity-name labels for mid pins, above the dots but below the
+                  // large cards (world-map.instructions.md, "Pin display"; z-order:
+                  // small < mid < labels < large).
+                  MidSizePinLabelsLayer(
+                    nonLargeCards: render.nonLargeCards,
+                    sideOf: render.labels.sideOf,
+                    sizeOf: (id) => render.labelSizes[id],
+                    stateOf: render.stateOf,
+                    nonStartableOf: render.nonStartableOf,
+                    onTap: widget.controller.openActivity,
+                  ).layer(),
+                  // Dying pins (a separate layer) so they don't disturb the live pins
+                  // while animating out.
+                  ExitingMarkersLayer(
+                    exiting: _exiting.values.toList(),
+                    markerBox: _markerBox,
+                    markerAlignment: _markerAlignment,
+                    onExited: _onExitedMarker,
+                  ).layer(),
+                  // Dying large cards (demoted, or bumped out) shrinking away beneath
+                  // the live layer.
+                  ExitingLargeMarkersLayer(
+                    exitingLarge: _exitingLarge.values.toList(),
+                    onExited: _onExitedLargeCardMarker,
+                  ).layer(),
+                  // Large cards (always visible): the featured cards the width affords.
+                  LargeMarkersLayer(
+                    largeCards: render.largeCards,
+                    currentLarge: currentLarge,
+                    focusedId: render.focusedId,
+                    onTap: widget.controller.openActivity,
+                    onClose: widget.controller.dismissLargeCard,
+                  ).layer(),
+                  Positioned(
+                    // On a narrow screen the bottom chrome (nav widget + the search bar
+                    // riding above it) owns the bottom edge, so lift the attribution
+                    // above it — otherwise it sits unreadable UNDER the floating rail
+                    // (#7218 on narrow).
+                    left: 0,
+                    bottom: FluffyThemes.isColumnMode(context)
+                        ? 0.0
+                        : _narrowBottomChromeInset,
+                    child: SafeArea(
+                      child: Stack(
+                        children: [
+                          // Background so attributions button
+                          // is visible in dark mode
+                          Positioned(
+                            left: PlatformInfos.isMobile ? 12 : 8,
+                            bottom: PlatformInfos.isMobile ? 12 : 8,
+                            child: Container(
+                              height: 32,
+                              width: 32,
+                              decoration: BoxDecoration(
+                                color: const Color.fromARGB(130, 135, 135, 135),
+                                shape: BoxShape.circle,
+                              ),
                             ),
                           ),
-                        ),
-                        RichAttributionWidget(
-                          // #7218: bottom-LEFT so the attribution and its expand popup don't
-                          // sit under the bottom-right zoom/World controls (where it was
-                          // covered and hard to read, especially in dark mode).
-                          alignment: AttributionAlignment.bottomLeft,
-                          attributions: [
-                            TextSourceAttribution(
-                              'OpenStreetMap contributors',
-                              onTap: () {},
-                            ),
-                            if (dark)
-                              TextSourceAttribution('CARTO', onTap: () {}),
-                          ],
-                        ),
-                      ],
+                          RichAttributionWidget(
+                            // #7218: bottom-LEFT so the attribution and its expand popup don't
+                            // sit under the bottom-right zoom/World controls (where it was
+                            // covered and hard to read, especially in dark mode).
+                            alignment: AttributionAlignment.bottomLeft,
+                            attributions: [
+                              TextSourceAttribution(
+                                'OpenStreetMap contributors',
+                                onTap: () {},
+                              ),
+                              if (dark)
+                                TextSourceAttribution('CARTO', onTap: () {}),
+                            ],
+                          ),
+                        ],
+                      ),
                     ),
                   ),
-                ),
-              ],
-            );
-          },
+                ],
+              );
+            },
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## What

Wrap the world map's subtree in `ExcludeSemantics` so its map-sized tappable semantics node stops blanketing DOM platform views layered over the map.

## Why

Closes #8013.

flutter_map builds `RawGestureDetector(gestures: _gestures)` without `excludeFromSemantics`, and `_gestures` holds a `TapGestureRecognizer` — so it publishes `SemanticsAction.tap` on a semantics node covering the map's whole hit area. Flutter web renders a tappable semantics node as `role=button` with `pointer-events: all`, and platform views are not in the semantics tree, so that one node sits above the activity plan's YouTube `<iframe>` (and any uploaded `<video>`) and swallows the mouse events the embed needs. The embed plays but its own controls never respond — no pause, scrub, CC, or settings.

Gated on the semantics tree being on: staging forces it (`ENABLE_SEMANTICS=true` in `main_deploy.yaml`), production doesn't, but Flutter web can enable it at runtime for assistive tech.

Root-cause detail, including the `elementFromPoint` measurements and the two narrower fixes that do **not** clear it, is in #8013.

**Accepted cost:** this also drops the pins' own `Semantics(button)` nodes, so map pins are not reachable by a screen reader. That is a deliberate, temporary trade against #7591 (a control that names itself to assistive tech should also be activatable through it), taken because the embed controls are unusable today on staging. The existing `world_map_semantics_activation_test.dart` still passes — it pumps the pin widgets standalone, not through the map — so the unit tests do not catch this; the loss is at the composed level.

Upstream fix submitted: fleaflet/flutter_map#2236 (with the diagnosis on fleaflet/flutter_map#2176, which this also explains — semantic taps synthesise their position at the map-sized node's centre, which is why that issue sees `onTap` always report the map centre). Once a release carries it, this `ExcludeSemantics` should be reverted so pins regain their semantics.

## Testing

- `fvm flutter test test/` — 1643 passed, 4 skipped, 0 failed (after `fvm flutter clean`; a stale `shaders/ink_sparkle.frag` artifact in a dirty build dir fails ~8 ink-ripple tests unrelated to this change).
- `fvm flutter analyze` on the changed file — clean. `scripts/a11y_floor_check.py` — pass.
- Manual, local web build against staging with `ENABLE_SEMANTICS=true`: with a fully-populated semantics tree (57 nodes, 36 tappable), the viewport-sized tappable node is gone — before this change there was always exactly one, and no large (>400×400) tappable node remains. Map panning still works.
- Not verified end-to-end by clicking real YouTube controls locally: the embed's platform view mounts only intermittently in the local debug web build, and staging carries no youtube-media activities (0 of 2962), so the hero was exercised via a temporary local-only harness (not committed). The causal link is nonetheless established in #8013: disabling `pointer-events` on that one node restored YouTube's full control bar.

## Deploy Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved map interaction behavior for screen readers and other assistive technologies.
  * Prevented the map’s full-area semantics from obscuring surrounding interactive content.
  * Map pins are no longer exposed as separate accessibility elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->