### PR TITLE
fix(mobile-nav): keep course cavity height across an occluding chat, forget on close

### DIFF
--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -67,6 +67,18 @@ class MobileNavWidget extends StatefulWidget {
   /// own default rather than inheriting the previous key's height.
   final String? cavityKey;
 
+  /// The active COURSE context (`?c=` / `activeSpaceId`), or null when the
+  /// workspace isn't course-scoped. This is what says a course is still "open":
+  /// a chat or an activity opened from a course keeps the same context (only the
+  /// cavity — hence [cavityKey] — swaps), and even closing the course card keeps
+  /// it; the context leaves a course only via World or choosing another course
+  /// (routing.instructions.md — "scope is reset only by the World control or by
+  /// choosing a different course, never by closing a panel"). A course's
+  /// remembered height is forgotten exactly when the context leaves it, so
+  /// sub-navigation preserves it (#7332) while a genuinely fresh course open
+  /// starts at peek (#7609). See [didUpdateWidget].
+  final String? cavityContextId;
+
   /// True for a course card (opens at a small peek by default); false for a
   /// section (opens at half by default).
   final bool cavityDefaultsToPeek;
@@ -136,6 +148,7 @@ class MobileNavWidget extends StatefulWidget {
     this.cavitySection,
     this.courseShortcutHostsCavity = false,
     this.cavityKey,
+    this.cavityContextId,
     this.cavityDefaultsToPeek = false,
     required this.maxHeightFraction,
     this.preferredCavityHeightPx,
@@ -156,11 +169,12 @@ class MobileNavWidget extends StatefulWidget {
   /// Last settled height per [cavityKey], surviving disposal when a full-screen
   /// surface (a live chat, an activity) mounts over this widget — mirrors
   /// `MobileCourseSheet._expandedBySheet` (#7332), generalized to any section
-  /// or course key and to three rest states instead of two. A course (peek) key
-  /// is dropped on a genuine close so the course reopens at its peek default
-  /// (#7609; [didUpdateWidget]); a chat covering the course only disposes the
-  /// widget, so that height survives here to be restored on return (#7332).
-  /// Section keys persist for the session (#7510).
+  /// or course key and to three rest states instead of two. A course entry is
+  /// dropped when the course CONTEXT leaves it (World / a different course), so a
+  /// fresh course open starts at peek (#7609; [didUpdateWidget]) while opening a
+  /// chat or activity from the course — or a chat that only disposes this widget
+  /// — keeps the context and restores the height on return (#7332). Section keys
+  /// persist for the session (#7510).
   static final Map<String, NavCavityHeight> _heightByKey = {};
 
   @visibleForTesting
@@ -229,19 +243,20 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
     final keyChanged =
         widget.cavityChild != null && oldWidget.cavityKey != widget.cavityKey;
 
-    // Forget a course's height on a GENUINE close — the X, or navigating the
-    // course away (to World, another course, or a section). Those keep the nav
-    // widget MOUNTED and empty/swap the cavity (this callback fires), so the
-    // course's next open falls back to the peek default — the deterministic
-    // entry state (#7609). A chat merely covering the course DISPOSES the widget
-    // instead (no didUpdateWidget runs), so that height survives in the static
-    // map and is restored on return (#7332). Gated to peek cavities: section
-    // sheets keep their memory across close/reopen (#7510). Keyed off the OLD
-    // widget — it identifies the cavity that is leaving.
-    if ((closedNow || keyChanged) &&
-        oldWidget.cavityDefaultsToPeek &&
-        oldWidget.cavityKey != null) {
-      MobileNavWidget._heightByKey.remove(oldWidget.cavityKey);
+    // Forget a course's remembered height exactly when the course CONTEXT leaves
+    // it — i.e. World or choosing a different course, the only two things that
+    // reset scope (routing.instructions.md). That is the deterministic fresh
+    // open (#7609). Everything that keeps the context — opening a chat or an
+    // activity from the course, or even closing the course card — is still the
+    // same course "open", so its height is preserved (#7332). Keyed by the OLD
+    // context (== the leaving course's [cavityKey]); a chat covering the course
+    // instead DISPOSES the widget with the context unchanged, so nothing is
+    // cleared and the height is restored on return.
+    final contextLeft =
+        oldWidget.cavityContextId != null &&
+        oldWidget.cavityContextId != widget.cavityContextId;
+    if (contextLeft) {
+      MobileNavWidget._heightByKey.remove(oldWidget.cavityContextId);
     }
 
     if (closedNow) {

--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -156,7 +156,11 @@ class MobileNavWidget extends StatefulWidget {
   /// Last settled height per [cavityKey], surviving disposal when a full-screen
   /// surface (a live chat, an activity) mounts over this widget — mirrors
   /// `MobileCourseSheet._expandedBySheet` (#7332), generalized to any section
-  /// or course key and to three rest states instead of two.
+  /// or course key and to three rest states instead of two. A course (peek) key
+  /// is dropped on a genuine close so the course reopens at its peek default
+  /// (#7609; [didUpdateWidget]); a chat covering the course only disposes the
+  /// widget, so that height survives here to be restored on return (#7332).
+  /// Section keys persist for the session (#7510).
   static final Map<String, NavCavityHeight> _heightByKey = {};
 
   @visibleForTesting
@@ -225,6 +229,21 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
     final keyChanged =
         widget.cavityChild != null && oldWidget.cavityKey != widget.cavityKey;
 
+    // Forget a course's height on a GENUINE close — the X, or navigating the
+    // course away (to World, another course, or a section). Those keep the nav
+    // widget MOUNTED and empty/swap the cavity (this callback fires), so the
+    // course's next open falls back to the peek default — the deterministic
+    // entry state (#7609). A chat merely covering the course DISPOSES the widget
+    // instead (no didUpdateWidget runs), so that height survives in the static
+    // map and is restored on return (#7332). Gated to peek cavities: section
+    // sheets keep their memory across close/reopen (#7510). Keyed off the OLD
+    // widget — it identifies the cavity that is leaving.
+    if ((closedNow || keyChanged) &&
+        oldWidget.cavityDefaultsToPeek &&
+        oldWidget.cavityKey != null) {
+      MobileNavWidget._heightByKey.remove(oldWidget.cavityKey);
+    }
+
     if (closedNow) {
       setState(() {
         _restState = null;
@@ -248,10 +267,13 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
   };
 
   NavCavityHeight _restoreHeight() {
-    // A peek cavity (course card) always opens at its default peek — a
-    // deterministic entry state, not the height it was left at (#7609). The
-    // height memory exists for SECTION sheets (#7510) and stays theirs.
-    if (widget.cavityDefaultsToPeek) return _defaultHeight();
+    // Restore the height this cavity was left at. For a course (peek) cavity this
+    // is what bridges a chat opening over it and closing: the widget is DISPOSED
+    // then freshly mounted, and the static [_heightByKey] is the only survivor,
+    // so the course reopens at the size the learner left it (#7332). A genuine
+    // close FORGETS the entry ([didUpdateWidget]), so a fresh open with no stored
+    // height falls back to the peek default — the deterministic entry state
+    // (#7609). Section sheets read the same memory (#7510).
     final key = widget.cavityKey;
     if (key == null) return NavCavityHeight.collapsed;
     return MobileNavWidget._heightByKey[key] ?? _defaultHeight();
@@ -262,17 +284,19 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
       : NavCavityHeight.half;
 
   void _remember(NavCavityHeight height) {
-    // A peek cavity never reads the memory ([_restoreHeight]) — it always
-    // reopens at peek (#7609) — so don't write it either.
-    if (widget.cavityDefaultsToPeek) return;
     final key = widget.cavityKey;
     if (key == null) return;
     // Dragging a SECTION sheet fully down is a dismissal, not a height
     // preference: collapsed renders 0px there (no handle left to grab), so
     // persisting it would make every reopen arrive already-dismissed and
     // stuck (#7510). The sheet still collapses now; the memory just keeps
-    // the last real height for the reopen.
-    if (height == NavCavityHeight.collapsed) return;
+    // the last real height for the reopen. A peek cavity's collapsed IS a
+    // visible, draggable rest height (the 128px peek), so it is remembered
+    // like any other — dragging a course down to peek and returning from a
+    // chat must restore the peek, not a stale expanded height (#7332).
+    if (height == NavCavityHeight.collapsed && !widget.cavityDefaultsToPeek) {
+      return;
+    }
     MobileNavWidget._heightByKey[key] = height;
   }
 

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -679,6 +679,11 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
                 ),
               ),
         cavityKey: cavityKey,
+        // The course scope (`?c=`): a course's height is remembered while this
+        // holds its id and forgotten when it leaves (World / a different
+        // course). Opening a chat or activity from the course keeps it, so the
+        // course reopens where it was left (#7332).
+        cavityContextId: activeSpaceId,
         // A course card opens at peek (the map leads); sections and the
         // activity plan open at half (the plan keeps its pin visible above —
         // the Google Maps UX).

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -230,7 +230,7 @@ void main() {
     });
 
     testWidgets(
-      'a course cavity reopens at peek, not the height it was left at (#7609)',
+      'a course covered by a chat and reopened restores its height (#7332)',
       (tester) async {
         await pumpNav(
           tester,
@@ -241,14 +241,50 @@ void main() {
         );
         final peek = cavityHeightOf(tester);
 
-        // Expand to full (tap-the-body, #7609), then leave.
+        // Expand to full (tap-the-body, #7609).
+        await tester.tap(find.text('Course card'));
+        await tester.pumpAndSettle();
+        final expanded = cavityHeightOf(tester);
+        expect(expanded, greaterThan(peek));
+
+        // A chat opening over the course DISPOSES the nav widget (the shell
+        // drops it under a full-screen focus); closing the chat mounts it fresh.
+        // The course token never left the URL — it was only covered — so it must
+        // reopen at the height the learner left it, not the peek (#7332).
+        await unmountNav(tester);
+        await pumpNav(
+          tester,
+          activeSection: AppSection.courses,
+          cavityChild: const Text('Course card'),
+          cavityKey: 'course-a',
+          cavityDefaultsToPeek: true,
+        );
+        expect(cavityHeightOf(tester), closeTo(expanded, 1.0));
+      },
+    );
+
+    testWidgets(
+      'a course genuinely closed reopens at peek, not its last height (#7609)',
+      (tester) async {
+        await pumpNav(
+          tester,
+          activeSection: AppSection.courses,
+          cavityChild: const Text('Course card'),
+          cavityKey: 'course-a',
+          cavityDefaultsToPeek: true,
+        );
+        final peek = cavityHeightOf(tester);
+
+        // Expand to full, then CLOSE the course in place — its token is dropped
+        // (the X / navigating away), so the still-mounted widget rebuilds with no
+        // cavity. Unlike a covering chat, this forgets the height (#7609).
         await tester.tap(find.text('Course card'));
         await tester.pumpAndSettle();
         expect(cavityHeightOf(tester), greaterThan(peek));
-        await unmountNav(tester);
+        await pumpNav(tester, activeSection: AppSection.world);
 
-        // Reopening the same course arrives at the default peek — a
-        // deterministic entry state; the height memory is section sheets'.
+        // Reopening the same course arrives at the default peek — the
+        // deterministic entry state; the expanded height was forgotten on close.
         await pumpNav(
           tester,
           activeSection: AppSection.courses,

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -23,6 +23,7 @@ void main() {
     AppSection activeSection = AppSection.world,
     Widget? cavityChild,
     String? cavityKey,
+    String? cavityContextId,
     bool cavityDefaultsToPeek = false,
     void Function(AppSection section)? onSectionTap,
     VoidCallback? onCourseShortcutTap,
@@ -50,6 +51,7 @@ void main() {
             onSectionTap: onSectionTap ?? (_) {},
             cavityChild: cavityChild,
             cavityKey: cavityKey,
+            cavityContextId: cavityContextId,
             cavityDefaultsToPeek: cavityDefaultsToPeek,
             maxHeightFraction: maxHeightFraction,
             preferredCavityHeightPx: preferredCavityHeightPx,
@@ -237,6 +239,7 @@ void main() {
           activeSection: AppSection.courses,
           cavityChild: const Text('Course card'),
           cavityKey: 'course-a',
+          cavityContextId: 'course-a',
           cavityDefaultsToPeek: true,
         );
         final peek = cavityHeightOf(tester);
@@ -249,14 +252,55 @@ void main() {
 
         // A chat opening over the course DISPOSES the nav widget (the shell
         // drops it under a full-screen focus); closing the chat mounts it fresh.
-        // The course token never left the URL — it was only covered — so it must
-        // reopen at the height the learner left it, not the peek (#7332).
+        // The course context (`?c=`) never left — the course was only covered —
+        // so it must reopen at the height the learner left it, not peek (#7332).
         await unmountNav(tester);
         await pumpNav(
           tester,
           activeSection: AppSection.courses,
           cavityChild: const Text('Course card'),
           cavityKey: 'course-a',
+          cavityContextId: 'course-a',
+          cavityDefaultsToPeek: true,
+        );
+        expect(cavityHeightOf(tester), closeTo(expanded, 1.0));
+      },
+    );
+
+    testWidgets(
+      'a course keeps its height across opening and closing an activity (#7332)',
+      (tester) async {
+        await pumpNav(
+          tester,
+          activeSection: AppSection.courses,
+          cavityChild: const Text('Course card'),
+          cavityKey: 'course-a',
+          cavityContextId: 'course-a',
+          cavityDefaultsToPeek: true,
+        );
+        final peek = cavityHeightOf(tester);
+
+        await tester.tap(find.text('Course card'));
+        await tester.pumpAndSettle();
+        final expanded = cavityHeightOf(tester);
+        expect(expanded, greaterThan(peek));
+
+        // Open an activity from the course: it rides the SAME cavity (the key
+        // swaps course->activity) but keeps the course context, so it must NOT
+        // forget the course's height. Then close the activity back to the card.
+        await pumpNav(
+          tester,
+          activeSection: AppSection.courses,
+          cavityChild: const Text('Activity plan'),
+          cavityKey: 'activity-x',
+          cavityContextId: 'course-a',
+        );
+        await pumpNav(
+          tester,
+          activeSection: AppSection.courses,
+          cavityChild: const Text('Course card'),
+          cavityKey: 'course-a',
+          cavityContextId: 'course-a',
           cavityDefaultsToPeek: true,
         );
         expect(cavityHeightOf(tester), closeTo(expanded, 1.0));
@@ -271,13 +315,15 @@ void main() {
           activeSection: AppSection.courses,
           cavityChild: const Text('Course card'),
           cavityKey: 'course-a',
+          cavityContextId: 'course-a',
           cavityDefaultsToPeek: true,
         );
         final peek = cavityHeightOf(tester);
 
-        // Expand to full, then CLOSE the course in place — its token is dropped
-        // (the X / navigating away), so the still-mounted widget rebuilds with no
-        // cavity. Unlike a covering chat, this forgets the height (#7609).
+        // Expand to full, then LEAVE the course context — World clears `?c=`
+        // (the only thing besides picking another course that resets scope).
+        // That, unlike a covering chat or an in-course activity, forgets the
+        // height (#7609).
         await tester.tap(find.text('Course card'));
         await tester.pumpAndSettle();
         expect(cavityHeightOf(tester), greaterThan(peek));
@@ -290,6 +336,7 @@ void main() {
           activeSection: AppSection.courses,
           cavityChild: const Text('Course card'),
           cavityKey: 'course-a',
+          cavityContextId: 'course-a',
           cavityDefaultsToPeek: true,
         );
         expect(cavityHeightOf(tester), closeTo(peek, 1.0));


### PR DESCRIPTION
## What
On mobile, a course cavity keeps the height the learner left it at while they stay in that course — opening/closing a **chat** or an **activity** from the course no longer snaps it back to peek. The height is forgotten only when the course is genuinely left (World, or switching to a different course), so a fresh course open still starts at the deterministic peek.

## Why
Closes #7332.

#7510 added the static per-key cavity height memory (survives the nav widget being disposed when a full-screen chat mounts over it). #7609 excluded course (peek) cavities to keep fresh opens deterministic — which reintroduced #7332.

The correct signal for "the course is still open" is the **course context** (`?c=` / `activeSpaceId`), not the cavity key. A chat *disposes* the nav widget but keeps `?c=`; an activity *rides the same cavity* (key swaps course→activity) but also keeps `?c=`; even closing the course card keeps `?c=` — "scope is reset only by the World control or by choosing a different course, never by closing a panel" (`routing.instructions.md` → Single-column bottom nav). So the fix keys the forget to the context leaving the course, passing `cavityContextId` (= `activeSpaceId`) into `MobileNavWidget` and clearing the entry only when that context changes away. Sections keep their memory (#7510).

## Testing
- `flutter test test/pangea/navigation/mobile_nav_widget_test.dart` → 34 passing. New/updated: course restores after an occluding chat (#7332); **course keeps its height across opening and closing an activity** (#7332, the reported regression); course genuinely closed (leaving to World) reopens at peek (#7609).
- `dart format` + `dart analyze` on the changed files → clean.
- Manual: reported broken-then-fixed on a physical iPhone by the author for the activity flow; iOS simulator build is currently blocked by an unrelated `receive_sharing_intent` Share-extension module error, so device/staging QA covers the on-device pass.

## Deploy Notes
None.