### PR TITLE
docs(signup-login): add slide inventory table

### DIFF
--- a/.github/instructions/signup-and-login.instructions.md
+++ b/.github/instructions/signup-and-login.instructions.md
@@ -25,6 +25,10 @@ The screen sits on the world map rather than on a flat surface colour, so the fi
 
 The backdrop also carries the leftover space on wide windows. Because a slide is capped rather than stretched, there is always area around it, and that area reads as part of the product instead of as an empty margin.
 
+There are **two backdrop files, not one** — [`world_map_background.png`](../../assets/pangea/world_map_background.png) for light and [`world_map_background_dark.png`](../../assets/pangea/world_map_background_dark.png) for dark — and both ship on every platform, mobile included. The screen picks one by theme brightness. A single light image would glare behind dark-mode UI, and it would defeat the headline outline described under Slide text, which takes the surface colour on the assumption that the backdrop moves with the theme.
+
+Unlike the slides, these two are bundled with the app rather than fetched. They do not change when features change, so the tradeoff runs the other way: the backdrop is worth pinning to the release to get an instant, offline-safe first screen, and it keeps signed-out visitors from spending tile requests on decoration.
+
 ### Layout and responsiveness
 
 The screen chooses between two layouts from the window's **shape**, not the device: when height divided by width is greater than 1.75 it uses the narrow layout. A tall phone and a narrowed desktop browser therefore get the same treatment, which is what someone resizing a window expects. This is deliberately not the app-wide column breakpoint in [`FluffyThemes`](../../lib/config/themes.dart), which switches on width alone — that rule decides how many panes fit side by side, a question this single-column screen does not ask.
@@ -87,6 +91,25 @@ The version suffix means a new set is added alongside the one it replaces rather
 
 **Upload both crops of a slide together.** The app chooses a crop from the window shape, so replacing only one leaves the other layout on older artwork. Nothing fails visibly when this happens; the two layouts simply drift apart, and the gap is only found by opening the app at a different window shape.
 
+### Slide inventory
+
+A slide is two things kept in separate places: **artwork in the bucket, headline in the code.** Artwork is swapped by uploading a file. A headline is a localized string, so changing one means a code edit, retranslation into every supported language, and a release. Reword a headline only when the wording is worth that; restyle or redraw freely.
+
+| # | Headline | String key | Artwork |
+|---|---|---|---|
+| 1 | Learn a language while texting your friends! | `learnLanguageWhileTexting` | `Carousel_1_ratio4x5_V5.png`, `Carousel_1_ratio2x1_NoPadding_V5.png` |
+| 2 | Write and speak worry-free with Pangea Bot anytime, anywhere! | `writeAndSpeakWorryFree` | `Carousel_2_…` |
+| 3 | Join international learning communities, or start your own! | `joinLearningCommunities` | `Carousel_3_…` |
+| 4 | Play conversation games with the bot, classmates, and new friends! | `playConversationGames` | `Carousel_4_…` |
+| 5 | Jump into conversation from Day One with AI writing tools! | `jumpIntoConversation` | `Carousel_5_…` |
+| 6 | Play practice games personalized to your vocabulary and grammar needs! | `playPersonalizedGames` | `Carousel_6_…` |
+
+Slide number in the filename is the position in this table, so artwork and headline stay paired by number alone. Reordering the carousel therefore means renaming files as well as reordering the strings — cheaper to change what a slide says than where it sits.
+
+The headlines above are the strings in the code today. The V5 comps rewrite all six into much shorter lines, which is a copy change, not an art change, and carries the release and translation cost described above. See Design refer in Figma.
+
+For how a headline is set and how it behaves as the window changes, see Slide text and Layout and responsiveness.
+
 Hosting the slides remotely rather than bundling them means the feature story can be refreshed without an app release — which matters because the slides show real product UI, and that UI keeps changing. The cost is a live dependency: a stale or unreachable bucket reaches every user at once, so a failed image falls back to the Pangea logo rather than a broken-image box.
 
 ## Buttons, dots and colour
@@ -113,6 +136,8 @@ Both buttons share the corner radius defined in `AppConfig`, so they read as one
 The comps cover the narrow layout only. The wide layout follows the rules in the tables above, which stand as its specification until a comp exists.
 
 The headline in the comps is drawn in a lighter purple than the role chosen above. Where the two disagree, the role wins — it keeps the screen inside one derived palette, and it follows the theme into dark mode on its own.
+
+The comps also shorten all six headlines. Those are the intended wording; the strings listed under Slide inventory are what the code says today.
 
 ## Choosing a method
 

--- a/.github/instructions/signup-and-login.instructions.md
+++ b/.github/instructions/signup-and-login.instructions.md
@@ -87,9 +87,11 @@ Slides are fetched at runtime from the bucket named in [`AppConfig`](../../lib/c
 
 `https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com`
 
-Files are named `Carousel_<number>_<crop>_<version>.png`. The number runs 1 to 6, the crop is `ratio4x5` for the narrow layout or `ratio2x1_NoPadding` for the wide one, and the version marks the design generation — currently `V5`. Twelve files make a full set.
+Files are named `Carousel_<number>_<crop>_<version>.png`. The number runs 1 to 6, the crop is `ratio4x5` for the narrow layout or `ratio2x1` for the wide one, and the version marks the design generation — currently `V5`. Twelve files make a full set.
 
-The version suffix means a new set is added alongside the one it replaces rather than overwriting it, so the previous artwork stays retrievable if a slide has to be rolled back or compared.
+The version suffix means a new set is added alongside the one it replaces rather than overwriting it, so the previous artwork stays retrievable if a slide has to be rolled back or compared. It also makes the files safe to cache forever, since a new generation never reuses an old name.
+
+**Spell the crop and version tokens identically across a whole set.** Bucket keys are case-sensitive and the app builds each filename from one rule, so a set uploaded half as `_V5` and half as `_v5`, or half as `ratio2x1` and half as `ratio2x1_NoPadding`, cannot be addressed at all. The half that does not match the rule returns a not-found and falls back to the Pangea logo, which reads as a loading failure rather than a naming mistake.
 
 **Upload both crops of a slide together.** The app chooses a crop from the window shape, so replacing only one leaves the other layout on older artwork. Nothing fails visibly when this happens; the two layouts simply drift apart, and the gap is only found by opening the app at a different window shape.
 
@@ -97,14 +99,16 @@ The version suffix means a new set is added alongside the one it replaces rather
 
 A slide is two things kept in separate places: **artwork in the bucket, headline in the code.** Carousel slides are images uploaded to AWS S3. A headline is a localized string, so changing one means a code edit, retranslation into every supported language, and a release. Reword a headline only when the wording is worth that; restyle or redraw freely.
 
-| # | Headline in code today | V5 headline | Artwork |
+| # | Headline in code today | V5 headline | V5 artwork |
 |---|---|---|---|
-| 1 | Learn a language while texting your friends! | none — carried in the artwork | `Carousel_1_ratio4x5_V5.png`, `Carousel_1_ratio2x1_NoPadding_V5.png` |
-| 2 | Write and speak worry-free with Pangea Bot anytime, anywhere! | Explore, play and learn | `Carousel_2_…` |
-| 3 | Join international learning communities, or start your own! | Conversation from Day One | `Carousel_3_…` |
-| 4 | Play conversation games with the bot, classmates, and new friends! | Built for connection | `Carousel_4_…` |
-| 5 | Jump into conversation from Day One with AI writing tools! | AI when you need it | `Carousel_5_…` |
-| 6 | Play practice games personalized to your vocabulary and grammar needs! | Practice tailored for you | `Carousel_6_…` |
+| 1 | Learn a language while texting your friends! | none — carried in the artwork | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_1_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_1_ratio2x1_v5.png) |
+| 2 | Write and speak worry-free with Pangea Bot anytime, anywhere! | Explore, play and learn | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_2_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_2_ratio2x1_v5.png) |
+| 3 | Join international learning communities, or start your own! | Conversation from Day One | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_3_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_3_ratio2x1_v5.png) |
+| 4 | Play conversation games with the bot, classmates, and new friends! | Built for connection | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_4_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_4_ratio2x1_v5.png) |
+| 5 | Jump into conversation from Day One with AI writing tools! | AI when you need it | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_5_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_5_ratio2x1_v5.png) |
+| 6 | Play practice games personalized to your vocabulary and grammar needs! | Practice tailored for you | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_6_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_6_ratio2x1_v5.png) |
+
+The V5 set is 800 x 1000 narrow and 1200 x 600 wide. Both land at roughly twice their on-screen size, which is what keeps the product UI inside the artwork legible rather than soft — the complaint that opened [#7415](https://github.com/pangeachat/client/issues/7415).
 
 Slide number in the filename is the position in this table, so artwork and headline stay paired by number alone. Reordering the carousel therefore means renaming files as well as reordering the strings — cheaper to change what a slide says than where it sits.
 

--- a/.github/instructions/signup-and-login.instructions.md
+++ b/.github/instructions/signup-and-login.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: "lib/routes/home/**"
-description: "Design for the pre-authentication experience — the intro carousel over the map backdrop, its responsive layout and type, the slide assets, and the choice between signup and login."
+description: "Design for the pre-authentication experience — the intro carousel, its narrow-only map backdrop, responsive layout and type, the slide assets, and the choice between signup and login."
 ---
 
 # Signup and Login
@@ -21,13 +21,15 @@ See also: [returning-user-detection.instructions.md](returning-user-detection.in
 
 ### Map backdrop
 
-The screen sits on the world map rather than on a flat surface colour, so the first thing a new user sees is the surface they will land on after onboarding. The backdrop is a static image rather than a live tile: this screen has no session, and spending tile requests on decoration would draw down the budget described in [world-map-tiles.instructions.md](world-map-tiles.instructions.md) for people who have not signed up yet.
+**The map backdrop belongs to the narrow layout only.** There, the screen sits on the world map rather than a flat surface colour, so the first thing a new user sees is the surface they will land on after onboarding. The wide layout keeps the plain surface background it uses today: the wide crop already carries its own full-bleed artwork, and a map behind it would compete rather than frame.
 
-The backdrop also carries the leftover space on wide windows. Because a slide is capped rather than stretched, there is always area around it, and that area reads as part of the product instead of as an empty margin.
+One consequence to keep in view: the wide layout's empty margin is therefore still empty. Because a slide is capped rather than stretched, there is always area around it on a broad window, and the backdrop is not what fills it. Anything done about that has to come from the cap or the crop, not from this image.
 
-There are **two backdrop files, not one** — [`world_map_background.png`](../../assets/pangea/world_map_background.png) for light and [`world_map_background_dark.png`](../../assets/pangea/world_map_background_dark.png) for dark — and both ship on every platform, mobile included. The screen picks one by theme brightness. A single light image would glare behind dark-mode UI, and it would defeat the headline outline described under Slide text, which takes the surface colour on the assumption that the backdrop moves with the theme.
+The backdrop is a static image rather than a live tile. This screen has no session, and spending tile requests on decoration would draw down the budget described in [world-map-tiles.instructions.md](world-map-tiles.instructions.md) for people who have not signed up yet.
 
-Unlike the slides, these two are bundled with the app rather than fetched. They do not change when features change, so the tradeoff runs the other way: the backdrop is worth pinning to the release to get an instant, offline-safe first screen, and it keeps signed-out visitors from spending tile requests on decoration.
+There are **two backdrop files, not one** — [`world_map_background.png`](../../assets/pangea/world_map_background.png) for light and [`world_map_background_dark.png`](../../assets/pangea/world_map_background_dark.png) for dark — and the narrow layout picks one by theme brightness. A single light image would glare behind dark-mode UI, and it would defeat the headline outline described under Slide text, which takes the surface colour on the assumption that the backdrop moves with the theme.
+
+Unlike the slides, both are bundled with the app rather than fetched. They do not change when features change, so the tradeoff runs the other way: the backdrop is worth pinning to the release to get an instant, offline-safe first screen, and it keeps signed-out visitors from spending tile requests on decoration.
 
 ### Layout and responsiveness
 
@@ -75,7 +77,7 @@ Each headline is localized text drawn over the artwork rather than baked into it
 
 The same size and weight apply in both layouts. A headline that changes weight with window shape reads as a different voice for the same sentence, which is why the narrow and wide columns of the tables above differ on position but not on type.
 
-Colour and outline come from the scheme roles listed under Buttons, dots and colour, so the headline carries no brand value of its own. The outline does the separating work over the map: because it takes the surface colour, it is near-white in light mode and near-dark in dark, which keeps the type punched out of the backdrop in both without needing a second rule.
+Colour and outline come from the scheme roles listed under Buttons, dots and colour, so the headline carries no brand value of its own. In the narrow layout the outline does the separating work over the map: because it takes the surface colour, it is near-white in light mode and near-dark in dark, which keeps the type punched out of the backdrop in both without needing a second rule.
 
 Headlines do not scale with the operating system's text-size setting, because the strip reserved for them is fixed and overflowing text would collide with the artwork and the buttons. This is a deliberate accessibility trade-off, recorded in [issue #6294](https://github.com/pangeachat/client/issues/6294).
 
@@ -93,20 +95,20 @@ The version suffix means a new set is added alongside the one it replaces rather
 
 ### Slide inventory
 
-A slide is two things kept in separate places: **artwork in the bucket, headline in the code.** Artwork is swapped by uploading a file. A headline is a localized string, so changing one means a code edit, retranslation into every supported language, and a release. Reword a headline only when the wording is worth that; restyle or redraw freely.
+A slide is two things kept in separate places: **artwork in the bucket, headline in the code.** Carousel slides are images uploaded to AWS S3. A headline is a localized string, so changing one means a code edit, retranslation into every supported language, and a release. Reword a headline only when the wording is worth that; restyle or redraw freely.
 
-| # | Headline | String key | Artwork |
+| # | Headline in code today | V5 headline | Artwork |
 |---|---|---|---|
-| 1 | Learn a language while texting your friends! | `learnLanguageWhileTexting` | `Carousel_1_ratio4x5_V5.png`, `Carousel_1_ratio2x1_NoPadding_V5.png` |
-| 2 | Write and speak worry-free with Pangea Bot anytime, anywhere! | `writeAndSpeakWorryFree` | `Carousel_2_…` |
-| 3 | Join international learning communities, or start your own! | `joinLearningCommunities` | `Carousel_3_…` |
-| 4 | Play conversation games with the bot, classmates, and new friends! | `playConversationGames` | `Carousel_4_…` |
-| 5 | Jump into conversation from Day One with AI writing tools! | `jumpIntoConversation` | `Carousel_5_…` |
-| 6 | Play practice games personalized to your vocabulary and grammar needs! | `playPersonalizedGames` | `Carousel_6_…` |
+| 1 | Learn a language while texting your friends! | none — carried in the artwork | `Carousel_1_ratio4x5_V5.png`, `Carousel_1_ratio2x1_NoPadding_V5.png` |
+| 2 | Write and speak worry-free with Pangea Bot anytime, anywhere! | Explore, play and learn | `Carousel_2_…` |
+| 3 | Join international learning communities, or start your own! | Conversation from Day One | `Carousel_3_…` |
+| 4 | Play conversation games with the bot, classmates, and new friends! | Built for connection | `Carousel_4_…` |
+| 5 | Jump into conversation from Day One with AI writing tools! | AI when you need it | `Carousel_5_…` |
+| 6 | Play practice games personalized to your vocabulary and grammar needs! | Practice tailored for you | `Carousel_6_…` |
 
 Slide number in the filename is the position in this table, so artwork and headline stay paired by number alone. Reordering the carousel therefore means renaming files as well as reordering the strings — cheaper to change what a slide says than where it sits.
 
-The headlines above are the strings in the code today. The V5 comps rewrite all six into much shorter lines, which is a copy change, not an art change, and carries the release and translation cost described above. See Design refer in Figma.
+Two things the V5 column changes beyond wording. **Slide 1 has no headline at all** — it opens on the brand line set inside the artwork, so the layout must allow an empty headline rather than assume six. And **slides 3 and 4 swap subjects** against the current order, so the pairing above is the mapping to build to, not a rename of the existing strings. Both are copy and ordering changes rather than art changes, and both carry the release and translation cost described above.
 
 For how a headline is set and how it behaves as the window changes, see Slide text and Layout and responsiveness.
 
@@ -137,7 +139,7 @@ The comps cover the narrow layout only. The wide layout follows the rules in the
 
 The headline in the comps is drawn in a lighter purple than the role chosen above. Where the two disagree, the role wins — it keeps the screen inside one derived palette, and it follows the theme into dark mode on its own.
 
-The comps also shorten all six headlines. Those are the intended wording; the strings listed under Slide inventory are what the code says today.
+The comps also rewrite the headlines — shorter on slides 2 to 6, and absent on slide 1. Those are the intended wording; the strings listed under Slide inventory are what the code says today.
 
 ## Choosing a method
 

--- a/.github/instructions/signup-and-login.instructions.md
+++ b/.github/instructions/signup-and-login.instructions.md
@@ -38,13 +38,15 @@ The screen chooses between two layouts from the window's **shape**, not the devi
 | | Narrow (ratio above 1.75) | Wide (ratio 1.75 or below) |
 |---|---|---|
 | Slide crop | Tall | Wide, without padding |
-| Slide width | Full window width | Capped at 600 |
+| Slide width | Full window width | Capped at 840 |
 | Slide height | Width times 1.25 | Two thirds of the space below the header |
 | Brand header | None — the first slide carries the name | Pangea logo at 48 beside the wordmark |
 | Headline | Over the artwork | Below the artwork |
 | Fallback logo when an image fails | 128 | 256 |
 
 One slide is always full-bleed across the carousel; slides never peek in from the edges, so a partly visible neighbour cannot be mistaken for content.
+
+The wide cap of 840 is chosen rather than inherited. It matches the point at which [`FluffyThemes`](../../lib/config/themes.dart) considers a window wide enough for side-by-side panes, so the screen changes character at the same width as the rest of the app. The narrower `MaxWidthBody` default described in [layout.instructions.md](layout.instructions.md) is not used here: that value is a reading measure, sized so a line of prose stays comfortable to read, and a slide is artwork rather than text.
 
 Spacing below is in logical pixels, as currently built. The three stacked gaps of 24 between carousel, dots and buttons are what keep the dots reading as a group with the carousel rather than with the buttons.
 
@@ -93,6 +95,8 @@ The version suffix means a new set is added alongside the one it replaces rather
 
 **Spell the crop and version tokens identically across a whole set.** Bucket keys are case-sensitive and the app builds each filename from one rule, so a set uploaded half as `_V5` and half as `_v5`, or half as `ratio2x1` and half as `ratio2x1_NoPadding`, cannot be addressed at all. The half that does not match the rule returns a not-found and falls back to the Pangea logo, which reads as a loading failure rather than a naming mistake.
 
+The client composes the older `ratio2x1_NoPadding` name and no version token at all, so it does not yet request the files described here. That switch is tracked as part of [#7415](https://github.com/pangeachat/client/issues/7415) and completes with it.
+
 **Upload both crops of a slide together.** The app chooses a crop from the window shape, so replacing only one leaves the other layout on older artwork. Nothing fails visibly when this happens; the two layouts simply drift apart, and the gap is only found by opening the app at a different window shape.
 
 ### Slide inventory
@@ -101,12 +105,12 @@ A slide is two things kept in separate places: **artwork in the bucket, headline
 
 | # | Headline in code today | V5 headline | V5 artwork |
 |---|---|---|---|
-| 1 | Learn a language while texting your friends! | none — carried in the artwork | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_1_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_1_ratio2x1_v5.png) |
-| 2 | Write and speak worry-free with Pangea Bot anytime, anywhere! | Explore, play and learn | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_2_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_2_ratio2x1_v5.png) |
-| 3 | Join international learning communities, or start your own! | Conversation from Day One | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_3_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_3_ratio2x1_v5.png) |
-| 4 | Play conversation games with the bot, classmates, and new friends! | Built for connection | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_4_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_4_ratio2x1_v5.png) |
-| 5 | Jump into conversation from Day One with AI writing tools! | AI when you need it | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_5_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_5_ratio2x1_v5.png) |
-| 6 | Play practice games personalized to your vocabulary and grammar needs! | Practice tailored for you | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_6_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_6_ratio2x1_v5.png) |
+| 1 | Learn a language while texting your friends! | none — carried in the artwork | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_1_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_1_ratio2x1_V5.png) |
+| 2 | Write and speak worry-free with Pangea Bot anytime, anywhere! | Explore, play and learn | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_2_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_2_ratio2x1_V5.png) |
+| 3 | Join international learning communities, or start your own! | Conversation from Day One | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_3_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_3_ratio2x1_V5.png) |
+| 4 | Play conversation games with the bot, classmates, and new friends! | Built for connection | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_4_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_4_ratio2x1_V5.png) |
+| 5 | Jump into conversation from Day One with AI writing tools! | AI when you need it | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_5_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_5_ratio2x1_V5.png) |
+| 6 | Play practice games personalized to your vocabulary and grammar needs! | Practice tailored for you | [narrow](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_6_ratio4x5_V5.png) · [wide](https://pangea-chat-client-assets.s3.us-east-1.amazonaws.com/Carousel_6_ratio2x1_V5.png) |
 
 The V5 set is 800 x 1000 narrow and 1200 x 600 wide. Both land at roughly twice their on-screen size, which is what keeps the product UI inside the artwork legible rather than soft — the complaint that opened [#7415](https://github.com/pangeachat/client/issues/7415).
 


### PR DESCRIPTION
Adds a **Slide inventory** section to the signup and login doc, scopes the map backdrop to the narrow layout, and adopts the decisions recorded in the #7415 change list.

Stacked on #8021 — based on that branch, not `main`, because both edit the same file. GitHub retargets this to `main` once #8021 merges. Review #8021 first; the diff here is only the new material.

## Slide inventory

**One table, six rows: the headline in code today, the V5 headline, and links to the V5 artwork.** Slide number in the filename is the position in the table, so artwork and copy stay paired by number alone.

The point of the table is that the two halves cost different amounts to change. Carousel slides are images uploaded to AWS S3, so artwork is swapped without a release. Headlines are localized strings in code, so rewording one means a code edit, retranslation into every supported language, and a release. Reordering is dearer still: moving a slide means renaming files as well as reordering strings, so changing what a slide *says* is cheaper than changing where it *sits*.

**The V5 column is not just shorter wording.** Two structural changes fall out of it, both worth catching before build:

1. **Slide 1 has no headline.** It opens on the brand line set inside the artwork, so the layout has to allow an empty headline rather than assume six.
2. **Slides 3 and 4 swap subjects** against the current order. The table is the mapping to build to, not a rename of the existing strings.

The V5 set is 800 x 1000 narrow and 1200 x 600 wide — both roughly twice their on-screen size, which is what makes the product UI inside the artwork legible rather than soft, the complaint that opened #7415.

## Adopted from the #7415 change list

**Wide slide cap is 840, not 600** (item 8). The doc records why the number was chosen rather than inherited: 840 is where `FluffyThemes` already considers a window wide enough for side-by-side panes, so the screen changes character at the same width as the rest of the app. The narrower `MaxWidthBody` default in `layout.instructions.md` is deliberately not reused — that value is a reading measure sized for a comfortable line of prose, and a slide is artwork, not text. Worth stating explicitly so the cap is not later "corrected" back to 600 for consistency.

**Artwork naming is `Carousel_<number>_<ratio>_V5.png`** (item 5), and the table links both crops at that spelling.

## Map backdrop is narrow-only

The world map sits behind the **narrow** layout only. The wide layout keeps its plain surface background, because the wide crop already carries its own full-bleed artwork and a map behind it would compete rather than frame.

Stated for reviewers because it removes a conclusion the earlier wording implied: **the margin around a capped wide slide is still empty.** The backdrop is not what fills it, so the empty-space half of #7415 is addressed by the 840 cap and the crop, not by this image.

The two backdrop files — light and dark, see #8024 — are therefore consumed by the narrow layout only, selected by theme brightness. A single light asset would glare behind dark-mode UI and would break the `surface`-coloured headline outline, which assumes the backdrop moves with the theme.

## Cross-references rather than repetition

Headline type and responsive behaviour already have homes under Slide text and Layout and responsiveness, so the new section points at them instead of restating them. Same for the Figma link.

## Notes for reviewers

**The client does not request these filenames yet.** `LoginOrSignupView` composes `ratio2x1_NoPadding` with no version token, so the switch to the V5 names is part of #7415 and completes with it. The doc says so rather than implying the links are already live.

**Bucket state is mid-migration.** The narrow `_V5` set is in place. The wide set is being renamed to the `_V5` spelling; the links here use the final names. A rule now sits in the doc requiring crop and version tokens be spelled identically across a set, since bucket keys are case-sensitive and a mismatch returns not-found and falls back to the logo — indistinguishable from a slow network.

**Two items from the change list are not covered here** and may belong in this doc or in code review rather than either: the padding change in item 3 (32 above, 24 below) reads as new spacing, but the existing spacing table already carries those values for the wide brand header, so which element is meant needs confirming. Item 7, the login button restyle, is described only as a scheme role in `Buttons, dots and colour`.

## Related measurement

Fetch timing on the wide set is dominated by round-trip, not payload — roughly 270 ms time-to-first-byte against 240 ms of transfer for a 470 KB file. The bucket serves directly from `us-east-1` with no CDN, and sends **no `Cache-Control` header**, so returning web visitors revalidate every slide. Versioned filenames make a long immutable policy safe whenever someone wants it. Infrastructure rather than design, so probably its own issue.