### PR TITLE
ci: stamp web builds with the CI run number

### DIFF
--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -30,11 +30,15 @@ jobs:
       - run: rm ./assets/vodozemac/.gitignore
       - run: flutter pub get
       - name: Build Release Web
+        # --build-number overrides the `+N` in pubspec.yaml for this build only
+        # (nothing is committed back), so the version shown in-app identifies the
+        # deploy rather than the last hand-edited pubspec. The semantic version
+        # still comes from pubspec. See ci.instructions.md.
         run: |
           flutter config --enable-web
           flutter clean
           flutter pub get
-          flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --pwa-strategy=none --profile --source-maps
+          flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --pwa-strategy=none --profile --source-maps --build-number=${{ github.run_number }}
 
       - name: Version Material Icons font
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,11 @@ jobs:
         run: |
           echo "$WEB_APP_ENV" > .env
       - name: Build Release Web
-        run: flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --pwa-strategy=none --release --source-maps
+        # --build-number overrides the `+N` in pubspec.yaml for this build only
+        # (nothing is committed back), so the version shown in-app identifies the
+        # deploy rather than the last hand-edited pubspec. The release tag still
+        # comes from the pubspec version, unaffected. See ci.instructions.md.
+        run: flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --pwa-strategy=none --release --source-maps --build-number=${{ github.run_number }}
       # The web app fetches /.env from the web root at runtime; it is not a
       # bundled asset, so the build output needs an explicit copy.
       - name: Add env to web root


### PR DESCRIPTION
## Why

Closes #8034

The Settings version line exists to identify which build you are looking at. On web it doesn't — it ships whatever `+N` was last hand-committed to `pubspec.yaml`. Staging has read `5.0.0+6` since 2026-06-27; production reads `4.1.28+1` from April.

Mobile already auto-increments (Android via `fastlane set_build_code_internal` off Play Store track codes, iOS via `increment_build_number` off TestFlight). Only web was unstamped — and never was: `git log -S "build-number" -- .github/` is empty across the repo's history.

## What changed

`--build-number=${{ github.run_number }}` on `flutter build web` in `main_deploy.yaml` (staging) and `release.yaml` (production).

- Build-time only. Nothing is committed back; `pubspec.yaml` is untouched.
- `release.yaml` tags from the pubspec version — **unaffected**, since the tag reads the file, not the build arg.
- The semantic version (`5.0.0`) still comes from pubspec and stays a deliberate manual decision.

Note the two workflows have independent `run_number` counters, so staging and production build numbers are not comparable to each other — each is only monotonic within its own environment.

## Testing

Verified the mechanism with a real local build rather than by inference:

```
flutter build web --pwa-strategy=none --build-number=99999
cat build/web/version.json
{"app_name":"fluffychat","version":"5.0.0","build_number":"99999","package_name":"fluffychat"}
```

`version.json` is what `PackageInfo.fromPlatform()` reads on web, which feeds `versionText(version, buildNumber)` in `settings_view.dart`. No Dart code changed, so the unit/integration buckets are unaffected and were not run.

### Pull Request has been tested on:

- [x] Browser (Chromium based) — local build output verified; staging verification is the TO TEST on #8034

### Accessibility

- [x] N/A — no UI change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release build versioning so each web build receives a unique build number.
  * Preserved the app’s semantic version and release tag while applying the build-specific identifier only during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->