### PR TITLE
ci: share one build-number sequence across web environments and document version policy

### DIFF
--- a/.github/hooks/on-domain-command.md
+++ b/.github/hooks/on-domain-command.md
@@ -6,3 +6,6 @@
 
 scripts/translate/|flutter gen-l10n
 Client l10n tooling — if the backfill-l10n skill isn't already in context, read .github/skills/backfill-l10n/SKILL.md first: which script fits (new keys vs new locale vs one locale), the `uv run` invocations, and the required post-run steps. localization.instructions.md governs.
+
+gh pr create [always]
+Does this change warrant a `pubspec.yaml` version bump? Most PRs need none — bump when this is the thing a future force-upgrade floor would target, or when cutting a release. Decide the level by asking "would we ever force someone onto this?": no → patch (the default), a feature or migration you may later force → minor, a protocol/stored-data break or fleet cutover → major. See deployment.instructions.md § Versioning. State your call before proceeding.

--- a/.github/instructions/ci.instructions.md
+++ b/.github/instructions/ci.instructions.md
@@ -26,6 +26,25 @@ Branch protection is **non-strict** — a PR need not be rebased onto the latest
 - **On push to `main`:** the above **plus** `build_debug_apk` and `build_debug_ios` (gated by `if: github.event_name == 'push'`). This catches native regressions at merge and — because the debug web build runs here too — writes the debug Rust cache to the `main` scope for PRs to restore.
 - **`concurrency: cancel-in-progress`** for `pull_request` only. Superseded PR-iteration pushes cancel; `merge_group` and `main` runs finish (they gate merges / warm caches).
 
+## Version and build number
+
+Settings shows `Version: <semver>+<build>` as a debugging aid. The two halves come from different places.
+
+**The semantic version** lives in `pubspec.yaml` and is bumped by hand. Pubspec's `+N` is no longer what web users see, but it still gates the release tag, so a release must still bump it. When to bump, and at which level, is part of the release process — see [deployment.instructions.md](deployment.instructions.md).
+
+**The build number is stamped at build time, from three unrelated per-platform sources:**
+
+| Platform | Stamped from |
+|---|---|
+| Web | a UTC `ddHHMM` timestamp, applied identically by both web workflows |
+| Android | the Play Store internal track's highest version code, via fastlane |
+| iOS | the latest TestFlight build number, via fastlane |
+
+- **A build number only identifies a build within its own platform.** Mobile numbers come from store state, web from a clock. They are not comparable, and mobile cannot be folded into the web sequence — the stores own those counters. Capture the platform alongside the number when logging a bug report.
+- **The web stamp identifies a build; it does not order one.** Dropping year and month keeps it short, at the cost of resetting on the 1st — so a later build can carry a smaller number, and web build numbers must not be compared to judge which is newer. Both web workflows share one scheme so staging and production draw from the same sequence; per-workflow run counters were tried first and drifted thousands of builds apart.
+
+**Latent coupling.** [`app_version_util.dart`](../../lib/routes/chat_list/app_version_util.dart) also compares build numbers numerically when deciding whether to prompt an update. That path is inert: the force-upgrade gate is semantic-version-based by design, and the endpoint's build number is vestigial — see [client-version-gating.instructions.md](https://github.com/pangeachat/2-step-choreographer/blob/main/.github/instructions/client-version-gating.instructions.md). If that ever changes, the monthly reset would suppress the web update prompt; revisit the stamp format then.
+
 ## Cache scoping
 
 A cache written during a run is scoped to that run's ref: `pull_request` runs write to `refs/pull/<N>/merge` (**isolated per PR**), `push` to main writes to `refs/heads/main`. A run restores from its own ref's scope **plus the default branch**, and can never read another PR's scope.

--- a/.github/instructions/deployment.instructions.md
+++ b/.github/instructions/deployment.instructions.md
@@ -24,6 +24,20 @@ Production is periodically synced from `main` via merge PRs. Between syncs, the 
 - Staging: app.staging.pangea.chat (S3 + CloudFront)
 - Production: app.pangea.chat (S3 + CloudFront)
 
+## Versioning
+
+The semantic version in `pubspec.yaml` is bumped by hand. (The build number after the `+` is stamped automatically per platform at build time — see [ci.instructions.md](ci.instructions.md).)
+
+**Which level to bump.** The levels are defined by what they let you do to the fleet, because major and minor are the only two that can wall a user out: the client raises a mandatory-update wall when the force-upgrade floor's major *or* minor exceeds the running client's. Patch never can. Raising that floor is a separate, deliberate release step — see [client-version-gating.instructions.md](https://github.com/pangeachat/2-step-choreographer/blob/main/.github/instructions/client-version-gating.instructions.md).
+
+- **Major** — a release you intend to eventually force the whole fleet onto: a protocol or stored-data break, or a cutover that ends coexistence with the previous line.
+- **Minor** — a release you may later want to force: a notable feature, or a migration users must land on before old clients become a liability.
+- **Patch** — the default, and right for most work including most feature work. Never used to retire a fleet.
+
+Choosing a level is answering one question: *would we ever force someone onto this?* If no, it is a patch.
+
+**Bumping is a judgment call, not a per-PR obligation** — most PRs need none. Raise it when a PR is the thing a future floor-raise would target, or when a release is being cut. A release must bump `+N` regardless, because the release workflow tags from the full version string and silently fails on a tag that already exists.
+
 ## Environment Config (`.env`)
 
 The root `.env` is the **single config source** on every platform. There is no tracked `assets/.env`; don't reintroduce one — a second copy is what previously let web silently ignore the root file.
@@ -52,7 +66,7 @@ When a bug must be fixed on production before the next full sync from `main`:
 1. **Branch from `production`** — not `main`. The branches may have diverged enough that code from `main` doesn't compile or behaves differently on `production`.
 2. **Assess cherry-pick feasibility** — If the fix already exists on `main`, try `git cherry-pick`. If `production` has diverged (e.g., a refactor changed the surrounding code), the cherry-pick may apply as a no-op or conflict. In that case, manually port the fix to be compatible with production's codebase.
 3. **PR to `production`** — open a PR targeting `production`, not `main`.
-4. **Bump the version** in `pubspec.yaml` — the release workflow tags from this version. If the tag already exists, the workflow fails silently. Always increment the build number (e.g., `4.1.18+6` → `4.1.18+7`).
+4. **Bump the version** in `pubspec.yaml` — see [Versioning](#versioning). A hotfix is a patch: increment the build number (e.g., `4.1.18+6` → `4.1.18+7`).
 5. **Push triggers deploy** — merging the PR (or pushing directly) to `production` triggers [`release.yaml`](../../.github/workflows/release.yaml).
 6. **Forward-port to `main`** — after the hotfix is confirmed working on production, ensure the fix also exists on `main` (via the original PR, a separate PR, or the next sync merge). Otherwise the fix regresses on the next production sync.
 

--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -30,15 +30,17 @@ jobs:
       - run: rm ./assets/vodozemac/.gitignore
       - run: flutter pub get
       - name: Build Release Web
-        # --build-number overrides the `+N` in pubspec.yaml for this build only
-        # (nothing is committed back), so the version shown in-app identifies the
-        # deploy rather than the last hand-edited pubspec. The semantic version
-        # still comes from pubspec. See ci.instructions.md.
+        # UTC ddHHMM stamp, identical scheme in release.yaml, so staging and
+        # production share one sequence instead of each workflow's own run_number
+        # (those had drifted to 3890 vs 104). Build-time only — nothing is
+        # committed back, and the release tag still reads pubspec's `+N`.
+        # Resets monthly, so it identifies a build, never orders one.
+        # See ci.instructions.md.
         run: |
           flutter config --enable-web
           flutter clean
           flutter pub get
-          flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --pwa-strategy=none --profile --source-maps --build-number=${{ github.run_number }}
+          flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --pwa-strategy=none --profile --source-maps --build-number=$(date -u +%d%H%M)
 
       - name: Version Material Icons font
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,11 +60,13 @@ jobs:
         run: |
           echo "$WEB_APP_ENV" > .env
       - name: Build Release Web
-        # --build-number overrides the `+N` in pubspec.yaml for this build only
-        # (nothing is committed back), so the version shown in-app identifies the
-        # deploy rather than the last hand-edited pubspec. The release tag still
-        # comes from the pubspec version, unaffected. See ci.instructions.md.
-        run: flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --pwa-strategy=none --release --source-maps --build-number=${{ github.run_number }}
+        # UTC ddHHMM stamp, identical scheme in main_deploy.yaml, so staging and
+        # production share one sequence instead of each workflow's own run_number
+        # (those had drifted to 3890 vs 104). Build-time only — nothing is
+        # committed back, and the release tag still reads pubspec's `+N`.
+        # Resets monthly, so it identifies a build, never orders one.
+        # See ci.instructions.md.
+        run: flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --pwa-strategy=none --release --source-maps --build-number=$(date -u +%d%H%M)
       # The web app fetches /.env from the web root at runtime; it is not a
       # bundled asset, so the build output needs an explicit copy.
       - name: Add env to web root


### PR DESCRIPTION
## Why

Closes #8036

#8034 stamped web builds with `github.run_number`, but that counter is per-workflow — staging sat at 3890 while production sat at 104, so production would have read as thousands of builds behind something it is ahead of.

Also codifies the version-bump policy, which did not exist anywhere: the only prior guidance was the hotfix step covering `+N`.

## What changed

**Shared stamp.** Both web workflows now use the identical `$(date -u +%d%H%M)`, so staging and production draw from one sequence by construction rather than convention. Year and month are dropped to keep it to 6 digits.

The trade-off is explicit and documented: it **identifies** a build, it does not **order** one. The stamp resets on the 1st, so a later build can carry a smaller number.

**Version policy** in `deployment.instructions.md § Versioning`, defined by force-upgrade semantics — major and minor are the levers that can wall a user out (the client raises a mandatory-update wall when the `MIN_CLIENT_VERSION` floor's major *or* minor exceeds the running client's); patch never can. The decision rule is one question: *would we ever force someone onto this?* If no, patch.

**PR-time reminder** in the client-scoped `.github/hooks/on-domain-command.md`, so it reaches agents at the moment of judgment without firing on other repos' PRs.

## Notes

- `ci.instructions.md` gains the build-number section and links to the policy rather than duplicating it. The hotfix step's tag rule was folded into the new Versioning section, same reason.
- **Ordering safety.** `app_version_util.dart` int-parses build numbers and compares them when deciding whether to prompt an update. That path is inert — the force-upgrade gate is semver-based by design and the endpoint's build number is hardcoded. Documented as a latent coupling: if that ever changes, the monthly reset would suppress the web update prompt.

## Testing

- Hook verified to fire on `gh pr create` in a client context and stay silent in a cms context.
- `date -u +%d%H%M` → `311420` (6 digits); leading-zero case `010500` int-parses to `10500`, which matters given the comparison above.
- No Dart code changed; unit/integration buckets unaffected and not run.

### Pull Request has been tested on:

- [x] Browser (Chromium based) — staging verification is the TO TEST on #8036

### Accessibility

- [x] N/A — no UI change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Web builds now use time-based build identifiers, improving build tracking while keeping release versions unchanged.
  * Build identifiers reset monthly and are generated automatically during the build process.

* **Documentation**
  * Clarified versioning, update requirements, build numbering, and hotfix release guidance.
  * Added guidance for assessing when a version bump is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->