### PR TITLE
fix(chat-search): only match events with searchable message text

### DIFF
--- a/lib/routes/chat/chat_search/chat_search_filter.dart
+++ b/lib/routes/chat/chat_search/chat_search_filter.dart
@@ -1,0 +1,24 @@
+import 'package:matrix/matrix.dart';
+
+/// Narrows the events scanned by `Room.searchEvents` down to those that carry
+/// searchable message text.
+///
+/// The SDK renders anything else as `Unknown message format of type "<type>"`
+/// (or `Redacted`), so state events, attachments and undecryptable events match
+/// arbitrary queries unless they are excluded before the text comparison.
+class ChatSearchFilter {
+  static const Set<String> searchableMessageTypes = {
+    MessageTypes.Text,
+    MessageTypes.Notice,
+    MessageTypes.Emote,
+  };
+
+  static bool hasSearchableContent(Event event) =>
+      event.type == EventTypes.Message &&
+      !event.redacted &&
+      searchableMessageTypes.contains(event.messageType);
+
+  static bool matches(Event event, String searchQuery) =>
+      hasSearchableContent(event) &&
+      event.body.toLowerCase().contains(searchQuery.toLowerCase());
+}

--- a/lib/routes/chat/chat_search/chat_search_page.dart
+++ b/lib/routes/chat/chat_search/chat_search_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:matrix/matrix.dart';
 
+import 'package:fluffychat/routes/chat/chat_search/chat_search_filter.dart';
 import 'package:fluffychat/routes/chat/chat_search/chat_search_view.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -63,7 +64,10 @@ class ChatSearchController extends State<ChatSearchPage>
           isLoading = true;
         });
         final result = await room!.searchEvents(
-          searchTerm: searchController.text.trim(),
+          // #Pangea
+          // searchTerm: searchController.text.trim(),
+          searchFunc: (event) => ChatSearchFilter.matches(event, searchQuery),
+          // Pangea#
           nextBatch: messagesNextBatch,
         );
         setState(() {

--- a/test/pangea/chat_search_filter_test.dart
+++ b/test/pangea/chat_search_filter_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/routes/chat/chat_search/chat_search_filter.dart';
+import 'get_test_client.dart';
+
+/// The message tab of chat search must only surface events that carry
+/// searchable message text. Everything else — state events, attachments,
+/// undecryptable and redacted events — is rendered by the SDK as
+/// `Unknown message format of type "<type>"` or `Redacted`, so it matches
+/// arbitrary queries if it reaches the text comparison.
+void main() {
+  late Client client;
+  late Room room;
+
+  setUp(() async {
+    client = await getTestClient();
+    room = Room(id: '!chat:fakeServer.notExisting', client: client);
+  });
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  Event event({
+    required String type,
+    required Map<String, Object?> content,
+    Map<String, Object?>? unsigned,
+  }) => Event(
+    type: type,
+    content: content,
+    senderId: '@test:fakeServer.notExisting',
+    eventId: '\$event',
+    originServerTs: DateTime.utc(2026, 1, 1, 12),
+    room: room,
+    unsigned: unsigned,
+  );
+
+  Event message(String msgtype, String body) => event(
+    type: EventTypes.Message,
+    content: {'msgtype': msgtype, 'body': body},
+  );
+
+  test('matches the body of text, notice and emote messages', () {
+    for (final msgtype in ChatSearchFilter.searchableMessageTypes) {
+      expect(
+        ChatSearchFilter.matches(
+          message(msgtype, 'my parent is here'),
+          'paren',
+        ),
+        isTrue,
+        reason: msgtype,
+      );
+    }
+  });
+
+  test('match is case insensitive', () {
+    expect(
+      ChatSearchFilter.matches(
+        message(MessageTypes.Text, 'My Parent'),
+        'pArEn',
+      ),
+      isTrue,
+    );
+  });
+
+  test('does not match a message whose body lacks the query', () {
+    expect(
+      ChatSearchFilter.matches(
+        message(MessageTypes.Text, 'hello there'),
+        'parent',
+      ),
+      isFalse,
+    );
+  });
+
+  test('excludes state events that fall back to a placeholder body', () {
+    for (final type in [
+      EventTypes.SpaceParent,
+      EventTypes.RoomName,
+      EventTypes.GuestAccess,
+      EventTypes.RoomCreate,
+    ]) {
+      final stateEvent = event(type: type, content: {});
+      // The placeholder the SDK renders is what makes these false positives.
+      expect(stateEvent.body, contains(type), reason: type);
+      expect(
+        ChatSearchFilter.matches(stateEvent, 'parent'),
+        isFalse,
+        reason: type,
+      );
+      expect(ChatSearchFilter.matches(stateEvent, 'a'), isFalse, reason: type);
+    }
+  });
+
+  test(
+    'excludes attachments, which carry a filename rather than message text',
+    () {
+      for (final msgtype in [
+        MessageTypes.Image,
+        MessageTypes.Video,
+        MessageTypes.Audio,
+        MessageTypes.File,
+      ]) {
+        expect(
+          ChatSearchFilter.matches(
+            message(msgtype, 'parent-photo.png'),
+            'parent',
+          ),
+          isFalse,
+          reason: msgtype,
+        );
+      }
+    },
+  );
+
+  test('excludes events that could not be decrypted', () {
+    final encrypted = event(
+      type: EventTypes.Encrypted,
+      content: {'algorithm': AlgorithmTypes.megolmV1AesSha2},
+    );
+    expect(ChatSearchFilter.matches(encrypted, 'encrypted'), isFalse);
+  });
+
+  test('excludes redacted messages', () {
+    final redacted = event(
+      type: EventTypes.Message,
+      content: {},
+      unsigned: {
+        'redacted_because': {
+          'type': EventTypes.Redaction,
+          'content': <String, Object?>{},
+          'sender': '@test:fakeServer.notExisting',
+          'event_id': '\$redaction',
+          'origin_server_ts': 0,
+        },
+      },
+    );
+    expect(redacted.body, 'Redacted');
+    expect(ChatSearchFilter.matches(redacted, 'redacted'), isFalse);
+  });
+}


### PR DESCRIPTION
## What

Chat message search now only matches events that actually carry message text.

## Why

Closes #7987

`Room.searchEvents`' default predicate compares the query against `Event.body`, and the SDK renders anything it can't show as text as `Unknown message format of type "<type>"` (or `Redacted`). The server-side leg of the search is type-filtered, but the local-database leg is not — so state events matched almost any query: `m.space.parent` for "parent", `m.room.name` / `m.room.create` / `m.room.guest_access` for "a".

New `ChatSearchFilter` (`lib/routes/chat/chat_search/chat_search_filter.dart`) is passed as `searchFunc` for the Messages tab: non-redacted `m.room.message` events with a `m.text` / `m.notice` / `m.emote` msgtype, then the case-insensitive body match. Attachments stay out of the Messages tab — their body is a filename, and images/video/files have their own tabs.

## Testing

- **Unit** — `fvm flutter test test/pangea/chat_search_filter_test.dart` (7 pass). Covers text/notice/emote matching, case insensitivity, and exclusion of state events (asserting the placeholder body that caused the bug), attachments, undecryptable events, and redacted messages.
- **Unit (full suite)** — `fvm flutter test`: 1655 pass, 3 skipped.
- **Analyzer** — `fvm flutter analyze lib/routes/chat/chat_search test/pangea/chat_search_filter_test.dart`: clean. Formatted with `scripts/format.sh`.
- Smoke / eval / load: N/A — no paid-API or capacity surface. No e2e trigger-map glob covers `lib/routes/chat/chat_search/**`.
- Manual TO TEST steps on the issue to be run against staging after deploy.

## Deploy Notes

None