### PR TITLE
fix(navigation): make the language flag open learning settings alone

### DIFF
--- a/lib/features/navigation/workspace_nav.dart
+++ b/lib/features/navigation/workspace_nav.dart
@@ -658,11 +658,19 @@ abstract class WorkspaceNav {
   /// analytics-family panel so the two don't clutter the right column together
   /// (#7109). See `routing.instructions.md`.
   /// [closeSections] mirrors [setRight]'s flag for single-column callers.
+  ///
+  /// [seatMenu] false opens the page ALONE — for a shortcut that jumps straight
+  /// to one page rather than drilling in from the menu (the cluster's language
+  /// flag → learning settings, #7961): the learner asked for that one page, so
+  /// seating a menu they didn't open puts a second panel on screen and turns
+  /// the page's narrow-screen close into a back arrow. An already-open menu is
+  /// still kept — the flag declines to seat one, it never closes one.
   static String openSettings(
     Uri current, {
     String? page,
     String? planId,
     bool closeSections = false,
+    bool seatMenu = true,
   }) {
     final String next;
     if (page == null || page.isEmpty) {
@@ -685,7 +693,7 @@ abstract class WorkspaceNav {
                   !t.type.isAnalyticsPanel,
             )
             .toList();
-        if (!result.any((t) => t.type == PanelTypesEnum.settings)) {
+        if (seatMenu && !result.any((t) => t.type == PanelTypesEnum.settings)) {
           result.insert(0, const SettingsPanelToken());
         }
         result.add(detail);

--- a/lib/routes/world/user_cluster_view_model.dart
+++ b/lib/routes/world/user_cluster_view_model.dart
@@ -255,6 +255,9 @@ class WorldUserClusterViewModel implements UserClusterViewModel {
       GoRouterState.of(context).uri,
       page: 'learning',
       closeSections: _closeSections(context),
+      // The flag is a shortcut straight to learning settings, not a drill-in
+      // from the menu, so it opens that page alone (#7961).
+      seatMenu: false,
     ),
   );
 

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -906,6 +906,63 @@ void main() {
       );
       expect(panels.right.single.type, PanelTypesEnum.settings); // menu remains
     });
+
+    test('seatMenu false opens the page ALONE — the flag shortcut (#7961)', () {
+      // The cluster's language flag jumps straight to learning settings; it is
+      // not a drill-in from the menu, so it must not put a menu the learner
+      // never opened on screen beside it.
+      final loc = WorkspaceNav.openSettings(
+        u('/'),
+        page: 'learning',
+        seatMenu: false,
+      );
+      expect(loc, '/?right=settingspage:learning'); // not `settings,…` (#7961)
+
+      final panels = parseOpenPanels(u(loc));
+      expect(panels.right.single.type, PanelTypesEnum.settingspage);
+
+      final param = panels.right.single.param;
+      expect(param, isA<SettingsTokenParam>());
+      expect((param as SettingsTokenParam).subpage, 'learning');
+
+      // With no menu behind it, the page is an independent right panel: its
+      // close drops the token and reveals the map (an `X`, not a back arrow).
+      expect(
+        parentIsOpen(
+          u(loc),
+          const SettingsPagePanelToken(SettingsTokenParam(subpage: 'learning')),
+        ),
+        isFalse,
+      );
+    });
+
+    test('seatMenu false keeps a menu that is ALREADY open', () {
+      // The shortcut declines to SEAT a menu; it never closes one. A learner
+      // who opened Settings and then taps the flag keeps the master beside the
+      // page, exactly as a menu row would.
+      final open = WorkspaceNav.openSettings(u('/'));
+      final loc = WorkspaceNav.openSettings(
+        u(open),
+        page: 'learning',
+        seatMenu: false,
+      );
+      expect(parseOpenPanels(u(loc)).right.map((t) => t.type), [
+        PanelTypesEnum.settings,
+        PanelTypesEnum.settingspage,
+      ]);
+    });
+
+    test('seatMenu false still drops the analytics family (#7109)', () {
+      final loc = WorkspaceNav.openSettings(
+        u('/?right=analytics:vocab'),
+        page: 'learning',
+        seatMenu: false,
+      );
+      expect(
+        parseOpenPanels(u(loc)).right.single.type,
+        PanelTypesEnum.settingspage,
+      );
+    });
   });
 
   group('setSection (move between sections, keep the live chat)', () {


### PR DESCRIPTION
## Why

Closes #7961

Tapping the cluster's language flag opened two panels — the settings menu *and* the learning-settings page (`?right=settings,settingspage:learning`). The flag is a shortcut to one page; the menu has its own entry point (the avatar).

## What changed

`WorkspaceNav.openSettings` gains `seatMenu` (default `true`, so every menu-row drill-in is unchanged). The flag passes `seatMenu: false`, so it emits `?right=settingspage:learning`.

- An **already-open** menu is kept — the flag declines to *seat* a master, it never closes one.
- The #7109 rule still applies: the shortcut drops an open analytics-family panel.
- No render-path change. An orphan `settingspage` is already a supported state (#7493), and the narrow-screen `X` falls out of the existing affordance rule — with no `settings` master open, `parentIsOpen` is false, so `CloseAffordance` gives close-only instead of back.

Design: [routing.instructions.md § How each surface opens](.github/instructions/routing.instructions.md) — the flag row already reads "opens the learning-settings page directly". No doc change needed.

## Testing

- `fvm flutter test test/pangea/` — **1629 passed**, 3 skipped (whole Pangea suite, not just navigation).
- 3 new cases in `workspace_nav_test.dart`: the page opens alone (pinning the literal `/?right=settingspage:learning` and asserting `parentIsOpen` is false, i.e. the `X`); an already-open menu survives; the analytics drop still happens.
- `fvm flutter analyze` on the three changed files — no issues.
- Not run in a browser locally; the on-screen wide/narrow checks are the TO TEST on #7961.

## Deploy Notes

None.

### Pull Request has been tested on:

- [ ] Browser (Chromium based) — staging verification is the TO TEST on #7961

### Accessibility

- [x] N/A — no new or changed controls; the flag's tooltip and the panel header are untouched.
