### PR TITLE
fix(courses): wrap course-invite button labels so long translations fit

### DIFF
--- a/lib/routes/courses/own/invite/course_invite_page.dart
+++ b/lib/routes/courses/own/invite/course_invite_page.dart
@@ -394,7 +394,12 @@ class CourseInvitePageController extends State<CourseInvitePage>
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
                           const Icon(Icons.upload_file),
-                          Text(L10n.of(context).inviteYourFriends),
+                          Flexible(
+                            child: Text(
+                              L10n.of(context).inviteYourFriends,
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
                         ],
                       ),
                     ),
@@ -422,7 +427,14 @@ class CourseInvitePageController extends State<CourseInvitePage>
                       child: Row(
                         spacing: 8.0,
                         mainAxisAlignment: MainAxisAlignment.center,
-                        children: [Text(L10n.of(context).playWithAI)],
+                        children: [
+                          Flexible(
+                            child: Text(
+                              L10n.of(context).playWithAI,
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   ],


### PR DESCRIPTION
## What

Long translations of the course-invite page's two bottom buttons ("Invite your friends" / "Play with AI for now") now wrap inside the button instead of overflowing off the right edge.

## Why

Closes #7946

Both buttons put their label in a `Row` that fills the panel width, but the `Text` was a non-flexible child — so any translation wider than the button overflowed rather than wrapping. Greek `playWithAI` is 45 characters vs. 20 in English, which is what the issue's screenshot shows.

Fix wraps both labels in `Flexible` with `textAlign: TextAlign.center`, matching the `Flexible(child: Text(..., textAlign: center))` pattern already used by the two toggle rows in the same file. `inviteYourFriends` gets the same treatment — same structure plus a leading icon, and Greek is already close to the limit there.

## Testing

- **Unit/widget (`fvm flutter test`)**: full suite, 1648 passed / 3 skipped.
- **Layout regression check**: a throwaway widget test pumped both button subtrees under `Locale('el')` at 260 / 300 / 380 px wide. Before the change: `RenderFlex overflowed by 195px` (invite) and `422px` (play-with-AI) — reproduces the issue. After: no exception, and each text rect stays inside its button rect at all three widths. Not committed — the replica would drift from the page it mirrors.
- **Manual run of the live course-creation flow: not done.** Port 8090 was held by another worktree's dev server and the flow needs the full local stack up to create a course. The issue's TO TEST steps (Greek L1, narrow right panel, create a course) are still worth a pass on staging.

## Deploy Notes

None