### PR TITLE
fix(chat-list): make the unread bubble a fixed-size circle

### DIFF
--- a/lib/routes/chat_list/unread_bubble.dart
+++ b/lib/routes/chat_list/unread_bubble.dart
@@ -3,7 +3,16 @@ import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/themes.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/widgets/unread_rooms_badge.dart';
 
+/// The unread indicator shown on a chat list row, a world map pin, and a world
+/// map large card: a **fixed-diameter circle**, never a pill that widens with
+/// the count. A count that outgrows the circle is scaled down to fit, and
+/// anything past 99 reads as `99+` — the same treatment the All-Chats nav badge
+/// gives its count ([UnreadRoomsBadge]), so the two read as one family (#8007).
+/// Letting the bubble stretch instead made three- and four-digit counts elbow
+/// the row's other content in the narrow space a chat list row has.
 class UnreadBubble extends StatelessWidget {
   final Room room;
 
@@ -13,52 +22,72 @@ class UnreadBubble extends StatelessWidget {
 
   const UnreadBubble({required this.room, this.borderColor, super.key});
 
+  /// Diameter of the circle when it carries a count.
+  static const double _countDiameter = 20.0;
+
+  /// Diameter of the plain "there's something new here" dot — no count.
+  static const double _dotDiameter = 14.0;
+
+  /// The square the count is fitted into, inset from the circle's edge so a
+  /// scaled-down `99+` still clears the ring. Matches [UnreadRoomsBadge]'s box.
+  static const double _countBox = 15.0;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final unread = room.isUnread;
     final hasNotifications = room.notificationCount > 0;
     final unreadBubbleSize = unread || room.hasNewMessages
-        ? room.notificationCount > 0
-              ? 20.0
-              : 14.0
+        ? hasNotifications
+              ? _countDiameter
+              : _dotDiameter
         : 0.0;
     final borderWidth = borderColor != null ? 1.5 : 0.0;
+    final diameter = unreadBubbleSize == 0
+        ? 0.0
+        : unreadBubbleSize + borderWidth * 2;
+    final countText = room.notificationCount < 100
+        ? room.notificationCount.toString()
+        : L10n.of(context).unreadPlus;
     return AnimatedContainer(
       duration: FluffyThemes.animationDuration,
       curve: FluffyThemes.animationCurve,
       alignment: Alignment.center,
-      padding: const EdgeInsets.symmetric(horizontal: 7),
-      height: unreadBubbleSize == 0 ? 0 : unreadBubbleSize + borderWidth * 2,
-      width: !hasNotifications && !unread && !room.hasNewMessages
-          ? 0
-          : (unreadBubbleSize - 9) * room.notificationCount.toString().length +
-                9 +
-                borderWidth * 2,
+      height: diameter,
+      width: diameter,
       decoration: BoxDecoration(
         color: room.highlightCount > 0
             ? theme.colorScheme.error
             : hasNotifications || room.markedUnread
             ? theme.colorScheme.primary
             : theme.colorScheme.primaryContainer,
-        borderRadius: BorderRadius.circular(7),
+        shape: BoxShape.circle,
         border: borderColor != null
             ? Border.all(color: borderColor!, width: borderWidth)
             : null,
       ),
       child: hasNotifications
-          ? Text(
-              room.notificationCount.toString(),
-              style: TextStyle(
-                color: room.highlightCount > 0
-                    ? theme.colorScheme.onError
-                    : hasNotifications
-                    ? theme.colorScheme.onPrimary
-                    : theme.colorScheme.onPrimaryContainer,
-                fontSize: 13,
-                fontWeight: FontWeight.w500,
+          // The count lives in a box inset from the circle's edge and shrinks
+          // to fit it, so `8`, `42` and `99+` all sit inside the same circle
+          // rather than widening it.
+          ? SizedBox(
+              width: _countBox,
+              height: _countBox,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  countText,
+                  semanticsLabel: L10n.of(context).unreadLabel(countText),
+                  style: TextStyle(
+                    color: room.highlightCount > 0
+                        ? theme.colorScheme.onError
+                        : theme.colorScheme.onPrimary,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
               ),
-              textAlign: TextAlign.center,
             )
           : const SizedBox.shrink(),
     );

--- a/test/pangea/unread_bubble_shape_test.dart
+++ b/test/pangea/unread_bubble_shape_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/chat_list/unread_bubble.dart';
+import 'get_test_client.dart';
+
+/// #8007 — the unread bubble is a fixed-size circle, not a pill that widens
+/// with the count. It shares a chat list row with the room name and last
+/// message, and a stretching bubble squeezed them; it also read as a different
+/// shape from the All-Chats nav badge next to it.
+void main() {
+  late Client client;
+
+  const roomId = '!1234:fakeServer.notExisting';
+
+  setUp(() async {
+    client = await getTestClient();
+  });
+
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  Room unreadRoom({required int notificationCount, int highlightCount = 0}) =>
+      Room(
+        id: roomId,
+        client: client,
+        notificationCount: notificationCount,
+        highlightCount: highlightCount,
+      );
+
+  Future<Size> pumpBubble(WidgetTester tester, Room room) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        // Unconstrained so the bubble reports the size it asks for, not one a
+        // parent forced on it.
+        home: Scaffold(
+          body: Center(child: UnreadBubble(room: room)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return tester.getSize(find.byType(UnreadBubble));
+  }
+
+  testWidgets('a one-digit count renders a circle', (tester) async {
+    final size = await pumpBubble(tester, unreadRoom(notificationCount: 8));
+    expect(size.width, size.height);
+  });
+
+  testWidgets('the circle does not grow with the number of digits', (
+    tester,
+  ) async {
+    final one = await pumpBubble(tester, unreadRoom(notificationCount: 8));
+    final two = await pumpBubble(tester, unreadRoom(notificationCount: 42));
+    final three = await pumpBubble(tester, unreadRoom(notificationCount: 999));
+
+    expect(two, one);
+    expect(three, one);
+  });
+
+  testWidgets('counts past 99 read as 99+, like the nav badge', (tester) async {
+    await pumpBubble(tester, unreadRoom(notificationCount: 128));
+    expect(find.text('99+'), findsOneWidget);
+    expect(find.text('128'), findsNothing);
+  });
+
+  testWidgets('the count text stays inside the circle', (tester) async {
+    // A FittedBox shrinks the widest count to fit, so nothing paints outside
+    // the circle's box.
+    await pumpBubble(tester, unreadRoom(notificationCount: 999));
+    final bubble = tester.getRect(find.byType(UnreadBubble));
+    final text = tester.getRect(find.text('99+'));
+
+    expect(bubble.contains(text.topLeft), isTrue);
+    expect(bubble.contains(text.bottomRight), isTrue);
+  });
+
+  testWidgets('an unread room with no count renders the plain dot', (
+    tester,
+  ) async {
+    final room = unreadRoom(notificationCount: 0);
+    room.roomAccountData['m.marked_unread'] = BasicEvent(
+      type: 'm.marked_unread',
+      content: {'unread': true},
+    );
+
+    final size = await pumpBubble(tester, room);
+    expect(size.width, size.height);
+    expect(find.text('0'), findsNothing);
+  });
+
+  testWidgets('a read room renders nothing', (tester) async {
+    final size = await pumpBubble(tester, unreadRoom(notificationCount: 0));
+    expect(size, Size.zero);
+  });
+
+  testWidgets('the count survives the open animation without overflowing', (
+    tester,
+  ) async {
+    // The circle animates open from zero width, so the count is briefly laid
+    // out in a box narrower than itself. The FittedBox has to absorb that
+    // rather than paint outside the circle.
+    final room = unreadRoom(notificationCount: 0);
+    await pumpBubble(tester, room);
+
+    room.notificationCount = 999;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(splashFactory: NoSplash.splashFactory),
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: Center(child: UnreadBubble(room: room)),
+        ),
+      ),
+    );
+    // Step through the growth rather than settling straight to the end state.
+    for (var i = 0; i < 5; i++) {
+      await tester.pump(const Duration(milliseconds: 25));
+      expect(tester.takeException(), isNull);
+    }
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Why

Closes #8007

The chat-list unread bubble was a rounded rect whose width grew ~11px per digit. In the narrow horizontal space a chat list row has, a 3- or 4-digit count stretched it into a wide pill — and it read as a different shape from the circular All-Chats nav badge sitting a few pixels away.

## What changed

`UnreadBubble` is now a **fixed-diameter circle** (`BoxShape.circle`) — 20px with a count, 14px for the plain no-count dot, as before. Width no longer varies with the count.

The count is fitted into a 15×15 box with `BoxFit.scaleDown`, and anything past 99 renders as `99+`. That is exactly what `UnreadRoomsBadge` (the All-Chats nav badge) already does, so the two now read as one family.

Also added a `semanticsLabel` (`Unread: 3`) so screen readers get more than a bare number — again matching the nav badge.

## Notes

**`UnreadBubble` is not only the chat list.** It is also the top-right badge on world map pins and large cards (`world_map_state_dot.dart`, `world_map_large_card.dart`), where it shares a slot with `WorldMapPingedBadge` — which is already a circle. The change makes that pairing more consistent, and the white border `world-map.instructions.md` calls for is untouched.

**Doc gap, flagged not filled.** Nothing under `.github/instructions/` governs the chat list row or the unread indicator's appearance. This was treated as a clear-intent cosmetic fix specified by the issue, so no `*.instructions.md` was drafted or edited. If the badge family (chat-list bubble / nav badge / pinged badge — shape, size, 99+ cap) is worth writing down as design intent, that is a separate chat-first conversation.

**Dead branch removed.** The count's text colour had an `onPrimary : onPrimaryContainer` ternary inside a branch that only renders when `hasNotifications` is true, so the `onPrimaryContainer` arm was unreachable.

## Testing

- New widget test `test/pangea/unread_bubble_shape_test.dart` (7 tests, all pass): the bubble is square for 1/2/3-digit counts and identical in size across them; `128` renders as `99+`; the text rect stays inside the bubble rect; an unread-no-count room still renders the dot; a read room renders nothing; and stepping through the open animation raises no overflow exception.
- Full `fvm flutter test`: **1655 passed, 3 skipped, 0 failures**.
- `fvm flutter analyze` clean on both changed files.
- Smoke/eval/load buckets: N/A — no backend surface touched.

## Deploy Notes

None

### Pull Request has been tested on:

- [ ] Staging verification is the TO TEST on #8007

### Accessibility

- [x] The count now carries a `semanticsLabel` (`Unread: {count}`); no new controls added.
