### PR TITLE
fix(analytics): keep earn/lose XP animation at a fixed size

### DIFF
--- a/lib/routes/chat/gain_points_animation.dart
+++ b/lib/routes/chat/gain_points_animation.dart
@@ -3,7 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/config/app_config.dart';
-import 'package:fluffychat/features/bot/utils/bot_style.dart';
+import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/features/overlay/overlay.dart';
 import 'package:fluffychat/features/overlay/overlay_display_details.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -56,6 +56,11 @@ class PointsGainedAnimationState extends State<PointsGainedAnimation>
   static const double _particleSpeed = 50;
   static const double gravity = 15;
   static const int duration = 2000;
+
+  /// Size of the "+" / "-" particles. Deliberately independent of
+  /// [AppSettings.fontSizeFactor] — these are decorative animation particles,
+  /// not readable text, so they stay the same size at every font size setting.
+  static const double _particleFontSize = AppConfig.messageFontSize * 1.2;
 
   @override
   void initState() {
@@ -132,11 +137,10 @@ class PointsGainedAnimationState extends State<PointsGainedAnimation>
 
     final plusWidget = Text(
       _points > 0 ? "+" : "-",
-      style: BotStyle.text(
-        context,
-        big: true,
-        setColor: textColor == null,
-        existingStyle: TextStyle(color: textColor),
+      style: TextStyle(
+        fontSize: _particleFontSize,
+        color: textColor ?? Theme.of(context).colorScheme.primary,
+        height: 1.3,
       ),
     );
 

--- a/test/pangea/gain_points_animation_font_size_test.dart
+++ b/test/pangea/gain_points_animation_font_size_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/config/setting_keys.dart';
+import 'package:fluffychat/routes/chat/gain_points_animation.dart';
+
+/// #7932 — the earn/lose XP particles are decoration, not readable text, so
+/// they render at a fixed size. They used to be styled with `BotStyle.text`,
+/// which multiplies by the settings > style font size factor, and the whole
+/// animation grew or shrank with that slider.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+    await AppSettings.init(loadWebConfigFile: false);
+  });
+
+  /// Renders the animation at [fontSizeFactor] and returns the size of one
+  /// particle. Stops short of the end of the animation so the overlay-closing
+  /// callback, which needs a live `MatrixState`, never runs.
+  Future<Size> pumpParticle(WidgetTester tester, double fontSizeFactor) async {
+    await AppSettings.fontSizeFactor.setItem(fontSizeFactor);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: PointsGainedAnimation(
+              points: 1,
+              targetID: 'gain_points_test',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 16));
+    final size = tester.getSize(find.text('+').first);
+
+    // Dispose the widget so its ticker stops before the test ends.
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    return size;
+  }
+
+  testWidgets('particle size does not follow the font size setting', (
+    tester,
+  ) async {
+    final small = await pumpParticle(tester, 0.5);
+    final normal = await pumpParticle(tester, 1.0);
+    final large = await pumpParticle(tester, 2.0);
+
+    expect(small, normal);
+    expect(large, normal);
+  });
+
+  testWidgets('particles render at the default message font size', (
+    tester,
+  ) async {
+    await AppSettings.fontSizeFactor.setItem(2.0);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: PointsGainedAnimation(
+              points: 1,
+              targetID: 'gain_points_test',
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 16));
+
+    final text = tester.widget<Text>(find.text('+').first);
+    expect(text.style?.fontSize, AppConfig.messageFontSize * 1.2);
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+  });
+
+  tearDownAll(() async {
+    await AppSettings.fontSizeFactor.setItem(1.0);
+  });
+}


### PR DESCRIPTION
### What

The earn/lose XP particle animation now renders at a fixed size instead of scaling with settings > style > font size.

### Why

Closes #7932

The `"+"` / `"-"` particles were styled with `BotStyle.text(big: true)`, which multiplies its font size by `AppSettings.fontSizeFactor`. That factor is the settings > style font size slider, so the whole animation grew or shrank with it. These particles are decoration, not readable text — the animation is the [`XPGainedEvent` feedback described in analytics-system.instructions.md](.github/instructions/analytics-system.instructions.md), whose job is to be legible in place, not to track the user's reading-size preference.

The particle size is now a constant derived from `AppConfig.messageFontSize`, so it matches what the animation looked like at the default factor of 1.0.

### Testing

- New regression test: [`test/pangea/gain_points_animation_font_size_test.dart`](test/pangea/gain_points_animation_font_size_test.dart) — renders the animation at font size factors 0.5 / 1.0 / 2.0 and asserts the particle's laid-out size is identical, plus that the style's `fontSize` is the fixed constant. Confirmed both cases **fail** against the pre-fix widget, so the test actually pins the bug.
- Full local suite: `fvm flutter test` — 1676 passed, 3 skipped.
- `fvm flutter analyze` and `fvm dart format` clean on both changed files.
- No smoke / eval / load buckets triggered: no paid-API code path, no request path with capacity concerns.
- Manual visual pass against the issue's TO TEST steps not run locally — QA on staging per the linked issue.

### Deploy Notes

None

### Accessibility

- [x] No new or changed controls or images — the change is a style swap on existing decorative animation text, so no accessible names are added or removed.