### PR TITLE
fix(activities): hide course invite CTA without invite permission

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
@@ -205,10 +205,13 @@ class _NotStartedSessionCTAButtons extends StatelessWidget {
                     : L10n.of(context).activityNeedsOneMember,
                 textAlign: TextAlign.center,
               ),
-              _CTAButton(
-                L10n.of(context).inviteFriendsToCourse,
-                controller.inviteToCourse,
-              ),
+              // Only for learners who can actually invite — without the power
+              // level the invite page just errors out (#7875).
+              if (controller.canInviteToCourse)
+                _CTAButton(
+                  L10n.of(context).inviteFriendsToCourse,
+                  controller.inviteToCourse,
+                ),
               _CTAButton(
                 L10n.of(context).pickDifferentActivity,
                 controller.goToCourse,

--- a/lib/routes/chat/activity_sessions/not_started_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/not_started_session_controller.dart
@@ -217,9 +217,13 @@ class NotStartedSessionController extends State<NotStartedSession>
     );
   }
 
+  /// Inviting to the course is power-gated. A learner without invite rights can
+  /// only fail on the invite page, so the CTA isn't offered to them (#7875).
+  bool get canInviteToCourse => widget.course?.canInvite == true;
+
   void inviteToCourse() {
     final course = widget.course;
-    if (course == null) return;
+    if (course == null || !course.canInvite) return;
     // world_v2: token nav to the course's invite page (no stacked route push).
     context.go(
       WorkspaceNav.openCoursePageFor(

--- a/test/pangea/course_invite_permission_gate_test.dart
+++ b/test/pangea/course_invite_permission_gate_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/pangea/common/constants/default_power_level.dart';
+import 'get_test_client.dart';
+
+/// Courses are created with `invite: 50` ([RoomDefaults.defaultPowerLevelsContent]),
+/// so an ordinary learner (PL 0) cannot invite anyone to the course. The
+/// activity start page's "Invite friends to my course" CTA — offered when a
+/// 3-or-4-person activity doesn't have enough coursemates — is gated on
+/// `course.canInvite` for exactly that reason: without the power level the
+/// invite page only produces errors (#7875).
+///
+/// This pins the input to that gate: the course's own defaults, plus the
+/// membership requirement (a learner who hasn't joined can't invite either).
+void main() {
+  late Client client;
+
+  const userId = '@test:fakeServer.notExisting';
+
+  setUp(() async {
+    client = await getTestClient();
+  });
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  Room courseRoom({
+    required int ownPowerLevel,
+    Membership membership = Membership.join,
+  }) {
+    final room = Room(
+      id: '!course:fakeServer.notExisting',
+      client: client,
+      membership: membership,
+    );
+    room.setState(
+      Event(
+        type: EventTypes.RoomPowerLevels,
+        content: {
+          ...RoomDefaults.defaultPowerLevelsContent(),
+          'users': {userId: ownPowerLevel},
+        },
+        stateKey: '',
+        senderId: userId,
+        eventId: '\$powerLevels',
+        originServerTs: DateTime.now(),
+        room: room,
+      ),
+    );
+    return room;
+  }
+
+  test('a learner at the default power level cannot invite to a course', () {
+    expect(courseRoom(ownPowerLevel: 0).canInvite, false);
+  });
+
+  test('a teacher/admin can invite to a course', () {
+    expect(courseRoom(ownPowerLevel: 50).canInvite, true);
+    expect(courseRoom(ownPowerLevel: 100).canInvite, true);
+  });
+
+  test('an un-joined user cannot invite, whatever the power levels say', () {
+    expect(
+      courseRoom(ownPowerLevel: 100, membership: Membership.invite).canInvite,
+      false,
+    );
+  });
+}


### PR DESCRIPTION
## What

The "Invite friends to my course" CTA on the activity start page only shows to learners who can actually invite.

## Why

Closes #7875

Courses are created with `invite: 50` (`RoomDefaults.defaultPowerLevelsContent`), so an ordinary member sits below the bar. The CTA — shown when a 3–4 person activity doesn't have enough coursemates — was unconditional, so tapping it took them to the course invite page where every invite just errored.

`NotStartedSessionController.canInviteToCourse` (`course.canInvite`) now gates the button, and `inviteToCourse()` early-returns on the same check so the nav can't fire from another path. The "This activity needs N more members" text and the "Pick a different activity" CTA are unchanged, so a learner without the permission still has somewhere to go.

Hide-vs-disable: the issue body says "Don't show this button", its TO TEST line says "disabled". Hiding was chosen — a greyed button with no explanation reads as broken. QA should expect the button to be **absent**, not disabled.

## Testing

- **Unit** — `fvm flutter test test/pangea/course_invite_permission_gate_test.dart` (3 pass). New test pins the gate's input against the course defaults: PL 0 can't invite, PL 50/100 can, an un-joined user can't regardless of power levels.
- **Unit (full suite)** — `fvm flutter test`: 1677 pass, 3 skipped.
- **Analyzer** — `fvm flutter analyze` on both changed `lib/` files and the new test: clean. `fvm dart format`: no changes.
- Smoke / eval / load: N/A — no paid-API or capacity surface.
- **Not manually verified in-app.** Reproducing needs a second account that is a non-admin member of a course; the issue's TO TEST steps are unrun and should go through the QA flow on staging.

## Accessibility

No new or changed controls — an existing button becomes conditional.

## Deploy Notes

None
