### PR TITLE
fix(phonetic-transcription): show the play affordance only when a transcription is loaded

### DIFF
--- a/lib/routes/chat/events/phonetic_transcription/phonetic_transcription_widget.dart
+++ b/lib/routes/chat/events/phonetic_transcription/phonetic_transcription_widget.dart
@@ -133,59 +133,78 @@ class _PhoneticTranscriptionWidgetState
       );
     }
 
-    return HoverBuilder(
-      builder: (context, hovering) {
-        return Tooltip(
-          message: _isPlaying
-              ? L10n.of(context).stop
-              : L10n.of(context).playAudio,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: () => _handleAudioTap(targetId),
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 150),
-              decoration: BoxDecoration(
-                color: hovering
-                    ? Colors.grey.withAlpha((0.2 * 255).round())
-                    : Colors.transparent,
-                borderRadius: BorderRadius.circular(6),
-              ),
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              child: CompositedTransformTarget(
-                link: MatrixState.pAnyState.layerLinkAndKey(targetId).link,
-                child: PhoneticTranscriptionBuilder(
-                  key: MatrixState.pAnyState.layerLinkAndKey(targetId).key,
-                  textLanguage: widget.textLanguage,
-                  text: widget.text,
-                  reloadNotifier: widget.reloadNotifier,
-                  builder: (context, controller) {
-                    return switch (controller.state) {
-                      AsyncError(error: final error) =>
-                        error is UnsubscribedException
-                            ? ErrorIndicator(
-                                message: L10n.of(
-                                  context,
-                                ).subscribeToUnlockTranscriptions,
-                                onTap: () => context.go(
-                                  WorkspaceNav.openSettings(
-                                    GoRouterState.of(context).uri,
-                                    page: 'subscription',
-                                  ),
-                                ),
-                              )
-                            : ErrorIndicator(
-                                message: L10n.of(
-                                  context,
-                                ).failedToFetchTranscription,
-                              ),
-                      AsyncLoaded<PTResponse>(value: final ptResponse) => Row(
+    return PhoneticTranscriptionBuilder(
+      textLanguage: widget.textLanguage,
+      text: widget.text,
+      reloadNotifier: widget.reloadNotifier,
+      builder: (context, controller) {
+        final state = controller.state;
+
+        // Only a loaded transcription is playable, so the play affordance —
+        // tooltip, hover highlight and tap target — wraps that state alone.
+        // While loading there is no pronunciation yet and on failure there
+        // never will be; either way the audio icon is absent, so a "Play"
+        // tooltip over the shimmer or the error chip promises audio that isn't
+        // there (#7843). Padding matches the container below so the layout
+        // doesn't shift when the transcription lands.
+        if (state is! AsyncLoaded<PTResponse>) {
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            child: switch (state) {
+              AsyncError(error: final error) =>
+                error is UnsubscribedException
+                    ? ErrorIndicator(
+                        message: L10n.of(
+                          context,
+                        ).subscribeToUnlockTranscriptions,
+                        onTap: () => context.go(
+                          WorkspaceNav.openSettings(
+                            GoRouterState.of(context).uri,
+                            page: 'subscription',
+                          ),
+                        ),
+                      )
+                    : ErrorIndicator(
+                        message: L10n.of(context).failedToFetchTranscription,
+                      ),
+              _ => const TextLoadingShimmer(width: 125.0, height: 20.0),
+            },
+          );
+        }
+
+        return HoverBuilder(
+          builder: (context, hovering) {
+            return Tooltip(
+              message: _isPlaying
+                  ? L10n.of(context).stop
+                  : L10n.of(context).playAudio,
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => _handleAudioTap(targetId),
+                child: AnimatedContainer(
+                  duration: const Duration(milliseconds: 150),
+                  decoration: BoxDecoration(
+                    color: hovering
+                        ? Colors.grey.withAlpha((0.2 * 255).round())
+                        : Colors.transparent,
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
+                  child: CompositedTransformTarget(
+                    link: MatrixState.pAnyState.layerLinkAndKey(targetId).link,
+                    child: KeyedSubtree(
+                      key: MatrixState.pAnyState.layerLinkAndKey(targetId).key,
+                      child: Row(
                         spacing: 8.0,
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           Flexible(
                             child: Text(
                               disambiguate(
-                                ptResponse.pronunciations,
+                                state.value.pronunciations,
                                 pos: widget.pos,
                                 morph: widget.morph,
                               ).displayTranscription,
@@ -206,13 +225,12 @@ class _PhoneticTranscriptionWidgetState
                           ),
                         ],
                       ),
-                      _ => const TextLoadingShimmer(width: 125.0, height: 20.0),
-                    };
-                  },
+                    ),
+                  ),
                 ),
               ),
-            ),
-          ),
+            );
+          },
         );
       },
     );


### PR DESCRIPTION
## What

`PhoneticTranscriptionWidget` now shows its play affordance — "Play"/"Stop" tooltip, hover highlight, tap target — only when a transcription has actually loaded.

## Why

Closes #7843

The interaction wrapper (`Tooltip` → `GestureDetector` → hover-highlight `AnimatedContainer`) sat outside `PhoneticTranscriptionBuilder`, so it wrapped every state. Hovering a "Failed to fetch transcription" chip produced a "Play" tooltip over an error message with no audio icon and nothing to play — and the grey rounded box behind the chip in the issue screenshot is that same wrapper's hover highlight. Two knock-ons from the same cause: the tap target still fired `_handleAudioTap` on the error, and the `UnsubscribedException` variant's "go to subscription" `TextButton` was nested inside a `GestureDetector` that plays audio.

The loading shimmer had the identical problem, so it is fixed in the same pass rather than left to a follow-up. It is not cosmetic there: the phoneme override resolves cache-only at playback time ([word-text-to-speech.instructions.md § Phoneme playback](.github/instructions/word-text-to-speech.instructions.md#phoneme-playback)), so a tap before the PT fetch landed fell through to un-disambiguated audio — the wrong reading for a heteronym.

`PhoneticTranscriptionBuilder` is hoisted above the wrapper; idle/loading/error render bare inside the same padding, so nothing shifts when the transcription lands. The layer-link `GlobalKey` moved onto a `KeyedSubtree` around the rendered content inside `CompositedTransformTarget` — same render box as before, so `TtsDisabledPopup` anchoring is unchanged. Dropping the key off the builder is safe: its `didUpdateWidget` already refetches on text/language change. `textOnly` callers are untouched (they never had the wrapper).

Surfaces affected: analytics vocab practice (`ongoing_analytics_practice_session_view`, `analytics_practice_choices_widget`, `audio_choice_card`) and the chat word card (`word_zoom_widget`).

## Testing

- **Unit (full suite)** — `fvm flutter test`: 1674 pass, 3 skipped.
- **Analyzer** — `fvm flutter analyze lib/`: clean. Formatted with `fvm dart format`.
- Smoke / eval / load: N/A — no paid-API or capacity surface. No `e2e/trigger-map.json` glob covers `lib/routes/chat/events/phonetic_transcription/**`.
- **Manual: not run — environment blocker.** Reproducing needs a failed PT fetch inside vocab practice on a logged-in session; the local `.env` carries no `TEST_MATRIX_*` credentials, so `?devlogin=1` can't sign in. No widget test either: the error path reaches `MatrixState.pangeaController`, which needs a booted `MatrixState` widget — no existing test does that. The issue's TO TEST steps are to be run against staging after deploy, watching both the failure state and the shimmer→loaded transition.

## Accessibility

The removed `Tooltip` was the accessible name for the wrapped subtree. In the error state the name is unchanged in substance — `ErrorIndicator` already exposes its message via a `liveRegion` `Semantics`, and that message ("Failed to fetch transcription") is now the name instead of a misleading "Play". The loading shimmer is decorative and has no control to name. The loaded state keeps its tooltip.

## Deploy Notes

None
