### PR TITLE
fix: ensure participants are loaded for activity session rooms on map

### DIFF
--- a/lib/features/activity_sessions/activity_roles_room_extension.dart
+++ b/lib/features/activity_sessions/activity_roles_room_extension.dart
@@ -60,6 +60,22 @@ Map<String, ActivityRoleModel> filterAssignedRoles(
   roles.entries.where((r) => !roleHolderVacated(membershipOf(r.value.userId))),
 );
 
+/// Whether [roles]' seat count is resting on the [roleHolderVacated] fallback
+/// instead of on evidence: at least one holder has no LOADED `m.room.member`
+/// event ([membershipOf] returns null), so its seat counts as occupied only
+/// because nothing proves otherwise.
+///
+/// Member events never ride the SDK's preloaded-state path — they live in
+/// their own store and come back into room state only through
+/// [Room.requestParticipants] — so this is true for every session room the
+/// learner hasn't opened this app session. The world map uses it to pick the
+/// rooms worth a member refill before trusting their seats (#8045).
+@visibleForTesting
+bool hasUnresolvedSeatEvidence(
+  Map<String, ActivityRoleModel>? roles,
+  String? Function(String userId) membershipOf,
+) => roles != null && roles.values.any((r) => membershipOf(r.userId) == null);
+
 /// Claim guard for [ActivityRolesRoomExtension.joinActivity], keyed by role
 /// ID: `updateRole` overwrites by id, so the guard must match on the same key
 /// (the old name-based check on the membership-filtered map let a claim on an
@@ -157,6 +173,13 @@ extension ActivityRolesRoomExtension on Room {
     if (roles == null) return null;
     return filterAssignedRoles(roles, _membershipOf);
   }
+
+  /// True when this session's seat math is resting on unloaded member state —
+  /// see [hasUnresolvedSeatEvidence]. Cheap: reads the loaded member list, never
+  /// fetches. It flags the room for the world map's member-refill sweep
+  /// (`WorldMapPinsManager.loadSessionParticipants`).
+  bool get hasUnresolvedSeats =>
+      hasUnresolvedSeatEvidence(activityRoles?.roles, _membershipOf);
 
   Future<void> joinActivity(ActivityRole role) async {
     final currentRoles = activityRoles ?? ActivityRolesModel.empty;

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -218,6 +218,7 @@ class WorldMapController extends State<WorldMap>
       _rebuildObjectiveCache(client);
       _recomputePinged(client);
       _discoverCoursemateSessions(client);
+      _loadSessionParticipants(client);
       _syncSub?.cancel();
       _syncSub = client.onSync.stream
           .where((s) => s.hasRoomUpdate)
@@ -228,6 +229,7 @@ class WorldMapController extends State<WorldMap>
             _maybeRebuildObjectiveCache(client);
             _recomputePinged(client);
             _discoverCoursemateSessions(client);
+            _loadSessionParticipants(client);
             // Keep the "can't start" count live: a new invite/join changes the
             // members available to fill roles, so re-fetch (rate-limited by this
             // handler) — a dimmed pin un-dims once enough people are in.
@@ -437,6 +439,17 @@ class WorldMapController extends State<WorldMap>
   Future<void> _recomputePinged(Client client) async {
     await _pinsManager.recomputePinged(client);
     if (mounted) setState(() {});
+  }
+
+  /// Refill the member lists the map's seat math and participant rows read —
+  /// see [WorldMapPinsManager.loadSessionParticipants] (#8045). Runs on the
+  /// same triggers as discovery: once on attach, then draining on sync.
+  Future<void> _loadSessionParticipants(Client client) async {
+    if (!await _pinsManager.loadSessionParticipants(client)) return;
+    // Members decide both halves of a live large card — the ongoing
+    // pending/active split (seats remaining) and the avatar row itself — so a
+    // fill has to re-derive signals, not just repaint.
+    if (mounted) _recomputeProgress();
   }
 
   Future<void> _discoverCoursemateSessions(Client client) async {

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -4,6 +4,8 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:matrix/matrix.dart';
 
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_session_discovery.dart';
 import 'package:fluffychat/features/activity_sessions/discovered_sessions_cache.dart';
 import 'package:fluffychat/features/bot/utils/bot_name.dart';
@@ -24,6 +26,27 @@ import 'package:fluffychat/routes/world/world_map_ranking.dart';
 import 'package:fluffychat/routes/world/world_map_search_overlay.dart';
 import 'package:fluffychat/routes/world/world_map_signals.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
+
+/// The pure rule behind [WorldMapPinsManager.loadSessionParticipants]'s room
+/// selection (#8045).
+///
+/// A room never filled ([everFilled] false) earns a refill while its seats are
+/// still resting on unloaded membership ([hasUnresolvedSeats]) — the startup
+/// case, where no `m.room.member` event has been read back into room state at
+/// all. A room already filled earns one only when its joined-member count has
+/// *moved* ([filledAtJoinedCount] vs [joinedCount]): sync merges the room
+/// summary even for the partial rooms whose member events it skips, so a moved
+/// count is real evidence that someone joined or left since. Comparing against
+/// the count at fill time — rather than asking whether the loaded list looks
+/// complete — is what keeps this loop-free: a room whose count the server
+/// reports inconsistently re-qualifies once and then never again.
+@visibleForTesting
+bool needsParticipantRefill({
+  required bool everFilled,
+  required int? filledAtJoinedCount,
+  required int? joinedCount,
+  required bool hasUnresolvedSeats,
+}) => everFilled ? filledAtJoinedCount != joinedCount : hasUnresolvedSeats;
 
 class WorldMapPinsManager {
   static final ValueNotifier<bool> notifier = ValueNotifier<bool>(false);
@@ -90,6 +113,28 @@ class WorldMapPinsManager {
   /// (the learner is not a member). Folded into [Client.deriveActivitySignals] as
   /// extra facts. See world-map.instructions.md ("Discovering joinable sessions").
   List<ActivitySessionFacts> _discoveredSessionFacts = const [];
+
+  /// Room id → the joined-member count its member list was last filled at, so
+  /// [loadSessionParticipants] sweeps a room once rather than on every sync
+  /// tick. A *changed* count re-qualifies it: sync merges the room summary even
+  /// for the partial rooms whose member events it skips, so a count that no
+  /// longer matches means someone joined or left since the fill. An unchanged
+  /// count never re-triggers, so a room the server reports inconsistently can't
+  /// put the sweep in a loop.
+  final Map<String, int?> _participantsLoadedAtCount = {};
+
+  /// Guards against overlapping member-refill sweeps.
+  bool _loadingParticipants = false;
+
+  /// Epoch ms of the last member-refill sweep. A filled room is skipped by
+  /// [_participantsLoadedAtCount], so this only paces retries of rooms the
+  /// sweep failed to fill and the drain of a long backlog.
+  int _lastParticipantLoadMs = 0;
+
+  /// Rooms filled per sweep. Most fills resolve from the local database with no
+  /// network at all, but a learner with a long activity history shouldn't do
+  /// them all at once; the sync listener drains the remainder.
+  static const int _participantLoadBatch = 25;
 
   /// Course members available to fill activity roles in the currently
   /// course-scoped map (the start page's invite math via
@@ -193,6 +238,85 @@ class WorldMapPinsManager {
       pingedActivityIds: pinged,
       extraFacts: _discoveredSessionFacts,
     );
+  }
+
+  /// Whether [room] earns a member refill this sweep — the Matrix-reading shell
+  /// over [needsParticipantRefill].
+  bool _needsParticipantRefill(Room room) => needsParticipantRefill(
+    everFilled: _participantsLoadedAtCount.containsKey(room.id),
+    filledAtJoinedCount: _participantsLoadedAtCount[room.id],
+    joinedCount: room.summary.mJoinedMemberCount,
+    hasUnresolvedSeats: room.hasUnresolvedSeats,
+  );
+
+  /// Refill the member lists behind the map's seat math and participant rows.
+  ///
+  /// `m.room.member` events never ride the SDK's preloaded-state path (they
+  /// live in their own store and return to room state only through
+  /// [Room.requestParticipants]), so at startup `Room.getParticipants()` is
+  /// empty for every session room the learner hasn't opened this session. That
+  /// left large cards rendering on guesses (#8045): the avatar row read empty,
+  /// and [Room.assignedRoles] scored every seat on the "unknown membership =
+  /// still occupied" fallback ([roleHolderVacated]) rather than on evidence —
+  /// so the pending/active split and the seat row were both decided without the
+  /// facts they are supposed to read.
+  ///
+  /// Cheap by construction: [Room.requestParticipants] refills from the local
+  /// database first and reaches the network only when that is still short of
+  /// the room's summary counts, and a room is swept once until its member count
+  /// moves ([_needsParticipantRefill]). Returns true when it filled anything,
+  /// so the caller re-derives signals.
+  Future<bool> loadSessionParticipants(Client client) async {
+    if (_loadingParticipants) return false;
+    final nowMs = DateTime.now().millisecondsSinceEpoch;
+    if (nowMs - _lastParticipantLoadMs < 3000) return false;
+
+    final pending = client.rooms
+        .where(
+          (r) =>
+              r.membership == Membership.join &&
+              r.activityId != null &&
+              // A finished session produces no live pin state and renders no
+              // participant row, so its seats never reach the screen.
+              !r.hasCompletedRole &&
+              _needsParticipantRefill(r),
+        )
+        .take(_participantLoadBatch)
+        .toList();
+    if (pending.isEmpty) return false;
+
+    _loadingParticipants = true;
+    _lastParticipantLoadMs = nowMs;
+    var filled = false;
+    try {
+      for (final room in pending) {
+        try {
+          // `cache: true` is load-bearing: it defaults to `encrypted`, and
+          // without it the SDK returns the members without writing them into
+          // room state — leaving `getParticipants()`, which the seat math and
+          // the avatar row actually read, exactly as empty as before.
+          await room.requestParticipants(const [
+            Membership.join,
+            Membership.invite,
+            Membership.knock,
+          ], false, true);
+          _participantsLoadedAtCount[room.id] = room.summary.mJoinedMemberCount;
+          filled = true;
+        } catch (e, s) {
+          // A room that won't load its members keeps the fallback seats it
+          // already had; the throttle above paces the retry.
+          ErrorHandler.logError(
+            e: e,
+            s: s,
+            m: 'session participant refill failed',
+            data: {'roomId': room.id},
+          );
+        }
+      }
+    } finally {
+      _loadingParticipants = false;
+    }
+    return filled;
   }
 
   /// Discover open sessions the learner is not yet in — BOTH reads of

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -295,11 +295,11 @@ class WorldMapPinsManager {
           // without it the SDK returns the members without writing them into
           // room state — leaving `getParticipants()`, which the seat math and
           // the avatar row actually read, exactly as empty as before.
-          await room.requestParticipants(const [
-            Membership.join,
-            Membership.invite,
-            Membership.knock,
-          ], false, true);
+          await room.requestParticipants(
+            const [Membership.join, Membership.invite, Membership.knock],
+            false,
+            true,
+          );
           _participantsLoadedAtCount[room.id] = room.summary.mJoinedMemberCount;
           filled = true;
         } catch (e, s) {

--- a/test/pangea/activity_role_seat_test.dart
+++ b/test/pangea/activity_role_seat_test.dart
@@ -66,6 +66,43 @@ void main() {
     });
   });
 
+  group('hasUnresolvedSeatEvidence', () {
+    final roles = {
+      'bot-role': role('bot-role', '@bot:server'),
+      'human-role': role('human-role', '@human:server'),
+    };
+
+    test('no member events loaded — the initial-load state that left large '
+        'cards deciding pending-vs-active without the facts (#8045)', () {
+      expect(hasUnresolvedSeatEvidence(roles, (_) => null), isTrue);
+    });
+
+    test('one unloaded holder is enough to distrust the seat count', () {
+      expect(
+        hasUnresolvedSeatEvidence(
+          roles,
+          (id) => id == '@human:server' ? 'join' : null,
+        ),
+        isTrue,
+      );
+    });
+
+    test('every holder resolved — nothing to refill', () {
+      expect(
+        hasUnresolvedSeatEvidence(
+          roles,
+          (id) => id == '@human:server' ? 'join' : 'leave',
+        ),
+        isFalse,
+      );
+    });
+
+    test('a room with no activity-role state has no seats to resolve', () {
+      expect(hasUnresolvedSeatEvidence(null, (_) => null), isFalse);
+      expect(hasUnresolvedSeatEvidence({}, (_) => null), isFalse);
+    });
+  });
+
   group('guardSeatClaim', () {
     test('claiming a seat whose holder is absent from loaded members throws '
         '— the overwrite hole: updateRole keys by id, so an allowed claim '

--- a/test/pangea/world/session_participant_refill_test.dart
+++ b/test/pangea/world/session_participant_refill_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/world/world_map_pins_manager.dart';
+
+/// #8045: the map decides a large card's seat row and its ongoing
+/// pending-vs-active split from `Room.getParticipants()`, but `m.room.member`
+/// events never ride the SDK's preloaded-state path — so at startup that list
+/// is empty for every session room the learner hasn't opened, and the seats
+/// fall back to "unknown membership = still occupied" instead of evidence.
+/// [needsParticipantRefill] picks the rooms worth a member refill.
+void main() {
+  group('needsParticipantRefill — a room never filled', () {
+    test('unresolved seats earn a refill: the startup state behind the '
+        'avatar-less, wrongly-seated large cards', () {
+      expect(
+        needsParticipantRefill(
+          everFilled: false,
+          filledAtJoinedCount: null,
+          joinedCount: 2,
+          hasUnresolvedSeats: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('seats already resting on real membership are left alone', () {
+      expect(
+        needsParticipantRefill(
+          everFilled: false,
+          filledAtJoinedCount: null,
+          joinedCount: 2,
+          hasUnresolvedSeats: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('needsParticipantRefill — a room already filled', () {
+    test('an unchanged joined count never re-qualifies, so an inconsistently '
+        'reported room cannot put the sweep in a loop', () {
+      expect(
+        needsParticipantRefill(
+          everFilled: true,
+          filledAtJoinedCount: 2,
+          joinedCount: 2,
+          // Would have earned a refill had it never been filled.
+          hasUnresolvedSeats: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a moved joined count re-qualifies it — someone joined or left since '
+        'the fill, and sync skips member events for these partial rooms', () {
+      expect(
+        needsParticipantRefill(
+          everFilled: true,
+          filledAtJoinedCount: 2,
+          joinedCount: 1,
+          hasUnresolvedSeats: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a count that only becomes known after the fill re-qualifies once', () {
+      expect(
+        needsParticipantRefill(
+          everFilled: true,
+          filledAtJoinedCount: null,
+          joinedCount: 3,
+          hasUnresolvedSeats: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a count that stays unknown never re-qualifies', () {
+      expect(
+        needsParticipantRefill(
+          everFilled: true,
+          filledAtJoinedCount: null,
+          joinedCount: null,
+          hasUnresolvedSeats: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/pangea/world/session_participant_refill_test.dart
+++ b/test/pangea/world/session_participant_refill_test.dart
@@ -64,17 +64,20 @@ void main() {
       );
     });
 
-    test('a count that only becomes known after the fill re-qualifies once', () {
-      expect(
-        needsParticipantRefill(
-          everFilled: true,
-          filledAtJoinedCount: null,
-          joinedCount: 3,
-          hasUnresolvedSeats: false,
-        ),
-        isTrue,
-      );
-    });
+    test(
+      'a count that only becomes known after the fill re-qualifies once',
+      () {
+        expect(
+          needsParticipantRefill(
+            everFilled: true,
+            filledAtJoinedCount: null,
+            joinedCount: 3,
+            hasUnresolvedSeats: false,
+          ),
+          isTrue,
+        );
+      },
+    );
 
     test('a count that stays unknown never re-qualifies', () {
       expect(


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
