### PR TITLE
fix(analytics): keep the level badge inside its box so it shimmers gray

### DIFF
--- a/lib/routes/world/hex_level_badge.dart
+++ b/lib/routes/world/hex_level_badge.dart
@@ -71,36 +71,51 @@ class HexLevelBadge extends StatelessWidget {
   }
 }
 
-/// Paints the badge hexagon: vertices at the horizontal extremes, flat top and
-/// bottom edges, gold fill with a darker gold outline (the Figma component).
+/// Builds the badge hexagon inside [size]: vertices at the horizontal extremes,
+/// flat top and bottom edges (the Figma component).
+///
+/// The path is inset by half [hexBadgeStrokeWidth] on every side so the
+/// centered outline — and the round joins, which reach exactly half a stroke
+/// past each vertex — paint **entirely inside** the badge's own box. Nothing
+/// may bleed outside: the narrow analytics bar sits the badge flush against
+/// the left edge of a shimmering `Stack`, and `Shimmer`'s mask covers only the
+/// render box, so an escaping pixel keeps its real gold while the rest of the
+/// cluster is gray (#7801). [XpBorderPainter] insets for the same reason.
+@visibleForTesting
+Path hexBadgePath(Size size) {
+  final d = hexBadgeStrokeWidth / 2;
+  final w = size.width - hexBadgeStrokeWidth;
+  final h = size.height - hexBadgeStrokeWidth;
+  return Path()
+    ..moveTo(d, d + h / 2)
+    ..lineTo(d + w * 0.25, d)
+    ..lineTo(d + w * 0.75, d)
+    ..lineTo(d + w, d + h / 2)
+    ..lineTo(d + w * 0.75, d + h)
+    ..lineTo(d + w * 0.25, d + h)
+    ..close();
+}
+
+/// Width of the badge's darker-gold outline.
+const double hexBadgeStrokeWidth = 2.5;
+
+/// Paints the badge hexagon ([hexBadgePath]) with a gold fill and a darker gold
+/// outline (the Figma component).
 class _HexBadgePainter extends CustomPainter {
   final Color fill;
   final Color border;
 
   const _HexBadgePainter({required this.fill, required this.border});
 
-  Path _hex(Size size) {
-    final w = size.width;
-    final h = size.height;
-    return Path()
-      ..moveTo(0, h / 2)
-      ..lineTo(w * 0.25, 0)
-      ..lineTo(w * 0.75, 0)
-      ..lineTo(w, h / 2)
-      ..lineTo(w * 0.75, h)
-      ..lineTo(w * 0.25, h)
-      ..close();
-  }
-
   @override
   void paint(Canvas canvas, Size size) {
-    final path = _hex(size);
+    final path = hexBadgePath(size);
     canvas.drawPath(path, Paint()..color = fill);
     canvas.drawPath(
       path,
       Paint()
         ..style = PaintingStyle.stroke
-        ..strokeWidth = 2.5
+        ..strokeWidth = hexBadgeStrokeWidth
         ..strokeJoin = StrokeJoin.round
         ..color = border,
     );

--- a/test/pangea/world/hex_level_badge_test.dart
+++ b/test/pangea/world/hex_level_badge_test.dart
@@ -1,0 +1,73 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/world/hex_level_badge.dart';
+
+/// Pins the paint-bounds contract behind #7801: the level badge's hexagon must
+/// stay inside its own render box.
+///
+/// The narrow analytics bar sits the badge flush against the left edge of the
+/// `Stack` that `Shimmer` wraps while analytics initialize, and `Shimmer`'s
+/// mask rect is exactly the render box — so a stroke that bleeds one pixel
+/// past the box is never recolored, and the hexagon's left tip stayed gold
+/// while the rest of the cluster shimmered gray. The path is inset by half the
+/// stroke; the round joins then reach the box edge and no further.
+void main() {
+  /// The sizes the badge is actually rendered at: the bar's Figma frame, the
+  /// app-bar mini badge (30x26 base scaled by 0.75), and the class defaults.
+  const sizes = <Size>[Size(42.0, 36.0), Size(22.5, 19.5), Size(48.0, 42.0)];
+
+  group('hexBadgePath', () {
+    for (final size in sizes) {
+      test('strokes entirely inside a ${size.width}x${size.height} box', () {
+        // Round joins extend half a stroke past each vertex in every
+        // direction, so the painted extent is the path bounds inflated by
+        // half the stroke width.
+        final painted = hexBadgePath(
+          size,
+        ).getBounds().inflate(hexBadgeStrokeWidth / 2);
+
+        // Tolerate float noise only; a real overflow is a full 1.25px.
+        const epsilon = 0.01;
+        expect(painted.left, greaterThanOrEqualTo(-epsilon));
+        expect(painted.top, greaterThanOrEqualTo(-epsilon));
+        expect(painted.right, lessThanOrEqualTo(size.width + epsilon));
+        expect(painted.bottom, lessThanOrEqualTo(size.height + epsilon));
+      });
+
+      test('still fills the ${size.width}x${size.height} box', () {
+        // The inset must not shrink the mark: the outline's outer edge should
+        // land ON the box, not somewhere inside it.
+        final painted = hexBadgePath(
+          size,
+        ).getBounds().inflate(hexBadgeStrokeWidth / 2);
+
+        expect(painted.width, closeTo(size.width, 0.01));
+        expect(painted.height, closeTo(size.height, 0.01));
+      });
+    }
+
+    test(
+      'keeps the hexagon silhouette — pointy sides, flat top and bottom',
+      () {
+        const size = Size(42.0, 36.0);
+        final path = hexBadgePath(size);
+        final d = hexBadgeStrokeWidth / 2;
+
+        // Left and right vertices at mid-height, on the inset edges.
+        expect(path.contains(Offset(d + 0.1, size.height / 2)), isTrue);
+        expect(
+          path.contains(Offset(size.width - d - 0.1, size.height / 2)),
+          isTrue,
+        );
+        // The corners the hexagon cuts away are outside it.
+        expect(path.contains(Offset(d + 0.1, d + 0.1)), isFalse);
+        expect(
+          path.contains(Offset(size.width - d - 0.1, size.height - d - 0.1)),
+          isFalse,
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What

Inset the hex level badge's outline by half its stroke so nothing paints outside the badge's render box — the escaping sliver was the gold spot at the hexagon's left tip during the narrow bar's loading shimmer.

## Why

Closes #7801

`_HexBadgePainter` strokes a 2.5px outline **centered** on a path whose vertices sit exactly on the render box's edge, so half the stroke landed 1.25px outside the badge's own bounds. In the narrow analytics bar the badge is `Positioned(left: 0)`, flush against the left edge of the `Stack` that `Shimmer` wraps while analytics initialize (`world_analytics_bar.dart`), and `shimmer`'s `_ShimmerFilter` sets `maskRect = offset & size` — exactly the render box. Anything painted outside that rect is never recolored, so the tip kept its real gold while the rest of the cluster went gray.

Narrow-screen-only because the web cluster's `LevelRibbon` is an SVG that stays in bounds, and `XpBorderPainter` already insets by `stroke / 2`. This fix does the same thing there; the round joins then reach the box edge and no further, so the mark keeps its full 42x36 silhouette.

Bar layout itself is unchanged — see routing.instructions.md § "Single-column analytics nav bar" for the cluster's design.

## Testing

- **Unit/widget** — `fvm flutter test test/pangea/world/ test/pangea/navigation/`: 398 passed. `fvm flutter analyze` clean.
- **New regression test** (`test/pangea/world/hex_level_badge_test.dart`, 7 cases): asserts the painted extent — path bounds inflated by half the stroke — stays inside the box at all three sizes the badge renders at, and that the hexagon silhouette is unchanged. Confirmed it fails on the old geometry (`Rect.fromLTRB(-1.3, -1.3, 43.3, 37.3)` against a 42x36 box).
- **Pixel readback** (throwaway harness, `RepaintBoundary.toImage` over the real badge under a real `Shimmer` in the bar's layout): old geometry → 28 gold pixels clustered at the left edge, mid-height; new geometry → 0. Location matches the gold pixels decoded from the issue screenshot (its hexagon's left vertex). Not committed — the shimmer's endless animation hangs the test on teardown; the committed geometry test pins the same invariant deterministically.
- **Not run: live app.** Reproducing "change languages on a narrow screen" needs a live login and a transient shimmer window, and the local iOS sim build is blocked on `receive_sharing_intent`. The readback above exercises the real widget under the real `Shimmer` at the bar's real geometry, but it is not a live-app check — the issue's TO TEST still wants a human pass on staging.
- Smoke/eval/load: N/A — no service surface touched.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)