### PR TITLE
fix(toolbar): scroll word card emoji choices when they overflow

### DIFF
--- a/lib/routes/chat/toolbar/word_card/lemma_reaction_picker.dart
+++ b/lib/routes/chat/toolbar/word_card/lemma_reaction_picker.dart
@@ -203,110 +203,98 @@ class LemmaReactionPickerState extends State<LemmaReactionPicker>
       builder: (context, controller) {
         return switch (controller.state) {
           AsyncError() => const SizedBox.shrink(),
-          AsyncLoaded(value: final lemmaInfo) => SizedBox(
-            height: 70.0,
-            child: Row(
-              spacing: 4.0,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                ...lemmaInfo.emoji.map((emoji) {
-                  final selected = _selectedEmoji == emoji;
-                  final targetId = "$targetIdBase-$emoji";
+          AsyncLoaded(value: final lemmaInfo) => ScrollableEmojiRow(
+            children: [
+              ...lemmaInfo.emoji.map((emoji) {
+                final selected = _selectedEmoji == emoji;
+                final targetId = "$targetIdBase-$emoji";
 
-                  final showReactionBadge = canShowReactionBadge && selected;
-                  final badge = showReactionBadge
-                      ? const Icon(Icons.add_reaction, size: 12.0)
-                      : null;
+                final showReactionBadge = canShowReactionBadge && selected;
+                final badge = showReactionBadge
+                    ? const Icon(Icons.add_reaction, size: 12.0)
+                    : null;
 
-                  final enabled = selected
-                      ? globallyEnableReactions
-                      : globallyEnableSelection;
+                final enabled = selected
+                    ? globallyEnableReactions
+                    : globallyEnableSelection;
 
-                  return HoverBuilder(
-                    builder: (context, hovered) => MouseRegion(
-                      cursor: enabled
-                          ? SystemMouseCursors.click
-                          : SystemMouseCursors.basic,
-                      child: GestureDetector(
-                        onTap: enabled
-                            ? () => emoji != _selectedEmoji
-                                  ? _setLemmaEmoji(emoji, targetId)
-                                  : _sendOrRedactReaction(emoji)
-                            : null,
-                        child: Stack(
-                          children: [
-                            ShimmerBackground(
-                              enabled: enabled && _selectedEmoji == null,
-                              delayBetweenPulses: const Duration(seconds: 5),
-                              child: CompositedTransformTarget(
-                                link: MatrixState.pAnyState
+                return HoverBuilder(
+                  builder: (context, hovered) => MouseRegion(
+                    cursor: enabled
+                        ? SystemMouseCursors.click
+                        : SystemMouseCursors.basic,
+                    child: GestureDetector(
+                      onTap: enabled
+                          ? () => emoji != _selectedEmoji
+                                ? _setLemmaEmoji(emoji, targetId)
+                                : _sendOrRedactReaction(emoji)
+                          : null,
+                      child: Stack(
+                        children: [
+                          ShimmerBackground(
+                            enabled: enabled && _selectedEmoji == null,
+                            delayBetweenPulses: const Duration(seconds: 5),
+                            child: CompositedTransformTarget(
+                              link: MatrixState.pAnyState
+                                  .layerLinkAndKey(targetId)
+                                  .link,
+                              child: AnimatedContainer(
+                                key: MatrixState.pAnyState
                                     .layerLinkAndKey(targetId)
-                                    .link,
-                                child: AnimatedContainer(
-                                  key: MatrixState.pAnyState
-                                      .layerLinkAndKey(targetId)
-                                      .key,
-                                  duration: const Duration(milliseconds: 200),
-                                  padding: const EdgeInsets.all(10),
-                                  decoration: BoxDecoration(
-                                    color:
-                                        globallyEnableSelection &&
-                                            (hovered || selected)
-                                        ? Theme.of(
-                                            context,
-                                          ).colorScheme.secondary.withAlpha(30)
-                                        : Colors.transparent,
-                                    borderRadius: BorderRadius.circular(
-                                      AppConfig.borderRadius,
-                                    ),
-                                    border: selected
-                                        ? Border.all(
-                                            color: Colors.transparent,
-                                            width: 4,
-                                          )
-                                        : null,
+                                    .key,
+                                duration: const Duration(milliseconds: 200),
+                                padding: const EdgeInsets.all(10),
+                                decoration: BoxDecoration(
+                                  color:
+                                      globallyEnableSelection &&
+                                          (hovered || selected)
+                                      ? Theme.of(
+                                          context,
+                                        ).colorScheme.secondary.withAlpha(30)
+                                      : Colors.transparent,
+                                  borderRadius: BorderRadius.circular(
+                                    AppConfig.borderRadius,
                                   ),
-                                  child: Text(
-                                    emoji,
-                                    style: Theme.of(
-                                      context,
-                                    ).textTheme.headlineSmall,
-                                  ),
+                                  border: selected
+                                      ? Border.all(
+                                          color: Colors.transparent,
+                                          width: 4,
+                                        )
+                                      : null,
+                                ),
+                                child: Text(
+                                  emoji,
+                                  style: Theme.of(
+                                    context,
+                                  ).textTheme.headlineSmall,
                                 ),
                               ),
                             ),
-                            if (badge != null)
-                              Positioned(right: 6, bottom: 6, child: badge),
-                          ],
-                        ),
+                          ),
+                          if (badge != null)
+                            Positioned(right: 6, bottom: 6, child: badge),
+                        ],
                       ),
                     ),
-                  );
-                }),
-              ],
-            ),
+                  ),
+                );
+              }),
+            ],
           ),
-          _ => SizedBox(
-            height: 70.0,
-            child: Row(
-              spacing: 4.0,
-              mainAxisSize: MainAxisSize.min,
-              children: List.generate(
-                3,
-                (_) => Shimmer.fromColors(
-                  baseColor: Colors.transparent,
-                  highlightColor: Theme.of(
-                    context,
-                  ).colorScheme.primary.withAlpha(70),
-                  child: Container(
-                    height: 55.0,
-                    width: 55.0,
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.primary,
-                      borderRadius: BorderRadius.circular(
-                        AppConfig.borderRadius,
-                      ),
-                    ),
+          _ => ScrollableEmojiRow(
+            children: List.generate(
+              3,
+              (_) => Shimmer.fromColors(
+                baseColor: Colors.transparent,
+                highlightColor: Theme.of(
+                  context,
+                ).colorScheme.primary.withAlpha(70),
+                child: Container(
+                  height: 55.0,
+                  width: 55.0,
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primary,
+                    borderRadius: BorderRadius.circular(AppConfig.borderRadius),
                   ),
                 ),
               ),
@@ -314,6 +302,39 @@ class LemmaReactionPickerState extends State<LemmaReactionPicker>
           ),
         };
       },
+    );
+  }
+}
+
+/// Lays the emoji choices out in a centered row that scrolls horizontally
+/// when there are too many of them to fit the width of the word card.
+class ScrollableEmojiRow extends StatelessWidget {
+  final List<Widget> children;
+
+  const ScrollableEmojiRow({super.key, required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 70.0,
+      child: LayoutBuilder(
+        builder: (context, constraints) => SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minWidth: constraints.hasBoundedWidth
+                  ? constraints.maxWidth
+                  : 0.0,
+            ),
+            child: Row(
+              spacing: 4.0,
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: children,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/test/pangea/widgets/scrollable_emoji_row_test.dart
+++ b/test/pangea/widgets/scrollable_emoji_row_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/chat/toolbar/word_card/lemma_reaction_picker.dart';
+
+/// #7931 — a word with 5+ emoji associations overflowed the word card, and the
+/// extra emojis were unreachable. The row scrolls horizontally instead, while
+/// still centering the emojis when they all fit.
+void main() {
+  Future<void> pumpRow(
+    WidgetTester tester, {
+    required int emojiCount,
+    required double width,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: width,
+              child: ScrollableEmojiRow(
+                children: List.generate(
+                  emojiCount,
+                  (i) => SizedBox(
+                    height: 55.0,
+                    width: 55.0,
+                    child: Center(child: Text('e$i')),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('does not overflow when the emojis exceed the available width', (
+    tester,
+  ) async {
+    await pumpRow(tester, emojiCount: 8, width: 200.0);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('scrolls to reveal emojis that do not fit', (tester) async {
+    await pumpRow(tester, emojiCount: 8, width: 200.0);
+
+    final lastEmoji = find.text('e7');
+    expect(lastEmoji, findsOneWidget);
+
+    final beforeScroll = tester.getTopLeft(lastEmoji).dx;
+    await tester.drag(
+      find.byType(ScrollableEmojiRow),
+      const Offset(-200.0, 0.0),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.getTopLeft(lastEmoji).dx, lessThan(beforeScroll));
+  });
+
+  testWidgets('centers the emojis when they all fit', (tester) async {
+    const width = 400.0;
+    await pumpRow(tester, emojiCount: 3, width: width);
+
+    final rowCenter = tester.getCenter(find.byType(ScrollableEmojiRow)).dx;
+    final emojisCenter =
+        (tester.getTopLeft(find.text('e0')).dx +
+            tester.getBottomRight(find.text('e2')).dx) /
+        2;
+
+    expect(emojisCenter, moreOrLessEquals(rowCenter, epsilon: 1.0));
+  });
+}


### PR DESCRIPTION
## What

The word card's emoji choices scroll horizontally instead of overflowing the card.

## Why

Closes #7931

A lemma with 5+ emoji associations rendered into a fixed `Row`, so the extra emojis spilled past the card edge and were unreachable — most visible on narrow screens or with two pages open side by side.

## Testing

- Added `test/pangea/widgets/scrollable_emoji_row_test.dart` — 8 emojis in a 200px-wide card raise no overflow exception, drag reveals the off-screen ones, and 3 emojis stay centered. All 3 pass; the overflow case fails against the pre-fix layout.
- Full unit/widget suite locally under `fvm`: `fvm flutter test` → 1692 passed, 3 skipped (endpoint suites skip without `TEST_MATRIX_*` creds). No `pubspec.lock` churn.
- Manual in-app check deferred to staging QA: reproducing needs a live lemma that happens to carry 5+ emojis, and the local iOS sim build is blocked by `receive_sharing_intent`. The widget test covers the layout behavior directly.

## Deploy Notes

None

### Accessibility

- [x] No new or changed controls — the existing emoji buttons are unchanged; only their container's layout changed.
