### PR TITLE
fix(settings): stop the color swatches from scrolling on their own

### DIFF
--- a/lib/routes/settings/settings_style/color_theme_picker.dart
+++ b/lib/routes/settings/settings_style/color_theme_picker.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/utils/color_value.dart';
+import 'settings_style.dart';
+
+/// The accent-colour swatches on settings > change your style.
+///
+/// Sized to its content: the grid renders every swatch and leaves scrolling to
+/// the page it sits in, so it never scrolls on its own (#7758).
+class ColorThemePicker extends StatelessWidget {
+  /// The platform's dynamic colour, or null where there is none (e.g. web).
+  /// When null, the "system theme" swatch is dropped from the list.
+  final Color? systemColor;
+  final Color? currentColor;
+  final void Function(Color?) onColorSelected;
+
+  const ColorThemePicker({
+    required this.systemColor,
+    required this.currentColor,
+    required this.onColorSelected,
+    super.key,
+  });
+
+  static const double colorPickerSize = 32.0;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = List<Color?>.from(SettingsStyleController.customColors);
+    if (systemColor == null) {
+      colors.remove(null);
+    }
+
+    return Semantics(
+      label: L10n.of(context).colorListLabel,
+      container: true,
+      child: GridView.builder(
+        shrinkWrap: true,
+        // The grid sizes to its content inside the page's scroll view, so it
+        // has nothing of its own to scroll; left scrollable, it only swallowed
+        // drags that should have scrolled the page.
+        physics: const NeverScrollableScrollPhysics(),
+        gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+          maxCrossAxisExtent: 64,
+        ),
+        itemCount: colors.length,
+        itemBuilder: (context, i) {
+          final color = colors[i];
+          return Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Tooltip(
+              message: color == null
+                  ? L10n.of(context).systemTheme
+                  : '#${color.hexValue.toRadixString(16).toUpperCase()}',
+              child: InkWell(
+                borderRadius: BorderRadius.circular(colorPickerSize),
+                onTap: () => onColorSelected(color),
+                child: Material(
+                  color: color ?? systemColor,
+                  elevation: 6,
+                  borderRadius: BorderRadius.circular(colorPickerSize),
+                  child: SizedBox(
+                    width: colorPickerSize,
+                    height: colorPickerSize,
+                    child:
+                        (currentColor == color ||
+                            // #7176: on the default (null) colour the system
+                            // swatch carries the selection, but where there is
+                            // no system colour (web) that swatch is removed and
+                            // the app falls back to its default colour — mark
+                            // that swatch selected so a theme always reads as
+                            // chosen.
+                            (currentColor == null &&
+                                systemColor == null &&
+                                color == AppConfig.chatColor))
+                        ? Center(
+                            child: Icon(
+                              Icons.check,
+                              size: 16,
+                              color: Theme.of(context).colorScheme.onPrimary,
+                            ),
+                          )
+                        : null,
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/routes/settings/settings_style/settings_style_view.dart
+++ b/lib/routes/settings/settings_style/settings_style_view.dart
@@ -4,16 +4,15 @@ import 'package:flutter/material.dart';
 
 import 'package:dynamic_color/dynamic_color.dart';
 
-import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/setting_keys.dart';
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/chat/style_example_message.dart';
 import 'package:fluffychat/utils/account_config.dart';
-import 'package:fluffychat/utils/color_value.dart';
 import 'package:fluffychat/widgets/layouts/max_width_body.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/mxc_image.dart';
+import 'color_theme_picker.dart';
 import 'settings_style.dart';
 
 class SettingsStyleView extends StatelessWidget {
@@ -25,7 +24,6 @@ class SettingsStyleView extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    const colorPickerSize = 32.0;
     final client = Matrix.of(context).client;
     return Semantics(
       label: L10n.of(context).bodyLabel(L10n.of(context).changeTheme),
@@ -88,81 +86,19 @@ class SettingsStyleView extends StatelessWidget {
                   ),
                 ),
               ),
+              // #Pangea
+              // The swatch grid lives in its own widget so it can be exercised
+              // directly in tests; see color_theme_picker.dart.
               DynamicColorBuilder(
-                builder: (light, dark) {
-                  final systemColor =
-                      Theme.of(context).brightness == Brightness.light
+                builder: (light, dark) => ColorThemePicker(
+                  systemColor: Theme.of(context).brightness == Brightness.light
                       ? light?.primary
-                      : dark?.primary;
-                  final colors = List<Color?>.from(
-                    SettingsStyleController.customColors,
-                  );
-                  if (systemColor == null) {
-                    colors.remove(null);
-                  }
-                  return Semantics(
-                    label: L10n.of(context).colorListLabel,
-                    container: true,
-                    child: GridView.builder(
-                      shrinkWrap: true,
-                      gridDelegate:
-                          const SliverGridDelegateWithMaxCrossAxisExtent(
-                            maxCrossAxisExtent: 64,
-                          ),
-                      itemCount: colors.length,
-                      itemBuilder: (context, i) {
-                        final color = colors[i];
-                        return Padding(
-                          padding: const EdgeInsets.all(12.0),
-                          child: Tooltip(
-                            message: color == null
-                                ? L10n.of(context).systemTheme
-                                : '#${color.hexValue.toRadixString(16).toUpperCase()}',
-                            child: InkWell(
-                              borderRadius: BorderRadius.circular(
-                                colorPickerSize,
-                              ),
-                              onTap: () => controller.setChatColor(color),
-                              child: Material(
-                                color: color ?? systemColor,
-                                elevation: 6,
-                                borderRadius: BorderRadius.circular(
-                                  colorPickerSize,
-                                ),
-                                child: SizedBox(
-                                  width: colorPickerSize,
-                                  height: colorPickerSize,
-                                  child:
-                                      (controller.currentColor == color ||
-                                          // #7176: on the default (null) colour the
-                                          // system swatch carries the selection, but
-                                          // where there is no system colour (web) that
-                                          // swatch is removed and the app falls back to
-                                          // its default colour — mark that swatch
-                                          // selected so a theme always reads as chosen.
-                                          (controller.currentColor == null &&
-                                              systemColor == null &&
-                                              color == AppConfig.chatColor))
-                                      ? Center(
-                                          child: Icon(
-                                            Icons.check,
-                                            size: 16,
-                                            color: Theme.of(
-                                              context,
-                                            ).colorScheme.onPrimary,
-                                          ),
-                                        )
-                                      : null,
-                                ),
-                              ),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-                  );
-                },
+                      : dark?.primary,
+                  currentColor: controller.currentColor,
+                  onColorSelected: controller.setChatColor,
+                ),
               ),
+              // Pangea#
               Divider(color: theme.dividerColor),
               ListTile(
                 title: Text(

--- a/test/pangea/settings/color_theme_picker_scroll_test.dart
+++ b/test/pangea/settings/color_theme_picker_scroll_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/settings/settings_style/color_theme_picker.dart';
+import 'package:fluffychat/routes/settings/settings_style/settings_style.dart';
+
+/// Coverage for #7758: the accent-colour swatches on settings > change your
+/// style show every row at once, so the grid must not be a scrollable of its
+/// own. Left scrollable it swallowed drags that belong to the page, which on a
+/// narrow phone reads as a stuck screen.
+void main() {
+  const narrowPhone = Size(360, 640);
+
+  /// Mounts the picker the way the settings page does: inside the page-level
+  /// scroll view, with a tall sibling below so the page itself has somewhere
+  /// to scroll.
+  Future<ScrollController> pumpPicker(
+    WidgetTester tester, {
+    Color? systemColor,
+    Color? currentColor,
+    void Function(Color?)? onColorSelected,
+  }) async {
+    final controller = ScrollController();
+    tester.view.physicalSize = narrowPhone;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: SingleChildScrollView(
+            controller: controller,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                ColorThemePicker(
+                  systemColor: systemColor,
+                  currentColor: currentColor,
+                  onColorSelected: onColorSelected ?? (_) {},
+                ),
+                const SizedBox(height: 2000),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return controller;
+  }
+
+  testWidgets('the swatch grid is not independently scrollable', (
+    tester,
+  ) async {
+    await pumpPicker(tester);
+
+    final grid = tester.widget<GridView>(find.byType(GridView));
+    expect(grid.physics, isA<NeverScrollableScrollPhysics>());
+    expect(grid.shrinkWrap, isTrue);
+  });
+
+  testWidgets('dragging on the swatches scrolls the page', (tester) async {
+    final page = await pumpPicker(tester);
+    expect(page.offset, 0.0);
+
+    await tester.drag(find.byType(GridView), const Offset(0, -200));
+    await tester.pumpAndSettle();
+
+    expect(page.offset, greaterThan(0.0));
+  });
+
+  testWidgets('every swatch is laid out, none clipped away', (tester) async {
+    await pumpPicker(tester);
+
+    // No system colour, so the "system theme" (null) swatch is dropped.
+    final expected = SettingsStyleController.customColors
+        .where((c) => c != null)
+        .length;
+    expect(find.byType(InkWell), findsNWidgets(expected));
+
+    final gridSize = tester.getSize(find.byType(GridView));
+    for (final swatch in find.byType(InkWell).evaluate()) {
+      final box = swatch.renderObject! as RenderBox;
+      final bottom =
+          box.localToGlobal(Offset.zero, ancestor: null).dy + box.size.height;
+      expect(bottom, lessThanOrEqualTo(gridSize.height + 1));
+    }
+  });
+
+  testWidgets('tapping a swatch reports the colour', (tester) async {
+    Color? picked;
+    await pumpPicker(tester, onColorSelected: (color) => picked = color);
+
+    await tester.tap(find.byType(InkWell).last);
+    await tester.pump();
+
+    expect(picked, SettingsStyleController.customColors.last);
+  });
+}


### PR DESCRIPTION
## What

The accent-color swatch grid on settings > change your style no longer scrolls independently of the page.

## Why

Closes #7758

The grid `shrinkWrap`s inside the page's `SingleChildScrollView`, so all its rows are always laid out and it has nothing of its own to scroll — but it was still a scrollable, so drags landing on the swatches were swallowed instead of scrolling the page. On a narrow phone that reads as a stuck screen.

## Changes

- `physics: NeverScrollableScrollPhysics()` on the swatch `GridView` (matches the `shrinkWrap` + never-scrollable pairing used elsewhere in the repo, e.g. `settings_notifications_view.dart`).
- Extracted the grid from `settings_style_view.dart` into `ColorThemePicker` (`lib/routes/settings/settings_style/color_theme_picker.dart`) so it can be mounted directly in a widget test. Pure move — same swatches, same `#7176` selection fallback, same `colorListLabel` semantics; the view now passes `systemColor` / `currentColor` / `onColorSelected`.
- New `test/pangea/settings/color_theme_picker_scroll_test.dart`.

No `*.instructions.md` governs this settings surface (grepped `client/.github/instructions/` for `settings_style` / `changeTheme` / `colorListLabel` — no hits). Flagging the gap rather than drafting a doc: this is a fix with an obvious expected outcome, not new design.

## Testing

- `fvm flutter test` — full suite green, 1693 passed / 3 skipped (4 of those new).
- `fvm flutter analyze lib/routes/settings/settings_style test/pangea/settings` — no issues.
- Verified the new tests actually pin the fix: with the `physics` line removed, "the swatch grid is not independently scrollable" and "dragging on the swatches scrolls the page" both fail (page offset stays `0.0`); restored, they pass.
- The new test mounts the picker at 360x640 (narrow phone, per the issue's TO TEST), inside a scroll view with a tall sibling, and asserts the drag scrolls the page, that every swatch is laid out unclipped, and that taps still report the color.
- Playwright specs not run locally — they run against staging post-deploy.

## Deploy Notes

None