### PR TITLE
fix(theme): let field error text wrap instead of truncating

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -35,6 +35,10 @@ abstract class AppConfig {
   static const double borderRadius = 18.0;
   static const double columnWidth = 360.0;
 
+  /// How many lines a `TextField`'s error message may wrap to before it is
+  /// truncated. Sentence-length errors need several on a narrow screen.
+  static const int inputErrorMaxLines = 4;
+
   static const String website = "https://pangea.chat/";
   static const String appOpenUrlScheme = 'matrix.pangea.chat';
 

--- a/lib/config/themes.dart
+++ b/lib/config/themes.dart
@@ -78,6 +78,12 @@ abstract class FluffyThemes {
           borderRadius: BorderRadius.circular(AppConfig.borderRadius),
         ),
         contentPadding: const EdgeInsets.all(12),
+        // #Pangea
+        // Flutter truncates errorText to a single line by default, so a
+        // sentence-length error (server errors especially) is unreadable on a
+        // narrow screen. Let it wrap app-wide.
+        errorMaxLines: AppConfig.inputErrorMaxLines,
+        // Pangea#
       ),
       chipTheme: ChipThemeData(
         showCheckmark: false,

--- a/test/pangea/input_error_max_lines_test.dart
+++ b/test/pangea/input_error_max_lines_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/config/setting_keys.dart';
+import 'package:fluffychat/config/themes.dart';
+
+void main() {
+  const longError =
+      'Your session has expired. Please log in again to change your password.';
+  const shortError = 'Wrong.';
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await AppSettings.init(loadWebConfigFile: false);
+  });
+
+  Future<void> pumpField(WidgetTester tester, String errorText) =>
+      tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => Theme(
+              data: FluffyThemes.buildTheme(context, Brightness.light),
+              child: Scaffold(
+                body: SizedBox(
+                  width: 200,
+                  child: TextField(
+                    decoration: InputDecoration(errorText: errorText),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+  testWidgets('field error text is allowed several lines', (tester) async {
+    await pumpField(tester, longError);
+
+    expect(AppConfig.inputErrorMaxLines, greaterThan(1));
+    expect(
+      tester.widget<Text>(find.text(longError)).maxLines,
+      AppConfig.inputErrorMaxLines,
+    );
+  });
+
+  testWidgets('a sentence-length error wraps on a narrow field', (
+    tester,
+  ) async {
+    await pumpField(tester, shortError);
+    final singleLineHeight = tester.getSize(find.text(shortError)).height;
+
+    await pumpField(tester, longError);
+    final wrappedHeight = tester.getSize(find.text(longError)).height;
+
+    expect(wrappedHeight, greaterThan(singleLineHeight));
+  });
+}


### PR DESCRIPTION
## What

Raise `errorMaxLines` on the shared `InputDecorationTheme` so a long `TextField` error wraps instead of being ellipsized to one line.

## Why

Closes #7787

Flutter renders `errorText` at `maxLines: 1` by default. On a narrow screen the change-password error is cut off — "Your session has expired. Please log in ag…" — with no way to read the rest. The truncation is the app-wide default rather than anything specific to that screen, so the fix goes in `FluffyThemes.buildTheme`'s `inputDecorationTheme` and every form benefits. Short errors are unaffected; long ones now wrap up to `AppConfig.inputErrorMaxLines` (4).

## Testing

- `fvm flutter test` — full suite, 1699 passed / 3 skipped (the endpoint suites, which skip without `TEST_MATRIX_*`).
- New `test/pangea/input_error_max_lines_test.dart` pumps a 200px-wide `TextField` under the real theme and asserts (a) the error `Text` carries `AppConfig.inputErrorMaxLines`, and (b) a sentence-length error renders taller than a one-word error, i.e. it actually wraps. Confirmed both fail with the theme line removed.
- `fvm flutter analyze` on the touched files — clean. `scripts/format.sh` — no changes.
- The issue's TO TEST needs a real expired-session response from the server, which can't be forced locally; that path gets its manual pass on staging.

## Deploy Notes

None