### PR TITLE
fix(invite): keep the invite-all label from overlapping the course avatar

### DIFF
--- a/lib/routes/chat/chat_details/invite/invite_all_in_space_tile.dart
+++ b/lib/routes/chat/chat_details/invite/invite_all_in_space_tile.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/course_plans/map_clipper.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/widgets/avatar.dart';
+
+/// Header of the contacts list on the invite page: the course this chat sits
+/// in, plus a button to invite everyone in it.
+///
+/// A Row rather than a ListTile, whose trailing widget keeps its intrinsic
+/// width and rides over the leading avatar once the label is long enough
+/// (#7784). Here the label and the course name share the space left by the
+/// avatar, so a long translation wraps instead.
+class InviteAllInSpaceTile extends StatelessWidget {
+  final Uri? avatar;
+  final String displayname;
+  final int memberCount;
+  final VoidCallback onPressed;
+
+  const InviteAllInSpaceTile({
+    required this.avatar,
+    required this.displayname,
+    required this.memberCount,
+    required this.onPressed,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+      child: Row(
+        spacing: 12.0,
+        children: [
+          ClipPath(
+            clipper: MapClipper(),
+            child: Avatar(
+              mxContent: avatar,
+              name: displayname,
+              borderRadius: BorderRadius.circular(AppConfig.borderRadius / 4),
+            ),
+          ),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  displayname,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyLarge,
+                ),
+                Text(
+                  L10n.of(context).countParticipants(memberCount),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: TextButton.icon(
+                onPressed: onPressed,
+                label: Text(L10n.of(context).inviteAllInSpace),
+                icon: const Icon(Icons.add),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/chat/chat_details/invite/pangea_invitation_selection_view.dart
+++ b/lib/routes/chat/chat_details/invite/pangea_invitation_selection_view.dart
@@ -7,9 +7,9 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/config/themes.dart';
-import 'package:fluffychat/features/course_plans/map_clipper.dart';
 import 'package:fluffychat/features/join_codes/share_room_button.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/chat/chat_details/invite/invite_all_in_space_tile.dart';
 import 'package:fluffychat/routes/chat/chat_details/invite/pangea_invitation_selection.dart';
 import 'package:fluffychat/routes/chat/chat_details/invite/room_settings_constants.dart';
 import 'package:fluffychat/utils/stream_extension.dart';
@@ -193,44 +193,17 @@ class PangeaInvitationSelectionView extends StatelessWidget {
                             itemBuilder: (BuildContext context, int i) {
                               if (i == 0) {
                                 return controller.showInviteAllInSpaceButton
-                                    ? ListTile(
-                                        leading: ClipPath(
-                                          clipper: MapClipper(),
-                                          child: Avatar(
-                                            mxContent:
-                                                controller.spaceParent!.avatar,
-                                            name: controller.spaceParent!
-                                                .getLocalizedDisplayname(),
-                                            borderRadius: BorderRadius.circular(
-                                              AppConfig.borderRadius / 4,
-                                            ),
-                                          ),
-                                        ),
-                                        title: Text(
-                                          controller.spaceParent!
-                                              .getLocalizedDisplayname(),
-                                          maxLines: 1,
-                                          overflow: TextOverflow.ellipsis,
-                                        ),
-                                        subtitle: Text(
-                                          L10n.of(context).countParticipants(
+                                    ? InviteAllInSpaceTile(
+                                        avatar: controller.spaceParent!.avatar,
+                                        displayname: controller.spaceParent!
+                                            .getLocalizedDisplayname(),
+                                        memberCount:
                                             controller
-                                                    .spaceParent!
-                                                    .summary
-                                                    .mJoinedMemberCount ??
-                                                1,
-                                          ),
-                                          maxLines: 1,
-                                          overflow: TextOverflow.ellipsis,
-                                        ),
-                                        trailing: TextButton.icon(
-                                          onPressed:
-                                              controller.inviteAllInSpace,
-                                          label: Text(
-                                            L10n.of(context).inviteAllInSpace,
-                                          ),
-                                          icon: const Icon(Icons.add),
-                                        ),
+                                                .spaceParent!
+                                                .summary
+                                                .mJoinedMemberCount ??
+                                            1,
+                                        onPressed: controller.inviteAllInSpace,
                                       )
                                     : const SizedBox();
                               }

--- a/test/pangea/invite_all_in_space_tile_test.dart
+++ b/test/pangea/invite_all_in_space_tile_test.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_storage/get_storage.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/chat/chat_details/invite/invite_all_in_space_tile.dart';
+import 'package:fluffychat/widgets/avatar.dart';
+
+/// #7784 — the invite-all row used to be a ListTile, whose trailing widget keeps
+/// its intrinsic width and so rode over the leading avatar. A long translation
+/// of "Invite all in this course" on a narrow screen overlapped the course
+/// avatar.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const germanLabel = 'Alle in diesem Kurs einladen';
+
+  setUpAll(() async {
+    // Avatar reads BotName.byEnvironment → Environment.botName, which needs
+    // GetStorage (path_provider-backed) and dotenv to be readable.
+    final tempDir = await Directory.systemTemp.createTemp('invite_all_tile');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (methodCall) async => tempDir.path,
+        );
+    await GetStorage.init('env_override');
+    dotenv.testLoad(mergeWith: {'BOT_NAME': 'pangeabot'});
+  });
+
+  /// German throughout: `inviteAllInSpace` is long there, which is the
+  /// condition that used to overlap the avatar. One locale per isolate — a
+  /// second locale's delegates load asynchronously and leave the Localizations
+  /// subtree empty for the frames a widget test pumps.
+  Future<void> pumpTile(WidgetTester tester, {required double width}) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('de'),
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: width,
+              child: InviteAllInSpaceTile(
+                avatar: null,
+                displayname: 'Deutsch für Anfängerinnen und Anfänger',
+                memberCount: 12,
+                onPressed: () {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  /// A RenderFlex overflow fails the test on its own; this catches the ListTile
+  /// failure mode, where the button was painted over the avatar with no
+  /// overflow reported at all.
+  void expectNoOverlap(WidgetTester tester) {
+    final avatar = tester.getRect(find.byType(Avatar));
+    final button = tester.getRect(find.byType(TextButton));
+    expect(button.left, greaterThanOrEqualTo(avatar.right));
+  }
+
+  testWidgets('invite-all label clears the course avatar on a narrow screen', (
+    tester,
+  ) async {
+    await pumpTile(tester, width: 320);
+
+    expect(find.text(germanLabel), findsOneWidget);
+    expectNoOverlap(tester);
+  });
+
+  testWidgets('invite-all label clears the course avatar on a wide screen', (
+    tester,
+  ) async {
+    await pumpTile(tester, width: 800);
+    expectNoOverlap(tester);
+  });
+
+  testWidgets(
+    'a long label wraps instead of pushing past its share of the row',
+    (tester) async {
+      await pumpTile(tester, width: 800);
+      final wideLabel = tester.getRect(find.text(germanLabel));
+
+      await pumpTile(tester, width: 320);
+      final narrowLabel = tester.getRect(find.text(germanLabel));
+
+      expect(narrowLabel.width, lessThan(wideLabel.width));
+      expect(narrowLabel.height, greaterThan(wideLabel.height));
+    },
+  );
+}


### PR DESCRIPTION
### What

The course row at the top of the invite page is now a `Row`, so a long "+ Invite all in this course" label wraps instead of being painted over the course avatar.

### Why

Closes #7784

`ListTile` lays its `trailing` widget out at intrinsic width and only gives the title whatever is left, which can go negative — so on a narrow screen (or with a long translation, e.g. German) the button rode over the leading avatar. No overflow was reported; it just overlapped.

What changed:
- The row moved out of `pangea_invitation_selection_view.dart` into `InviteAllInSpaceTile`, taking plain data (avatar, displayname, member count, callback) rather than the controller, so it can be pumped in a widget test.
- Avatar, the name/participant-count column and the button now share one `Row`: the avatar takes its fixed width, the text column and the button split the rest, and the label wraps within its half.
- Title and subtitle carry the `ListTile` M3 text styles explicitly (`bodyLarge`, `bodyMedium` on `onSurfaceVariant`) so the row still reads the same.

### Testing

`fvm flutter test test/pangea/invite_all_in_space_tile_test.dart` — 3 pass. The tests assert the button's left edge never crosses the avatar's right edge at 320px and 800px wide, and that the German label wraps (narrower + taller) as the row narrows. Reverting just the widget body to the old `ListTile` fails the narrow-screen test (button left = 16, avatar right = 60 — i.e. the reported overlap) and the wrap test, so the guard is real.

`fvm flutter test` — 1692 pass, 0 fail, 3 skipped (the local-only endpoint suites, which skip without `.env`).

`fvm flutter analyze lib/routes/chat/chat_details/invite/` — clean. No `e2e/trigger-map.json` glob covers `lib/routes/chat/chat_details/invite/**`, so no browser spec applies.

Not done: no pass in a running client — this worktree has no `.env` and no staging account to log in with, so the visual check is the issue's TO TEST list on staging.

No new or changed controls — the button keeps its text label, so no new semantics to name.

Note: #7986 reindents this whole build method for semantics work. Whichever of the two lands second will need a rebase.

### Deploy Notes

None
