### PR TITLE
feat(analytics): light the level badge for the open Level page on mobile

### DIFF
--- a/lib/routes/world/world_analytics_bar.dart
+++ b/lib/routes/world/world_analytics_bar.dart
@@ -184,9 +184,17 @@ class _PowerupsRow extends StatelessWidget {
   static const double _pillVerticalPadding = 2.0;
   static const double _pillRightPadding = 14.0;
 
-  /// Half the hex badge's width — how far it sticks out past the pill's
-  /// left edge (the Figma overhang).
-  static final double _hexBadgeOverhang = _badgeWidth / 2;
+  /// Ring of space kept around the hex badge so its open-panel highlight has
+  /// somewhere to paint (the badge itself is solid gold, so a wash *under* it
+  /// only reads in the margin). Reserved whether or not the Level tab is open,
+  /// so selecting it never nudges the badge.
+  static const double _badgeHighlightPadding = 6.0;
+
+  /// How far the badge unit sticks out past the pill's left edge (the Figma
+  /// overhang): half the hex, plus the highlight ring around it, so the
+  /// hexagon still lands centered on the pill's edge.
+  static final double _hexBadgeOverhang =
+      _badgeWidth / 2 + _badgeHighlightPadding;
 
   // The bar's hex badge is smaller than [_HexLevelBadge]'s web-facing
   // defaults, per the Figma bar frame.
@@ -311,14 +319,33 @@ class _PowerupsRow extends StatelessWidget {
                       left: 0,
                       child: Material(
                         type: MaterialType.transparency,
-                        child: LevelUpBadgeCelebration(
-                          levelUpdates: viewModel.levelUpdates,
-                          child: HexLevelBadge(
-                            level: level,
-                            onTap: () => viewModel.openLevel(context),
-                            width: _badgeWidth,
-                            height: _badgeHeight,
-                            fontSize: _badgeFontSize,
+                        // Open-panel highlight, the badge's version of the
+                        // trackers' sticky wash (#7977, #8062): the same gold
+                        // wash on the same stadium geometry, but painted in the
+                        // reserved ring AROUND the hexagon — washing the badge
+                        // itself would be gold on gold. Outside the
+                        // celebration so the pulse keeps wrapping the bare
+                        // badge, and the padding is unconditional so the
+                        // highlight only ever adds color, never layout.
+                        child: Container(
+                          padding: const EdgeInsets.all(_badgeHighlightPadding),
+                          decoration: selectedTab == ProgressIndicatorEnum.level
+                              ? BoxDecoration(
+                                  color: AppConfig.goldByTheme(
+                                    context,
+                                  ).withAlpha(50),
+                                  borderRadius: BorderRadius.circular(100),
+                                )
+                              : null,
+                          child: LevelUpBadgeCelebration(
+                            levelUpdates: viewModel.levelUpdates,
+                            child: HexLevelBadge(
+                              level: level,
+                              onTap: () => viewModel.openLevel(context),
+                              width: _badgeWidth,
+                              height: _badgeHeight,
+                              fontSize: _badgeFontSize,
+                            ),
                           ),
                         ),
                       ),

--- a/test/pangea/navigation/world_analytics_bar_test.dart
+++ b/test/pangea/navigation/world_analytics_bar_test.dart
@@ -5,14 +5,18 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/features/analytics_data/analytics_update_dispatcher.dart';
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/world/analytics_header_avatar.dart';
+import 'package:fluffychat/routes/world/hex_level_badge.dart';
 import 'package:fluffychat/routes/world/level_up_badge_celebration.dart';
 import 'package:fluffychat/routes/world/user_cluster_view_model.dart';
 import 'package:fluffychat/routes/world/world_analytics_bar.dart';
+import 'package:fluffychat/routes/world/world_user_cluster.dart';
+import 'package:fluffychat/widgets/analytics_summary/progress_indicators_enum.dart';
 import 'mock_user_cluster_view_model.dart';
 
 /// Coverage for the world_v2 single-column analytics NAV BAR
@@ -80,9 +84,14 @@ void main() {
   Future<void> pumpBar(
     WidgetTester tester, {
     required UserClusterViewModel viewModel,
+    ProgressIndicatorEnum? selectedTab,
   }) => pumpShellMounted(
     tester,
-    WorldAnalyticsBarInternal(flagBuilder: flagStandIn, viewModel: viewModel),
+    WorldAnalyticsBarInternal(
+      flagBuilder: flagStandIn,
+      viewModel: viewModel,
+      selectedTab: selectedTab,
+    ),
   );
 
   setUpAll(() {
@@ -191,6 +200,100 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text(chipText), findsNothing);
       await controller.close();
+    });
+  });
+
+  /// The open-panel highlight: the bar is the single-column rendering of the
+  /// web cluster, so whichever analytics page is open is lit here too — all
+  /// four controls, the level badge included (#7977, #8062).
+  group('full bar — open-panel highlight', () {
+    /// The trackers' sticky wash: the only decorated [Ink] in the bar.
+    final trackerHighlights = find.byWidgetPredicate(
+      (w) => w is Ink && w.decoration != null,
+    );
+
+    Finder trackerHighlight(ProgressIndicatorEnum indicator) => find.descendant(
+      of: find.byWidgetPredicate(
+        (w) => w is ClusterTrackerButton && w.indicator == indicator,
+      ),
+      matching: trackerHighlights,
+    );
+
+    /// The badge's wash, painted in the ring reserved around the hexagon.
+    final levelHighlight = find.ancestor(
+      of: find.byType(HexLevelBadge),
+      matching: find.byWidgetPredicate(
+        (w) => w is Container && w.decoration != null,
+      ),
+    );
+
+    testWidgets('nothing is lit while no analytics panel is open', (
+      tester,
+    ) async {
+      await pumpBar(tester, viewModel: MockUserClusterViewModel());
+
+      expect(trackerHighlights, findsNothing);
+      expect(levelHighlight, findsNothing);
+    });
+
+    for (final (tab, name) in [
+      (ProgressIndicatorEnum.stars, 'stars'),
+      (ProgressIndicatorEnum.morphsUsed, 'grammar'),
+      (ProgressIndicatorEnum.wordsUsed, 'vocab'),
+    ]) {
+      testWidgets('the $name tracker alone is lit for its open panel', (
+        tester,
+      ) async {
+        await pumpBar(
+          tester,
+          viewModel: MockUserClusterViewModel(),
+          selectedTab: tab,
+        );
+
+        expect(trackerHighlight(tab), findsOneWidget);
+        // Exactly one control wears the wash — no sibling tracker, and not
+        // the badge.
+        expect(trackerHighlights, findsOneWidget);
+        expect(levelHighlight, findsNothing);
+      });
+    }
+
+    testWidgets('the level badge alone is lit for the open Level page', (
+      tester,
+    ) async {
+      await pumpBar(
+        tester,
+        viewModel: MockUserClusterViewModel(),
+        selectedTab: ProgressIndicatorEnum.level,
+      );
+
+      expect(levelHighlight, findsOneWidget);
+      expect(trackerHighlights, findsNothing);
+
+      // The same gold wash the trackers use, so the two read as one state.
+      final decoration =
+          tester.widget<Container>(levelHighlight).decoration! as BoxDecoration;
+      expect(
+        decoration.color,
+        AppConfig.goldByTheme(
+          tester.element(find.byType(Scaffold)),
+        ).withAlpha(50),
+      );
+    });
+
+    testWidgets('lighting the badge moves nothing', (tester) async {
+      // The highlight paints in a ring the badge reserves either way — if it
+      // were added only when selected, opening the Level page would shove the
+      // badge (and the pill it overhangs) sideways.
+      await pumpBar(tester, viewModel: MockUserClusterViewModel());
+      final unlit = tester.getRect(find.byType(HexLevelBadge));
+
+      await pumpBar(
+        tester,
+        viewModel: MockUserClusterViewModel(),
+        selectedTab: ProgressIndicatorEnum.level,
+      );
+      expect(tester.getRect(find.byType(HexLevelBadge)), unlit);
     });
   });
 


### PR DESCRIPTION
## What

Light the hex level badge in the single-column analytics bar when the Level page is the open panel — the one control in the mobile cluster that never showed the open-panel highlight.

## Why

Closes #8062

The bar already derived `selectedTab` from the URL and passed it to all three trackers (#7977), so Stars / Grammar / Vocabulary were lit on mobile; the level badge is the mobile counterpart of the web cluster's `ClusterLevelMedal`, which takes `selected`, but `HexLevelBadge` had no such wiring. Confirmed before touching anything: with an analytics panel open, the bar rendered exactly one highlight for each tracker and none for Level.

The badge is solid gold, so the trackers' translucent gold wash is invisible painted *under* it. It now paints in a 6px ring reserved around the hexagon — same color, same stadium geometry, and the same idiom as web, where the medal's wash reads in the space around the ribbon. The ring is reserved whether or not Level is open, so selecting it never nudges the badge or the pill it overhangs; `_hexBadgeOverhang` absorbs the ring so the hexagon still lands centered on the pill's left edge.

`HexLevelBadge` itself is untouched, so the chat app-bar avatar that also mounts it (`analytics_header_avatar.dart`) is unaffected. See routing.instructions.md § "Single-column analytics nav bar" for the bar's design.

## Testing

- **Unit/widget** — `fvm flutter test` (full suite): 1711 passed, 3 skipped. `fvm dart format` + `fvm flutter analyze` clean on the touched files.
- **New tests** (`test/pangea/navigation/world_analytics_bar_test.dart`, 6 cases): nothing lit with no panel open; each of the four controls lit alone for its own page (guarding the three trackers that already worked); the badge's wash is the same gold the trackers use; and the badge's rect is identical lit vs unlit. Confirmed the Level cases fail on `main`.
- **Pixel readback** (throwaway harness, `RepaintBoundary.toImage` over the real bar): rendered the bar unselected, Level-selected, and Vocab-selected and compared. 4px of ring was a thin rim next to the trackers' filled stadium, so the ring is 6px — the halo now reads at the same weight. Not committed (nothing deterministic left to assert beyond the geometry tests above).
- **Not run: live app.** Needs a live login on a narrow viewport; the local iOS sim build is still blocked on `receive_sharing_intent`. The issue's TO TEST wants a human pass on staging.
- Smoke/eval/load: N/A — no service surface touched.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
