### PR TITLE
feat(activities): let learners leave an unsupported activity session

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_button_widget.dart
@@ -5,6 +5,7 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_state_controller.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/archived_session_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/confirmed_role_session_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/full_session_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/not_started_session_controller.dart';
@@ -70,7 +71,10 @@ class ActivitySessionButtons extends StatelessWidget {
   }
 }
 
-class _CTAButton extends StatelessWidget {
+/// The session page's call-to-action button: a full-width filled button in the
+/// primary container colour. Public because the archived fallback body renders
+/// its own leave CTA outside this footer (#8064).
+class ActivitySessionCTAButton extends StatelessWidget {
   final String text;
   final VoidCallback? onPressed;
 
@@ -79,7 +83,12 @@ class _CTAButton extends StatelessWidget {
   /// encouraged choice.
   final bool secondary;
 
-  const _CTAButton(this.text, this.onPressed, {this.secondary = false});
+  const ActivitySessionCTAButton(
+    this.text,
+    this.onPressed, {
+    this.secondary = false,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -140,6 +149,10 @@ class _SessionCTAButtons extends StatelessWidget {
       return _ConfirmedRoleSessionCTAButtons(controller);
     }
 
+    if (controller is ArchivedSessionController) {
+      return _ArchivedSessionCTAButtons(controller);
+    }
+
     return SizedBox();
   }
 }
@@ -150,7 +163,7 @@ class _SelectRoleSessionCTAButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _CTAButton(
+    return ActivitySessionCTAButton(
       L10n.of(context).confirm,
       controller.canConfirmRole ? controller.confirmRoleSelection : null,
     );
@@ -163,7 +176,7 @@ class _FullSessionCTAButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return _CTAButton(
+    return ActivitySessionCTAButton(
       controller.course != null
           ? L10n.of(context).returnToCourse
           : L10n.of(context).returnHome,
@@ -180,7 +193,10 @@ class _NotStartedSessionCTAButtons extends StatelessWidget {
   Widget build(BuildContext context) {
     // Sub-pages show a single Back button.
     if (controller.subPage != NotStartedSubPage.main) {
-      return _CTAButton(L10n.of(context).back, controller.goToMainPage);
+      return ActivitySessionCTAButton(
+        L10n.of(context).back,
+        controller.goToMainPage,
+      );
     }
 
     return FutureBuilder(
@@ -208,16 +224,16 @@ class _NotStartedSessionCTAButtons extends StatelessWidget {
               // Only for learners who can actually invite — without the power
               // level the invite page just errors out (#7875).
               if (controller.canInviteToCourse)
-                _CTAButton(
+                ActivitySessionCTAButton(
                   L10n.of(context).inviteFriendsToCourse,
                   controller.inviteToCourse,
                 ),
-              _CTAButton(
+              ActivitySessionCTAButton(
                 L10n.of(context).pickDifferentActivity,
                 controller.goToCourse,
               ),
             ] else if (controller.joinedActivityRoomId != null) ...[
-              _CTAButton(
+              ActivitySessionCTAButton(
                 L10n.of(context).continueText,
                 controller.goToJoinedActivity,
               ),
@@ -226,20 +242,23 @@ class _NotStartedSessionCTAButtons extends StatelessWidget {
               // and "start my own" drops to a de-emphasized option; with none to
               // join, starting is the single primary action.
               if (controller.openSessionCount > 0) ...[
-                _CTAButton(
+                ActivitySessionCTAButton(
                   '${L10n.of(context).joinOpenSession} (${controller.openSessionCount})',
                   controller.goToJoinPage,
                 ),
-                _CTAButton(
+                ActivitySessionCTAButton(
                   L10n.of(context).startOwn,
                   controller.startNewActivity,
                   secondary: true,
                 ),
               ] else
-                _CTAButton(L10n.of(context).start, controller.startNewActivity),
+                ActivitySessionCTAButton(
+                  L10n.of(context).start,
+                  controller.startNewActivity,
+                ),
               if (controller.course?.isRoomAdmin == true &&
                   controller.hasCurrentOrFinishedSessions)
-                _CTAButton(
+                ActivitySessionCTAButton(
                   '${L10n.of(context).viewCurrentOrFinished} (${controller.currentOrFinishedSessionCount})',
                   controller.goToViewPage,
                 ),
@@ -247,6 +266,24 @@ class _NotStartedSessionCTAButtons extends StatelessWidget {
           ],
         );
       },
+    );
+  }
+}
+
+/// A removed activity's session can't be continued or finished and no one else
+/// can be invited into it, so the only action left in the footer is getting it
+/// out of the chat list (#8064).
+class _ArchivedSessionCTAButtons extends StatelessWidget {
+  final ArchivedSessionController controller;
+  const _ArchivedSessionCTAButtons(this.controller);
+
+  @override
+  Widget build(BuildContext context) {
+    final page = controller.widget.controller;
+    if (!page.canLeaveArchivedSession) return const SizedBox.shrink();
+    return ActivitySessionCTAButton(
+      L10n.of(context).leave,
+      page.leaveArchivedSession,
     );
   }
 }
@@ -263,7 +300,7 @@ class _ConfirmedRoleSessionCTAButtons extends StatelessWidget {
         if (controller.showPingCourse) ...[
           FutureBuilder(
             future: controller.canPingParticipants,
-            builder: (context, snapshot) => _CTAButton(
+            builder: (context, snapshot) => ActivitySessionCTAButton(
               L10n.of(context).pingParticipants,
               snapshot.data == true ? controller.pingCourse : null,
             ),
@@ -273,13 +310,16 @@ class _ConfirmedRoleSessionCTAButtons extends StatelessWidget {
         if (controller.showInviteOptions)
           Padding(
             padding: EdgeInsetsGeometry.only(bottom: 16.0),
-            child: _CTAButton(
+            child: ActivitySessionCTAButton(
               L10n.of(context).playWithBot,
               controller.enablePlayWithBot ? controller.playWithBot : null,
             ),
           ),
         if (controller.showInviteOptions)
-          _CTAButton(L10n.of(context).inviteFriends, controller.inviteFriends),
+          ActivitySessionCTAButton(
+            L10n.of(context).inviteFriends,
+            controller.inviteFriends,
+          ),
       ],
     );
   }

--- a/lib/routes/chat/activity_sessions/activity_session_start_page.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_start_page.dart
@@ -13,6 +13,7 @@ import 'package:fluffychat/features/activity_sessions/activity_roles_room_extens
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_session_discovery.dart';
 import 'package:fluffychat/features/activity_sessions/discovered_sessions_cache.dart';
+import 'package:fluffychat/features/navigation/room_close_location.dart';
 import 'package:fluffychat/features/room_summaries/activity_session_previews_extension.dart';
 import 'package:fluffychat/features/room_summaries/room_summaries_model.dart';
 import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
@@ -25,6 +26,7 @@ import 'package:fluffychat/routes/chat/activity_sessions/confirmed_role_session_
 import 'package:fluffychat/routes/chat/activity_sessions/full_session_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/not_started_session_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/select_role_session_controller.dart';
+import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -63,6 +65,17 @@ bool archivedSessionGate({
   required bool activityRemoved,
   required bool hasSessionRoom,
 }) => activityRemoved && hasSessionRoom;
+
+/// Whether the archived view offers a way out of the session room.
+///
+/// A removed activity's session can never be continued or finished — no one
+/// else can be invited into it — so without this the room sits in the chat
+/// list forever with no exit (#8064). Offered only to a learner actually
+/// joined: an observer previewing the room has nothing to leave.
+bool archivedLeaveGate({
+  required bool isArchived,
+  required Membership? membership,
+}) => isArchived && membership == Membership.join;
 
 class ActivitySessionStartPage extends StatefulWidget {
   final String activityId;
@@ -355,6 +368,45 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
     activityRemoved: activityRemoved,
     hasSessionRoom: widget.roomId != null,
   );
+
+  /// See [archivedLeaveGate].
+  bool get canLeaveArchivedSession => archivedLeaveGate(
+    isArchived: isArchived,
+    membership: activityRoom?.membership,
+  );
+
+  /// Leave the session room of a removed activity and close its panel — the
+  /// only exit for a session that can never be continued (#8064). Same
+  /// confirm-then-wait-for-sync flow as the chat's own leave, so the room is
+  /// gone from the list before the panel closes.
+  Future<void> leaveArchivedSession() async {
+    final room = activityRoom;
+    if (room == null) return;
+
+    final confirmed = await showOkCancelAlertDialog(
+      context: context,
+      title: L10n.of(context).areYouSure,
+      message: L10n.of(context).leaveRoomDescription,
+      okLabel: L10n.of(context).leave,
+      cancelLabel: L10n.of(context).cancel,
+      isDestructive: true,
+    );
+    if (confirmed != OkCancelResult.ok || !mounted) return;
+
+    final result = await showFutureLoadingDialog(
+      context: context,
+      future: room.leave,
+    );
+    if (result.isError || !mounted) return;
+
+    final left = Matrix.of(context).client.getRoomById(room.id);
+    if (left != null && left.membership != Membership.leave) {
+      await Matrix.of(context).client.waitForRoomInSync(room.id, leave: true);
+    }
+
+    if (!mounted) return;
+    closeOwnRoomPanel(context, room.id);
+  }
 
   SessionState get _sessionState {
     if (isArchived) return SessionState.archived;

--- a/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
+++ b/lib/routes/chat/activity_sessions/activity_sessions_start_view.dart
@@ -323,6 +323,16 @@ class _ArchivedSessionFallbackBody extends StatelessWidget {
               style: theme.textTheme.bodyLarge,
             ),
             const SizedBox(height: 16.0),
+            // This rung has no CTA footer to hang the leave action off, so the
+            // way out sits with the notice that explains why there is no way
+            // forward (#8064).
+            if (controller.canLeaveArchivedSession) ...[
+              ActivitySessionCTAButton(
+                L10n.of(context).leave,
+                controller.leaveArchivedSession,
+              ),
+              const SizedBox(height: 16.0),
+            ],
             ...roles.map((role) {
               final user = room!.unsafeGetUserFromMemoryOrFallback(role.userId);
               final stars = awards?.awards[role.id]?.length ?? 0;

--- a/test/pangea/activity_archived_session_gate_test.dart
+++ b/test/pangea/activity_archived_session_gate_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/routes/chat/activity_sessions/activity_session_start_page.dart';
 
@@ -40,6 +41,45 @@ void main() {
         archivedSessionGate(activityRemoved: false, hasSessionRoom: false),
         isFalse,
       );
+    });
+  });
+
+  /// The gate deciding whether the archived view offers a Leave button.
+  ///
+  /// A removed activity's session can never be continued or finished and no
+  /// one else can be invited into it, so before #8064 a joined learner had no
+  /// exit at all: the session sat in their chat list forever. Leaving is the
+  /// one action still available on this dead room — but only to someone
+  /// actually in it.
+  group('archivedLeaveGate', () {
+    test('a joined learner on an archived session can leave', () {
+      expect(
+        archivedLeaveGate(isArchived: true, membership: Membership.join),
+        isTrue,
+      );
+    });
+
+    test('a live activity never offers leave here — its session is still '
+        'playable and the ⋮ menu owns that action', () {
+      expect(
+        archivedLeaveGate(isArchived: false, membership: Membership.join),
+        isFalse,
+      );
+    });
+
+    test('nothing to leave without a joined membership', () {
+      for (final membership in [
+        Membership.invite,
+        Membership.leave,
+        Membership.ban,
+        null,
+      ]) {
+        expect(
+          archivedLeaveGate(isArchived: true, membership: membership),
+          isFalse,
+          reason: 'membership $membership should not offer leave',
+        );
+      }
     });
   });
 }

--- a/test/pangea/activity_session_cta_button_test.dart
+++ b/test/pangea/activity_session_cta_button_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/chat/activity_sessions/activity_session_button_widget.dart';
+
+/// The session page's CTA button became public so the archived fallback body
+/// could render a Leave action outside the CTA footer (#8064). These pin the
+/// look it is reused for: a filled `primaryContainer` button that spans the
+/// width it is given, so the leave CTA on a removed activity is visually the
+/// same call to action as Start / Continue / Confirm.
+void main() {
+  Widget wrap(Widget child, {double width = 600.0}) => MaterialApp(
+    home: Scaffold(
+      body: Center(
+        child: SizedBox(width: width, child: child),
+      ),
+    ),
+  );
+
+  testWidgets('primary CTA is a primaryContainer ElevatedButton', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      wrap(const ActivitySessionCTAButton('Leave', null)),
+    );
+
+    final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+    final context = tester.element(find.byType(ElevatedButton));
+    final scheme = Theme.of(context).colorScheme;
+
+    expect(button.style?.backgroundColor?.resolve({}), scheme.primaryContainer);
+    expect(
+      button.style?.foregroundColor?.resolve({}),
+      scheme.onPrimaryContainer,
+    );
+    expect(find.text('Leave'), findsOneWidget);
+  });
+
+  testWidgets('CTA spans the width it is given', (tester) async {
+    await tester.pumpWidget(
+      wrap(const ActivitySessionCTAButton('Leave', null), width: 480.0),
+    );
+
+    expect(tester.getSize(find.byType(ElevatedButton)).width, 480.0);
+  });
+
+  testWidgets('the secondary variant is outlined, not filled', (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        const ActivitySessionCTAButton('Start my own', null, secondary: true),
+      ),
+    );
+
+    expect(find.byType(OutlinedButton), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsNothing);
+  });
+}


### PR DESCRIPTION
## What

A "Leave" CTA on the archived (no-longer-supported) activity session view, so a session for a removed activity can be cleared out of the chat list.

## Why

Closes #8064

These sessions can never be continued or finished — no one else can be invited into them — and until now there was no exit from the session page, so they piled up in the chat list. The surface is the removed-activity fallback ladder in [activities.instructions.md → When the activity can't be fetched](.github/instructions/activities.instructions.md).

Both rungs get the button:

- **Legacy-plan rung** (plan recovered from room state) — through the existing CTA footer, which previously fell through to an empty `SizedBox` for the archived controller.
- **No-plan rung** (`_ArchivedSessionFallbackBody`) — beside the "no longer supported" notice, per the issue's suggestion; that rung has no CTA footer to hang it off.

Shown only when the learner is actually joined to the room (`archivedLeaveGate`). Leaving reuses the chat's own confirm → leave → wait-for-sync → close-panel flow, so the room is gone from the list before the panel closes.

`_CTAButton` becomes the public `ActivitySessionCTAButton` so the fallback body renders the same `primaryContainer` `ElevatedButton` as Start / Continue / Confirm.

**Doc note for review:** `activities.instructions.md` describes what each rung of the ladder shows, and doesn't yet mention a leave affordance. Per the doc-edit invariant that stays out of this PR — flagging it so the doc change can be agreed in chat.

## Testing

- `fvm flutter test` — full suite, 1718 passed / 3 skipped.
- `fvm dart analyze lib test` — clean.
- Added `archivedLeaveGate` unit tests (joined-and-archived → leave; live activity → no leave; invite/leave/ban/null membership → no leave) in `test/pangea/activity_archived_session_gate_test.dart`.
- Added `test/pangea/activity_session_cta_button_test.dart` pinning the CTA look now that it is public: `primaryContainer`/`onPrimaryContainer` `ElevatedButton`, spans the width it is given, secondary variant stays outlined.
- **Not manually exercised in-app.** Reaching the archived rungs needs a session room whose activity the backend has actually removed, which I couldn't reproduce locally. To verify on staging: open one of the sessions from the issue, confirm the Leave button renders under the "no longer supported" notice, and that leaving drops the room from the chat list.

## Deploy Notes

None
