### PR TITLE
ci: restore the rust cache on PRs via cache-base

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -107,6 +107,8 @@ jobs:
           cache: true
       - uses: ./.github/actions/free_up_space
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
+        with:
+          cache-base: main
       - name: Add Firebase Messaging
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
@@ -124,6 +126,8 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
+        with:
+          cache-base: main
       - run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
       - run: flutter pub get
       - name: Prepare web
@@ -169,6 +173,8 @@ jobs:
         run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - run: brew install sqlcipher
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
+        with:
+          cache-base: main
       - name: Add Firebase Messaging
         env:
           GOOGLE_SERVICES_PLIST: ${{ secrets.GOOGLE_SERVICES_PLIST }}

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -59,6 +59,8 @@ jobs:
         run: sudo xcode-select --switch /Applications/Xcode_26.3.app
       - run: brew install sqlcipher
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
+        with:
+          cache-base: main
       - name: Set up Ruby
         uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
         with:

--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -23,7 +23,10 @@ jobs:
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
+        with:
+          cache-base: main
       - run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
       - name: Prepare web
         run: ./scripts/prepare-web.sh
@@ -240,6 +243,7 @@ jobs:
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
       - name: Download web
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,8 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install nodejs -y
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
+        with:
+          cache-base: main
       - run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
       - run: flutter pub get
       - name: Prepare web
@@ -137,6 +139,8 @@ jobs:
           rm -rf fonts/NotoEmoji
           yq -i 'del( .flutter.fonts[] | select(.family == "NotoEmoji") )' pubspec.yaml
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
+        with:
+          cache-base: main
       - run: flutter pub get
       - name: Prepare Android Release Build
         env:
@@ -187,6 +191,8 @@ jobs:
           git clone --branch ${{ env.FLUTTER_VERSION }} https://github.com/flutter/flutter.git
           ./flutter/bin/flutter doctor
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
+        with:
+          cache-base: main
       - run: ./flutter/bin/flutter pub get
       - run: ./flutter/bin/flutter build linux --target-platform linux-${{ matrix.arch }}
       - name: Create archive
@@ -338,6 +344,7 @@ jobs:
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
+          cache: true
       - name: Download web
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:


### PR DESCRIPTION
## Why

Closes #8053

Investigating #8053's "confirm the warm-Rust web build" found that it never worked. #6781 made the main-push web build write the Rust cache to the `refs/heads/main` scope so PRs could restore it. The write happens; **the read never does.**

Evidence:

- The key `setup-rustcargo-v1-linux-9a0dcb6b...` exists on `refs/heads/main`, created 17:18, `lastAccessedAt` still 17:18 — never read since creation.
- Nine PRs *after* 17:18 each wrote their own copy of that **byte-identical** key. A restore hit would have skipped the save.
- A PR job at 19:03 logs `Cache does not exist using key setup-rustcargo-v1-linux-9a0dcb6b...`, then `Saving cache with key <same key>`. Flutter and pub in the same job log `Cache hit` and `not saving cache`.

Root cause: `moonrepo/setup-rust` only looks in the current ref's scope. It does not implicitly fall back to the default branch the way `actions/cache` does. Its `cache-base` input exists for exactly this — *"Base branch/ref to save a warmup cache on. Other branches/refs will restore from this base."* It was never set, so every PR has been recompiling `target/debug` from source.

## What changed

- `cache-base: main` on all 8 active `moonrepo/setup-rust` steps (`integrate.yaml` ×3, `release.yaml` ×3, `main_deploy.yaml`, `ios-testflight.yml`). The commented-out `build_debug_linux` step is untouched.
- `cache: true` on the 3 `subosito/flutter-action` steps that lacked it — `main_deploy.yaml`'s `build_web` (#8053's "easy win") plus the `update_sentry` jobs in `main_deploy.yaml` and `release.yaml`. Those two genuinely need the SDK (`flutter pub get`, `sentry_dart_plugin`), they were just re-downloading ~1.6 GB every run.

**Node 20 deprecation** (#8053's third bullet) is upstream-only — the warning names `actions/cache@v4` and `moonrepo/setup-rust`, and clears when they update. Nothing actionable here, so I am closing #8053 rather than leaving it open on an external dependency.

## Testing

- All 14 workflows parse (Ruby/Psych), and all 8 `setup-rust` steps parse with `with.cache-base == "main"` on the correct step — verified structurally, not just by grep.
- Both pinned action SHAs are byte-identical to `origin/main` (I introduced a typo in one mid-edit and caught it; this check is why).
- No Dart code touched, so the test buckets are unaffected.

**This needs a bake to confirm.** The payoff only appears after a main-push run saves a warmup cache under the new scheme; the *next* PR after that should log a Rust cache hit and a shorter `build_debug_web`. Worth spot-checking a PR run tomorrow against the ~6–8m baseline.

### Pull Request has been tested on:

- [x] N/A — CI configuration only, no runtime surface

### Accessibility

- [x] N/A — no UI change