### PR TITLE
fix(analytics): show level hover and selection in the badge's own gold

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -76,8 +76,6 @@ abstract class AppConfig {
   static const int overlayAnimationDuration = 250;
   static const Color gold = Color.fromARGB(255, 253, 191, 1);
   static const Color goldLight = Color.fromARGB(255, 254, 223, 73);
-  static const String goldHexCode = "#fdbf01";
-  static const String goldLightHexCode = "#fedf49";
 
   static Color goldByTheme(BuildContext context) =>
       Theme.of(context).brightness == Brightness.light ? gold : goldLight;
@@ -91,10 +89,27 @@ abstract class AppConfig {
         : theme.colorScheme.surface;
   }
 
-  static String goldHexByTheme(BuildContext context) =>
-      Theme.of(context).brightness == Brightness.light
-      ? goldHexCode
-      : goldLightHexCode;
+  /// The gold a **level badge** wears while hovered, or while the Level panel
+  /// it opens is showing: [goldByTheme] deepened by [_goldHighlightDepth].
+  ///
+  /// The cluster's trackers show those two states with a translucent gold wash
+  /// behind them, but the level badge is itself a solid gold mark — a wash
+  /// behind it is gold on gold and reads as nothing, and a wash *around* it is
+  /// a circle the design doesn't want. So the mark's own gold shifts instead
+  /// (#8067), on both the web cluster's shield medal and the mobile bar's hex
+  /// badge.
+  ///
+  /// Deepened toward black rather than down the HSL lightness axis: the dark
+  /// theme's [goldLight] sits near the top of that axis, where dropping
+  /// lightness mostly saturates the yellow and barely darkens it — the state
+  /// has to read as the same shift in both brightnesses.
+  static Color goldHighlightByTheme(BuildContext context) =>
+      Color.lerp(goldByTheme(context), Colors.black, _goldHighlightDepth)!;
+
+  /// How far [goldHighlightByTheme] pulls the gold toward black — enough to
+  /// read as a state change at a glance, not so far that the badge's black
+  /// level number loses contrast (both themes stay above 8:1).
+  static const double _goldHighlightDepth = 0.2;
 
   // The "powerups" gold palette for the right-nav cluster (Figma
   // AvatarLangFlags). See the cluster section of routing.instructions.md.

--- a/lib/routes/world/hex_level_badge.dart
+++ b/lib/routes/world/hex_level_badge.dart
@@ -7,13 +7,19 @@ import 'package:fluffychat/l10n/l10n.dart';
 /// top/bottom) with a darker gold border and the level number centered —
 /// unlike the web cluster's tailed shield medal, which hangs its number low
 /// and carries the notched ribbon bottom the mobile design drops. Same
-/// semantics contract as [ClusterLevelMedal] (named button, tap opens Level).
-class HexLevelBadge extends StatelessWidget {
+/// semantics contract as [ClusterLevelMedal] (named button, tap opens Level),
+/// and the same state treatment: hover and the open Level panel deepen the
+/// badge's own gold instead of putting a wash behind or around it (#8067).
+class HexLevelBadge extends StatefulWidget {
   final int level;
   final VoidCallback onTap;
   final double width;
   final double height;
   final double fontSize;
+
+  /// Whether the Level analytics panel is open — then the badge stays in its
+  /// deepened gold, the sticky counterpart of hover (#8062, #8067).
+  final bool selected;
 
   const HexLevelBadge({
     super.key,
@@ -22,12 +28,25 @@ class HexLevelBadge extends StatelessWidget {
     this.width = 48.0,
     this.height = 42.0,
     this.fontSize = 18.0,
+    this.selected = false,
   });
 
   @override
+  State<HexLevelBadge> createState() => _HexLevelBadgeState();
+}
+
+class _HexLevelBadgeState extends State<HexLevelBadge> {
+  bool _hovered = false;
+
+  @override
   Widget build(BuildContext context) {
-    final label = '${L10n.of(context).level} $level';
-    final fill = AppConfig.goldByTheme(context);
+    final label = '${L10n.of(context).level} ${widget.level}';
+    final lit = _hovered || widget.selected;
+    final fill = lit
+        ? AppConfig.goldHighlightByTheme(context)
+        : AppConfig.goldByTheme(context);
+    // The outline is always a step darker than whatever the fill is, so the
+    // lit badge deepens as one mark.
     final hsl = HSLColor.fromColor(fill);
     final border = hsl
         .withLightness((hsl.lightness * 0.72).clamp(0.0, 1.0))
@@ -43,23 +62,28 @@ class HexLevelBadge extends StatelessWidget {
         container: true,
         excludeSemantics: true,
         // Expose the tap on the announced node for assistive tech (#7185).
-        onTap: onTap,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTap: onTap,
-          child: CustomPaint(
-            size: Size(width, height),
-            painter: _HexBadgePainter(fill: fill, border: border),
-            child: SizedBox(
-              width: width,
-              height: height,
-              child: Center(
-                child: Text(
-                  '$level',
-                  style: TextStyle(
-                    fontSize: fontSize,
-                    fontWeight: FontWeight.bold,
-                    color: Colors.black,
+        onTap: widget.onTap,
+        child: MouseRegion(
+          cursor: SystemMouseCursors.click,
+          onEnter: (_) => setState(() => _hovered = true),
+          onExit: (_) => setState(() => _hovered = false),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: widget.onTap,
+            child: CustomPaint(
+              size: Size(widget.width, widget.height),
+              painter: HexBadgePainter(fill: fill, border: border),
+              child: SizedBox(
+                width: widget.width,
+                height: widget.height,
+                child: Center(
+                  child: Text(
+                    '${widget.level}',
+                    style: TextStyle(
+                      fontSize: widget.fontSize,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.black,
+                    ),
                   ),
                 ),
               ),
@@ -100,12 +124,13 @@ Path hexBadgePath(Size size) {
 const double hexBadgeStrokeWidth = 2.5;
 
 /// Paints the badge hexagon ([hexBadgePath]) with a gold fill and a darker gold
-/// outline (the Figma component).
-class _HexBadgePainter extends CustomPainter {
+/// outline (the Figma component). Public so tests can read the gold the badge
+/// is actually wearing — that color IS the hover / open-panel state (#8067).
+class HexBadgePainter extends CustomPainter {
   final Color fill;
   final Color border;
 
-  const _HexBadgePainter({required this.fill, required this.border});
+  const HexBadgePainter({required this.fill, required this.border});
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -122,6 +147,6 @@ class _HexBadgePainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_HexBadgePainter old) =>
+  bool shouldRepaint(HexBadgePainter old) =>
       old.fill != fill || old.border != border;
 }

--- a/lib/routes/world/world_analytics_bar.dart
+++ b/lib/routes/world/world_analytics_bar.dart
@@ -184,17 +184,11 @@ class _PowerupsRow extends StatelessWidget {
   static const double _pillVerticalPadding = 2.0;
   static const double _pillRightPadding = 14.0;
 
-  /// Ring of space kept around the hex badge so its open-panel highlight has
-  /// somewhere to paint (the badge itself is solid gold, so a wash *under* it
-  /// only reads in the margin). Reserved whether or not the Level tab is open,
-  /// so selecting it never nudges the badge.
-  static const double _badgeHighlightPadding = 6.0;
-
-  /// How far the badge unit sticks out past the pill's left edge (the Figma
-  /// overhang): half the hex, plus the highlight ring around it, so the
-  /// hexagon still lands centered on the pill's edge.
-  static final double _hexBadgeOverhang =
-      _badgeWidth / 2 + _badgeHighlightPadding;
+  /// Half the hex badge's width — how far it sticks out past the pill's
+  /// left edge (the Figma overhang). No ring is reserved around it: the badge
+  /// shows the open Level panel in its own gold, not in a wash beside it
+  /// (#8067).
+  static final double _hexBadgeOverhang = _badgeWidth / 2;
 
   // The bar's hex badge is smaller than [_HexLevelBadge]'s web-facing
   // defaults, per the Figma bar frame.
@@ -319,33 +313,23 @@ class _PowerupsRow extends StatelessWidget {
                       left: 0,
                       child: Material(
                         type: MaterialType.transparency,
-                        // Open-panel highlight, the badge's version of the
-                        // trackers' sticky wash (#7977, #8062): the same gold
-                        // wash on the same stadium geometry, but painted in the
-                        // reserved ring AROUND the hexagon — washing the badge
-                        // itself would be gold on gold. Outside the
-                        // celebration so the pulse keeps wrapping the bare
-                        // badge, and the padding is unconditional so the
-                        // highlight only ever adds color, never layout.
-                        child: Container(
-                          padding: const EdgeInsets.all(_badgeHighlightPadding),
-                          decoration: selectedTab == ProgressIndicatorEnum.level
-                              ? BoxDecoration(
-                                  color: AppConfig.goldByTheme(
-                                    context,
-                                  ).withAlpha(50),
-                                  borderRadius: BorderRadius.circular(100),
-                                )
-                              : null,
-                          child: LevelUpBadgeCelebration(
-                            levelUpdates: viewModel.levelUpdates,
-                            child: HexLevelBadge(
-                              level: level,
-                              onTap: () => viewModel.openLevel(context),
-                              width: _badgeWidth,
-                              height: _badgeHeight,
-                              fontSize: _badgeFontSize,
-                            ),
+                        // Open-panel highlight (#7977, #8062): the badge wears
+                        // its own deepened gold, the same treatment as hover
+                        // and as the web cluster's shield — a wash under a
+                        // solid gold hexagon is gold on gold, and one around it
+                        // is the circle #8067 removes. Purely a color change,
+                        // so lighting it never moves the badge or the pill it
+                        // overhangs.
+                        child: LevelUpBadgeCelebration(
+                          levelUpdates: viewModel.levelUpdates,
+                          child: HexLevelBadge(
+                            level: level,
+                            selected:
+                                selectedTab == ProgressIndicatorEnum.level,
+                            onTap: () => viewModel.openLevel(context),
+                            width: _badgeWidth,
+                            height: _badgeHeight,
+                            fontSize: _badgeFontSize,
                           ),
                         ),
                       ),

--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -464,12 +464,17 @@ class _ClusterTrackerButtonState extends State<ClusterTrackerButton> {
 
 /// The gold level shield overhanging the powerups pill (opens the level tab).
 /// Public so [WorldAnalyticsBar] can place it at the bar's left end.
-class ClusterLevelMedal extends StatelessWidget {
+///
+/// Unlike the trackers, the medal shows hover and the open Level panel in
+/// **its own gold** ([AppConfig.goldHighlightByTheme]) rather than behind
+/// itself: the trackers' circular wash sat gold-on-gold under a solid gold
+/// shield and read as a stray circle instead of feedback (#8067).
+class ClusterLevelMedal extends StatefulWidget {
   final int level;
   final VoidCallback onTap;
 
-  /// Whether the Level analytics tab is open — then the medal wears the same
-  /// persistent highlight the trackers use (#7977).
+  /// Whether the Level analytics tab is open — then the shield stays in its
+  /// deepened gold, the sticky counterpart of hover (#7977, #8067).
   final bool selected;
 
   const ClusterLevelMedal({
@@ -480,32 +485,40 @@ class ClusterLevelMedal extends StatelessWidget {
   });
 
   @override
+  State<ClusterLevelMedal> createState() => _ClusterLevelMedalState();
+}
+
+class _ClusterLevelMedalState extends State<ClusterLevelMedal> {
+  bool _hovered = false;
+
+  @override
   Widget build(BuildContext context) {
-    final label = '${L10n.of(context).level} $level';
+    final label = '${L10n.of(context).level} ${widget.level}';
+    final lit = _hovered || widget.selected;
     return Tooltip(
       message: label,
       // Semantics below names this; exclude the Tooltip to avoid "Level 2 Level 2".
       excludeFromSemantics: true,
       child: InkWell(
-        onTap: onTap,
-        hoverColor: AppConfig.goldByTheme(context).withAlpha(50),
+        onTap: widget.onTap,
+        onHover: (hovered) => setState(() => _hovered = hovered),
+        // No circular wash behind the shield — the shield's own gold carries
+        // hover (#8067). The focus highlight is left alone: keyboard users
+        // still get a visible ring.
+        hoverColor: Colors.transparent,
         borderRadius: BorderRadius.circular(100.0),
         child: Semantics(
           button: true,
           label: label,
           excludeSemantics: true,
           // Expose the tap on the announced node for assistive tech (#7185).
-          onTap: onTap,
-          child: Ink(
-            decoration: selected
-                ? BoxDecoration(
-                    color: AppConfig.goldByTheme(context).withAlpha(50),
-                    borderRadius: BorderRadius.circular(100.0),
-                  )
-                : null,
-            child: Padding(
-              padding: const EdgeInsets.all(4.0),
-              child: LevelRibbon(height: 44, level: level),
+          onTap: widget.onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(4.0),
+            child: LevelRibbon(
+              height: 44,
+              level: widget.level,
+              color: lit ? AppConfig.goldHighlightByTheme(context) : null,
             ),
           ),
         ),

--- a/lib/widgets/users/level_ribbon.dart
+++ b/lib/widgets/users/level_ribbon.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/pangea/common/widgets/customized_svg.dart';
 
 /// The gold ribbon/shield that represents a learner's level across the app —
 /// the single source of the level symbol, so the right-nav cluster medal
@@ -17,7 +18,12 @@ class LevelRibbon extends StatelessWidget {
   final int? level;
   final double height;
 
-  const LevelRibbon({required this.height, this.level, super.key});
+  /// Fill for the shield; defaults to the theme's gold. The cluster medal
+  /// passes [AppConfig.goldHighlightByTheme] to show hover and the open Level
+  /// panel in the mark itself rather than behind it (#8067).
+  final Color? color;
+
+  const LevelRibbon({required this.height, this.level, this.color, super.key});
 
   /// The shield outline from Figma (icon/warning-secondary), filled [hexcode].
   static String _shieldSvg(String hexcode) =>
@@ -31,7 +37,7 @@ class LevelRibbon extends StatelessWidget {
     // Shield aspect ratio from the viewBox (24.6667 x 28.875).
     final width = height * (24.6667 / 28.875);
     final ribbon = SvgPicture.string(
-      _shieldSvg(AppConfig.goldHexByTheme(context)),
+      _shieldSvg(colorToHex(color ?? AppConfig.goldByTheme(context))),
       width: width,
       height: height,
       fit: BoxFit.contain,

--- a/test/pangea/navigation/world_analytics_bar_test.dart
+++ b/test/pangea/navigation/world_analytics_bar_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -219,8 +220,22 @@ void main() {
       matching: trackerHighlights,
     );
 
-    /// The badge's wash, painted in the ring reserved around the hexagon.
-    final levelHighlight = find.ancestor(
+    /// The badge's lit state is its own gold, not a wash behind or around it
+    /// (#8067) — so read the color it is actually painted with.
+    Color badgeFill(WidgetTester tester) =>
+        (tester
+                    .widget<CustomPaint>(
+                      find.descendant(
+                        of: find.byType(HexLevelBadge),
+                        matching: find.byType(CustomPaint),
+                      ),
+                    )
+                    .painter!
+                as HexBadgePainter)
+            .fill;
+
+    /// No decorated box may wrap the badge: the circular wash #8067 removed.
+    final levelWash = find.ancestor(
       of: find.byType(HexLevelBadge),
       matching: find.byWidgetPredicate(
         (w) => w is Container && w.decoration != null,
@@ -233,7 +248,10 @@ void main() {
       await pumpBar(tester, viewModel: MockUserClusterViewModel());
 
       expect(trackerHighlights, findsNothing);
-      expect(levelHighlight, findsNothing);
+      expect(
+        badgeFill(tester),
+        AppConfig.goldByTheme(tester.element(find.byType(Scaffold))),
+      );
     });
 
     for (final (tab, name) in [
@@ -251,10 +269,13 @@ void main() {
         );
 
         expect(trackerHighlight(tab), findsOneWidget);
-        // Exactly one control wears the wash — no sibling tracker, and not
-        // the badge.
+        // Exactly one control wears the wash — no sibling tracker, and the
+        // badge keeps its default gold.
         expect(trackerHighlights, findsOneWidget);
-        expect(levelHighlight, findsNothing);
+        expect(
+          badgeFill(tester),
+          AppConfig.goldByTheme(tester.element(find.byType(Scaffold))),
+        );
       });
     }
 
@@ -267,24 +288,18 @@ void main() {
         selectedTab: ProgressIndicatorEnum.level,
       );
 
-      expect(levelHighlight, findsOneWidget);
       expect(trackerHighlights, findsNothing);
-
-      // The same gold wash the trackers use, so the two read as one state.
-      final decoration =
-          tester.widget<Container>(levelHighlight).decoration! as BoxDecoration;
+      // The badge's own gold deepens — no wash of any kind around it (#8067).
       expect(
-        decoration.color,
-        AppConfig.goldByTheme(
-          tester.element(find.byType(Scaffold)),
-        ).withAlpha(50),
+        badgeFill(tester),
+        AppConfig.goldHighlightByTheme(tester.element(find.byType(Scaffold))),
       );
+      expect(levelWash, findsNothing);
     });
 
     testWidgets('lighting the badge moves nothing', (tester) async {
-      // The highlight paints in a ring the badge reserves either way — if it
-      // were added only when selected, opening the Level page would shove the
-      // badge (and the pill it overhangs) sideways.
+      // Lighting is a pure color change, so opening the Level page must not
+      // shove the badge (or the pill it overhangs) sideways.
       await pumpBar(tester, viewModel: MockUserClusterViewModel());
       final unlit = tester.getRect(find.byType(HexLevelBadge));
 
@@ -294,6 +309,28 @@ void main() {
         selectedTab: ProgressIndicatorEnum.level,
       );
       expect(tester.getRect(find.byType(HexLevelBadge)), unlit);
+    });
+
+    testWidgets('hovering the badge deepens its gold, without a wash', (
+      tester,
+    ) async {
+      await pumpBar(tester, viewModel: MockUserClusterViewModel());
+      final context = tester.element(find.byType(Scaffold));
+      expect(badgeFill(tester), AppConfig.goldByTheme(context));
+
+      final pointer = TestPointer(1, PointerDeviceKind.mouse);
+      await tester.sendEventToBinding(
+        pointer.hover(tester.getCenter(find.byType(HexLevelBadge))),
+      );
+      await tester.pump();
+
+      expect(badgeFill(tester), AppConfig.goldHighlightByTheme(context));
+      expect(levelWash, findsNothing);
+
+      // And it goes back when the pointer leaves.
+      await tester.sendEventToBinding(pointer.hover(Offset.zero));
+      await tester.pump();
+      expect(badgeFill(tester), AppConfig.goldByTheme(context));
     });
   });
 

--- a/test/pangea/world/cluster_level_medal_test.dart
+++ b/test/pangea/world/cluster_level_medal_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/world_user_cluster.dart';
+import 'package:fluffychat/widgets/users/level_ribbon.dart';
+
+/// The web cluster's level medal shows hover and the open Level panel in the
+/// shield's OWN gold (#8067). The trackers beside it use a translucent gold
+/// wash on a circle; behind a solid gold shield that wash is gold on gold, and
+/// around it it reads as a stray circle — so the medal changes color instead.
+void main() {
+  Future<void> pumpMedal(
+    WidgetTester tester, {
+    bool selected = false,
+    VoidCallback? onTap,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: Center(
+            child: ClusterLevelMedal(
+              level: 3,
+              selected: selected,
+              onTap: onTap ?? () {},
+            ),
+          ),
+        ),
+      ),
+    );
+    // The L10n delegates load asynchronously; one pump isn't enough for the
+    // medal to mount (same as the other cluster tests).
+    await tester.pumpAndSettle();
+  }
+
+  Color? ribbonColor(WidgetTester tester) =>
+      tester.widget<LevelRibbon>(find.byType(LevelRibbon)).color;
+
+  BuildContext contextOf(WidgetTester tester) =>
+      tester.element(find.byType(Scaffold));
+
+  group('ClusterLevelMedal', () {
+    testWidgets('wears the default gold at rest', (tester) async {
+      await pumpMedal(tester);
+
+      expect(ribbonColor(tester), isNull);
+    });
+
+    testWidgets('deepens its gold while hovered, and back on exit', (
+      tester,
+    ) async {
+      await pumpMedal(tester);
+
+      final pointer = TestPointer(1, PointerDeviceKind.mouse);
+      await tester.sendEventToBinding(
+        pointer.hover(tester.getCenter(find.byType(ClusterLevelMedal))),
+      );
+      await tester.pump();
+      expect(
+        ribbonColor(tester),
+        AppConfig.goldHighlightByTheme(contextOf(tester)),
+      );
+
+      await tester.sendEventToBinding(pointer.hover(Offset.zero));
+      await tester.pump();
+      expect(ribbonColor(tester), isNull);
+    });
+
+    testWidgets('stays in the deepened gold while the Level panel is open', (
+      tester,
+    ) async {
+      await pumpMedal(tester, selected: true);
+
+      expect(
+        ribbonColor(tester),
+        AppConfig.goldHighlightByTheme(contextOf(tester)),
+      );
+    });
+
+    testWidgets('never paints a circle behind or around the shield', (
+      tester,
+    ) async {
+      // The regression #8067 names: a hover wash and a sticky selected wash,
+      // both circles under the medal. Neither may come back — in either state.
+      for (final selected in [false, true]) {
+        await pumpMedal(tester, selected: selected);
+
+        expect(
+          tester.widget<InkWell>(find.byType(InkWell)).hoverColor,
+          Colors.transparent,
+        );
+        expect(
+          find.descendant(
+            of: find.byType(ClusterLevelMedal),
+            matching: find.byWidgetPredicate(
+              (w) =>
+                  (w is Ink && w.decoration != null) ||
+                  (w is Container && w.decoration != null) ||
+                  (w is DecoratedBox),
+            ),
+          ),
+          findsNothing,
+        );
+      }
+    });
+
+    testWidgets('still opens the Level panel when tapped', (tester) async {
+      var taps = 0;
+      await pumpMedal(tester, onTap: () => taps++);
+
+      await tester.tap(find.byType(ClusterLevelMedal));
+      await tester.pump();
+
+      expect(taps, 1);
+    });
+  });
+}

--- a/test/pangea/world/hex_level_badge_test.dart
+++ b/test/pangea/world/hex_level_badge_test.dart
@@ -1,7 +1,9 @@
-import 'dart:ui';
+import 'package:flutter/material.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/world/hex_level_badge.dart';
 
 /// Pins the paint-bounds contract behind #7801: the level badge's hexagon must
@@ -69,5 +71,62 @@ void main() {
         );
       },
     );
+  });
+
+  /// The badge carries hover / open-panel state in its own gold (#8067), and
+  /// the outline tracks the fill so the badge deepens as ONE mark rather than
+  /// keeping a border that no longer relates to it.
+  group('lit badge', () {
+    Future<HexBadgePainter> pumpBadge(
+      WidgetTester tester, {
+      required bool selected,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          supportedLocales: L10n.supportedLocales,
+          home: Scaffold(
+            body: Center(
+              child: HexLevelBadge(level: 4, selected: selected, onTap: () {}),
+            ),
+          ),
+        ),
+      );
+      // The L10n delegates load asynchronously; one pump isn't enough.
+      await tester.pumpAndSettle();
+      return tester
+              .widget<CustomPaint>(
+                find.descendant(
+                  of: find.byType(HexLevelBadge),
+                  matching: find.byType(CustomPaint),
+                ),
+              )
+              .painter!
+          as HexBadgePainter;
+    }
+
+    testWidgets('selected deepens the fill from the default gold', (
+      tester,
+    ) async {
+      final unlit = await pumpBadge(tester, selected: false);
+      final context = tester.element(find.byType(Scaffold));
+      expect(unlit.fill, AppConfig.goldByTheme(context));
+
+      final lit = await pumpBadge(tester, selected: true);
+      expect(lit.fill, AppConfig.goldHighlightByTheme(context));
+    });
+
+    testWidgets('the outline stays a step darker than whatever the fill is', (
+      tester,
+    ) async {
+      for (final selected in [false, true]) {
+        final painter = await pumpBadge(tester, selected: selected);
+        expect(
+          HSLColor.fromColor(painter.border).lightness,
+          lessThan(HSLColor.fromColor(painter.fill).lightness),
+          reason: 'selected: $selected',
+        );
+      }
+    });
   });
 }


### PR DESCRIPTION
## What

The level control in both user clusters shows hover and the open Level panel by deepening its own gold, instead of a circular gold wash behind/around it.

## Why

Closes #8067

- Web: the medal's `InkWell` hover wash and the sticky `Ink` decoration were circles behind a solid gold shield.
- Mobile: because a wash *under* a solid gold hexagon is gold on gold, #8062 painted it in a 6px ring reserved around the badge — which is the surrounding circle #8067 removes. That ring is gone, restoring the Figma half-hex overhang.

Both surfaces now use `AppConfig.goldHighlightByTheme` — the theme gold lerped 20% toward black. Deepened toward black rather than down the HSL lightness axis because the dark theme's `goldLight` sits near the top of that axis, where dropping lightness mostly saturates the yellow instead of darkening it. Black level-number contrast stays above 8:1 in both brightnesses. Hover and selected use the same treatment, matching how the trackers share one wash for both states. Keyboard focus rings are untouched.

`LevelRibbon` gained an optional `color` (defaults to theme gold, so the profile/analytics level chips are unchanged); `HexLevelBadge` gained `selected` plus a hover region — it previously had no click cursor either.

## Testing

- `fvm flutter test` — full suite, 1729 passing.
- New: `test/pangea/world/cluster_level_medal_test.dart` — default/hover/selected gold on the web medal, no decorated box in any state, tap still fires.
- Updated: `test/pangea/navigation/world_analytics_bar_test.dart` — the badge's lit state is now read off `HexBadgePainter.fill`; added a hover case and kept the "lighting the badge moves nothing" layout guard.
- Updated: `test/pangea/world/hex_level_badge_test.dart` — selected deepens the fill, outline stays a step darker than whatever the fill is.
- Rendered both themes to a throwaway golden locally to eyeball the four states; the shift reads clearly in light and dark.
- Playwright a11y specs (triggered by `lib/routes/world/**`) **not run**: `auth.setup.ts` needs `TEST_MATRIX_USERNAME`/`TEST_MATRIX_PASSWORD`, which aren't in the local `.env`. No DOM changed — the badge is canvas-painted, which axe can't inspect anyway.

## Deploy Notes

None