### PR TITLE
docs(ci): correct the cache-scoping section — writing on main is not enough

### DIFF
--- a/.github/instructions/ci.instructions.md
+++ b/.github/instructions/ci.instructions.md
@@ -49,7 +49,9 @@ Settings shows `Version: <semver>+<build>` as a debugging aid. The two halves co
 
 A cache written during a run is scoped to that run's ref: `pull_request` runs write to `refs/pull/<N>/merge` (**isolated per PR**), `push` to main writes to `refs/heads/main`. A run restores from its own ref's scope **plus the default branch**, and can never read another PR's scope.
 
-**So the only way to share a cache across PRs is to write it on `main`.** `integrate.yaml` originally ran only on `pull_request` + `merge_group`, so the Rust cache (`target/debug`, ~425 MB) never restored on any PR and it was recompiled from source on every web/apk/ios build. Running the debug web build on push to `main` is what fixes it. The Flutter SDK and pub caches hit reliably and are left alone.
+**Sharing a cache across PRs takes two things: writing it on `main`, and telling the action to read from there.** `integrate.yaml` originally ran only on `pull_request` + `merge_group`, so nothing wrote to the `main` scope at all. Running the debug web build on push to `main` fixed the write — but `moonrepo/setup-rust` only looks in the current ref's scope, so PRs kept missing a byte-identical key sitting on `main` and recompiled `target/debug` on every build. **`cache-base: main` on every `setup-rust` step is what makes the read happen; without it the write is inert.** `subosito/flutter-action` needs no equivalent — it uses `actions/cache`, which falls back to the default branch on its own, which is why the Flutter and pub caches hit reliably.
+
+A warm cache that is never read looks exactly like a cold one in the build log. To tell them apart, compare `lastAccessedAt` to `createdAt` on the `main`-scope entry (`gh cache list`): if they are equal, nothing has ever restored from it.
 
 ## Gotchas for future edits
 


### PR DESCRIPTION
## Why

The Cache scoping section in `ci.instructions.md` claimed writing the Rust cache on `main` was what fixed PR restores. Investigating #8053 disproved that: the write happened and the read never did. The section as written would send the next person to the wrong conclusion.

Wording agreed in chat before this edit, per the instructions-doc invariant.

## What changed

One paragraph. Three corrections:

- **"Running the debug web build on push to `main` is what fixes it"** → it fixed the write only. `moonrepo/setup-rust` reads only the current ref's scope, so PRs kept missing a byte-identical key sitting on `main`. `cache-base: main` (added in #8068) is what makes the read happen; without it the write is inert.
- **Why the two actions differ** — `subosito/flutter-action` needs no equivalent because it uses `actions/cache`, which falls back to the default branch on its own. That is why Flutter and pub hit while Rust never did, and it stops someone "tidying up" the asymmetry later.
- **Dropped the `~425 MB` figure** — observed entries are 64 MB.

Adds a two-sentence diagnostic: a warm cache that is never read is indistinguishable from a cold one in the build log, so compare `lastAccessedAt` to `createdAt` on the `main`-scope entry via `gh cache list`. That is how this was caught.

## Testing

Docs-only, no executable surface. Verified both stale claims are gone.

### Pull Request has been tested on:

- [x] N/A — documentation only

### Accessibility

- [x] N/A — no UI change