### PR TITLE
fix(practice): show the sent message in grammar fill-in-the-blank examples

### DIFF
--- a/lib/routes/analytics/construct_analytics/practice/grammar_error_practice_generator.dart
+++ b/lib/routes/analytics/construct_analytics/practice/grammar_error_practice_generator.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:fluffychat/routes/chat/choreographer/choreo_edit_model.dart';
+import 'package:fluffychat/routes/chat/choreographer/choreo_record_model.dart';
 import 'package:fluffychat/routes/chat/toolbar/practice_exercises/message_practice_exercise_request.dart';
 import 'package:fluffychat/routes/chat/toolbar/practice_exercises/multiple_choice_practice_exercise_model.dart';
 import 'package:fluffychat/routes/chat/toolbar/practice_exercises/practice_exercise_model.dart';
@@ -25,39 +27,35 @@ class GrammarErrorPracticeGenerator {
     final correctChoice = igcMatch!.bestChoice!.value;
     final choices = igcMatch.choices!.map((c) => c.value).toList();
 
-    // Display the sentence off igcMatch.fullText and blank the target span in
-    // it. The offset indexes fullText correctly, but the blank length must be
-    // derived from the accepted correction (bestChoice), NOT igcMatch.length: on
-    // accept, IgcController._applyReplacement overwrites fullText with the
-    // CORRECTED sentence, and for messages sent before the 2026-02-25 length fix
-    // (#5655) it left `length` at the pre-correction span length. Trusting that
-    // stale length under-covers the blank by the correction's length delta,
-    // orphaning the tail of the target word (e.g. the "n" of "están").
-    // bestChoice.value is exactly the corrected span sitting at `offset`, so it
-    // aligns the blank for both old and new records; fall back to the stored
-    // length only if that span isn't present (malformed record) (#7360).
-    final baseText = igcMatch.fullText;
-    final baseChars = baseText.characters;
-    final blankLength = targetBlankLength(
-      baseText: baseText,
-      offset: igcMatch.offset,
-      correctChoice: correctChoice,
+    final example = resolveExample(
+      choreo: choreo,
+      stepIndex: stepIndex,
+      matchOffset: igcMatch.offset,
       storedLength: igcMatch.length,
+      correctChoice: correctChoice,
+      sentText: req.grammarErrorInfo!.sentText,
+      fallbackText: igcMatch.fullText,
     );
-    final errorSpan = baseChars
-        .skip(igcMatch.offset)
-        .take(blankLength)
-        .toString();
 
-    if (!req.grammarErrorInfo!.translation.contains(errorSpan)) {
+    // Offer the learner's own pre-correction text as a distractor — the whole
+    // point of the exercise is choosing between it and the correction. Skipped
+    // when it already appears in the L1 translation printed under the sentence.
+    final errorSpan = originalErrorSpan(
+      choreo: choreo,
+      stepIndex: stepIndex,
+      matchOffset: igcMatch.offset,
+      correctChoice: correctChoice,
+    );
+    if (errorSpan != null &&
+        !req.grammarErrorInfo!.translation.contains(errorSpan)) {
       choices.add(errorSpan);
     }
 
-    if (igcMatch.offset + blankLength > baseChars.length) {
+    if (example.offset + example.length > example.text.characters.length) {
       // Sometimes choreo records turn out weird when users edit the message
       // mid-IGC. If the offsets / lengths don't make sense, skip this target.
       throw Exception(
-        "IGC match offset and span exceed base text length. Base text: '$baseText', match offset: ${igcMatch.offset}, span length: $blankLength",
+        "IGC match offset and span exceed base text length. Base text: '${example.text}', match offset: ${example.offset}, span length: ${example.length}",
       );
     }
 
@@ -70,24 +68,229 @@ class GrammarErrorPracticeGenerator {
           choices: choices.toSet(),
           answers: {correctChoice},
         ),
-        text: baseText,
-        errorOffset: igcMatch.offset,
-        errorLength: blankLength,
+        text: example.text,
+        errorOffset: example.offset,
+        errorLength: example.length,
         eventID: eventID,
         translation: req.grammarErrorInfo!.translation,
       ),
     );
   }
 
+  /// The sentence to show the learner, and where the blank goes in it
+  /// (grapheme-indexed, as `GrammarErrorExampleWidget.splitAroundBlank` wants).
+  ///
+  /// The example must read as the message the learner actually sent — every
+  /// accepted writing-assistance correction applied, with just this one span
+  /// blanked (#8044). The match's own `fullText` is not that sentence: on
+  /// accept, `IgcController._applyReplacement` rewrites it to the text as of
+  /// that single replacement, so a step-0 match still carries every later error.
+  /// For a learner writing in their L1 and accepting suggestions one at a time,
+  /// that reads as English.
+  ///
+  /// So the target span is walked forward out of `stepText(stepIndex)` and into
+  /// [sentText]. Anything that makes the walk unsafe — a later edit overlapping
+  /// the span, a malformed legacy record, no sent text on a restored session —
+  /// falls back to [fallbackText] (the old behavior), so no target is ever lost.
+  @visibleForTesting
+  static ({String text, int offset, int length}) resolveExample({
+    required ChoreoRecordModel choreo,
+    required int stepIndex,
+    required int matchOffset,
+    required int storedLength,
+    required String correctChoice,
+    required String? sentText,
+    required String fallbackText,
+  }) {
+    final fallback = (
+      text: fallbackText,
+      offset: matchOffset,
+      length: targetBlankLength(
+        baseText: fallbackText,
+        offset: matchOffset,
+        correctChoice: correctChoice,
+        storedLength: storedLength,
+      ),
+    );
+
+    if (sentText == null || sentText.isEmpty) return fallback;
+    if (stepIndex < 0 || stepIndex >= choreo.choreoSteps.length) {
+      return fallback;
+    }
+
+    try {
+      final blankLength = targetBlankLength(
+        baseText: choreo.stepText(stepIndex: stepIndex),
+        offset: matchOffset,
+        correctChoice: correctChoice,
+        storedLength: storedLength,
+      );
+
+      final mapped = mapSpanToSentText(
+        choreo: choreo,
+        stepIndex: stepIndex,
+        offset: matchOffset,
+        length: blankLength,
+        sentText: sentText,
+      );
+      if (mapped == null) return fallback;
+
+      // The mapped span must still be the accepted correction. If it isn't, the
+      // learner reworked that stretch of text afterwards and the walk landed
+      // somewhere else — better the old sentence than a misplaced blank.
+      final mappedSpan = sentText.characters
+          .skip(mapped.offset)
+          .take(mapped.length)
+          .toString();
+      if (mappedSpan != correctChoice) return fallback;
+
+      return (text: sentText, offset: mapped.offset, length: mapped.length);
+    } on RangeError {
+      return fallback;
+    }
+  }
+
+  /// Walks the span at [offset]/[length] in `stepText(stepIndex)` forward
+  /// through every later choreo edit, landing it in [sentText]. Null when a
+  /// later edit overlaps the span, or when the result doesn't sit on grapheme
+  /// boundaries.
+  ///
+  /// [ChoreoEditModel] offsets are code units, while match offsets and the
+  /// blank renderer are graphemes — so the walk runs entirely in code units and
+  /// converts back exactly once, at the end. Mixing the two is the class of bug
+  /// #7360 already was.
+  @visibleForTesting
+  static ({int offset, int length})? mapSpanToSentText({
+    required ChoreoRecordModel choreo,
+    required int stepIndex,
+    required int offset,
+    required int length,
+    required String sentText,
+  }) {
+    final stepChars = choreo.stepText(stepIndex: stepIndex).characters;
+    if (offset < 0 || length < 0 || offset + length > stepChars.length) {
+      return null;
+    }
+
+    int start = stepChars.take(offset).toString().length;
+    int end = start + stepChars.skip(offset).take(length).toString().length;
+
+    for (int i = stepIndex + 1; i < choreo.choreoSteps.length; i++) {
+      final edit = choreo.choreoSteps[i].edits;
+      if (edit == null) continue;
+      final shifted = _shiftSpan(start, end, edit);
+      if (shifted == null) return null;
+      start = shifted.$1;
+      end = shifted.$2;
+    }
+
+    // The learner can keep typing after their last correction, so the sent text
+    // is not always the last step's text. That trailing difference is one more
+    // edit to walk through.
+    final lastStepText = choreo.stepText();
+    if (lastStepText != sentText) {
+      final shifted = _shiftSpan(
+        start,
+        end,
+        ChoreoEditModel.fromText(
+          originalText: lastStepText,
+          editedText: sentText,
+        ),
+      );
+      if (shifted == null) return null;
+      start = shifted.$1;
+      end = shifted.$2;
+    }
+
+    if (start < 0 || start > end || end > sentText.length) return null;
+
+    final before = sentText.substring(0, start);
+    final span = sentText.substring(start, end);
+    final beforeLength = before.characters.length;
+    final spanLength = span.characters.length;
+
+    // Reject boundaries that landed inside a grapheme cluster.
+    if (sentText.characters.take(beforeLength).toString() != before)
+      return null;
+    if (sentText.characters.skip(beforeLength).take(spanLength).toString() !=
+        span) {
+      return null;
+    }
+
+    return (offset: beforeLength, length: spanLength);
+  }
+
+  /// [start]/[end] (code units) after [edit] is applied to the text they index,
+  /// or null if the edit overlaps the span — a step's edit is the minimal
+  /// whole-text diff ([ChoreoEditModel.fromText]), so it absorbs any typing the
+  /// learner did between steps as well as the correction itself, and can well
+  /// cover the span we're tracking.
+  static (int, int)? _shiftSpan(int start, int end, ChoreoEditModel edit) {
+    if (edit.length == 0 && edit.insert.isEmpty) return (start, end);
+
+    final editEnd = edit.offset + edit.length;
+    if (editEnd <= start) {
+      final delta = edit.insert.length - edit.length;
+      return (start + delta, end + delta);
+    }
+    if (edit.offset >= end) return (start, end);
+    return null;
+  }
+
+  /// The learner's own text for this span before the correction — the wrong
+  /// answer worth offering alongside the right one.
+  ///
+  /// Recovered by shifting the corrected span's end back by the step's edit
+  /// delta, which is only sound when that edit sits inside the corrected span;
+  /// returns null otherwise (the learner typed elsewhere between steps, so the
+  /// diff covers more than this correction). Note the stored match `length` is
+  /// no use here — `_applyReplacement` overwrites it with the *corrected*
+  /// length on accept.
+  @visibleForTesting
+  static String? originalErrorSpan({
+    required ChoreoRecordModel choreo,
+    required int stepIndex,
+    required int matchOffset,
+    required String correctChoice,
+  }) {
+    if (stepIndex < 0 || stepIndex >= choreo.choreoSteps.length) return null;
+    final edit = choreo.choreoSteps[stepIndex].edits;
+    if (edit == null) return null;
+
+    try {
+      final stepText = choreo.stepText(stepIndex: stepIndex);
+      final priorText = choreo.stepText(stepIndex: stepIndex - 1);
+
+      final start = stepText.characters.take(matchOffset).toString().length;
+      final end = start + correctChoice.length;
+      if (end > stepText.length) return null;
+      if (stepText.substring(start, end) != correctChoice) return null;
+
+      // Containment also guarantees the text before [start] is untouched by the
+      // edit, so [start] indexes priorText the same way it indexes stepText.
+      if (edit.offset < start || edit.offset + edit.insert.length > end) {
+        return null;
+      }
+
+      final priorEnd = end - (edit.insert.length - edit.length);
+      if (priorEnd < start || priorEnd > priorText.length) return null;
+
+      final span = priorText.substring(start, priorEnd);
+      return span.isEmpty || span == correctChoice ? null : span;
+    } on RangeError {
+      return null;
+    }
+  }
+
   /// The number of graphemes the blank should span in [baseText] starting at
   /// [offset]. Prefers the length of the accepted correction [correctChoice] —
-  /// the true corrected span sitting at [offset] in fullText — over
-  /// [storedLength]. On accept, `IgcController._applyReplacement` overwrites the
-  /// match's fullText with the corrected sentence; for messages sent before the
-  /// 2026-02-25 length fix (#5655) it left `length` at the pre-correction span
-  /// length, which under-covers the blank by the correction's length delta and
-  /// orphans the tail of the target word (e.g. the "n" of "están"). Falls back
-  /// to [storedLength] when the corrected span isn't present at [offset]
+  /// the true corrected span sitting at [offset] — over [storedLength]. On
+  /// accept, `IgcController._applyReplacement` rewrites the match's length to
+  /// the corrected one; for messages sent before the 2026-02-25 length fix
+  /// (#5655) it left `length` at the pre-correction span length, which
+  /// under-covers the blank by the correction's length delta and orphans the
+  /// tail of the target word (e.g. the "n" of "están"). Falls back to
+  /// [storedLength] when the corrected span isn't present at [offset]
   /// (malformed record) (#7360).
   @visibleForTesting
   static int targetBlankLength({

--- a/lib/routes/analytics/construct_analytics/practice/grammar_error_practice_generator.dart
+++ b/lib/routes/analytics/construct_analytics/practice/grammar_error_practice_generator.dart
@@ -210,8 +210,9 @@ class GrammarErrorPracticeGenerator {
     final spanLength = span.characters.length;
 
     // Reject boundaries that landed inside a grapheme cluster.
-    if (sentText.characters.take(beforeLength).toString() != before)
+    if (sentText.characters.take(beforeLength).toString() != before) {
       return null;
+    }
     if (sentText.characters.skip(beforeLength).take(spanLength).toString() !=
         span) {
       return null;
@@ -246,7 +247,6 @@ class GrammarErrorPracticeGenerator {
   /// diff covers more than this correction). Note the stored match `length` is
   /// no use here — `_applyReplacement` overwrites it with the *corrected*
   /// length on accept.
-  @visibleForTesting
   static String? originalErrorSpan({
     required ChoreoRecordModel choreo,
     required int stepIndex,

--- a/lib/routes/analytics/construct_analytics/practice/grammar_error_target_generator.dart
+++ b/lib/routes/analytics/construct_analytics/practice/grammar_error_target_generator.dart
@@ -191,6 +191,9 @@ class GrammarErrorTargetGenerator {
             stepIndex: i,
             eventID: event.eventId,
             translation: translation,
+            // The example is shown off the sent message, which is gated to L2
+            // above, so it reads as L2 with every correction applied (#8044).
+            sentText: originalSent?.text ?? event.body,
           ),
         ),
       );

--- a/lib/routes/analytics/construct_analytics/practice/grammar_error_target_generator.dart
+++ b/lib/routes/analytics/construct_analytics/practice/grammar_error_target_generator.dart
@@ -6,6 +6,7 @@ import 'package:fluffychat/features/analytics/construct_use_type_enum.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/practice/analytics_practice_constants.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/practice/analytics_practice_session_model.dart';
+import 'package:fluffychat/routes/analytics/construct_analytics/practice/grammar_error_practice_generator.dart';
 import 'package:fluffychat/routes/chat/events/event_wrappers/pangea_message_event.dart';
 import 'package:fluffychat/routes/chat/toolbar/practice_exercises/message_practice_exercise_request.dart';
 import 'package:fluffychat/routes/chat/toolbar/practice_exercises/practice_exercise_type_enum.dart';
@@ -133,17 +134,28 @@ class GrammarErrorTargetGenerator {
       final igcMatch = step.acceptedOrIgnoredMatch;
 
       final stepText = choreo.stepText(stepIndex: i - 1);
-      final errorSpan = stepText.characters
-          .skip(igcMatch!.match.offset)
-          .take(igcMatch.match.length)
-          .toString();
+      // The stored `length` is the *corrected* span's length —
+      // `IgcController._applyReplacement` overwrites it on accept — so slicing
+      // the pre-correction text with it drifts by the correction's length delta
+      // and can hide an accent-only fix from the normalization check below.
+      final errorSpan =
+          GrammarErrorPracticeGenerator.originalErrorSpan(
+            choreo: choreo,
+            stepIndex: i,
+            matchOffset: igcMatch!.match.offset,
+            correctChoice: igcMatch.match.bestChoice!.value,
+          ) ??
+          stepText.characters
+              .skip(igcMatch.match.offset)
+              .take(igcMatch.match.length)
+              .toString();
 
       if (igcMatch.match.isNormalizationError(errorSpanOverride: errorSpan)) {
         continue;
       }
 
       if (igcMatch.match.offset == 0 &&
-          igcMatch.match.length >= stepText.trim().characters.length) {
+          errorSpan.characters.length >= stepText.trim().characters.length) {
         continue;
       }
 

--- a/lib/routes/chat/toolbar/practice_exercises/message_practice_exercise_request.dart
+++ b/lib/routes/chat/toolbar/practice_exercises/message_practice_exercise_request.dart
@@ -44,11 +44,19 @@ class GrammarErrorRequestInfo {
   final String eventID;
   final String translation;
 
+  /// The message as it was actually sent — every accepted writing-assistance
+  /// correction applied. The example sentence is rendered off this, not off the
+  /// choreo step's own text, which only carries the corrections made up to that
+  /// step and so can still read as L1 (#8044). Null on sessions restored from
+  /// storage that predate this field; the generator falls back in that case.
+  final String? sentText;
+
   const GrammarErrorRequestInfo({
     required this.choreo,
     required this.stepIndex,
     required this.eventID,
     required this.translation,
+    this.sentText,
   });
 
   Map<String, dynamic> toJson() {
@@ -57,6 +65,7 @@ class GrammarErrorRequestInfo {
       'step_index': stepIndex,
       'event_id': eventID,
       'translation': translation,
+      'sent_text': sentText,
     };
   }
 
@@ -66,6 +75,7 @@ class GrammarErrorRequestInfo {
       stepIndex: json['step_index'] as int,
       eventID: json['event_id'] as String,
       translation: json['translation'] as String,
+      sentText: json['sent_text'] as String?,
     );
   }
 }

--- a/test/pangea/grammar_error_example_mapping_test.dart
+++ b/test/pangea/grammar_error_example_mapping_test.dart
@@ -1,0 +1,277 @@
+import 'package:characters/characters.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/analytics/construct_analytics/practice/grammar_error_practice_generator.dart';
+import 'package:fluffychat/routes/chat/choreographer/choreo_record_model.dart';
+
+/// Coverage for #8044: the grammar-practice example must read as the message
+/// the learner actually sent — every accepted writing-assistance correction
+/// applied — with just the one target span blanked. The match's own `fullText`
+/// only carries the corrections made up to its own step, so a learner writing
+/// in their L1 and accepting suggestions one at a time saw a mostly-English
+/// example.
+///
+/// Records are built the way the choreographer builds them, via [addRecord],
+/// so the edits under test are real [ChoreoEditModel] diffs.
+ChoreoRecordModel _record(String originalText, List<String> steps) {
+  final record = ChoreoRecordModel(
+    originalText: originalText,
+    choreoSteps: [],
+    openMatches: [],
+  );
+  for (final step in steps) {
+    record.addRecord(step);
+  }
+  return record;
+}
+
+void main() {
+  group('GrammarErrorPracticeGenerator.resolveExample', () {
+    test('shows the sent text with every later correction applied, blanking '
+        'only the step-0 target', () {
+      // "have" -> "habe" (step 0, the target), then "hund" -> "Hund".
+      final record = _record('Ich have ein hund', [
+        'Ich habe ein hund',
+        'Ich habe ein Hund',
+      ]);
+
+      final example = GrammarErrorPracticeGenerator.resolveExample(
+        choreo: record,
+        stepIndex: 0,
+        matchOffset: 4,
+        storedLength: 4,
+        correctChoice: 'habe',
+        sentText: 'Ich habe ein Hund',
+        // What the old code showed: the sentence as of step 0, still carrying
+        // the uncorrected "hund".
+        fallbackText: 'Ich habe ein hund',
+      );
+
+      expect(example.text, 'Ich habe ein Hund');
+      expect(example.offset, 4);
+      expect(example.length, 4);
+      expect(
+        example.text.characters
+            .skip(example.offset)
+            .take(example.length)
+            .toString(),
+        'habe',
+      );
+    });
+
+    test('stays aligned when the learner kept typing after the last '
+        'correction', () {
+      final record = _record('Ich have ein hund', ['Ich habe ein hund']);
+
+      final example = GrammarErrorPracticeGenerator.resolveExample(
+        choreo: record,
+        stepIndex: 0,
+        matchOffset: 4,
+        storedLength: 4,
+        correctChoice: 'habe',
+        sentText: 'Ich habe ein hund und eine Katze',
+        fallbackText: 'Ich habe ein hund',
+      );
+
+      expect(example.text, 'Ich habe ein hund und eine Katze');
+      expect(example.offset, 4);
+      expect(example.length, 4);
+    });
+
+    test('uses the corrected length over a stale stored length (#5655), '
+        'measured against the step text', () {
+      final record = _record('Yo creo que esta bien', [
+        'Yo creo que están bien',
+        'Yo creo que están bueno',
+      ]);
+
+      final example = GrammarErrorPracticeGenerator.resolveExample(
+        choreo: record,
+        stepIndex: 0,
+        matchOffset: 12,
+        storedLength: 4, // pre-correction "esta"
+        correctChoice: 'están',
+        sentText: 'Yo creo que están bueno',
+        fallbackText: 'Yo creo que están bien',
+      );
+
+      expect(example.text, 'Yo creo que están bueno');
+      expect(example.offset, 12);
+      expect(example.length, 5);
+      expect(
+        example.text.characters
+            .skip(example.offset)
+            .take(example.length)
+            .toString(),
+        'están',
+      );
+    });
+
+    test('a multi-code-unit grapheme before the target keeps the blank '
+        'aligned', () {
+      // The emoji is one grapheme but two UTF-16 code units. The walk runs in
+      // code units and converts back once, so the returned offset must be the
+      // grapheme one the blank renderer expects.
+      final record = _record('🙂 Ich have ein hund', [
+        '🙂 Ich habe ein hund',
+        '🙂 Ich habe ein Hund',
+      ]);
+
+      final example = GrammarErrorPracticeGenerator.resolveExample(
+        choreo: record,
+        stepIndex: 0,
+        matchOffset: 6,
+        storedLength: 4,
+        correctChoice: 'habe',
+        sentText: '🙂 Ich habe ein Hund',
+        fallbackText: '🙂 Ich habe ein hund',
+      );
+
+      expect(example.text, '🙂 Ich habe ein Hund');
+      expect(example.offset, 6);
+      expect(example.length, 4);
+      expect(
+        example.text.characters
+            .skip(example.offset)
+            .take(example.length)
+            .toString(),
+        'habe',
+      );
+    });
+
+    test('falls back to the old base text when a later edit reworked the '
+        'target span', () {
+      final record = _record('Ich have ein hund', [
+        'Ich habe ein hund',
+        'Ich hab ein hund', // the learner edited the corrected word afterwards
+      ]);
+
+      final example = GrammarErrorPracticeGenerator.resolveExample(
+        choreo: record,
+        stepIndex: 0,
+        matchOffset: 4,
+        storedLength: 4,
+        correctChoice: 'habe',
+        sentText: 'Ich hab ein hund',
+        fallbackText: 'Ich habe ein hund',
+      );
+
+      expect(example.text, 'Ich habe ein hund');
+      expect(example.offset, 4);
+      expect(example.length, 4);
+    });
+
+    test('falls back when the session carries no sent text (restored from '
+        'storage before #8044)', () {
+      final record = _record('Ich have ein hund', ['Ich habe ein hund']);
+
+      final example = GrammarErrorPracticeGenerator.resolveExample(
+        choreo: record,
+        stepIndex: 0,
+        matchOffset: 4,
+        storedLength: 4,
+        correctChoice: 'habe',
+        sentText: null,
+        fallbackText: 'Ich habe ein hund',
+      );
+
+      expect(example.text, 'Ich habe ein hund');
+      expect(example.offset, 4);
+      expect(example.length, 4);
+    });
+  });
+
+  group('GrammarErrorPracticeGenerator.mapSpanToSentText', () {
+    test('returns null when a later edit overlaps the span', () {
+      final record = _record('Ich have ein hund', [
+        'Ich habe ein hund',
+        'Ich hab ein hund',
+      ]);
+
+      final mapped = GrammarErrorPracticeGenerator.mapSpanToSentText(
+        choreo: record,
+        stepIndex: 0,
+        offset: 4,
+        length: 4,
+        sentText: 'Ich hab ein hund',
+      );
+
+      expect(mapped, isNull);
+    });
+
+    test('returns null when the span runs past the step text', () {
+      final record = _record('Ich have ein hund', ['Ich habe ein hund']);
+
+      final mapped = GrammarErrorPracticeGenerator.mapSpanToSentText(
+        choreo: record,
+        stepIndex: 0,
+        offset: 14,
+        length: 20,
+        sentText: 'Ich habe ein hund',
+      );
+
+      expect(mapped, isNull);
+    });
+  });
+
+  group('GrammarErrorPracticeGenerator.originalErrorSpan', () {
+    test('recovers the learner\'s own word for a same-length correction', () {
+      final record = _record('Ich have ein hund', ['Ich habe ein hund']);
+
+      expect(
+        GrammarErrorPracticeGenerator.originalErrorSpan(
+          choreo: record,
+          stepIndex: 0,
+          matchOffset: 4,
+          correctChoice: 'habe',
+        ),
+        'have',
+      );
+    });
+
+    test('recovers it when the correction changed the span length', () {
+      final record = _record('Yo creo que esta bien', [
+        'Yo creo que están bien',
+      ]);
+
+      expect(
+        GrammarErrorPracticeGenerator.originalErrorSpan(
+          choreo: record,
+          stepIndex: 0,
+          matchOffset: 12,
+          correctChoice: 'están',
+        ),
+        'esta',
+      );
+    });
+
+    test('returns null when the learner typed elsewhere in the same step, so '
+        'the diff covers more than the correction', () {
+      final record = _record('Ich have ein hund', ['Ich habe ein hund heute']);
+
+      expect(
+        GrammarErrorPracticeGenerator.originalErrorSpan(
+          choreo: record,
+          stepIndex: 0,
+          matchOffset: 4,
+          correctChoice: 'habe',
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null when the corrected span is not at the match offset', () {
+      final record = _record('Ich have ein hund', ['Ich habe ein hund']);
+
+      expect(
+        GrammarErrorPracticeGenerator.originalErrorSpan(
+          choreo: record,
+          stepIndex: 0,
+          matchOffset: 9,
+          correctChoice: 'habe',
+        ),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
### What

Grammar-practice "fill in the blank" examples now render the message as it was **sent** — every accepted writing-assistance correction applied — with just the one target span blanked.

### Why

Closes #8044

The example was rendered off the accepted IGC match's own `fullText`. On accept, `IgcController._applyReplacement` rewrites `fullText` to the text as of that *single* replacement, so a step-0 match still carries every later error. A learner writing largely in their L1 and accepting suggestions one at a time got a mostly-English example — the screenshots on the issue. The existing test fixture showed the same staleness: `'¿Dónde están las fiesta? Mis amigos se gustan ir.'` still carries two uncorrected errors.

Per Will's comment on the issue, the example must show all suggestions applied and blank exactly one.

### Changes

- `GrammarErrorPracticeGenerator.resolveExample` / `mapSpanToSentText` — walk the target span forward out of `stepText(stepIndex)`, through every later choreo edit plus the trailing diff to the sent text, and blank it there. The walk runs in code units (`ChoreoEditModel` is code-unit indexed, while match offsets and the blank renderer are graphemes) and converts back exactly once.
- Any unsafe case — a later edit overlapping the span, a malformed legacy record, a session restored from storage with no sent text — falls back to the old base text, so no practice target is lost.
- `sentText` plumbed onto `GrammarErrorRequestInfo` from `originalSent?.text ?? event.body`; target selection already gates that representation to L2.
- `originalErrorSpan` recovers the learner's own pre-correction text by shifting the corrected span's end back by the step's edit delta. Used for two things:
  - As a distractor. That was the intent of the existing `!translation.contains(errorSpan)` guard, but `errorSpan` was sliced out of `fullText` at the target offset, which yields the *correct* answer — a no-op against the choices `Set`.
  - In target selection, where the same stored-`length` drift could hide an accent-only fix from the `isNormalizationError` check and turn it into a practice target that should have been filtered out.

`GrammarErrorExampleWidget` is unchanged — `splitAroundBlank` already takes grapheme offsets.

### Testing

- 12 new unit tests in `test/pangea/grammar_error_example_mapping_test.dart`, building choreo records through `addRecord` so the edits under test are real `ChoreoEditModel` diffs: both-corrections-applied, typing after the last correction, stale stored length, multi-code-unit grapheme before the target, overlapping later edit → fallback, no sent text → fallback, and the `originalErrorSpan` recovery + its null cases.
- `fvm flutter test test/pangea/` — 1711 pass. The only failures are the two endpoint tests that always fail locally without `TEST_MATRIX_*` credentials (`choreo_endpoint_test`, `cms_endpoint_test`); unchanged from baseline on `main`.
- `fvm flutter analyze` clean.
- Not manually run: reproducing the original report needs an account with English L1 and German/French L2 with existing corrected messages. Follow the issue's TO TEST on staging.

### Deploy Notes

None.