### PR TITLE
ci: cache the generated vodozemac bindings, revert the inert rust cache-base

### DIFF
--- a/.github/instructions/ci.instructions.md
+++ b/.github/instructions/ci.instructions.md
@@ -23,7 +23,7 @@ Branch protection is **non-strict** — a PR need not be rebased onto the latest
 ## Workflow shape and rationale
 
 - **On `pull_request` / `merge_group`:** `code_tests`, `accessibility_floor_check`, `e2e_locator_check`, `build_debug_web`. Web is the active ship target and gets fast per-push feedback.
-- **On push to `main`:** the above **plus** `build_debug_apk` and `build_debug_ios` (gated by `if: github.event_name == 'push'`). This catches native regressions at merge and — because the debug web build runs here too — writes the debug Rust cache to the `main` scope for PRs to restore.
+- **On push to `main`:** the above **plus** `build_debug_apk` and `build_debug_ios` (gated by `if: github.event_name == 'push'`). This catches native regressions at merge, where a break is cheap to spot, without paying for a native build on every PR push.
 - **`concurrency: cancel-in-progress`** for `pull_request` only. Superseded PR-iteration pushes cancel; `merge_group` and `main` runs finish (they gate merges / warm caches).
 
 ## Version and build number
@@ -49,12 +49,22 @@ Settings shows `Version: <semver>+<build>` as a debugging aid. The two halves co
 
 A cache written during a run is scoped to that run's ref: `pull_request` runs write to `refs/pull/<N>/merge` (**isolated per PR**), `push` to main writes to `refs/heads/main`. A run restores from its own ref's scope **plus the default branch**, and can never read another PR's scope.
 
-**Sharing a cache across PRs takes two things: writing it on `main`, and telling the action to read from there.** `integrate.yaml` originally ran only on `pull_request` + `merge_group`, so nothing wrote to the `main` scope at all. Running the debug web build on push to `main` fixed the write — but `moonrepo/setup-rust` only looks in the current ref's scope, so PRs kept missing a byte-identical key sitting on `main` and recompiled `target/debug` on every build. **`cache-base: main` on every `setup-rust` step is what makes the read happen; without it the write is inert.** `subosito/flutter-action` needs no equivalent — it uses `actions/cache`, which falls back to the default branch on its own, which is why the Flutter and pub caches hit reliably.
+**`actions/cache` reads the default-branch scope. `moonrepo/setup-rust` does not.** That asymmetry is why the Flutter, pub, and vodozemac caches hit on every PR while the Rust one never has. Two attempts to fix the Rust side both failed: running the debug web build on push to `main` wrote a cache nothing ever read, and `cache-base: main` made the key ref-dependent so `main` and PRs could never match. Both are reverted.
+
+**Do not spend more effort on the Rust cache.** The step it guards costs 2 seconds; the web build's real Rust cost is in `prepare-web.sh`, below. Anything that must be shared across PRs should use `actions/cache` directly.
 
 A warm cache that is never read looks exactly like a cold one in the build log. To tell them apart, compare `lastAccessedAt` to `createdAt` on the `main`-scope entry (`gh cache list`): if they are equal, nothing has ever restored from it.
+
+## The web build's Rust step
+
+`scripts/prepare-web.sh` generates the vodozemac wasm bindings: it clones `dart-vodozemac` at the version pinned in `pubspec.yaml`, compiles `flutter_rust_bridge_codegen` from source, builds the wasm, moves two files into `assets/vodozemac/`, and deletes the clone. That takes **~4 minutes** and dominates every web build — for comparison, `setup-rust` costs 2 seconds.
+
+**Cache the output, not the toolchain.** The two generated files depend only on the pinned vodozemac version and the script, so CI caches them on an exact key (`runner.os` + version + script hash) and the script skips the build when they are already present. **No `restore-keys`** — a prefix hit would restore bindings built from different inputs, which is a correctness bug rather than a slow build. `flutter_rust_bridge_codegen` is pinned for the same reason: an unpinned `cargo install` would let the output drift under a fixed key.
+
+Two dead ends, recorded so they are not retried: repo-root `target/debug` does not exist in this repo, so caching it achieves nothing; and the vodozemac Rust build lives in `.vodozemac/rust/target`, which the script deletes before any cache-save step could see it.
 
 ## Gotchas for future edits
 
 - **A required check must report on every PR.** The native jobs run push-only (`if: github.event_name == 'push'`), so they must **never** be required, or PRs will wait on checks that never run. Same trap by another route: a workflow skipped by `paths` filtering leaves its check **pending**, not passing, blocking the merge forever — so never path-filter a workflow whose job is required. Gate the job with `if:` instead, which reports a *skipped* conclusion that branch protection accepts.
 - **Required-check names live in branch protection, not in this repo.** Renaming a job in `integrate.yaml` without updating protection leaves PRs waiting on a context that no longer reports, and the failure reads as an infra hiccup rather than a rename. Change both together.
-- **Keep the PR and main-push builds using identical debug steps.** The cache key is derived from the build; if the main-push web build diverges from the PR web build (e.g. profile vs debug, like `main_deploy.yaml`), the key stops matching and PRs miss again.
+- **Measure before optimising a CI step.** Two rounds of work went into a Rust cache guarding a 2-second step while `prepare-web.sh` burned four minutes beside it. Per-step timings are in the job log; read them before assuming where the time goes.

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -107,8 +107,6 @@ jobs:
           cache: true
       - uses: ./.github/actions/free_up_space
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
-        with:
-          cache-base: main
       - name: Add Firebase Messaging
         env:
           GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
@@ -126,10 +124,17 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
-        with:
-          cache-base: main
       - run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
       - run: flutter pub get
+      # See the note in main_deploy.yaml — same cache, same key scheme.
+      - name: Resolve vodozemac version
+        id: vodozemac
+        run: echo "version=$(yq '.dependencies.flutter_vodozemac' pubspec.yaml | tr -d '^')" >> $GITHUB_OUTPUT
+      - name: Cache vodozemac bindings
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: assets/vodozemac/vodozemac_bindings_dart*
+          key: vodozemac-bindings-v1-${{ runner.os }}-${{ steps.vodozemac.outputs.version }}-${{ hashFiles('scripts/prepare-web.sh') }}
       - name: Prepare web
         run: ./scripts/prepare-web.sh
       - run: flutter build web
@@ -173,8 +178,6 @@ jobs:
         run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - run: brew install sqlcipher
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
-        with:
-          cache-base: main
       - name: Add Firebase Messaging
         env:
           GOOGLE_SERVICES_PLIST: ${{ secrets.GOOGLE_SERVICES_PLIST }}

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -60,8 +60,6 @@ jobs:
         run: sudo xcode-select --switch /Applications/Xcode_26.3.app
       - run: brew install sqlcipher
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
-        with:
-          cache-base: main
       - name: Set up Ruby
         uses: ruby/setup-ruby@6ca151fd1bfcfd6fe0c4eb6837eb0584d0134a0c # v1
         with:

--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -25,9 +25,20 @@ jobs:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
-        with:
-          cache-base: main
       - run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+      # prepare-web spends ~4m cloning dart-vodozemac, compiling
+      # flutter_rust_bridge_codegen, and building wasm — to produce two files.
+      # The output depends only on the pinned flutter_vodozemac version and the
+      # script, so an exact-key cache (no restore-keys — a stale binding would be
+      # wrong) makes it a restore. See ci.instructions.md.
+      - name: Resolve vodozemac version
+        id: vodozemac
+        run: echo "version=$(yq '.dependencies.flutter_vodozemac' pubspec.yaml | tr -d '^')" >> $GITHUB_OUTPUT
+      - name: Cache vodozemac bindings
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: assets/vodozemac/vodozemac_bindings_dart*
+          key: vodozemac-bindings-v1-${{ runner.os }}-${{ steps.vodozemac.outputs.version }}-${{ hashFiles('scripts/prepare-web.sh') }}
       - name: Prepare web
         run: ./scripts/prepare-web.sh
       - run: rm ./assets/vodozemac/.gitignore

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,10 +52,17 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install nodejs -y
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
-        with:
-          cache-base: main
       - run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
       - run: flutter pub get
+      # See the note in main_deploy.yaml — same cache, same key scheme.
+      - name: Resolve vodozemac version
+        id: vodozemac
+        run: echo "version=$(yq '.dependencies.flutter_vodozemac' pubspec.yaml | tr -d '^')" >> $GITHUB_OUTPUT
+      - name: Cache vodozemac bindings
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: assets/vodozemac/vodozemac_bindings_dart*
+          key: vodozemac-bindings-v1-${{ runner.os }}-${{ steps.vodozemac.outputs.version }}-${{ hashFiles('scripts/prepare-web.sh') }}
       - name: Prepare web
         run: ./scripts/prepare-web.sh
       - name: Update Website files
@@ -139,8 +146,6 @@ jobs:
           rm -rf fonts/NotoEmoji
           yq -i 'del( .flutter.fonts[] | select(.family == "NotoEmoji") )' pubspec.yaml
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
-        with:
-          cache-base: main
       - run: flutter pub get
       - name: Prepare Android Release Build
         env:
@@ -191,8 +196,6 @@ jobs:
           git clone --branch ${{ env.FLUTTER_VERSION }} https://github.com/flutter/flutter.git
           ./flutter/bin/flutter doctor
       - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1
-        with:
-          cache-base: main
       - run: ./flutter/bin/flutter pub get
       - run: ./flutter/bin/flutter build linux --target-platform linux-${{ matrix.arch }}
       - name: Create archive

--- a/scripts/prepare-web.sh
+++ b/scripts/prepare-web.sh
@@ -19,16 +19,26 @@ retry() {
   done
 }
 
-version=$(yq ".dependencies.flutter_vodozemac" < pubspec.yaml)
-version=$(expr "$version" : '\^*\(.*\)')
-git clone https://github.com/famedly/dart-vodozemac.git -b ${version} .vodozemac
-cd .vodozemac
-cargo install flutter_rust_bridge_codegen
-retry flutter_rust_bridge_codegen build-web --dart-root dart --rust-root $(readlink -f rust) --release
-cd ..
-rm -f ./assets/vodozemac/vodozemac_bindings_dart*
-mv .vodozemac/dart/web/pkg/vodozemac_bindings_dart* ./assets/vodozemac/
-rm -rf .vodozemac
+# Generating the bindings costs ~4 minutes (clone + cargo install + wasm build)
+# and its output depends only on the pinned flutter_vodozemac version and this
+# script, so CI caches ./assets/vodozemac and skips the build when it restores.
+# See ci.instructions.md. Delete the files (or the cache) to force a rebuild.
+if ls ./assets/vodozemac/vodozemac_bindings_dart* >/dev/null 2>&1; then
+  echo "prepare-web: vodozemac bindings already present, skipping build"
+else
+  version=$(yq ".dependencies.flutter_vodozemac" < pubspec.yaml)
+  version=$(expr "$version" : '\^*\(.*\)')
+  git clone https://github.com/famedly/dart-vodozemac.git -b ${version} .vodozemac
+  cd .vodozemac
+  # Pinned so the generated bindings are reproducible — the cache key assumes
+  # the same inputs yield the same output. Bump alongside flutter_vodozemac.
+  cargo install flutter_rust_bridge_codegen --version 2.12.0
+  retry flutter_rust_bridge_codegen build-web --dart-root dart --rust-root $(readlink -f rust) --release
+  cd ..
+  rm -f ./assets/vodozemac/vodozemac_bindings_dart*
+  mv .vodozemac/dart/web/pkg/vodozemac_bindings_dart* ./assets/vodozemac/
+  rm -rf .vodozemac
+fi
 
 flutter pub get
 dart compile js ./web/native_executor.dart -o ./web/native_executor.js -m


### PR DESCRIPTION
## Why

Refs #8053 — **deliberately not `Closes`.** I closed that issue once on a fix that turned out not to work; this one stays open until a PR run logs an actual cache hit.

Step timings from a real `build_debug_web` run reframe the problem:

| Step | Duration |
|---|---|
| **Prepare web** | **4m13s** |
| flutter build web | 2m54s |
| flutter-action (cached) | 19s |
| `rustup component add rust-src` | 8s |
| flutter pub get | 5s |
| **setup-rust** | **2s** |

Everything #6781 and #8068 chased — the Rust cache, the `main`-scope warmup, `cache-base` — was optimising a **2-second step**. The cost is `prepare-web.sh`: clone dart-vodozemac, `cargo install flutter_rust_bridge_codegen` (compiles from source), build wasm, then `rm -rf` the whole tree.

Two things that were never true: repo-root `target/debug` (what `setup-rust` caches) **does not exist** here — the vodozemac build happens in `.vodozemac/rust/target`, which the script deletes before any cache save could run. And the `~425 MB target/debug` in the old doc was never real; the 64 MB entry is just `~/.cargo/registry`.

## What changed

**Cache the output, not the toolchain.** `prepare-web.sh` produces two files in `assets/vodozemac/`, fully determined by the pinned `flutter_vodozemac` version plus the script.

- New `actions/cache` step in the 3 workflows that run `prepare-web.sh`, keyed on `runner.os` + the resolved vodozemac version + `hashFiles('scripts/prepare-web.sh')`. **No `restore-keys`** — a prefix hit could restore stale bindings, which would be a correctness bug, so exact match only.
- `prepare-web.sh` skips the clone/install/build when the bindings are already present. `flutter pub get` and the `native_executor.dart` compile still run every time — they are cheap and their output is not cached.
- Pinned `cargo install flutter_rust_bridge_codegen --version 2.12.0` — the version CI already resolves to, so no behaviour change today, but the cache key now assumes the same inputs give the same output and an unpinned codegen would break that assumption silently.

**Reverted `cache-base: main`** from all 8 `setup-rust` steps. It never restored (`main` and PRs derive different keys; the lookup is exact-match), and it was guarding a 2-second step. Removing it also restores a single stable key across refs.

**Kept** the `cache: true` additions on the 3 `flutter-action` steps from #8068 — those work and save a ~1.6 GB SDK re-download.

## Testing

- All 14 workflows parse (Ruby/Psych); semantic check confirms 3 identical cache steps and no leftover `with:` on any `setup-rust` step.
- `sh -n scripts/prepare-web.sh` clean.
- Guard tested live in both states. The `ls` returns non-zero when bindings are absent, and under `#!/bin/sh -ve` that must not abort the script — confirmed it does not, because the test sits in an `if` condition.
- Action SHAs verified; `actions/cache` pinned to `0057852` (v4), resolved from the API rather than copied.

**Expected effect:** first run on each key still pays the 4m13s and populates the cache. Every run after that should skip it. `build_debug_web` should drop from ~7-8m to ~3-4m.

**Do not close #8053 on this PR merging.** Verify with a PR run showing `prepare-web: vodozemac bindings already present, skipping build` and a shorter job. The trap that produced two wrong conclusions here is that an unread cache is indistinguishable from a cold one unless you check the log.

### Pull Request has been tested on:

- [x] N/A — CI and build tooling, no runtime surface

### Accessibility

- [x] N/A — no UI change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved web build efficiency by caching generated security bindings.
  * Reuses cached bindings when available, reducing repeated build work.

* **Reliability**
  * Pinned the binding generator version for more consistent web builds.
  * Updated build workflows to use dependency- and script-specific cache keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->