### PR TITLE
fix(pt): skip phonetic transcription requests for phrase surfaces

### DIFF
--- a/lib/routes/chat/events/phonetic_transcription/phonetic_transcription_widget.dart
+++ b/lib/routes/chat/events/phonetic_transcription/phonetic_transcription_widget.dart
@@ -219,6 +219,12 @@ class _PhoneticTranscriptionWidgetState
 
   @override
   Widget build(BuildContext context) {
+    // PT covers isolated words only (design doc §5). Practice hints route
+    // whole example sentences through this widget; requesting those spends
+    // an LLM call per unique sentence and renders a meaningless chain of
+    // per-word transcriptions, so phrases render nothing at all (#8077).
+    if (isPhraseSurface(widget.text)) return const SizedBox.shrink();
+
     if (widget.textOnly) {
       return PhoneticTranscriptionBuilder(
         key: Key(_baseTargetId),

--- a/lib/routes/chat/events/phonetic_transcription/pt_v2_models.dart
+++ b/lib/routes/chat/events/phonetic_transcription/pt_v2_models.dart
@@ -9,6 +9,22 @@ import 'package:fluffychat/pangea/common/constants/model_keys.dart';
 import 'package:fluffychat/pangea/common/utils/base_request.dart';
 import 'package:fluffychat/pangea/common/utils/base_response.dart';
 
+/// Sentence punctuation, Latin and CJK. Any occurrence marks the text as a
+/// phrase rather than an isolated word.
+final RegExp _sentencePunctuation = RegExp(r'[.?!,;:…！？。，、；：「」『』（）《》【】]');
+
+/// True when [text] is a phrase or sentence rather than the isolated word
+/// phonetic transcription is specified for (design doc §5). Sentence
+/// punctuation, or more than three whitespace-separated words, marks a
+/// phrase; short multi-word tokens (phrasal verbs, idioms — "give up") stay
+/// eligible. Callers skip the PT request entirely for phrases: the per-word
+/// heteronym contract is meaningless at sentence length, and every unique
+/// sentence would become a paid LLM call and a permanent cache row (#8077).
+bool isPhraseSurface(String text) {
+  if (_sentencePunctuation.hasMatch(text)) return true;
+  return text.trim().split(RegExp(r'\s+')).length > 3;
+}
+
 class Pronunciation {
   final String transcription;
   final String ttsPhoneme;

--- a/test/pangea/phonetic_transcription/pt_v2_phrase_gate_test.dart
+++ b/test/pangea/phonetic_transcription/pt_v2_phrase_gate_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/chat/events/phonetic_transcription/pt_v2_models.dart';
+
+// Unit tests for the phrase gate that keeps whole sentences out of the
+// phonetic-transcription endpoint (#8077). PT is specified for isolated
+// words only — design doc §5. The example inputs are real surfaces observed
+// in the staging pt-v2 cache.
+
+void main() {
+  group('isPhraseSurface', () {
+    test('single words are not phrases', () {
+      for (final word in ['还', '学习', 'lluvia', 'read', "l'art", 'なか']) {
+        expect(isPhraseSurface(word), isFalse, reason: word);
+      }
+    });
+
+    test('short multi-word tokens stay eligible (phrasal verbs, idioms)', () {
+      expect(isPhraseSurface('give up'), isFalse);
+      expect(isPhraseSurface('à + le'), isFalse);
+    });
+
+    test('sentence punctuation marks a phrase', () {
+      expect(isPhraseSurface('Ciao, bot!'), isTrue);
+      expect(isPhraseSurface("Qu'est-ce que tu étudies ?"), isTrue);
+      expect(isPhraseSurface('你好！你今天好吗？'), isTrue);
+      expect(isPhraseSurface('こんにちは、元気です。'), isTrue);
+      expect(isPhraseSurface('Sì, mi piace la mia cucina.'), isTrue);
+    });
+
+    test('long word runs are phrases even without punctuation', () {
+      expect(
+        isPhraseSurface('Zeker ava huisgenoot gezamenlijk afspraak'),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Phrase and sentence surfaces no longer trigger phonetic-transcription requests — the widget renders nothing for them.

## Why

Closes #8077. Depends on pangeachat/client#8079 (stacked on its branch; retarget to main after it merges).

PT is specified for isolated words only (design doc §5), but practice-exercise hints routed whole example sentences through `PhoneticTranscriptionWidget` — 194 of 6,473 staging cache rows are phrase surfaces (up to 178 chars, ~30/month), each a paid LLM call and a permanent cache row, rendering as a slash-joined chain of per-word transcriptions.

`isPhraseSurface` ([pt_v2_models.dart](lib/routes/chat/events/phonetic_transcription/pt_v2_models.dart)) marks text with sentence punctuation (Latin + CJK) or more than three words; the widget short-circuits before the builder exists, so no request fires. Short multi-word tokens (phrasal verbs, idioms, "à + le") stay eligible.

**Judgment call flagged**: of the three options in #8077 (drop the hint transcription / transcribe the target word / build a phrase-level PT path) this implements the first, as the only one consistent with doc §5 without new design. The >3-word threshold is a heuristic; the punctuation check catches nearly all real sentences.

## Testing

- `fvm flutter test` — 1,760 pass (~3 skipped, pre-existing). New: [pt_v2_phrase_gate_test.dart](test/pangea/phonetic_transcription/pt_v2_phrase_gate_test.dart) with real surfaces observed in the staging cache.
- `fvm dart analyze` clean.

## Deploy Notes

None.