### PR TITLE
fix(pt): skip phonetic transcription requests for phrase surfaces

### DIFF
--- a/lib/routes/chat/events/phonetic_transcription/phonetic_transcription_widget.dart
+++ b/lib/routes/chat/events/phonetic_transcription/phonetic_transcription_widget.dart
@@ -219,6 +219,12 @@ class _PhoneticTranscriptionWidgetState
 
   @override
   Widget build(BuildContext context) {
+    // PT covers isolated words only (design doc §5). Practice hints route
+    // whole example sentences through this widget; requesting those spends
+    // an LLM call per unique sentence and renders a meaningless chain of
+    // per-word transcriptions, so phrases render nothing at all (#8077).
+    if (isPhraseSurface(widget.text)) return const SizedBox.shrink();
+
     if (widget.textOnly) {
       return PhoneticTranscriptionBuilder(
         key: Key(_baseTargetId),

--- a/lib/routes/chat/events/phonetic_transcription/pt_v2_models.dart
+++ b/lib/routes/chat/events/phonetic_transcription/pt_v2_models.dart
@@ -9,6 +9,22 @@ import 'package:fluffychat/pangea/common/constants/model_keys.dart';
 import 'package:fluffychat/pangea/common/utils/base_request.dart';
 import 'package:fluffychat/pangea/common/utils/base_response.dart';
 
+/// Sentence punctuation, Latin and CJK. Any occurrence marks the text as a
+/// phrase rather than an isolated word.
+final RegExp _sentencePunctuation = RegExp(r'[.?!,;:…！？。，、；：「」『』（）《》【】]');
+
+/// True when [text] is a phrase or sentence rather than the isolated word
+/// phonetic transcription is specified for (design doc §5). Sentence
+/// punctuation, or more than three whitespace-separated words, marks a
+/// phrase; short multi-word tokens (phrasal verbs, idioms — "give up") stay
+/// eligible. Callers skip the PT request entirely for phrases: the per-word
+/// heteronym contract is meaningless at sentence length, and every unique
+/// sentence would become a paid LLM call and a permanent cache row (#8077).
+bool isPhraseSurface(String text) {
+  if (_sentencePunctuation.hasMatch(text)) return true;
+  return text.trim().split(RegExp(r'\s+')).length > 3;
+}
+
 class Pronunciation {
   final String transcription;
   final String ttsPhoneme;

--- a/test/pangea/phonetic_transcription/pt_v2_phrase_gate_test.dart
+++ b/test/pangea/phonetic_transcription/pt_v2_phrase_gate_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/chat/events/phonetic_transcription/pt_v2_models.dart';
+
+// Unit tests for the phrase gate that keeps whole sentences out of the
+// phonetic-transcription endpoint (#8077). PT is specified for isolated
+// words only — design doc §5. The example inputs are real surfaces observed
+// in the staging pt-v2 cache.
+
+void main() {
+  group('isPhraseSurface', () {
+    test('single words are not phrases', () {
+      for (final word in ['还', '学习', 'lluvia', 'read', "l'art", 'なか']) {
+        expect(isPhraseSurface(word), isFalse, reason: word);
+      }
+    });
+
+    test('short multi-word tokens stay eligible (phrasal verbs, idioms)', () {
+      expect(isPhraseSurface('give up'), isFalse);
+      expect(isPhraseSurface('à + le'), isFalse);
+    });
+
+    test('sentence punctuation marks a phrase', () {
+      expect(isPhraseSurface('Ciao, bot!'), isTrue);
+      expect(isPhraseSurface("Qu'est-ce que tu étudies ?"), isTrue);
+      expect(isPhraseSurface('你好！你今天好吗？'), isTrue);
+      expect(isPhraseSurface('こんにちは、元気です。'), isTrue);
+      expect(isPhraseSurface('Sì, mi piace la mia cucina.'), isTrue);
+    });
+
+    test('long word runs are phrases even without punctuation', () {
+      expect(
+        isPhraseSurface('Zeker ava huisgenoot gezamenlijk afspraak'),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Phrase and sentence surfaces no longer trigger phonetic-transcription requests — the widget renders nothing for them.

## Why

Closes #8077. Replaces #8080, which was auto-closed when its stacked base branch (#8079) was deleted on merge; identical content rebased onto main.

See #8080 for the full rationale: PT is specified for isolated words only (design doc §5); practice hints were routing whole sentences through the widget (194 staging cache rows, ~30/month, each a paid LLM call). `isPhraseSurface` blocks text with sentence punctuation or more than three words; short multi-word tokens stay eligible. The >3-word threshold is the flagged judgment call.

## Testing

- `fvm flutter test` — 1,760 passed on the identical content (#8080 CI also green); targeted PT tests re-run after rebase.
- `fvm dart analyze` clean.

## Deploy Notes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Phonetic transcriptions are no longer requested or displayed for full phrases and sentences.
  * Sentence detection now recognizes supported punctuation across multiple languages, as well as longer unpunctuated text.
  * Short, multi-word expressions remain eligible for phonetic transcription.

* **Tests**
  * Added coverage for single words, short expressions, multilingual punctuation, and longer word sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->