### PR TITLE
fix(activities): show the rating aggregate as a thumbs-up pill

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_rating_meter.dart
+++ b/lib/routes/chat/activity_sessions/activity_rating_meter.dart
@@ -7,8 +7,9 @@ import 'package:fluffychat/routes/world/world_map_ranking.dart';
 /// The activity plan page's rating indicator, top-right of the header per the
 /// #7194/#7993 designs: a NEW pill while the activity has fewer than
 /// [kNewRatingThreshold] ratings, then a pill carrying a thumbs-up icon and the
-/// up-percentage, tinted between light red (all thumbs down) and light purple
-/// (all thumbs up). The thumb — not a ring or dial — is what reads as "share of
+/// up-percentage, tinted between the scheme's error container (all thumbs down)
+/// and its primary container (all thumbs up) — light red to light purple under
+/// the default seed. The thumb — not a ring or dial — is what reads as "share of
 /// thumbs up" (#8088): a ring at 0% looked like an empty progress meter rather
 /// than an all-negative rating. This is the ONLY surface that shows the
 /// badge/meter — map pins and cards carry neither (the rating enters the map
@@ -19,13 +20,6 @@ class ActivityRatingMeter extends StatelessWidget {
   final int? count;
 
   const ActivityRatingMeter({super.key, this.average, this.count});
-
-  static const Color _downColor = Color(0xFFEFB8B8); // light red
-  static const Color _upColor = AppConfig.primaryColorLight; // light purple
-
-  /// Both tint endpoints are light, in either theme, so the pill's contents
-  /// stay dark rather than following the theme's onSurface.
-  static const Color _onPillColor = Colors.black87;
 
   @override
   Widget build(BuildContext context) {
@@ -53,29 +47,38 @@ class ActivityRatingMeter extends StatelessWidget {
 
     final clamped = (average ?? 0.0).clamp(0.0, 1.0);
     final percent = (clamped * 100).round();
-    final color = Color.lerp(_downColor, _upColor, clamped)!;
+
+    // The tint runs across a matched pair of scheme roles, so the pill and its
+    // contents stay contrasting at both ends and under either brightness.
+    final colors = theme.colorScheme;
+    final background = Color.lerp(
+      colors.errorContainer,
+      colors.primaryContainer,
+      clamped,
+    )!;
+    final foreground = Color.lerp(
+      colors.onErrorContainer,
+      colors.onPrimaryContainer,
+      clamped,
+    )!;
 
     return Tooltip(
       message: L10n.of(context).activityRatingMeterLabel(percent, count!),
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
         decoration: BoxDecoration(
-          color: color,
+          color: background,
           borderRadius: BorderRadius.circular(20),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
           spacing: 4.0,
           children: [
-            const Icon(
-              Icons.thumb_up_outlined,
-              size: 16.0,
-              color: _onPillColor,
-            ),
+            Icon(Icons.thumb_up_outlined, size: 16.0, color: foreground),
             Text(
               "$percent%",
               style: theme.textTheme.labelMedium?.copyWith(
-                color: _onPillColor,
+                color: foreground,
                 fontWeight: FontWeight.bold,
               ),
             ),

--- a/lib/routes/chat/activity_sessions/activity_rating_meter.dart
+++ b/lib/routes/chat/activity_sessions/activity_rating_meter.dart
@@ -6,9 +6,11 @@ import 'package:fluffychat/routes/world/world_map_ranking.dart';
 
 /// The activity plan page's rating indicator, top-right of the header per the
 /// #7194/#7993 designs: a NEW pill while the activity has fewer than
-/// [kNewRatingThreshold] ratings, then a small ring filled to the up-fraction
-/// with the percentage beside it, tinted between light red (all thumbs down)
-/// and light purple (all thumbs up). This is the ONLY surface that shows the
+/// [kNewRatingThreshold] ratings, then a pill carrying a thumbs-up icon and the
+/// up-percentage, tinted between light red (all thumbs down) and light purple
+/// (all thumbs up). The thumb — not a ring or dial — is what reads as "share of
+/// thumbs up" (#8088): a ring at 0% looked like an empty progress meter rather
+/// than an all-negative rating. This is the ONLY surface that shows the
 /// badge/meter — map pins and cards carry neither (the rating enters the map
 /// solely as a score term; world-map.instructions.md).
 class ActivityRatingMeter extends StatelessWidget {
@@ -20,6 +22,10 @@ class ActivityRatingMeter extends StatelessWidget {
 
   static const Color _downColor = Color(0xFFEFB8B8); // light red
   static const Color _upColor = AppConfig.primaryColorLight; // light purple
+
+  /// Both tint endpoints are light, in either theme, so the pill's contents
+  /// stay dark rather than following the theme's onSurface.
+  static const Color _onPillColor = Colors.black87;
 
   @override
   Widget build(BuildContext context) {
@@ -51,22 +57,30 @@ class ActivityRatingMeter extends StatelessWidget {
 
     return Tooltip(
       message: L10n.of(context).activityRatingMeterLabel(percent, count!),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        spacing: 4.0,
-        children: [
-          SizedBox(
-            height: 18.0,
-            width: 18.0,
-            child: CircularProgressIndicator(
-              value: clamped,
-              strokeWidth: 3.0,
-              color: color,
-              backgroundColor: theme.colorScheme.surfaceContainerHighest,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          spacing: 4.0,
+          children: [
+            const Icon(
+              Icons.thumb_up_outlined,
+              size: 16.0,
+              color: _onPillColor,
             ),
-          ),
-          Text("$percent%", style: theme.textTheme.labelMedium),
-        ],
+            Text(
+              "$percent%",
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: _onPillColor,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/test/pangea/activity_rating_meter_test.dart
+++ b/test/pangea/activity_rating_meter_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_rating_meter.dart';
+
+/// Render contract of the activity header's rating indicator (#8088): the
+/// aggregate reads as a thumbs-up share — a thumb icon plus the percentage —
+/// never a ring, so an all-negative activity shows "0%" rather than an empty
+/// progress dial. An unrated activity still shows the NEW pill instead.
+void main() {
+  Future<void> pumpMeter(
+    WidgetTester tester, {
+    double? average,
+    int? count,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: ActivityRatingMeter(average: average, count: count),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('all-negative reads as a thumbs up at 0%', (tester) async {
+    await pumpMeter(tester, average: 0.0, count: 1);
+
+    expect(find.byIcon(Icons.thumb_up_outlined), findsOneWidget);
+    expect(find.text('0%'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('one down and one up reads 50%', (tester) async {
+    await pumpMeter(tester, average: 0.5, count: 2);
+
+    expect(find.byIcon(Icons.thumb_up_outlined), findsOneWidget);
+    expect(find.text('50%'), findsOneWidget);
+  });
+
+  testWidgets('all-positive reads 100%', (tester) async {
+    await pumpMeter(tester, average: 1.0, count: 3);
+
+    expect(find.text('100%'), findsOneWidget);
+  });
+
+  testWidgets('an unrated activity shows the NEW pill, no thumb', (
+    tester,
+  ) async {
+    await pumpMeter(tester, average: null, count: 0);
+
+    expect(find.byIcon(Icons.thumb_up_outlined), findsNothing);
+    expect(find.textContaining('%'), findsNothing);
+  });
+}


### PR DESCRIPTION
### What

The activity header's rating aggregate renders as a thumbs-up pill (icon + up-percentage) instead of a ring meter.

### Why

Closes #8088 — a ring at 0% read as an empty progress dial rather than an all-negative rating. The thumb is what carries "share of thumbs up", matching how raters gave the input.

The red→purple tint the design already specified is kept and moves to the pill background, so 0% also reads red. It now interpolates across a matched pair of `ColorScheme` roles — `errorContainer`/`onErrorContainer` → `primaryContainer`/`onPrimaryContainer` — rather than the previous colour literals, so the pill and its contents stay contrasting under either brightness and follow a custom scheme seed. Under the default seed that is the same light red → light purple. The NEW pill (unrated) path is unchanged.

**Docs not updated here.** [`activities.instructions.md`](.github/instructions/activities.instructions.md) ("Rating an activity") and [`world-map.instructions.md`](.github/instructions/world-map.instructions.md) (Priority matrix, ratings term) still describe this indicator as a ring meter. Per the invariant, an `*.instructions.md` edit is agreed in chat with Will before the PR exists, so those two sentences need a doc pass separately.

### Testing

- New widget test `test/pangea/activity_rating_meter_test.dart` covers the issue's TO TEST cases directly: 0% (all-negative) and 50% (one down, one up) both render a thumbs-up icon and the percentage with no `CircularProgressIndicator`; 100%; and the unrated NEW pill.
- `fvm flutter test` — full suite green locally (1781 passed, 3 skipped).
- `fvm flutter analyze` on the changed files — clean.
- Rendered the widget across 0 / 50 / 78 / 100% in **both** light and dark schemes to confirm the tint reads red → purple and the icon/text stay legible at both ends.
- No e2e bucket: the changed path matches no glob in `e2e/trigger-map.json`.

### Deploy Notes

None.

<!-- #Pangea -->
### Accessibility

- [x] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)

The existing `Tooltip` (localized "N% positive (M ratings)") still wraps the whole indicator and remains the accessible name; the icon is unlabeled and contributes no semantics node of its own. Foreground and background come from the same scheme container pair, so contrast is the scheme's guarantee rather than a hand-picked value.
<!-- Pangea# -->
