### PR TITLE
fix(room-summaries): isolate per-room parse failures from the batch

### DIFF
--- a/lib/features/room_summaries/room_summary_extension.dart
+++ b/lib/features/room_summaries/room_summary_extension.dart
@@ -15,6 +15,7 @@ import 'package:fluffychat/features/activity_sessions/activity_session_constants
 import 'package:fluffychat/features/activity_sessions/activity_summary_model.dart';
 import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_event.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
 
 extension RoomSummaryExtension on Api {
@@ -74,8 +75,21 @@ class RoomSummariesResponse {
   }) {
     final summaries = <String, RoomSummaryResponse>{};
     json["rooms"].forEach((key, value) {
-      if (value.isNotEmpty) {
-        summaries[key] = RoomSummaryResponse.fromJson(value, l1Code: l1Code);
+      // Parse each room independently. Room state is open-ended — a shape one
+      // client version doesn't expect (a newer event schema, a hand-edited
+      // state event) is a normal occurrence, and letting it throw out of here
+      // would reject the whole batched request and drop every other room's
+      // summary along with it. Skip the room we can't read, keep the rest.
+      try {
+        if (value.isNotEmpty) {
+          summaries[key] = RoomSummaryResponse.fromJson(value, l1Code: l1Code);
+        }
+      } catch (e, s) {
+        ErrorHandler.logError(
+          e: e,
+          s: s,
+          data: {"message": "Failed to parse room summary", "roomId": key},
+        );
       }
     });
     return RoomSummariesResponse(summaries: summaries);

--- a/test/pangea/room_summaries_batch_isolation_test.dart
+++ b/test/pangea/room_summaries_batch_isolation_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_session_constants.dart';
+import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+
+/// Room state is open-ended, so a summaries batch can always contain a room
+/// whose state this client version can't parse. That must cost only *that*
+/// room: `RoomSummariesResponse.fromJson` feeds a single batched request of up
+/// to 50 rooms, and a throw escaping it rejects the whole `Future.wait` in
+/// `loadRoomSummaries` — the space's activity list then renders with no session
+/// data at all (Sentry CLIENT-DG7, #8090).
+void main() {
+  Map<String, dynamic> membersOnly(String userId) => {
+    'membership_summary': {userId: 'join'},
+  };
+
+  test(
+    'a room that throws while parsing does not drop the rest of the batch',
+    () {
+      final response = RoomSummariesResponse.fromJson({
+        'rooms': {
+          '!before:pangea.chat': membersOnly('@ana:pangea.chat'),
+          // Passes the `req != null` reference guard but is not a map, so
+          // ActivityPlanRequest.fromJson throws the CLIENT-DG7 TypeError.
+          '!bad:pangea.chat': {
+            'membership_summary': {'@bo:pangea.chat': 'join'},
+            PangeaEventTypes.activityPlan: {
+              'default': {
+                'content': {
+                  ActivitySessionConstants.activityId: 'a1',
+                  ActivitySessionConstants.activityPlanRequest: 'not-a-map',
+                },
+              },
+            },
+          },
+          '!after:pangea.chat': membersOnly('@cy:pangea.chat'),
+        },
+      }, l1Code: 'en');
+
+      expect(response.summaries.keys, [
+        '!before:pangea.chat',
+        '!after:pangea.chat',
+      ]);
+      expect(response.summaries['!after:pangea.chat']!.membershipSummary, {
+        '@cy:pangea.chat': 'join',
+      });
+    },
+  );
+
+  test('a room whose payload is not a collection at all is skipped', () {
+    // `value.isNotEmpty` itself throws here (NoSuchMethodError on an int), so
+    // the emptiness check has to sit inside the per-room guard too.
+    final response = RoomSummariesResponse.fromJson({
+      'rooms': {
+        '!junk:pangea.chat': 7,
+        '!good:pangea.chat': membersOnly('@ana:pangea.chat'),
+      },
+    }, l1Code: 'en');
+
+    expect(response.summaries.keys, ['!good:pangea.chat']);
+  });
+
+  test('empty room payloads are still omitted', () {
+    final response = RoomSummariesResponse.fromJson({
+      'rooms': {
+        '!empty:pangea.chat': <String, dynamic>{},
+        '!good:pangea.chat': membersOnly('@ana:pangea.chat'),
+      },
+    }, l1Code: 'en');
+
+    expect(response.summaries.keys, ['!good:pangea.chat']);
+  });
+}


### PR DESCRIPTION
### What

Parse each room independently in `RoomSummariesResponse.fromJson` — a room whose state this client can't read is skipped and logged, instead of throwing out of the batch.

### Why

Closes #8090. Sentry [CLIENT-DG7](https://pangea-chat.sentry.io/issues/7631045856/).

`RoomSummariesResponse.fromJson` covers one batched request of up to 50 rooms, and `loadRoomSummaries` fans those batches through `Future.wait`. A throw from any single room rejected the whole thing, so `ChatDetailsController._loadSummaries` caught it and the space's activity list rendered with no session data at all.

CLIENT-DG7's specific trigger — a v3 thin `{activity_id, version_id}` reference parsed as an embedded plan — was already fixed by #7028 and only still fires on the shipped 4.1.28 build. Room state is open-ended, though, so the next unexpected shape does the same thing; the blast radius is the part worth closing.

The emptiness check moved inside the guard too: `value.isNotEmpty` on a non-collection throws on its own.

### Testing

- New `test/pangea/room_summaries_batch_isolation_test.dart` — 3 cases. Verified red on `main`'s parser (2 of 3 fail) and green with the change.
- Full `fvm flutter test`: 1780 passed, 3 skipped, 0 failed.
- `fvm flutter analyze` on the changed files: no issues.
- Smoke/eval/load buckets N/A — client-side parsing only, no choreo/CMS surface.

### Deploy Notes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room summary processing so invalid or incomplete room data no longer prevents valid summaries from loading.
  * Added safer handling for errors encountered while parsing individual rooms.

* **Tests**
  * Added coverage for malformed activity-plan data, non-collection payloads, and empty room responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->