### PR TITLE
fix(quests): identify course rollups by room id so two courses from one quest don't cross

### DIFF
--- a/lib/features/quests/lo_progression.dart
+++ b/lib/features/quests/lo_progression.dart
@@ -13,12 +13,21 @@ const int kDefaultStarsToUnlockObjective = 10;
 /// objective, plus the star threshold that unlocks the next objective. Built
 /// from a quest outline (the ordered sequence and its per-objective activities).
 class CourseLoOutline {
-  /// The course-plan uuid (v3: also the quest-plans id) this outline was
-  /// resolved for. Identity, not decoration: Missions are a shared catalog
-  /// reused across quests, so a resolution spanning several joined courses can
-  /// hold the same Mission more than once — this is how a per-course surface
-  /// finds ITS rollup instead of a cross-course blend.
+  /// The course's unique identity — its Matrix **room id** for a joined course.
+  /// A per-course surface looks its own rollup up by this ([forCourse]).
+  ///
+  /// NOT the quest uuid: one quest can back several courses (launched into
+  /// several rooms), so the quest uuid is shared and would collapse two courses
+  /// that share a quest into one — the exact cross-contamination #8087 fixes.
+  /// The room id is the thing that is one-per-course. (For the world map's
+  /// scoped outline of a course the learner hasn't joined there is no room, so
+  /// it falls back to [questId] — never a [forCourse] key, only banded.)
   final String courseId;
+
+  /// The quest this course realizes (the quest-plans uuid). Shared across every
+  /// course built from the same quest, so the world-map band can dedupe a quest
+  /// the learner joined in two rooms instead of double-counting its gradient.
+  final String questId;
 
   final List<String> orderedLoIds;
   final Map<String, Set<String>> activityIdsByLo;
@@ -33,6 +42,7 @@ class CourseLoOutline {
 
   const CourseLoOutline({
     required this.courseId,
+    required this.questId,
     required this.orderedLoIds,
     required this.activityIdsByLo,
     this.starsToUnlock = kDefaultStarsToUnlockObjective,

--- a/lib/features/quests/quest_objectives_loader.dart
+++ b/lib/features/quests/quest_objectives_loader.dart
@@ -37,9 +37,13 @@ class QuestObjectivesLoader {
   int _loadGeneration = 0;
   bool _disposed = false;
 
-  /// The course this loader is showing. The shared resolution spans every
-  /// joined course, so every progress read below scopes through it — a course
-  /// panel must never show another course's star totals (#7771).
+  /// The course this loader is showing — its Matrix ROOM id, the course's
+  /// identity ([ProgressionResolution.forCourse]). The shared resolution spans
+  /// every joined course, so every progress read below scopes through it: a
+  /// course panel must never show another course's star totals (#7771). Keyed
+  /// by room id, not the quest uuid, so two courses built from one quest don't
+  /// collapse into each other (#8087). Null for a preview (no room) → no star
+  /// display, the fail-soft default.
   String? _courseId;
 
   void dispose() {
@@ -110,7 +114,10 @@ class QuestObjectivesLoader {
 
     _loadGeneration++;
     final loadGen = _loadGeneration;
-    _courseId = questId;
+    // Identity is the room, not the quest: [forCourse] keys by room id so two
+    // courses sharing a quest stay distinct (#8087). A preview has no room, so
+    // this is null and the panel shows no star display.
+    _courseId = courseRoomId;
     _updateProgression(ProgressionResolution.empty, loadGen);
 
     // world_v2 → v3: the course space's coursePlan.uuid (or the previewed

--- a/lib/features/quests/quest_progression_resolver.dart
+++ b/lib/features/quests/quest_progression_resolver.dart
@@ -59,9 +59,16 @@ class QuestStarSummary {
 /// One in-scope quest: its ordered Mission sequence, the resolved anchor (the
 /// Mission the learner most needs next), and a position lookup for the gradient.
 class QuestProgress {
-  /// The course-plan uuid this quest was resolved from — the key a per-course
-  /// surface looks itself up by ([ProgressionResolution.forCourse]).
+  /// The course's unique identity — its Matrix room id for a joined course —
+  /// the key a per-course surface looks itself up by
+  /// ([ProgressionResolution.forCourse]). NOT the quest uuid: one quest can
+  /// back several courses, so keying by the quest would collapse them (#8087).
   final String courseId;
+
+  /// The quest this course realizes (shared across courses built from the same
+  /// quest). [missionGradient] dedupes by it so a quest joined in two rooms
+  /// contributes to the band once, not twice.
+  final String questId;
 
   final List<String> orderedMissionIds;
 
@@ -92,6 +99,7 @@ class QuestProgress {
 
   const QuestProgress({
     required this.courseId,
+    required this.questId,
     required this.orderedMissionIds,
     required this.anchorMissionId,
     required this.indexByMission,
@@ -161,13 +169,22 @@ class ProgressionResolution {
   /// Missions ranks higher) and saturate at the ceiling. Outside any quest the
   /// activity's refs match nothing and this is 0 — the consumer then ranks it on
   /// plain level/L2 fit. See world-map.instructions.md Priority matrix.
+  ///
+  /// Distinct quests accumulate; the SAME quest joined in two rooms does not —
+  /// it is one quest, so it contributes once (deduped by [QuestProgress.questId],
+  /// #8087). Per-course star totals ([forCourse]) still see both rooms; only the
+  /// band, whose unit is the quest, collapses them.
   double missionGradient(Iterable<String> objectiveRefs) {
     if (quests.isEmpty) return 0;
     final refs = objectiveRefs.toSet();
     if (refs.isEmpty) return 0;
 
+    final countedQuests = <String>{};
     var total = 0.0;
     for (final quest in quests) {
+      // Same quest in another room → already counted; the band's unit is the
+      // quest, so it contributes once (#8087).
+      if (!countedQuests.add(quest.questId)) continue;
       final anchor = quest.anchorMissionId;
       if (anchor == null) continue;
       final anchorIdx = quest.indexByMission[anchor];
@@ -199,11 +216,11 @@ class ProgressionResolution {
     final cache = JoinedObjectiveCache();
     await cache.rebuildFromJoinedCourses(
       client,
-      onError: (uuid, e, s) => ErrorHandler.logError(
+      onError: (courseId, e, s) => ErrorHandler.logError(
         e: e,
         s: s,
         m: 'course progression failed to resolve',
-        data: {'courseUuid': uuid},
+        data: {'courseRoomId': courseId},
       ),
     );
     return cache.resolution(client.userStarsByActivity);
@@ -266,6 +283,7 @@ ProgressionResolution resolveProgression({
     quests.add(
       QuestProgress(
         courseId: outline.courseId,
+        questId: outline.questId,
         orderedMissionIds: seq,
         anchorMissionId: _anchorFor(seq, rollup),
         indexByMission: {for (var i = 0; i < seq.length; i++) seq[i]: i},

--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -108,9 +108,12 @@ class QuestOutline {
   CourseLoOutline toCourseLoOutline({
     int starsToUnlock = kDefaultStarsToUnlockObjective,
   }) => CourseLoOutline(
-    // v3: the quest-plans id IS the course-plan uuid callers resolved by, so
-    // this is the key a per-course surface looks its own rollup up under.
+    // No room context here (this is the raw quest projection). The joined-course
+    // cache overrides [courseId] with the course's room id — its true identity;
+    // only the world map's scoped outline for a not-yet-joined course uses this
+    // fallback, and it is banded by [questId], never a [forCourse] key (#8087).
     courseId: quest.id,
+    questId: quest.id,
     orderedLoIds: quest.learningObjectiveIds,
     activityIdsByLo: {
       for (final group in groups)

--- a/lib/routes/world/joined_objective_cache.dart
+++ b/lib/routes/world/joined_objective_cache.dart
@@ -4,7 +4,6 @@ import 'package:fluffychat/features/course_plans/courses/course_plan_room_extens
 import 'package:fluffychat/features/quests/lo_progression.dart';
 import 'package:fluffychat/features/quests/quest_progression_resolver.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
-import 'package:fluffychat/routes/chat/chat_details/teacher_mode_model.dart';
 import 'package:fluffychat/routes/world/world_map_client_extension.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 
@@ -46,36 +45,46 @@ class JoinedObjectiveCache {
     starsByActivity: starsByActivity,
   );
 
-  /// Rebuild from the joined courses' quest outlines. [outlineOf] resolves a
-  /// course-plan uuid to its outline (defaults to the v3 quest read layer);
-  /// [starsToUnlockOf] supplies the per-course teacher override (defaults to the
-  /// standard threshold). A course that fails to resolve is skipped (rather than
-  /// failing the whole set) and reported to [onError] — it must NOT be swallowed
-  /// silently: a dropped course contributes no objective ids, and a fully empty
-  /// cache blanks relevance banding and fail-opens the progression gate with no
-  /// visible signal. [onError] is injectable so the rebuild stays unit-testable
-  /// without Matrix, the network, or Sentry.
+  /// Rebuild from one outline per identity key. A key is the course's identity
+  /// ([CourseLoOutline.courseId]) — the Matrix room id for a joined course; the
+  /// produced outline's [courseId] IS that key. [outlineOf] resolves a key to
+  /// its outline (default assumes the key is itself a quest uuid — the degenerate
+  /// courseId==questId case, used by direct tests and the not-joined scoped
+  /// read); the resolved outline's own [questId] is preserved so the band can
+  /// dedupe courses that share a quest. [starsToUnlockOf] supplies the per-course
+  /// teacher override (defaults to the standard threshold). A course that fails
+  /// to resolve is skipped (rather than failing the whole set) and reported to
+  /// [onError] — it must NOT be swallowed silently: a dropped course contributes
+  /// no objective ids, and a fully empty cache blanks relevance banding and
+  /// fail-opens the progression gate with no visible signal. [onError] is
+  /// injectable so the rebuild stays unit-testable without Matrix or the network.
   Future<void> rebuild(
-    List<String> courseUuids, {
-    Future<CourseLoOutline> Function(String uuid)? outlineOf,
-    int Function(String uuid)? starsToUnlockOf,
-    void Function(String uuid, Object error, StackTrace stack)? onError,
+    List<String> courseIds, {
+    Future<CourseLoOutline> Function(String courseId)? outlineOf,
+    int Function(String courseId)? starsToUnlockOf,
+    void Function(String courseId, Object error, StackTrace stack)? onError,
   }) async {
     final resolve = outlineOf ?? _outlineFromQuest;
     final next = <CourseLoOutline>[];
     await Future.wait(
-      courseUuids.map((uuid) async {
+      courseIds.map((courseId) async {
         try {
-          final o = await resolve(uuid);
+          final o = await resolve(courseId);
           next.add(
             CourseLoOutline(
-              // The uuid the caller asked for, not the resolved outline's own
-              // id: this is the key the course panel scopes its rollup by.
-              courseId: uuid,
+              // The identity key the caller asked for (a room id for a joined
+              // course), NOT the resolved outline's own id: this is what the
+              // course panel scopes its rollup by, and it must stay unique per
+              // course even when two courses share one quest (#8087).
+              courseId: courseId,
+              // ...but the quest identity travels through from the outline, so
+              // the band still treats two rooms of one quest as one quest.
+              questId: o.questId,
               orderedLoIds: o.orderedLoIds,
               activityIdsByLo: o.activityIdsByLo,
               starsToUnlock:
-                  starsToUnlockOf?.call(uuid) ?? kDefaultStarsToUnlockObjective,
+                  starsToUnlockOf?.call(courseId) ??
+                  kDefaultStarsToUnlockObjective,
               earnableByActivity: o.earnableByActivity,
             ),
           );
@@ -83,7 +92,7 @@ class JoinedObjectiveCache {
           // Skip a course that won't resolve; the rest still band and gate. But
           // report it — a silently-empty cache is exactly how banding and the
           // gate go dark unnoticed.
-          onError?.call(uuid, e, s);
+          onError?.call(courseId, e, s);
         }
       }),
     );
@@ -91,38 +100,39 @@ class JoinedObjectiveCache {
     _ids = {for (final o in next) ...o.orderedLoIds};
   }
 
-  /// [rebuild] from the client's joined courses — each course's quest uuid with
-  /// its teacher config (stars-to-unlock override + per-Mission activity pins).
+  /// [rebuild] from the client's joined courses — one outline per course ROOM,
+  /// keyed by room id, resolving each room's quest with its teacher config
+  /// (stars-to-unlock override + per-Mission activity pins). Keying by room id,
+  /// not quest uuid, is the fix for #8087: one quest can back several courses,
+  /// and a quest-keyed map collapses them so one course's rollup serves both.
   /// The single home for that mapping: the world map's pins manager and the
   /// course panel's star display both rebuild through here, so every surface
-  /// resolves identical outlines. Pins are applied as a pure copy per course
-  /// (never to the shared quest-outline cache), so two courses sharing a quest
-  /// can restrict differently.
+  /// resolves identical outlines.
   Future<void> rebuildFromJoinedCourses(
     Client client, {
-    void Function(String uuid, Object error, StackTrace stack)? onError,
+    void Function(String courseId, Object error, StackTrace stack)? onError,
   }) {
-    final modes = <String, TeacherModeModel>{
-      for (final room in client.joinedCourseRooms)
-        room.coursePlan!.uuid: room.teacherMode,
-    };
-    // A joined member's outline read carries the course room id, so the quest
-    // owner's private activities are included (membership-verified
-    // server-side; activities.instructions.md § Ownership, visibility, and
-    // removal).
-    final roomIds = <String, String>{
-      for (final room in client.joinedCourseRooms)
-        room.coursePlan!.uuid: room.id,
+    // Keyed by room id — the course's identity. Two rooms built from the same
+    // quest are two distinct courses and must both survive here.
+    final roomsById = <String, Room>{
+      for (final room in client.joinedCourseRooms) room.id: room,
     };
     return rebuild(
-      modes.keys.toList(),
-      outlineOf: (uuid) => _outlineFromQuest(
-        uuid,
-        pinnedByObjective: modes[uuid]?.pinnedActivitiesByObjective,
-        courseRoomId: roomIds[uuid],
-      ),
-      starsToUnlockOf: (uuid) =>
-          modes[uuid]?.starsToUnlockObjective ?? kDefaultStarsToUnlockObjective,
+      roomsById.keys.toList(),
+      outlineOf: (courseId) {
+        final room = roomsById[courseId]!;
+        return _outlineFromQuest(
+          room.coursePlan!.uuid,
+          pinnedByObjective: room.teacherMode.pinnedActivitiesByObjective,
+          // The course room id admits the quest owner's private activities
+          // (membership-verified server-side; activities.instructions.md
+          // § Ownership, visibility, and removal).
+          courseRoomId: room.id,
+        );
+      },
+      starsToUnlockOf: (courseId) =>
+          roomsById[courseId]!.teacherMode.starsToUnlockObjective ??
+          kDefaultStarsToUnlockObjective,
       onError: onError,
     );
   }

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -537,11 +537,11 @@ class WorldMapPinsManager {
           .toList();
       await _objectiveCache.rebuildFromJoinedCourses(
         client,
-        onError: (uuid, e, s) => ErrorHandler.logError(
+        onError: (courseId, e, s) => ErrorHandler.logError(
           e: e,
           s: s,
           m: 'JoinedObjectiveCache: course outline failed to resolve',
-          data: {'courseUuid': uuid},
+          data: {'courseRoomId': courseId},
         ),
       );
       _objectiveCacheUuids = uuids.toSet();

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -78,12 +78,16 @@ class WorldMapPinsManager {
   /// banding. Rebuilt async on course join/leave (see [_maybeRebuildObjectiveCache]).
   final JoinedObjectiveCache _objectiveCache = JoinedObjectiveCache();
 
-  /// The joined-course uuids [_objectiveCache] was last (re)built from. The
-  /// initial build happens on client-set, but the joined-course rooms (or their
-  /// outlines) may not be ready yet; tracking the set lets the sync listener
-  /// rebuild when it changes — or when a prior build resolved nothing — instead
-  /// of the banding + gate staying blank for the whole session.
-  Set<String> _objectiveCacheUuids = const {};
+  /// The joined-course ROOM ids [_objectiveCache] was last (re)built from —
+  /// room ids because that is the cache's own key: one quest can back several
+  /// course rooms, so a quest-uuid set wouldn't change when a second room of an
+  /// already-joined quest joins or leaves, and the cache would silently stay
+  /// stale (#8087). The initial build happens on client-set, but the
+  /// joined-course rooms (or their outlines) may not be ready yet; tracking the
+  /// set lets the sync listener rebuild when it changes — or when a prior build
+  /// resolved nothing — instead of the banding + gate staying blank for the
+  /// whole session.
+  Set<String> _objectiveCacheRoomIds = const {};
 
   /// Guards against overlapping objective-cache rebuilds (and stops a
   /// persistently-failing course from rebuilding on every single sync).
@@ -532,9 +536,7 @@ class WorldMapPinsManager {
     if (_objectiveCacheRebuilding) return;
     _objectiveCacheRebuilding = true;
     try {
-      final uuids = client.joinedCourseRooms
-          .map((r) => r.coursePlan!.uuid)
-          .toList();
+      final roomIds = client.joinedCourseRooms.map((r) => r.id).toList();
       await _objectiveCache.rebuildFromJoinedCourses(
         client,
         onError: (courseId, e, s) => ErrorHandler.logError(
@@ -544,7 +546,7 @@ class WorldMapPinsManager {
           data: {'courseRoomId': courseId},
         ),
       );
-      _objectiveCacheUuids = uuids.toSet();
+      _objectiveCacheRoomIds = roomIds.toSet();
       resolveProgression(); // re-resolve the band with the loaded outlines
     } finally {
       _objectiveCacheRebuilding = false;
@@ -559,15 +561,14 @@ class WorldMapPinsManager {
   /// rebuilding more than once at a time, and it self-heals once the data is fixed.
   bool shouldRebuildObjectiveCache(Client client) {
     if (_objectiveCacheRebuilding) return false;
-    final uuids = client.joinedCourseRooms
-        .map((r) => r.coursePlan!.uuid)
-        .toSet();
+    final roomIds = client.joinedCourseRooms.map((r) => r.id).toSet();
 
     final setChanged =
-        uuids.length != _objectiveCacheUuids.length ||
-        !uuids.containsAll(_objectiveCacheUuids);
+        roomIds.length != _objectiveCacheRoomIds.length ||
+        !roomIds.containsAll(_objectiveCacheRoomIds);
 
-    final emptyButHasCourses = _objectiveCache.ids.isEmpty && uuids.isNotEmpty;
+    final emptyButHasCourses =
+        _objectiveCache.ids.isEmpty && roomIds.isNotEmpty;
     return setChanged || emptyButHasCourses;
   }
 
@@ -579,7 +580,9 @@ class WorldMapPinsManager {
     if (_scopedCourseOutlineId == coursePlanId) return;
     _scopedCourseOutlineId = coursePlanId;
     _scopedCourseOutline = null;
-    if (_objectiveCacheUuids.contains(coursePlanId)) {
+    // The cache is keyed by room, so ask its outlines' quest identity — any
+    // joined room realizing this quest means the cache already carries it.
+    if (_objectiveCache.outlines.any((o) => o.questId == coursePlanId)) {
       resolveProgression(); // joined: the cache already carries it
       return;
     }

--- a/test/pangea/joined_objective_cache_test.dart
+++ b/test/pangea/joined_objective_cache_test.dart
@@ -3,12 +3,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fluffychat/features/quests/lo_progression.dart';
 import 'package:fluffychat/routes/world/joined_objective_cache.dart';
 
-CourseLoOutline _outline(List<String> los, {String courseId = 'c1'}) =>
-    CourseLoOutline(
-      courseId: courseId,
-      orderedLoIds: los,
-      activityIdsByLo: const {},
-    );
+CourseLoOutline _outline(
+  List<String> los, {
+  String courseId = 'c1',
+  String? questId,
+}) => CourseLoOutline(
+  courseId: courseId,
+  questId: questId ?? courseId,
+  orderedLoIds: los,
+  activityIdsByLo: const {},
+);
 
 void main() {
   group('JoinedObjectiveCache.rebuild', () {
@@ -83,5 +87,26 @@ void main() {
       expect(cache.ids, isEmpty);
       expect(cache.outlines, isEmpty);
     });
+
+    test(
+      'keys each outline by the identity passed, preserving questId (#8087)',
+      () async {
+        // Two courses (room ids R1, R2) that realize the same quest 'Q'. rebuild
+        // stamps courseId with the identity key it was given (the room id) while
+        // the quest identity travels through from the resolved outline — so the
+        // two stay distinct courses, and the band can still tell they are one
+        // quest.
+        final cache = JoinedObjectiveCache();
+        await cache.rebuild(
+          ['R1', 'R2'],
+          outlineOf: (roomId) async =>
+              _outline(['lo-a'], courseId: roomId, questId: 'Q'),
+        );
+        final byCourse = {for (final o in cache.outlines) o.courseId: o};
+        expect(byCourse.keys, {'R1', 'R2'});
+        expect(byCourse['R1']!.questId, 'Q');
+        expect(byCourse['R2']!.questId, 'Q');
+      },
+    );
   });
 }

--- a/test/pangea/quest_progression_resolver_test.dart
+++ b/test/pangea/quest_progression_resolver_test.dart
@@ -8,10 +8,12 @@ void main() {
     List<String> seq,
     Map<String, Set<String>> acts, {
     String courseId = 'c1',
+    String? questId,
     int threshold = kDefaultStarsToUnlockObjective,
     Map<String, int> earnable = const {},
   }) => CourseLoOutline(
     courseId: courseId,
+    questId: questId ?? courseId,
     orderedLoIds: seq,
     activityIdsByLo: acts,
     starsToUnlock: threshold,

--- a/test/pangea/quest_star_summary_test.dart
+++ b/test/pangea/quest_star_summary_test.dart
@@ -26,6 +26,7 @@ void main() {
           quests: [
             QuestProgress(
               courseId: 'c1',
+              questId: 'c1',
               orderedMissionIds: rollup.keys.toList(),
               anchorMissionId: null,
               indexByMission: const {},

--- a/test/pangea/quests/per_course_mission_rollup_test.dart
+++ b/test/pangea/quests/per_course_mission_rollup_test.dart
@@ -13,10 +13,12 @@ void main() {
     String courseId,
     List<String> seq,
     Map<String, Set<String>> acts, {
+    String? questId,
     int threshold = kDefaultStarsToUnlockObjective,
     Map<String, int> earnable = const {},
   }) => CourseLoOutline(
     courseId: courseId,
+    questId: questId ?? courseId,
     orderedLoIds: seq,
     activityIdsByLo: acts,
     starsToUnlock: threshold,
@@ -280,6 +282,100 @@ void main() {
       );
 
       expect(r.missionGradient(['m1']), 0.0);
+    });
+  });
+
+  group('two courses built from the same quest (#8087)', () {
+    // Course R1 and course R2 are distinct courses (distinct room ids) that
+    // realize the SAME quest 'Q', each with its own activity under Mission m1.
+    // The identity is the course (room id), not the shared quest uuid — so the
+    // two must not collapse into one another.
+    List<CourseLoOutline> twoRoomsOneQuest() => [
+      outline(
+        'R1',
+        ['m1'],
+        {
+          'm1': {'a1'},
+        },
+        questId: 'Q',
+        earnable: {'a1': 4},
+      ),
+      outline(
+        'R2',
+        ['m1'],
+        {
+          'm1': {'b1'},
+        },
+        questId: 'Q',
+        earnable: {'b1': 4},
+      ),
+    ];
+
+    test('resolve to two distinct courses, not one collapsed entry', () {
+      final r = resolveProgression(
+        outlines: twoRoomsOneQuest(),
+        starsByActivity: const {},
+      );
+      expect(r.quests.length, 2);
+      expect(r.forCourse('R1'), isNotNull);
+      expect(r.forCourse('R2'), isNotNull);
+    });
+
+    test("each course counts only ITS OWN stars — TigToggle's inversion", () {
+      // Play R1's own activity: R1 reflects it, R2 does not.
+      final afterR1 = resolveProgression(
+        outlines: twoRoomsOneQuest(),
+        starsByActivity: const {'a1': 3},
+      );
+      expect(afterR1.forCourse('R1')!.rollup['m1']!.stars, 3);
+      expect(afterR1.forCourse('R2')!.rollup['m1']!.stars, 0);
+
+      // Play R2's own activity: R2 reflects it, R1 is untouched. (Before the
+      // fix R1 showed 0 for its own play, then 2 after R2's — inverted.)
+      final afterR2 = resolveProgression(
+        outlines: twoRoomsOneQuest(),
+        starsByActivity: const {'b1': 2},
+      );
+      expect(afterR2.forCourse('R1')!.rollup['m1']!.stars, 0);
+      expect(afterR2.forCourse('R2')!.rollup['m1']!.stars, 2);
+    });
+
+    test('each course clamps its threshold to its own content', () {
+      final r = resolveProgression(
+        outlines: twoRoomsOneQuest(),
+        starsByActivity: const {},
+      );
+      // Each has one 4-star activity — not the union (8).
+      expect(r.questStars('R1')!.total, 4);
+      expect(r.questStars('R2')!.total, 4);
+    });
+
+    test('the band counts the shared quest ONCE, not once per room', () {
+      // Both rooms carry the same anchor Mission via activity 'x'. A distinct
+      // second quest would accumulate to 2.0 (tested above); the SAME quest in
+      // two rooms is one quest, so it saturates at a single 1.0.
+      final r = resolveProgression(
+        outlines: [
+          outline(
+            'R1',
+            ['m1'],
+            {
+              'm1': {'x'},
+            },
+            questId: 'Q',
+          ),
+          outline(
+            'R2',
+            ['m1'],
+            {
+              'm1': {'x'},
+            },
+            questId: 'Q',
+          ),
+        ],
+        starsByActivity: const {},
+      );
+      expect(r.missionGradient(['m1']), 1.0);
     });
   });
 }

--- a/test/pangea/world_map_ranking_test.dart
+++ b/test/pangea/world_map_ranking_test.dart
@@ -29,6 +29,7 @@ ProgressionResolution _progressionWithAnchor(String anchor) =>
       outlines: [
         CourseLoOutline(
           courseId: 'c1',
+          questId: 'c1',
           orderedLoIds: [anchor],
           activityIdsByLo: {
             anchor: const {'someActivity'},
@@ -82,6 +83,7 @@ void main() {
         outlines: [
           CourseLoOutline(
             courseId: 'c1',
+            questId: 'c1',
             orderedLoIds: ['q1'],
             activityIdsByLo: {
               'q1': const {'x'},
@@ -89,6 +91,7 @@ void main() {
           ),
           CourseLoOutline(
             courseId: 'c2',
+            questId: 'c2',
             orderedLoIds: ['q2'],
             activityIdsByLo: {
               'q2': const {'y'},
@@ -516,6 +519,7 @@ void main() {
         outlines: [
           CourseLoOutline(
             courseId: 'c1',
+            questId: 'c1',
             orderedLoIds: ['q1'],
             activityIdsByLo: {
               'q1': const {'topAvailable'},
@@ -523,6 +527,7 @@ void main() {
           ),
           CourseLoOutline(
             courseId: 'c2',
+            questId: 'c2',
             orderedLoIds: ['q2'],
             activityIdsByLo: {
               'q2': const {'topAvailable'},


### PR DESCRIPTION
## What

Key per-course star rollups by the course's Matrix room id (unique per course) instead of `coursePlan.uuid` (the quest id, shared when one quest is launched into two rooms), keeping the quest uuid as a second key so the world-map band still counts a quest joined in two rooms once.

## Why

Closes #8087

## What changed

- `CourseLoOutline` / `QuestProgress` split identity into `courseId` (room id — the `forCourse` key) and `questId` (quest uuid — the band's dedupe key).
- `rebuildFromJoinedCourses` builds one outline per joined course **room**; the panel's loader sets `_courseId` to the room id (null for previews → no star display, the existing fail-soft default).
- `missionGradient` dedupes contributions by `questId`, so the same quest in two rooms feeds the band once while each room keeps its own rollup.
- The pins manager's staleness check (`shouldRebuildObjectiveCache`) now tracks the room-id set — the cache's actual key. It was still comparing quest-uuid sets, so joining/leaving a second room of an already-joined quest never triggered a rebuild and the band silently missed (or kept) that course's outline. Its scoped-outline skip now asks the cache's outlines' `questId` directly.

Design: quests.instructions.md ("Star totals are per course, never blended across them") — no doc change; the room-id keying implements the already-agreed per-course scoping.

## Testing

- `fvm flutter test` (Flutter 3.41.4 via fvm) — 1782 passed; only the 2 known local-env failures (`choreo_endpoint_test`, `cms_endpoint_test` setUpAll — missing `TEST_MATRIX_*` creds, same on a clean checkout).
- New `#8087` cases in `per_course_mission_rollup_test.dart`: two rooms of one quest resolve as distinct courses, each counts only its own stars (the reported inversion), each clamps to its own content, and the band counts the shared quest once. `joined_objective_cache_test.dart` covers room-id keying with `questId` pass-through.
- `fvm flutter analyze` — no issues; `fvm dart format --set-exit-if-changed` — clean; `pubspec.lock` unchanged.
- Not verified in a running client — the issue's TO TEST (two same-quest courses) needs staging content; smoke after deploy per the issue.
- The staleness-check fix has no unit test: `shouldRebuildObjectiveCache` reads `client.joinedCourseRooms` (an extension over Matrix room state), which the existing quest tests don't mock.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)