### PR TITLE
docs(client): add repo layer and error handling standard

### DIFF
--- a/.github/instructions/repos-and-error-handling.instructions.md
+++ b/.github/instructions/repos-and-error-handling.instructions.md
@@ -1,0 +1,79 @@
+---
+applyTo: "lib/pangea/common/network/**,lib/pangea/common/utils/base_repo.dart,lib/pangea/common/utils/error_handler.dart,**/*_repo.dart"
+description: "Client repo layer and error contract — repos own network access, reporting, and severity; callers own UI. What Requests throws, what repos return, who reports to Sentry, and what each status means."
+---
+
+# Client Repos & Error Handling
+
+A **repo** is the only place the client talks to a backend. It owns the request, the
+failure, and the Sentry report. A **caller** — route, controller, widget — receives a
+value or an error and decides only what the user sees.
+
+The split exists because the alternative was tried and did not hold. Reporting spread
+across 241 call sites at whatever altitude the author happened to be at, and the same
+404 arrived in Sentry at two different severities depending on which repo shape the
+author had picked.
+
+## The contract
+
+- **Repos return `Result<T>`.** Not a bare `T`, not `T?`, not an empty list standing in
+  for an error, not a raw `Response`. A caller must be able to tell "no data" from
+  "failed" without inspecting a sentinel.
+- **The repo reports; the caller does not.** A repo captures each failure to Sentry
+  exactly once, then returns `Result.error`. Callers do not call `ErrorHandler.logError`
+  on an error a repo already returned — that double-reports and re-severitizes.
+- **Callers may escalate, not re-report.** When a caller has context the repo lacks — a
+  failure that is routine on a background refresh but user-visible on a tap — it may
+  raise the level on the error it received. It does not create a second event.
+- **Repos never return an error the user cannot be told about.** If a failure is expected
+  and non-actionable, the repo returns a successful empty value and documents why; it
+  does not return an error that every caller then swallows.
+
+Prefer `BaseRepo` for anything cached or request-shaped — it implements this contract. A
+repo that bypasses it re-implements timeout, cache, and severity by hand, and
+historically gets severity wrong.
+
+## What `Requests` throws
+
+`Requests` throws `PangeaHttpException` for any response ≥ 400 — never the raw
+`http.Response`. The exception carries status, method, normalized path, and the parsed
+`detail`, and its `toString()` renders them.
+
+This is not a style preference. A thrown `http.Response` has no `toString()` override, so
+every failure across every endpoint arrives in Sentry titled `Instance of 'Response'` —
+66 issues and 3,386 events in a single 14-day window, none diagnosable without opening an
+individual event.
+
+- **Never put a response body in the exception.** Only the `detail` field, length-capped.
+  Bodies carry learner content; Sentry is not where that belongs.
+- Paths are normalized (opaque id segments → `{id}`) so titles group and read cleanly.
+- `UnsubscribedException` keeps its own type — it is control flow, not an error, and is
+  never reported.
+
+The rule lives in `Requests` alone. A second copy of it anywhere else drifts.
+
+## Severity policy
+
+Severity is a property of the failure, not of the author's judgment at the call site. One
+table, applied by the repo layer:
+
+| Condition                  | Level   | Why                                                                       |
+| -------------------------- | ------- | ------------------------------------------------------------------------- |
+| Timeout                    | warning | Transient; retry is the answer                                            |
+| 401                        | warning | Token lifecycle is routine                                                |
+| 404, 410                   | warning | The resource is gone — a normal state, e.g. a stale room reference        |
+| 429                        | warning | Expected under load                                                       |
+| 403                        | error   | We asked for something we should not have — a code bug                    |
+| Other 4xx (400, 405, 422)  | error   | We sent something malformed — a code bug                                  |
+| 5xx                        | error   | The only signal the client has that a backend is regressing               |
+
+**404 means gone.** This is a cross-service constraint, not a client-local one: a backend
+that returns 404 for an internal failure breaks the table above and makes a real outage
+invisible on both sides. Choreo endpoints must distinguish "not found" from "lookup
+failed" — the latter is a 5xx with a Sentry capture, never a 404.
+
+## Adoption
+
+Binding for new repos and for any repo already being modified. Existing repos migrate
+opportunistically, not in a sweep — a repo touched for other work comes along with the
+change.

--- a/.github/instructions/repos-and-error-handling.instructions.md
+++ b/.github/instructions/repos-and-error-handling.instructions.md
@@ -5,57 +5,34 @@ description: "Client repo layer and error contract — repos own network access,
 
 # Client Repos & Error Handling
 
-A **repo** is the only place the client talks to a backend. It owns the request, the
-failure, and the Sentry report. A **caller** — route, controller, widget — receives a
-value or an error and decides only what the user sees.
+A **repo** is the only place the client talks to a backend. It owns the request, the failure, and the Sentry report. A **caller** — route, controller, widget — receives a value or an error and decides only what the user sees.
 
-The split exists because the alternative was tried and did not hold. Reporting spread
-across 241 call sites at whatever altitude the author happened to be at, and the same
-404 arrived in Sentry at two different severities depending on which repo shape the
-author had picked.
+The split exists because the alternative was tried and did not hold. Reporting spread across 241 call sites at whatever altitude the author happened to be at, and the same 404 arrived in Sentry at two different severities depending on which repo shape the author had picked.
 
 ## The contract
 
-- **Repos return `Result<T>`.** Not a bare `T`, not `T?`, not an empty list standing in
-  for an error, not a raw `Response`. A caller must be able to tell "no data" from
-  "failed" without inspecting a sentinel.
-- **The repo reports; the caller does not.** A repo captures each failure to Sentry
-  exactly once, then returns `Result.error`. Callers do not call `ErrorHandler.logError`
-  on an error a repo already returned — that double-reports and re-severitizes.
-- **Callers may escalate, not re-report.** When a caller has context the repo lacks — a
-  failure that is routine on a background refresh but user-visible on a tap — it may
-  raise the level on the error it received. It does not create a second event.
-- **Repos never return an error the user cannot be told about.** If a failure is expected
-  and non-actionable, the repo returns a successful empty value and documents why; it
-  does not return an error that every caller then swallows.
+- **Repos return `Result<T>`.** Not a bare `T`, not `T?`, not an empty list standing in for an error, not a raw `Response`. A caller must be able to tell "no data" from "failed" without inspecting a sentinel.
+- **The repo reports; the caller does not.** A repo captures each failure to Sentry exactly once, then returns `Result.error`. Callers do not call `ErrorHandler.logError` on an error a repo already returned — that double-reports and re-severitizes.
+- **Callers may escalate, not re-report.** When a caller has context the repo lacks — a failure that is routine on a background refresh but user-visible on a tap — it may raise the level on the error it received. It does not create a second event.
+- **Repos never return an error the user cannot be told about.** If a failure is expected and non-actionable, the repo returns a successful empty value and documents why; it does not return an error that every caller then swallows.
 
-Prefer `BaseRepo` for anything cached or request-shaped — it implements this contract. A
-repo that bypasses it re-implements timeout, cache, and severity by hand, and
-historically gets severity wrong.
+Prefer `BaseRepo` for anything cached or request-shaped — it implements this contract. A repo that bypasses it re-implements timeout, cache, and severity by hand, and historically gets severity wrong.
 
 ## What `Requests` throws
 
-`Requests` throws `PangeaHttpException` for any response ≥ 400 — never the raw
-`http.Response`. The exception carries status, method, normalized path, and the parsed
-`detail`, and its `toString()` renders them.
+`Requests` throws `PangeaHttpException` for any response ≥ 400 — never the raw `http.Response`. The exception carries status, method, normalized path, and the parsed `detail`, and its `toString()` renders them.
 
-This is not a style preference. A thrown `http.Response` has no `toString()` override, so
-every failure across every endpoint arrives in Sentry titled `Instance of 'Response'` —
-66 issues and 3,386 events in a single 14-day window, none diagnosable without opening an
-individual event.
+This is not a style preference. A thrown `http.Response` has no `toString()` override, so every failure across every endpoint arrives in Sentry titled `Instance of 'Response'` — 66 issues and 3,386 events in a single 14-day window, none diagnosable without opening an individual event.
 
-- **Never put a response body in the exception.** Only the `detail` field, length-capped.
-  Bodies carry learner content; Sentry is not where that belongs.
+- **Never put a response body in the exception.** Only the `detail` field, length-capped. Bodies carry learner content; Sentry is not where that belongs.
 - Paths are normalized (opaque id segments → `{id}`) so titles group and read cleanly.
-- `UnsubscribedException` keeps its own type — it is control flow, not an error, and is
-  never reported.
+- `UnsubscribedException` keeps its own type — it is control flow, not an error, and is never reported.
 
 The rule lives in `Requests` alone. A second copy of it anywhere else drifts.
 
 ## Severity policy
 
-Severity is a property of the failure, not of the author's judgment at the call site. One
-table, applied by the repo layer:
+Severity is a property of the failure, not of the author's judgment at the call site. One table, applied by the repo layer:
 
 | Condition                  | Level   | Why                                                                       |
 | -------------------------- | ------- | ------------------------------------------------------------------------- |
@@ -67,13 +44,8 @@ table, applied by the repo layer:
 | Other 4xx (400, 405, 422)  | error   | We sent something malformed — a code bug                                  |
 | 5xx                        | error   | The only signal the client has that a backend is regressing               |
 
-This table leans on what each status actually asserts — 404 meaning the resource is gone,
-5xx meaning the lookup itself failed. Those meanings are a contract every Pangea service
-holds to, not a client-local reading, and they live in
-[error-handling.instructions.md](../../../.github/.github/instructions/error-handling.instructions.md).
+This table leans on what each status actually asserts — 404 meaning the resource is gone, 5xx meaning the lookup itself failed. Those meanings are a contract every Pangea service holds to, not a client-local reading, and they live in [error-handling.instructions.md](../../../.github/.github/instructions/error-handling.instructions.md).
 
 ## Adoption
 
-Binding for new repos and for any repo already being modified. Existing repos migrate
-opportunistically, not in a sweep — a repo touched for other work comes along with the
-change.
+Binding for new repos and for any repo already being modified. Existing repos migrate opportunistically, not in a sweep — a repo touched for other work comes along with the change.

--- a/.github/instructions/repos-and-error-handling.instructions.md
+++ b/.github/instructions/repos-and-error-handling.instructions.md
@@ -67,10 +67,10 @@ table, applied by the repo layer:
 | Other 4xx (400, 405, 422)  | error   | We sent something malformed — a code bug                                  |
 | 5xx                        | error   | The only signal the client has that a backend is regressing               |
 
-**404 means gone.** This is a cross-service constraint, not a client-local one: a backend
-that returns 404 for an internal failure breaks the table above and makes a real outage
-invisible on both sides. Choreo endpoints must distinguish "not found" from "lookup
-failed" — the latter is a 5xx with a Sentry capture, never a 404.
+This table leans on what each status actually asserts — 404 meaning the resource is gone,
+5xx meaning the lookup itself failed. Those meanings are a contract every Pangea service
+holds to, not a client-local reading, and they live in
+[error-handling.instructions.md](../../../.github/.github/instructions/error-handling.instructions.md).
 
 ## Adoption
 


### PR DESCRIPTION
## What

Adds `client/.github/instructions/repos-and-error-handling.instructions.md`. Doc only — no code.

## Why

Closes #8094

Every HTTP failure lands in Sentry as `Response: Instance of 'Response'` — **66 issues, 3,386 events in 14 days**, none diagnosable without opening an event. Sentry [CLIENT-DRV](https://pangea-chat.sentry.io/issues/7645044137/) (404 on quest activities) and [CLIENT-DRY](https://pangea-chat.sentry.io/issues/7645138551/) (504 on bbox) share a title and have nothing else in common.

The throw is where it surfaces; the gap is the repo layer — 48 repo files, 17 on `BaseRepo`, 6 return conventions, and 241 `ErrorHandler.logError` sites of which only 24 are in repos. The evidence is in #8094.

The doc owns the design; this body doesn't restate it.

## Resolved in review

@ggurdin answered all three. Two settle as written; the third changed the doc.

1. **5xx severity** — stays `error`. Their argument is better than the one in the doc: a gateway 504 would not be logged server-side *if the server was down*, so the client is the only witness.
2. **401 vs 403 split** — confirmed. A 403 usually means a request fired after logout, which is a client bug.
3. **Where "404 means gone" lives** — moved out. It constrains the client, the choreographer, and Synapse modules, so a client doc was the wrong altitude. It now lives in **pangeachat/.github#342**, and this doc links there — which is also the delivery mechanism, since org docs are `applyTo: ""` and never auto-apply.

**Depends on pangeachat/.github#342.** Merge that first, or this doc's link dangles.

## Implementation follows separately

Not in this PR. Once the design settles:

- **Slice 1 (client)** — `PangeaHttpException` with status/method/normalized-path/detail and a real `toString()`; unified severity; drop the duplicate throw in `BaseRepo._fetch` (unreachable, since `fetch()` already went through `Requests`). Five sites type-test the thrown `Response` today and move with it: `ErrorCopy.errorCode`, `BaseRepo.errorLevel`, `quest_repo.dart:241`, `activity_plan_repo.dart:156`.
- **Companion (2-step-choreographer)** — ~~three sites converting any exception into a 404~~ **merged** as pangeachat/2-step-choreographer#2934. Its doc companion is pangeachat/2-step-choreographer#2941.
- **CLIENT-DQC** — a second worked example, added to #8094: a bare `MissingQuestException` with no `toString()`, reported by a caller on an error the repo had deliberately marked benign. Same standard, different defect; not fixed by `PangeaHttpException` alone.

## Testing

N/A — doc only, no runtime surface.

## Deploy Notes

None.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-layer guidance for consistent error handling and result contracts.
  * Documented exception handling, error reporting, response processing, severity levels, and incremental adoption practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->