### PR TITLE
fix(navigation): make the `+` shortcut toggle the add-course hub

### DIFF
--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -125,6 +125,38 @@ String _recencyKey(PanelToken token) {
   return rootType.name;
 }
 
+/// Whether the narrow rail's 4th slot — the course shortcut — is showing the
+/// surface the cavity currently hosts, which makes its tap the
+/// tap-the-active-item TOGGLE rather than a navigation
+/// (routing.instructions.md → "Collapsing is not closing").
+///
+/// The slot resolves contextually, so "its own surface" does too:
+///
+/// - **A joined course** ([shortcutCourseId] non-null) — the shortcut is that
+///   course's avatar, and its surface is that course's card: hosted exactly
+///   when the cavity is a course panel under that course's context (#7537).
+/// - **No joined courses** — the shortcut is the `+` add-course button, so its
+///   surface is the add-course hub the Courses rail item ALSO opens. Without
+///   this arm the shortcut re-issued a same-URL `setSection(addcourse)` — a
+///   silent no-op — so the button neither opened nor closed the hub once it
+///   was up, while the Courses item beside it toggled fine (#8098).
+///
+/// Pure so it is unit-tested directly, away from the shell's Matrix lookups.
+@visibleForTesting
+bool courseShortcutHostsCavity({
+  required PanelToken? cavityToken,
+  required String? shortcutCourseId,
+  required String? activeSpaceId,
+}) {
+  if (cavityToken == null) return false;
+  if (shortcutCourseId == null) {
+    // The `+` slot: its surface is the add-course family, which is exactly what
+    // `cavitySection` reports as the Courses rail item's own surface.
+    return cavityToken.type.cavitySection == AppSection.courses;
+  }
+  return cavityToken.type.isCoursePanel && shortcutCourseId == activeSpaceId;
+}
+
 /// Sync the back-stack [recency] against the currently open [allTokens] (merged
 /// `[left…, right…]`, the allocator's entry order) and return the allocator
 /// `focusHint` index, or null when nothing is open.
@@ -661,12 +693,14 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
           ),
         }),
         cavitySection: cavitySection,
-        // The shortcut hosts the cavity when the hosted course sheet IS the
-        // shortcut's course (course cavities key by their space id).
-        courseShortcutHostsCavity:
-            isCourseCavity &&
-            shortcutCourse != null &&
-            shortcutCourse.id == activeSpaceId,
+        // The shortcut hosts the cavity when it is showing that surface: the
+        // shortcut's own course sheet, or — with no courses joined, where the
+        // slot is the `+` button — the add-course hub (#8098).
+        courseShortcutHostsCavity: courseShortcutHostsCavity(
+          cavityToken: cavityToken,
+          shortcutCourseId: shortcutCourse?.id,
+          activeSpaceId: activeSpaceId,
+        ),
         cavityChild: cavityToken == null
             ? null
             : FocusTraversalGroup(

--- a/test/pangea/navigation/course_shortcut_toggle_test.dart
+++ b/test/pangea/navigation/course_shortcut_toggle_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/token_params/add_course_token.dart';
+import 'package:fluffychat/features/navigation/token_params/room_token.dart';
+import 'package:fluffychat/widgets/layouts/workspace_shell.dart';
+
+/// Regression coverage for #8098: with NO joined courses the narrow rail's 4th
+/// slot is the `+` add-course button, whose own surface is the add-course hub —
+/// the same surface the Courses rail item opens. The shell was only ever
+/// reporting `courseShortcutHostsCavity` for a joined COURSE sheet, so with the
+/// hub already up the `+` tap fell through to `setSection(addcourse)`: a
+/// same-URL navigation, i.e. a silent no-op. The button neither opened nor
+/// closed the hub, while the Courses item beside it toggled fine.
+///
+/// Drives the production predicate ([courseShortcutHostsCavity] in
+/// `workspace_shell.dart`) directly — the widget's toggle behaviour once the
+/// flag is set is pinned in `mobile_nav_widget_test.dart`.
+void main() {
+  const courseA = '!course-a:example.org';
+  const courseB = '!course-b:example.org';
+
+  group('no joined courses — the shortcut IS the add-course button', () {
+    test('the hub cavity is the shortcut\'s own surface (#8098)', () {
+      expect(
+        courseShortcutHostsCavity(
+          cavityToken: const AddCoursePanelToken(),
+          shortcutCourseId: null,
+          activeSpaceId: null,
+        ),
+        isTrue,
+      );
+    });
+
+    test('an add-course SUBPAGE cavity is the shortcut\'s surface too', () {
+      // Browse / start-my-own / enter-a-code are the same rail item's family
+      // (`cavitySection` reports Courses for them), so the shortcut toggles
+      // them exactly as the Courses item does — the two must not disagree.
+      expect(
+        courseShortcutHostsCavity(
+          cavityToken: const AddCoursePagePanelToken(
+            AddCoursePageTokenParam(subpage: AddCourseSubpageEnum.browse),
+          ),
+          shortcutCourseId: null,
+          activeSpaceId: null,
+        ),
+        isTrue,
+      );
+    });
+
+    test('another section cavity navigates instead of toggling', () {
+      expect(
+        courseShortcutHostsCavity(
+          cavityToken: const ChatsPanelToken(),
+          shortcutCourseId: null,
+          activeSpaceId: null,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a bare map (no cavity) navigates', () {
+      expect(
+        courseShortcutHostsCavity(
+          cavityToken: null,
+          shortcutCourseId: null,
+          activeSpaceId: null,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('a joined course fills the slot (#7537, unchanged)', () {
+    test('its own course sheet toggles', () {
+      expect(
+        courseShortcutHostsCavity(
+          cavityToken: const CoursePanelToken(),
+          shortcutCourseId: courseA,
+          activeSpaceId: courseA,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a DIFFERENT course sheet navigates', () {
+      expect(
+        courseShortcutHostsCavity(
+          cavityToken: const CoursePanelToken(),
+          shortcutCourseId: courseA,
+          activeSpaceId: courseB,
+        ),
+        isFalse,
+      );
+    });
+
+    test('the add-course hub navigates — the hub is not this course', () {
+      expect(
+        courseShortcutHostsCavity(
+          cavityToken: const AddCoursePanelToken(),
+          shortcutCourseId: courseA,
+          activeSpaceId: courseA,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a live room over the course context navigates', () {
+      expect(
+        courseShortcutHostsCavity(
+          cavityToken: const RoomPanelToken(RoomTokenParam(id: '!room:x.org')),
+          shortcutCourseId: courseA,
+          activeSpaceId: courseA,
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -642,6 +642,39 @@ void main() {
     });
 
     testWidgets(
+      'the `+` shortcut toggles the add-course hub it is showing (#8098)',
+      (tester) async {
+        // With no courses joined the 4th slot IS the `+` add-course button, so
+        // the hub is its own surface and the Courses item beside it toggles the
+        // very same cavity. Distinct from the course-sheet case above: a
+        // SECTION cavity is not a peek, so the collapse renders 0px and the
+        // re-expand comes from the remembered content-fit height, not a peek.
+        var shortcutTaps = 0;
+        await pumpNav(
+          tester,
+          activeSection: AppSection.courses,
+          cavitySection: AppSection.courses,
+          courseShortcutHostsCavity: true,
+          cavityChild: const Text('Courses hub'),
+          cavityKey: 'addcourse',
+          onCourseShortcutTap: () => shortcutTaps++,
+        );
+        final open = cavityHeightOf(tester);
+        expect(open, greaterThan(0.0));
+
+        await tester.tap(find.byTooltip('Add a course'));
+        await tester.pumpAndSettle();
+        expect(shortcutTaps, 0, reason: 'the active hub tap is a toggle');
+        expect(cavityHeightOf(tester), 0.0);
+
+        await tester.tap(find.byTooltip('Add a course'));
+        await tester.pumpAndSettle();
+        expect(shortcutTaps, 0);
+        expect(cavityHeightOf(tester), closeTo(open, 1.0));
+      },
+    );
+
+    testWidgets(
       'the course shortcut navigates when its course is NOT the hosted sheet',
       (tester) async {
         var shortcutTaps = 0;


### PR DESCRIPTION
## What

With no joined courses, the narrow rail's `+` add-course button now toggles the add-course hub instead of doing nothing.

## Why

Closes #8098

The narrow rail's 4th slot resolves contextually (routing.instructions.md → [Single-column bottom nav](.github/instructions/routing.instructions.md)): a joined course's avatar, or the `+` add-course button when the learner is in no courses. The tap-the-active-item toggle ("Collapsing is not closing") was only wired for the *course* case — the shell reported `courseShortcutHostsCavity` solely for a hosted course sheet.

So with no joined courses and the hub already up, the `+` tap fell through to `WorkspaceNav.setSection(addcourse)`: a same-URL navigation, i.e. a silent no-op. The button neither opened nor closed the hub, while the Courses rail item beside it — which reads `cavitySection` and toggles correctly — worked fine.

## Changes

- `lib/widgets/layouts/workspace_shell.dart` — extracts the shortcut's hosts-the-cavity test into a pure top-level `courseShortcutHostsCavity` (`@visibleForTesting`, alongside `recencyFocusHint`) and adds the `+` arm: with no joined course in the slot, the shortcut's own surface is the add-course family, which is exactly what `cavitySection` already reports for the Courses rail item. The joined-course arm is unchanged (#7537).
- `test/pangea/navigation/course_shortcut_toggle_test.dart` (new) — unit coverage of the predicate: hub and add-course subpage toggle for the `+`; chats sheet, bare map, a different course, the hub-under-a-course, and a live room all navigate.
- `test/pangea/navigation/mobile_nav_widget_test.dart` — widget test for the `+`-toggles-the-hub path. Distinct from the existing course-sheet toggle: a section cavity is not a peek, so collapse renders 0px and the re-expand comes from the remembered content-fit height.

No behavior change for a learner with at least one joined course.

## Testing

- `fvm flutter analyze` on the changed files — clean.
- `fvm dart format --set-exit-if-changed` — clean.
- `fvm flutter test test/pangea/navigation/` — 358 passed.
- `fvm flutter test` (full suite) — 1796 passed, 3 skipped (the credential-gated endpoint suites; no `TEST_MATRIX_*` locally).
- Playwright a11y specs are glob-triggered by `lib/widgets/layouts/**` but **deferred to the post-deploy run** — no staging test credentials in this environment. The change adds no rendered nodes and no semantics: the widget tree is identical, only the shortcut's tap branch differs.

## Deploy Notes

None.
