### PR TITLE
fix(activities): re-enable play with bot when bot holds no role

### DIFF
--- a/lib/features/activity_sessions/bot_activty_role_room_extension.dart
+++ b/lib/features/activity_sessions/bot_activty_role_room_extension.dart
@@ -1,10 +1,29 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:matrix/matrix.dart';
 
+import 'package:fluffychat/features/activity_sessions/activity_role_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
+import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
 
+/// Whether the bot occupies one of [assignedRoles] — the seats whose holders
+/// have not provably left the room (see [filterAssignedRoles]). This, not the
+/// pangea.bot_participant marker, is what "the bot is in the activity" means
+/// for UI gates (#8099): the marker is sticky and outlives the bot leaving,
+/// so gating on it left "Play with Pangea Bot" dead after the bot dropped out
+/// of a session with its role unfilled.
+@visibleForTesting
+bool botHoldsLiveSeat(
+  Iterable<ActivityRoleModel> assignedRoles,
+  String botUserId,
+) => assignedRoles.any((r) => r.userId == botUserId);
+
 extension BotActivtyRoleRoomExtension on Room {
-  bool get botAddedToActivity =>
-      getState(PangeaEventTypes.botParticipant) != null;
+  bool get botHasActivityRole => botHoldsLiveSeat(
+    assignedRoles?.values ?? const [],
+    BotName.byEnvironment,
+  );
 
   Future<void> addBotToActivity() =>
       client.setRoomStateWithKey(id, PangeaEventTypes.botParticipant, "", {});

--- a/lib/routes/chat/activity_sessions/bot_join_error_dialog.dart
+++ b/lib/routes/chat/activity_sessions/bot_join_error_dialog.dart
@@ -11,7 +11,6 @@ import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/features/bot/widgets/bot_face_svg.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
-import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
 
 class PlayWithBotLoadingDialog extends StatefulWidget {
   final Room room;
@@ -33,13 +32,14 @@ class PlayWithBotLoadingDialogState extends State<PlayWithBotLoadingDialog> {
   }
 
   Future<void> _execute() async {
-    final future = widget.room.client.onRoomState.stream
-        .where(
-          (state) =>
-              state.roomId == widget.room.id &&
-              state.state.type == PangeaEventTypes.activityRole &&
-              state.state.senderId == BotName.byEnvironment,
-        )
+    // Success is the bot holding a live seat, not the bot sending a fresh
+    // activity-role event: on the recovery path (#8099 — re-invite after the
+    // bot left mid-session) the bot resumes the role entry it left behind
+    // without writing new role state, so an event-identity wait would time
+    // out on a session that actually recovered. Re-checking seat state per
+    // sync covers both that path and a fresh role claim.
+    final future = widget.room.client.onSync.stream
+        .where((_) => widget.room.botHasActivityRole)
         .first;
 
     try {

--- a/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
@@ -64,8 +64,11 @@ class ConfirmedRoleSessionController extends State<ConfirmedRoleSession>
 
   bool get showInviteOptions => widget.room.isRoomAdmin;
 
+  // Gate on the bot's live seat, not the sticky pangea.bot_participant
+  // marker: the marker survives the bot leaving, and the button must come
+  // back whenever the bot holds no role (#8099).
   bool get enablePlayWithBot =>
-      showInviteOptions && !widget.room.botAddedToActivity;
+      showInviteOptions && !widget.room.botHasActivityRole;
 
   @override
   String get descriptionText {

--- a/test/pangea/bot_activity_seat_gate_test.dart
+++ b/test/pangea/bot_activity_seat_gate_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_role_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/bot_activty_role_room_extension.dart';
+
+/// The "Play with Pangea Bot" gate behind #8099: the button must track the
+/// bot's LIVE seat, not the sticky pangea.bot_participant marker. The
+/// regression this locks: the bot dropped out of a session mid-activity, its
+/// role went unfilled, and the button stayed dead because the marker written
+/// on the first click exists forever — leaving no way to bring the bot back.
+void main() {
+  const bot = '@bot:server';
+  const human = '@human:server';
+
+  ActivityRoleModel role(String id, String userId) =>
+      ActivityRoleModel(id: id, userId: userId, role: id);
+
+  final roles = {
+    'bot-role': role('bot-role', bot),
+    'human-role': role('human-role', human),
+  };
+
+  Iterable<ActivityRoleModel> assigned(String? Function(String) membershipOf) =>
+      filterAssignedRoles(roles, membershipOf).values;
+
+  group('botHoldsLiveSeat', () {
+    test('a provably-left bot holds no seat — the #8099 case: its role shows '
+        'unfilled, so Play with Pangea Bot must come back', () {
+      expect(
+        botHoldsLiveSeat(assigned((id) => id == bot ? 'leave' : 'join'), bot),
+        isFalse,
+      );
+    });
+
+    test('a joined bot holds its seat, so the button stays disabled while a '
+        'session with the bot is live', () {
+      expect(botHoldsLiveSeat(assigned((_) => 'join'), bot), isTrue);
+    });
+
+    test('an unloaded bot member event (lazy loading) keeps the seat occupied '
+        '— same conservative default as the seat math (#7556)', () {
+      expect(
+        botHoldsLiveSeat(assigned((id) => id == bot ? null : 'join'), bot),
+        isTrue,
+      );
+    });
+
+    test('a re-invited bot counts as seated again — the recovery path settles '
+        'as soon as the invite lands', () {
+      expect(
+        botHoldsLiveSeat(assigned((id) => id == bot ? 'invite' : 'join'), bot),
+        isTrue,
+      );
+    });
+
+    test('no role entry for the bot at all — never added — leaves the button '
+        'available', () {
+      expect(
+        botHoldsLiveSeat(
+          filterAssignedRoles({
+            'human-role': role('human-role', human),
+          }, (_) => 'join').values,
+          bot,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a room with no role state has no bot seat', () {
+      expect(botHoldsLiveSeat(const [], bot), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
### What

Waiting room's **Play with Pangea Bot** button now tracks the bot's live seat instead of the sticky `pangea.bot_participant` marker, so it comes back when the bot drops out of a session with its role unfilled.

### Why

Closes #8099. The marker is written once on the first click and exists forever, so after the bot left mid-session the button stayed greyed out with no way to bring the bot back.

### Changes

- `botAddedToActivity` (marker exists) → `botHasActivityRole` (bot occupies a seat in `assignedRoles`, which frees seats whose holder provably left — same evidence basis as the seat math, #7556).
- `PlayWithBotLoadingDialog` success condition is now "bot holds a live seat" checked per sync, instead of waiting for a fresh activity-role state event from the bot. On the recovery path the bot is re-invited and silently resumes the role entry it left behind (bot-side `ensure_has_an_activity_role` no-ops via `has_picked_a_role`), so the old event-identity wait would time out on a session that actually recovered. Note: re-clicking also re-sends the marker, but Synapse dedups an identical same-sender state event — the re-invite, which the dialog already does, is what actually brings the bot back.
- New `botHoldsLiveSeat` pure gate + regression tests (`test/pangea/bot_activity_seat_gate_test.dart`) locking: provably-left bot → button available; joined/invited/unloaded-membership bot → seat occupied, button disabled.

### Testing

- `fvm flutter test` full suite: 1793 passed, 3 skipped.
- New unit tests cover the gate composed with `filterAssignedRoles`.
- Staging QA per the issue's TO TEST (bot leaving mid-activity has no known repro yet) tracks on the linked issue.

### Deploy Notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)