### PR TITLE
fix(web): version the self-hosted CanvasKit URL by engine revision

### DIFF
--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -54,7 +54,7 @@ jobs:
           flutter config --enable-web
           flutter clean
           flutter pub get
-          flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --pwa-strategy=none --profile --source-maps --build-number=$(date -u +%d%H%M)
+          ./scripts/build-web-versioned-canvaskit.sh --pwa-strategy=none --profile --source-maps --build-number=$(date -u +%d%H%M)
 
       - name: Version Material Icons font
         run: |
@@ -229,9 +229,14 @@ jobs:
               || { echo "::error::.well-known/$f is missing, invalid JSON, or lacks the app id (SPA fallback?)"; exit 1; }
           done
 
-          # 2. Runtime entry scripts serve as JavaScript, not the SPA shell.
-          for f in flutter.js main.dart.js; do
-            head=$(curl -sf "$BASE/$f" | head -c 1)
+          # 2. Runtime entry scripts — and the versioned CanvasKit dir this
+          #    exact build requests (scripts/build-web-versioned-canvaskit.sh)
+          #    — serve as JavaScript, not the SPA shell.
+          CK_REV=$(ls build/web/canvaskit)
+          for f in flutter.js main.dart.js "canvaskit/$CK_REV/canvaskit.js"; do
+            # First non-whitespace byte: canvaskit.js opens with a newline,
+            # which a bare `head -c 1` + command substitution would eat.
+            head=$(curl -sf "$BASE/$f" | tr -d '[:space:]' | head -c 1)
             [ "$head" != "<" ] && [ -n "$head" ] \
               || { echo "::error::$f served HTML or empty — partial deploy?"; exit 1; }
           done

--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -196,12 +196,15 @@ jobs:
             "assets/AssetManifest.bin.json"
           )
 
+          # Every entry is required: a missing runtime file is a partial
+          # deploy (same silent-failure class the post-deploy smoke exists
+          # for, #7862) and must fail the run, not skip quietly.
           for f in "${RUNTIME_FILES[@]}"; do
-            if [ -f "./build/web/$f" ]; then
-              aws s3 cp "./build/web/$f" \
-                "s3://$WEBAPP_S3_BUCKET/$f" \
-                --cache-control "no-cache, must-revalidate"
-            fi
+            [ -f "./build/web/$f" ] \
+              || { echo "::error::runtime file $f missing from build output"; exit 1; }
+            aws s3 cp "./build/web/$f" \
+              "s3://$WEBAPP_S3_BUCKET/$f" \
+              --cache-control "no-cache, must-revalidate"
           done
       - name: Invalidate CloudFront cache
         run: |

--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -157,7 +157,7 @@ jobs:
             --exclude "version.json" \
             --exclude "manifest.json" \
             --exclude "assets/FontManifest.json" \
-            --exclude "assets/assets.json" \
+            --exclude "assets/AssetManifest.bin*" \
             --exclude "assets/fonts/*"
 
           # =========================
@@ -192,7 +192,8 @@ jobs:
             "version.json"
             "manifest.json"
             "assets/FontManifest.json"
-            "assets/assets.json"
+            "assets/AssetManifest.bin"
+            "assets/AssetManifest.bin.json"
           )
 
           for f in "${RUNTIME_FILES[@]}"; do

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -227,6 +227,14 @@ jobs:
         with:
           name: web
           path: build/web
+      - name: Update Website files
+        # Rebuild .env here, mirroring main_deploy.yaml: upload-artifact v4
+        # defaults include-hidden-files to false, so a .env baked into
+        # build/web at build time never survives into the web artifact.
+        # Writing it in the deploy job keeps config resolution in the job
+        # that owns the environment.
+        run: |
+          echo "$WEB_APP_ENV" > build/web/.env
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
@@ -291,12 +299,15 @@ jobs:
             "assets/AssetManifest.bin.json"
           )
 
+          # Every entry is required: a missing runtime file is a partial
+          # deploy (same silent-failure class the post-deploy smoke exists
+          # for, #7862) and must fail the run, not skip quietly.
           for f in "${RUNTIME_FILES[@]}"; do
-            if [ -f "./build/web/$f" ]; then
-              aws s3 cp "./build/web/$f" \
-                "s3://$WEBAPP_S3_BUCKET/$f" \
-                --cache-control "no-cache, must-revalidate"
-            fi
+            [ -f "./build/web/$f" ] \
+              || { echo "::error::runtime file $f missing from build output"; exit 1; }
+            aws s3 cp "./build/web/$f" \
+              "s3://$WEBAPP_S3_BUCKET/$f" \
+              --cache-control "no-cache, must-revalidate"
           done
       - name: Invalidate CloudFront cache
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,7 @@ jobs:
         # committed back, and the release tag still reads pubspec's `+N`.
         # Resets monthly, so it identifies a build, never orders one.
         # See ci.instructions.md.
-        run: flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --pwa-strategy=none --release --source-maps --build-number=$(date -u +%d%H%M)
+        run: ./scripts/build-web-versioned-canvaskit.sh --pwa-strategy=none --release --source-maps --build-number=$(date -u +%d%H%M)
       # The web app fetches /.env from the web root at runtime; it is not a
       # bundled asset, so the build output needs an explicit copy.
       - name: Add env to web root
@@ -322,9 +322,14 @@ jobs:
               || { echo "::error::.well-known/$f is missing, invalid JSON, or lacks the app id (SPA fallback?)"; exit 1; }
           done
 
-          # 2. Runtime entry scripts serve as JavaScript, not the SPA shell.
-          for f in flutter.js main.dart.js; do
-            head=$(curl -sf "$BASE/$f" | head -c 1)
+          # 2. Runtime entry scripts — and the versioned CanvasKit dir this
+          #    exact build requests (scripts/build-web-versioned-canvaskit.sh)
+          #    — serve as JavaScript, not the SPA shell.
+          CK_REV=$(ls build/web/canvaskit)
+          for f in flutter.js main.dart.js "canvaskit/$CK_REV/canvaskit.js"; do
+            # First non-whitespace byte: canvaskit.js opens with a newline,
+            # which a bare `head -c 1` + command substitution would eat.
+            head=$(curl -sf "$BASE/$f" | tr -d '[:space:]' | head -c 1)
             [ "$head" != "<" ] && [ -n "$head" ] \
               || { echo "::error::$f served HTML or empty — partial deploy?"; exit 1; }
           done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -243,6 +243,7 @@ jobs:
           aws s3 sync ./build/web s3://$WEBAPP_S3_BUCKET \
             --cache-control "public, max-age=31536000, immutable" \
             --exclude "index.html" \
+            --exclude ".env" \
             --exclude "main.dart.js" \
             --exclude "*.part.js" \
             --exclude "flutter.js" \
@@ -251,7 +252,7 @@ jobs:
             --exclude "version.json" \
             --exclude "manifest.json" \
             --exclude "assets/FontManifest.json" \
-            --exclude "assets/assets.json" \
+            --exclude "assets/AssetManifest.bin*" \
             --exclude "assets/fonts/*"
 
           # =========================
@@ -273,11 +274,12 @@ jobs:
             --cache-control "no-cache, must-revalidate"
 
           # =========================
-          # 4. FLUTTER RUNTIME ENTRY FILES
+          # 4. FLUTTER RUNTIME ENTRY FILES + .env (config must propagate every deploy)
           # Must always stay fresh
           # =========================
           RUNTIME_FILES=(
             "index.html"
+            ".env"
             "main.dart.js"
             "flutter.js"
             "flutter_bootstrap.js"
@@ -285,7 +287,8 @@ jobs:
             "version.json"
             "manifest.json"
             "assets/FontManifest.json"
-            "assets/assets.json"
+            "assets/AssetManifest.bin"
+            "assets/AssetManifest.bin.json"
           )
 
           for f in "${RUNTIME_FILES[@]}"; do

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
 RUN ./scripts/prepare-web.sh
 COPY config.* /app/
 RUN flutter pub get
-RUN flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ --release --source-maps
+RUN ./scripts/build-web-versioned-canvaskit.sh --release --source-maps
 
 FROM docker.io/nginx:alpine
 RUN rm -rf /usr/share/nginx/html

--- a/scripts/build-web-versioned-canvaskit.sh
+++ b/scripts/build-web-versioned-canvaskit.sh
@@ -1,0 +1,30 @@
+#!/bin/sh -e
+
+# flutter build web, with the self-hosted CanvasKit served from an
+# engine-revision-versioned path (canvaskit/<engineRevision>/) instead of the
+# default unversioned canvaskit/.
+#
+# main.dart.js and canvaskit.{js,wasm} are one artifact split across files: a
+# bundle from one engine running against CanvasKit from another crashes at the
+# first canvas paint (#8084, Sentry CLIENT-CN4 — a cached pre-Flutter-3.41
+# shell calling Path.addRect on a CanvasKit that had moved it to PathBuilder).
+# Our deploys cache canvaskit/* as immutable for a year, so the unversioned
+# path made that skew inevitable across engine bumps. Versioning the path by
+# engine revision makes each bundle request exactly the engine it was built
+# with, and keeping old revision dirs in the bucket (the s3 sync never
+# deletes) lets stale cached shells keep finding theirs.
+#
+# Usage: ./scripts/build-web-versioned-canvaskit.sh [flutter build web flags...]
+
+ENGINE_REV=$(flutter --version --machine | jq -r .engineRevision)
+if [ -z "$ENGINE_REV" ] || [ "$ENGINE_REV" = "null" ]; then
+  echo "build-web-versioned-canvaskit: could not resolve engine revision" >&2
+  exit 1
+fi
+echo "build-web-versioned-canvaskit: CanvasKit URL is canvaskit/$ENGINE_REV/"
+
+flutter build web --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/$ENGINE_REV/ "$@"
+
+mv build/web/canvaskit "build/web/canvaskit-$ENGINE_REV"
+mkdir build/web/canvaskit
+mv "build/web/canvaskit-$ENGINE_REV" "build/web/canvaskit/$ENGINE_REV"


### PR DESCRIPTION
### What

Serve the self-hosted CanvasKit from `canvaskit/<engineRevision>/` instead of the unversioned `canvaskit/`, via a shared build wrapper ([scripts/build-web-versioned-canvaskit.sh](https://github.com/pangeachat/client/blob/8084-version-canvaskit-url/scripts/build-web-versioned-canvaskit.sh)) used by the Dockerfile, `main_deploy.yaml`, and `release.yaml`. The post-deploy smoke now also asserts the versioned `canvaskit.js` the deployed bundle requests is actually served as JS.

### Why

Closes #8084. Sentry: CLIENT-CN4, CLIENT-DMW.

`main.dart.js` and `canvaskit.{js,wasm}` are one artifact split across files, but the deploy caches `canvaskit/*` as `immutable, max-age=1y` at an unversioned URL while `main.dart.js` is `no-cache` — so any engine bump can pair a stale half with a fresh one. That skew is exactly what fired: the Sentry events self-report Flutter 3.38.7 (a stale cached app shell, the legacy-service-worker problem documented in `web/index.html`) running against the post-#7330 CanvasKit, where `addRect` moved from `Path` to `PathBuilder` → `NoSuchMethodError: method not found: 'addRect'` at the first canvas paint (the world map, hence the issue's framing — there is no `addRect` call anywhere in app code). Both issues affect a single QA browser (`@test_3_27_1`, Safari), but the skew class is a real risk for prod's v5 web rollout, in both directions; the fresh-app/stale-CanvasKit direction never self-heals because `immutable` responses are never revalidated.

Versioning the path makes the pair atomic: each bundle requests exactly the engine it was built with, retained old revision dirs (the s3 sync never deletes) keep stale shells working, and the year-long `immutable` header becomes correct instead of dangerous. This should be in the v5 web release.

### Testing

- No Dart changes; unit/integration buckets untouched.
- Ran `./scripts/build-web-versioned-canvaskit.sh --pwa-strategy=none --release` locally (Flutter 3.41.4 via FVM): build succeeds; `build/web/canvaskit/` contains exactly `e4b8dca3f1b4ede4c30371002441c88c12187ed6/` with the full engine payload (canvaskit, chromium/, skwasm); `main.dart.js` and `flutter_bootstrap.js` reference `canvaskit/e4b8dca…/`.
- Simulated the updated smoke pipeline against the local build output: all three files pass, including the first-non-whitespace-byte fix (`canvaskit.js` opens with a newline, which the previous `head -c 1` + command substitution would have eaten → false deploy failure).
- Workflow YAML validated with `yq`; script with `sh -n`.
- Post-deploy on staging: confirm `curl -sI https://app.staging.pangea.chat/canvaskit/<rev>/canvaskit.js` serves immutable at the versioned path and both Sentry issues stay silent.

### Deploy Notes

None — no ordering constraints or manual steps. Old unversioned `canvaskit/*` objects stay in the bucket for stale cached shells; new bundles fetch a never-before-cached path, so already-poisoned clients recover on their next `main.dart.js` refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)