### PR TITLE
fix(quests): never cache outline errors; pace and dedupe orphaned-course error logging

### DIFF
--- a/lib/features/course_plans/courses/course_plan_builder.dart
+++ b/lib/features/course_plans/courses/course_plan_builder.dart
@@ -29,7 +29,16 @@ mixin CoursePlanProvider<T extends StatefulWidget> on State<T> {
       }
       course = quest;
     } catch (e, s) {
-      ErrorHandler.logError(e: e, s: s, data: {'courseId': courseId});
+      // Once per course (and error type) per session: the known
+      // orphaned-content case (#7479 — a course space whose quest plan no
+      // longer resolves) re-fails on every visit to the course, and each
+      // repeat carries no new signal (#8083).
+      ErrorHandler.logErrorOnce(
+        key: 'course-plan-load:$courseId:${e.runtimeType}',
+        e: e,
+        s: s,
+        data: {'courseId': courseId},
+      );
       courseError = e;
     } finally {
       if (mounted) setState(() => loadingCourse = false);

--- a/lib/features/quests/quest_progression_resolver.dart
+++ b/lib/features/quests/quest_progression_resolver.dart
@@ -199,7 +199,11 @@ class ProgressionResolution {
     final cache = JoinedObjectiveCache();
     await cache.rebuildFromJoinedCourses(
       client,
-      onError: (uuid, e, s) => ErrorHandler.logError(
+      // Once per course per session, sharing the map rebuild's key: this runs
+      // on every course-panel open, and a course that persistently fails to
+      // resolve (e.g. an orphaned quest plan) re-fails on each of them (#8083).
+      onError: (uuid, e, s) => ErrorHandler.logErrorOnce(
+        key: 'course-outline-resolve:$uuid',
         e: e,
         s: s,
         m: 'course progression failed to resolve',

--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -409,11 +409,33 @@ class QuestRepo {
   /// doesn't, so the two must not share a cache row). In-memory (not
   /// GetStorage) because [QuestOutline] carries session-scoped media CDN URLs —
   /// same reasoning as `ActivityPlanRepo`'s in-memory resolve cache.
+  ///
+  /// Holds SUCCESSES ONLY: caching an error would pin a transient failure (or
+  /// a since-restored quest) for the process lifetime, so every retry — the
+  /// world map's empty-cache self-heal, a panel reopen — would replay the
+  /// stale error instead of ever recovering (#8083).
   static final Map<String, Result<QuestOutline>> _outlineCache = {};
   static final Map<String, Future<Result<QuestOutline>>> _outlineInflight = {};
 
+  /// Test seam for [outline]: replaces [_buildOutline] when set, so the
+  /// cache-on-success / never-cache-errors contract is testable without the
+  /// networked read layer.
+  @visibleForTesting
+  static Future<Result<QuestOutline>> Function(
+    String questId, {
+    String? courseRoomId,
+  })?
+  debugBuildOutline;
+
+  @visibleForTesting
+  static void resetOutlineCacheForTest() {
+    _outlineCache.clear();
+    _outlineInflight.clear();
+  }
+
   /// The full outline: quest + objective groups (LOs in order, each with its
-  /// matching activities). Cached per (quest id, course room); concurrent
+  /// matching activities). Successes are cached per (quest id, course room);
+  /// errors are returned but never cached (see [_outlineCache]). Concurrent
   /// calls for the same key share one in-flight read. [courseRoomId] admits
   /// the quest owner's private activities when the caller is a joined member
   /// of that course. Pass [forceRefresh] to bypass the cache.
@@ -430,12 +452,17 @@ class QuestRepo {
       if (inflight != null) return inflight;
     }
 
-    final future = _buildOutline(questId, courseRoomId: courseRoomId);
+    final future = (debugBuildOutline ?? _buildOutline)(
+      questId,
+      courseRoomId: courseRoomId,
+    );
     _outlineInflight[cacheKey] = future;
 
     final outline = await future;
 
-    _outlineCache[cacheKey] = outline;
+    if (outline.isValue) {
+      _outlineCache[cacheKey] = outline;
+    }
     _outlineInflight.remove(cacheKey);
 
     return outline;

--- a/lib/pangea/common/utils/error_handler.dart
+++ b/lib/pangea/common/utils/error_handler.dart
@@ -50,6 +50,30 @@ class ErrorHandler {
     };
   }
 
+  /// Keys already reported this session via [logErrorOnce].
+  static final Set<String> _reportedOnceKeys = {};
+
+  @visibleForTesting
+  static void resetReportedOnceKeysForTest() => _reportedOnceKeys.clear();
+
+  /// [logError], capped at one report per app session per [key]. For known
+  /// recurring degrade paths — e.g. a joined course whose quest plan no longer
+  /// resolves, retried on every sync (#8083) — the first event per session
+  /// carries the signal (Sentry tallies affected users per issue); each repeat
+  /// is pure event volume. Returns whether this call reported.
+  static Future<bool> logErrorOnce({
+    required String key,
+    Object? e,
+    StackTrace? s,
+    String? m,
+    required Map<String, dynamic> data,
+    SentryLevel level = SentryLevel.error,
+  }) async {
+    if (!_reportedOnceKeys.add(key)) return false;
+    await logError(e: e, s: s, m: m, data: data, level: level);
+    return true;
+  }
+
   static Future<void> logError({
     Object? e,
     StackTrace? s,

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -47,6 +47,33 @@ bool needsParticipantRefill({
   required bool hasUnresolvedSeats,
 }) => everFilled ? filledAtJoinedCount != joinedCount : hasUnresolvedSeats;
 
+/// Minimum spacing between empty-cache self-heal rebuilds of the objective
+/// cache. A set-change rebuild (course join/leave) is never subject to it —
+/// only the "resolved nothing while courses exist" retry, which would
+/// otherwise re-fire on every rate-limited sync for a learner whose joined
+/// courses are all unresolvable (e.g. orphaned quest plans, #8083).
+const Duration kEmptyObjectiveCacheRetryCooldown = Duration(seconds: 30);
+
+/// The pure rule behind [WorldMapPinsManager.shouldRebuildObjectiveCache]
+/// (#8083). A set change (join/leave) rebuilds immediately; the empty-cache
+/// self-heal retries only once [kEmptyObjectiveCacheRetryCooldown] has passed
+/// since the last completed rebuild ([lastRebuildAt] null means none has run,
+/// so the retry is due). Never while a rebuild is already in flight.
+@visibleForTesting
+bool shouldRebuildObjectiveCacheNow({
+  required bool rebuilding,
+  required bool setChanged,
+  required bool emptyButHasCourses,
+  required DateTime? lastRebuildAt,
+  required DateTime now,
+}) {
+  if (rebuilding) return false;
+  if (setChanged) return true;
+  if (!emptyButHasCourses) return false;
+  return lastRebuildAt == null ||
+      now.difference(lastRebuildAt) >= kEmptyObjectiveCacheRetryCooldown;
+}
+
 class WorldMapPinsManager {
   static final ValueNotifier<bool> notifier = ValueNotifier<bool>(false);
 
@@ -88,6 +115,12 @@ class WorldMapPinsManager {
   /// Guards against overlapping objective-cache rebuilds (and stops a
   /// persistently-failing course from rebuilding on every single sync).
   bool _objectiveCacheRebuilding = false;
+
+  /// When the last objective-cache rebuild completed — the empty-cache
+  /// self-heal retry waits [kEmptyObjectiveCacheRetryCooldown] from here, so a
+  /// learner whose joined courses all fail to resolve doesn't refetch (and
+  /// re-log) on every rate-limited sync (#8083).
+  DateTime? _lastObjectiveCacheRebuildAt;
 
   /// The course-plan id [_scopedCourseOutline] was resolved for, so a re-scope to
   /// the same course doesn't re-fetch and a re-scope away clears it.
@@ -528,6 +561,9 @@ class WorldMapPinsManager {
   /// Guarded so overlapping syncs don't stack rebuilds. A course whose outline
   /// fails to resolve is logged (not silently dropped): an empty cache means no
   /// relevance banding and a fail-open gate, which is otherwise invisible.
+  /// Logged once per course per session — the self-heal retry re-attempts the
+  /// same failing course for as long as the map is open, and each repeat
+  /// carries no new signal (#8083).
   Future<void> rebuildObjectiveCache(Client client) async {
     if (_objectiveCacheRebuilding) return;
     _objectiveCacheRebuilding = true;
@@ -537,7 +573,8 @@ class WorldMapPinsManager {
           .toList();
       await _objectiveCache.rebuildFromJoinedCourses(
         client,
-        onError: (uuid, e, s) => ErrorHandler.logError(
+        onError: (uuid, e, s) => ErrorHandler.logErrorOnce(
+          key: 'course-outline-resolve:$uuid',
           e: e,
           s: s,
           m: 'JoinedObjectiveCache: course outline failed to resolve',
@@ -548,6 +585,7 @@ class WorldMapPinsManager {
       resolveProgression(); // re-resolve the band with the loaded outlines
     } finally {
       _objectiveCacheRebuilding = false;
+      _lastObjectiveCacheRebuildAt = DateTime.now();
     }
   }
 
@@ -555,10 +593,12 @@ class WorldMapPinsManager {
   /// last build, or when it resolved nothing while courses exist (the rooms or
   /// their outlines weren't ready at the initial build, or a read transiently
   /// failed). Idempotent for an unchanged, already-populated set, so it's safe on
-  /// every sync; the in-flight guard keeps a persistently-failing course from
-  /// rebuilding more than once at a time, and it self-heals once the data is fixed.
+  /// every sync; the in-flight guard keeps overlapping rebuilds from stacking,
+  /// the empty-cache retry is paced by [kEmptyObjectiveCacheRetryCooldown] so a
+  /// persistently-failing course isn't refetched on every sync, and it
+  /// self-heals once the data is fixed (which is why [QuestRepo.outline] must
+  /// never cache errors — see its cache doc, #8083).
   bool shouldRebuildObjectiveCache(Client client) {
-    if (_objectiveCacheRebuilding) return false;
     final uuids = client.joinedCourseRooms
         .map((r) => r.coursePlan!.uuid)
         .toSet();
@@ -567,8 +607,13 @@ class WorldMapPinsManager {
         uuids.length != _objectiveCacheUuids.length ||
         !uuids.containsAll(_objectiveCacheUuids);
 
-    final emptyButHasCourses = _objectiveCache.ids.isEmpty && uuids.isNotEmpty;
-    return setChanged || emptyButHasCourses;
+    return shouldRebuildObjectiveCacheNow(
+      rebuilding: _objectiveCacheRebuilding,
+      setChanged: setChanged,
+      emptyButHasCourses: _objectiveCache.ids.isEmpty && uuids.isNotEmpty,
+      lastRebuildAt: _lastObjectiveCacheRebuildAt,
+      now: DateTime.now(),
+    );
   }
 
   /// Resolve the viewed course's outline for a course-scoped map so the band

--- a/test/pangea/error_handler_log_once_test.dart
+++ b/test/pangea/error_handler_log_once_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+
+void main() {
+  // #8083: known recurring degrade paths (an orphaned course's quest plan,
+  // retried on every sync / panel open) report once per session per key —
+  // the first event carries the signal; repeats are pure Sentry volume.
+  // Sentry is uninitialized here, so captures no-op — these tests pin the
+  // dedupe contract only.
+  group('ErrorHandler.logErrorOnce', () {
+    setUp(ErrorHandler.resetReportedOnceKeysForTest);
+    tearDown(ErrorHandler.resetReportedOnceKeysForTest);
+
+    test('reports the first call for a key, suppresses repeats', () async {
+      expect(
+        await ErrorHandler.logErrorOnce(
+          key: 'course-outline-resolve:c1',
+          e: Exception('missing quest'),
+          data: {'courseUuid': 'c1'},
+        ),
+        isTrue,
+      );
+      expect(
+        await ErrorHandler.logErrorOnce(
+          key: 'course-outline-resolve:c1',
+          e: Exception('missing quest'),
+          data: {'courseUuid': 'c1'},
+        ),
+        isFalse,
+      );
+    });
+
+    test('distinct keys report independently', () async {
+      await ErrorHandler.logErrorOnce(
+        key: 'course-outline-resolve:c1',
+        e: Exception('missing quest'),
+        data: {'courseUuid': 'c1'},
+      );
+      expect(
+        await ErrorHandler.logErrorOnce(
+          key: 'course-outline-resolve:c2',
+          e: Exception('missing quest'),
+          data: {'courseUuid': 'c2'},
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/pangea/quests/quest_outline_error_cache_test.dart
+++ b/test/pangea/quests/quest_outline_error_cache_test.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import 'package:async/async.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/quests/models/quest_plan_model.dart';
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+
+void main() {
+  // #8083: QuestRepo.outline must cache successes only. A cached error pins a
+  // transient failure (or a since-restored quest) for the process lifetime,
+  // which defeats the world map's empty-cache self-heal retry — the retry
+  // replays the stale error forever instead of recovering.
+  group('QuestRepo.outline error caching', () {
+    const quest = QuestPlan(
+      id: 'quest-1',
+      name: 'Quest',
+      description: '',
+      targetLanguage: 'es',
+      sequence: [],
+    );
+
+    var buildCalls = 0;
+
+    setUp(() {
+      buildCalls = 0;
+      QuestRepo.resetOutlineCacheForTest();
+    });
+
+    tearDown(() {
+      QuestRepo.debugBuildOutline = null;
+      QuestRepo.resetOutlineCacheForTest();
+    });
+
+    test('an error result is not cached — the next call retries', () async {
+      QuestRepo.debugBuildOutline = (id, {courseRoomId}) async {
+        buildCalls++;
+        return Result.error(MissingQuestException());
+      };
+
+      final first = await QuestRepo.outline('quest-1');
+      expect(first.isError, isTrue);
+      final second = await QuestRepo.outline('quest-1');
+      expect(second.isError, isTrue);
+
+      expect(buildCalls, 2);
+    });
+
+    test('a retry after an error can succeed and then caches', () async {
+      QuestRepo.debugBuildOutline = (id, {courseRoomId}) async {
+        buildCalls++;
+        if (buildCalls == 1) return Result.error(MissingQuestException());
+        return Result.value(const QuestOutline(quest: quest, groups: []));
+      };
+
+      expect((await QuestRepo.outline('quest-1')).isError, isTrue);
+      expect((await QuestRepo.outline('quest-1')).isValue, isTrue);
+      // The success is now cached — no further build.
+      expect((await QuestRepo.outline('quest-1')).isValue, isTrue);
+      expect(buildCalls, 2);
+    });
+
+    test('a success is cached per (quest id, course room)', () async {
+      QuestRepo.debugBuildOutline = (id, {courseRoomId}) async {
+        buildCalls++;
+        return Result.value(const QuestOutline(quest: quest, groups: []));
+      };
+
+      await QuestRepo.outline('quest-1');
+      await QuestRepo.outline('quest-1');
+      expect(buildCalls, 1);
+
+      // A course-member read must not share the plain read's cache row.
+      await QuestRepo.outline('quest-1', courseRoomId: '!room:server');
+      expect(buildCalls, 2);
+    });
+
+    test('concurrent calls share one in-flight build, even on error', () async {
+      final gate = Completer<Result<QuestOutline>>();
+      QuestRepo.debugBuildOutline = (id, {courseRoomId}) {
+        buildCalls++;
+        return gate.future;
+      };
+
+      final first = QuestRepo.outline('quest-1');
+      final second = QuestRepo.outline('quest-1');
+      gate.complete(Result.error(MissingQuestException()));
+
+      expect((await first).isError, isTrue);
+      expect((await second).isError, isTrue);
+      expect(buildCalls, 1);
+
+      // The shared error was not cached — a later call retries.
+      await QuestRepo.outline('quest-1');
+      expect(buildCalls, 2);
+    });
+  });
+}

--- a/test/pangea/world/objective_cache_retry_cooldown_test.dart
+++ b/test/pangea/world/objective_cache_retry_cooldown_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/world/world_map_pins_manager.dart';
+
+void main() {
+  // #8083: the empty-cache self-heal used to re-fire on every rate-limited
+  // sync for a learner whose joined courses are all unresolvable (e.g.
+  // orphaned quest plans), refetching and re-logging in a loop. The pure rule
+  // paces that retry by kEmptyObjectiveCacheRetryCooldown while leaving
+  // set-change rebuilds (course join/leave) immediate.
+  group('shouldRebuildObjectiveCacheNow', () {
+    final now = DateTime(2026, 8, 3, 12);
+
+    test('never rebuilds while a rebuild is in flight', () {
+      expect(
+        shouldRebuildObjectiveCacheNow(
+          rebuilding: true,
+          setChanged: true,
+          emptyButHasCourses: true,
+          lastRebuildAt: null,
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test('a set change rebuilds immediately, cooldown or not', () {
+      expect(
+        shouldRebuildObjectiveCacheNow(
+          rebuilding: false,
+          setChanged: true,
+          emptyButHasCourses: false,
+          lastRebuildAt: now.subtract(const Duration(seconds: 1)),
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+
+    test('a populated, unchanged cache does not rebuild', () {
+      expect(
+        shouldRebuildObjectiveCacheNow(
+          rebuilding: false,
+          setChanged: false,
+          emptyButHasCourses: false,
+          lastRebuildAt: null,
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test('the empty-cache retry is due when no rebuild has run', () {
+      expect(
+        shouldRebuildObjectiveCacheNow(
+          rebuilding: false,
+          setChanged: false,
+          emptyButHasCourses: true,
+          lastRebuildAt: null,
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+
+    test('the empty-cache retry waits out the cooldown', () {
+      expect(
+        shouldRebuildObjectiveCacheNow(
+          rebuilding: false,
+          setChanged: false,
+          emptyButHasCourses: true,
+          lastRebuildAt: now.subtract(
+            kEmptyObjectiveCacheRetryCooldown - const Duration(seconds: 1),
+          ),
+          now: now,
+        ),
+        isFalse,
+      );
+    });
+
+    test('the empty-cache retry fires once the cooldown has passed', () {
+      expect(
+        shouldRebuildObjectiveCacheNow(
+          rebuilding: false,
+          setChanged: false,
+          emptyButHasCourses: true,
+          lastRebuildAt: now.subtract(kEmptyObjectiveCacheRetryCooldown),
+          now: now,
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Stops the unbounded Sentry event loop for courses whose quest plan no longer resolves: quest-outline errors are no longer cached for the process lifetime, the world map's empty-cache self-heal retry is paced by a 30s cooldown, and the recurring orphaned-course errors report once per course per session instead of on every sync/panel open.

## Why

Closes #8083. Fixes CLIENT-CTX / CLIENT-CY3 / CLIENT-D46 / CLIENT-CTW (`MissingQuestException`) and CLIENT-C4V / CLIENT-C2H (`No quest plan found for course id`).

Root cause (triage in the issue's investigation): a joined course whose `coursePlan.uuid` 404s on the CMS `quest-plans` read hit two compounding defects —

- `QuestRepo.outline` cached **error** results, so the documented empty-cache self-heal (`shouldRebuildObjectiveCache`) could never recover, even after the data was fixed.
- That self-heal re-fired on every rate-limited sync, and each attempt logged to Sentry per failing course — an event every ~2s for a learner sitting on the persistent world map, matching the observed volumes.

The user-facing degrade path is unchanged and already graceful (the `MissingQuestException` → "pick a new course" CTA from #7529).

## Changes

- `QuestRepo.outline`: cache successes only; in-flight dedupe unchanged. Test seam (`debugBuildOutline`) added following the file's existing `@visibleForTesting` pattern.
- `WorldMapPinsManager`: empty-cache retry paced by `kEmptyObjectiveCacheRetryCooldown` (30s) via a pure rule (`shouldRebuildObjectiveCacheNow`, same pattern as `needsParticipantRefill`); join/leave rebuilds stay immediate.
- `ErrorHandler.logErrorOnce`: once-per-session-per-key reporting; adopted by both outline-resolve `onError` sites (shared key per course) and `CoursePlanProvider.loadCourse` (keyed per course + error type). First event per course per session still lands in Sentry, so affected users/courses stay visible.

## Testing

- New unit tests: `quest_outline_error_cache_test.dart` (error results never cached, success cached per cache row, in-flight dedupe preserved), `objective_cache_retry_cooldown_test.dart` (cooldown rule), `error_handler_log_once_test.dart` (dedupe contract).
- Full local suite: `fvm flutter test test/pangea` — 1777 passed, 3 skipped, 0 failed.
- `fvm flutter analyze` clean on all touched files.
- Staging repro of the issue's TO TEST (orphaned course id on web/Android/iOS/iPad) tracked on the linked issue per the QA label flow.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)