### PR TITLE
fix(invite): drop course/participants filters for world activities

### DIFF
--- a/lib/routes/chat/chat_details/invite/pangea_invitation_selection.dart
+++ b/lib/routes/chat/chat_details/invite/pangea_invitation_selection.dart
@@ -35,6 +35,42 @@ enum InvitationFilter {
       value == null ? null : fromString(value);
 }
 
+/// Which filters the invite page can offer for a given room. Kept on [Room] so
+/// the rules are decidable from room state alone, without a [BuildContext].
+extension InvitationFiltersRoomExtension on Room {
+  /// The course whose roster the "in this course" filter offers, or null when
+  /// there is none to offer.
+  ///
+  /// For an activity session this is the course the session was LAUNCHED from
+  /// (`source_course_id`) — NOT merely a space parent. Launching also shares the
+  /// session into every other eligible joined course as an `m.space.child` (see
+  /// `activities.instructions.md`), so a session started from the world map
+  /// collects course parents it was never "in". Offering those rosters reads as
+  /// "invite this course" to someone who is not in a course at all, and the
+  /// launcher has no reason to expect them (#8097). A world-launched session
+  /// pins no source course, so it gets no course filter.
+  ///
+  /// Every other room keeps the plain first-space-parent rule: a chat inside a
+  /// course space really is "in this course".
+  Room? get invitationCourseSpace {
+    final parents = pangeaSpaceParents;
+    if (parents.isEmpty) return null;
+    if (!isActivitySession) return parents.first;
+
+    final sourceCourseId = pinnedSourceCourseId;
+    if (sourceCourseId == null) return null;
+    return parents.firstWhereOrNull((p) => p.id == sourceCourseId);
+  }
+
+  /// Whether the invite page offers a roster ("participants") filter.
+  ///
+  /// An activity session's start page already lists everyone — role holders in
+  /// their roles, the rest below them — so a second roster on the invite page is
+  /// redundant there (#8097). Other rooms keep it; it is where the "N
+  /// participants" button on the chat details page lands.
+  bool get showInvitationParticipantsFilter => !isActivitySession;
+}
+
 class PangeaInvitationSelection extends StatefulWidget {
   final String roomId;
   final InvitationFilter? initialFilter;
@@ -147,11 +183,7 @@ class PangeaInvitationSelectionController
 
   Room? get _room => Matrix.of(context).client.getRoomById(widget.roomId);
 
-  Room? get spaceParent {
-    final parents = _room?.pangeaSpaceParents;
-    if (parents == null || parents.isEmpty) return null;
-    return parents.first;
-  }
+  Room? get spaceParent => _room?.invitationCourseSpace;
 
   bool get showInviteAllInSpaceButton {
     final roomParticipants = participants;
@@ -180,7 +212,8 @@ class PangeaInvitationSelectionController
           InvitationFilter.banned =>
             participants?.any((u) => u.membership == Membership.ban) ?? false,
           InvitationFilter.public => true,
-          InvitationFilter.participants => true,
+          InvitationFilter.participants =>
+            _room?.showInvitationParticipantsFilter ?? true,
         },
       )
       .toList();

--- a/test/pangea/invitation_filters_test.dart
+++ b/test/pangea/invitation_filters_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_media_enum.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_request.dart';
+import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/activity_session_constants.dart';
+import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
+import 'package:fluffychat/routes/chat/chat_details/invite/pangea_invitation_selection.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_room_types.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+import 'get_test_client.dart';
+
+/// #8097 — the invite page offered "in this course" to activity sessions
+/// launched from the world map. Launching a session shares it into EVERY
+/// eligible joined course as an `m.space.child`, while only the launched-from
+/// course is pinned as `source_course_id` (activities.instructions.md), so a
+/// world-launched session collects course parents it was never "in" and the
+/// filter appeared — and was auto-selected — for someone not in a course at all.
+///
+/// Same issue: an activity session's start page already lists every
+/// participant by role, so the invite page's roster filter is redundant there.
+void main() {
+  late Client client;
+
+  const userId = '@test:fakeServer.notExisting';
+  const activityId = 'activity-123';
+  const sessionId = '!session:fakeServer.notExisting';
+
+  setUp(() async {
+    client = await getTestClient();
+  });
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  Event stateEvent(
+    Room room, {
+    required String type,
+    required Map<String, dynamic> content,
+    String stateKey = '',
+  }) => Event(
+    type: type,
+    content: content,
+    stateKey: stateKey,
+    senderId: userId,
+    eventId: '\$${type}_$stateKey',
+    originServerTs: DateTime.now(),
+    room: room,
+  );
+
+  /// A course space that lists [childId] as an `m.space.child`, registered on
+  /// the client so `pangeaSpaceParents` (which scans `client.rooms`) sees it.
+  Room courseSpace(String id, {required String childId}) {
+    final space = Room(id: id, client: client, membership: Membership.join);
+    space.setState(
+      stateEvent(
+        space,
+        type: EventTypes.RoomCreate,
+        content: {'type': RoomCreationTypes.mSpace},
+      ),
+    );
+    space.setState(
+      stateEvent(
+        space,
+        type: EventTypes.SpaceChild,
+        content: {
+          'via': ['fakeServer.notExisting'],
+        },
+        stateKey: childId,
+      ),
+    );
+    client.rooms.add(space);
+    return space;
+  }
+
+  ActivityPlanModel plan() => ActivityPlanModel(
+    req: ActivityPlanRequest(
+      topic: 'jobs',
+      mode: 'Roleplay',
+      objective: 'introduce yourself',
+      media: MediaEnum.nan,
+      cefrLevel: LanguageLevelTypeEnum.a1,
+      languageOfInstructions: 'en',
+      targetLanguage: 'de',
+      numberOfParticipants: 2,
+    ),
+    title: 'Speed-Dating Interview',
+    learningObjective: 'introduce yourself',
+    instructions: 'i',
+    vocab: const [],
+    activityId: activityId,
+    roles: const {},
+  );
+
+  /// An activity session room, optionally pinning the course it was launched
+  /// from. No pin = launched from the world map. The plan is carried inline so
+  /// `isActivitySession` resolves without hydrating through `ActivityPlanRepo`.
+  Room activitySession({String? sourceCourseId}) {
+    final room = Room(
+      id: sessionId,
+      client: client,
+      membership: Membership.join,
+    );
+    room.setState(
+      stateEvent(
+        room,
+        type: EventTypes.RoomCreate,
+        content: {'type': '${PangeaRoomTypes.activitySession}:$activityId'},
+      ),
+    );
+    room.setState(
+      stateEvent(
+        room,
+        type: PangeaEventTypes.activityPlan,
+        content: {
+          ...plan().toJson(),
+          ActivitySessionConstants.sourceCourseId: ?sourceCourseId,
+        },
+      ),
+    );
+    client.rooms.add(room);
+    return room;
+  }
+
+  group('invitationCourseSpace', () {
+    test('is null for a world-launched session fanned out into a course', () {
+      final session = activitySession();
+      courseSpace('!fannedOut:fakeServer.notExisting', childId: sessionId);
+
+      expect(session.pangeaSpaceParents, isNotEmpty);
+      expect(session.invitationCourseSpace, isNull);
+    });
+
+    test('is the launching course for a course-launched session', () {
+      const courseId = '!launchedFrom:fakeServer.notExisting';
+      final session = activitySession(sourceCourseId: courseId);
+      final course = courseSpace(courseId, childId: sessionId);
+
+      expect(session.invitationCourseSpace, course);
+    });
+
+    test(
+      'ignores fan-out courses and picks the pinned one when both are parents',
+      () {
+        const courseId = '!launchedFrom:fakeServer.notExisting';
+        final session = activitySession(sourceCourseId: courseId);
+        // Registered first, so it is `pangeaSpaceParents.first`.
+        courseSpace('!fannedOut:fakeServer.notExisting', childId: sessionId);
+        final course = courseSpace(courseId, childId: sessionId);
+
+        expect(session.pangeaSpaceParents, hasLength(2));
+        expect(session.invitationCourseSpace, course);
+      },
+    );
+
+    test('is null when the pinned course is no longer a parent', () {
+      final session = activitySession(
+        sourceCourseId: '!leftCourse:fakeServer.notExisting',
+      );
+      courseSpace('!fannedOut:fakeServer.notExisting', childId: sessionId);
+
+      expect(session.invitationCourseSpace, isNull);
+    });
+
+    test('is the first space parent for a non-session room', () {
+      const chatId = '!chat:fakeServer.notExisting';
+      final chat = Room(
+        id: chatId,
+        client: client,
+        membership: Membership.join,
+      );
+      client.rooms.add(chat);
+      final course = courseSpace(
+        '!course:fakeServer.notExisting',
+        childId: chatId,
+      );
+
+      expect(chat.isActivitySession, isFalse);
+      expect(chat.invitationCourseSpace, course);
+    });
+
+    test('is null for a room with no space parents', () {
+      final chat = Room(
+        id: '!orphan:fakeServer.notExisting',
+        client: client,
+        membership: Membership.join,
+      );
+      client.rooms.add(chat);
+
+      expect(chat.invitationCourseSpace, isNull);
+    });
+  });
+
+  group('showInvitationParticipantsFilter', () {
+    test('is false for an activity session', () {
+      expect(activitySession().showInvitationParticipantsFilter, isFalse);
+    });
+
+    test('is true for a regular chat', () {
+      final chat = Room(
+        id: '!chat:fakeServer.notExisting',
+        client: client,
+        membership: Membership.join,
+      );
+      expect(chat.showInvitationParticipantsFilter, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## What

The invite page no longer offers "in this course" for an activity session launched from the world map, and no longer offers the "participants" roster filter for activity sessions at all.

## Why

Closes #8097

Launching a session shares it into **every** eligible joined course as an `m.space.child`, while only the launched-from course is pinned as `source_course_id` — one provenance field vs. the full eligible fan-out ([activities.instructions.md](.github/instructions/activities.instructions.md)). The invite page's "in this course" filter was gated on `pangeaSpaceParents.first`, i.e. *any* space parent, so a session started from the world map picked up the fan-out courses it was never "in" — and because the filter existing also drives the page's initial selection, it opened pre-selected on a course the learner never chose to invite.

`source_course_id` is the signal that already distinguishes the two; the getter now uses it.

The participants filter is a separate ask on the same issue: an activity session's start page already lists every participant (role holders in their roles, everyone else below), so a second roster on the invite page is redundant there.

## Changes

- `lib/routes/chat/chat_details/invite/pangea_invitation_selection.dart` — new `InvitationFiltersRoomExtension` on `Room` holding both rules, so they are decidable from room state alone (no `BuildContext`, hence unit-testable):
  - `invitationCourseSpace` — for an activity session, the space parent whose id matches `pinnedSourceCourseId`; null when nothing is pinned (world-launched) or the pinned course is no longer a parent. Every other room keeps the plain first-space-parent rule.
  - `showInvitationParticipantsFilter` — false for an activity session, true otherwise.

  The controller's `spaceParent` and `availableFilters` delegate to these. `showInviteAllInSpaceButton`, `filteredContacts`, and `inviteAllInSpace` all read `spaceParent`, so they follow automatically — "invite all in this course" can no longer target a fan-out course either.

- `test/pangea/invitation_filters_test.dart` (new) — 8 unit tests over both getters: world-launched-with-fan-out-parent, course-launched, both-parents-present (pinned wins over `.first`), pinned course no longer a parent, non-session room, no space parents, and the participants rule for a session vs. a regular chat.

**Scope notes.** A session launched *from* a course is unchanged — it still shows and defaults to "in this course". Non-session rooms are untouched in both respects, so the "N participants" button in chat details ([chat_details_content.dart](lib/routes/chat/chat_details/chat_details_content.dart), which deep-links `filter: participants`) still lands on its tab. If that link is ever aimed at a session, the existing `availableFilters.contains(initialFilter)` guard drops it to "my contacts" rather than opening on a missing tab.

## Testing

- `fvm flutter analyze lib test` — clean.
- `fvm dart format --set-exit-if-changed` on the changed files — clean.
- `fvm flutter test test/pangea/invitation_filters_test.dart` — 8 passed.
- `fvm flutter test` (full suite) — 1795 passed, 3 skipped (the credential-gated endpoint suites; no `TEST_MATRIX_*` locally).
- **Not manually exercised in-app.** Reproducing it end-to-end needs a joined course whose plan contains the activity plus a world-map launch of that same activity, which this environment isn't provisioned for. The unit tests pin the decision the UI reads; the issue's two TO TEST steps are the staging check.

## Deploy Notes

None.
