### PR TITLE
fix(analytics): drop stale practice-FAB bottom spacer in vocab/grammar lists

### DIFF
--- a/lib/routes/analytics/construct_analytics/morph_analytics_list_view.dart
+++ b/lib/routes/analytics/construct_analytics/morph_analytics_list_view.dart
@@ -57,7 +57,6 @@ class MorphAnalyticsListView extends StatelessWidget {
                       : const SizedBox.shrink();
                 }, childCount: controller.morphs.features.length),
               ),
-              const SliverToBoxAdapter(child: SizedBox(height: 75.0)),
             ],
           ),
         ),

--- a/lib/routes/analytics/construct_analytics/vocab_analytics_list_view.dart
+++ b/lib/routes/analytics/construct_analytics/vocab_analytics_list_view.dart
@@ -322,7 +322,6 @@ class VocabAnalyticsListView extends StatelessWidget {
                         );
                       }, childCount: sortedFilteredVocab.length),
                     ),
-              const SliverToBoxAdapter(child: SizedBox(height: 75.0)),
             ],
           ),
         ),


### PR DESCRIPTION
## What

Remove the 75px bottom spacer sliver from the vocab and grammar analytics list views.

## Why

Closes #8105

The spacer was added in #5132 so the **bottom-floating practice FAB wouldn't cover the last entries**. #7979 moved practice into the app bar (see the comment in `analytics_details_popup.dart`), so the spacer no longer clears anything — it just leaves dead space under the last row. The popup body already applies a uniform 16px inset, which is the padding that remains.

## Changes to look over

- `lib/routes/analytics/construct_analytics/vocab_analytics_list_view.dart` — dropped the trailing `SliverToBoxAdapter(SizedBox(height: 75.0))`; the grid now ends against the body's 16px padding.
- `lib/routes/analytics/construct_analytics/morph_analytics_list_view.dart` — same removal; the last feature box keeps its own 16px bottom padding, so grammar ends with 32px.

No other analytics scroll view carries a comparable spacer (grepped `SizedBox(height: 4x–9x)` under `lib/routes/analytics/`).

## Testing

- `fvm flutter analyze lib/routes/analytics/construct_analytics/` — clean.
- `fvm flutter test` — 1805 passed, 3 skipped (endpoint suites skip without `TEST_MATRIX_*`), 0 failed.
- **Visual check not run by me.** This agent session has no way to log the local web client in (no `TEST_MATRIX_*` credentials, so `?devlogin=1` is unavailable), so the two pages were not rendered locally; the author is eyeballing them. The issue's TO TEST steps (scroll to the bottom of grammar/vocab, padding looks normal) are the check.

## Deploy Notes

None
