### PR TITLE
chore: register workspace-doctor SessionStart hook (sync fan-out)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,10 @@
           {
             "type": "command",
             "command": "python3 \"$HOME/PangeaChat/.github/scripts/sync-copilot-to-claude.py\""
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$HOME/PangeaChat/.github/scripts/workspace-doctor.py\""
           }
         ]
       }


### PR DESCRIPTION
Sync fan-out refresh of the generated .claude/settings.json: adds the workspace-doctor.py SessionStart registration from the central base (pangeachat/.github). No hand-written content. Registration design: harness-sync.instructions.md in pangeachat/.github. No client testing needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated workspace health check that runs when a new session starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->