### PR TITLE
fix(analytics): grant instructor analytics access via the server-recorded room id

### DIFF
--- a/lib/features/analytics_access/join_room_analytics_access_extension.dart
+++ b/lib/features/analytics_access/join_room_analytics_access_extension.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:matrix/matrix.dart';
 
+import 'package:fluffychat/features/analytics/analytics_constants.dart';
 import 'package:fluffychat/features/analytics/client_analytics_extension.dart';
 import 'package:fluffychat/features/analytics_access/access_notice_extension.dart';
 import 'package:fluffychat/features/analytics_access/course_settings_extension.dart';
@@ -11,6 +12,7 @@ import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/languages/p_language_store.dart';
 import 'package:fluffychat/features/quests/repo/quest_plans_repo.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
 
 class JoinResponse {
   final String roomId;
@@ -83,12 +85,27 @@ extension JoinRoomAnalyticsAccessClientExtension on Client {
     return getRoomById(roomId);
   }
 
-  Future<LanguageModel?> _getCourseLanguage(String courseId) async {
+  LanguageModel? _languageByCode(String? langCode) {
+    if (langCode == null || langCode.isEmpty) return null;
+    return PLanguageStore.byLangCode(langCode) ??
+        LanguageModel(langCode: langCode, displayName: langCode);
+  }
+
+  /// The course's target language. Prefer the course room's OWN
+  /// `pangea.course_plan` `l2` (already in local state — no network, so it works
+  /// on a lagging fresh-page-load sync); fall back to the localized plan fetch.
+  Future<LanguageModel?> _getCourseLanguage(Room room) async {
+    final coursePlan = room.coursePlan;
+    final languageFromRoom = _languageByCode(coursePlan?.l2);
+    if (languageFromRoom != null) return languageFromRoom;
+
+    final courseId = coursePlan?.uuid;
+    return courseId == null ? null : _getCourseLanguageByCourseId(courseId);
+  }
+
+  Future<LanguageModel?> _getCourseLanguageByCourseId(String courseId) async {
     final course = await QuestPlansRepo.get(courseId);
-    final targetLanguage = course?.targetLanguage;
-    return targetLanguage == null
-        ? null
-        : PLanguageStore.byLangCode(targetLanguage);
+    return _languageByCode(course?.targetLanguage);
   }
 
   Future<Map<String, LanguageModel?>> _getCourseLanguages(
@@ -96,9 +113,45 @@ extension JoinRoomAnalyticsAccessClientExtension on Client {
   ) async {
     final output = <String, LanguageModel?>{};
     for (final courseId in courseIds) {
-      output[courseId] = await _getCourseLanguage(courseId);
+      output[courseId] = await _getCourseLanguageByCourseId(courseId);
     }
     return output;
+  }
+
+  /// The student's OWN analytics room id for [lang] as recorded in their
+  /// server-side `pangea.analytics_profile` — the SAME source the teacher
+  /// dashboard reads to resolve a student's analytics room. Fetched fresh (no
+  /// cache) so it does NOT depend on the analytics room having surfaced in the
+  /// local sync. Matches both the short and full language-code keys the profile
+  /// may use. Null when the profile has no room for the language, or on error.
+  Future<String?> _ownAnalyticsRoomIdFromPublicProfile(
+    LanguageModel lang,
+  ) async {
+    try {
+      final userId = userID;
+      if (userId == null) return null;
+
+      final profile = await getUserProfile(userId, maxCacheAge: Duration.zero);
+      final analyticsProfile =
+          profile.additionalProperties[PangeaEventTypes.profileAnalytics];
+      if (analyticsProfile is! Map) return null;
+
+      final analytics = analyticsProfile[AnalyticsConstants.analytics];
+      if (analytics is! Map) return null;
+
+      final entry = analytics[lang.langCodeShort] ?? analytics[lang.langCode];
+      if (entry is! Map) return null;
+
+      final roomId = entry[AnalyticsConstants.analyticsRoomId];
+      return roomId is String && roomId.isNotEmpty ? roomId : null;
+    } catch (e, s) {
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"requested_lang": lang.langCode},
+      );
+      return null;
+    }
   }
 
   Future<void> grantInstructorsAnalyticsAccess(String roomId) async {
@@ -118,7 +171,7 @@ extension JoinRoomAnalyticsAccessClientExtension on Client {
         return;
       }
 
-      final languageModel = await _getCourseLanguage(courseId);
+      final languageModel = await _getCourseLanguage(room);
       if (languageModel == null) {
         ErrorHandler.logError(
           e: "Failed to derive language model from course target language",
@@ -127,15 +180,31 @@ extension JoinRoomAnalyticsAccessClientExtension on Client {
         return;
       }
 
-      final analyticsRoom = ownAnalyticsRoomLocal(lang: languageModel);
-      if (analyticsRoom == null) {
+      // Resolve the analytics room to grant the instructor into. Prefer the
+      // SERVER-RECORDED id from the student's own analytics profile
+      // (`pangea.analytics_profile`) — the SAME source the teacher dashboard
+      // reads to decide granted-vs-pending, fetched fresh so it does NOT depend
+      // on the room having surfaced in the local sync yet. Fall back to the
+      // local canonical room. The old code used ONLY the local room, which on a
+      // required-course join (a fresh page load whose initial sync lags) was
+      // routinely still null, so the grant module was never called and the
+      // instructor stayed "pending"/"awaiting" on the dashboard forever, even
+      // after the student accepted (admin-dash#35, scenario 2).
+      final analyticsRoomId =
+          await _ownAnalyticsRoomIdFromPublicProfile(languageModel) ??
+          ownAnalyticsRoomLocal(lang: languageModel)?.id;
+      if (analyticsRoomId == null) {
+        // Genuinely no analytics room for this language yet (the student has not
+        // studied it). NOT the bug above: a later first-practice creates the
+        // room and `grantAnalyticsAccessByAnalyticsRoom` (fired on room
+        // creation) grants the instructors then.
         Logs().w(
           "User has no analytics room for course target language ${languageModel.langCode}",
         );
         return;
       }
 
-      await grantInstructorAnalyticsAccess(roomId, analyticsRoom.id);
+      await grantInstructorAnalyticsAccess(roomId, analyticsRoomId);
     } catch (e, s) {
       ErrorHandler.logError(e: e, s: s, data: {"joining_room_id": roomId});
     }

--- a/test/pangea/join_room_analytics_access_extension_test.dart
+++ b/test/pangea/join_room_analytics_access_extension_test.dart
@@ -1,0 +1,169 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/analytics_access/course_settings_model.dart';
+import 'package:fluffychat/features/analytics_access/join_room_analytics_access_extension.dart';
+import 'package:fluffychat/features/course_plans/courses/course_plan_event.dart';
+import 'package:fluffychat/pangea/common/constants/model_keys.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_room_types.dart';
+import 'get_test_client.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const userId = '@test:fakeServer.notExisting';
+  const courseRoomId = '!course:fakeServer.notExisting';
+  const analyticsRoomId = '!analytics:fakeServer.notExisting';
+  const grantPath =
+      '/_synapse/client/pangea/v1/grant_instructor_analytics_access';
+
+  late Client client;
+  late FakeMatrixApi api;
+  late List<Map<String, dynamic>> grants;
+
+  setUp(() async {
+    client = await getTestClient();
+    api = FakeMatrixApi.currentApi!;
+    grants = [];
+
+    api.api['POST']![grantPath] = (body) {
+      grants.add(jsonDecode(body as String) as Map<String, dynamic>);
+      return {};
+    };
+  });
+
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  Room courseRoom() {
+    final room = Room(
+      id: courseRoomId,
+      client: client,
+      membership: Membership.join,
+    );
+    room.setState(
+      Event(
+        type: PangeaEventTypes.coursePlan,
+        content: CoursePlanEvent(uuid: 'quest-1', l2: 'de').toJson(),
+        senderId: userId,
+        eventId: '\$coursePlan',
+        originServerTs: DateTime.utc(2026, 1, 1),
+        stateKey: '',
+        room: room,
+      ),
+    );
+    room.setState(
+      Event(
+        type: PangeaEventTypes.courseSettings,
+        content: const CourseSettingsModel(
+          requireAnalyticsAccess: true,
+        ).toJson(),
+        senderId: userId,
+        eventId: '\$courseSettings',
+        originServerTs: DateTime.utc(2026, 1, 1),
+        stateKey: '',
+        room: room,
+      ),
+    );
+    return room;
+  }
+
+  Room analyticsRoom(String id) {
+    final room = Room(id: id, client: client, membership: Membership.join);
+    room.setState(
+      Event(
+        type: EventTypes.RoomCreate,
+        content: {'type': PangeaRoomTypes.analytics, ModelKey.langCode: 'de'},
+        senderId: userId,
+        eventId: '\$create-$id',
+        originServerTs: DateTime.utc(2026, 1, 1),
+        stateKey: '',
+        room: room,
+      ),
+    );
+    return room;
+  }
+
+  void profileWithAnalyticsRoom(String? roomId) {
+    api.api['GET']!['/client/v3/profile/%40test%3AfakeServer.notExisting'] =
+        (_) => {
+          PangeaEventTypes.profileAnalytics: {
+            'analytics': {
+              'de': {
+                'level': 1,
+                ...roomId == null ? const {} : {'analytics_room_id': roomId},
+              },
+            },
+          },
+        };
+  }
+
+  List<String> createRoomCalls() => FakeMatrixApi.calledEndpoints.keys
+      .where((path) => path.contains('/createRoom'))
+      .toList();
+
+  group('grantInstructorsAnalyticsAccess', () {
+    test(
+      'grants using profile analytics_room_id without a local analytics room',
+      () async {
+        profileWithAnalyticsRoom(analyticsRoomId);
+        client.rooms = [courseRoom()];
+
+        await client.grantInstructorsAnalyticsAccess(courseRoomId);
+
+        expect(grants, [
+          {
+            'mx_course_id': courseRoomId,
+            'mx_analytics_room_id': analyticsRoomId,
+          },
+        ]);
+        expect(createRoomCalls(), isEmpty);
+      },
+    );
+
+    test(
+      'falls back to the local canonical analytics room before the call',
+      () async {
+        profileWithAnalyticsRoom(null);
+        client.rooms = [courseRoom(), analyticsRoom(analyticsRoomId)];
+
+        await client.grantInstructorsAnalyticsAccess(courseRoomId);
+
+        expect(grants.single['mx_analytics_room_id'], analyticsRoomId);
+        expect(createRoomCalls(), isEmpty);
+      },
+    );
+
+    test('prefers the profile room id over the local canonical room', () async {
+      // The profile is authoritative and is the SAME source the teacher
+      // dashboard reads, so it must win over any local room.
+      profileWithAnalyticsRoom(analyticsRoomId);
+      client.rooms = [
+        courseRoom(),
+        analyticsRoom('!stale:fakeServer.notExisting'),
+      ];
+
+      await client.grantInstructorsAnalyticsAccess(courseRoomId);
+
+      expect(grants.single['mx_analytics_room_id'], analyticsRoomId);
+      expect(createRoomCalls(), isEmpty);
+    });
+
+    test(
+      'does not grant or create a room when neither profile nor local has one',
+      () async {
+        profileWithAnalyticsRoom(null);
+        client.rooms = [courseRoom()];
+
+        await client.grantInstructorsAnalyticsAccess(courseRoomId);
+
+        expect(grants, isEmpty);
+        expect(createRoomCalls(), isEmpty);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Problem

When a student accepts a **required-analytics** course, the app should grant the course's instructors access to the student's analytics room (via the Synapse grant module). Instead the instructor stays **"pending"/"awaiting"** on the teacher dashboard forever, even after the student accepts. (pangeachat/admin-dash#35, scenario 2)

Root cause: `grantInstructorsAnalyticsAccess` resolved the analytics room via the **local-only** `ownAnalyticsRoomLocal(lang)` and, on `null`, **silently returned** — never calling the grant module. A required-course join is a fresh page load whose initial sync lags (the same lag `_loadRoom` guards for the joined course room, #7579), so the canonical analytics room was routinely not yet in local state at consent time → the grant was skipped.

```mermaid
flowchart LR
    A["Student accepts required course"] --> B{"ownAnalyticsRoomLocal(lang)?"}
    B -- "null: sync lag" --> C["silently return"]
    C --> D["instructor never joined; dash stuck 'pending'"]
```

## Fix

Resolve the analytics room id from the student's **own server-recorded** `pangea.analytics_profile` first — the **same field the teacher dashboard reads** to decide granted-vs-pending, fetched fresh so it does not depend on local sync — then fall back to the local canonical room. Course language is derived from the course room's local `pangea.course_plan` `l2` first (no network on the lagging path).

```mermaid
flowchart LR
    A["Student accepts"] --> B["read pangea.analytics_profile room id"]
    B -- "found" --> G["grant module: instructor joined"]
    B -- "none" --> L{"local canonical room?"}
    L -- "yes" --> G
    L -- "no" --> S["no room yet: retroactive grant on first practice"]
```

Because the grant now reads the **exact** field the dashboard reads, a successful accept always flips the dashboard to "granted".

## Changes

| File | Change |
|---|---|
| `lib/features/analytics_access/join_room_analytics_access_extension.dart` | Grant off `pangea.analytics_profile` room id (fresh fetch) + local fallback; derive course language from local `course_plan.l2` first |
| `test/pangea/join_room_analytics_access_extension_test.dart` *(new)* | Tests: profile-only, local fallback, profile-precedence, no-room/no-create |

## Test plan

- [x] `flutter test test/pangea/join_room_analytics_access_extension_test.dart` — 4/4
- [x] `flutter analyze` (no issues), `dart format --set-exit-if-changed` (clean)
- [x] Full suite: 1791 passed / 3 skipped / 0 failed
- [ ] Staging E2E: student accepts a required course → dash shows "granted"

## Notes

- No duplicate-room creation; no stream subscription/leak; no arbitrary time cutoff.
- Genuinely-no-room-yet is unchanged — the retroactive grant on room creation covers first practice.
- Pairs with `pangeachat/admin-dash-api#99` (scenario 1, the request path). Deploy backend first.
