### PR TITLE
fix(courses): paint the invited chip the same gold as its badge

### DIFF
--- a/lib/routes/courses/course_info_chip_widget.dart
+++ b/lib/routes/courses/course_info_chip_widget.dart
@@ -12,6 +12,13 @@ class CourseInfoChip extends StatelessWidget {
   final double? fontSize;
   final double? iconSize;
   final EdgeInsets? padding;
+
+  /// The chip's pill fill, used as given. It used to be washed with a
+  /// translucent [ColorScheme.surface] first, which in the dark theme dragged
+  /// the invited chip's gold toward the near-black surface and left it muddy
+  /// and visibly off the gold of the `InvitedCourseBadge` sitting right beside
+  /// it on the same tile (#8109). The chip and the badge are one state marker,
+  /// so they wear one color — the same gold the level-up chip wears.
   final Color? highlightColor;
 
   /// Ink for the icon and text. Needed when [highlightColor] is dark or
@@ -50,10 +57,7 @@ class CourseInfoChip extends StatelessWidget {
           : Container(
               padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
               decoration: BoxDecoration(
-                color: Color.alphaBlend(
-                  Theme.of(context).colorScheme.surface.withAlpha(70),
-                  highlightColor!,
-                ),
+                color: highlightColor,
                 borderRadius: BorderRadius.circular(12),
               ),
               child: row,

--- a/test/pangea/courses/invited_course_tile_test.dart
+++ b/test/pangea/courses/invited_course_tile_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:badges/badges.dart' as b;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:matrix/matrix.dart';
@@ -41,11 +42,16 @@ void main() {
     dotenv.testLoad(fileInput: 'BOT_NAME=@bot:example.org');
   });
 
-  Future<void> pumpTile(WidgetTester tester, {required bool invited}) async {
+  Future<void> pumpTile(
+    WidgetTester tester, {
+    required bool invited,
+    Brightness brightness = Brightness.light,
+  }) async {
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates: L10n.localizationsDelegates,
         supportedLocales: L10n.supportedLocales,
+        theme: ThemeData(brightness: brightness),
         home: Scaffold(
           body: Align(
             alignment: Alignment.topCenter,
@@ -111,6 +117,58 @@ void main() {
       );
     },
   );
+
+  /// #8109: the chip and the badge are one state marker on one tile, so they
+  /// must paint the *same* gold. Asserting `highlightColor` alone was not
+  /// enough — the chip used to wash that gold with the surface before painting
+  /// it, which in the dark theme dragged it toward the near-black surface and
+  /// left a muddy pill beside a bright badge.
+  for (final brightness in Brightness.values) {
+    testWidgets(
+      'invited chip paints the same gold as the badge ($brightness)',
+      (tester) async {
+        await pumpTile(tester, invited: true, brightness: brightness);
+
+        final context = tester.element(find.byType(AddCourseTile));
+        final gold = AppConfig.goldByTheme(context);
+
+        final pill = tester.widget<Container>(
+          find.descendant(
+            of: find.byType(CourseInfoChip),
+            matching: find.byType(Container),
+          ),
+        );
+        final badge = tester.widget<b.Badge>(
+          find.descendant(
+            of: find.byType(InvitedCourseBadge),
+            matching: find.byType(b.Badge),
+          ),
+        );
+
+        expect((pill.decoration! as BoxDecoration).color, gold);
+        expect(badge.badgeStyle.badgeColor, gold);
+      },
+    );
+  }
+
+  testWidgets('the dark theme wears the lighter gold the level-up chip wears', (
+    tester,
+  ) async {
+    await pumpTile(tester, invited: true, brightness: Brightness.dark);
+
+    final pill = tester.widget<Container>(
+      find.descendant(
+        of: find.byType(CourseInfoChip),
+        matching: find.byType(Container),
+      ),
+    );
+
+    expect(
+      (pill.decoration! as BoxDecoration).color,
+      AppConfig.goldLight,
+      reason: 'the hue named in #8109 — #FEDF49, shared with the level-up chip',
+    );
+  });
 
   testWidgets('invited state is announced instead of the participant count', (
     tester,


### PR DESCRIPTION
## What

The courses-list "Invited" chip paints its gold as given instead of washing it with the surface first, so it matches the envelope badge beside it.

## Why

Closes #8109

`CourseInfoChip` blended `highlightColor` with `colorScheme.surface.withAlpha(70)` before painting the pill. The invited chip and the `InvitedCourseBadge` on the same tile are both handed `AppConfig.goldByTheme`, but only the chip got washed — so in the dark theme the near-black surface dragged its gold to `#BEA73C` (the muddy pill in the issue screenshot) beside a `#FEDF49` badge. Removing the wash lands the chip on the gold the issue names, which is also the gold the level-up chip wears.

| Theme | Chip before | Chip after | Badge |
| --- | --- | --- | --- |
| Dark | `#BEA73C` | `#FEDF49` | `#FEDF49` |
| Light | `#FDCE47` | `#FDBF01` | `#FDBF01` |

The wash had one caller — this chip — so nothing else changes. `onGoldByTheme` is already documented as the ink for an unblended `goldByTheme` fill, and contrast improves in both themes.

## Testing

- `fvm flutter test` — full suite, 1828 passed / 3 skipped (the endpoint suites, no local `TEST_MATRIX_*`).
- `fvm flutter analyze` + `fvm dart format` on both changed files — clean.
- Added three widget tests in `invited_course_tile_test.dart` asserting the *painted* fill (the existing tests only checked the `highlightColor` prop, which is why the bug got through): chip fill == badge fill in both brightnesses, and the dark-theme fill is `AppConfig.goldLight`. Confirmed all three fail on the pre-fix widget and pass after.
- Rendered the tile in both themes to eyeball the pill against the badge; the harness was temporary and is not in the diff.

## Deploy Notes

None
