### PR TITLE
fix(morphs): stop English fallback flags hiding other-L2 grammar

### DIFF
--- a/lib/pangea/morphs/default_grammar_constructs_response.dart
+++ b/lib/pangea/morphs/default_grammar_constructs_response.dart
@@ -217,15 +217,6 @@ const Map<String, dynamic> defaultGrammarConstructsResponse = {
       "feature_title": "Adverb type",
       "values": [
         {
-          "value": "Adverbial",
-          "display": true,
-          "sequence_position": 2.5,
-          "example": "she ran *fast*",
-          "title": "Adverbial",
-          "description":
-              "An adverbial word or phrase modifying a verb or sentence.",
-        },
-        {
           "value": "Tim",
           "display": true,
           "sequence_position": 1.5,
@@ -388,14 +379,6 @@ const Map<String, dynamic> defaultGrammarConstructsResponse = {
           "description": "The case marking a part of a whole.",
         },
         {
-          "value": "Adv",
-          "display": false,
-          "sequence_position": 5.5,
-          "example": "adverbial form",
-          "title": "Adverbial",
-          "description": "A case used to form adverbial expressions.",
-        },
-        {
           "value": "Ref",
           "display": false,
           "sequence_position": 6.0,
@@ -512,47 +495,6 @@ const Map<String, dynamic> defaultGrammarConstructsResponse = {
           "title": "Accusative/Nominative",
           "description":
               "A form that serves as both accusative and nominative.",
-        },
-        {
-          "value": "Pre",
-          "display": false,
-          "sequence_position": 5.5,
-          "example": "prepositional form",
-          "title": "Prepositional",
-          "description":
-              "A case used after prepositions, common in some Slavic languages.",
-        },
-      ],
-    },
-    {
-      "feature": "conjtype",
-      "feature_title": "Conjunction type",
-      "values": [
-        {
-          "value": "Coord",
-          "display": true,
-          "sequence_position": 1.5,
-          "example": "bread *and* butter",
-          "title": "Coordinating",
-          "description":
-              "Joins equal parts of a sentence, like 'and' or 'but'.",
-        },
-        {
-          "value": "Sub",
-          "display": true,
-          "sequence_position": 2.5,
-          "example": "*because* it rained",
-          "title": "Subordinating",
-          "description":
-              "Connects a dependent clause to a main clause, like 'because'.",
-        },
-        {
-          "value": "Cmp",
-          "display": true,
-          "sequence_position": 3.5,
-          "example": "taller *than* me",
-          "title": "Comparative",
-          "description": "Used in comparisons, like 'than' or 'as'.",
         },
       ],
     },
@@ -813,37 +755,6 @@ const Map<String, dynamic> defaultGrammarConstructsResponse = {
           "example": "*do* you run?",
           "title": "Interrogative",
           "description": "Forms a question, like 'do you run?'",
-        },
-      ],
-    },
-    {
-      "feature": "nountype",
-      "feature_title": "Noun type",
-      "values": [
-        {
-          "value": "Prop",
-          "display": true,
-          "sequence_position": 1.5,
-          "example": "*Paris*",
-          "title": "Proper noun",
-          "description":
-              "A name of a specific person, place, or thing, like 'Paris'.",
-        },
-        {
-          "value": "Comm",
-          "display": true,
-          "sequence_position": 1.5,
-          "example": "*city*",
-          "title": "Common noun",
-          "description": "A general noun, like 'city' or 'book'.",
-        },
-        {
-          "value": "Not_proper",
-          "display": false,
-          "sequence_position": 1.5,
-          "example": "*book*",
-          "title": "Not proper",
-          "description": "A noun that is not a proper name.",
         },
       ],
     },
@@ -1462,14 +1373,6 @@ const Map<String, dynamic> defaultGrammarConstructsResponse = {
               "A simple past action viewed as a whole, common in Greek and Slavic.",
         },
         {
-          "value": "Eps",
-          "display": false,
-          "sequence_position": 6.0,
-          "example": "episodic past form",
-          "title": "Episodic past",
-          "description": "A specific past episode, used in some languages.",
-        },
-        {
           "value": "Prosp",
           "display": false,
           "sequence_position": 4.5,
@@ -1545,24 +1448,6 @@ const Map<String, dynamic> defaultGrammarConstructsResponse = {
           "description":
               "An '-ing' verb form used as a noun, like 'running is fun'.",
         },
-        {
-          "value": "Adn",
-          "display": false,
-          "sequence_position": 6.0,
-          "example": "adnominal form",
-          "title": "Adnominal",
-          "description":
-              "A verb form modifying a noun, like Korean adnominal endings.",
-        },
-        {
-          "value": "Lng",
-          "display": false,
-          "sequence_position": 6.0,
-          "example": "long verb form",
-          "title": "Long form",
-          "description":
-              "A longer or fuller form of a verb, used in some languages.",
-        },
       ],
     },
     {
@@ -1577,15 +1462,6 @@ const Map<String, dynamic> defaultGrammarConstructsResponse = {
           "title": "Modal",
           "description":
               "Expresses possibility, necessity, or permission, like 'can' or 'must'.",
-        },
-        {
-          "value": "Caus",
-          "display": false,
-          "sequence_position": 4.5,
-          "example": "*made* him run",
-          "title": "Causative",
-          "description":
-              "Indicates causing an action, like 'make someone do' something.",
         },
       ],
     },
@@ -1663,14 +1539,6 @@ const Map<String, dynamic> defaultGrammarConstructsResponse = {
           "title": "Reciprocal",
           "description":
               "The participants act on each other, like 'they hugged each other'.",
-        },
-        {
-          "value": "Caus",
-          "display": false,
-          "sequence_position": 5.5,
-          "example": "*made* him run",
-          "title": "Causative",
-          "description": "Indicates causing an action, like 'made him run'.",
         },
       ],
     },

--- a/lib/pangea/morphs/morph_features_and_tags.dart
+++ b/lib/pangea/morphs/morph_features_and_tags.dart
@@ -24,23 +24,30 @@ class MorphFeaturesAndTags {
 
   factory MorphFeaturesAndTags.fromGrammarConstructsResponse({
     required GrammarConstructsResponse response,
+    bool applyDisplayFilter = true,
+    String? targetLanguage,
+    String? userL1,
   }) {
     final List<MorphFeatureTags> sortedFeatures = [];
     for (final feature in response.features) {
       final tags = List<GrammarTag>.from(
         feature.tags,
-      ).where((t) => t.display).toList();
+      ).where((t) => !applyDisplayFilter || t.display).toList();
 
       tags.sort((a, b) => a.sequencePosition.compareTo(b.sequencePosition));
       sortedFeatures.add(MorphFeatureTags(feature: feature, tags: tags));
     }
     return MorphFeaturesAndTags(
-      targetLanguage: response.targetLanguage,
-      userL1: response.userL1,
+      targetLanguage: targetLanguage ?? response.targetLanguage,
+      userL1: userL1 ?? response.userL1,
       features: sortedFeatures,
     );
   }
 
+  /// Offline fallback. The default bundle is English-targeted, so its
+  /// `display` flags only describe English — filtering by them for another L2
+  /// hides real grammar (Russian `Case=Ins`). Non-English L2s get the
+  /// unfiltered superset until the server bundle loads (#2931).
   factory MorphFeaturesAndTags.defaultFeaturesAndTags({
     required String targetLanguage,
     required String userL1,
@@ -48,7 +55,13 @@ class MorphFeaturesAndTags {
     response: GrammarConstructsResponse.fromJson(
       defaultGrammarConstructsResponse,
     ),
+    applyDisplayFilter: _isEnglish(targetLanguage),
+    targetLanguage: targetLanguage,
+    userL1: userL1,
   );
+
+  static bool _isEnglish(String languageCode) =>
+      languageCode.split(RegExp(r'[-_]')).first.toLowerCase() == 'en';
 
   String get _langKey => "$_targetLanguage-$_userL1";
 

--- a/test/pangea/morphs/default_fallback_language_test.dart
+++ b/test/pangea/morphs/default_fallback_language_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/morphs/default_grammar_constructs_response.dart';
+import 'package:fluffychat/pangea/morphs/grammar_constructs_response.dart';
+import 'package:fluffychat/pangea/morphs/morph_features_and_tags.dart';
+
+/// Regression coverage for pangeachat/2-step-choreographer#2931.
+///
+/// The offline fallback bundle is English-targeted (`target_language: "en"`).
+/// Its `display` flags describe which constructs manifest *in English* and
+/// carry no information about any other L2. Applying them to a Russian
+/// learner hid `Case=Ins` — instrumental case — from every surface that
+/// reads the fallback, even though the token carried `Case=Ins` and the
+/// server's `ru` bundle marks it `display: true`.
+///
+/// Also pins the fallback inventory to the post-#2873 master: the invented
+/// (feature, value) pairs purged server-side must not survive here, or the
+/// unfiltered mismatch path would resurface the #2357 duplicates.
+void main() {
+  setUp(MorphFeaturesAndTags.clearLookupCache);
+
+  group('defaultFeaturesAndTags language matching', () {
+    test('does not hide non-English constructs for a non-English L2', () {
+      final morphs = MorphFeaturesAndTags.defaultFeaturesAndTags(
+        targetLanguage: 'ru',
+        userL1: 'en',
+      );
+
+      expect(
+        morphs.getTags('Case').map((t) => t.value),
+        contains('Ins'),
+        reason:
+            'instrumental case manifests in Russian; the English fallback '
+            'marks it display:false and must not filter it out for ru',
+      );
+    });
+
+    test('still applies display filtering when the L2 is English', () {
+      final morphs = MorphFeaturesAndTags.defaultFeaturesAndTags(
+        targetLanguage: 'en',
+        userL1: 'en',
+      );
+
+      expect(
+        morphs.getTags('Case').map((t) => t.value),
+        isNot(contains('Ins')),
+        reason:
+            'for English the fallback flags are authoritative, so '
+            'display:false values stay filtered',
+      );
+      expect(morphs.getTags('Case').map((t) => t.value), contains('Nom'));
+    });
+
+    test('regional variants of English still filter', () {
+      final morphs = MorphFeaturesAndTags.defaultFeaturesAndTags(
+        targetLanguage: 'en-US',
+        userL1: 'en',
+      );
+
+      expect(
+        morphs.getTags('Case').map((t) => t.value),
+        isNot(contains('Ins')),
+      );
+    });
+
+    test('server responses are always display-filtered regardless of L2', () {
+      final morphs = MorphFeaturesAndTags.fromGrammarConstructsResponse(
+        response: GrammarConstructsResponse.fromJson({
+          "user_l1": "en",
+          "source_l1": "en",
+          "target_language": "ru",
+          "features": [
+            {
+              "feature": "Case",
+              "feature_title": "Case",
+              "values": [
+                {
+                  "value": "Ins",
+                  "display": true,
+                  "example": "",
+                  "sequence_position": 3.5,
+                  "title": "Instrumental",
+                  "description": "",
+                },
+                {
+                  "value": "Abs",
+                  "display": false,
+                  "example": "",
+                  "sequence_position": 5.5,
+                  "title": "Absolutive",
+                  "description": "",
+                },
+              ],
+            },
+          ],
+        }),
+      );
+
+      expect(morphs.getTags('Case').map((t) => t.value), ['Ins']);
+    });
+  });
+
+  group('fallback inventory matches the post-#2873 master', () {
+    late GrammarConstructsResponse fallback;
+
+    setUp(() {
+      fallback = GrammarConstructsResponse.fromJson(
+        defaultGrammarConstructsResponse,
+      );
+    });
+
+    List<String> valuesOf(String feature) => fallback.features
+        .where((f) => f.value.toLowerCase() == feature.toLowerCase())
+        .expand((f) => f.tags.map((t) => t.value))
+        .toList();
+
+    bool hasFeature(String feature) => fallback.features.any(
+      (f) => f.value.toLowerCase() == feature.toLowerCase(),
+    );
+
+    test('purged features are absent', () {
+      // ConjType duplicated Pos=CCONJ/SCONJ; NounType duplicated
+      // Pos=PROPN/NOUN. Both were removed from the master in #2873.
+      expect(hasFeature('ConjType'), isFalse);
+      expect(hasFeature('NounType'), isFalse);
+    });
+
+    test('purged values are absent', () {
+      expect(valuesOf('AdvType'), isNot(contains('Adverbial')));
+      expect(valuesOf('Case'), isNot(contains('Adv')));
+      expect(valuesOf('Case'), isNot(contains('Pre')));
+      expect(valuesOf('Tense'), isNot(contains('Eps')));
+      for (final gone in ['Adn', 'Lng', 'Shrt', 'Compl', 'Aux']) {
+        expect(valuesOf('VerbForm'), isNot(contains(gone)), reason: gone);
+      }
+      expect(valuesOf('VerbType'), isNot(contains('Caus')));
+      expect(valuesOf('Voice'), isNot(contains('Caus')));
+      expect(
+        valuesOf('Voice'),
+        contains('Cau'),
+        reason: 'Cau is the real UD causative voice and must survive',
+      );
+    });
+
+    test('real constructs survive the purge', () {
+      expect(valuesOf('Case'), contains('Ins'));
+      expect(valuesOf('Pos'), contains('CCONJ'));
+      expect(valuesOf('Tense'), contains('Pres'));
+      expect(valuesOf('AdvType'), contains('Tim'));
+    });
+
+    test('never-learner-facing POS values are not displayed', () {
+      final pos = fallback.features.firstWhere(
+        (f) => f.value.toLowerCase() == 'pos',
+      );
+      for (final value in ['PROPN', 'PUNCT', 'SYM', 'X']) {
+        final match = pos.tags.where((t) => t.value == value);
+        for (final tag in match) {
+          expect(tag.display, isFalse, reason: 'Pos=$value must stay hidden');
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Why

Closes pangeachat/2-step-choreographer#2931.

QA found instrumental case uncredited for Russian. The token is fine — Kelrap's event shows `ложкой` carrying `{"Pos": "NOUN", "Case": "Ins", ...}`, and the server's `ru` bundle marks `Case=Ins` `display: true`. The loss is client-side display.

`MorphFeaturesAndTags.defaultFeaturesAndTags` accepted `targetLanguage` / `userL1` and ignored both, always returning the English-targeted offline bundle (`target_language: "en"`). Its `display` flags were then used to filter which tags a learner of ANY L2 sees. `Case=Ins` is `display: false` there (correct for English), so Russian instrumental was filtered out on every surface reading the fallback — including the analytics popup, which seeds from it before its fetch resolves.

## What changed

- `defaultFeaturesAndTags` honours its parameters: display-filtering is applied only when the L2 is actually English (base-code match, so `en-US` counts). Other L2s get the unfiltered fallback — a brief superset until the server bundle loads, rather than silently dropping constructs the learner is producing. Server responses are always filtered, unchanged.
- Purged the invented (feature, value) pairs from the offline bundle so it mirrors the post-#2873 master: dropped the `ConjType` and `NounType` features and `AdvType=Adverbial`, `Case=Adv/Pre`, `Tense=Eps`, `VerbForm=Adn/Lng`, `VerbType=Caus`, `Voice=Caus`.

  This part is load-bearing, not tidying: the fallback still displayed `ConjType=Coord "Coordinating"` alongside `Pos=CCONJ` — the exact duplicate from pangeachat/2-step-choreographer#2357 — so the offline path was still showing the bug #2873 fixed server-side. Without this, serving the fallback unfiltered would have surfaced more of them.

## Testing

New `test/pangea/morphs/default_fallback_language_test.dart` (8 tests, written first): `Case=Ins` survives for `ru`, English still filters (incl. `en-US`), server responses stay filtered, and the fallback inventory is pinned against the purged pairs.

`fvm flutter test test/pangea/`: 697 passed / 124 failed. Identical baseline on a clean tree is 694 / 127 — the 124 are pre-existing (stale local l10n codegen, e.g. `practiceSessionTimedOut`), and this branch flips exactly the 3 tests it should. `flutter analyze` clean on the touched paths; formatted with the pinned fvm SDK.