### PR TITLE
fix(quests): key per-course star rollups by course room id

### DIFF
--- a/lib/features/quests/lo_progression.dart
+++ b/lib/features/quests/lo_progression.dart
@@ -13,12 +13,22 @@ const int kDefaultStarsToUnlockObjective = 10;
 /// objective, plus the star threshold that unlocks the next objective. Built
 /// from a quest outline (the ordered sequence and its per-objective activities).
 class CourseLoOutline {
-  /// The course-plan uuid (v3: also the quest-plans id) this outline was
-  /// resolved for. Identity, not decoration: Missions are a shared catalog
+  /// The key a per-course surface scopes its rollup by — the course ROOM id
+  /// for joined courses, or the quest uuid for scoped/preview outlines that
+  /// have no room. Identity, not decoration: Missions are a shared catalog
   /// reused across quests, so a resolution spanning several joined courses can
   /// hold the same Mission more than once — this is how a per-course surface
-  /// finds ITS rollup instead of a cross-course blend.
+  /// finds ITS rollup instead of a cross-course blend. The room id (never the
+  /// quest uuid) is what keeps two courses built from ONE quest distinct
+  /// (#8087).
   final String courseId;
+
+  /// The quest (course-plan) uuid this outline resolved from, when known. The
+  /// second key: two courses of one quest carry distinct [courseId]s but the
+  /// same [questId], which is how the world-map band counts the quest once
+  /// instead of double-counting per room. Null for legacy callers that only
+  /// have one id — dedupe then falls back to [courseId].
+  final String? questId;
 
   final List<String> orderedLoIds;
   final Map<String, Set<String>> activityIdsByLo;
@@ -33,6 +43,7 @@ class CourseLoOutline {
 
   const CourseLoOutline({
     required this.courseId,
+    this.questId,
     required this.orderedLoIds,
     required this.activityIdsByLo,
     this.starsToUnlock = kDefaultStarsToUnlockObjective,

--- a/lib/features/quests/quest_objectives_loader.dart
+++ b/lib/features/quests/quest_objectives_loader.dart
@@ -37,9 +37,13 @@ class QuestObjectivesLoader {
   int _loadGeneration = 0;
   bool _disposed = false;
 
-  /// The course this loader is showing. The shared resolution spans every
-  /// joined course, so every progress read below scopes through it — a course
-  /// panel must never show another course's star totals (#7771).
+  /// The course this loader is showing — its room id when the caller has one,
+  /// matching the room-id-keyed resolution entries; the quest uuid otherwise
+  /// (previews resolve nothing and fail soft). The shared resolution spans
+  /// every joined course, so every progress read below scopes through it — a
+  /// course panel must never show another course's star totals (#7771), and
+  /// the quest uuid can't distinguish two courses built from one quest
+  /// (#8087).
   String? _courseId;
 
   void dispose() {
@@ -110,7 +114,7 @@ class QuestObjectivesLoader {
 
     _loadGeneration++;
     final loadGen = _loadGeneration;
-    _courseId = questId;
+    _courseId = courseRoomId ?? questId;
     _updateProgression(ProgressionResolution.empty, loadGen);
 
     // world_v2 → v3: the course space's coursePlan.uuid (or the previewed

--- a/lib/features/quests/quest_progression_resolver.dart
+++ b/lib/features/quests/quest_progression_resolver.dart
@@ -59,9 +59,17 @@ class QuestStarSummary {
 /// One in-scope quest: its ordered Mission sequence, the resolved anchor (the
 /// Mission the learner most needs next), and a position lookup for the gradient.
 class QuestProgress {
-  /// The course-plan uuid this quest was resolved from — the key a per-course
-  /// surface looks itself up by ([ProgressionResolution.forCourse]).
+  /// The key a per-course surface looks itself up by
+  /// ([ProgressionResolution.forCourse]) — the course ROOM id for joined
+  /// courses, or the quest uuid for scoped/preview outlines with no room. Two
+  /// courses built from one quest carry distinct room ids, which is what keeps
+  /// their rollups from crossing (#8087).
   final String courseId;
+
+  /// The quest (course-plan) uuid this entry resolved from. The second key:
+  /// entries for two rooms of ONE quest share it, and [missionGradient] counts
+  /// each quest once by grouping on it.
+  final String questId;
 
   final List<String> orderedMissionIds;
 
@@ -92,6 +100,7 @@ class QuestProgress {
 
   const QuestProgress({
     required this.courseId,
+    required this.questId,
     required this.orderedMissionIds,
     required this.anchorMissionId,
     required this.indexByMission,
@@ -157,21 +166,29 @@ class ProgressionResolution {
   /// [objectiveRefs]: 1.0 at a quest's anchor Mission, decaying linearly to 0
   /// over [kBandFalloffMissions] Missions further along, ~0 for an already
   /// satisfied Mission or a Mission before the anchor. Contributions SUM across
-  /// every in-scope quest (so an activity advancing several quests' unfinished
-  /// Missions ranks higher) and saturate at the ceiling. Outside any quest the
-  /// activity's refs match nothing and this is 0 — the consumer then ranks it on
-  /// plain level/L2 fit. See world-map.instructions.md Priority matrix.
+  /// every in-scope QUEST (so an activity advancing several quests' unfinished
+  /// Missions ranks higher) and saturate at the ceiling — a quest joined in
+  /// more than one course room contributes once, at its strongest per-room
+  /// value, never once per room (#8087). Outside any quest the activity's refs
+  /// match nothing and this is 0 — the consumer then ranks it on plain
+  /// level/L2 fit. See world-map.instructions.md Priority matrix.
   double missionGradient(Iterable<String> objectiveRefs) {
     if (quests.isEmpty) return 0;
     final refs = objectiveRefs.toSet();
     if (refs.isEmpty) return 0;
 
-    var total = 0.0;
+    // Grouped by questId so two rooms of one quest can't double-count. MAX
+    // (not first-wins) because the rooms can diverge via pins: a Mission
+    // satisfied in room A may still be room B's genuine next step, so the
+    // strongest signal stands — and max is order-independent, where [quests]
+    // order (rebuild completion order) is not.
+    final bestByQuest = <String, double>{};
     for (final quest in quests) {
       final anchor = quest.anchorMissionId;
       if (anchor == null) continue;
       final anchorIdx = quest.indexByMission[anchor];
       if (anchorIdx == null) continue;
+      var contribution = 0.0;
       for (final ref in refs) {
         final idx = quest.indexByMission[ref];
         if (idx == null) continue; // ref not part of this quest
@@ -180,9 +197,17 @@ class ProgressionResolution {
         if (quest.rollup[ref]?.satisfied ?? false) continue;
         final distance = idx - anchorIdx;
         if (distance < 0) continue; // a Mission before the anchor
-        final contribution = 1.0 - distance / kBandFalloffMissions;
-        if (contribution > 0) total += contribution;
+        final refContribution = 1.0 - distance / kBandFalloffMissions;
+        if (refContribution > 0) contribution += refContribution;
       }
+      final best = bestByQuest[quest.questId];
+      if (best == null || contribution > best) {
+        bestByQuest[quest.questId] = contribution;
+      }
+    }
+    var total = 0.0;
+    for (final contribution in bestByQuest.values) {
+      total += contribution;
     }
     return total.clamp(0.0, kBandCeiling);
   }
@@ -202,12 +227,15 @@ class ProgressionResolution {
       // Once per course per session, sharing the map rebuild's key: this runs
       // on every course-panel open, and a course that persistently fails to
       // resolve (e.g. an orphaned quest plan) re-fails on each of them (#8083).
-      onError: (uuid, e, s) => ErrorHandler.logErrorOnce(
-        key: 'course-outline-resolve:$uuid',
+      // Keyed per course ROOM — two rooms of one quest can fail independently
+      // (e.g. a per-room private-activity read); questId keeps orphaned-quest
+      // reports diagnosable.
+      onError: (roomId, questId, e, s) => ErrorHandler.logErrorOnce(
+        key: 'course-outline-resolve:$roomId',
         e: e,
         s: s,
         m: 'course progression failed to resolve',
-        data: {'courseUuid': uuid},
+        data: {'courseRoomId': roomId, 'questId': questId},
       ),
     );
     return cache.resolution(client.userStarsByActivity);
@@ -270,6 +298,10 @@ ProgressionResolution resolveProgression({
     quests.add(
       QuestProgress(
         courseId: outline.courseId,
+        // Legacy/scoped outlines carry no separate questId; falling back to
+        // courseId gives each its own dedupe group — exactly the pre-#8087
+        // behavior.
+        questId: outline.questId ?? outline.courseId,
         orderedMissionIds: seq,
         anchorMissionId: _anchorFor(seq, rollup),
         indexByMission: {for (var i = 0; i < seq.length; i++) seq[i]: i},

--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -108,9 +108,13 @@ class QuestOutline {
   CourseLoOutline toCourseLoOutline({
     int starsToUnlock = kDefaultStarsToUnlockObjective,
   }) => CourseLoOutline(
-    // v3: the quest-plans id IS the course-plan uuid callers resolved by, so
-    // this is the key a per-course surface looks its own rollup up under.
+    // The quest id serves as the scoping key here — right for scoped/preview
+    // outlines that have no room. The joined-course cache re-keys courseId to
+    // the course room id (unique per course) so two courses built from one
+    // quest stay distinct (#8087); questId survives that re-key for the
+    // world-map band's per-quest dedupe.
     courseId: quest.id,
+    questId: quest.id,
     orderedLoIds: quest.learningObjectiveIds,
     activityIdsByLo: {
       for (final group in groups)

--- a/lib/routes/world/joined_objective_cache.dart
+++ b/lib/routes/world/joined_objective_cache.dart
@@ -47,35 +47,40 @@ class JoinedObjectiveCache {
   );
 
   /// Rebuild from the joined courses' quest outlines. [outlineOf] resolves a
-  /// course-plan uuid to its outline (defaults to the v3 quest read layer);
-  /// [starsToUnlockOf] supplies the per-course teacher override (defaults to the
-  /// standard threshold). A course that fails to resolve is skipped (rather than
-  /// failing the whole set) and reported to [onError] — it must NOT be swallowed
-  /// silently: a dropped course contributes no objective ids, and a fully empty
-  /// cache blanks relevance banding and fail-opens the progression gate with no
-  /// visible signal. [onError] is injectable so the rebuild stays unit-testable
-  /// without Matrix, the network, or Sentry.
+  /// course key to its outline (defaults to the v3 quest read layer, which
+  /// treats the key as a quest uuid; [rebuildFromJoinedCourses] keys by course
+  /// room id instead — see #8087); [starsToUnlockOf] supplies the per-course
+  /// teacher override (defaults to the standard threshold). A course that fails
+  /// to resolve is skipped (rather than failing the whole set) and reported to
+  /// [onError] — it must NOT be swallowed silently: a dropped course
+  /// contributes no objective ids, and a fully empty cache blanks relevance
+  /// banding and fail-opens the progression gate with no visible signal.
+  /// [onError] is injectable so the rebuild stays unit-testable without
+  /// Matrix, the network, or Sentry.
   Future<void> rebuild(
-    List<String> courseUuids, {
-    Future<CourseLoOutline> Function(String uuid)? outlineOf,
-    int Function(String uuid)? starsToUnlockOf,
-    void Function(String uuid, Object error, StackTrace stack)? onError,
+    List<String> courseKeys, {
+    Future<CourseLoOutline> Function(String key)? outlineOf,
+    int Function(String key)? starsToUnlockOf,
+    void Function(String key, Object error, StackTrace stack)? onError,
   }) async {
     final resolve = outlineOf ?? _outlineFromQuest;
     final next = <CourseLoOutline>[];
     await Future.wait(
-      courseUuids.map((uuid) async {
+      courseKeys.map((key) async {
         try {
-          final o = await resolve(uuid);
+          final o = await resolve(key);
           next.add(
             CourseLoOutline(
-              // The uuid the caller asked for, not the resolved outline's own
+              // The key the caller asked for, not the resolved outline's own
               // id: this is the key the course panel scopes its rollup by.
-              courseId: uuid,
+              courseId: key,
+              // The resolved outline's quest identity survives the re-key so
+              // the world-map band can dedupe a quest joined in two rooms.
+              questId: o.questId,
               orderedLoIds: o.orderedLoIds,
               activityIdsByLo: o.activityIdsByLo,
               starsToUnlock:
-                  starsToUnlockOf?.call(uuid) ?? kDefaultStarsToUnlockObjective,
+                  starsToUnlockOf?.call(key) ?? kDefaultStarsToUnlockObjective,
               earnableByActivity: o.earnableByActivity,
             ),
           );
@@ -83,7 +88,7 @@ class JoinedObjectiveCache {
           // Skip a course that won't resolve; the rest still band and gate. But
           // report it — a silently-empty cache is exactly how banding and the
           // gate go dark unnoticed.
-          onError?.call(uuid, e, s);
+          onError?.call(key, e, s);
         }
       }),
     );
@@ -91,39 +96,51 @@ class JoinedObjectiveCache {
     _ids = {for (final o in next) ...o.orderedLoIds};
   }
 
-  /// [rebuild] from the client's joined courses — each course's quest uuid with
-  /// its teacher config (stars-to-unlock override + per-Mission activity pins).
-  /// The single home for that mapping: the world map's pins manager and the
-  /// course panel's star display both rebuild through here, so every surface
-  /// resolves identical outlines. Pins are applied as a pure copy per course
-  /// (never to the shared quest-outline cache), so two courses sharing a quest
-  /// can restrict differently.
+  /// [rebuild] from the client's joined courses — each course room with its
+  /// quest uuid and teacher config (stars-to-unlock override + per-Mission
+  /// activity pins). The single home for that mapping: the world map's pins
+  /// manager and the course panel's star display both rebuild through here, so
+  /// every surface resolves identical outlines. Pins are applied as a pure copy
+  /// per course (never to the shared quest-outline cache), so two courses
+  /// sharing a quest can restrict differently.
+  ///
+  /// Keyed by course ROOM id, not quest uuid: one quest launched into two
+  /// rooms is two courses, and uuid keys collapsed them to a single entry
+  /// (last room won), crossing their star totals (#8087).
   Future<void> rebuildFromJoinedCourses(
     Client client, {
-    void Function(String uuid, Object error, StackTrace stack)? onError,
+    void Function(
+      String roomId,
+      String questId,
+      Object error,
+      StackTrace stack,
+    )?
+    onError,
   }) {
-    final modes = <String, TeacherModeModel>{
+    final questIdByRoom = <String, String>{
       for (final room in client.joinedCourseRooms)
-        room.coursePlan!.uuid: room.teacherMode,
+        room.id: room.coursePlan!.uuid,
     };
-    // A joined member's outline read carries the course room id, so the quest
-    // owner's private activities are included (membership-verified
-    // server-side; activities.instructions.md § Ownership, visibility, and
-    // removal).
-    final roomIds = <String, String>{
-      for (final room in client.joinedCourseRooms)
-        room.coursePlan!.uuid: room.id,
+    final modes = <String, TeacherModeModel>{
+      for (final room in client.joinedCourseRooms) room.id: room.teacherMode,
     };
     return rebuild(
-      modes.keys.toList(),
-      outlineOf: (uuid) => _outlineFromQuest(
-        uuid,
-        pinnedByObjective: modes[uuid]?.pinnedActivitiesByObjective,
-        courseRoomId: roomIds[uuid],
+      questIdByRoom.keys.toList(),
+      // A joined member's outline read carries the course room id, so the
+      // quest owner's private activities are included (membership-verified
+      // server-side; activities.instructions.md § Ownership, visibility, and
+      // removal).
+      outlineOf: (roomId) => _outlineFromQuest(
+        questIdByRoom[roomId]!,
+        pinnedByObjective: modes[roomId]?.pinnedActivitiesByObjective,
+        courseRoomId: roomId,
       ),
-      starsToUnlockOf: (uuid) =>
-          modes[uuid]?.starsToUnlockObjective ?? kDefaultStarsToUnlockObjective,
-      onError: onError,
+      starsToUnlockOf: (roomId) =>
+          modes[roomId]?.starsToUnlockObjective ??
+          kDefaultStarsToUnlockObjective,
+      onError: onError == null
+          ? null
+          : (roomId, e, s) => onError(roomId, questIdByRoom[roomId]!, e, s),
     );
   }
 

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -105,12 +105,20 @@ class WorldMapPinsManager {
   /// banding. Rebuilt async on course join/leave (see [_maybeRebuildObjectiveCache]).
   final JoinedObjectiveCache _objectiveCache = JoinedObjectiveCache();
 
-  /// The joined-course uuids [_objectiveCache] was last (re)built from. The
+  /// The joined-course ROOM ids [_objectiveCache] was last (re)built from. The
   /// initial build happens on client-set, but the joined-course rooms (or their
   /// outlines) may not be ready yet; tracking the set lets the sync listener
   /// rebuild when it changes — or when a prior build resolved nothing — instead
-  /// of the banding + gate staying blank for the whole session.
-  Set<String> _objectiveCacheUuids = const {};
+  /// of the banding + gate staying blank for the whole session. Room ids, not
+  /// quest uuids: a second room of an already-joined quest leaves the uuid set
+  /// unchanged and would silently skip the rebuild (#8087).
+  Set<String> _objectiveCacheRoomIds = const {};
+
+  /// The quest uuids of those same joined courses, kept solely for
+  /// [ensureScopedCourseOutline]: the map's course scope carries a quest uuid
+  /// (CourseMapContext), so "is this course already in the cache?" is a
+  /// quest-uuid question even though the cache itself keys by room id.
+  Set<String> _objectiveCacheQuestIds = const {};
 
   /// Guards against overlapping objective-cache rebuilds (and stops a
   /// persistently-failing course from rebuilding on every single sync).
@@ -568,20 +576,21 @@ class WorldMapPinsManager {
     if (_objectiveCacheRebuilding) return;
     _objectiveCacheRebuilding = true;
     try {
-      final uuids = client.joinedCourseRooms
-          .map((r) => r.coursePlan!.uuid)
-          .toList();
+      final rooms = client.joinedCourseRooms;
       await _objectiveCache.rebuildFromJoinedCourses(
         client,
-        onError: (uuid, e, s) => ErrorHandler.logErrorOnce(
-          key: 'course-outline-resolve:$uuid',
+        // Keyed per course ROOM — two rooms of one quest can fail
+        // independently; questId keeps orphaned-quest reports diagnosable.
+        onError: (roomId, questId, e, s) => ErrorHandler.logErrorOnce(
+          key: 'course-outline-resolve:$roomId',
           e: e,
           s: s,
           m: 'JoinedObjectiveCache: course outline failed to resolve',
-          data: {'courseUuid': uuid},
+          data: {'courseRoomId': roomId, 'questId': questId},
         ),
       );
-      _objectiveCacheUuids = uuids.toSet();
+      _objectiveCacheRoomIds = rooms.map((r) => r.id).toSet();
+      _objectiveCacheQuestIds = rooms.map((r) => r.coursePlan!.uuid).toSet();
       resolveProgression(); // re-resolve the band with the loaded outlines
     } finally {
       _objectiveCacheRebuilding = false;
@@ -599,18 +608,18 @@ class WorldMapPinsManager {
   /// self-heals once the data is fixed (which is why [QuestRepo.outline] must
   /// never cache errors — see its cache doc, #8083).
   bool shouldRebuildObjectiveCache(Client client) {
-    final uuids = client.joinedCourseRooms
-        .map((r) => r.coursePlan!.uuid)
-        .toSet();
+    // Room ids, not quest uuids: joining a second room of an already-joined
+    // quest must register as a change (#8087).
+    final roomIds = client.joinedCourseRooms.map((r) => r.id).toSet();
 
     final setChanged =
-        uuids.length != _objectiveCacheUuids.length ||
-        !uuids.containsAll(_objectiveCacheUuids);
+        roomIds.length != _objectiveCacheRoomIds.length ||
+        !roomIds.containsAll(_objectiveCacheRoomIds);
 
     return shouldRebuildObjectiveCacheNow(
       rebuilding: _objectiveCacheRebuilding,
       setChanged: setChanged,
-      emptyButHasCourses: _objectiveCache.ids.isEmpty && uuids.isNotEmpty,
+      emptyButHasCourses: _objectiveCache.ids.isEmpty && roomIds.isNotEmpty,
       lastRebuildAt: _lastObjectiveCacheRebuildAt,
       now: DateTime.now(),
     );
@@ -624,7 +633,7 @@ class WorldMapPinsManager {
     if (_scopedCourseOutlineId == coursePlanId) return;
     _scopedCourseOutlineId = coursePlanId;
     _scopedCourseOutline = null;
-    if (_objectiveCacheUuids.contains(coursePlanId)) {
+    if (_objectiveCacheQuestIds.contains(coursePlanId)) {
       resolveProgression(); // joined: the cache already carries it
       return;
     }

--- a/test/pangea/joined_objective_cache_test.dart
+++ b/test/pangea/joined_objective_cache_test.dart
@@ -3,12 +3,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fluffychat/features/quests/lo_progression.dart';
 import 'package:fluffychat/routes/world/joined_objective_cache.dart';
 
-CourseLoOutline _outline(List<String> los, {String courseId = 'c1'}) =>
-    CourseLoOutline(
-      courseId: courseId,
-      orderedLoIds: los,
-      activityIdsByLo: const {},
-    );
+CourseLoOutline _outline(
+  List<String> los, {
+  String courseId = 'c1',
+  String? questId,
+}) => CourseLoOutline(
+  courseId: courseId,
+  questId: questId,
+  orderedLoIds: los,
+  activityIdsByLo: const {},
+);
 
 void main() {
   group('JoinedObjectiveCache.rebuild', () {
@@ -74,6 +78,28 @@ void main() {
         // The failure is surfaced, not swallowed (a silently-empty cache is the
         // exact failure mode this guards against).
         expect(failed, ['bad']);
+      },
+    );
+
+    test(
+      'two rooms of one quest stay distinct entries, questId preserved (#8087)',
+      () async {
+        // The #8087 collapse happened upstream of rebuild (uuid-keyed maps in
+        // rebuildFromJoinedCourses); this pins the contract that makes the
+        // room-id keying work: each key gets its own entry with courseId = the
+        // key, and the resolved outline's questId survives for band dedupe.
+        final cache = JoinedObjectiveCache();
+        await cache.rebuild(
+          ['!r1:x', '!r2:x'],
+          outlineOf: (roomId) async =>
+              _outline(roomId == '!r1:x' ? ['lo-a'] : ['lo-b'], questId: 'q1'),
+        );
+        expect(cache.outlines.length, 2);
+        expect(cache.outlines.map((o) => o.courseId).toSet(), {
+          '!r1:x',
+          '!r2:x',
+        });
+        expect(cache.outlines.map((o) => o.questId).toSet(), {'q1'});
       },
     );
 

--- a/test/pangea/quest_star_summary_test.dart
+++ b/test/pangea/quest_star_summary_test.dart
@@ -26,6 +26,7 @@ void main() {
           quests: [
             QuestProgress(
               courseId: 'c1',
+              questId: 'c1',
               orderedMissionIds: rollup.keys.toList(),
               anchorMissionId: null,
               indexByMission: const {},

--- a/test/pangea/quests/per_course_mission_rollup_test.dart
+++ b/test/pangea/quests/per_course_mission_rollup_test.dart
@@ -13,10 +13,12 @@ void main() {
     String courseId,
     List<String> seq,
     Map<String, Set<String>> acts, {
+    String? questId,
     int threshold = kDefaultStarsToUnlockObjective,
     Map<String, int> earnable = const {},
   }) => CourseLoOutline(
     courseId: courseId,
+    questId: questId,
     orderedLoIds: seq,
     activityIdsByLo: acts,
     starsToUnlock: threshold,
@@ -280,6 +282,103 @@ void main() {
       );
 
       expect(r.missionGradient(['m1']), 0.0);
+    });
+  });
+
+  group('two course rooms from one quest (#8087)', () {
+    /// One quest ('q1') launched into two course rooms: room A pins Mission m1
+    /// to its own 4-star activity, room B carries the same Mission with a
+    /// different (side-quest) activity. Courses are keyed by room id; the
+    /// shared quest uuid is the second key the band dedupes by.
+    List<CourseLoOutline> twoRoomsOneQuest() => [
+      outline(
+        '!roomA:x',
+        ['m1'],
+        {
+          'm1': {'a1'},
+        },
+        questId: 'q1',
+        earnable: {'a1': 4},
+      ),
+      outline(
+        '!roomB:x',
+        ['m1'],
+        {
+          'm1': {'b1'},
+        },
+        questId: 'q1',
+        earnable: {'b1': 4},
+      ),
+    ];
+
+    test('each room resolves its own rollup — no last-room-wins collapse', () {
+      final r = resolveProgression(
+        outlines: twoRoomsOneQuest(),
+        starsByActivity: const {'a1': 3},
+      );
+
+      expect(r.forCourse('!roomA:x')!.rollup['m1']!.stars, 3);
+      expect(r.forCourse('!roomB:x')!.rollup['m1']!.stars, 0);
+    });
+
+    test("stars earned in one room's activity never credit the other", () {
+      // The reported repro: earn stars in course B, course A displayed them.
+      final r = resolveProgression(
+        outlines: twoRoomsOneQuest(),
+        starsByActivity: const {'b1': 2},
+      );
+
+      final a = r.questStars('!roomA:x')!;
+      expect(a.earned, 0);
+      final b = r.questStars('!roomB:x')!;
+      expect(b.earned, 2);
+    });
+
+    test('the band counts the shared quest once, not once per room', () {
+      final r = resolveProgression(
+        outlines: twoRoomsOneQuest(),
+        starsByActivity: const {},
+      );
+
+      expect(r.missionGradient(['m1']), 1.0);
+    });
+
+    test("a Mission satisfied in one room keeps the other room's signal", () {
+      // Room A's m1 is satisfied (contribution 0); room B's differently-pinned
+      // m1 is not. The quest's strongest per-room value stands (max, not
+      // first-wins): the activity genuinely is the learner's next step in B.
+      final r = resolveProgression(
+        outlines: twoRoomsOneQuest(),
+        starsByActivity: const {'a1': 4},
+      );
+
+      expect(r.missionGradient(['m1']), 1.0);
+    });
+
+    test('distinct quests with explicit questIds still sum', () {
+      final r = resolveProgression(
+        outlines: [
+          outline(
+            '!roomA:x',
+            ['m1'],
+            {
+              'm1': {'x'},
+            },
+            questId: 'q1',
+          ),
+          outline(
+            '!roomB:x',
+            ['m2'],
+            {
+              'm2': {'x'},
+            },
+            questId: 'q2',
+          ),
+        ],
+        starsByActivity: const {},
+      );
+
+      expect(r.missionGradient(['m1', 'm2']), 2.0);
     });
   });
 }


### PR DESCRIPTION
## What

Per-course Mission star rollups are now keyed by the course's Matrix room id (unique per course) instead of `coursePlan.uuid` (the quest id), with the quest uuid kept as a second key so the world-map band still counts a quest joined in two rooms once.

## Why

Closes #8087

## Testing

- New regression group `two course rooms from one quest (#8087)` in `test/pangea/quests/per_course_mission_rollup_test.dart`: each room resolves its own rollup (no last-room-wins collapse), stars earned in one room never credit the other, the band counts the shared quest once (1.0, not 2.0), a Mission satisfied in one room keeps the other room's signal (max per-room contribution), and distinct quests still sum.
- New case in `test/pangea/joined_objective_cache_test.dart`: `rebuild` with two room-id keys sharing one questId yields two distinct entries with questId preserved.
- `fvm flutter test` — full suite: 1851 passed, 3 skipped. `fvm flutter analyze` — clean. `fvm dart format` on changed files.
- The issue's TO TEST (two live courses from one quest, cross-course star isolation, world-map pins) needs staging QA per the issue's label flow — not reproducible against local unit fixtures alone.

Notes for review:

- Root cause was the uuid-keyed maps in `JoinedObjectiveCache.rebuildFromJoinedCourses`: two rooms of one quest collapsed to one entry (last room wins), so `forCourse` served one course's rollup to both panels — defeating the per-course scoping rule in [quests.instructions.md](.github/instructions/quests.instructions.md) ("Star totals are per course, never blended", #7771). In code, "course" identity is now the room id; the doc's design intent is unchanged.
- `missionGradient` dedupes by questId taking the **max** per-room contribution: rooms of one quest can diverge via pins, so a Mission satisfied in room A may still be room B's genuine next step — the strongest signal stands, and max is order-independent where `quests` order (rebuild completion order) is not.
- `WorldMapPinsManager` now tracks the joined **room-id** set for rebuild change-detection — fixing a latent bug where joining a second room of an already-joined quest never triggered a rebuild — plus the quest-uuid set solely for `ensureScopedCourseOutline`, whose scope key (`CourseMapContext`) is a quest uuid.
- Outline `onError` reporting is per room (`course-outline-resolve:<roomId>`, keeping the #8083 once-per-session dedupe), with questId retained in the data for orphaned-quest diagnosis.
- The panel loader scopes by `courseRoomId ?? questId`; previews (no room) fall back to the quest uuid, match nothing, and keep today's muted empty star display.
- Out of scope: `CourseMapContext`/`?c=` stays quest-uuid keyed, and `world_map.dart`'s quest-uuid→room `firstWhereOrNull` for the course-scoped map keeps its pick-first ambiguity — a separate surface from the star rollup this issue covers.

## Deploy Notes

None
