### PR TITLE
fix(courses): reject whitespace-only course titles in edit form

### DIFF
--- a/lib/routes/chat/chat_details/edit_course/edit_course.dart
+++ b/lib/routes/chat/chat_details/edit_course/edit_course.dart
@@ -77,7 +77,7 @@ class EditCourseController extends State<EditCourse> {
   }
 
   bool get _isValid {
-    return _titleController.text.isNotEmpty;
+    return _titleController.text.trim().isNotEmpty;
   }
 
   Future<void> _saveChanges() async {


### PR DESCRIPTION
Closes #8123

## Problem
The edit-course form's submit validation checked `_titleController.text.isNotEmpty` on the raw text, so a title of only spaces passed validation. `_saveChanges` then trimmed it to an empty string and set that as the room name, leaving the course displayed as "Empty chat".

## Fix
Trim the title before the validity check in `EditCourseController._isValid`, so a whitespace-only title disables the save button — matching how `hasChanges` and `_saveChanges` already treat the trimmed value.

## To test
- [ ] Edit a course
- [ ] Replace the title with ` ` (spaces only)
- [ ] Submit button should be greyed out

🤖 Generated with [Claude Code](https://claude.com/claude-code)