### PR TITLE
fix(errors): typed PangeaHttpException, one severity policy, benign missing-quest reports (Closes #8094)

### DIFF
--- a/lib/features/activity_sessions/activity_plan_repo.dart
+++ b/lib/features/activity_sessions/activity_plan_repo.dart
@@ -9,6 +9,7 @@ import 'package:fluffychat/features/activity_sessions/activity_media_repo.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_fetch_request.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_fetch_response.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/base_repo.dart';
@@ -153,7 +154,7 @@ class ActivityPlanRepo
 
   @visibleForTesting
   static ActivityPlanLookupStatus classifyLookupError(Object error) =>
-      error is Response && error.statusCode == 404
+      PangeaHttpException.statusCodeOf(error) == 404
       ? ActivityPlanLookupStatus.removed
       : ActivityPlanLookupStatus.failed;
 

--- a/lib/features/course_plans/payload_client/payload_client.dart
+++ b/lib/features/course_plans/payload_client/payload_client.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import 'package:fluffychat/features/course_plans/payload_client/paginated_response.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 
 /// Generic PayloadCMS client for CRUD operations
 class PayloadClient {
@@ -110,9 +111,7 @@ class PayloadClient {
     final response = await _get(endpoint);
 
     if (response.statusCode >= 400) {
-      throw Exception(
-        'Failed to load documents: ${response.statusCode} ${response.body}',
-      );
+      throw PangeaHttpException.fromResponse(response);
     }
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;
@@ -133,7 +132,7 @@ class PayloadClient {
     final endpoint = '$basePath/$collection/$id$query';
     final response = await _get(endpoint);
     if (response.statusCode >= 400) {
-      throw response;
+      throw PangeaHttpException.fromResponse(response);
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
     return fromJson(json);
@@ -149,9 +148,7 @@ class PayloadClient {
     final response = await _post(endpoint, data);
 
     if (response.statusCode >= 400) {
-      throw Exception(
-        'Failed to create document: ${response.statusCode} ${response.body}',
-      );
+      throw PangeaHttpException.fromResponse(response);
     }
 
     final json = jsonDecode(response.body) as Map<String, dynamic>;
@@ -168,9 +165,7 @@ class PayloadClient {
     final endpoint = '$basePath/$collection/$id';
     final response = await _patch(endpoint, data);
     if (response.statusCode >= 400) {
-      throw Exception(
-        'Failed to update document: ${response.statusCode} ${response.body}',
-      );
+      throw PangeaHttpException.fromResponse(response);
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
     return fromJson(json);
@@ -185,9 +180,7 @@ class PayloadClient {
     final endpoint = '$basePath/$collection/$id';
     final response = await _delete(endpoint);
     if (response.statusCode >= 400) {
-      throw Exception(
-        'Failed to delete document: ${response.statusCode} ${response.body}',
-      );
+      throw PangeaHttpException.fromResponse(response);
     }
     final json = jsonDecode(response.body) as Map<String, dynamic>;
     return fromJson(json);

--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -322,6 +322,9 @@ class QuestRepo {
           : null;
       return Result.value((refs ?? const []).map((e) => e as String).toList());
     } catch (e, s) {
+      if (PangeaHttpException.statusCodeOf(e) == 404) {
+        return Result.value(const []);
+      }
       ErrorHandler.logError(
         e: e,
         s: s,

--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 
 import 'package:async/async.dart';
-import 'package:http/http.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_media_block.dart';
 import 'package:fluffychat/features/activity_sessions/activity_media_repo.dart';
@@ -15,13 +14,24 @@ import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
 import 'package:fluffychat/features/quests/models/quest_plan_model.dart';
 import 'package:fluffychat/features/quests/repo/activity_v2_mapper.dart';
 import 'package:fluffychat/pangea/common/config/environment.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
-class MissingQuestException implements Exception {}
+/// A quest plan id that no longer resolves in the CMS (confirmed 404). A known
+/// benign state — old course rooms keep referencing removed quests — which
+/// [QuestRepo.quest] returns WITHOUT reporting; callers render it as a known
+/// state (or report it at warning, never error). The `toString()` matters:
+/// without it, any report arrives in Sentry as `Instance of
+/// 'MissingQuestException'` (CLIENT-DQC, #8094).
+class MissingQuestException implements Exception {
+  @override
+  String toString() =>
+      'MissingQuestException: quest plan not found in CMS (confirmed 404)';
+}
 
 /// The single home of the per-course activity-pin rule (org quests doc,
 /// client#7748): which of a Mission's [available] activity ids count when the
@@ -203,7 +213,12 @@ class QuestRepo {
         questActivityEntriesFromJson(jsonDecode(response.body)),
       );
     } catch (e, s) {
-      ErrorHandler.logError(e: e, s: s, data: {"quest_id": questId});
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"quest_id": questId},
+        level: PangeaHttpException.severityOf(e),
+      );
       return Result.error(e);
     }
   }
@@ -239,11 +254,16 @@ class QuestRepo {
       );
       return Result.value(quest);
     } catch (e, s) {
-      if (e is Response && e.statusCode == 404) {
+      if (PangeaHttpException.statusCodeOf(e) == 404) {
         return Result.error(MissingQuestException());
       }
 
-      ErrorHandler.logError(e: e, s: s, data: {"quest_id": questId});
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"quest_id": questId},
+        level: PangeaHttpException.severityOf(e),
+      );
       return Result.error(e);
     }
   }
@@ -265,7 +285,12 @@ class QuestRepo {
       );
       return Result.value({for (final lo in resp.docs) lo.id: lo});
     } catch (e, s) {
-      ErrorHandler.logError(e: e, s: s, data: {"lo_ids": ids});
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"lo_ids": ids},
+        level: PangeaHttpException.severityOf(e),
+      );
       return Result.error(e);
     }
   }
@@ -297,7 +322,12 @@ class QuestRepo {
           : null;
       return Result.value((refs ?? const []).map((e) => e as String).toList());
     } catch (e, s) {
-      ErrorHandler.logError(e: e, s: s, data: {"activity_id": activityId});
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"activity_id": activityId},
+        level: PangeaHttpException.severityOf(e),
+      );
       return Result.error(e);
     }
   }
@@ -368,7 +398,12 @@ class QuestRepo {
           (plan: resolved[i], refs: entries[i].refs),
       ]);
     } catch (e, s) {
-      ErrorHandler.logError(e: e, s: s, data: {});
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {},
+        level: PangeaHttpException.severityOf(e),
+      );
       return Result.error(e);
     }
   }
@@ -529,7 +564,12 @@ class QuestRepo {
 
       return Result.value(QuestOutline(quest: quest, groups: groups));
     } catch (e, s) {
-      ErrorHandler.logError(e: e, s: s, data: {"quest_id": questId});
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"quest_id": questId},
+        level: PangeaHttpException.severityOf(e),
+      );
       return Result.error(e);
     }
   }

--- a/lib/pangea/common/network/pangea_http_exception.dart
+++ b/lib/pangea/common/network/pangea_http_exception.dart
@@ -1,0 +1,106 @@
+import 'dart:async';
+
+import 'package:http/http.dart' as http;
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// A failed HTTP call, typed. Thrown by [Requests] (and [PayloadClient]) for
+/// any response ≥ 400 — never the raw [http.Response], whose missing
+/// `toString()` collapsed every failure across every endpoint into one Sentry
+/// title, `Instance of 'Response'` (#8094).
+///
+/// Carries only what a Sentry title needs to be diagnosable and groupable:
+/// status, method, normalized path, and the parsed `detail` field. Never the
+/// response body — bodies carry learner content, and Sentry is not where that
+/// belongs (repos-and-error-handling.instructions.md).
+class PangeaHttpException implements Exception {
+  final int statusCode;
+  final String method;
+
+  /// Request path with opaque id segments (UUIDs, CMS ObjectIds, numeric ids,
+  /// Matrix identifiers) replaced by `{id}`, so titles group per endpoint
+  /// rather than per resource. Query strings are dropped entirely.
+  final String path;
+
+  /// The backend's parsed `detail` message, capped at [maxDetailLength].
+  /// Only ever the `detail` field — never the body.
+  final String? detail;
+
+  static const int maxDetailLength = 200;
+
+  PangeaHttpException({
+    required this.statusCode,
+    required this.method,
+    required this.path,
+    String? detail,
+  }) : detail = detail == null || detail.length <= maxDetailLength
+           ? detail
+           : detail.substring(0, maxDetailLength);
+
+  factory PangeaHttpException.fromResponse(
+    http.Response response, {
+    String? detail,
+  }) {
+    final request = response.request;
+    return PangeaHttpException(
+      statusCode: response.statusCode,
+      method: request?.method ?? 'UNKNOWN',
+      path: request == null ? 'unknown' : normalizePath(request.url),
+      detail: detail,
+    );
+  }
+
+  static final _uuid = RegExp(
+    r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
+  );
+  static final _objectId = RegExp(r'^[0-9a-fA-F]{24}$');
+  static final _numericId = RegExp(r'^\d+$');
+  static const _matrixSigils = ['!', '@', r'$', '#', '+'];
+
+  /// The path of [url] with each opaque id segment replaced by `{id}`.
+  static String normalizePath(Uri url) {
+    final segments = url.pathSegments
+        .where((s) => s.isNotEmpty)
+        .map((s) => _isOpaqueId(s) ? '{id}' : s);
+    return '/${segments.join('/')}';
+  }
+
+  static bool _isOpaqueId(String segment) =>
+      _uuid.hasMatch(segment) ||
+      _objectId.hasMatch(segment) ||
+      _numericId.hasMatch(segment) ||
+      _matrixSigils.any(segment.startsWith);
+
+  /// The HTTP status of [error] when it carries one — a [PangeaHttpException],
+  /// or a raw [http.Response] from a not-yet-migrated throw site — else null.
+  /// The single test callers use instead of type-testing `Response` directly.
+  static int? statusCodeOf(Object? error) {
+    if (error is PangeaHttpException) return error.statusCode;
+    if (error is http.Response) return error.statusCode;
+    return null;
+  }
+
+  /// The one severity table for a repo-layer fetch failure
+  /// (repos-and-error-handling.instructions.md § Severity policy). Severity is
+  /// a property of the failure, not of the author's judgment at the call site:
+  /// timeouts are transient, 401 is token lifecycle, 404/410 mean the resource
+  /// is gone (a normal state), 429 is expected under load — all warnings.
+  /// Everything else — malformed requests (4xx) and backend regressions (5xx)
+  /// — is an error.
+  static SentryLevel severityOf(Object? error) {
+    if (error is TimeoutException) return SentryLevel.warning;
+    switch (statusCodeOf(error)) {
+      case 401:
+      case 404:
+      case 410:
+      case 429:
+        return SentryLevel.warning;
+      default:
+        return SentryLevel.error;
+    }
+  }
+
+  @override
+  String toString() =>
+      'PangeaHttpException: $statusCode $method $path'
+      '${detail == null ? '' : ' — $detail'}';
+}

--- a/lib/pangea/common/network/pangea_http_exception.dart
+++ b/lib/pangea/common/network/pangea_http_exception.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -45,7 +46,7 @@ class PangeaHttpException implements Exception {
       statusCode: response.statusCode,
       method: request?.method ?? 'UNKNOWN',
       path: request == null ? 'unknown' : normalizePath(request.url),
-      detail: detail,
+      detail: detail ?? detailFromResponse(response),
     );
   }
 
@@ -77,6 +78,17 @@ class PangeaHttpException implements Exception {
     if (error is PangeaHttpException) return error.statusCode;
     if (error is http.Response) return error.statusCode;
     return null;
+  }
+
+  static String? detailFromResponse(http.Response response) {
+    try {
+      final decoded = jsonDecode(utf8.decode(response.bodyBytes));
+      if (decoded is! Map<String, dynamic>) return null;
+      final detail = decoded['detail'];
+      return detail is String ? detail : null;
+    } catch (_) {
+      return null;
+    }
   }
 
   /// The one severity table for a repo-layer fetch failure

--- a/lib/pangea/common/network/requests.dart
+++ b/lib/pangea/common/network/requests.dart
@@ -5,6 +5,7 @@ import 'package:matrix/matrix_api_lite/utils/logs.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'package:fluffychat/pangea/common/models/base_request_model.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 import 'package:fluffychat/pangea/common/utils/error_response_parser.dart';
 
 class Requests {
@@ -73,7 +74,8 @@ class Requests {
     String? message;
     try {
       final responseBody = jsonDecode(utf8.decode(response.bodyBytes));
-      message = responseBody['detail'];
+      final detail = responseBody['detail'];
+      message = detail is String ? detail : null;
     } catch (e) {
       Logs().w("Failed to parse error response body");
       message = null;
@@ -85,7 +87,8 @@ class Requests {
     }
 
     _addBreadcrumb(response, body: body);
-    throw errorResponseParser?.parse(response) ?? response;
+    throw errorResponseParser?.parse(response) ??
+        PangeaHttpException.fromResponse(response, detail: message);
   }
 
   Map<String, String> get _headers {

--- a/lib/pangea/common/utils/base_repo.dart
+++ b/lib/pangea/common/utils/base_repo.dart
@@ -8,6 +8,7 @@ import 'package:http/http.dart' hide BaseRequest, BaseResponse;
 import 'package:matrix/matrix_api_lite/utils/logs.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/utils/base_request.dart';
 import 'package:fluffychat/pangea/common/utils/base_response.dart';
@@ -102,23 +103,19 @@ abstract class BaseRepo<
     accessToken: MatrixState.pangeaController.userController.accessToken,
   );
 
-  /// Sentry level for a fetch failure. Timeouts and confirmed 404s are
-  /// warnings — a 404 means the resource is gone (expected for e.g. removed
-  /// activities referenced by old rooms), not that code broke.
+  /// Sentry level for a fetch failure — the shared severity table
+  /// ([PangeaHttpException.severityOf]): timeouts and gone/routine statuses
+  /// (401, 404, 410, 429) are warnings; everything else is an error.
   @visibleForTesting
-  static SentryLevel errorLevel(Object e) =>
-      e is TimeoutException || (e is Response && e.statusCode == 404)
-      ? SentryLevel.warning
-      : SentryLevel.error;
+  static SentryLevel errorLevel(Object e) => PangeaHttpException.severityOf(e);
 
   Future<Result<TResponse>> _fetch(TRequest request) async {
     try {
       final Requests req = createRequests();
 
+      // No ≥400 check here: [fetch] goes through [Requests], which already
+      // threw a typed error for any failing status.
       final Response res = await fetch(req, request).timeout(timeout);
-      if (res.statusCode >= 400) {
-        throw errorResponseParser?.parse(res) ?? res;
-      }
 
       final Map<String, dynamic> json = jsonDecode(
         utf8.decode(res.bodyBytes).toString(),

--- a/lib/pangea/common/utils/error_handler.dart
+++ b/lib/pangea/common/utils/error_handler.dart
@@ -3,11 +3,11 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import 'package:http/http.dart' as http;
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/config/environment.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 
 class PangeaWarningError implements Exception {
@@ -105,13 +105,7 @@ class ErrorCopy {
   Object error;
   ErrorCopy(this.error);
 
-  int? get errorCode {
-    if (error is http.Response) {
-      return (error as http.Response).statusCode;
-    } else {
-      return null;
-    }
-  }
+  int? get errorCode => PangeaHttpException.statusCodeOf(error);
 
   String toLocalizedString(BuildContext context) {
     try {

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:matrix/matrix.dart';
+import 'package:sentry_flutter/sentry_flutter.dart' show SentryLevel;
 
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
@@ -46,6 +47,18 @@ bool needsParticipantRefill({
   required int? joinedCount,
   required bool hasUnresolvedSeats,
 }) => everFilled ? filledAtJoinedCount != joinedCount : hasUnresolvedSeats;
+
+/// Severity for a course outline that failed to resolve during the objective
+/// cache rebuild. [MissingQuestException] is a state the repo already
+/// classified benign — [QuestRepo.quest] returns it without reporting, and the
+/// course panel renders it as a known state — so re-reporting it at `error`
+/// re-severitized a handled condition (CLIENT-DQC, #8094). It still reports at
+/// `warning` (once per course per session) because a dropped course blanks
+/// relevance banding with no other visible signal. Everything else keeps
+/// `error`: the outline read failing for any other reason is real breakage.
+@visibleForTesting
+SentryLevel courseOutlineErrorLevel(Object error) =>
+    error is MissingQuestException ? SentryLevel.warning : SentryLevel.error;
 
 /// Minimum spacing between empty-cache self-heal rebuilds of the objective
 /// cache. A set-change rebuild (course join/leave) is never subject to it —
@@ -587,6 +600,7 @@ class WorldMapPinsManager {
           s: s,
           m: 'JoinedObjectiveCache: course outline failed to resolve',
           data: {'courseRoomId': roomId, 'questId': questId},
+          level: courseOutlineErrorLevel(e),
         ),
       );
       _objectiveCacheRoomIds = rooms.map((r) => r.id).toSet();

--- a/test/pangea/activity_plan_lookup_test.dart
+++ b/test/pangea/activity_plan_lookup_test.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 import 'package:fluffychat/pangea/common/utils/base_repo.dart';
 
 /// The 404-vs-transient split behind the removed-activity fallback ladder
@@ -15,8 +16,19 @@ import 'package:fluffychat/pangea/common/utils/base_repo.dart';
 /// (old rooms referencing removed activities), not code breakage — they log
 /// as warnings, not Sentry errors.
 void main() {
+  PangeaHttpException http(int status) => PangeaHttpException(
+    statusCode: status,
+    method: 'GET',
+    path: '/choreo/v2/activity',
+  );
+
   group('ActivityPlanRepo.classifyLookupError', () {
     test('404 is a confirmed miss — the only status that walks the ladder', () {
+      expect(
+        ActivityPlanRepo.classifyLookupError(http(404)),
+        ActivityPlanLookupStatus.removed,
+      );
+      // A raw Response from a not-yet-migrated throw site still classifies.
       expect(
         ActivityPlanRepo.classifyLookupError(Response('not found', 404)),
         ActivityPlanLookupStatus.removed,
@@ -25,11 +37,11 @@ void main() {
 
     test('server errors are transient, never removed', () {
       expect(
-        ActivityPlanRepo.classifyLookupError(Response('boom', 500)),
+        ActivityPlanRepo.classifyLookupError(http(500)),
         ActivityPlanLookupStatus.failed,
       );
       expect(
-        ActivityPlanRepo.classifyLookupError(Response('bad gateway', 502)),
+        ActivityPlanRepo.classifyLookupError(http(502)),
         ActivityPlanLookupStatus.failed,
       );
     });
@@ -48,6 +60,8 @@ void main() {
 
   group('BaseRepo.errorLevel — Sentry severity', () {
     test('404 logs as warning (expected data state, not breakage)', () {
+      expect(BaseRepo.errorLevel(http(404)), SentryLevel.warning);
+      // Raw Response from a not-yet-migrated throw site keeps its severity.
       expect(
         BaseRepo.errorLevel(Response('not found', 404)),
         SentryLevel.warning,
@@ -62,7 +76,7 @@ void main() {
     });
 
     test('other failures stay errors', () {
-      expect(BaseRepo.errorLevel(Response('boom', 500)), SentryLevel.error);
+      expect(BaseRepo.errorLevel(http(500)), SentryLevel.error);
       expect(BaseRepo.errorLevel(Exception('parse')), SentryLevel.error);
     });
   });

--- a/test/pangea/pangea_http_exception_test.dart
+++ b/test/pangea/pangea_http_exception_test.dart
@@ -1,0 +1,154 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+
+/// The typed HTTP failure behind #8094: every ≥400 response used to be thrown
+/// as a raw [Response], whose missing `toString()` collapsed 66 distinct
+/// Sentry issues into one title, `Instance of 'Response'`. These tests pin the
+/// three things the exception exists for: a diagnosable `toString()`, path
+/// normalization so titles group per endpoint, and the one severity table.
+void main() {
+  Response response(
+    int status, {
+    String method = 'GET',
+    String url = 'https://api.pangea.chat/choreo/health',
+  }) => Response('', status, request: Request(method, Uri.parse(url)));
+
+  group('PangeaHttpException.toString', () {
+    test('carries status, method, and normalized path', () {
+      final e = PangeaHttpException.fromResponse(
+        response(
+          404,
+          url:
+              'https://api.pangea.chat/choreo/quests/123e4567-e89b-12d3-a456-426614174000/activities',
+        ),
+      );
+      expect(
+        e.toString(),
+        'PangeaHttpException: 404 GET /choreo/quests/{id}/activities',
+      );
+    });
+
+    test('appends the parsed detail when present', () {
+      final e = PangeaHttpException.fromResponse(
+        response(504, url: 'https://api.pangea.chat/choreo/v2/activities/bbox'),
+        detail: 'upstream timed out',
+      );
+      expect(
+        e.toString(),
+        'PangeaHttpException: 504 GET /choreo/v2/activities/bbox'
+        ' — upstream timed out',
+      );
+    });
+
+    test('caps detail length — never a whole body', () {
+      final e = PangeaHttpException.fromResponse(
+        response(500),
+        detail: 'x' * 1000,
+      );
+      expect(e.detail!.length, PangeaHttpException.maxDetailLength);
+    });
+
+    test('survives a response with no request attached', () {
+      final e = PangeaHttpException.fromResponse(Response('', 502));
+      expect(e.toString(), 'PangeaHttpException: 502 UNKNOWN unknown');
+    });
+  });
+
+  group('PangeaHttpException.normalizePath', () {
+    test('replaces opaque id segments with {id}', () {
+      expect(
+        // UUID
+        PangeaHttpException.normalizePath(
+          Uri.parse(
+            'https://x/choreo/quests/123e4567-e89b-12d3-a456-426614174000/activities',
+          ),
+        ),
+        '/choreo/quests/{id}/activities',
+      );
+      expect(
+        // CMS (Mongo) ObjectId
+        PangeaHttpException.normalizePath(
+          Uri.parse('https://x/cms/api/quest-plans/507f1f77bcf86cd799439011'),
+        ),
+        '/cms/api/quest-plans/{id}',
+      );
+      expect(
+        // numeric id
+        PangeaHttpException.normalizePath(Uri.parse('https://x/things/12345')),
+        '/things/{id}',
+      );
+      expect(
+        // Matrix room id (percent-encoded in the URL, decoded per segment)
+        PangeaHttpException.normalizePath(
+          Uri.parse('https://x/rooms/${Uri.encodeComponent('!abc:server')}'),
+        ),
+        '/rooms/{id}',
+      );
+    });
+
+    test('keeps ordinary segments and drops the query string', () {
+      expect(
+        PangeaHttpException.normalizePath(
+          Uri.parse('https://x/choreo/v2/activities/bbox?course_room_id=!r:s'),
+        ),
+        '/choreo/v2/activities/bbox',
+      );
+    });
+  });
+
+  group('PangeaHttpException.statusCodeOf', () {
+    test('reads a PangeaHttpException', () {
+      expect(
+        PangeaHttpException.statusCodeOf(
+          PangeaHttpException.fromResponse(response(404)),
+        ),
+        404,
+      );
+    });
+
+    test('still reads a raw Response from a not-yet-migrated throw site', () {
+      expect(PangeaHttpException.statusCodeOf(Response('', 503)), 503);
+    });
+
+    test('is null for anything else', () {
+      expect(PangeaHttpException.statusCodeOf(Exception('offline')), isNull);
+      expect(PangeaHttpException.statusCodeOf(null), isNull);
+    });
+  });
+
+  group('PangeaHttpException.severityOf — the one severity table', () {
+    PangeaHttpException http(int status) =>
+        PangeaHttpException.fromResponse(response(status));
+
+    test('timeouts, 401, 404, 410, and 429 are warnings', () {
+      expect(
+        PangeaHttpException.severityOf(TimeoutException('slow')),
+        SentryLevel.warning,
+      );
+      for (final status in [401, 404, 410, 429]) {
+        expect(
+          PangeaHttpException.severityOf(http(status)),
+          SentryLevel.warning,
+        );
+      }
+    });
+
+    test('other 4xx and all 5xx are errors', () {
+      for (final status in [400, 403, 405, 422, 500, 502, 504]) {
+        expect(PangeaHttpException.severityOf(http(status)), SentryLevel.error);
+      }
+    });
+
+    test('non-HTTP failures are errors', () {
+      expect(
+        PangeaHttpException.severityOf(Exception('parse')),
+        SentryLevel.error,
+      );
+    });
+  });
+}

--- a/test/pangea/quests/missing_quest_reporting_test.dart
+++ b/test/pangea/quests/missing_quest_reporting_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/routes/world/world_map_pins_manager.dart';
+
+/// CLIENT-DQC (#8094): a missing quest is a state the repo classified benign —
+/// [QuestRepo.quest] returns [MissingQuestException] without reporting, and the
+/// course panel renders it as a known state — yet the world map's objective
+/// cache rebuild reported it to Sentry at `error`, titled `Instance of
+/// 'MissingQuestException'`. These pin both halves of the fix: a real
+/// `toString()`, and the caller keeping the repo's classification (warning,
+/// not error) while other outline failures stay errors.
+void main() {
+  test('MissingQuestException has a diagnosable toString', () {
+    expect(
+      MissingQuestException().toString(),
+      'MissingQuestException: quest plan not found in CMS (confirmed 404)',
+    );
+  });
+
+  group('courseOutlineErrorLevel', () {
+    test('a missing quest reports at warning — repo classified it benign', () {
+      expect(
+        courseOutlineErrorLevel(MissingQuestException()),
+        SentryLevel.warning,
+      );
+    });
+
+    test('any other outline failure stays an error', () {
+      expect(
+        courseOutlineErrorLevel(Exception('choreo unreachable')),
+        SentryLevel.error,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Why

Every HTTP failure in the client arrived in Sentry titled `Response: Instance of 'Response'` — 66 distinct unresolved issues, 3,386 events in a 14-day window, none diagnosable without opening an individual event. The doc half of #8094 merged in #8095; this is the code half (slice 1 + the CLIENT-DQC companion).

## What

**`PangeaHttpException`** ([pangea_http_exception.dart](https://github.com/pangeachat/client/blob/claude/dreamy-elgamal-61912c/lib/pangea/common/network/pangea_http_exception.dart)) — carries status, method, normalized path, and the parsed `detail` with a real `toString()`:

```
PangeaHttpException: 404 GET /choreo/quests/{id}/activities
```

- Opaque id segments (UUIDs, CMS ObjectIds, numeric ids, Matrix identifiers) normalize to `{id}` so titles group per endpoint; query strings are dropped.
- `detail` is length-capped (200 chars) and only ever the parsed `detail` field — never the response body. `PayloadClient`'s old `Exception(...)` messages embedded whole response bodies; those five throw sites now throw the typed exception too.
- `Requests._handleError` throws it instead of the raw `http.Response`. `UnsubscribedException` keeps its own type (control flow, never reported).

**One severity policy** — `PangeaHttpException.severityOf` implements the table from repos-and-error-handling.instructions.md (timeouts + 401/404/410/429 → warning; other 4xx and all 5xx → error). `BaseRepo.errorLevel` delegates to it, and `QuestRepo`'s ad-hoc reports now use it — the CLIENT-DRV case where `_questActivityEntries` logged a 404 at `error` while the same 404 through `BaseRepo` logged `warning`.

**Removed the unreachable ≥400 throw in `BaseRepo._fetch`** — `fetch()` goes through `Requests`, which already threw.

**Migrated the sites that type-tested the thrown `Response`**: `QuestRepo.quest`, `ActivityPlanRepo.classifyLookupError`, `BaseRepo.errorLevel`, `ErrorCopy.errorCode` — all via `statusCodeOf`, which still reads a raw `Response` from not-yet-migrated ad-hoc throw sites (there are a few, e.g. `activity_summary_repo.dart`; they migrate opportunistically per the contract).

**CLIENT-DQC**: `MissingQuestException` gets a real `toString()`, and the world map's objective-cache rebuild (`world_map_pins_manager.dart`) reports it at **warning** instead of error — `QuestRepo.quest` had already classified it benign and the course panel renders it as a known state. Kept at warning rather than dropped: a dropped course blanks relevance banding with no other visible signal (the report is already once-per-course-per-session).

## Tests

- New [pangea_http_exception_test.dart](https://github.com/pangeachat/client/blob/claude/dreamy-elgamal-61912c/test/pangea/pangea_http_exception_test.dart): `toString()` format, path normalization, detail cap, `statusCodeOf` (both shapes), the full severity table.
- New [missing_quest_reporting_test.dart](https://github.com/pangeachat/client/blob/claude/dreamy-elgamal-61912c/test/pangea/quests/missing_quest_reporting_test.dart): CLIENT-DQC's two halves.
- Updated [activity_plan_lookup_test.dart](https://github.com/pangeachat/client/blob/claude/dreamy-elgamal-61912c/test/pangea/activity_plan_lookup_test.dart) to exercise the typed exception (raw-`Response` compat cases kept).
- Full suite: 1888 passed, `dart analyze` clean.

## TO TEST

(from #8094 — needs a device/manual pass)

- [ ] Open the world map — verify activity pins load and render
- [ ] Enter a joined course from the map — verify the course-scoped pins load
- [ ] Turn off network, pull the world map to refresh — verify a readable empty/error state, not a hang or raw error text
- [ ] Turn network back on, refresh — verify pins recover
- [ ] Open a chat, tap a word to open its word card — verify translation and audio still load
- [ ] Send a message with a grammar error — verify the correction still appears
- [ ] Open the subscription page — verify entitlement status displays correctly

Closes #8094

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of network and server errors across activity plans, courses, quests, and related content.
  - Missing or removed content is now identified more consistently, including proper handling of 404 responses.
  - Error messages are safer and clearer, with sensitive response details excluded and diagnostic text kept concise.

- **Monitoring**
  - Improved error severity classification for more accurate reporting.
  - Missing content is reported as a warning, while unexpected failures remain errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->