### PR TITLE
feat(wa): make writing assistance popup take up more space

### DIFF
--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -2963,15 +2963,41 @@ class ChatController extends State<ChatPageWithRoom>
     }
 
     if (!isSpanCardOpen) {
+      // Size the popup to the chat's available space: as wide as the input
+      // field, and as tall as the space above it, so choices are visible
+      // without scrolling (#8130). The card itself sizes to its content.
+      final inputRenderBox = MatrixState.pAnyState.getRenderBox(
+        ChoreoConstants.inputTransformTargetKey,
+      );
+      final overlayRenderBox = OverlayUtil.overlayRenderBox(context);
+
+      double maxWidth = 325;
+      double maxHeight = 325;
+      if (inputRenderBox != null && overlayRenderBox != null) {
+        maxWidth = inputRenderBox.size.width;
+        final spaceAboveInput = OverlayUtil.localOffset(
+          inputRenderBox,
+          overlayRenderBox,
+        ).dy;
+        maxHeight = (spaceAboveInput - kToolbarHeight - 16.0).clamp(
+          200.0,
+          double.infinity,
+        );
+      }
+
       _spanCardOverlayController.open(
         context,
         openOverlay: (overlayKey) => OverlayUtil.showPositionedCard(
           context: context,
-          cardToShow: SpanCard(controller: _spanCardOverlayController),
+          cardToShow: SpanCard(
+            controller: _spanCardOverlayController,
+            // Leave room for the OverlayContainer's padding and border.
+            maxHeight: maxHeight - 24.0,
+          ),
           displayDetails: PositionedOverlayDisplayDetails(
             overlayKey: overlayKey,
-            maxHeight: 325,
-            maxWidth: 325,
+            maxHeight: maxHeight,
+            maxWidth: maxWidth,
             transformTargetId: ChoreoConstants.inputTransformTargetKey,
             ignorePointer: true,
             isScrollable: false,

--- a/lib/routes/chat/choreographer/igc/span_card.dart
+++ b/lib/routes/chat/choreographer/igc/span_card.dart
@@ -21,8 +21,13 @@ import 'package:fluffychat/widgets/matrix.dart';
 
 class SpanCard extends StatefulWidget {
   final WritingAssistancePopupManager controller;
+  final double maxHeight;
 
-  const SpanCard({super.key, required this.controller});
+  const SpanCard({
+    super.key,
+    required this.controller,
+    required this.maxHeight,
+  });
 
   @override
   State<SpanCard> createState() => SpanCardState();
@@ -135,7 +140,7 @@ class SpanCardState extends State<SpanCard> {
         stream: _choreographer.igcController.matchUpdateStream.stream,
         builder: (context, _) {
           final match = _activeMatch.value;
-          if (match == null) return SizedBox(height: 200.0);
+          if (match == null) return const SizedBox.shrink();
 
           final newOffset = match.updatedMatch.match.offset.toDouble();
           if (_previousOffset != null) {
@@ -150,8 +155,10 @@ class SpanCardState extends State<SpanCard> {
           _previousOffset = newOffset;
           final theme = Theme.of(context);
 
-          return SizedBox(
-            height: 200.0,
+          // Size to content so all choices are visible without scrolling,
+          // up to the available space above the input field.
+          return ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: widget.maxHeight),
             child: Column(
               mainAxisSize: .min,
               children: [
@@ -185,31 +192,36 @@ class SpanCardState extends State<SpanCard> {
                     ),
                   ],
                 ),
-                Expanded(
-                  child: AnimatedSwitcher(
-                    duration: const Duration(milliseconds: 300),
-                    switchInCurve: Curves.easeOut,
-                    switchOutCurve: Curves.easeIn,
-                    transitionBuilder: (child, animation) {
-                      final slideAnimation = Tween<Offset>(
-                        begin: _slideFrom,
-                        end: Offset.zero,
-                      ).animate(animation);
+                Flexible(
+                  child: AnimatedSize(
+                    duration: const Duration(milliseconds: 200),
+                    curve: Curves.easeOut,
+                    alignment: Alignment.topCenter,
+                    child: AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 300),
+                      switchInCurve: Curves.easeOut,
+                      switchOutCurve: Curves.easeIn,
+                      transitionBuilder: (child, animation) {
+                        final slideAnimation = Tween<Offset>(
+                          begin: _slideFrom,
+                          end: Offset.zero,
+                        ).animate(animation);
 
-                      return FadeTransition(
-                        opacity: animation,
-                        child: SlideTransition(
-                          position: slideAnimation,
-                          child: child,
-                        ),
-                      );
-                    },
-                    child: _MatchContent(
-                      key: ValueKey(match.hashCode),
-                      match: match,
-                      scrollController: scrollController,
-                      onChoiceSelect: _onChoiceSelect,
-                      onUpdateMatch: _updateMatch,
+                        return FadeTransition(
+                          opacity: animation,
+                          child: SlideTransition(
+                            position: slideAnimation,
+                            child: child,
+                          ),
+                        );
+                      },
+                      child: _MatchContent(
+                        key: ValueKey(match.hashCode),
+                        match: match,
+                        scrollController: scrollController,
+                        onChoiceSelect: _onChoiceSelect,
+                        onUpdateMatch: _updateMatch,
+                      ),
                     ),
                   ),
                 ),


### PR DESCRIPTION
### What

Size the writing assistance span card to the available screen space — as wide as the input field and as tall as its content needs (up to the space above the input) — so all correction choices are visible without vertical scrolling.

### Why

Closes #8130

### How

- [chat.dart](https://github.com/pangeachat/client/blob/ggurdin/8130-wa-popup-size/lib/routes/chat/chat.dart): compute the popup's max width from the input field's render box and max height from the space above it (was fixed 325×325).
- [span_card.dart](https://github.com/pangeachat/client/blob/ggurdin/8130-wa-popup-size/lib/routes/chat/choreographer/igc/span_card.dart): drop the fixed 200px card height; the card now sizes to its content up to the computed max, with the existing internal scroll kept only as an overflow fallback. Added an `AnimatedSize` so the card resizes smoothly when navigating between matches of different sizes.

Span card design/interaction is unchanged — see [writing-assistance.instructions.md](https://github.com/pangeachat/client/blob/main/.github/instructions/writing-assistance.instructions.md#span-card-redesigned).

### Testing

- `fvm dart analyze` clean on changed files; `fvm flutter test`: 1886 passed, 1 failed — `choreo_endpoint_test.dart: Custom course endpoint test`, the known local-environment endpoint failure (suite pointed at the local stack), unrelated to this UI change.
- Manual web QA on the local stack (grammar_v2 can't run locally — no LLM access — so the repo fetch was temporarily stubbed with canned matches, not committed):
  - Wide chat: popup spans the input width, 4 choices in 2 rows, no scroll — matches the issue mockup.
  - Mobile width (375px): popup spans full width, choices stacked, all visible without scroll.
  - Accepting a choice, auto-advance to next match, and the card's smooth resize between large/small match content all work.
- Real `/grammar_v2` responses need staging QA per the issue's TO TEST list.

### Deploy Notes

None

### Accessibility

- [x] No new or changed controls — existing buttons keep their tooltips; layout/sizing change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)