### PR TITLE
fix(world): make the activity search bar reachable via Tab (Closes #7219)

### DIFF
--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -1047,24 +1047,33 @@ class _WorldMapViewState extends State<WorldMapView> {
               top: 12,
               left: searchLeft,
               width: searchWidth,
-              child: WorldMapSearchOverlay(
-                filter: widget.controller.filter,
-                updateQuery: widget.controller.setQuery,
-                // Widen = clear every pill to All (language is fixed by
-                // settings; zoom-out is the empty card's other lever).
-                onWidenSearch: widget.controller.widenFilters,
-                setCefrLevel: widget.controller.setCefrLevel,
-                setPartySize: widget.controller.setPartySize,
-                setStatus: widget.controller.setStatus,
-                results: render.visible,
-                onResultTap: widget.controller.flyTo,
-                onReset: widget.controller.resetFilters,
-                emptyVerdict: widget.controller.emptyVerdict,
-                canZoomOut: widget.controller.canZoomOut,
-                // "Zoom out" resets to the whole-world view (all the way out and
-                // re-centered), the same as the map's World control — one tap
-                // guarantees every off-screen match comes into view.
-                onZoomOut: widget.controller.resetToWorld,
+              // Tab stop 2 of the shell's ordered traversal (#7219): the
+              // search bar and its filter pills come right after the nav rail
+              // (stop 1) and before the top-right cluster (stop 3) — both
+              // pinned in workspace_shell.dart. Without an explicit order the
+              // overlay (mounted deep in the map base layer) lost to reading
+              // order and was effectively unreachable via Tab.
+              child: FocusTraversalOrder(
+                order: const NumericFocusOrder(2),
+                child: WorldMapSearchOverlay(
+                  filter: widget.controller.filter,
+                  updateQuery: widget.controller.setQuery,
+                  // Widen = clear every pill to All (language is fixed by
+                  // settings; zoom-out is the empty card's other lever).
+                  onWidenSearch: widget.controller.widenFilters,
+                  setCefrLevel: widget.controller.setCefrLevel,
+                  setPartySize: widget.controller.setPartySize,
+                  setStatus: widget.controller.setStatus,
+                  results: render.visible,
+                  onResultTap: widget.controller.flyTo,
+                  onReset: widget.controller.resetFilters,
+                  emptyVerdict: widget.controller.emptyVerdict,
+                  canZoomOut: widget.controller.canZoomOut,
+                  // "Zoom out" resets to the whole-world view (all the way out and
+                  // re-centered), the same as the map's World control — one tap
+                  // guarantees every off-screen match comes into view.
+                  onZoomOut: widget.controller.resetToWorld,
+                ),
               ),
             ),
           controls,

--- a/lib/routes/world/world_user_cluster.dart
+++ b/lib/routes/world/world_user_cluster.dart
@@ -115,7 +115,7 @@ class WorldUserClusterInternal extends StatelessWidget {
 /// mechanical visibility change made to this file for that reuse; no behavior
 /// changed for the cluster's own usage (the default matches the old fixed
 /// `_size`).
-class ClusterAvatar extends StatelessWidget {
+class ClusterAvatar extends StatefulWidget {
   final Uri? avatarUrl;
   final String? name;
   final VoidCallback onTap;
@@ -132,32 +132,58 @@ class ClusterAvatar extends StatelessWidget {
   static const double _defaultSize = 56.0;
 
   @override
+  State<ClusterAvatar> createState() => _ClusterAvatarState();
+}
+
+class _ClusterAvatarState extends State<ClusterAvatar> {
+  /// Keyboard focus, made visible as a gold ring over the avatar: the InkWell's
+  /// own focus highlight paints BEHIND the child, and the avatar is opaque, so
+  /// without the ring a keyboard user gets no indication this stop is selected
+  /// (#7219).
+  bool _focused = false;
+
+  @override
   Widget build(BuildContext context) {
     final label = L10n.of(context).settings;
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: Tooltip(
-        message: label,
-        // The Semantics below already names this control; without this the
-        // Tooltip's own message is announced too, doubling the accessible name
-        // ("Account Account"). See accessibility.instructions.md.
-        excludeFromSemantics: true,
-        child: Semantics(
-          button: true,
-          label: label,
-          excludeSemantics: true,
-          // Expose the tap on the announced node so screen-reader users can
-          // activate it (e.g. open Settings); GestureDetector alone leaves the
-          // button unactivatable via assistive tech. See issue #7185.
-          onTap: onTap,
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: onTap,
-            child: Avatar(
-              mxContent: avatarUrl,
-              name: name,
-              size: size,
-              showPresence: false,
+    return Tooltip(
+      message: label,
+      // The Semantics below already names this control; without this the
+      // Tooltip's own message is announced too, doubling the accessible name
+      // ("Account Account"). See accessibility.instructions.md.
+      excludeFromSemantics: true,
+      // An InkWell (not a bare GestureDetector) so the avatar has a focus node:
+      // it was unreachable via Tab and unactivatable by keyboard (#7219). The
+      // Material is required by InkWell and paints nothing.
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: widget.onTap,
+          customBorder: const CircleBorder(),
+          onFocusChange: (focused) => setState(() => _focused = focused),
+          child: Semantics(
+            button: true,
+            label: label,
+            excludeSemantics: true,
+            // Expose the tap on the announced node so screen-reader users can
+            // activate it (e.g. open Settings); GestureDetector alone leaves the
+            // button unactivatable via assistive tech. See issue #7185.
+            onTap: widget.onTap,
+            child: Container(
+              foregroundDecoration: _focused
+                  ? BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: AppConfig.goldByTheme(context),
+                        width: 3,
+                      ),
+                    )
+                  : null,
+              child: Avatar(
+                mxContent: widget.avatarUrl,
+                name: widget.name,
+                size: widget.size,
+                showPresence: false,
+              ),
             ),
           ),
         ),
@@ -540,7 +566,7 @@ class _ClusterLevelMedalState extends State<ClusterLevelMedal> {
 /// can reuse it at the "slightly smaller than web" size the mobile chrome
 /// calls for (routing.instructions.md, "Single-column analytics nav bar") without
 /// duplicating the flag/outline/tooltip logic.
-class ClusterLanguageFlag extends StatelessWidget {
+class ClusterLanguageFlag extends StatefulWidget {
   final LanguageModel language;
   final VoidCallback onTap;
   final double width;
@@ -561,6 +587,24 @@ class ClusterLanguageFlag extends StatelessWidget {
   static const double _defaultFontSize = 18.0;
   static const double _radius = 6.0;
   static const double _borderWidth = 2.0;
+
+  @override
+  State<ClusterLanguageFlag> createState() => _ClusterLanguageFlagState();
+}
+
+class _ClusterLanguageFlagState extends State<ClusterLanguageFlag> {
+  LanguageModel get language => widget.language;
+  double get width => widget.width;
+  double get height => widget.height;
+  double get fontSize => widget.fontSize;
+
+  static const double _radius = ClusterLanguageFlag._radius;
+  static const double _borderWidth = ClusterLanguageFlag._borderWidth;
+
+  /// Keyboard focus, made visible as a gold ring over the chip: the InkWell's
+  /// focus highlight paints behind the chip's solid fill, so without the ring
+  /// a keyboard user gets no indication this stop is selected (#7219).
+  bool _focused = false;
 
   @override
   Widget build(BuildContext context) {
@@ -586,24 +630,27 @@ class ClusterLanguageFlag extends StatelessWidget {
       ],
     );
 
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: Tooltip(
-        message: l10n.learningSettings,
-        // Semantics below names this (language + settings); exclude the Tooltip
-        // so its message isn't appended again.
-        excludeFromSemantics: true,
-        child: Semantics(
-          button: true,
-          label: '${language.getDisplayName(l10n)}, ${l10n.learningSettings}',
-          excludeSemantics: true,
-          // Expose the tap on the announced node for assistive tech (#7185).
-          onTap: onTap,
-          // Opaque so the whole chip is tappable — not just the painted glyphs
-          // / flag pixels (a transparent-interior box defers the hit test).
-          child: GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: onTap,
+    return Tooltip(
+      message: l10n.learningSettings,
+      // Semantics below names this (language + settings); exclude the Tooltip
+      // so its message isn't appended again.
+      excludeFromSemantics: true,
+      // An InkWell (not a bare GestureDetector) so the flag has a focus node:
+      // it was unreachable via Tab and unactivatable by keyboard (#7219). The
+      // Material is required by InkWell and paints nothing; the chip's own
+      // opaque Container keeps the whole surface tappable.
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: widget.onTap,
+          borderRadius: BorderRadius.circular(_radius + _borderWidth),
+          onFocusChange: (focused) => setState(() => _focused = focused),
+          child: Semantics(
+            button: true,
+            label: '${language.getDisplayName(l10n)}, ${l10n.learningSettings}',
+            excludeSemantics: true,
+            // Expose the tap on the announced node for assistive tech (#7185).
+            onTap: widget.onTap,
             child: Container(
               width: width,
               height: height,
@@ -613,6 +660,17 @@ class ClusterLanguageFlag extends StatelessWidget {
                 color: theme.colorScheme.primary,
                 borderRadius: BorderRadius.circular(_radius + _borderWidth),
               ),
+              foregroundDecoration: _focused
+                  ? BoxDecoration(
+                      borderRadius: BorderRadius.circular(
+                        _radius + _borderWidth,
+                      ),
+                      border: Border.all(
+                        color: AppConfig.goldByTheme(context),
+                        width: 2,
+                      ),
+                    )
+                  : null,
               child: language.shouldShowFlag
                   ? ClipRRect(
                       borderRadius: BorderRadius.circular(_radius),

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -243,193 +243,229 @@ class WorkspaceShell extends StatelessWidget {
           // The persistent WorldMap stays full-bleed (edge to edge, behind the
           // status bar) as the base layer — routing.instructions.md. Only the
           // foreground chrome/panels sit inside the SafeArea below.
-          body: Stack(
-            fit: StackFit.expand,
-            children: [
-              /// Persistent world map — the base layer everything overlays. Overlays pad the
-              /// camera so a course fit lands in the exposed area: left = rail + column +
-              /// detail; right = the panel zone.
-              WorldMap(
-                key: _persistentWorldMapKey,
-                leftOverlayWidth: l.mapLeftOverlay,
-                rightOverlayWidth: l.allocation.mapRightOverlay,
-                bottomOverlayHeight: l.mapBottomOverlay,
-                availableVisibleMapWidth: l.availableVisibleMapWidth,
-                focus: mapFocusFor(state),
-              ),
+          //
+          // Tab order over the whole shell is EXPLICIT (#7219): the search
+          // overlay lives deep inside the WorldMap base layer while the rail
+          // and cluster are siblings up here, so geometric reading order (the
+          // framework default) put the map chrome in an unpredictable spot —
+          // the activity search bar was effectively unreachable via Tab. The
+          // ordered group pins rail (1) → map search overlay (2, mounted in
+          // world_map_view.dart) → user cluster (3); everything unordered
+          // (open panels, the narrow nav widget, map pins) follows in reading
+          // order.
+          body: FocusTraversalGroup(
+            policy: OrderedTraversalPolicy(),
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                /// Persistent world map — the base layer everything overlays. Overlays pad the
+                /// camera so a course fit lands in the exposed area: left = rail + column +
+                /// detail; right = the panel zone.
+                WorldMap(
+                  key: _persistentWorldMapKey,
+                  leftOverlayWidth: l.mapLeftOverlay,
+                  rightOverlayWidth: l.allocation.mapRightOverlay,
+                  bottomOverlayHeight: l.mapBottomOverlay,
+                  availableVisibleMapWidth: l.availableVisibleMapWidth,
+                  focus: mapFocusFor(state),
+                ),
 
-              // Everything above the map respects the device safe area; the
-              // map itself does not (it is full-bleed, see above).
-              Positioned.fill(
-                child: SafeArea(
-                  child: Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      /// The route canvas, as one stable child
-                      Positioned(
-                        left: l.leftInset,
-                        top: 0,
-                        bottom: 0,
-                        right: 0,
-                        width: null,
-                        child: Offstage(child: l.canvasChild),
-                      ),
-
-                      /// The narrow floating nav widget: the 4-item rail with the
-                      /// expandable cavity above it hosting the focused section surface
-                      /// (the chat list, the Courses hub, a course card) bare — the widget
-                      /// is the card. Hidden while a map-pin preview sheet is open (the
-                      /// map owns that selection; the notifier carries the signal up), and
-                      /// entirely absent under a focused full-screen surface. See
-                      /// `routing.instructions.md` → Single-column bottom nav.
-                      if (l.navWidgetVisible)
-                        ValueListenableBuilder<bool>(
-                          valueListenable: WorldMapPinsManager.notifier,
-                          builder: (context, pinSheetOpen, child) =>
-                              pinSheetOpen ? const SizedBox.shrink() : child!,
-                          child: _MobileNavLayer(
-                            state: state,
-                            layout: l,
-                            screenPadding: MediaQuery.viewPaddingOf(context),
-                            // Only the keyboard's overlap BEYOND the bottom safe
-                            // area (home indicator) should trim the cavity: once
-                            // the keyboard covers that strip, the SafeArea stops
-                            // reserving it and the bottom-anchored nav layer
-                            // already drops by that much. Trimming by the raw
-                            // inset would double-count it and settle the cavity
-                            // top ~34pt low. Read above the Scaffold, where
-                            // `viewInsets` is still intact (#7754).
-                            keyboardInset:
-                                (MediaQuery.viewInsetsOf(context).bottom -
-                                        MediaQuery.viewPaddingOf(
-                                          context,
-                                        ).bottom)
-                                    .clamp(0.0, double.infinity),
+                // Everything above the map respects the device safe area; the
+                // map itself does not (it is full-bleed, see above).
+                Positioned.fill(
+                  child: SafeArea(
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        /// The route canvas, as one stable child. It is
+                        /// permanently offstage (all detail renders as panels
+                        /// since #7921), but Offstage alone does NOT remove its
+                        /// descendants from focus traversal — Tab landed on
+                        /// invisible widgets here, an indistinguishable "nothing
+                        /// selected" stop (#7219). ExcludeFocus keeps the hidden
+                        /// navigator out of the tab cycle.
+                        Positioned(
+                          left: l.leftInset,
+                          top: 0,
+                          bottom: 0,
+                          right: 0,
+                          width: null,
+                          child: ExcludeFocus(
+                            child: Offstage(child: l.canvasChild),
                           ),
                         ),
 
-                      /// The nav rail must size to its content, NOT fill the Stack: this Stack is
-                      /// StackFit.expand, which forces non-positioned children to full size — and the
-                      /// rail's root (opaque-canvas) Material would then paint over the entire
-                      /// persistent map below it (blank map; mobile was fine because the rail is
-                      /// `SizedBox.shrink` there). Align tops it left at its natural size so the map
-                      /// stays full-bleed behind it.
-                      Align(
-                        alignment: Alignment.topLeft,
-                        child: Padding(
-                          padding: const EdgeInsets.all(
-                            _ShellLayout.chromeMargin,
+                        /// The narrow floating nav widget: the 4-item rail with the
+                        /// expandable cavity above it hosting the focused section surface
+                        /// (the chat list, the Courses hub, a course card) bare — the widget
+                        /// is the card. Hidden while a map-pin preview sheet is open (the
+                        /// map owns that selection; the notifier carries the signal up), and
+                        /// entirely absent under a focused full-screen surface. See
+                        /// `routing.instructions.md` → Single-column bottom nav.
+                        if (l.navWidgetVisible)
+                          ValueListenableBuilder<bool>(
+                            valueListenable: WorldMapPinsManager.notifier,
+                            builder: (context, pinSheetOpen, child) =>
+                                pinSheetOpen ? const SizedBox.shrink() : child!,
+                            child: _MobileNavLayer(
+                              state: state,
+                              layout: l,
+                              screenPadding: MediaQuery.viewPaddingOf(context),
+                              // Only the keyboard's overlap BEYOND the bottom safe
+                              // area (home indicator) should trim the cavity: once
+                              // the keyboard covers that strip, the SafeArea stops
+                              // reserving it and the bottom-anchored nav layer
+                              // already drops by that much. Trimming by the raw
+                              // inset would double-count it and settle the cavity
+                              // top ~34pt low. Read above the Scaffold, where
+                              // `viewInsets` is still intact (#7754).
+                              keyboardInset:
+                                  (MediaQuery.viewInsetsOf(context).bottom -
+                                          MediaQuery.viewPaddingOf(
+                                            context,
+                                          ).bottom)
+                                      .clamp(0.0, double.infinity),
+                            ),
                           ),
-                          child: SpacesNavigationRail(
-                            state: state,
-                            showNavRail: l.navRail,
-                            naviRailWidth: FluffyThemes.navRailWidth + 1.0,
-                            activeSpaceId: activeSpaceIdFor(state.uri),
-                          ),
-                        ),
-                      ),
 
-                      /// Left-column panels (the chat list, a live room, a course, the
-                      /// settings/profile menu) from `?left=`, each at its allocator slot. The
-                      /// floating-card chrome AND margin live in [PanelCard] (inside
-                      /// WorkspaceLeftPanel), shared with the right column and the center detail.
-                      /// Keyed by token so opening/closing a sibling panel doesn't shift indices and
-                      /// remount this one; a `room` panel additionally carries a roomId GlobalKey so
-                      /// its ChatController repositions rather than remounts when the slot moves.
-                      ...[
-                        for (var i = 0; i < l.leftTokens.length; i++)
-                          // Skip the cavity-hosted surface (the chat list, the Courses
-                          // hub, a course card) — it renders inside the nav widget's
-                          // cavity, not as a full-screen left panel (no double-render).
-                          if (i != l.cavityIndex &&
-                              l.allocation.left[i].vis != PanelVis.hidden)
-                            Positioned(
-                              key: ValueKey(l.leftTokens[i].encode()),
-                              // The narrow full-screen focus (a live room / session) is
-                              // FULL-BLEED: no card chrome, edge to edge, top 0 — its own
-                              // app bar absorbs the status-bar inset, and skipping the
-                              // shell's extra safe-area offset removes the doubled top
-                              // padding (#7554). Column-mode / non-focused panels keep
-                              // the card and respect the top inset so their close/back
-                              // control clears the system top bar (#7143); PanelCard's
-                              // 12px top margin aligns them with the top-right cluster.
-                              top: 0,
-                              bottom: 0,
-                              left: l.allocation.left[i].left,
-                              width: l.allocation.left[i].width,
-                              child: LeftPanelLayer(
-                                token: l.leftTokens[i],
+                        /// The nav rail must size to its content, NOT fill the Stack: this Stack is
+                        /// StackFit.expand, which forces non-positioned children to full size — and the
+                        /// rail's root (opaque-canvas) Material would then paint over the entire
+                        /// persistent map below it (blank map; mobile was fine because the rail is
+                        /// `SizedBox.shrink` there). Align tops it left at its natural size so the map
+                        /// stays full-bleed behind it.
+                        // Tab stop 1 of the shell's ordered traversal (#7219):
+                        // World → Chats → Courses come first.
+                        FocusTraversalOrder(
+                          order: const NumericFocusOrder(1),
+                          child: Align(
+                            alignment: Alignment.topLeft,
+                            child: Padding(
+                              padding: const EdgeInsets.all(
+                                _ShellLayout.chromeMargin,
+                              ),
+                              child: SpacesNavigationRail(
                                 state: state,
-                                foldedOver: l.allocation.left[i].foldedOver,
-                                getRoomKey: _roomKeyFor,
-                                bare:
-                                    !l.isColumnMode &&
-                                    l.allocation.left[i].vis == PanelVis.full,
+                                showNavRail: l.navRail,
+                                naviRailWidth: FluffyThemes.navRailWidth + 1.0,
+                                activeSpaceId: activeSpaceIdFor(state.uri),
                               ),
                             ),
-                      ],
+                          ),
+                        ),
 
-                      /// Right-column panels (analytics summary, a vocab/grammar detail, a
-                      /// completed-activity review) from `?right=`, each placed at its allocator
-                      /// slot. The slots tile and never overlap by construction; a folded slot is
-                      /// `hidden` (not drawn), its content one back-step away on the higher-priority
-                      /// sibling that stayed.
-                      ...[
-                        for (var i = 0; i < l.rightTokens.length; i++)
-                          if (l.allocation.right[i].vis != PanelVis.hidden)
-                            Positioned(
-                              // Keyed by token so a left-column open/close (which shifts sibling
-                              // indices in this Stack) reconciles the right panel by identity, not
-                              // position — otherwise its stateful content (analytics, a detail) would
-                              // remount and re-fetch.
-                              key: ValueKey(l.rightTokens[i].encode()),
-                              // Respect the top safe-area inset so the close/back control clears the
-                              // system top bar (#7143). On narrow the analytics bar heads the panel
-                              // ("the analytics bar itself remains visible at the top throughout" —
-                              // routing.instructions.md), so the panel starts below it.
-                              top: l.isColumnMode
-                                  ? 0
-                                  : _ShellLayout.analyticsBarAllowance,
-                              bottom: 0,
-                              left: l.allocation.right[i].left,
-                              width: l.allocation.right[i].width,
-                              child: FocusTraversalGroup(
-                                policy: OrderedTraversalPolicy(),
-                                child: WorkspaceRightPanel(
-                                  token: l.rightTokens[i],
-                                  currentUri: state.uri,
-                                  foldedOver: l.allocation.right[i].foldedOver,
+                        /// Left-column panels (the chat list, a live room, a course, the
+                        /// settings/profile menu) from `?left=`, each at its allocator slot. The
+                        /// floating-card chrome AND margin live in [PanelCard] (inside
+                        /// WorkspaceLeftPanel), shared with the right column and the center detail.
+                        /// Keyed by token so opening/closing a sibling panel doesn't shift indices and
+                        /// remount this one; a `room` panel additionally carries a roomId GlobalKey so
+                        /// its ChatController repositions rather than remounts when the slot moves.
+                        ...[
+                          for (var i = 0; i < l.leftTokens.length; i++)
+                            // Skip the cavity-hosted surface (the chat list, the Courses
+                            // hub, a course card) — it renders inside the nav widget's
+                            // cavity, not as a full-screen left panel (no double-render).
+                            if (i != l.cavityIndex &&
+                                l.allocation.left[i].vis != PanelVis.hidden)
+                              Positioned(
+                                key: ValueKey(l.leftTokens[i].encode()),
+                                // The narrow full-screen focus (a live room / session) is
+                                // FULL-BLEED: no card chrome, edge to edge, top 0 — its own
+                                // app bar absorbs the status-bar inset, and skipping the
+                                // shell's extra safe-area offset removes the doubled top
+                                // padding (#7554). Column-mode / non-focused panels keep
+                                // the card and respect the top inset so their close/back
+                                // control clears the system top bar (#7143); PanelCard's
+                                // 12px top margin aligns them with the top-right cluster.
+                                top: 0,
+                                bottom: 0,
+                                left: l.allocation.left[i].left,
+                                width: l.allocation.left[i].width,
+                                child: LeftPanelLayer(
+                                  token: l.leftTokens[i],
+                                  state: state,
+                                  foldedOver: l.allocation.left[i].foldedOver,
+                                  getRoomKey: _roomKeyFor,
+                                  bare:
+                                      !l.isColumnMode &&
+                                      l.allocation.left[i].vis == PanelVis.full,
                                 ),
                               ),
-                            ),
-                      ],
+                        ],
 
-                      /// The right column's entry point. In column mode: the persistent
-                      /// top-right vertical cluster, in the gutter the allocator reserves.
-                      /// On narrow: the horizontal ANALYTICS NAV BAR pinned to the top
-                      /// safe area — full form only, on the surfaces where it IS
-                      /// navigation (the map/cavity ground and the right panels it
-                      /// heads). A full-screen chat hosts the avatar in its own app bar
-                      /// instead, and a route-driven detail page shows nothing. See
-                      /// `routing.instructions.md` → Single-column analytics nav bar.
-                      if (l.isColumnMode && l.allocation.clusterVisible)
-                        Positioned(
-                          top: _ShellLayout.chromeMargin,
-                          right: _ShellLayout.chromeMargin,
-                          child: WorldUserCluster(key: _userClusterKey),
-                        )
-                      else if (l.analyticsBarVisible)
-                        Positioned(
-                          top: _ShellLayout.chromeMargin,
-                          left: _ShellLayout.chromeMargin,
-                          right: _ShellLayout.chromeMargin,
-                          child: WorldAnalyticsBar(key: _userClusterKey),
-                        ),
-                    ],
+                        /// Right-column panels (analytics summary, a vocab/grammar detail, a
+                        /// completed-activity review) from `?right=`, each placed at its allocator
+                        /// slot. The slots tile and never overlap by construction; a folded slot is
+                        /// `hidden` (not drawn), its content one back-step away on the higher-priority
+                        /// sibling that stayed.
+                        ...[
+                          for (var i = 0; i < l.rightTokens.length; i++)
+                            if (l.allocation.right[i].vis != PanelVis.hidden)
+                              Positioned(
+                                // Keyed by token so a left-column open/close (which shifts sibling
+                                // indices in this Stack) reconciles the right panel by identity, not
+                                // position — otherwise its stateful content (analytics, a detail) would
+                                // remount and re-fetch.
+                                key: ValueKey(l.rightTokens[i].encode()),
+                                // Respect the top safe-area inset so the close/back control clears the
+                                // system top bar (#7143). On narrow the analytics bar heads the panel
+                                // ("the analytics bar itself remains visible at the top throughout" —
+                                // routing.instructions.md), so the panel starts below it.
+                                top: l.isColumnMode
+                                    ? 0
+                                    : _ShellLayout.analyticsBarAllowance,
+                                bottom: 0,
+                                left: l.allocation.right[i].left,
+                                width: l.allocation.right[i].width,
+                                child: FocusTraversalGroup(
+                                  policy: OrderedTraversalPolicy(),
+                                  child: WorkspaceRightPanel(
+                                    token: l.rightTokens[i],
+                                    currentUri: state.uri,
+                                    foldedOver:
+                                        l.allocation.right[i].foldedOver,
+                                  ),
+                                ),
+                              ),
+                        ],
+
+                        /// The right column's entry point. In column mode: the persistent
+                        /// top-right vertical cluster, in the gutter the allocator reserves.
+                        /// On narrow: the horizontal ANALYTICS NAV BAR pinned to the top
+                        /// safe area — full form only, on the surfaces where it IS
+                        /// navigation (the map/cavity ground and the right panels it
+                        /// heads). A full-screen chat hosts the avatar in its own app bar
+                        /// instead, and a route-driven detail page shows nothing. See
+                        /// `routing.instructions.md` → Single-column analytics nav bar.
+                        // Tab stop 3 (#7219): Settings avatar → trackers →
+                        // level medal → language flag, after the map's search
+                        // overlay (stop 2, mounted in world_map_view.dart).
+                        if (l.isColumnMode && l.allocation.clusterVisible)
+                          Positioned(
+                            top: _ShellLayout.chromeMargin,
+                            right: _ShellLayout.chromeMargin,
+                            child: FocusTraversalOrder(
+                              order: const NumericFocusOrder(3),
+                              child: WorldUserCluster(key: _userClusterKey),
+                            ),
+                          )
+                        else if (l.analyticsBarVisible)
+                          Positioned(
+                            top: _ShellLayout.chromeMargin,
+                            left: _ShellLayout.chromeMargin,
+                            right: _ShellLayout.chromeMargin,
+                            child: FocusTraversalOrder(
+                              order: const NumericFocusOrder(3),
+                              child: WorldAnalyticsBar(key: _userClusterKey),
+                            ),
+                          ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/test/pangea/navigation/cluster_keyboard_focus_test.dart
+++ b/test/pangea/navigation/cluster_keyboard_focus_test.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/languages/language_model.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/world_user_cluster.dart';
+import 'package:fluffychat/widgets/avatar.dart';
+
+/// Keyboard reachability for the cluster's Settings avatar and language flag
+/// (#7219): both were bare GestureDetectors with no focus node, so Tab skipped
+/// them entirely — the "Settings" and "Learning settings" stops in the shell's
+/// expected tab order could never be reached or activated by keyboard. They
+/// are InkWell-backed now; these tests pin that each one takes focus from a
+/// single Tab, shows its gold focus ring, and fires its tap on Enter.
+void main() {
+  setUpAll(() {
+    // `Avatar` resolves the bot name from the environment at build time;
+    // initialize dotenv with an inline value so no real `.env` file is needed
+    // (CI has none).
+    dotenv.testLoad(fileInput: 'BOT_NAME=@bot:example.org');
+    // The flag chip fetches its SVG over HTTP; the test binding's default
+    // client 400s every request with an empty body, which the SVG parser
+    // reports as an uncatchable async "Invalid SVG data" zone error. Serve a
+    // minimal valid SVG instead so the real chip renders offline.
+    HttpOverrides.global = _FakeSvgHttpOverrides();
+  });
+
+  tearDownAll(() => HttpOverrides.global = null);
+
+  Future<void> pump(WidgetTester tester, Widget child) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(body: Center(child: child)),
+      ),
+    );
+    // The L10n delegates load asynchronously, so one pump isn't enough for
+    // the home to mount (same as the other mobile-chrome tests).
+    await tester.pumpAndSettle();
+  }
+
+  /// The widget under [finder] shows its focus ring: some descendant
+  /// Container carries a non-null foregroundDecoration.
+  bool showsFocusRing(WidgetTester tester, Finder finder) => tester
+      .widgetList<Container>(
+        find.descendant(of: finder, matching: find.byType(Container)),
+      )
+      .any((c) => c.foregroundDecoration != null);
+
+  testWidgets('settings avatar: Tab focuses it, ring shows, Enter activates', (
+    tester,
+  ) async {
+    var taps = 0;
+    await pump(
+      tester,
+      ClusterAvatar(avatarUrl: null, name: 'Tester', onTap: () => taps++),
+    );
+
+    final avatar = find.byType(ClusterAvatar);
+    expect(showsFocusRing(tester, avatar), isFalse);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pumpAndSettle();
+    expect(
+      Focus.of(tester.element(find.byType(Avatar))).hasFocus,
+      isTrue,
+      reason: 'one Tab must land on the avatar (it is the only stop here)',
+    );
+    expect(showsFocusRing(tester, avatar), isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(taps, 1);
+  });
+
+  testWidgets('language flag: Tab focuses it, ring shows, Enter activates', (
+    tester,
+  ) async {
+    var taps = 0;
+    final es = LanguageModel(langCode: 'es-ES', displayName: 'Spanish');
+    await pump(tester, ClusterLanguageFlag(language: es, onTap: () => taps++));
+
+    final flag = find.byType(ClusterLanguageFlag);
+    expect(showsFocusRing(tester, flag), isFalse);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pumpAndSettle();
+    expect(showsFocusRing(tester, flag), isTrue);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pumpAndSettle();
+    expect(taps, 1);
+  });
+}
+
+/// Serves every HTTP request a 200 with a minimal valid SVG body, replacing
+/// the test binding's default 400-everything client (see [main]'s setUpAll).
+/// `package:http`'s IOClient — what flutter_svg's network loader uses — runs
+/// on `dart:io`'s [HttpClient], so overriding at this level covers it.
+class _FakeSvgHttpOverrides extends HttpOverrides {
+  @override
+  HttpClient createHttpClient(SecurityContext? context) => _FakeHttpClient();
+}
+
+class _FakeHttpClient implements HttpClient {
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) async =>
+      _FakeHttpClientRequest();
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) async => _FakeHttpClientRequest();
+
+  // Config setters/getters IOClient pokes (autoUncompress etc.) — accept and
+  // ignore everything else.
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeHttpClientRequest implements HttpClientRequest {
+  @override
+  final HttpHeaders headers = _FakeHttpHeaders();
+
+  @override
+  Future<void> addStream(Stream<List<int>> stream) => stream.drain<void>();
+
+  @override
+  Future<HttpClientResponse> close() async => _FakeHttpClientResponse();
+
+  @override
+  Future<HttpClientResponse> get done => close();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeHttpClientResponse extends Stream<List<int>>
+    implements HttpClientResponse {
+  static final List<int> _svgBytes = utf8.encode(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>',
+  );
+
+  @override
+  int get statusCode => 200;
+
+  @override
+  String get reasonPhrase => 'OK';
+
+  @override
+  int get contentLength => _svgBytes.length;
+
+  @override
+  bool get isRedirect => false;
+
+  @override
+  bool get persistentConnection => false;
+
+  @override
+  HttpClientResponseCompressionState get compressionState =>
+      HttpClientResponseCompressionState.notCompressed;
+
+  @override
+  List<RedirectInfo> get redirects => const [];
+
+  @override
+  final HttpHeaders headers = _FakeHttpHeaders();
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) => Stream<List<int>>.value(_svgBytes).listen(
+    onData,
+    onError: onError,
+    onDone: onDone,
+    cancelOnError: cancelOnError,
+  );
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeHttpHeaders implements HttpHeaders {
+  @override
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {}
+
+  @override
+  void forEach(void Function(String name, List<String> values) action) {}
+
+  @override
+  List<String>? operator [](String name) => null;
+
+  @override
+  String? value(String name) => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}


### PR DESCRIPTION
Closes #7219 (part of #7185)

## Problem

Tabbing on the main page went World → Chats → Courses → **???** → (eventually, sometimes) the activity tags — the Search Activities bar was effectively unreachable, and one stop showed no visible selection at all.

Three distinct gaps caused this:

1. **No explicit focus order existed anywhere in the app.** Every existing `OrderedTraversalPolicy` had zero `FocusTraversalOrder` wrappers, so tab order fell back to geometric reading order. The search overlay is mounted deep inside the persistent `WorldMap` base layer while the nav rail and top-right cluster are shell-level siblings, so the overlay's position in the cycle was unpredictable and usually wrong.
2. **The "???" stop was an invisible widget.** The route canvas in the shell is permanently offstage (since #7921), but `Offstage` does not remove its descendants from focus traversal — Tab was landing on hidden UI with no visible indication.
3. **The Settings avatar and language flag had no focus node at all.** Both were bare `GestureDetector`s, so Tab could never reach Settings/Learning-settings regardless of ordering.

## Changes

- `workspace_shell.dart`: the shell body is now a `FocusTraversalGroup(OrderedTraversalPolicy)` with pinned stops — nav rail (1) → map search overlay (2) → user cluster (3); unordered focusables (open panels, the narrow nav widget, map pins) follow in reading order. The offstage route canvas is wrapped in `ExcludeFocus`.
- `world_map_view.dart`: the search overlay's mount point carries `FocusTraversalOrder(2)`, so Tab reaches the search field right after Courses, then its three filter pills left-to-right, then the filter-reset button.
- `world_user_cluster.dart`: `ClusterAvatar` (Settings) and `ClusterLanguageFlag` (Learning settings) are now `InkWell`-backed — focusable, Enter/Space-activatable, and each shows a gold focus ring when focused (their fills are opaque, so the InkWell's behind-the-child highlight alone was invisible). Semantics labels and tap behavior are unchanged; `WorldAnalyticsBar` reuses these same widgets, so the narrow layout gets the fix too.
- New test `cluster_keyboard_focus_test.dart`: pins that one Tab focuses the avatar/flag, the focus ring appears, and Enter fires their action.

## TO TEST

- [ ] Log in on a desktop-width window with the world map showing and press Tab 4 times: World → Chats → Courses → the **Search Activities bar** is focused (text cursor blinking in the field)
- [ ] Type immediately — characters appear in the search field and results filter
- [ ] Keep tabbing: the three filter pills (Level, Party size, Status) focus **left to right**, then the filter-reset button; Enter opens a pill's menu
- [ ] Keep tabbing: Settings avatar (gold ring appears), then the Stars/Grammar/Vocab trackers, level medal, and language flag (gold ring) — Enter on each opens its page
- [ ] Repeat the 4-Tab check after navigating around (open/close a chat, switch sections, click the map, then Shift-Tab/Tab back) — the search bar stays reachable, and no Tab press ever lands on "nothing visible"

## Testing done

- `fvm flutter test` — full suite, 1875 passed / 3 skipped
- New keyboard-focus widget tests pass; `fvm dart analyze` and `fvm dart format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved keyboard navigation order across the world map and workspace interface.
  - Added visible focus indicators and keyboard activation support for user avatars and language flags.
  - Ensured hidden map content is skipped during keyboard traversal.

- **Bug Fixes**
  - Corrected focus movement between navigation, search, map controls, and analytics areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->