### PR TITLE
docs: describe how the client should refresh subscription statuses

### DIFF
--- a/.github/instructions/subscriptions.instructions.md
+++ b/.github/instructions/subscriptions.instructions.md
@@ -11,7 +11,7 @@ The client holds no payment state. It reads entitlement status from the choreogr
 
 ## Entitlement state
 
-[`SubscriptionController`](../../lib/features/subscription/controllers/subscription_controller.dart) resolves the user's status from the choreographer on startup and on app resume — returning from web checkout must feel immediate, and server-side grants (seats, trials, comps) appear the same way. There is no RevenueCat SDK and no store-package merging: entitlement is a choreographer-served record that the app reflects, never unlocks. Paid features gate on `showSubscriptionGatedContent`; the paywall surfaces only when the user is unsubscribed outside the trial window and hasn't dismissed it.
+[`SubscriptionController`](../../lib/features/subscription/controllers/subscription_controller.dart) resolves the user's status from the choreographer on startup — returning from web checkout must feel immediate, and server-side grants (seats, trials, comps) appear the same way. There is no RevenueCat SDK and no store-package merging: entitlement is a choreographer-served record that the app reflects, never unlocks. Paid features gate on `showSubscriptionGatedContent`; the paywall surfaces only when the user is unsubscribed outside the trial window and hasn't dismissed it.
 
 ## Purchase surface
 
@@ -20,6 +20,21 @@ Which purchase surface the client renders — the plans, prices, discount field,
 ## Purchase flow
 
 Selecting a plan requests a checkout URL from the choreographer and opens it in the system browser ([`PaymentPageMixin`](../../lib/routes/settings/settings_subscription/payment_page_mixin.dart)). A `beganPayment` flag survives the round-trip, so returning to the app is recognized as a completed purchase and the entitlement refresh runs. The discount-code field validates the code server-side before checkout, so an error surfaces in the app and the code reaches Stripe pre-applied; the field appears only where the paywall may appear.
+
+## Refreshing subscription info
+
+Subscription info is initially fetched on session startup, and cached in the [SubscriptionController](../../lib/features/subscription/controllers/subscription_controller.dart) until explicitly reset. The client much refresh the cached subscription status info when it changes. All refreshes go through the SubscriptionController's [_updateCurrentSubscription](../../lib/features/subscription/controllers/subscription_controller.dart) function, which force-refreshes the cached value. The SubscriptionController calls this internally on startup ([_initialize](../../lib/features/subscription/controllers/subscription_controller.dart)), when a free trial is activated ([_activateNewUserTrial](../../lib/features/subscription/controllers/subscription_controller.dart)), and when the controller is explicitly reinitialized ([reinitialize](../../lib/features/subscription/controllers/subscription_controller.dart)). 
+
+The settings page pulls subscription status from the SubscriptionController instead of fetching that info itself, and rebuilds automatically when updates are made in the SubscriptionController.
+
+The client called reinitialize when:
+1. A new user logs in ([PangeaController._onLogin](../../lib/pangea/common/controllers/pangea_controller.dart))
+2. After a user creates an account, to trigger free trial activation
+3. When a checkout request fails because the user already has a subscription. This is a fallback to account for the cache not being updated for a user with a subscription, so the UI allows them to start the checkout flow.
+4. After a user cancels their subscription via the "Cancel" button in the [SubscriptionHistory](../../lib/routes/settings/settings_subscription/subscription_history.dart) page
+5. When a refresh button is pressed in the errored-out subscription settings view
+
+The client tracks potential subscription changes via the [SubscriptionManagementRepo](../../lib/features/subscription/repo_v2/subscription_management_repo.dart). It tracks if the user has started a payment and if the user has launched their billing portal, which can be used to cancel or restart subscriptions. The client uses with info the the [didChangeAppLifecycleState](../../lib/widgets/matrix.dart) override in [Matrix](../../lib/widgets/matrix.dart) to poll for refreshes to the subscription status when the user returns to the app. The polling has an exponential backoff, with a maximum of 5 calls to the status endpoint.
 
 ## Managing a subscription
 

--- a/lib/features/subscription/controllers/subscription_controller.dart
+++ b/lib/features/subscription/controllers/subscription_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 
@@ -22,6 +23,7 @@ class SubscriptionController {
     SubscriptionLoading(),
   );
   Completer<void>? _initCompleter;
+  bool _refreshingOnResume = false;
   final ValueNotifier<bool> subscriptionNotifier = ValueNotifier<bool>(false);
 
   ValueNotifier<SubscriptionState> get state => _state;
@@ -118,17 +120,65 @@ class SubscriptionController {
         await _activateNewUserTrial(userID);
       }
 
-      final isSubscribed = _state.value is SubscriptionActive;
-      final beganPayment = SubscriptionManagementRepo.getBeganPayment();
-      if (beganPayment && isSubscribed) {
-        final planId = SubscriptionManagementRepo.getBeganPaymentPlanId();
-        await SubscriptionManagementRepo.removeBeganPayment();
-        GoogleAnalytics.purchaseSubscription(planId);
-        _onSubscribe();
-      }
+      await _completeBeganPayment();
     } catch (e, s) {
       ErrorHandler.logError(e: e, s: s, data: {});
       _state.value = SubscriptionError(error: e);
+    }
+  }
+
+  Future<void> _completeBeganPayment() async {
+    final isSubscribed = _state.value is SubscriptionActive;
+    final beganPayment = SubscriptionManagementRepo.getBeganPayment();
+    if (beganPayment && isSubscribed) {
+      final planId = SubscriptionManagementRepo.getBeganPaymentPlanId();
+      await SubscriptionManagementRepo.removeBeganPayment();
+      GoogleAnalytics.purchaseSubscription(planId);
+      _onSubscribe();
+    }
+  }
+
+  /// App-resume refresh: when a checkout or billing-portal round trip may
+  /// have changed the subscription, poll the status endpoint until the
+  /// server reflects a change from the cached value. The portal flag is
+  /// consumed after one round either way — portal visits that change
+  /// nothing must not leave the app re-polling on every resume — while
+  /// [SubscriptionManagementRepo.getBeganPayment] persists until a
+  /// subscription is observed, so a checkout completed after an early
+  /// bounce back to the app is still picked up.
+  Future<void> refreshOnAppResume(String? userID) async {
+    if (userID == null || _refreshingOnResume) return;
+    if (_initCompleter?.isCompleted != true) return;
+
+    final beganPayment = SubscriptionManagementRepo.getBeganPayment();
+    final launchedBillingPortal =
+        SubscriptionManagementRepo.getLaunchedBillingPortal();
+    if (!beganPayment && !launchedBillingPortal) return;
+
+    _refreshingOnResume = true;
+    try {
+      final previous = subscriptionStatus;
+      final previousJson = previous == null
+          ? null
+          : jsonEncode(previous.toJson());
+      final response = await SubscriptionStatusRepo.instance
+          .pollSubscriptionStatus(
+            SubscriptionStatusRequest(userID: userID),
+            (r) =>
+                previousJson == null || jsonEncode(r.toJson()) != previousJson,
+          );
+
+      if (response != null) {
+        _state.value = SubscriptionState.fromSubscriptionStatus(response);
+        await _completeBeganPayment();
+      }
+    } catch (e, s) {
+      ErrorHandler.logError(e: e, s: s, data: {});
+    } finally {
+      if (launchedBillingPortal) {
+        await SubscriptionManagementRepo.removeLaunchedBillingPortal();
+      }
+      _refreshingOnResume = false;
     }
   }
 

--- a/lib/features/subscription/repo_v2/subscription_management_repo.dart
+++ b/lib/features/subscription/repo_v2/subscription_management_repo.dart
@@ -27,6 +27,21 @@ class SubscriptionManagementRepo {
     await _cache.remove(PLocalKey.beganPaymentPlanId);
   }
 
+  static bool getLaunchedBillingPortal() {
+    return _cache.read(PLocalKey.launchedBillingPortal) ?? false;
+  }
+
+  /// Portal actions (cancel, renew, card change) happen outside the app, so
+  /// this flag marks that the status may have changed while the app was
+  /// backgrounded. The app-resume poll consumes it.
+  static Future<void> setLaunchedBillingPortal() async {
+    await _cache.write(PLocalKey.launchedBillingPortal, true);
+  }
+
+  static Future<void> removeLaunchedBillingPortal() async {
+    await _cache.remove(PLocalKey.launchedBillingPortal);
+  }
+
   static bool getDismissedPaywall() {
     final entry = _cache.read(PLocalKey.dismissedPaywall);
     if (entry == null) return false;

--- a/lib/pangea/common/constants/local.key.dart
+++ b/lib/pangea/common/constants/local.key.dart
@@ -5,6 +5,7 @@ class PLocalKey {
   static const String cachedActivityToOpenAt = "cachedactivitytoopenat";
   static const String beganPayment = "beganWebPayment";
   static const String beganPaymentPlanId = "beganWebPaymentPlanId";
+  static const String launchedBillingPortal = "launchedBillingPortal";
   static const String dismissedPaywall = 'dismissedPaywall';
   static const String paywallBackoff = 'paywallBackoff';
   static const String clickedCancelSubscription = 'clickedCancelSubscription';

--- a/lib/routes/settings/settings_subscription/subscription_history.dart
+++ b/lib/routes/settings/settings_subscription/subscription_history.dart
@@ -11,6 +11,7 @@ import 'package:fluffychat/features/subscription/repo_v2/products_request.dart';
 import 'package:fluffychat/features/subscription/repo_v2/products_response.dart';
 import 'package:fluffychat/features/subscription/repo_v2/subscription_cancel_repo.dart';
 import 'package:fluffychat/features/subscription/repo_v2/subscription_cancel_request.dart';
+import 'package:fluffychat/features/subscription/repo_v2/subscription_management_repo.dart';
 import 'package:fluffychat/features/subscription/repo_v2/subscription_status_repo.dart';
 import 'package:fluffychat/features/subscription/repo_v2/subscription_status_request.dart';
 import 'package:fluffychat/features/subscription/repo_v2/subscription_status_response.dart';
@@ -197,7 +198,11 @@ class SubscriptionHistoryState extends State<SubscriptionHistory> {
       throw "Cannot manage subscription without billing portal link";
     }
 
-    await launchUrlString(billingPortal);
+    await SubscriptionManagementRepo.setLaunchedBillingPortal();
+    final success = await launchUrlString(billingPortal);
+    if (!success) {
+      await SubscriptionManagementRepo.removeLaunchedBillingPortal();
+    }
   }
 
   @override

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -682,6 +682,10 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
         Logs().v('Set background sync to', foreground);
       }
     }
+
+    if (state == AppLifecycleState.resumed) {
+      pangeaController.subscriptionController.refreshOnAppResume(client.userID);
+    }
   }
 
   @override


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
