### PR TITLE
fix(activities): send session room id in course ping payload

### DIFF
--- a/lib/features/notifications/notification_tap_utils.dart
+++ b/lib/features/notifications/notification_tap_utils.dart
@@ -130,7 +130,11 @@ class NotificationTapUtil {
   }) {
     try {
       final session = client.getRoomById(sessionRoomId);
-      if (session?.membership == Membership.join) {
+      // Pings sent before #8138 carry the course space id instead of the
+      // session room id, so a space here falls through to the activity page.
+      if (session != null &&
+          !session.isSpace &&
+          session.membership == Membership.join) {
         router.go(
           WorkspaceNav.openRoomById(
             router.routeInformationProvider.value.uri,

--- a/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
@@ -181,6 +181,7 @@ class ConfirmedRoleSessionController extends State<ConfirmedRoleSession>
         widget.room.getLocalizedDisplayname(MatrixLocals(L10n.of(context))),
       ),
       activityId: widget.activityId,
+      sessionRoomId: widget.room.id,
     );
 
     if (mounted) {

--- a/lib/routes/chat/activity_sessions/course_ping_extension.dart
+++ b/lib/routes/chat/activity_sessions/course_ping_extension.dart
@@ -26,13 +26,16 @@ extension CoursePingRoomExtension on Room {
     }
   }
 
-  Future<void> sendActivityPing(String body, {required String activityId}) =>
-      sendEvent({
-        "body": body,
-        "msgtype": MessageTypes.Text,
-        CoursePingConstants.coursePingRoomId: id,
-        CoursePingConstants.coursePingActivityId: activityId,
-      });
+  Future<void> sendActivityPing(
+    String body, {
+    required String activityId,
+    required String sessionRoomId,
+  }) => sendEvent({
+    "body": body,
+    "msgtype": MessageTypes.Text,
+    CoursePingConstants.coursePingRoomId: sessionRoomId,
+    CoursePingConstants.coursePingActivityId: activityId,
+  });
 }
 
 extension on Event {


### PR DESCRIPTION
### What

Ping events now carry the activity session room id (not the course space id) in `pangea.activity.session_room_id`, and notification-tap routing falls back to the activity page when the payload's room is a space.

### Why

Closes #8138. Regression from #7842: `sendActivityPing` wrote `id` of the room it was called on into the payload, but its only caller invokes it on `courseParent` — so the "session room id" was the course space. Every ping recipient is a joined course member, so the tap handler's membership check always routed to `openRoomById` with a space id, and `LeftPanelRoomSubpage` renders spaces as the "You are no longer participating in this chat" page.

### Changes

- `course_ping_extension.dart` — `sendActivityPing` takes a required `sessionRoomId` and sends it instead of `id`.
- `confirmed_role_session_controller.dart` — passes `sessionRoomId: widget.room.id`.
- `notification_tap_utils.dart` — `_navigateToActivitySession` only opens the room as a chat when it is joined **and not a space**; otherwise it falls through to `openCourseActivity` (role selection). This makes already-sent pings with the bad payload degrade to the activity page instead of the error page.

### Testing

- `dart analyze` clean on touched files.
- `fvm flutter test`: 1899 passed; only failures are the 2 known local-baseline endpoint tests (`choreo_endpoint_test`, `cms_endpoint_test` — missing `TEST_MATRIX_*` creds), reproduced at base.
- Cross-device push flow (browser ping → mobile tap) can't run locally; verify on staging per the issue's TO TEST list.

### Deploy Notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)