### PR TITLE
docs: update description of world map zoom out to show available acti…

### DIFF
--- a/.github/instructions/world-map.instructions.md
+++ b/.github/instructions/world-map.instructions.md
@@ -156,7 +156,7 @@ Re-ranking is debounced on pan and zoom (as the working-set re-fetch already is)
 | [MapEmptyVerdict.noSearchMatches](../../lib/routes/world/world_map_filter.dart) | the query matches nothing loaded | no lever |
 | [MapEmptyVerdict.noActivities](../../lib/routes/world/world_map_filter.dart) | empty area, no query | *Zoom out* | 
 
-Zoom out **greys out at the [zoom floor](#what-appears-on-the-map)** rather than hiding, so the advice stays visible. 
+Zoom out **greys out at the [zoom floor](#what-appears-on-the-map)** rather than hiding, so the advice stays visible. On narrow, fully zooming out does not make the full map visible. When zooming out, attempt to zoom to a view of the map that shows the maximum number of possible visibile activities ([#8121](https://github.com/pangeachat/client/issues/8121)).
 
 On narrow, the card rides above the filter row (message first, then filters to act on); on the wide overlay it pins under the bar/filters. 
 

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -679,12 +679,35 @@ class WorldMapController extends State<WorldMap>
   /// step — a deliberate tap goes straight to focus, no peek.
   void flyTo(QuestActivityCard card) => openActivity(card);
 
-  /// Glide back to the whole-world view (the initial camera). Pins and search
-  /// only ever zoom the camera IN, so this is the one explicit "zoom out to
-  /// everything" affordance (#7086). Camera-only: the course scope, focus, and
-  /// open panels are untouched.
+  /// Glide back to the whole-world view. Pins and search only ever zoom the
+  /// camera IN, so this is the one explicit "zoom out to everything"
+  /// affordance (#7086). Camera-only: the course scope, focus, and open panels
+  /// are untouched.
+  ///
+  /// The center is not fixed (#8121): at the zoom floor a narrow viewport
+  /// shows only a slice of the world's longitudes, so a fixed (Europe-ish)
+  /// center could leave every matching activity off-screen with nothing left
+  /// to zoom. Center instead on the fullest viewport-sized window of the
+  /// currently-matching pins ([WorldMapConstants.worldResetCenter]), falling
+  /// back to the old fixed center when nothing is loaded.
   void resetToWorld() {
-    _animateCameraTo(const LatLng(20, 0), minZoom);
+    _animateCameraTo(_worldResetCenter(), minZoom);
+  }
+
+  /// The reset's target center: the view showing the maximum number of the
+  /// currently-matching pins (#8121) — the same [visiblePins] set the
+  /// empty-view card's matches-offscreen verdict counts, so its "Zoom out"
+  /// lever reveals the matches it promised.
+  LatLng _worldResetCenter() {
+    const fallback = LatLng(20, 0);
+    final Size viewport;
+    try {
+      viewport = mapController.camera.nonRotatedSize;
+    } catch (_) {
+      return fallback; // camera not laid out yet
+    }
+    final points = visiblePins.map((c) => c.point).whereType<LatLng>().toList();
+    return WorldMapConstants.worldResetCenter(viewport, points) ?? fallback;
   }
 
   /// The viewport-derived zoom-out floor (#7813, [WorldMapConstants.minZoomFor])

--- a/lib/routes/world/world_map_constants.dart
+++ b/lib/routes/world/world_map_constants.dart
@@ -2,6 +2,8 @@ import 'dart:math' as math;
 
 import 'package:flutter/animation.dart';
 
+import 'package:latlong2/latlong.dart';
+
 class WorldMapConstants {
   /// The camera zoom ceiling — the single source for FlutterMap's MapOptions,
   /// the +/- step clamp in [zoomBy], and the on-map control disabled states
@@ -167,4 +169,97 @@ class WorldMapConstants {
     final eased = Curves.easeInOut.transform(t);
     return (pan: eased, zoom: eased);
   }
+
+  /// Where the whole-world reset points the camera (#8121). At the
+  /// viewport-derived zoom floor ([minZoomFor]) one world copy fits the LARGER
+  /// viewport axis, so the smaller axis shows only a slice of the world — on a
+  /// portrait phone roughly half its longitudes — and a fixed center can leave
+  /// every activity outside that slice. Slide a window the size of the visible
+  /// slice over [points] and center on the fullest one (ties go to the tightest
+  /// cluster, so the pins land mid-screen rather than at an edge), so the reset
+  /// shows the maximum number of activities the floor allows. Longitude is the
+  /// free axis when the floor fits the height (phones); latitude — measured in
+  /// projected Mercator space, where the viewport height is a fixed fraction of
+  /// the world — when it fits the width (wide desktops). Null when [points] is
+  /// empty: the caller keeps its fixed fallback center.
+  static LatLng? worldResetCenter(Size viewport, List<LatLng> points) {
+    if (points.isEmpty) return null;
+    final worldPx =
+        _worldSideAtZoomZero * math.pow(2, minZoomFor(viewport)).toDouble();
+
+    // Longitude: a circular sliding window over the visible longitude span
+    // (the classic doubled-sorted-array walk, since longitudes wrap).
+    final lonSpan = math.min(360.0, viewport.width / worldPx * 360.0);
+    final lons = points.map((p) => p.longitude).toList()..sort();
+    final n = lons.length;
+    final ext = [...lons, ...lons.map((l) => l + 360)];
+    final lonWin = _fullestWindow(ext, n, lonSpan);
+    var centerLon = (ext[lonWin.first] + ext[lonWin.last]) / 2;
+    if (centerLon > 180) centerLon -= 360;
+
+    // Latitude picks among the points the longitude window kept — visibility
+    // needs both axes, and the longitude cut is the coarser of the two.
+    final lo = ext[lonWin.first], hi = ext[lonWin.last];
+    bool inLonWindow(double l) =>
+        (l >= lo && l <= hi) || (l + 360 >= lo && l + 360 <= hi);
+    final latFrac = math.min(1.0, viewport.height / worldPx);
+    final ys =
+        points
+            .where((p) => inLonWindow(p.longitude))
+            .map((p) => _mercatorY(p.latitude))
+            .toList()
+          ..sort();
+    final latWin = _fullestWindow(ys, ys.length, latFrac);
+    final centerLat = _latFromMercatorY(
+      (ys[latWin.first] + ys[latWin.last]) / 2,
+    );
+    return LatLng(centerLat, centerLon);
+  }
+
+  /// The (first, last) indices of the fullest [span]-wide window over the first
+  /// [n] window-start candidates of sorted [values]; ties prefer the tightest
+  /// spread. Two-pointer walk — [values] may be the doubled array of a circular
+  /// domain, with [n] the real count so every rotation is tried exactly once.
+  static ({int first, int last}) _fullestWindow(
+    List<double> values,
+    int n,
+    double span,
+  ) {
+    var bestFirst = 0, bestLast = 0, bestCount = 0;
+    var j = 0;
+    for (var i = 0; i < n; i++) {
+      if (j < i) j = i;
+      while (j + 1 < i + n &&
+          j + 1 < values.length &&
+          values[j + 1] - values[i] <= span) {
+        j++;
+      }
+      final count = j - i + 1;
+      final spread = values[j] - values[i];
+      if (count > bestCount ||
+          (count == bestCount &&
+              spread < values[bestLast] - values[bestFirst])) {
+        bestCount = count;
+        bestFirst = i;
+        bestLast = j;
+      }
+    }
+    return (first: bestFirst, last: bestLast);
+  }
+
+  /// Web-Mercator projection of a latitude to normalized world y in [0, 1]
+  /// (0 = north edge), clamped to the projection's ±85.05° band — the linear
+  /// space the sliding latitude window must run in, since screen pixels are
+  /// linear in projected y, not in degrees.
+  static double _mercatorY(double latDeg) {
+    final lat = latDeg.clamp(-_maxMercatorLat, _maxMercatorLat) * math.pi / 180;
+    return (1 - math.log(math.tan(math.pi / 4 + lat / 2)) / math.pi) / 2;
+  }
+
+  static double _latFromMercatorY(double y) =>
+      (2 * math.atan(math.exp(math.pi * (1 - 2 * y))) - math.pi / 2) *
+      180 /
+      math.pi;
+
+  static const double _maxMercatorLat = 85.05112878;
 }

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -1061,9 +1061,10 @@ class _WorldMapViewState extends State<WorldMapView> {
                 onReset: widget.controller.resetFilters,
                 emptyVerdict: widget.controller.emptyVerdict,
                 canZoomOut: widget.controller.canZoomOut,
-                // "Zoom out" resets to the whole-world view (all the way out and
-                // re-centered), the same as the map's World control — one tap
-                // guarantees every off-screen match comes into view.
+                // "Zoom out" resets to the whole-world view (all the way out,
+                // centered over the fullest window of matching pins, #8121),
+                // the same as the map's World control — one tap brings the
+                // most matches a floor-zoomed viewport can show into view.
                 onZoomOut: widget.controller.resetToWorld,
               ),
             ),

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -548,9 +548,10 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
             emptyVerdict: () => mapController.emptyVerdict,
             canZoomOut: () => mapController.canZoomOut,
             onWidenSearch: mapController.widenFilters,
-            // Resets to the whole-world view (all the way out, re-centered) —
-            // the map's World control — so one tap reveals every off-screen
-            // match, not just the next zoom level.
+            // Resets to the whole-world view (all the way out, centered over
+            // the fullest window of matching pins, #8121) — the map's World
+            // control — so one tap reveals the most matches a floor-zoomed
+            // narrow viewport can show, not just the next zoom level.
             onZoomOut: mapController.resetToWorld,
             viewRevision: mapController.viewRevision,
             // The collapsible filter surface riding above the bar — the narrow

--- a/test/pangea/world_map_zoom_test.dart
+++ b/test/pangea/world_map_zoom_test.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
 
 import 'package:fluffychat/routes/world/world_map_constants.dart';
 
@@ -94,6 +95,110 @@ void main() {
         WorldMapConstants.fallbackMinZoom,
         lessThan(WorldMapConstants.maxZoom),
       );
+    });
+  });
+
+  // The whole-world reset centers on the fullest viewport-sized window of the
+  // given pins (#8121): at the zoom floor a portrait phone shows only a slice
+  // of the world's longitudes, so a fixed (Europe) center could leave every
+  // activity off-screen with nothing left to zoom.
+  group('WorldMapConstants.worldResetCenter (#8121)', () {
+    const phone = Size(390, 844); // height binds: ~half the longitudes visible
+    const desktop = Size(1440, 900); // width binds: all longitudes visible
+
+    /// The visible longitude span at the viewport's zoom floor.
+    double lonSpanAt(Size viewport) {
+      final worldPx =
+          256 * math.pow(2, WorldMapConstants.minZoomFor(viewport)).toDouble();
+      return math.min(360.0, viewport.width / worldPx * 360.0);
+    }
+
+    /// Wrapped absolute longitude distance in degrees.
+    double lonDist(double a, double b) {
+      final d = (a - b).abs() % 360;
+      return d > 180 ? 360 - d : d;
+    }
+
+    test('no pins → null (caller keeps its fixed fallback)', () {
+      expect(WorldMapConstants.worldResetCenter(phone, const []), isNull);
+    });
+
+    test('a phone centers on the bigger cluster when both cannot fit', () {
+      // The ticket's scenario shape: an East Asia cluster (L2 Chinese) plus a
+      // lone far-away pin. A phone's floor shows ~165° of longitude, so the
+      // outlier must sit >165° from the cluster (measured the short way
+      // around) to genuinely not co-fit; three Asian pins then outweigh one.
+      final center = WorldMapConstants.worldResetCenter(phone, const [
+        LatLng(10, -50), // South America — no 165° arc holds it + all of Asia
+        LatLng(35, 105),
+        LatLng(31, 121),
+        LatLng(39, 116),
+      ]);
+      expect(center, isNotNull);
+      // Every Asian pin sits inside the visible slice around the center.
+      final half = lonSpanAt(phone) / 2;
+      for (final lon in const [105.0, 121.0, 116.0]) {
+        expect(lonDist(center!.longitude, lon), lessThanOrEqualTo(half));
+      }
+      // The outlier is (unavoidably) outside — the window took the cluster.
+      expect(lonDist(center!.longitude, -50), greaterThan(half));
+    });
+
+    test('a co-fittable spread keeps every pin in view', () {
+      // Europe + East Asia span ~111°, well inside a phone's ~165° slice: the
+      // reset must show ALL of them, centered mid-spread, excluding none.
+      final center = WorldMapConstants.worldResetCenter(phone, const [
+        LatLng(10, 10),
+        LatLng(35, 105),
+        LatLng(31, 121),
+      ]);
+      expect(center, isNotNull);
+      final half = lonSpanAt(phone) / 2;
+      for (final lon in const [10.0, 105.0, 121.0]) {
+        expect(lonDist(center!.longitude, lon), lessThanOrEqualTo(half));
+      }
+    });
+
+    test('the window wraps across the antimeridian', () {
+      final center = WorldMapConstants.worldResetCenter(phone, const [
+        LatLng(0, 170),
+        LatLng(0, -175),
+        LatLng(0, 178),
+      ]);
+      expect(center, isNotNull);
+      final half = lonSpanAt(phone) / 2;
+      for (final lon in const [170.0, -175.0, 178.0]) {
+        expect(lonDist(center!.longitude, lon), lessThanOrEqualTo(half));
+      }
+      expect(center!.longitude, inInclusiveRange(-180, 180));
+    });
+
+    test(
+      'when everything fits, pins center in view rather than at an edge',
+      () {
+        // Desktop floor shows all longitudes; a tight cluster should sit at the
+        // middle of the view, not at the window's leading edge.
+        final center = WorldMapConstants.worldResetCenter(desktop, const [
+          LatLng(45, 10),
+          LatLng(50, 30),
+        ]);
+        expect(center, isNotNull);
+        expect(center!.longitude, closeTo(20, 1));
+      },
+    );
+
+    test('latitude picks the fuller band when height is the cut axis', () {
+      // Width binds on desktop, so latitude is the constrained axis there —
+      // its floor still shows ~62% of the projected world height, so the
+      // outlier must sit near a pole (Mercator stretch) to genuinely not
+      // co-fit with the southern pair; the two-pin cluster then wins.
+      final center = WorldMapConstants.worldResetCenter(desktop, const [
+        LatLng(84, 0), // near-polar outlier
+        LatLng(-55, 0),
+        LatLng(-60, 0),
+      ]);
+      expect(center, isNotNull);
+      expect(center!.latitude, inInclusiveRange(-62, -50));
     });
   });
 }


### PR DESCRIPTION
Closes #8121

The whole-world reset (`resetToWorld` — the empty-view card's **Zoom out** lever and the on-map **World** control) previously flew to a fixed center of (20, 0), over Europe. At the viewport-derived zoom floor a narrow screen shows only a slice of the world's longitudes (~165° on a phone), so a learner whose activities cluster elsewhere (e.g. L2 Chinese → East Asia) could zoom all the way out and still have every match off-screen, with nothing left to zoom.

Per the doc update in this PR (world-map.instructions.md, empty-view card section): when zooming out, the camera now centers on the view showing the **maximum number of currently-matching activities**. `WorldMapConstants.worldResetCenter` slides a viewport-sized window over the matching pins — a circular sliding window over longitude, then a projected-Mercator window over latitude among its survivors (ties prefer the tightest cluster, so pins land mid-screen) — and `resetToWorld` glides there at the zoom floor, falling back to the old fixed center when nothing is loaded. The pin set used is the same `visiblePins` the matches-offscreen verdict counts, so the lever reveals exactly the matches it promised.

Unit tests cover the window algorithm (cluster preference, antimeridian wrap, co-fittable spread, Mercator latitude banding) in `test/pangea/world_map_zoom_test.dart`. Also verified live against the local stack on a 375×812 viewport: with the ES catalog clustered in the Americas and the camera over a pin-free area, pressing the card's Zoom out landed the entire catalog in view (old behavior would have cut off everything west of ~−63°).

**TO TEST**
- [ ] On a narrow screen, set L2 to a language whose activities sit far from Europe (e.g. Chinese)
- [ ] Zoom/pan until the "There are matches outside your view" popup appears, then press **Zoom out**
- [ ] The map should land fully zoomed out *centered over the activity cluster* (e.g. East Asia), with the most activities the screen can show visible
- [ ] Press the round **World** (globe) control on a wide screen — same behavior: fully out, centered over the activities
- [ ] With no activities loaded (e.g. a dead search query cleared), Zoom out still works and centers on the old default view

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [x] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (No new controls — this changes only where the existing Zoom out / World controls point the camera.)
<!-- Pangea# -->
