### PR TITLE
feat(courses): add 'user is knocking' ping circle for course admins

### DIFF
--- a/lib/features/navigation/workspace_nav.dart
+++ b/lib/features/navigation/workspace_nav.dart
@@ -298,16 +298,21 @@ abstract class WorkspaceNav {
   /// list), a section switch replaces the left column
   /// (routing.instructions.md). This is the token-native replacement for the
   /// old `setSection(uri, PRoutes.course(id), …)` hybrid that bounced through
-  /// the legacy redirect.
+  /// the legacy redirect. [tab] seats the card on a specific tab instead of
+  /// its default — e.g. a knock-badged course opens on Chats so the admin
+  /// lands on the pending knock (#8139).
   static String openCourseSection(
     Uri current,
     String spaceId, {
     bool keepRoom = true,
     bool clearRight = false,
+    SpaceSettingsTabs? tab,
   }) {
     final lists = parseOpenPanels(current);
     final left = <PanelToken>[
-      CoursePanelToken(),
+      CoursePanelToken(
+        tab != null ? CourseDetailsTokenParam(activeTab: tab) : null,
+      ),
       if (keepRoom) ...lists.left.where((t) => t.type == PanelTypesEnum.room),
     ];
     final parts = WorkspaceQuery.parts(current.query);

--- a/lib/pangea/common/widgets/course_avatar.dart
+++ b/lib/pangea/common/widgets/course_avatar.dart
@@ -5,6 +5,7 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/features/course_plans/map_clipper.dart';
 import 'package:fluffychat/pangea/common/widgets/invited_course_badge.dart';
+import 'package:fluffychat/pangea/spaces/knocking_users_badge.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/unread_rooms_badge.dart';
 
@@ -21,6 +22,12 @@ class CourseAvatar extends StatelessWidget {
   final Set<String?>? courseChildrenIds;
   final bool invite;
 
+  /// Someone is knocking on this course and the viewer is an admin who can
+  /// act on it: show the red "!" knock badge in the notification slot,
+  /// outranking the course-ping bell — a waiting user needs attention first
+  /// (#8139). The badge clears when the knock is accepted or denied.
+  final bool hasKnockingUsers;
+
   final Widget? child;
 
   const CourseAvatar({
@@ -31,6 +38,7 @@ class CourseAvatar extends StatelessWidget {
     this.unreadCoursePingEvent,
     this.courseChildrenIds,
     this.invite = false,
+    this.hasKnockingUsers = false,
     this.child,
   });
 
@@ -60,6 +68,14 @@ class CourseAvatar extends StatelessWidget {
     final courseChildrenIds = this.courseChildrenIds;
     if (unreadCoursePingEvent == null || courseChildrenIds == null) {
       return child;
+    }
+
+    if (hasKnockingUsers) {
+      return UnreadRoomsBadge(
+        filter: (room) => courseChildrenIds.contains(room.id),
+        badgePosition: position,
+        child: KnockingUsersBadge(position: position, child: child),
+      );
     }
 
     return UnreadRoomsBadge(

--- a/lib/pangea/extensions/room_user_permissions_extension.dart
+++ b/lib/pangea/extensions/room_user_permissions_extension.dart
@@ -6,6 +6,13 @@ extension UserPermissionsRoomExtension on Room {
 
   bool get isRoomAdmin => ownPowerLevel >= SpaceConstants.powerLevelOfAdmin;
 
+  /// The users currently knocking on this room, from the locally loaded member
+  /// list. Empty for non-admins: only an admin can accept/deny a knock, so
+  /// knock indicators are admin-only by design (#8139). Callers that need the
+  /// full member list loaded should sit under a `KnockingUsersBuilder`.
+  List<User> get knockingUsers =>
+      isRoomAdmin ? getParticipants([Membership.knock]) : [];
+
   List<User> get nonBotRoomAdminsLocal {
     final List<User> participants = getParticipants();
     return participants

--- a/lib/pangea/spaces/knocking_users_badge.dart
+++ b/lib/pangea/spaces/knocking_users_badge.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+import 'package:badges/badges.dart' as b;
+
+import 'package:fluffychat/l10n/l10n.dart';
+
+/// The badge on the avatar of a course someone is knocking on: a white "!"
+/// in an error-colored circle, matching the red bell of the in-course knock
+/// notification so the two read as the same alert (#8139). Admin-only — the
+/// caller gates on knocking users being present, which `Room.knockingUsers`
+/// already restricts to admins. Sized to match the unread-ping badge in
+/// `CourseAvatar` so the avatar doesn't shift as a course moves between
+/// states.
+class KnockingUsersBadge extends StatelessWidget {
+  final b.BadgePosition? position;
+  final Widget? child;
+
+  const KnockingUsersBadge({super.key, this.position, this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return b.Badge(
+      badgeStyle: b.BadgeStyle(
+        badgeColor: Theme.of(context).colorScheme.error,
+        elevation: 4,
+        borderSide: BorderSide.none,
+        padding: const EdgeInsetsGeometry.all(2),
+      ),
+      badgeContent: Icon(
+        Icons.priority_high,
+        color: Theme.of(context).colorScheme.onError,
+        size: 12,
+        semanticLabel: L10n.of(context).aUserIsKnocking,
+      ),
+      position: position,
+      child: child,
+    );
+  }
+}

--- a/lib/pangea/spaces/knocking_users_builder.dart
+++ b/lib/pangea/spaces/knocking_users_builder.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
+import 'package:fluffychat/utils/stream_extension.dart';
+
+/// Loads and watches the users knocking on [room], rebuilding [builder] as
+/// knocks arrive or get resolved (accepted → invite, denied → leave), so a
+/// knock indicator clears exactly when the admin acts on it (#8139).
+///
+/// Only admins can accept/deny a knock, so for non-admins (and rooms the user
+/// hasn't joined) this never requests the member list and always builds with
+/// an empty list — knock indicators are admin-only by design.
+class KnockingUsersBuilder extends StatefulWidget {
+  final Room room;
+  final Widget Function(BuildContext context, List<User> knockingUsers) builder;
+
+  const KnockingUsersBuilder({
+    super.key,
+    required this.room,
+    required this.builder,
+  });
+
+  @override
+  State<KnockingUsersBuilder> createState() => KnockingUsersBuilderState();
+}
+
+class KnockingUsersBuilderState extends State<KnockingUsersBuilder> {
+  List<User> _knockingUsers = [];
+  StreamSubscription? _memberSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _setKnockingSubscription();
+  }
+
+  @override
+  void didUpdateWidget(covariant KnockingUsersBuilder oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.room.id != widget.room.id) {
+      _setKnockingSubscription();
+    }
+  }
+
+  @override
+  void dispose() {
+    _memberSubscription?.cancel();
+    super.dispose();
+  }
+
+  bool _isMemberUpdate(({String roomId, StrippedStateEvent state}) event) =>
+      event.roomId == widget.room.id &&
+      event.state.type == EventTypes.RoomMember;
+
+  void _setKnockingSubscription() {
+    _memberSubscription?.cancel();
+    _knockingUsers = widget.room.knockingUsers;
+
+    if (widget.room.membership != Membership.join || !widget.room.isRoomAdmin) {
+      return;
+    }
+
+    _memberSubscription = widget.room.client.onRoomState.stream
+        .where(_isMemberUpdate)
+        .rateLimit(const Duration(seconds: 1))
+        .listen((_) => _setKnockingUsers());
+
+    widget.room
+        .requestParticipants(
+          [Membership.join, Membership.invite, Membership.knock],
+          false,
+          true,
+        )
+        .then((_) => _setKnockingUsers());
+  }
+
+  void _setKnockingUsers() {
+    if (mounted) {
+      setState(() {
+        _knockingUsers = widget.room.knockingUsers;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => widget.builder(context, _knockingUsers);
+}

--- a/lib/pangea/spaces/knocking_users_indicator.dart
+++ b/lib/pangea/spaces/knocking_users_indicator.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
 import 'package:go_router/go_router.dart';
@@ -10,124 +8,68 @@ import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/navigation/token_params/room_subpage_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
+import 'package:fluffychat/pangea/spaces/knocking_users_builder.dart';
 import 'package:fluffychat/routes/chat/chat_details/invite/pangea_invitation_selection.dart';
-import 'package:fluffychat/utils/stream_extension.dart';
 
-class KnockingUsersIndicator extends StatefulWidget {
+class KnockingUsersIndicator extends StatelessWidget {
   final Room room;
   const KnockingUsersIndicator({super.key, required this.room});
 
   @override
-  KnockingUsersIndicatorState createState() => KnockingUsersIndicatorState();
-}
-
-class KnockingUsersIndicatorState extends State<KnockingUsersIndicator> {
-  List<User> _knockingUsers = [];
-  StreamSubscription? _memberSubscription;
-
-  KnockingUsersIndicatorState();
-
-  @override
-  void initState() {
-    super.initState();
-    _setKnockingSubscription();
-  }
-
-  @override
-  void didUpdateWidget(covariant KnockingUsersIndicator oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.room.id != widget.room.id) {
-      _setKnockingSubscription();
-    }
-  }
-
-  @override
-  void dispose() {
-    _memberSubscription?.cancel();
-    super.dispose();
-  }
-
-  bool _isMemberUpdate(({String roomId, StrippedStateEvent state}) event) =>
-      event.roomId == widget.room.id &&
-      event.state.type == EventTypes.RoomMember;
-
-  void _setKnockingSubscription() {
-    _memberSubscription?.cancel();
-    _memberSubscription = widget.room.client.onRoomState.stream
-        .where(_isMemberUpdate)
-        .rateLimit(const Duration(seconds: 1))
-        .listen((_) => _setKnockingUsers());
-
-    widget.room
-        .requestParticipants(
-          [Membership.join, Membership.invite, Membership.knock],
-          false,
-          true,
-        )
-        .then((_) => _setKnockingUsers());
-  }
-
-  void _setKnockingUsers() {
-    if (mounted) {
-      setState(() {
-        _knockingUsers = widget.room.getParticipants([Membership.knock]);
-      });
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return AnimatedSize(
-      duration: FluffyThemes.animationDuration,
-      child: _knockingUsers.isEmpty || !widget.room.isRoomAdmin
-          ? const SizedBox()
-          : Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
-              child: Material(
-                borderRadius: BorderRadius.circular(AppConfig.borderRadius),
-                clipBehavior: Clip.hardEdge,
-                child: ListTile(
-                  minVerticalPadding: 0,
-                  trailing: Icon(
-                    Icons.adaptive.arrow_forward_outlined,
-                    size: 16,
-                  ),
-                  title: Row(
-                    spacing: 8.0,
-                    children: [
-                      Icon(
-                        Icons.notifications_outlined,
-                        color: Theme.of(context).colorScheme.error,
-                      ),
-                      Expanded(
-                        child: Text(
-                          _knockingUsers.length == 1
-                              ? L10n.of(context).aUserIsKnocking
-                              : L10n.of(
-                                  context,
-                                ).usersAreKnocking(_knockingUsers.length),
-                          style: Theme.of(context).textTheme.bodyMedium,
+    return KnockingUsersBuilder(
+      room: room,
+      builder: (context, knockingUsers) => AnimatedSize(
+        duration: FluffyThemes.animationDuration,
+        child: knockingUsers.isEmpty
+            ? const SizedBox()
+            : Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 1),
+                child: Material(
+                  borderRadius: BorderRadius.circular(AppConfig.borderRadius),
+                  clipBehavior: Clip.hardEdge,
+                  child: ListTile(
+                    minVerticalPadding: 0,
+                    trailing: Icon(
+                      Icons.adaptive.arrow_forward_outlined,
+                      size: 16,
+                    ),
+                    title: Row(
+                      spacing: 8.0,
+                      children: [
+                        Icon(
+                          Icons.notifications_outlined,
+                          color: Theme.of(context).colorScheme.error,
                         ),
-                      ),
-                    ],
+                        Expanded(
+                          child: Text(
+                            knockingUsers.length == 1
+                                ? L10n.of(context).aUserIsKnocking
+                                : L10n.of(
+                                    context,
+                                  ).usersAreKnocking(knockingUsers.length),
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                        ),
+                      ],
+                    ),
+                    onTap: () {
+                      // world_v2: token nav to the course's invite page scoped to
+                      // this space, with the knock filter riding in the
+                      // `coursepage:invite/knock` token param.
+                      context.go(
+                        WorkspaceNav.openCoursePageFor(
+                          GoRouterState.of(context).uri,
+                          room.id,
+                          RoomSubpageEnum.invite,
+                          filter: InvitationFilter.knocking,
+                        ),
+                      );
+                    },
                   ),
-                  onTap: () {
-                    // world_v2: token nav to the course's invite page scoped to
-                    // this space, with the knock filter riding in the
-                    // `coursepage:invite/knock` token param.
-                    context.go(
-                      WorkspaceNav.openCoursePageFor(
-                        GoRouterState.of(context).uri,
-                        widget.room.id,
-                        RoomSubpageEnum.invite,
-                        filter: InvitationFilter.knocking,
-                      ),
-                    );
-                  },
                 ),
               ),
-            ),
+      ),
     );
   }
 }

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -21,6 +21,9 @@ import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/pangea/spaces/client_spaces_extension.dart';
+import 'package:fluffychat/pangea/spaces/knocking_users_badge.dart';
+import 'package:fluffychat/pangea/spaces/knocking_users_builder.dart';
+import 'package:fluffychat/routes/chat/chat_details/space_details_content.dart';
 import 'package:fluffychat/routes/world/left_panel/workspace_left_panel.dart';
 import 'package:fluffychat/routes/world/map_context.dart';
 import 'package:fluffychat/routes/world/mobile_search_bar.dart';
@@ -645,13 +648,28 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
       child: MobileNavWidget(
         activeSection: sectionFor(uri),
         courseShortcutIcon: shortcutCourse != null
-            ? Avatar(
-                mxContent: shortcutCourse.avatar,
-                name: shortcutCourse.getLocalizedDisplayname(
-                  MatrixLocals(l10n),
-                ),
-                size: 32,
-                borderRadius: BorderRadius.circular(8),
+            // The same knock badge the web rail's course avatar wears: the
+            // builder loads the member list (admins only) and rebuilds on
+            // member changes, so the red "!" appears while users are knocking
+            // and clears when the admin accepts/denies (#8139).
+            ? KnockingUsersBuilder(
+                room: shortcutCourse,
+                builder: (context, knockingUsers) {
+                  final avatar = Avatar(
+                    mxContent: shortcutCourse.avatar,
+                    name: shortcutCourse.getLocalizedDisplayname(
+                      MatrixLocals(l10n),
+                    ),
+                    size: 32,
+                    borderRadius: BorderRadius.circular(8),
+                  );
+                  return knockingUsers.isEmpty
+                      ? avatar
+                      : KnockingUsersBadge(
+                          position: BadgePosition.topEnd(top: -5, end: -7),
+                          child: avatar,
+                        );
+                },
               )
             : const Icon(Icons.add),
         courseShortcutLabel: shortcutCourse != null
@@ -671,6 +689,13 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
                   shortcutCourse.id,
                   keepRoom: false,
                   clearRight: true,
+                  // While users are knocking, land the admin on the Chats
+                  // tab — where the knock notification lives — instead of
+                  // the Course Plan default, until the knock is accepted or
+                  // denied (#8139).
+                  tab: shortcutCourse.knockingUsers.isNotEmpty
+                      ? SpaceSettingsTabs.chat
+                      : null,
                 )
               : WorkspaceNav.setSection(
                   uri,

--- a/lib/widgets/navigation_rail.dart
+++ b/lib/widgets/navigation_rail.dart
@@ -13,7 +13,9 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/widgets/course_avatar.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/pangea/spaces/client_spaces_extension.dart';
+import 'package:fluffychat/pangea/spaces/knocking_users_builder.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/course_ping_extension.dart';
+import 'package:fluffychat/routes/chat/chat_details/space_details_content.dart';
 import 'package:fluffychat/routes/home/pangea_logo_svg.dart';
 import 'package:fluffychat/routes/world/workspace_dock.dart';
 import 'package:fluffychat/utils/chat_list_handle_space_tap.dart';
@@ -249,7 +251,15 @@ class _SpaceItem extends StatelessWidget {
       context.go(
         // A left-nav click replaces the open left panels rather than stacking
         // beside them (drop any open room/section). See routing.instructions.md.
-        WorkspaceNav.openCourseSection(uri, space.id, keepRoom: false),
+        WorkspaceNav.openCourseSection(
+          uri,
+          space.id,
+          keepRoom: false,
+          // While users are knocking, land the admin on the Chats tab — where
+          // the knock notification lives — instead of the Course Plan default,
+          // every time, until the knock is accepted or denied (#8139).
+          tab: space.knockingUsers.isNotEmpty ? SpaceSettingsTabs.chat : null,
+        ),
       );
       return;
     }
@@ -278,21 +288,28 @@ class _SpaceItem extends StatelessWidget {
       MatrixLocals(L10n.of(context)),
     );
     final courseChildrenIds = space.spaceChildren.map((c) => c.roomId).toSet();
-    return NaviRailItem(
-      toolTip: displayname,
-      isSelected: selected,
-      backgroundColor: Colors.transparent,
-      borderRadius: BorderRadius.circular(0),
-      onTap: () => _onTapSpace(context),
-      icon: CourseAvatar(
-        avatar: space.avatar,
-        displayname: displayname,
-        size: iconWidth,
-        unreadCoursePingEvent: space.unreadCoursePingEvent,
-        courseChildrenIds: courseChildrenIds,
-        invite: space.membership == .invite,
+    // The builder loads the member list (admins only) and rebuilds on member
+    // changes, so the knock badge appears when someone knocks and clears the
+    // moment the admin accepts/denies (#8139).
+    return KnockingUsersBuilder(
+      room: space,
+      builder: (context, knockingUsers) => NaviRailItem(
+        toolTip: displayname,
+        isSelected: selected,
+        backgroundColor: Colors.transparent,
+        borderRadius: BorderRadius.circular(0),
+        onTap: () => _onTapSpace(context),
+        icon: CourseAvatar(
+          avatar: space.avatar,
+          displayname: displayname,
+          size: iconWidth,
+          unreadCoursePingEvent: space.unreadCoursePingEvent,
+          courseChildrenIds: courseChildrenIds,
+          invite: space.membership == .invite,
+          hasKnockingUsers: knockingUsers.isNotEmpty,
+        ),
+        naviRailWidth: naviRailWidth,
       ),
-      naviRailWidth: naviRailWidth,
     );
   }
 }

--- a/test/pangea/navigation/workspace_nav_test.dart
+++ b/test/pangea/navigation/workspace_nav_test.dart
@@ -233,6 +233,33 @@ void main() {
       expect(lists.right, isEmpty);
       expect(lists.left.single, const CoursePanelToken());
     });
+
+    test('openCourseSection tab rides the course token param (#8139)', () {
+      // A knock-badged course opens on its Chats tab, so the admin lands on
+      // the knock notification instead of the Course Plan default.
+      final loc = WorkspaceNav.openCourseSection(
+        u('/'),
+        '!course',
+        keepRoom: false,
+        tab: SpaceSettingsTabs.chat,
+      );
+      final uri = u(loc);
+      expect(uri.queryParameters['c'], '!course');
+      expect(parseOpenPanels(uri).left, [
+        const CoursePanelToken(
+          CourseDetailsTokenParam(activeTab: SpaceSettingsTabs.chat),
+        ),
+      ]);
+    });
+
+    test('openCourseSection without tab keeps the bare course token', () {
+      final loc = WorkspaceNav.openCourseSection(
+        u('/'),
+        '!course',
+        keepRoom: false,
+      );
+      expect(parseOpenPanels(u(loc)).left, [const CoursePanelToken()]);
+    });
   });
 
   group('openRoomById (event folds into the room token; no loose params)', () {


### PR DESCRIPTION
### What

Course avatars in the web nav rail and the mobile nav row's course shortcut now wear a red (!) badge for admins while users are knocking, and tapping the badged course lands on the Course Chats tab (where the knock notification lives) instead of the Course Plan default.

### Why

Closes #8139

### What changed

- New `KnockingUsersBuilder`: loads/watches a space's knocking members (admin-gated — non-admins never request the member list and always get an empty list). `KnockingUsersIndicator` now reuses it instead of duplicating the subscription.
- New `KnockingUsersBadge`: white `!` in an error-colored circle, matching the red knock bell; sized like the existing course-ping/invite badges.
- `CourseAvatar` gains `hasKnockingUsers`; the knock badge outranks the course-ping bell in the notification slot.
- `WorkspaceNav.openCourseSection` gains a `tab` param (rides the `course:` token param). Web rail `_SpaceItem` and the mobile course-shortcut tap pass `SpaceSettingsTabs.chat` while knocks are pending — every tap, until the knock is accepted/denied, so the badge and routing clear together off member state.
- New `Room.knockingUsers` getter beside `isRoomAdmin`.

### Testing

- `fvm flutter test` — full suite green locally (1901 passed, 3 skipped, 0 failed).
- Added `workspace_nav_test` cases: `openCourseSection` with `tab` encodes `course:chat` in the token; without `tab` keeps the bare token.
- `fvm flutter analyze` — no issues.
- Manual 3-user knock QA (see issue TO TEST) needs a knock-enabled course with admin/non-admin/outsider accounts — not reproducible on the local stack; flows through the issue's QA labels on staging.

### Accessibility

- Badge icon carries `semanticLabel` ("1 user is requesting to join your course").

### Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)