### PR TITLE
fix(nav): dead back button when a room reopens under a different panel token

### DIFF
--- a/lib/routes/world/left_panel/left_panel_close_button.dart
+++ b/lib/routes/world/left_panel/left_panel_close_button.dart
@@ -4,7 +4,9 @@ import 'package:go_router/go_router.dart';
 
 import 'package:fluffychat/features/navigation/close_affordance.dart';
 import 'package:fluffychat/features/navigation/panel_token.dart';
+import 'package:fluffychat/features/navigation/room_close_location.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/features/navigation/token_params/room_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 
@@ -66,13 +68,28 @@ class LeftPanelCloseButton extends StatelessWidget {
   // A `room`/`session` is a token-only panel, so dropping its token closes it.
   // A section panel (a course) is also addressable by its map filter, so
   // closing it returns to the world map. See WorkspaceNav.closeSection.
+  //
+  // Like [currentUri], the CAPTURED token can be stale for a room panel: the
+  // chat renders inside a room-keyed nested Navigator whose route holds the
+  // close button built at open time, so when the same room reopens under a
+  // different token (`room:X` from the chat list, then `session:X` from the
+  // Stars archive after the activity ends) a surviving stale button would try
+  // to drop the departed token — a no-op, i.e. a dead back button (#8142).
+  // Resolve the token to drop by ROOM ID against the live URL instead, so the
+  // close always drops whatever room-panel token is actually open for this
+  // room.
   void _close(BuildContext context) {
     final uri = _liveUri(context);
-    context.go(
-      token.type.isRoomPanel
-          ? WorkspaceNav.closeLeft(uri, token)
-          : WorkspaceNav.closeSection(uri, token),
-    );
+    if (token.type.isRoomPanel) {
+      final param = token.param;
+      final close = roomTokenCloseLocation(
+        uri,
+        param is RoomTokenParam ? param.id : null,
+      );
+      context.go(close ?? WorkspaceNav.closeLeft(uri, token));
+      return;
+    }
+    context.go(WorkspaceNav.closeSection(uri, token));
   }
 
   @override

--- a/lib/routes/world/left_panel/left_panel_room_subpage.dart
+++ b/lib/routes/world/left_panel/left_panel_room_subpage.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:fluffychat/features/navigation/panel_types_enum.dart';
 import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/token_params/room_subpage_token.dart';
 import 'package:fluffychat/features/navigation/token_params/room_token.dart';
@@ -12,13 +13,29 @@ import 'package:fluffychat/routes/world/left_panel/left_panel_room_details_subpa
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/share_scaffold_dialog.dart';
 
+/// The pAnyState id of the nested [Navigator] that hosts a room panel's chat.
+/// Keyed by the panel's TOKEN TYPE as well as the room id: the same room can
+/// reopen under a different token — `room:X` from the chat list, then
+/// `session:X` from the Stars archive once the activity ends — and a shared id
+/// would GlobalKey-reparent the old Navigator into the new panel, preserving
+/// the stale route whose close button drops the departed token (a no-op on the
+/// live URL — the dead back button of #8142). Same-type moves still share one
+/// id, so the ChatController repositions rather than remounts when its slot
+/// moves.
+String chatPanelNavigatorId(PanelTypesEnum tokenType, String roomId) =>
+    "chat_page_with_room_${tokenType.name}_$roomId";
+
 class LeftPanelRoomSubpage extends StatelessWidget {
+  /// The panel's token type (`room`, `session`, or `archivedroom`) — part of
+  /// the nested Navigator's identity, see [chatPanelNavigatorId].
+  final PanelTypesEnum tokenType;
   final RoomTokenParam? param;
   final List<ShareItem>? shareItems;
   final Widget closeButton;
 
   const LeftPanelRoomSubpage({
     super.key,
+    required this.tokenType,
     required this.param,
     required this.shareItems,
     required this.closeButton,
@@ -97,7 +114,7 @@ class LeftPanelRoomSubpage extends StatelessWidget {
     // read. A bare room and a jump-to-message both render here (no sub-page).
     return Navigator(
       key: MatrixState.pAnyState
-          .layerLinkAndKey("chat_page_with_room_$roomId")
+          .layerLinkAndKey(chatPanelNavigatorId(tokenType, roomId))
           .key,
       onGenerateRoute: (_) => MaterialPageRoute(
         builder: (_) => ChatPage(

--- a/lib/routes/world/left_panel/workspace_left_panel.dart
+++ b/lib/routes/world/left_panel/workspace_left_panel.dart
@@ -79,6 +79,7 @@ class WorkspaceLeftPanel extends StatelessWidget {
       RoomPanelToken(param: final param) ||
       SessionPanelToken(param: final param) ||
       ArchivedRoomPanelToken(param: final param) => LeftPanelRoomSubpage(
+        tokenType: token.type,
         param: param,
         shareItems: shareItems,
         closeButton: closeButton,

--- a/test/pangea/navigation/left_panel_close_button_test.dart
+++ b/test/pangea/navigation/left_panel_close_button_test.dart
@@ -75,4 +75,67 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+    'a stale-token room close still drops the LIVE token for that room (#8142)',
+    (tester) async {
+      // A room panel's chat renders inside a room-keyed nested Navigator whose
+      // route captures the close button built at open time. When the same room
+      // reopens under a DIFFERENT token — `room:!x` from the chat list, then
+      // `session:!x` from the Stars archive after the activity ends — the
+      // reparented Navigator can surface a close button still holding the
+      // departed `room` token. Dropping that token from the live URL is a
+      // no-op: the back button did nothing. The close must resolve what to
+      // drop by ROOM ID against the live URL instead.
+      const liveLocation = '/?left=chats,session:!x&right=analytics:sessions';
+
+      final router = GoRouter(
+        initialLocation: liveLocation,
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (context, state) => Scaffold(
+              body: LeftPanelCloseButton(
+                // STALE on purpose: the token the room was first opened under,
+                // captured before the swap to `session:!x`.
+                token: RoomPanelToken(RoomTokenParam.parse('!x')),
+                currentUri: Uri.parse(liveLocation),
+                foldedOver: false,
+                isColumnMode: true,
+              ),
+            ),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerConfig: router,
+          localizationsDelegates: L10n.localizationsDelegates,
+          supportedLocales: L10n.supportedLocales,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      final result = router.routerDelegate.currentConfiguration.uri;
+      final panels = parseOpenPanels(result);
+
+      expect(
+        panels.left.any((t) => t.type == PanelTypesEnum.session),
+        isFalse,
+        reason:
+            'the close must drop the live session token for the room, even '
+            'when the button captured the stale room token: got $result',
+      );
+      // Only the room's own token is dropped — the chat list beneath survives.
+      expect(
+        panels.left.any((t) => t.type == PanelTypesEnum.chats),
+        isTrue,
+        reason: 'closing the room panel must not close the chat list beneath',
+      );
+    },
+  );
 }

--- a/test/pangea/navigation/left_panel_room_navigator_key_test.dart
+++ b/test/pangea/navigation/left_panel_room_navigator_key_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/navigation/panel_types_enum.dart';
+import 'package:fluffychat/routes/world/left_panel/left_panel_room_subpage.dart';
+
+void main() {
+  group('chatPanelNavigatorId (#8142)', () {
+    const roomId = '!abc:example.com';
+
+    test('each room-panel token type gets its own Navigator identity', () {
+      // The same room can reopen under a different token: `room` from the chat
+      // list, then `session` from the Stars archive after the activity ends.
+      // One shared id let the session panel GlobalKey-reparent the room
+      // panel's Navigator, preserving the stale route whose close button
+      // dropped the departed `room` token — a no-op on the live URL, so the
+      // back button did nothing. Distinct ids force a fresh ChatPage (and a
+      // close button bound to the live token) on a cross-type swap.
+      final ids = {
+        for (final type in PanelTypesEnum.values.where((t) => t.isRoomPanel))
+          type: chatPanelNavigatorId(type, roomId),
+      };
+      expect(
+        ids.values.toSet().length,
+        ids.length,
+        reason: 'room/session/archivedroom must not share a Navigator id: $ids',
+      );
+    });
+
+    test('the id is stable for the same token type and room', () {
+      // Same-type stability is the key's original job: a slot move repositions
+      // the same ChatController instead of remounting it.
+      expect(
+        chatPanelNavigatorId(PanelTypesEnum.room, roomId),
+        chatPanelNavigatorId(PanelTypesEnum.room, roomId),
+      );
+    });
+
+    test('different rooms of one type never collide', () {
+      expect(
+        chatPanelNavigatorId(PanelTypesEnum.room, '!a:example.com'),
+        isNot(chatPanelNavigatorId(PanelTypesEnum.room, '!b:example.com')),
+      );
+    });
+  });
+}

--- a/test/pangea/navigation/left_panel_room_subpage_empty_state_test.dart
+++ b/test/pangea/navigation/left_panel_room_subpage_empty_state_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:fluffychat/features/navigation/panel_types_enum.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/world/left_panel/left_panel_room_subpage.dart';
 
@@ -21,6 +22,7 @@ void main() {
           supportedLocales: L10n.supportedLocales,
           home: const Scaffold(
             body: LeftPanelRoomSubpage(
+              tokenType: PanelTypesEnum.room,
               param: null,
               shareItems: null,
               closeButton: IconButton(


### PR DESCRIPTION
### What

Fixes the dead back button on an activity session reopened from the Stars page after it was first opened from the chat list.

### Why

Closes #8142. The chat inside a room panel renders in a nested `Navigator` GlobalKey'd by room id alone. Opening the activity from the chat list creates `room:X`; selecting the finished activity on the Stars page swaps it to `session:X` — same room id, so the new panel GlobalKey-reparents the old panel's `Navigator` instead of remounting. The reparented route still holds the close button built at open time, which drops the departed `room:X` token — a no-op on the live URL (`left=chats,session:X`), so the button did nothing.

### Changes

- `left_panel_room_subpage.dart` — the nested chat `Navigator`'s pAnyState id now includes the panel token type (`chatPanelNavigatorId`), so a cross-type swap (`room`/`session`/`archivedroom`) for the same room remounts a fresh `ChatPage` whose close button is bound to the live token; same-type slot moves still reparent the same `ChatController` as before.
- `left_panel_close_button.dart` — `_close` resolves the token to drop by room id against the live URL (the existing `roomTokenCloseLocation` helper) instead of dropping the captured token, so even a stale-captured button closes the panel that is actually open. Mirrors the live-URI rule this button already follows for `currentUri` (#7268).
- Tests: `left_panel_close_button_test.dart` gains a #8142 regression case (stale `room:!x` button over a live `session:!x` URL must still drop the session token — fails pre-fix, passes post-fix); new `left_panel_room_navigator_key_test.dart` pins the per-type Navigator identity; the empty-state test is updated for the new required `tokenType` param.

### Testing

- `fvm flutter analyze` clean on touched directories.
- `fvm flutter test test/pangea/navigation/`: 364 passed.
- New regression test verified to fail with the close-button fix reverted.
- Full suite: `fvm flutter test` — 1903 passed, 3 skipped (env-gated endpoint tests), 0 failed.
- The end-to-end repro (ongoing bot activity in current L2, end it, reopen from Stars) needs a live activity session, which the local stack can't run (no LLM access) — verify on staging per the issue's TO TEST list.

### Deploy Notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
