### PR TITLE
fix(analytics): XP animation reflects action XP, not capped construct delta

### DIFF
--- a/lib/features/analytics_data/analytics_data_service.dart
+++ b/lib/features/analytics_data/analytics_data_service.dart
@@ -537,7 +537,7 @@ class AnalyticsDataService {
         final newPoints = newConstructs[id]?.points ?? 0;
         points += (newPoints - prevPoints);
       }
-      events.add(XPGainedEvent(points, update.targetID));
+      events.add(XPGainedEvent.fromUses(addedConstructs, update.targetID));
     }
 
     final newData = prevData.addXP(points);

--- a/lib/features/analytics_data/analytics_data_service.dart
+++ b/lib/features/analytics_data/analytics_data_service.dart
@@ -33,11 +33,17 @@ class _AnalyticsClient {
 
 class AnalyticsStreamUpdate {
   final int points;
+
+  /// Uncapped point value of the update's added uses — see
+  /// [XPGainedEvent.totalPoints]. Read only by the XP gain/loss animation.
+  final int totalPoints;
+
   final Set<ConstructIdentifier>? blockedConstructs;
   final String? targetID;
 
   AnalyticsStreamUpdate({
     this.points = 0,
+    this.totalPoints = 0,
     this.blockedConstructs,
     this.targetID,
   });
@@ -537,7 +543,9 @@ class AnalyticsDataService {
         final newPoints = newConstructs[id]?.points ?? 0;
         points += (newPoints - prevPoints);
       }
-      events.add(XPGainedEvent.fromUses(addedConstructs, update.targetID));
+      events.add(
+        XPGainedEvent.fromUses(addedConstructs, points, update.targetID),
+      );
     }
 
     final newData = prevData.addXP(points);

--- a/lib/features/analytics_data/analytics_update_dispatcher.dart
+++ b/lib/features/analytics_data/analytics_update_dispatcher.dart
@@ -153,7 +153,7 @@ class AnalyticsUpdateDispatcher {
         _onUnlockMorphLemmas(e.unlocked, e.targetId);
         break;
       case final XPGainedEvent e:
-        _onXPGained(e.points, e.targetID);
+        _onXPGained(e.points, e.totalPoints, e.targetID);
         break;
       case final ConstructLevelUpEvent e:
         _onConstructLevelUp(e.constructId, e.level, e.targetID);
@@ -190,8 +190,12 @@ class AnalyticsUpdateDispatcher {
     }
   }
 
-  void _onXPGained(int points, String? targetID) {
-    final update = AnalyticsStreamUpdate(points: points, targetID: targetID);
+  void _onXPGained(int points, int totalPoints, String? targetID) {
+    final update = AnalyticsStreamUpdate(
+      points: points,
+      totalPoints: totalPoints,
+      targetID: targetID,
+    );
     constructUpdateStream.add(update);
   }
 

--- a/lib/features/analytics_data/analytics_update_events.dart
+++ b/lib/features/analytics_data/analytics_update_events.dart
@@ -29,20 +29,27 @@ class ConstructLevelUpEvent extends AnalyticsUpdateEvent {
 }
 
 class XPGainedEvent extends AnalyticsUpdateEvent {
+  /// XP actually gained: the per-construct delta, capped at the flower
+  /// threshold. This is what total XP / level math is based on.
   final int points;
+
+  /// Raw point value of the uses the update added, ignoring the flower cap.
+  /// Only the XP gain/loss animation reads this — a use on a flower-level
+  /// (capped) construct has [points] of 0 but still animates (#7756).
+  final int totalPoints;
+
   final String? targetID;
 
-  const XPGainedEvent(this.points, this.targetID);
+  const XPGainedEvent(this.points, this.totalPoints, this.targetID);
 
-  /// Build the event for one analytics update from the uses just added.
-  ///
-  /// Carries the raw point value of the action itself rather than the capped
-  /// per-construct XP delta — a use on a flower-level (capped) construct still
-  /// animates even though it changes total XP by 0 (#7756).
+  /// Build the event for one analytics update: [points] is the capped delta
+  /// computed by the caller; [totalPoints] is summed from the added uses.
   factory XPGainedEvent.fromUses(
     List<OneConstructUse> addedUses,
+    int cappedPoints,
     String? targetID,
   ) => XPGainedEvent(
+    cappedPoints,
     addedUses.fold<int>(0, (sum, use) => sum + use.xp),
     targetID,
   );

--- a/lib/features/analytics_data/analytics_update_events.dart
+++ b/lib/features/analytics_data/analytics_update_events.dart
@@ -1,5 +1,6 @@
 import 'package:fluffychat/features/analytics/construct_identifier.dart';
 import 'package:fluffychat/features/analytics/construct_level_enum.dart';
+import 'package:fluffychat/features/analytics/constructs_model.dart';
 
 sealed class AnalyticsUpdateEvent {
   const AnalyticsUpdateEvent();
@@ -32,6 +33,19 @@ class XPGainedEvent extends AnalyticsUpdateEvent {
   final String? targetID;
 
   const XPGainedEvent(this.points, this.targetID);
+
+  /// Build the event for one analytics update from the uses just added.
+  ///
+  /// Carries the raw point value of the action itself rather than the capped
+  /// per-construct XP delta — a use on a flower-level (capped) construct still
+  /// animates even though it changes total XP by 0 (#7756).
+  factory XPGainedEvent.fromUses(
+    List<OneConstructUse> addedUses,
+    String? targetID,
+  ) => XPGainedEvent(
+    addedUses.fold<int>(0, (sum, use) => sum + use.xp),
+    targetID,
+  );
 }
 
 class NewConstructsEvent extends AnalyticsUpdateEvent {

--- a/lib/features/analytics_data/analytics_updater_mixin.dart
+++ b/lib/features/analytics_data/analytics_updater_mixin.dart
@@ -43,7 +43,9 @@ mixin AnalyticsUpdater<T extends StatefulWidget> on State<T> {
 
   void _onAnalyticsUpdate(AnalyticsStreamUpdate update) {
     if (update.targetID != null) {
-      PointsGainedAnimation.show(update.targetID!, update.points, context);
+      // totalPoints, not points: the animation shows the action's own value,
+      // so uses on flower-level (capped) constructs still animate (#7756).
+      PointsGainedAnimation.show(update.targetID!, update.totalPoints, context);
     }
   }
 

--- a/test/pangea/analytics_practice/xp_gained_event_test.dart
+++ b/test/pangea/analytics_practice/xp_gained_event_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/analytics/analytics_constants.dart';
+import 'package:fluffychat/features/analytics/construct_type_enum.dart';
+import 'package:fluffychat/features/analytics/construct_use_model.dart';
+import 'package:fluffychat/features/analytics/construct_use_type_enum.dart';
+import 'package:fluffychat/features/analytics/constructs_model.dart';
+import 'package:fluffychat/features/analytics_data/analytics_update_events.dart';
+
+/// Regression test for #7756: XP gain/loss animations stopped showing on
+/// practice exercises whose construct had already reached the flower XP cap.
+///
+/// The animation is driven by [XPGainedEvent.points]. It used to carry the
+/// capped per-construct XP delta, which is 0 for a flower-level construct, so
+/// answering an exercise on a maxed-out word animated nothing. The event now
+/// carries the raw point value of the added uses ([XPGainedEvent.fromUses]),
+/// while total XP still uses the capped delta.
+void main() {
+  OneConstructUse use(ConstructUseTypeEnum useType) => OneConstructUse(
+    useType: useType,
+    lemma: 'gato',
+    constructType: ConstructTypeEnum.vocab,
+    metadata: ConstructUseMetaData(roomId: null, timeStamp: DateTime.now()),
+    category: 'noun',
+    form: 'gato',
+    xp: useType.pointValue,
+  );
+
+  group('XPGainedEvent.fromUses', () {
+    test('carries the raw XP of a correct answer', () {
+      final event = XPGainedEvent.fromUses([
+        use(ConstructUseTypeEnum.corLM),
+      ], 'target-id');
+      expect(event.points, ConstructUseTypeEnum.corLM.pointValue);
+      expect(event.points, greaterThan(0));
+      expect(event.targetID, 'target-id');
+    });
+
+    test('carries the raw XP of an incorrect answer', () {
+      final event = XPGainedEvent.fromUses([
+        use(ConstructUseTypeEnum.incLM),
+      ], 'target-id');
+      expect(event.points, ConstructUseTypeEnum.incLM.pointValue);
+      expect(event.points, lessThan(0));
+    });
+
+    test('sums the XP of multiple added uses', () {
+      final event = XPGainedEvent.fromUses([
+        use(ConstructUseTypeEnum.corLM),
+        use(ConstructUseTypeEnum.incLM),
+      ], null);
+      expect(
+        event.points,
+        ConstructUseTypeEnum.corLM.pointValue +
+            ConstructUseTypeEnum.incLM.pointValue,
+      );
+    });
+
+    test('is nonzero for answers on a flower-level (capped) construct', () {
+      // Enough correct uses to push the construct past the flower cap.
+      final pastCap = List.generate(
+        (AnalyticsConstants.xpForFlower ~/
+                ConstructUseTypeEnum.corLM.pointValue) +
+            2,
+        (_) => use(ConstructUseTypeEnum.corLM),
+      );
+      final construct = ConstructUses(
+        uses: pastCap,
+        constructType: ConstructTypeEnum.vocab,
+        lemma: 'gato',
+        category: 'noun',
+      );
+
+      // The construct's points are capped, so one more use changes the capped
+      // total by 0 — the delta the animation used to (wrongly) show.
+      expect(construct.points, AnalyticsConstants.xpForFlower);
+      final before = construct.points;
+      construct.addUses([use(ConstructUseTypeEnum.corLM)]);
+      expect(construct.points - before, 0);
+
+      // The event for that same use still animates.
+      final event = XPGainedEvent.fromUses([
+        use(ConstructUseTypeEnum.corLM),
+      ], 'target-id');
+      expect(event.points, isNot(0));
+    });
+  });
+}

--- a/test/pangea/analytics_practice/xp_gained_event_test.dart
+++ b/test/pangea/analytics_practice/xp_gained_event_test.dart
@@ -10,11 +10,12 @@ import 'package:fluffychat/features/analytics_data/analytics_update_events.dart'
 /// Regression test for #7756: XP gain/loss animations stopped showing on
 /// practice exercises whose construct had already reached the flower XP cap.
 ///
-/// The animation is driven by [XPGainedEvent.points]. It used to carry the
-/// capped per-construct XP delta, which is 0 for a flower-level construct, so
+/// The animation used to be driven by [XPGainedEvent.points] — the capped
+/// per-construct XP delta, which is 0 for a flower-level construct — so
 /// answering an exercise on a maxed-out word animated nothing. The event now
-/// carries the raw point value of the added uses ([XPGainedEvent.fromUses]),
-/// while total XP still uses the capped delta.
+/// also carries [XPGainedEvent.totalPoints], the raw point value of the added
+/// uses, which only the animation reads. [XPGainedEvent.points] keeps the
+/// capped delta for everything else (total XP / level math).
 void main() {
   OneConstructUse use(ConstructUseTypeEnum useType) => OneConstructUse(
     useType: useType,
@@ -27,62 +28,84 @@ void main() {
   );
 
   group('XPGainedEvent.fromUses', () {
-    test('carries the raw XP of a correct answer', () {
-      final event = XPGainedEvent.fromUses([
-        use(ConstructUseTypeEnum.corLM),
-      ], 'target-id');
-      expect(event.points, ConstructUseTypeEnum.corLM.pointValue);
-      expect(event.points, greaterThan(0));
+    test('totalPoints carries the raw XP of a correct answer', () {
+      final event = XPGainedEvent.fromUses(
+        [use(ConstructUseTypeEnum.corLM)],
+        3,
+        'target-id',
+      );
+      expect(event.totalPoints, ConstructUseTypeEnum.corLM.pointValue);
+      expect(event.totalPoints, greaterThan(0));
       expect(event.targetID, 'target-id');
     });
 
-    test('carries the raw XP of an incorrect answer', () {
-      final event = XPGainedEvent.fromUses([
-        use(ConstructUseTypeEnum.incLM),
-      ], 'target-id');
-      expect(event.points, ConstructUseTypeEnum.incLM.pointValue);
-      expect(event.points, lessThan(0));
+    test('totalPoints carries the raw XP of an incorrect answer', () {
+      final event = XPGainedEvent.fromUses(
+        [use(ConstructUseTypeEnum.incLM)],
+        0,
+        'target-id',
+      );
+      expect(event.totalPoints, ConstructUseTypeEnum.incLM.pointValue);
+      expect(event.totalPoints, lessThan(0));
     });
 
-    test('sums the XP of multiple added uses', () {
-      final event = XPGainedEvent.fromUses([
-        use(ConstructUseTypeEnum.corLM),
-        use(ConstructUseTypeEnum.incLM),
-      ], null);
+    test('totalPoints sums the raw XP of multiple added uses', () {
+      final event = XPGainedEvent.fromUses(
+        [use(ConstructUseTypeEnum.corLM), use(ConstructUseTypeEnum.incLM)],
+        0,
+        null,
+      );
       expect(
-        event.points,
+        event.totalPoints,
         ConstructUseTypeEnum.corLM.pointValue +
             ConstructUseTypeEnum.incLM.pointValue,
       );
     });
 
-    test('is nonzero for answers on a flower-level (capped) construct', () {
-      // Enough correct uses to push the construct past the flower cap.
-      final pastCap = List.generate(
-        (AnalyticsConstants.xpForFlower ~/
-                ConstructUseTypeEnum.corLM.pointValue) +
-            2,
-        (_) => use(ConstructUseTypeEnum.corLM),
+    test('points keeps the capped delta the caller computed', () {
+      final event = XPGainedEvent.fromUses(
+        [use(ConstructUseTypeEnum.corLM)],
+        0,
+        'target-id',
       );
-      final construct = ConstructUses(
-        uses: pastCap,
-        constructType: ConstructTypeEnum.vocab,
-        lemma: 'gato',
-        category: 'noun',
-      );
-
-      // The construct's points are capped, so one more use changes the capped
-      // total by 0 — the delta the animation used to (wrongly) show.
-      expect(construct.points, AnalyticsConstants.xpForFlower);
-      final before = construct.points;
-      construct.addUses([use(ConstructUseTypeEnum.corLM)]);
-      expect(construct.points - before, 0);
-
-      // The event for that same use still animates.
-      final event = XPGainedEvent.fromUses([
-        use(ConstructUseTypeEnum.corLM),
-      ], 'target-id');
-      expect(event.points, isNot(0));
+      expect(event.points, 0);
+      expect(event.totalPoints, ConstructUseTypeEnum.corLM.pointValue);
     });
+
+    test(
+      'totalPoints is nonzero for answers on a flower-level (capped) construct',
+      () {
+        // Enough correct uses to push the construct past the flower cap.
+        final pastCap = List.generate(
+          (AnalyticsConstants.xpForFlower ~/
+                  ConstructUseTypeEnum.corLM.pointValue) +
+              2,
+          (_) => use(ConstructUseTypeEnum.corLM),
+        );
+        final construct = ConstructUses(
+          uses: pastCap,
+          constructType: ConstructTypeEnum.vocab,
+          lemma: 'gato',
+          category: 'noun',
+        );
+
+        // The construct's points are capped, so one more use changes the
+        // capped total by 0 — the delta the animation used to (wrongly) show.
+        expect(construct.points, AnalyticsConstants.xpForFlower);
+        final before = construct.points;
+        construct.addUses([use(ConstructUseTypeEnum.corLM)]);
+        final cappedDelta = construct.points - before;
+        expect(cappedDelta, 0);
+
+        // The event for that same use still animates via totalPoints.
+        final event = XPGainedEvent.fromUses(
+          [use(ConstructUseTypeEnum.corLM)],
+          cappedDelta,
+          'target-id',
+        );
+        expect(event.points, 0);
+        expect(event.totalPoints, isNot(0));
+      },
+    );
   });
 }


### PR DESCRIPTION
### What
Practice XP gain/loss animations now always show when an answer is selected, including on constructs already at the flower XP cap.

### Why
Closes #7756

`XPGainedEvent` (which drives `PointsGainedAnimation`) carried only the capped per-construct XP delta. Once a construct reaches the flower cap (100, see [analytics-system.instructions.md § XP cap](.github/instructions/analytics-system.instructions.md)), that delta is 0 for every further use — so answers on maxed-out words animated nothing. Sessions mix capped and uncapped lemmas once the practice pool is well-worn, which is why animations appeared to skip exercises.

### How
- `XPGainedEvent` and `AnalyticsStreamUpdate` now carry both values: `points` keeps its existing meaning (capped delta — total XP / level math and all other consumers unchanged), and a new `totalPoints` holds the raw point value of the uses just added (+5 correct, −1/−2 incorrect).
- Only `PointsGainedAnimation` (via `AnalyticsUpdater` mixin) reads `totalPoints`, so the animation reflects the action itself while everything else keeps the capped value.

### Testing
- New regression test `test/pangea/analytics_practice/xp_gained_event_test.dart`: `totalPoints` carries raw XP for correct/incorrect/multiple uses, `points` keeps the capped delta, and `totalPoints` stays nonzero for a use on a capped construct where the capped delta is 0.
- Full local suite: 1904 passed, 3 skipped (`fvm flutter test test/`).
- Not manually reproduced in-app: the repro needs an account whose practice pool is mostly flower-level constructs.

### Deploy Notes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)