### PR TITLE
fix(world): stop mid-pin size and unread-badge flicker on zoom

### DIFF
--- a/lib/routes/world/dot_markers_layer.dart
+++ b/lib/routes/world/dot_markers_layer.dart
@@ -21,6 +21,11 @@ class DotMarkersLayer {
   final Alignment Function(ActivityPinState, PinTier) markerAlignment;
   final String? focusedId;
   final void Function(QuestActivityCard) onTap;
+
+  /// Whether this pin should play its entry scale-in — false for pins already
+  /// on screen at the last settle, so a State recreated by MarkerLayer's
+  /// per-frame positional reconciliation doesn't replay its pop-in (#8136).
+  final bool Function(String) animateInOf;
   final ({List<LargeCardParticipant> participants, int openSlots}) Function(
     String,
     ActivityPinState,
@@ -39,6 +44,7 @@ class DotMarkersLayer {
     required this.markerAlignment,
     required this.focusedId,
     required this.onTap,
+    required this.animateInOf,
     required this.sessionParticipants,
   });
 
@@ -93,7 +99,16 @@ class DotMarkersLayer {
           width: box.width,
           height: box.height,
           alignment: markerAlignment(state, tier),
+          // The key goes on the CHILD, never on Marker.key: MarkerLayer emits
+          // one Positioned(key: marker.key) per visible world copy as siblings
+          // of one Stack, so a Marker.key crashes with duplicate keys when the
+          // map repeats at min zoom (#7947). A child key sits one level down,
+          // inside its own Positioned subtree, so copies can't collide — while
+          // still forcing a positionally re-matched slot to discard a
+          // different activity's state instead of reusing it, which is what
+          // made unread badges flash on the wrong pins during zoom (#8136).
           child: Opacity(
+            key: ValueKey(card.activityId),
             opacity: nonStartableOf(card.activityId) ? 0.5 : 1.0,
             child: WorldMapDot(
               card: card,
@@ -106,6 +121,7 @@ class DotMarkersLayer {
               participantsFilled: counts.filled,
               participantsTotal: counts.total,
               isFocused: card.activityId == focusedId,
+              animateIn: animateInOf(card.activityId),
             ),
           ),
         );

--- a/lib/routes/world/exiting_large_markers_layer.dart
+++ b/lib/routes/world/exiting_large_markers_layer.dart
@@ -28,7 +28,10 @@ class ExitingLargeMarkersLayer {
               WorldMapLargeCard.tailHeight +
               WorldMapLargeCard.badgeOverhang,
           alignment: Alignment.topCenter,
+          // Child key, never Marker.key — see dot_markers_layer.dart
+          // (#7947/#8136).
           child: Align(
+            key: ValueKey('exiting_large_${snap.card.activityId}'),
             alignment: Alignment.bottomCenter,
             child: WorldMapLargeCardAnimated(
               dying: true,

--- a/lib/routes/world/exiting_markers_layer.dart
+++ b/lib/routes/world/exiting_markers_layer.dart
@@ -29,7 +29,11 @@ class ExitingMarkersLayer {
           width: box.width,
           height: box.height,
           alignment: markerAlignment(p.state, p.tier),
+          // Child key, never Marker.key — see dot_markers_layer.dart
+          // (#7947/#8136). Keeps a dying dot's exit animation tied to its own
+          // activity through MarkerLayer's positional reconciliation.
           child: WorldMapDot(
+            key: ValueKey('exiting_${p.card.activityId}'),
             card: p.card,
             state: p.state,
             tier: p.tier,

--- a/lib/routes/world/large_markers_layer.dart
+++ b/lib/routes/world/large_markers_layer.dart
@@ -14,12 +14,19 @@ class LargeMarkersLayer {
   final void Function(QuestActivityCard) onTap;
   final void Function(QuestActivityCard) onClose;
 
+  /// Whether this card should play its entry grow-in — false for cards
+  /// already on screen at the last settle, so a State recreated by
+  /// MarkerLayer's per-frame positional reconciliation doesn't replay its
+  /// pop-in (#8136). Mirrors [DotMarkersLayer.animateInOf].
+  final bool Function(String) animateInOf;
+
   const LargeMarkersLayer({
     required this.largeCards,
     required this.currentLarge,
     required this.focusedId,
     required this.onTap,
     required this.onClose,
+    required this.animateInOf,
   });
 
   MarkerLayer layer() {
@@ -48,11 +55,16 @@ class LargeMarkersLayer {
                   WorldMapLargeCard.tailHeight +
                   WorldMapLargeCard.badgeOverhang,
               alignment: Alignment.topCenter,
+              // Child key, never Marker.key — see dot_markers_layer.dart
+              // (#7947/#8136). Keeps the animated card's state tied to its own
+              // activity through MarkerLayer's positional reconciliation.
               child: Align(
+                key: ValueKey(card.activityId),
                 // Bottom-align so the card+tail hugs its pin (the tail tip lands on
                 // the dot) instead of floating with a gap above it (#7153).
                 alignment: Alignment.bottomCenter,
                 child: WorldMapLargeCardAnimated(
+                  animateIn: animateInOf(card.activityId),
                   child: WorldMapLargeCard(
                     card: snap.card,
                     state: snap.state,

--- a/lib/routes/world/mid_size_pin_labels_layer.dart
+++ b/lib/routes/world/mid_size_pin_labels_layer.dart
@@ -60,7 +60,13 @@ class MidSizePinLabelsLayer {
             width: size.width,
             height: size.height,
             alignment: _labelAlignment(side, size),
+            // Child key, never Marker.key — see dot_markers_layer.dart: a
+            // Marker.key duplicates across world copies at min zoom (#7947);
+            // the child key keeps the label's GestureDetector state tied to
+            // its own activity through MarkerLayer's per-frame positional
+            // reconciliation (#8136).
             child: Opacity(
+              key: ValueKey('label_$id'),
               // Match the pin: a non-startable available pin's label dims too.
               opacity: nonStartableOf(id) ? 0.5 : 1.0,
               // ExcludeSemantics: the pin's own Semantics(button) node stays the

--- a/lib/routes/world/world_map_large_card.dart
+++ b/lib/routes/world/world_map_large_card.dart
@@ -34,11 +34,19 @@ class WorldMapLargeCardAnimated extends StatefulWidget {
   final bool dying;
   final VoidCallback? onExited;
 
+  /// Whether a freshly created state plays the entry grow-in. False for cards
+  /// already on screen at the last settle — MarkerLayer's per-frame positional
+  /// reconciliation can discard and recreate this State mid-gesture, and such
+  /// a card must render at full scale instead of replaying its pop-in (#8136).
+  /// Mirrors [WorldMapDot.animateIn].
+  final bool animateIn;
+
   const WorldMapLargeCardAnimated({
     super.key,
     required this.child,
     this.dying = false,
     this.onExited,
+    this.animateIn = true,
   });
 
   @override
@@ -56,7 +64,18 @@ class _WorldMapLargeCardAnimatedState extends State<WorldMapLargeCardAnimated>
   void initState() {
     super.initState();
     _ctrl = AnimationController(vsync: this, duration: _duration);
-    if (!widget.dying) _ctrl.forward();
+    if (widget.dying) {
+      // Built fresh by ExitingLargeMarkersLayer, so didUpdateWidget's
+      // false→true arm never runs — play the exit from here or onExited never
+      // fires and the card leaks into _exitingLarge (#8136). Mirrors
+      // WorldMapDot.
+      _ctrl.value = 1.0;
+      _ctrl.reverse().then((_) => widget.onExited?.call());
+    } else if (widget.animateIn) {
+      _ctrl.forward();
+    } else {
+      _ctrl.value = 1.0;
+    }
   }
 
   @override

--- a/lib/routes/world/world_map_ranking.dart
+++ b/lib/routes/world/world_map_ranking.dart
@@ -346,26 +346,34 @@ RankingResult rankPins({
 }) {
   PinSignals sig(String id) => signals[id] ?? const PinSignals();
 
-  final scored = inViewPins.map((p) {
-    final band = relevanceBand(
-      p,
-      userL2: userL2,
-      userCefr: userCefr,
-      progression: progression,
-    );
-    return _Scored(
-      p,
-      pinScore(
-        band: band,
-        s: sig(p.activityId),
-        roleCount: p.roleCount,
-        isNewLearner: isNewLearner,
-        isDismissed: dismissedIds.contains(p.activityId),
-        ratingAverage: p.ratingAverage,
-        ratingCount: p.ratingCount,
-      ),
-    );
-  }).toList()..sort((a, b) => b.score.compareTo(a.score));
+  final scored =
+      inViewPins.map((p) {
+        final band = relevanceBand(
+          p,
+          userL2: userL2,
+          userCefr: userCefr,
+          progression: progression,
+        );
+        return _Scored(
+          p,
+          pinScore(
+            band: band,
+            s: sig(p.activityId),
+            roleCount: p.roleCount,
+            isNewLearner: isNewLearner,
+            isDismissed: dismissedIds.contains(p.activityId),
+            ratingAverage: p.ratingAverage,
+            ratingCount: p.ratingCount,
+          ),
+        );
+      }).toList()..sort((a, b) {
+        // activityId tiebreaker: List.sort is unstable, so without it equal-score
+        // pins can swap order between settles and flip mid<->small tiers (#8136).
+        final byScore = b.score.compareTo(a.score);
+        return byScore != 0
+            ? byScore
+            : a.pin.activityId.compareTo(b.pin.activityId);
+      });
 
   // The full score-ranked list with the per-objective diversity cap applied (not
   // yet truncated to N — the trail reservation needs the tail). Splitting it into

--- a/lib/routes/world/world_map_state_dot.dart
+++ b/lib/routes/world/world_map_state_dot.dart
@@ -50,6 +50,13 @@ class WorldMapDot extends StatefulWidget {
   final bool dying;
   final VoidCallback? onExited;
 
+  /// Whether a freshly created state plays the 0→1 entry scale-in. False for
+  /// pins already on screen at the last settle: flutter_map's MarkerLayer
+  /// culls/reorders its (unkeyed) Positioned children every camera frame, so
+  /// this State can be discarded and recreated mid-gesture — such a pin must
+  /// render at full scale immediately instead of replaying its pop-in (#8136).
+  final bool animateIn;
+
   const WorldMapDot({
     super.key,
     required this.card,
@@ -64,6 +71,7 @@ class WorldMapDot extends StatefulWidget {
     this.isFocused = false,
     this.dying = false,
     this.onExited,
+    this.animateIn = true,
   });
 
   @override
@@ -81,7 +89,18 @@ class _WorldMapDotState extends State<WorldMapDot>
       vsync: this,
       duration: const Duration(milliseconds: 200),
     );
-    if (!widget.dying) _ctrl.forward();
+    if (widget.dying) {
+      // A dying dot is built fresh by ExitingMarkersLayer, so didUpdateWidget's
+      // false→true arm never runs for it — play the exit from here, or the
+      // controller stays at 0 (invisible) and onExited never fires, leaking the
+      // pin into the view's _exiting map forever (#8136).
+      _ctrl.value = 1.0;
+      _ctrl.reverse().then((_) => widget.onExited?.call());
+    } else if (widget.animateIn) {
+      _ctrl.forward();
+    } else {
+      _ctrl.value = 1.0;
+    }
   }
 
   @override

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -188,6 +188,17 @@ class _WorldMapViewState extends State<WorldMapView> {
   /// [_exiting] with the correct visual state when a pin leaves.
   Map<String, PinSnapshot> _lastActive = {};
 
+  /// Non-large pin ids that have already played their entry scale-in. A pin
+  /// only animates in on its first appearance ([Set.add] returning true at
+  /// build time); after that, a [WorldMapDot] State recreated mid-gesture by
+  /// MarkerLayer's positional reconciliation renders at full scale instead of
+  /// replaying the pop-in (#8136). Pruned at each settle in [_updateExiting],
+  /// so a pin that leaves and later returns pops in fresh again.
+  final Set<String> _enteredIds = {};
+
+  /// Mirrors [_enteredIds] for the large tier ([WorldMapLargeCardAnimated]).
+  final Set<String> _enteredLargeIds = {};
+
   /// Large cards that have left the large tier (demoted, or the dot promoted
   /// past it out of view) and are animating to scale/opacity 0 — mirrors
   /// [_exiting]/[_lastActive] but for [WorldMapLargeCard] (world-map card
@@ -334,6 +345,12 @@ class _WorldMapViewState extends State<WorldMapView> {
     // Re-appeared as a (still) non-large pin: cancel any in-progress exit.
     _exiting.removeWhere((id, _) => currentNonLargeIds.contains(id));
 
+    // A pin gone from the render model forgets its "already entered" mark, so
+    // its next appearance (incl. demotion back from large) pops in fresh.
+    // While the camera is moving the frozen renderer yields the same id set,
+    // so nothing churns mid-gesture (#8136).
+    _enteredIds.retainAll(currentNonLargeIds);
+
     // Anything that was a dot last frame and isn't a dot this frame —
     // genuinely gone, or promoted to large — plays the shrink-out.
     for (final entry in _lastActive.entries) {
@@ -365,6 +382,9 @@ class _WorldMapViewState extends State<WorldMapView> {
     final currentIds = currentLarge.keys.toSet();
 
     _exitingLarge.removeWhere((id, _) => currentIds.contains(id));
+
+    // Mirror of _updateExiting's pruning (#8136).
+    _enteredLargeIds.retainAll(currentIds);
 
     for (final entry in _lastActiveLarge.entries) {
       if (!currentIds.contains(entry.key) &&
@@ -898,6 +918,10 @@ class _WorldMapViewState extends State<WorldMapView> {
                     sessionParticipants: (a, b) => _sessionParticipants(a, b),
                     focusedId: render.focusedId,
                     onTap: widget.controller.openActivity,
+                    // Set.add returns true only on first insertion — a pin
+                    // animates in the first build it appears, then holds full
+                    // scale through State recreations (#8136).
+                    animateInOf: _enteredIds.add,
                   ).layer(),
                   // Activity-name labels for mid pins, above the dots but below the
                   // large cards (world-map.instructions.md, "Pin display"; z-order:
@@ -931,6 +955,7 @@ class _WorldMapViewState extends State<WorldMapView> {
                     focusedId: render.focusedId,
                     onTap: widget.controller.openActivity,
                     onClose: widget.controller.dismissLargeCard,
+                    animateInOf: _enteredLargeIds.add,
                   ).layer(),
                   Positioned(
                     // On a narrow screen the bottom chrome (nav widget + the search bar

--- a/test/pangea/world/world_map_dot_animation_test.dart
+++ b/test/pangea/world/world_map_dot_animation_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/chat_list/unread_bubble.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_state_dot.dart';
+
+/// Covers #8136: flutter_map's MarkerLayer culls/reorders its (unkeyed)
+/// Positioned children every camera frame, so a [WorldMapDot]'s State can be
+/// discarded and recreated mid-gesture. A recreated pin must not replay its
+/// entry pop-in (`animateIn: false` renders settled immediately), a dying pin
+/// built fresh must actually play its exit and fire `onExited` (or it leaks
+/// into the view's `_exiting` map forever), and a mid pin with no unread room
+/// must not mount an [UnreadBubble] at all.
+void main() {
+  const card = QuestActivityCard(
+    activityId: 'a1',
+    title: 'Test Activity',
+    l2: 'es',
+    coordinates: [0, 0],
+    learningObjectiveRefs: [],
+  );
+
+  Future<void> pump(WidgetTester tester, Widget child) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(body: Center(child: child)),
+      ),
+    );
+    // The async L10n delegate leaves the home empty on the very first frame;
+    // one zero-duration pump builds the dot without advancing the clock, so
+    // assertions below still see the animation's first frame.
+    await tester.pump(Duration.zero);
+  }
+
+  /// The dot's own entry/exit ScaleTransition — the outermost one in its
+  /// subtree (`_WorldMapDotState.build`).
+  double scaleOf(WidgetTester tester) => tester
+      .widget<ScaleTransition>(
+        find
+            .descendant(
+              of: find.byType(WorldMapDot),
+              matching: find.byType(ScaleTransition),
+            )
+            .first,
+      )
+      .scale
+      .value;
+
+  group('WorldMapDot entry animation (#8136)', () {
+    testWidgets('animateIn: false renders at full scale on the first frame', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        const WorldMapDot(
+          card: card,
+          state: ActivityPinState.available,
+          tier: PinTier.mid,
+          onTap: _noop,
+          pinged: false,
+          animateIn: false,
+        ),
+      );
+
+      // First frame only — no settle. A recreated pin must never show a
+      // transient sub-scale frame.
+      expect(
+        scaleOf(tester),
+        1.0,
+        reason:
+            'a pin recreated mid-gesture (animateIn: false) must render '
+            'settled immediately, not replay its pop-in (#8136)',
+      );
+    });
+
+    testWidgets('animateIn: true (default) plays the 0→1 scale-in', (
+      tester,
+    ) async {
+      await pump(
+        tester,
+        const WorldMapDot(
+          card: card,
+          state: ActivityPinState.available,
+          tier: PinTier.mid,
+          onTap: _noop,
+          pinged: false,
+        ),
+      );
+
+      expect(
+        scaleOf(tester),
+        lessThan(1.0),
+        reason: 'a genuinely new pin still animates in from 0',
+      );
+
+      await tester.pumpAndSettle();
+      expect(scaleOf(tester), 1.0);
+    });
+
+    testWidgets('dying at construction plays the exit and fires onExited', (
+      tester,
+    ) async {
+      // ExitingMarkersLayer builds dying dots FRESH, so didUpdateWidget's
+      // false→true arm never runs — before #8136 the controller stayed at 0
+      // and onExited never fired, leaking the pin into _exiting forever.
+      var exited = false;
+      await pump(
+        tester,
+        WorldMapDot(
+          card: card,
+          state: ActivityPinState.available,
+          tier: PinTier.mid,
+          onTap: _noop,
+          pinged: false,
+          dying: true,
+          onExited: () => exited = true,
+        ),
+      );
+
+      // The exit starts from full scale (the pin was visible when it died).
+      expect(scaleOf(tester), 1.0);
+
+      await tester.pumpAndSettle();
+      expect(
+        exited,
+        isTrue,
+        reason:
+            'a freshly built dying dot must complete its shrink-out and '
+            'call onExited so the view can drain _exiting (#8136)',
+      );
+      expect(scaleOf(tester), 0.0);
+    });
+  });
+
+  testWidgets('a mid pin with no unread room mounts no UnreadBubble', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      const WorldMapDot(
+        card: card,
+        state: ActivityPinState.ongoingActive,
+        tier: PinTier.mid,
+        onTap: _noop,
+        pinged: false,
+        // unreadRoom omitted (null): the badge slot must stay empty.
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byType(UnreadBubble),
+      findsNothing,
+      reason:
+          'an ongoing pin whose chat has nothing unread must not show an '
+          'unread badge at any point (#8136)',
+    );
+  });
+}
+
+void _noop() {}

--- a/test/pangea/world/world_map_marker_keys_test.dart
+++ b/test/pangea/world/world_map_marker_keys_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/dot_markers_layer.dart';
+import 'package:fluffychat/routes/world/world_map_client_extension.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_state_dot.dart';
+
+/// Regression guard for #7947 × #8136.
+///
+/// At minimum zoom the map is narrower than the screen, so MarkerLayer emits
+/// each marker once per visible world copy — as sibling Positioned widgets in
+/// ONE Stack. A key on [Marker.key] therefore duplicates and crashes (#7947,
+/// which removed all marker keys). #8136 restored identity by keying the
+/// marker's CHILD instead: child keys live one level down, each inside its own
+/// Positioned subtree, so world copies can never collide as siblings. This
+/// test pins both halves: multiple world copies render, and no duplicate-key
+/// FlutterError is thrown — including across a camera move.
+void main() {
+  const cards = [
+    QuestActivityCard(
+      activityId: 'a1',
+      title: 'Activity One',
+      l2: 'es',
+      coordinates: [0, 10],
+      learningObjectiveRefs: [],
+    ),
+    QuestActivityCard(
+      activityId: 'a2',
+      title: 'Activity Two',
+      l2: 'es',
+      coordinates: [20, -10],
+      learningObjectiveRefs: [],
+    ),
+  ];
+
+  MarkerLayer dotLayer() => DotMarkersLayer(
+    nonLargeCards: cards,
+    tierOf: (_) => PinTier.mid,
+    stateOf: (_) => ActivityPinState.available,
+    starLevelOf: (_) => ActivityStarLevel.none,
+    nonStartableOf: (_) => false,
+    pingedOf: (_) => false,
+    activeActivityInstance: null,
+    markerBox: (_, _) => const Size(44, 54),
+    markerAlignment: (_, _) => Alignment.center,
+    focusedId: null,
+    onTap: (_) {},
+    animateInOf: (_) => true,
+    sessionParticipants: (_, _) => (participants: const [], openSlots: 0),
+  ).layer();
+
+  testWidgets(
+    'child-keyed markers survive the multi-world-copy view and a camera move',
+    (tester) async {
+      final controller = MapController();
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          supportedLocales: L10n.supportedLocales,
+          home: FlutterMap(
+            mapController: controller,
+            options: const MapOptions(
+              // Zoom 0: the whole world is 256px in an 800px test surface, so
+              // MarkerLayer repeats it — the exact #7947 crash scenario.
+              initialCenter: LatLng(0, 0),
+              initialZoom: 0,
+              minZoom: 0,
+            ),
+            children: [dotLayer()],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.takeException(),
+        isNull,
+        reason:
+            'keys on marker CHILDREN must not duplicate across world copies '
+            '(#7947) — only Marker.key does',
+      );
+      expect(
+        find.byType(WorldMapDot),
+        findsAtLeast(3),
+        reason:
+            'the world must actually be repeating (each activity rendered in '
+            'multiple world copies) for this regression test to mean anything',
+      );
+
+      // Pan across the antimeridian seam — world-copy membership changes,
+      // exercising the per-frame cull/reorder path that #8136 fixes.
+      controller.move(const LatLng(0, 180), 0);
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(WorldMapDot), findsAtLeast(3));
+    },
+  );
+}

--- a/test/pangea/world_map_ranking_test.dart
+++ b/test/pangea/world_map_ranking_test.dart
@@ -761,4 +761,42 @@ void main() {
       },
     );
   });
+
+  group('rankPins — deterministic order for equal scores (#8136)', () {
+    test('equal-score pins rank in activityId order', () {
+      // Four identical pins (same band, same signals) — only activityId can
+      // break the tie, so the ranked order must be lexicographic.
+      final pins = [
+        _card('delta', refs: ['k1']),
+        _card('alpha', refs: ['k2']),
+        _card('charlie', refs: ['k3']),
+        _card('bravo', refs: ['k4']),
+      ];
+      final result = rank(pins, {
+        for (final p in pins) p.activityId: const PinSignals(),
+      });
+      expect(result.ordered, ['alpha', 'bravo', 'charlie', 'delta']);
+    });
+
+    test('the ranked order is identical across shuffled input orders', () {
+      // List.sort is unstable, so without the tiebreaker equal-score pins can
+      // swap between calls and flip mid<->small tiers between settles.
+      final pins = [
+        for (var i = 0; i < 12; i++) _card('pin$i', refs: ['k$i']),
+      ];
+      final signals = {for (final p in pins) p.activityId: const PinSignals()};
+      final baseline = rank(pins, signals, midBudget: 6).ordered;
+      for (var rotation = 1; rotation < pins.length; rotation++) {
+        final rotated = [
+          ...pins.sublist(rotation),
+          ...pins.sublist(0, rotation),
+        ];
+        expect(
+          rank(rotated, signals, midBudget: 6).ordered,
+          baseline,
+          reason: 'rotation $rotation changed the ranked order',
+        );
+      }
+    });
+  });
 }


### PR DESCRIPTION
### What

Stop mid pins replaying their pop-in and unread badges flashing on the wrong pins while the map camera zooms.

### Why

Closes #8136

flutter_map's `MarkerLayer` culls and reorders its `Positioned` children every camera frame. Since #7947 removed all marker keys (duplicate-key crash across world copies at min zoom), that reconciliation was positional: pin `State`s were discarded (entry animation replays → size flicker) or re-associated with a different activity (`UnreadBubble` animates its diameter on a non-unread pin → badge flash). Intended behavior is already specified in `world-map.instructions.md` ("nothing about pin display changes until the camera settles") — no doc change.

### How

- **Keys on marker *children*, never `Marker.key`** — a child key sits inside its own `Positioned` subtree, so world copies can't collide as siblings (the #7947 crash), while a re-matched slot now discards a different activity's state instead of reusing it. Commented at each site.
- **`animateIn` on `WorldMapDot` / `WorldMapLargeCardAnimated`**, driven by view-owned entered-id sets pruned at each settle: only a pin's first appearance animates in; a `State` recreated mid-gesture renders settled.
- **Deterministic ranking tiebreaker** (activityId on equal scores) so equal-score pins can't swap mid↔small between settles (`List.sort` is unstable).
- **Exit-animation fix**: dying dots/cards are built fresh by the exiting layers, so `didUpdateWidget`'s `false→true` arm never ran — the controller stayed at 0 and `onExited` never fired, leaking into `_exiting` forever. `initState` now plays the reverse and fires `onExited`.

### Testing

- `fvm flutter test test/pangea/` — 1903 passed; only failure is the known local baseline (`choreo_endpoint_test.dart`, no `TEST_MATRIX_*` creds).
- New `test/pangea/world/world_map_dot_animation_test.dart` — `animateIn: false` full-scale on first frame; default still animates; fresh `dying: true` fires `onExited`; no `UnreadBubble` without an unread room.
- New `test/pangea/world/world_map_marker_keys_test.dart` — #7947 regression guard: real `FlutterMap` at zoom 0 (multiple world copies) + camera move across the seam, no duplicate-key error, pins render in every copy.
- Extended `world_map_ranking_test.dart` — equal-score order is lexicographic and identical across shuffled inputs.
- Manual (local stack, web): zoom cycles over mid pins/labels/small dots — sizes constant across settles, no badges on non-unread ongoing pins, no rendering exceptions. Fine-grained flicker + unread-badge checks per the issue's TO TEST need a staging account with multiple ongoing chats.

### Accessibility

No new or changed controls — keys and animation timing only.

### Deploy Notes

None
