### PR TITLE
fix(courses): stop the chat list from navigating into an auto-accepted course

### DIFF
--- a/lib/routes/chat_list/chat_list.dart
+++ b/lib/routes/chat_list/chat_list.dart
@@ -682,6 +682,13 @@ class ChatListController extends State<ChatList>
     if (mounted) showSubscribedSnackbar(context);
   }
 
+  /// Settle pending space invites when the chat list opens: auto-accept the
+  /// ones the client takes without asking, prompt on the rest. The accepting
+  /// stays — a knock the user sent must never sit around looking like an
+  /// unsolicited invite — but the chat list does NOT follow the join to the
+  /// course. Opening the chat list means the user came to read chats, not to be
+  /// moved into a course (#7792). Matches what [_onInviteSync] already does for
+  /// an approved knock that lands live.
   Future<void> _joinInvitedSpaces() async {
     final client = Matrix.of(context).client;
     final invitedSpaces = client.rooms.where(
@@ -689,16 +696,13 @@ class ChatListController extends State<ChatList>
     );
 
     for (final space in invitedSpaces) {
+      if (!mounted) return;
       final joinResp = await SpaceTapUtil.onInviteTap(context, space);
       if (joinResp == null) continue;
 
+      if (!mounted) return;
       final handler = JoinRoomAnalyticsConsentHandler(joinResp, space);
-      final joinedRoomId = await handler.handle(context);
-      if (joinedRoomId == null) continue;
-
-      context.go(
-        WorkspaceNav.openCourse(GoRouterState.of(context).uri, joinedRoomId),
-      );
+      await handler.handle(context);
     }
   }
 

--- a/lib/utils/chat_list_handle_space_tap.dart
+++ b/lib/utils/chat_list_handle_space_tap.dart
@@ -8,7 +8,6 @@ import 'package:fluffychat/features/join_codes/knocked_rooms_extension.dart';
 import 'package:fluffychat/features/join_codes/space_code_repo.dart';
 import 'package:fluffychat/routes/chat_list/room_invite_dialog.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
-import 'package:fluffychat/widgets/matrix.dart';
 
 class SpaceTapUtil {
   static Future<JoinResponse?> autoJoin(
@@ -22,6 +21,21 @@ class SpaceTapUtil {
     return resp.result;
   }
 
+  /// Whether an invite to [space] is one the client accepts without asking the
+  /// user — a child of a course they're already in, or the approval of a knock
+  /// they sent themselves. Everything else needs an explicit accept/decline.
+  static bool isAutoAcceptedInvite(Room space) {
+    if (space.hasKnocked) return true;
+
+    final joinedSpaces = space.client.rooms.where(
+      (element) => element.isSpace && element.membership == Membership.join,
+    );
+
+    return joinedSpaces.any(
+      (s) => s.spaceChildren.any((c) => c.roomId == space.id),
+    );
+  }
+
   static Future<JoinResponse?> onInviteTap(
     BuildContext context,
     Room space,
@@ -32,15 +46,7 @@ class SpaceTapUtil {
       return null;
     }
 
-    final rooms = Matrix.of(context).client.rooms.where(
-      (element) => element.isSpace && element.membership == Membership.join,
-    );
-
-    final isSpaceChild = rooms.any(
-      (s) => s.spaceChildren.any((c) => c.roomId == space.id),
-    );
-
-    if (isSpaceChild || space.hasKnocked) {
+    if (isAutoAcceptedInvite(space)) {
       return autoJoin(context, space);
     }
 

--- a/test/pangea/auto_accepted_invite_test.dart
+++ b/test/pangea/auto_accepted_invite_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/join_codes/knocked_rooms_model.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/utils/chat_list_handle_space_tap.dart';
+import 'get_test_client.dart';
+
+/// Two of the three space-invite outcomes in joining-courses.instructions.md
+/// — "child of a joined parent" and "previously knocked" — join without ever
+/// asking the user. A knock the learner sent must never come back looking like
+/// an unsolicited invite, so this is load-bearing: an invite that stops being
+/// auto-accepted is a regression, not a fix (see #7792, where the chat list
+/// dropped the accepting instead of dropping the navigation that followed it).
+void main() {
+  late Client client;
+
+  const userId = '@test:fakeServer.notExisting';
+  const invitedSpaceId = '!invited:fakeServer.notExisting';
+
+  setUp(() async {
+    client = await getTestClient();
+  });
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  Event stateEvent(
+    Room room, {
+    required String type,
+    required Map<String, dynamic> content,
+    String stateKey = '',
+  }) => Event(
+    type: type,
+    content: content,
+    stateKey: stateKey,
+    senderId: userId,
+    eventId: '\$${type}_$stateKey',
+    originServerTs: DateTime.now(),
+    room: room,
+  );
+
+  Room space(String id, {required Membership membership, String? childId}) {
+    final room = Room(id: id, client: client, membership: membership);
+    room.setState(
+      stateEvent(
+        room,
+        type: EventTypes.RoomCreate,
+        content: {'type': RoomCreationTypes.mSpace},
+      ),
+    );
+    if (childId != null) {
+      room.setState(
+        stateEvent(
+          room,
+          type: EventTypes.SpaceChild,
+          content: {
+            'via': ['fakeServer.notExisting'],
+          },
+          stateKey: childId,
+        ),
+      );
+    }
+    client.rooms.add(room);
+    return room;
+  }
+
+  void recordKnock(String roomId) {
+    client.accountData[PangeaEventTypes.knockedRooms] = BasicEvent(
+      type: PangeaEventTypes.knockedRooms,
+      content: KnockedRoomsModel(knockedRoomIds: [roomId]).toJson(),
+    );
+  }
+
+  test('an invite the user never knocked on is not auto-accepted', () {
+    final invited = space(invitedSpaceId, membership: Membership.invite);
+    expect(SpaceTapUtil.isAutoAcceptedInvite(invited), isFalse);
+  });
+
+  test('an approved knock is auto-accepted', () {
+    final invited = space(invitedSpaceId, membership: Membership.invite);
+    recordKnock(invitedSpaceId);
+    expect(SpaceTapUtil.isAutoAcceptedInvite(invited), isTrue);
+  });
+
+  test('an invite to a child of a joined course is auto-accepted', () {
+    final invited = space(invitedSpaceId, membership: Membership.invite);
+    space(
+      '!parent:fakeServer.notExisting',
+      membership: Membership.join,
+      childId: invitedSpaceId,
+    );
+    expect(SpaceTapUtil.isAutoAcceptedInvite(invited), isTrue);
+  });
+
+  test('a child of a course the user has not joined is not auto-accepted', () {
+    final invited = space(invitedSpaceId, membership: Membership.invite);
+    space(
+      '!parent:fakeServer.notExisting',
+      membership: Membership.invite,
+      childId: invitedSpaceId,
+    );
+    expect(SpaceTapUtil.isAutoAcceptedInvite(invited), isFalse);
+  });
+
+  test('a knock recorded for another room does not leak across invites', () {
+    final invited = space(invitedSpaceId, membership: Membership.invite);
+    recordKnock('!other:fakeServer.notExisting');
+    expect(SpaceTapUtil.isAutoAcceptedInvite(invited), isFalse);
+  });
+}


### PR DESCRIPTION
## What

The chat list no longer navigates into a course it auto-accepted an invite for. The accepting itself is unchanged.

## Why

Closes #7792

`ChatListController.initState` sweeps pending space invites through `SpaceTapUtil.onInviteTap` and then `context.go`s to whatever it joined. Opening the chat list to read chats pulled the learner into a course.

Only the navigation is removed. The auto-accept stays and is load-bearing: a knock the learner sent must never come back looking like an unsolicited invite, which is exactly what auto-accepting it prevents. The sweep now settles the invite in place and leaves the user on the chat list — the same shape `_onInviteSync` already has for an approved knock that lands while the client is running.

The `Invite Handling` and `All auto-join cases` tables in [joining-courses.instructions.md](.github/instructions/joining-courses.instructions.md#invite-handling) are unaffected: every auto-join case still auto-joins.

Changes to look over:
- `lib/routes/chat_list/chat_list.dart` — `_joinInvitedSpaces` drops the trailing `context.go(WorkspaceNav.openCourse(...))`. Join + analytics-consent handling are untouched. Added `mounted` guards around the awaits in the loop.
- `lib/utils/chat_list_handle_space_tap.dart` — the auto-accept condition (`hasKnocked`, or child of a joined course) is extracted from `onInviteTap` into `SpaceTapUtil.isAutoAcceptedInvite`, behavior identical. It takes a `Room` rather than a `BuildContext` (`Room.client` is the same client `Matrix.of(context)` returned) so it can be unit-tested.
- `test/pangea/auto_accepted_invite_test.dart` — new; pins which invites auto-accept so a later change can't quietly turn an approved knock back into a visible invite.

## Testing

**Unit** — `fvm flutter test`: 1939 pass, 3 skipped. 2 pre-existing local failures (`choreo_endpoint_test`, `cms_endpoint_test`) are the documented no-credentials/no-server baseline, unrelated to this diff. `fvm flutter analyze lib test`: clean.

New `test/pangea/auto_accepted_invite_test.dart` covers five cases: plain invite, approved knock, child of a joined course, child of a course not joined, and a knock recorded for a different room.

**Manual, local stack** (Synapse :8008, web build of this branch, two accounts):
1. `learner` knocks on a knock-rule course space; knock recorded in `org.pangea.knocked_rooms`.
2. Course owner accepts → `learner`'s membership becomes `invite`.
3. `learner` opens the chat list → **stays on the chat list**.
4. The invite was auto-accepted in place: membership `join` server-side, and the knock record moved from `room_ids` to `accepted_invite_room_ids`.
5. Courses panel and nav rail show it as a normal joined course — no "Invited" badge at any point.

E2E/Playwright not run — no spec covers the knock-accept flow and this change adds no web surface.

## Deploy Notes

None
