### PR TITLE
fix(nav): remove per-item rail fills causing hairline seams on Windows

### DIFF
--- a/lib/widgets/navi_rail_item.dart
+++ b/lib/widgets/navi_rail_item.dart
@@ -46,9 +46,12 @@ class NaviRailItem extends StatelessWidget {
         onTap: onTap,
         child: HoverBuilder(
           builder: (context, hovered) {
-            return Container(
+            // No background fill here: WorkspaceDock already paints the
+            // rail-wide surface. Per-item opaque fills leave hairline seams
+            // between items at fractional device pixel ratios (Windows
+            // 125%/150% display scaling) — see #7032.
+            return SizedBox(
               height: height,
-              decoration: BoxDecoration(color: theme.colorScheme.surface),
               child: Stack(
                 children: [
                   Positioned(


### PR DESCRIPTION
### What

Remove the per-item opaque `surface` fill from `NaviRailItem` — the rail's background is now the single continuous fill painted by `WorkspaceDock`.

### Why

Closes #7032.

- Windows commonly runs 125%/150% display scaling → fractional `devicePixelRatio` (1.25/1.5). Every `NaviRailItem` painted its own full-width opaque fill, and the rail's `ListView` puts each item in its own repaint boundary — abutting opaque fills rasterized in separate layers at fractional device offsets leave sub-pixel anti-aliasing seams exactly at item boundaries. macOS/mobile run integer DPRs, which is why the lines are Windows-only.
- The per-item fill is vestigial: #7028 added it solely to mask the sliding hover-label drawer, which has since been deleted. It now only duplicates `WorkspaceDock`'s rail-wide surface. With it gone, item boundaries paint nothing, so there is nothing to seam at any DPR.
- Prior attempt #7035 removed a `ClipRect` on the goals dropdown — wrong lever (the clip painted nothing), hence the reopen. The dropdown half of #7032 was since structurally fixed by the `ActivityGoalHeaderCard` refactor (header/body no longer paint separate abutting fills; one `AnimatedContainer` paints the card) — it needs Windows re-verification along with the rail.

### Testing

- `fvm flutter analyze` clean; `fvm flutter test`: 1947 passed, 1 pre-existing environment-dependent failure (`choreo_endpoint_test` course request 401 — test account has no email 3pid; unrelated).
- Local web build with the engine forced to DPR 1.25 (Windows-like fractional scaling), rail inspected at 4× magnification before/after: renders identically and cleanly — continuous dock fill, rounded corners, selection indicator intact. The Windows-only artifact does not reproduce under CanvasKit locally, so the definitive check is Windows QA per the issue's TO TEST.

### Accessibility

- [x] N/A — no new or changed controls (background-decoration removal only).

### Deploy Notes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)