### PR TITLE
fix(activities): park an activity-plan fetch on the attempt, not the outcome

### DIFF
--- a/lib/features/activity_sessions/activity_plan_repo.dart
+++ b/lib/features/activity_sessions/activity_plan_repo.dart
@@ -304,23 +304,20 @@ class ActivityPlanRepo
     // above could never be.
     _nextAttempt[key] = now().add(_attemptCooldown);
     _hydrating.add(key);
-    getPlan(
-      activityId,
-      l1: l1,
-      version: version,
-      forceRefresh: doRevalidate,
-    ).catchError((Object e, StackTrace s) {
-      // `getPlan` is fire-and-forget here, and `.plan`'s mapping runs outside
-      // BaseRepo's try/catch, so without this a malformed body is an unhandled
-      // async error. The parked entry stays put, so it cannot re-arm.
-      ErrorHandler.logError(
-        e: e,
-        s: s,
-        data: {'activityId': activityId, 'l1': l1, 'version': version},
-        level: SentryLevel.warning,
-      );
-      return null;
-    }).whenComplete(() => _hydrating.remove(key));
+    getPlan(activityId, l1: l1, version: version, forceRefresh: doRevalidate)
+        .catchError((Object e, StackTrace s) {
+          // `getPlan` is fire-and-forget here, and `.plan`'s mapping runs outside
+          // BaseRepo's try/catch, so without this a malformed body is an unhandled
+          // async error. The parked entry stays put, so it cannot re-arm.
+          ErrorHandler.logError(
+            e: e,
+            s: s,
+            data: {'activityId': activityId, 'l1': l1, 'version': version},
+            level: SentryLevel.warning,
+          );
+          return null;
+        })
+        .whenComplete(() => _hydrating.remove(key));
     return true;
   }
 

--- a/lib/features/activity_sessions/activity_plan_repo.dart
+++ b/lib/features/activity_sessions/activity_plan_repo.dart
@@ -80,6 +80,55 @@ class ActivityPlanRepo
   /// [ensure] stops re-fetching a known-missing id on every widget rebuild.
   final Set<String> _confirmedRemoved = {};
 
+  /// Earliest wall-clock time [ensure] may re-attempt a key.
+  ///
+  /// Set **before** the fetch is issued, and cleared only on success. That
+  /// ordering is the whole point: the previous guards (`_confirmedRemoved`,
+  /// `_hydrating`, `_resolved`) each recorded a specific *outcome*, so any
+  /// outcome nobody had enumerated — a 429, a 5xx, a mapping throw — matched
+  /// none of them and re-fetched on the very next rebuild. [ensure] is reached
+  /// from `build()`, so "no guard matched" meant "re-fetch at frame rate".
+  /// Parking on the *attempt* is total over outcomes that do not exist yet.
+  ///
+  /// Staging 2026-08-04: a 429 returns in ~47ms against ~5s for a success, so
+  /// the unguarded path turned ~1 fetch/5s into ~20/sec per card — the throttle
+  /// *increased* load ~100x and kept the per-user budget exhausted for hours.
+  final Map<String, DateTime> _nextAttempt = {};
+
+  /// Repo-wide pause after the backend rate-limits us.
+  ///
+  /// [_nextAttempt] is per key, and the number of keys is unbounded (the world
+  /// map hydrates one per visible pin — 104 distinct ids during the incident).
+  /// K keys under a per-key cooldown still emit K/cooldown requests, which at
+  /// K=104 exceeds the 60/min budget on its own. Only a repo-wide pause
+  /// restores the invariant "we stop when the server says stop", independent
+  /// of K. Deliberately scoped to this repo rather than shared: choreo budgets
+  /// `/choreo` and `/subscription` separately, so an activity 429 must never
+  /// stall checkout.
+  DateTime? _rateLimitedUntil;
+
+  static const Duration _attemptCooldown = Duration(seconds: 60);
+  static const Duration _rateLimitPause = Duration(seconds: 60);
+
+  /// Test seam: [ensure]'s clock. Backoff is wall-clock, so tests would
+  /// otherwise need real delays.
+  @visibleForTesting
+  static DateTime Function() now = DateTime.now;
+
+  /// Drops all backoff state. Exposed for tests and for an explicit
+  /// user-initiated refresh, which must never be suppressed.
+  @visibleForTesting
+  void resetBackoff() {
+    _nextAttempt.clear();
+    _rateLimitedUntil = null;
+  }
+
+  /// Test seam: simulate the repo having just been rate-limited, without
+  /// needing a live 429 from the network layer.
+  @visibleForTesting
+  void rateLimitedForTesting(Duration pause) =>
+      _rateLimitedUntil = now().add(pause);
+
   @override
   Future<Response> fetch(Requests req, ActivityPlanFetchRequest request) {
     final uri = Uri.parse(PApiUrls.activityById(request.activityId)).replace(
@@ -138,7 +187,15 @@ class ActivityPlanRepo
     final request = _request(activityId, l1, version: version);
     final result = await get(request, forceRefresh: forceRefresh);
     if (result.isError) {
-      final status = classifyLookupError(result.asError!.error);
+      final error = result.asError!.error;
+      // A 429 is a statement about RATE, not about this key, so it pauses the
+      // whole repo. Per-key backoff alone cannot honour it: the map hydrates
+      // one key per visible pin, and K keys each backing off independently
+      // still emit K/cooldown requests.
+      if (PangeaHttpException.statusCodeOf(error) == 429) {
+        _rateLimitedUntil = now().add(_rateLimitPause);
+      }
+      final status = classifyLookupError(error);
       if (status == ActivityPlanLookupStatus.removed) {
         _confirmedRemoved.add(activityId);
       }
@@ -148,8 +205,32 @@ class ActivityPlanRepo
     _confirmedRemoved.remove(activityId);
     final resolved = await resolveMedia(result.asValue!.value.plan);
     _resolved[request.storageKey] = resolved;
+    // Cleared only on a fully-mapped success. `.plan` above is a lazy getter
+    // that runs the whole v2 mapping, so a malformed body throws HERE, after a
+    // perfectly good HTTP 200 — leaving the parked entry in place, which is
+    // exactly what we want.
+    _nextAttempt.remove(request.storageKey);
     notifyListeners();
     return ActivityPlanLookup(ActivityPlanLookupStatus.found, resolved);
+  }
+
+  /// Refuse to memoize a body whose mapping throws.
+  ///
+  /// `ActivityPlanFetchResponse.plan` is a LAZY getter, so `BaseRepo.get`
+  /// writes to disk before anything has tried to map it. A malformed body
+  /// would therefore be persisted for the full TTL and then re-thrown on every
+  /// frame by [cachedPlan], which is called synchronously from `build()`.
+  /// Mapping once here turns that into an ordinary cache miss — which the
+  /// attempt cooldown then bounds. Same policy hook, and same reasoning, as
+  /// `SpeechToTextRepo` refusing to cache an exhausted-fallback response.
+  @override
+  bool shouldCache(ActivityPlanFetchResponse response) {
+    try {
+      response.plan;
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
 
   @visibleForTesting
@@ -188,7 +269,10 @@ class ActivityPlanRepo
   /// does NOT revalidate (one fetch per visible pin would be a fetch storm).
   /// Stale-while-revalidate: [cachedPlan] keeps serving the old plan until the
   /// fresh one lands, so there is no loading flicker.
-  void ensure(
+  /// Returns whether this call actually issued a fetch. Callers may ignore it;
+  /// it exists so the suppression policy is observable without reaching into
+  /// private state.
+  bool ensure(
     String activityId, {
     String? l1,
     String? version,
@@ -196,18 +280,48 @@ class ActivityPlanRepo
   }) {
     // A confirmed-removed id can't hydrate; re-fetching on every rebuild of
     // the sync getter would loop 404s.
-    if (_confirmedRemoved.contains(activityId)) return;
+    if (_confirmedRemoved.contains(activityId)) return false;
     final key = _request(activityId, l1, version: version).storageKey;
-    if (_hydrating.contains(key)) return;
+    // Checked before `_revalidated.add` so a revalidate token is never spent
+    // on a call that is about to bail.
+    if (_hydrating.contains(key)) return false;
     final doRevalidate = revalidate && _revalidated.add(key);
-    if (!doRevalidate && _resolved.containsKey(key)) return;
+    if (!doRevalidate) {
+      if (_resolved.containsKey(key)) return false;
+      final at = now();
+      final pausedUntil = _rateLimitedUntil;
+      if (pausedUntil != null) {
+        if (at.isBefore(pausedUntil)) return false;
+        _rateLimitedUntil = null;
+      }
+      final retryAt = _nextAttempt[key];
+      if (retryAt != null && at.isBefore(retryAt)) return false;
+    }
+    // PARK BEFORE THE I/O, not after it resolves. Every failure mode — 429,
+    // 5xx, network, timeout, a `.plan` mapping throw, and anything added
+    // later — is covered by this single line, because it does not depend on
+    // classifying the outcome. This is the guard the three outcome-keyed sets
+    // above could never be.
+    _nextAttempt[key] = now().add(_attemptCooldown);
     _hydrating.add(key);
     getPlan(
       activityId,
       l1: l1,
       version: version,
       forceRefresh: doRevalidate,
-    ).whenComplete(() => _hydrating.remove(key));
+    ).catchError((Object e, StackTrace s) {
+      // `getPlan` is fire-and-forget here, and `.plan`'s mapping runs outside
+      // BaseRepo's try/catch, so without this a malformed body is an unhandled
+      // async error. The parked entry stays put, so it cannot re-arm.
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {'activityId': activityId, 'l1': l1, 'version': version},
+        level: SentryLevel.warning,
+      );
+      return null;
+    }).whenComplete(() => _hydrating.remove(key));
+    return true;
   }
 
   /// Resolves upload-referenced media blocks to CDN urls. Applied to every

--- a/test/pangea/activity_plan_fetch_backoff_test.dart
+++ b/test/pangea/activity_plan_fetch_backoff_test.dart
@@ -60,7 +60,8 @@ void main() {
   /// against the old code too, and prove nothing. Every assertion below that
   /// targets the new backoff runs only AFTER the failure has landed — which is
   /// precisely the frame on which the old code re-armed.
-  Future<void> settle() => Future<void>.delayed(const Duration(milliseconds: 10));
+  Future<void> settle() =>
+      Future<void>.delayed(const Duration(milliseconds: 10));
 
   group('attempt cooldown', () {
     test('a settled failure does not re-arm on later frames', () async {
@@ -75,7 +76,8 @@ void main() {
       expect(
         issued,
         0,
-        reason: '100 post-failure frames issued $issued fetches; '
+        reason:
+            '100 post-failure frames issued $issued fetches; '
             'before the fix this was 100 — the incident itself',
       );
     });
@@ -161,17 +163,24 @@ void main() {
   });
 
   group('classifyLookupError', () {
-    test('404 is terminal, via the typed exception Requests actually throws', () {
-      // Requests throws PangeaHttpException, never a raw http.Response, so a
-      // check written against Response would silently never match and 404s
-      // would loop like everything else.
-      expect(
-        ActivityPlanRepo.classifyLookupError(
-          PangeaHttpException(statusCode: 404, method: 'GET', path: '/a/{id}'),
-        ),
-        ActivityPlanLookupStatus.removed,
-      );
-    });
+    test(
+      '404 is terminal, via the typed exception Requests actually throws',
+      () {
+        // Requests throws PangeaHttpException, never a raw http.Response, so a
+        // check written against Response would silently never match and 404s
+        // would loop like everything else.
+        expect(
+          ActivityPlanRepo.classifyLookupError(
+            PangeaHttpException(
+              statusCode: 404,
+              method: 'GET',
+              path: '/a/{id}',
+            ),
+          ),
+          ActivityPlanLookupStatus.removed,
+        );
+      },
+    );
 
     test('429 is retryable, not terminal', () {
       expect(

--- a/test/pangea/activity_plan_fetch_backoff_test.dart
+++ b/test/pangea/activity_plan_fetch_backoff_test.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
 import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart';
 
+import 'package:flutter_test/flutter_test.dart';
 import 'package:get_storage/get_storage.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_plan_fetch_response.dart';

--- a/test/pangea/activity_plan_fetch_backoff_test.dart
+++ b/test/pangea/activity_plan_fetch_backoff_test.dart
@@ -1,0 +1,185 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:get_storage/get_storage.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_plan_fetch_response.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+
+/// Regression: staging 2026-08-04.
+///
+/// `ensure()` is reached from `build()`, which runs per frame. Its guards used
+/// to be a whitelist of reasons NOT to fetch — 404 (`_confirmedRemoved`), in
+/// flight (`_hydrating`), success (`_resolved`). A 429, a 5xx, or a mapping
+/// throw matched none of them, so "no guard matched" meant "re-fetch at frame
+/// rate". A 429 returns in ~47ms against ~5s for a success, so the throttle
+/// engaging *increased* load ~100x and kept the per-user budget exhausted.
+/// 52,475 requests/day, 190 per activity, ending in 451 user-facing 503s.
+///
+/// The fix parks a key on the ATTEMPT, before the I/O, so it is total over
+/// outcomes nobody enumerated — including ones added later.
+///
+/// These tests drive the real singleton. `createRequests()` reaches into
+/// `MatrixState`, which does not exist under test, so every fetch fails inside
+/// `BaseRepo._fetch`'s try/catch and surfaces as `Result.error`. That is
+/// exactly the shape under test: a failing fetch must not re-arm.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Registered synchronously, BEFORE `ActivityPlanRepo.instance` is touched:
+  // the singleton's `PersistentRepoCache` field builds a `GetStorage`
+  // container on construction, which reaches for path_provider immediately.
+  // Doing this in `setUpAll` is too late — the singleton is already built.
+  final tempDir = Directory.systemTemp.createTempSync('plan_backoff_test');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        (methodCall) async => tempDir.path,
+      );
+
+  final repo = ActivityPlanRepo.instance;
+  var clock = DateTime(2026, 8, 4, 12);
+
+  setUpAll(() => GetStorage.init('activity_plan_storage'));
+
+  setUp(() {
+    clock = DateTime(2026, 8, 4, 12);
+    ActivityPlanRepo.now = () => clock;
+    repo.resetBackoff();
+  });
+
+  tearDownAll(() => ActivityPlanRepo.now = DateTime.now);
+
+  /// Lets the in-flight fetch settle so `_hydrating` clears.
+  ///
+  /// This matters: while a fetch is in flight the PRE-EXISTING in-flight guard
+  /// suppresses re-entry all by itself. A test that never settles would pass
+  /// against the old code too, and prove nothing. Every assertion below that
+  /// targets the new backoff runs only AFTER the failure has landed — which is
+  /// precisely the frame on which the old code re-armed.
+  Future<void> settle() => Future<void>.delayed(const Duration(milliseconds: 10));
+
+  group('attempt cooldown', () {
+    test('a settled failure does not re-arm on later frames', () async {
+      expect(repo.ensure('storm-1', l1: 'en'), isTrue);
+      await settle();
+
+      var issued = 0;
+      for (var i = 0; i < 100; i++) {
+        if (repo.ensure('storm-1', l1: 'en')) issued++;
+      }
+
+      expect(
+        issued,
+        0,
+        reason: '100 post-failure frames issued $issued fetches; '
+            'before the fix this was 100 — the incident itself',
+      );
+    });
+
+    test('re-attempt is allowed once the cooldown lapses', () async {
+      expect(repo.ensure('lapse-1', l1: 'en'), isTrue);
+      await settle();
+      expect(repo.ensure('lapse-1', l1: 'en'), isFalse);
+
+      clock = clock.add(const Duration(seconds: 61));
+      expect(
+        repo.ensure('lapse-1', l1: 'en'),
+        isTrue,
+        reason: 'backoff must expire — a transient failure is not terminal',
+      );
+    });
+
+    test('the cooldown is per key, not global', () {
+      expect(repo.ensure('key-a', l1: 'en'), isTrue);
+      expect(
+        repo.ensure('key-b', l1: 'en'),
+        isTrue,
+        reason: 'one parked key must not block an unrelated activity',
+      );
+    });
+
+    test('distinct l1 variants are distinct keys', () {
+      expect(repo.ensure('multi', l1: 'en'), isTrue);
+      expect(repo.ensure('multi', l1: 'es'), isTrue);
+      expect(repo.ensure('multi', l1: 'en'), isFalse);
+    });
+  });
+
+  group('rate-limit pause', () {
+    test('a 429 pauses the whole repo, not just the key that saw it', () {
+      // Per-key backoff alone cannot honour a 429: the map hydrates one key per
+      // visible pin, so K keys each backing off independently still emit
+      // K/cooldown requests. At the incident's K=104 that is 104/min against a
+      // 60/min budget — still saturated.
+      repo.rateLimitedForTesting(const Duration(seconds: 60));
+
+      expect(repo.ensure('any-a', l1: 'en'), isFalse);
+      expect(repo.ensure('any-b', l1: 'en'), isFalse);
+      expect(repo.ensure('any-c', l1: 'en'), isFalse);
+    });
+
+    test('the pause lifts on its own', () {
+      repo.rateLimitedForTesting(const Duration(seconds: 60));
+      expect(repo.ensure('lift-1', l1: 'en'), isFalse);
+
+      clock = clock.add(const Duration(seconds: 61));
+      expect(repo.ensure('lift-1', l1: 'en'), isTrue);
+    });
+  });
+
+  group('shouldCache refuses an unmappable body', () {
+    ActivityPlanFetchResponse resp(Map<String, dynamic> plan) =>
+        ActivityPlanFetchResponse(rawPlan: plan, l1: 'en', versionId: 'v1');
+
+    test('a healthy plan is cached', () {
+      expect(
+        repo.shouldCache(
+          resp({
+            'activity_id': 'a1',
+            'roles': [
+              {'role_id': 'r1', 'name': 'Cliente'},
+            ],
+          }),
+        ),
+        isTrue,
+      );
+    });
+
+    test('a body whose mapping throws is NOT written to disk', () {
+      // `.plan` is a LAZY getter, so BaseRepo.get() persists before anything
+      // maps it. Without this hook a poison body would sit in the cache for the
+      // full TTL and be re-thrown by cachedPlan() from build(), every frame.
+      expect(
+        repo.shouldCache(resp({'roles': []})), // no activity_id -> throws
+        isFalse,
+      );
+    });
+  });
+
+  group('classifyLookupError', () {
+    test('404 is terminal, via the typed exception Requests actually throws', () {
+      // Requests throws PangeaHttpException, never a raw http.Response, so a
+      // check written against Response would silently never match and 404s
+      // would loop like everything else.
+      expect(
+        ActivityPlanRepo.classifyLookupError(
+          PangeaHttpException(statusCode: 404, method: 'GET', path: '/a/{id}'),
+        ),
+        ActivityPlanLookupStatus.removed,
+      );
+    });
+
+    test('429 is retryable, not terminal', () {
+      expect(
+        ActivityPlanRepo.classifyLookupError(
+          PangeaHttpException(statusCode: 429, method: 'GET', path: '/a/{id}'),
+        ),
+        ActivityPlanLookupStatus.failed,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Client-side follow-up to the 2026-08-04 staging incident. The server-side shock absorber has already merged (2-step-choreographer#2951: whoami negative cache + single-flight); **this is the change that stops the traffic.**

## The defect

`ensure()` decided whether to fetch by consulting three sets:

```dart
if (_confirmedRemoved.contains(activityId)) return;  // 404 only
if (_hydrating.contains(key)) return;                // in flight only
if (!doRevalidate && _resolved.containsKey(key)) return;  // success only
_hydrating.add(key);                                 // ← everything else fetches
```

That is a **whitelist of reasons not to fetch**. Any outcome without a matching set falls through. A 429 matches none. A 5xx matches none. A `.plan` mapping throw matches none.

`ensure()` is reached from `build()` — `world_map_view.dart` resolves pins "once per frame" (its own comment) and calls `ensure()` per card. So the default behaviour of an unhandled outcome is *re-fetch at frame rate*.

## Why it escalated instead of settling

Measured on staging: a **429 returns in ~47ms**; a **200 takes ~5,088ms**.

So the moment the 60/min budget engaged, each affected card went from ~1 request per 5s to ~20/sec. **The throttle increased load ~100x** and guaranteed the budget stayed exhausted. It ran for hours and stopped only when the client did.

Consequence: 52,475 requests in a day (~190 per unique activity), `/v2/activity` p50 at 5s, Matrix `whoami` timing out behind it, and **451 user-facing 503s in one minute**. The staging bot lost sync in the same squeeze.

## The change

Record the **attempt**, not the outcome.

- **`_nextAttempt`** is written *before* the fetch is issued and cleared only on a fully-mapped success. Because it does not depend on classifying the result, one line covers 429, 5xx, network, timeout, and a mapping throw — including failure modes added later.

  The three outcome-keyed sets structurally could not do this, and there is proof in the file's own history: `classifyLookupError` tested `error is Response`, but `Requests` throws `PangeaHttpException` and *never* a raw `Response`, so the 404 guard silently never matched. That is what an outcome-keyed guard looks like when it rots. (Fixed separately on main; this change makes that class of rot non-fatal.)

- **`_rateLimitedUntil`** pauses the whole repo on a 429. Per-key backoff cannot honour a rate limit: the map hydrates one key per visible pin, so K keys each backing off independently still emit K/cooldown requests — at the incident's **K=104** that is 104/min against a 60/min budget, still saturated. Deliberately scoped to this repo rather than global, because choreo budgets `/choreo` and `/subscription` separately and an activity 429 must never stall checkout.

- **`shouldCache`** refuses a body whose mapping throws. `.plan` is a *lazy* getter, so `BaseRepo.get` persists before anything maps it; a malformed body would otherwise sit in the cache for the full TTL and be re-thrown by `cachedPlan()` from `build()` on every frame. Same hook and same reasoning as `SpeechToTextRepo` refusing to cache an exhausted-fallback response.

- **`ensure` now returns whether it issued a fetch**, so the policy is testable without reaching into private state. Non-breaking; callers may ignore it.

`_confirmedRemoved`, `_hydrating` and `_resolved` are all **kept**. This adds the one piece of state that was missing rather than re-deriving behaviour that already works.

## Testing

10 new tests, all passing. Full `test/pangea/` suite: **1,924 pass, 4 fail** — all four (`choreo_endpoint`, two `invite_all_in_space_tile`, `navigation_guardrails`) verified **pre-existing** by re-running them against a stashed baseline.

The headline test: after a failed fetch settles, **100 subsequent frames issue zero fetches**. Before this change that was 100 — the incident itself.

> One note for anyone editing these tests: assertions must run **after** the failed fetch settles. While a fetch is in flight the pre-existing in-flight guard suppresses re-entry on its own, so a test that never settles passes against the old code too and proves nothing. My first draft made exactly that mistake.

## Design note

An earlier draft of this put a sealed `FetchState` machine in the shared `BaseRepo`. Three independent reviews rejected it, correctly:

- The ledger's only reader is `ensure()`, but the writer would sit in a base class **17 repos** inherit — all blast radius, no benefit.
- Enforcing it in `get()` would have broken the **payment path** (`CheckoutRepo` attempt 0 is not forced, so a prior failure would return a synthetic error with zero network traffic) and silently killed tap-to-retry for TTS/STT.
- Deriving `Loading` from `_inflightCache` would have **reintroduced the storm**: `BaseRepo.get()`'s first statement is `await _cacheInit`, so that map is never populated synchronously, unlike the `_hydrating` set it would have replaced.
- The planned `Retry-After` handling was dead code — choreo's limiter sends no such header, and `PangeaHttpException` carries no headers by design.

## Follow-ups (not in this PR)

- A `SchedulerPhase` assert turning "I/O from `build()`" into a CI failure.
- A visibility controller that removes I/O from the render path entirely. That is the correct end state, but the fan-out is ~35 files (`ensure()` is transitively reachable from four synchronous getters), so it wants its own change — guided by the assert above.

Full analysis: `devops/postmortems/2026-08-04-staging-activity-refetch-latch.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added cooldowns and rate-limit pauses to prevent repeated failed requests.
  * Prevented invalid or incomplete activity plans from being cached.
  * Improved handling and logging of background loading errors.
  * Ensured successful activity plans can resume normal retry behavior.

* **Improvements**
  * Added clearer fetch-status reporting for activity plan requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->