### PR TITLE
fix: prevent map pins flickering on appear

### DIFF
--- a/lib/routes/world/map_exit_tracker.dart
+++ b/lib/routes/world/map_exit_tracker.dart
@@ -1,0 +1,78 @@
+/// Per-tier bookkeeping for the map's pin pop-in / shrink-out animations,
+/// shared by the small/mid dot tier and the large-card tier of
+/// [WorldMapView](world_map_view.dart). One instance owns three things for its
+/// tier: which snapshots are currently animating out ([exiting]), which ids
+/// have already played their entry pop-in ([markEntered]), and the previous
+/// frame's active set that the two are derived from.
+///
+/// The rule that shapes it, and the reason it is its own class rather than
+/// inline state, is that **only an on-screen item may animate out**:
+/// flutter_map's `MarkerLayer` culls markers outside the camera, so a dying
+/// marker off screen is never built, never runs its animation controller and
+/// never fires its `onExited` callback. Queueing one therefore strands it here
+/// forever; panning back over it builds it fresh, and the dying branch of
+/// [WorldMapDot](world_map_state_dot.dart) /
+/// [WorldMapLargeCardAnimated](world_map_large_card.dart) replays the shrink
+/// from full scale — a phantom pin that collapses (repeatedly, as the layer
+/// culls and reorders) before the real one pops in at the settle (#8155).
+///
+/// So an item that leaves the active set because the camera panned away is
+/// dropped outright — there is nothing on screen to animate — while one that
+/// leaves for a *ranking* reason (demoted past the width budget's cap, promoted
+/// to a large card, filtered out) is still visible and earns its shrink-out.
+/// See world-map.instructions.md ("Pin display").
+class MapExitTracker<T> {
+  final Map<String, T> _exiting = {};
+  Map<String, T> _lastActive = const {};
+  final Set<String> _entered = {};
+
+  /// The snapshots currently animating out, in the order they left.
+  List<T> get exiting => _exiting.values.toList();
+
+  /// True the first time [id] is seen — the item plays its entry animation on
+  /// exactly that build, and renders settled on every later one. A `MarkerLayer`
+  /// State discarded and recreated mid-gesture must not replay its pop-in
+  /// (#8136).
+  bool markEntered(String id) => _entered.add(id);
+
+  /// Drop [id]'s exit once its animation has finished and its widget has
+  /// reported back.
+  void finishExit(String id) => _exiting.remove(id);
+
+  /// Reconcile against this frame's [active] set — id to render snapshot —
+  /// deciding which items start (or abandon) a shrink-out. [isOnScreen] answers
+  /// whether a snapshot's map point currently falls inside the camera; see the
+  /// class doc for why it gates both halves.
+  ///
+  /// Called during build, so it must not call setState: it only mutates this
+  /// tracker's own maps, and the layers are built from the result in the same
+  /// frame.
+  void update({
+    required Map<String, T> active,
+    required bool Function(T snapshot) isOnScreen,
+  }) {
+    // Re-appeared in the active set: cancel any in-progress exit. Scrolled off
+    // screen: drop it, the exit can no longer play.
+    _exiting.removeWhere(
+      (id, snapshot) => active.containsKey(id) || !isOnScreen(snapshot),
+    );
+
+    // An item gone from the active set forgets its "already entered" mark, so
+    // its next appearance pops in fresh. While the camera is moving the view
+    // holds its last-settled render model, so the id set — and this — doesn't
+    // churn mid-gesture (#8136).
+    _entered.retainAll(active.keys);
+
+    // Anything active last frame, gone this frame, and still on screen starts
+    // its shrink-out from its last-known render state.
+    for (final entry in _lastActive.entries) {
+      if (!active.containsKey(entry.key) &&
+          !_exiting.containsKey(entry.key) &&
+          isOnScreen(entry.value)) {
+        _exiting[entry.key] = entry.value;
+      }
+    }
+
+    _lastActive = active;
+  }
+}

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -20,6 +20,7 @@ import 'package:fluffychat/routes/world/dot_markers_layer.dart';
 import 'package:fluffychat/routes/world/exiting_large_markers_layer.dart';
 import 'package:fluffychat/routes/world/exiting_markers_layer.dart';
 import 'package:fluffychat/routes/world/large_markers_layer.dart';
+import 'package:fluffychat/routes/world/map_exit_tracker.dart';
 import 'package:fluffychat/routes/world/mid_size_pin_labels_layer.dart';
 import 'package:fluffychat/routes/world/world_map.dart';
 import 'package:fluffychat/routes/world/world_map_client_extension.dart';
@@ -182,33 +183,16 @@ class _WorldMapViewState extends State<WorldMapView> {
   /// clear (#7218). Update alongside the chrome if its heights change.
   static const double _narrowBottomChromeInset = 140.0;
 
-  /// Pins that have left the active set and are animating to scale 0.
-  final Map<String, PinSnapshot> _exiting = {};
+  /// Entry/exit animation bookkeeping for the small/mid dot tier: which pins
+  /// are shrinking out, and which have already played their pop-in. See
+  /// [MapExitTracker] for why only an on-screen pin ever animates out (#8155).
+  final MapExitTracker<PinSnapshot> _dotExits = MapExitTracker();
 
-  /// Last-known render snapshot of each active non-large pin, used to seed
-  /// [_exiting] with the correct visual state when a pin leaves.
-  Map<String, PinSnapshot> _lastActive = {};
-
-  /// Non-large pin ids that have already played their entry scale-in. A pin
-  /// only animates in on its first appearance ([Set.add] returning true at
-  /// build time); after that, a [WorldMapDot] State recreated mid-gesture by
-  /// MarkerLayer's positional reconciliation renders at full scale instead of
-  /// replaying the pop-in (#8136). Pruned at each settle in [_updateExiting],
-  /// so a pin that leaves and later returns pops in fresh again.
-  final Set<String> _enteredIds = {};
-
-  /// Mirrors [_enteredIds] for the large tier ([WorldMapLargeCardAnimated]).
-  final Set<String> _enteredLargeIds = {};
-
-  /// Large cards that have left the large tier (demoted, or the dot promoted
-  /// past it out of view) and are animating to scale/opacity 0 — mirrors
-  /// [_exiting]/[_lastActive] but for [WorldMapLargeCard] (world-map card
-  /// pop-in/out; see [WorldMapLargeCardAnimated]).
-  final Map<String, LargeCardSnapshot> _exitingLarge = {};
-
-  /// Last-known render snapshot of each active large card, used to seed
-  /// [_exitingLarge] with the correct content when a card leaves.
-  Map<String, LargeCardSnapshot> _lastActiveLarge = {};
+  /// Mirrors [_dotExits] for the large tier ([WorldMapLargeCardAnimated]): a
+  /// card demoted out of the tier (X-dismissed, out-ranked, or no longer fits)
+  /// shrinks away instead of vanishing instantly, while its dot (mid where
+  /// eligible, else small) pops in fresh the same frame.
+  final MapExitTracker<LargeCardSnapshot> _largeExits = MapExitTracker();
 
   /// The last render model computed while the camera was settled. Reused
   /// as-is while [WorldMapController.isActivelyMoving] is true, instead of
@@ -331,70 +315,54 @@ class _WorldMapViewState extends State<WorldMapView> {
     }
   }
 
-  /// Detects newly-gone non-large pins and adds them to [_exiting] using their
-  /// last-known render state — **including** a pin promoted to large: its dot
-  /// shrinks away in this layer while [WorldMapLargeCardAnimated] grows the new
-  /// card in at the same spot ([_largeMarkers]), so promotion reads as one pin
-  /// morphing into a card rather than an instant swap. Called at the top of
-  /// [build] before the marker layers are constructed — mutates tracking maps
-  /// without calling setState.
-  void _updateExiting(_PinRenderer render) {
-    final currentNonLargeIds = {
-      for (final c in render.nonLargeCards) c.activityId,
-    };
-
-    // Re-appeared as a (still) non-large pin: cancel any in-progress exit.
-    _exiting.removeWhere((id, _) => currentNonLargeIds.contains(id));
-
-    // A pin gone from the render model forgets its "already entered" mark, so
-    // its next appearance (incl. demotion back from large) pops in fresh.
-    // While the camera is moving the frozen renderer yields the same id set,
-    // so nothing churns mid-gesture (#8136).
-    _enteredIds.retainAll(currentNonLargeIds);
-
-    // Anything that was a dot last frame and isn't a dot this frame —
-    // genuinely gone, or promoted to large — plays the shrink-out.
-    for (final entry in _lastActive.entries) {
-      if (!currentNonLargeIds.contains(entry.key) &&
-          !_exiting.containsKey(entry.key)) {
-        _exiting[entry.key] = entry.value;
-      }
+  /// Whether [point] currently falls inside the camera's visible bounds — the
+  /// gate on queueing (and keeping) an exit animation, since flutter_map's
+  /// MarkerLayer only builds markers it doesn't cull. Null point, or a camera
+  /// that isn't laid out yet, counts as on screen so nothing is dropped before
+  /// the map can answer.
+  bool _isOnScreen(LatLng? point) {
+    if (point == null) return true;
+    try {
+      return widget.controller.mapController.camera.visibleBounds.contains(
+        point,
+      );
+    } catch (_) {
+      return true;
     }
-
-    // Refresh the snapshot for the next frame.
-    _lastActive = {
-      for (final card in render.nonLargeCards)
-        card.activityId: PinSnapshot(
-          card: card,
-          state: render.stateOf(card.activityId),
-          tier: render.tierOf(card.activityId),
-          pinged: render.pingedOf(card.activityId),
-          starLevel: render.starLevelOf(card.activityId),
-        ),
-    };
   }
 
-  /// Mirrors [_updateExiting] for the large tier: a card demoted out of
-  /// [currentLarge] (X-dismissed, out-ranked, or no longer fits) plays its
-  /// shrink-out in [_exitingLarge] instead of vanishing instantly. Its dot
-  /// (mid, if eligible, else small) pops in fresh the same frame, the mirror
-  /// image of a promotion.
+  /// Hands this frame's non-large pins to [_dotExits], which detects the ones
+  /// newly gone and starts their shrink-out from their last-known render state
+  /// — **including** a pin promoted to large: its dot shrinks away in this layer
+  /// while [WorldMapLargeCardAnimated] grows the new card in at the same spot
+  /// ([_largeMarkers]), so promotion reads as one pin morphing into a card
+  /// rather than an instant swap. A pin the camera merely panned away from is
+  /// dropped instead of animated (#8155 — see [MapExitTracker]). Called at the
+  /// top of [build] before the marker layers are constructed — mutates the
+  /// trackers without calling setState.
+  void _updateExiting(_PinRenderer render) {
+    _dotExits.update(
+      active: {
+        for (final card in render.nonLargeCards)
+          card.activityId: PinSnapshot(
+            card: card,
+            state: render.stateOf(card.activityId),
+            tier: render.tierOf(card.activityId),
+            pinged: render.pingedOf(card.activityId),
+            starLevel: render.starLevelOf(card.activityId),
+          ),
+      },
+      isOnScreen: (snapshot) => _isOnScreen(snapshot.card.point),
+    );
+  }
+
+  /// Mirrors [_updateExiting] for the large tier, over the cards resolved for
+  /// this frame.
   void _updateExitingLarge(Map<String, LargeCardSnapshot> currentLarge) {
-    final currentIds = currentLarge.keys.toSet();
-
-    _exitingLarge.removeWhere((id, _) => currentIds.contains(id));
-
-    // Mirror of _updateExiting's pruning (#8136).
-    _enteredLargeIds.retainAll(currentIds);
-
-    for (final entry in _lastActiveLarge.entries) {
-      if (!currentIds.contains(entry.key) &&
-          !_exitingLarge.containsKey(entry.key)) {
-        _exitingLarge[entry.key] = entry.value;
-      }
-    }
-
-    _lastActiveLarge = currentLarge;
+    _largeExits.update(
+      active: currentLarge,
+      isOnScreen: (snapshot) => _isOnScreen(snapshot.card.point),
+    );
   }
 
   /// Resolve the per-frame pin draw model: the width-driven budget, the ranked +
@@ -786,12 +754,12 @@ class _WorldMapViewState extends State<WorldMapView> {
   }
 
   void _onExitedMarker(String activityId) {
-    if (mounted) setState(() => _exiting.remove(activityId));
+    if (mounted) setState(() => _dotExits.finishExit(activityId));
   }
 
   void _onExitedLargeCardMarker(String activityId) {
     if (mounted) {
-      setState(() => _exitingLarge.remove(activityId));
+      setState(() => _largeExits.finishExit(activityId));
     }
   }
 
@@ -878,10 +846,10 @@ class _WorldMapViewState extends State<WorldMapView> {
                 sessionParticipants: (a, b) => _sessionParticipants(a, b),
                 focusedId: render.focusedId,
                 onTap: widget.controller.openActivity,
-                // Set.add returns true only on first insertion — a pin
-                // animates in the first build it appears, then holds full
-                // scale through State recreations (#8136).
-                animateInOf: _enteredIds.add,
+                // markEntered returns true only the first build a pin appears
+                // — it animates in then, and holds full scale through the
+                // State recreations MarkerLayer causes mid-gesture (#8136).
+                animateInOf: _dotExits.markEntered,
               ).layer();
               final Widget largeLayer = LargeMarkersLayer(
                 largeCards: render.largeCards,
@@ -889,7 +857,7 @@ class _WorldMapViewState extends State<WorldMapView> {
                 focusedId: render.focusedId,
                 onTap: widget.controller.openActivity,
                 onClose: widget.controller.dismissLargeCard,
-                animateInOf: _enteredLargeIds.add,
+                animateInOf: _largeExits.markEntered,
               ).layer();
               return FlutterMap(
                 mapController: widget.controller.mapController,
@@ -954,7 +922,7 @@ class _WorldMapViewState extends State<WorldMapView> {
                   // Dying pins (a separate layer) so they don't disturb the live pins
                   // while animating out.
                   ExitingMarkersLayer(
-                    exiting: _exiting.values.toList(),
+                    exiting: _dotExits.exiting,
                     markerBox: _markerBox,
                     markerAlignment: _markerAlignment,
                     onExited: _onExitedMarker,
@@ -962,7 +930,7 @@ class _WorldMapViewState extends State<WorldMapView> {
                   // Dying large cards (demoted, or bumped out) shrinking away beneath
                   // the live layer.
                   ExitingLargeMarkersLayer(
-                    exitingLarge: _exitingLarge.values.toList(),
+                    exitingLarge: _largeExits.exiting,
                     onExited: _onExitedLargeCardMarker,
                   ).layer(),
                   // Large cards (always visible): the featured cards the width affords.

--- a/test/pangea/world/map_exit_tracker_test.dart
+++ b/test/pangea/world/map_exit_tracker_test.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/exiting_markers_layer.dart';
+import 'package:fluffychat/routes/world/map_exit_tracker.dart';
+import 'package:fluffychat/routes/world/world_map_client_extension.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+import 'package:fluffychat/routes/world/world_map_state_dot.dart';
+import 'package:fluffychat/routes/world/world_map_view.dart';
+
+/// Regression guard for #8155: scrolling away from mid pins and back made them
+/// play a few collapse/expand animations before settling.
+///
+/// The cause was an exit animation queued for a pin that had left the *camera*,
+/// not the ranking. flutter_map's MarkerLayer culls off-screen markers, so that
+/// dying pin is never built, never runs its controller and never fires
+/// `onExited` — it strands in the exit tracker. Panning back builds it fresh,
+/// and [WorldMapDot]'s dying branch replays the shrink from full scale, so a
+/// phantom pin collapses (once per cull/reorder of the layer) before the real
+/// pin finally pops in at the settle.
+///
+/// [MapExitTracker] fixes it by only ever animating out an item that is still
+/// on screen. The widget test at the bottom pins the framework behaviour the
+/// rule exists for.
+void main() {
+  QuestActivityCard card(String id) => QuestActivityCard(
+    activityId: id,
+    title: 'Activity $id',
+    l2: 'es',
+    coordinates: const [0, 0],
+    learningObjectiveRefs: const [],
+  );
+
+  PinSnapshot snapshot(String id) => PinSnapshot(
+    card: card(id),
+    state: ActivityPinState.joinable,
+    tier: PinTier.mid,
+    pinged: false,
+    starLevel: ActivityStarLevel.none,
+  );
+
+  Map<String, PinSnapshot> active(List<String> ids) => {
+    for (final id in ids) id: snapshot(id),
+  };
+
+  bool alwaysOnScreen(PinSnapshot _) => true;
+  bool neverOnScreen(PinSnapshot _) => false;
+
+  List<String> idsOf(MapExitTracker<PinSnapshot> t) =>
+      t.exiting.map((s) => s.card.activityId).toList();
+
+  group('MapExitTracker exits', () {
+    test('a pin ranked out while on screen plays its shrink-out', () {
+      final tracker = MapExitTracker<PinSnapshot>();
+      tracker.update(active: active(['a', 'b']), isOnScreen: alwaysOnScreen);
+
+      // 'b' loses its slot (demoted past the cap, promoted to large, filtered
+      // out) while still in view — that transition is what the animation is for.
+      tracker.update(active: active(['a']), isOnScreen: alwaysOnScreen);
+
+      expect(idsOf(tracker), ['b']);
+    });
+
+    test('a pin the camera scrolled away from is dropped, never queued', () {
+      final tracker = MapExitTracker<PinSnapshot>();
+      tracker.update(active: active(['a', 'b']), isOnScreen: alwaysOnScreen);
+
+      // Camera pans away: both leave the render set AND the screen.
+      tracker.update(active: active([]), isOnScreen: neverOnScreen);
+
+      expect(
+        idsOf(tracker),
+        isEmpty,
+        reason:
+            'an off-screen dying marker is culled, so its exit can never play '
+            'or report back — queueing it strands a phantom pin that replays '
+            'its collapse when the camera comes back (#8155)',
+      );
+    });
+
+    test('an exit already running is abandoned once it leaves the screen', () {
+      final tracker = MapExitTracker<PinSnapshot>();
+      tracker.update(active: active(['a']), isOnScreen: alwaysOnScreen);
+      tracker.update(active: active([]), isOnScreen: alwaysOnScreen);
+      expect(idsOf(tracker), ['a']);
+
+      // The learner pans away mid-shrink: nothing left to watch it finish.
+      tracker.update(active: active([]), isOnScreen: neverOnScreen);
+
+      expect(idsOf(tracker), isEmpty);
+    });
+
+    test('re-entering the active set cancels an in-progress exit', () {
+      final tracker = MapExitTracker<PinSnapshot>();
+      tracker.update(active: active(['a']), isOnScreen: alwaysOnScreen);
+      tracker.update(active: active([]), isOnScreen: alwaysOnScreen);
+      expect(idsOf(tracker), ['a']);
+
+      tracker.update(active: active(['a']), isOnScreen: alwaysOnScreen);
+
+      expect(idsOf(tracker), isEmpty);
+    });
+
+    test('finishExit drains the pin its widget reported done', () {
+      final tracker = MapExitTracker<PinSnapshot>();
+      tracker.update(active: active(['a', 'b']), isOnScreen: alwaysOnScreen);
+      tracker.update(active: active([]), isOnScreen: alwaysOnScreen);
+      expect(idsOf(tracker), ['a', 'b']);
+
+      tracker.finishExit('a');
+
+      expect(idsOf(tracker), ['b']);
+    });
+  });
+
+  group('MapExitTracker entries', () {
+    test('a pin animates in on its first build only (#8136)', () {
+      final tracker = MapExitTracker<PinSnapshot>();
+      tracker.update(active: active(['a']), isOnScreen: alwaysOnScreen);
+
+      expect(tracker.markEntered('a'), isTrue);
+      expect(
+        tracker.markEntered('a'),
+        isFalse,
+        reason:
+            'a State recreated by MarkerLayer mid-gesture must render settled, '
+            'not replay its pop-in (#8136)',
+      );
+    });
+
+    test('a pin that leaves and returns pops in fresh again', () {
+      final tracker = MapExitTracker<PinSnapshot>();
+      tracker.update(active: active(['a']), isOnScreen: alwaysOnScreen);
+      expect(tracker.markEntered('a'), isTrue);
+
+      // Scrolled away (the #8155 repro), then scrolled back.
+      tracker.update(active: active([]), isOnScreen: neverOnScreen);
+      tracker.update(active: active(['a']), isOnScreen: alwaysOnScreen);
+
+      expect(
+        tracker.markEntered('a'),
+        isTrue,
+        reason: 'the returning pin must pop up cleanly, once (#8155)',
+      );
+    });
+  });
+
+  testWidgets(
+    'a culled dying marker never builds, so its onExited never fires',
+    (tester) async {
+      // The framework fact the on-screen gate exists for: MarkerLayer drops
+      // markers outside the camera before building them, so an off-screen
+      // dying dot cannot animate or report back — it would sit in the tracker
+      // until the camera returned and then replay its collapse.
+      var exited = false;
+      final controller = MapController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          supportedLocales: L10n.supportedLocales,
+          home: FlutterMap(
+            mapController: controller,
+            options: const MapOptions(
+              initialCenter: LatLng(0, 0),
+              initialZoom: 12,
+            ),
+            children: [
+              ExitingMarkersLayer(
+                // Far off screen at zoom 12 — the pin the camera left behind.
+                exiting: [
+                  PinSnapshot(
+                    card: const QuestActivityCard(
+                      activityId: 'gone',
+                      title: 'Gone',
+                      l2: 'es',
+                      coordinates: [60, 60],
+                      learningObjectiveRefs: [],
+                    ),
+                    state: ActivityPinState.joinable,
+                    tier: PinTier.mid,
+                    pinged: false,
+                    starLevel: ActivityStarLevel.none,
+                  ),
+                ],
+                markerBox: (_, _) => const Size(44, 54),
+                markerAlignment: (_, _) => Alignment.center,
+                onExited: (_) => exited = true,
+              ).layer(),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.byType(WorldMapDot), findsNothing);
+      expect(
+        exited,
+        isFalse,
+        reason:
+            'MarkerLayer culls the off-screen marker, so the exit animation '
+            'never runs and never drains itself — which is why an off-screen '
+            'pin must not be queued for one at all (#8155)',
+      );
+    },
+  );
+}


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
