### PR TITLE
feat(world): show map search + filters on a course-scoped map

### DIFF
--- a/lib/routes/world/mobile_search_bar.dart
+++ b/lib/routes/world/mobile_search_bar.dart
@@ -7,13 +7,14 @@ import 'package:fluffychat/widgets/pangea_search_bar.dart';
 
 /// The single-column floating search bar riding above the nav widget
 /// (routing.instructions.md → Single-column search bar): ONE persistent bar for
-/// the WORLD map's activity search. It rides the nav widget's expansion for free
+/// the map's activity search. It rides the nav widget's expansion for free
 /// by rendering in the widget's `topAttachment` slot.
 ///
-/// WORLD scope only — the shell mounts it over the bare world map and hides it
-/// entirely on a course-scoped map (where the query does not filter pins) and
-/// over a selected activity, mirroring the web overlay ([WorldMapSearchOverlay]),
-/// which only renders in world scope.
+/// Mounted over the bare map in BOTH scopes (#7716) — world and course alike,
+/// mirroring the web overlay ([WorldMapSearchOverlay]) — and hidden entirely
+/// over a selected activity or an open section sheet, which cover the exposed
+/// map band it rides. On a course-scoped map it starts [minimized] to the
+/// compact icon (routing.instructions.md → Single-column search bar).
 ///
 /// Typing filters the map's pins live; there is no results dropdown on narrow —
 /// the pins ARE the results. What rides above the bar instead (in addition to
@@ -22,10 +23,11 @@ import 'package:fluffychat/widgets/pangea_search_bar.dart';
 /// view shows no matches it diagnoses WHY (off-screen matches, pill-excluded
 /// matches, a dead query) and offers the one remedy that fixes it.
 ///
-/// Presentational: the shell decides the [hintText] (the scope) and where the
-/// callbacks route. State is read through BUILDERS ([emptyVerdict],
-/// [canZoomOut]) re-evaluated on every local rebuild, because this bar is
-/// shell-built and the map's own setState never reaches it; [viewRevision]
+/// Presentational: the shell decides the [hintText] (the scope), the
+/// [minimized] state, and where the callbacks route. State is read through
+/// BUILDERS ([emptyVerdict], [canZoomOut]) re-evaluated on every local
+/// rebuild, because this bar is shell-built and the map's own setState never
+/// reaches it; [viewRevision]
 /// (the map's filter/pin-load tick) triggers those rebuilds for changes that
 /// don't originate here (a filter pill tap, a pin load after zooming out).
 class MobileSearchBar extends StatefulWidget {
@@ -61,10 +63,21 @@ class MobileSearchBar extends StatefulWidget {
   /// Active map filter chips, rendered above the bar (map scope only).
   final Widget? filtersChild;
 
+  /// Compact-icon state: a single search icon button pinned left, restoring the
+  /// full bar via [onRestore]. The course-scoped resting state
+  /// (routing.instructions.md → Single-column search bar) — the scoped map's
+  /// own chrome already owns the band, so search waits behind one tap. The
+  /// empty-view card and filters stay hidden while minimized: they belong to
+  /// the expanded bar.
+  final bool minimized;
+  final VoidCallback? onRestore;
+
   const MobileSearchBar({
     required this.hintText,
     required this.query,
     required this.onQueryChanged,
+    this.minimized = false,
+    this.onRestore,
     this.emptyVerdict,
     this.canZoomOut,
     this.onWidenSearch,
@@ -118,6 +131,24 @@ class _MobileSearchBarState extends State<MobileSearchBar> {
   @override
   Widget build(BuildContext context) {
     final l10n = L10n.of(context);
+
+    if (widget.minimized) {
+      // The compact state: one labeled icon button pinned to the left, just
+      // above the nav rail; tapping restores the full bar.
+      return Align(
+        alignment: Alignment.centerLeft,
+        child: Material(
+          elevation: 4,
+          borderRadius: BorderRadius.circular(99),
+          color: Theme.of(context).colorScheme.surface,
+          child: IconButton(
+            tooltip: widget.hintText,
+            icon: const Icon(Icons.search),
+            onPressed: widget.onRestore,
+          ),
+        ),
+      );
+    }
 
     // Drive the clear (X) button off the field's own controller, not the
     // externally-owned query. This bar is built by the shell, whose

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -998,11 +998,22 @@ class WorldMapController extends State<WorldMap>
   /// new camera instead of the frozen last-settled one (#7245). Applies in
   /// every map context (world and course), unlike the world-only re-fetch
   /// above.
+  ///
+  /// The settle also ticks [viewRevision]. The camera is an input to
+  /// [emptyVerdict] ([MapEmptyVerdict.matchesOffscreen] is exactly "the
+  /// matches are outside these bounds"), and the narrow surfaces are built by
+  /// the shell — this State's `setState` never reaches them, so without the
+  /// tick their empty-view card keeps answering for the camera it was last
+  /// built at. On the world map the settle re-fetch above ticks anyway; in a
+  /// course scope it doesn't run, which left the card's own Zoom out lever
+  /// unable to clear the card it had just fixed (#7716).
   void _onMapEvent(MapEvent event) {
     final wasMoving = isActivelyMoving;
     _moveSettleTimer?.cancel();
     _moveSettleTimer = Timer(WorldMapConstants.moveSettle, () {
-      if (mounted) setState(() {});
+      if (!mounted) return;
+      setState(() {});
+      viewRevision.value++;
     });
     if (!wasMoving && mounted) setState(() {});
   }

--- a/lib/routes/world/world_map.dart
+++ b/lib/routes/world/world_map.dart
@@ -381,12 +381,18 @@ class WorldMapController extends State<WorldMap>
   ProgressionResolution get progression => _pinsManager.progression;
 
   /// The pins actually shown: the loaded set narrowed by the active CEFR band,
-  /// party-size and status filters, and free-text query. World only; a course
-  /// shows its set.
-  List<QuestActivityCard> get visiblePins => _pinsManager.filteredPins((c) {
-    if (!isWorld) return true;
-    return _filterState.include(c, _pinsManager.displayStateOf(c));
-  });
+  /// party-size and status filters, and free-text query. Applied in BOTH
+  /// scopes (#7716) — a course scope only decides which items compete, not
+  /// whether the learner can refine them (world-map.instructions.md). The one
+  /// scope-dependent term is the settings-fixed language, applied on the world
+  /// map only; see [WorldMapFilterState.include].
+  List<QuestActivityCard> get visiblePins => _pinsManager.filteredPins(
+    (c) => _filterState.include(
+      c,
+      _pinsManager.displayStateOf(c),
+      applyLanguage: isWorld,
+    ),
+  );
 
   /// Why the view shows no matches — the empty-view card's diagnosis
   /// ([MapEmptyVerdict]), shared by the wide overlay and the narrow bar so the
@@ -394,7 +400,7 @@ class WorldMapController extends State<WorldMap>
   /// coordinates count anywhere here: a match that can never render can't be
   /// revealed by any remedy the card offers.
   MapEmptyVerdict get emptyVerdict {
-    if (!isWorld || loadingPins) return MapEmptyVerdict.none;
+    if (loadingPins) return MapEmptyVerdict.none;
     final loaded = visiblePins.where((c) => c.point != null).toList();
     if (loaded.isNotEmpty) {
       // Matches exist under the current filters/query — the verdict is about
@@ -414,7 +420,9 @@ class WorldMapController extends State<WorldMap>
     // Nothing passes anywhere loaded: diagnose the excluder. If the pills are
     // it (matches exist ignoring them), widening fixes it by construction.
     final ignoringPills = _pinsManager.filteredPins(
-      (c) => c.point != null && _filterState.matchesIgnoringPills(c),
+      (c) =>
+          c.point != null &&
+          _filterState.matchesIgnoringPills(c, applyLanguage: isWorld),
     );
     if (ignoringPills.isNotEmpty) return MapEmptyVerdict.filtersHideMatches;
     return filter.query.trim().isNotEmpty

--- a/lib/routes/world/world_map_filter.dart
+++ b/lib/routes/world/world_map_filter.dart
@@ -10,8 +10,8 @@ import 'package:fluffychat/routes/world/world_map_ranking.dart';
 /// off-screen matches → zoom out; pill-excluded matches → widen the search;
 /// a query matching nothing → no remedy pretends to help.
 enum MapEmptyVerdict {
-  /// Matches are visible (or the verdict doesn't apply — loading, course
-  /// scope, camera not laid out): no card.
+  /// Matches are visible (or the verdict doesn't apply — loading, camera not
+  /// laid out): no card.
   none,
 
   /// Matches pass the filters/query but every one sits OUTSIDE the current
@@ -130,8 +130,20 @@ class WorldMapFilterState {
 
   WorldMapFilter get filter => _filter;
 
-  bool include(QuestActivityCard card, ActivityPinState state) {
-    return _langMatches(card) &&
+  /// [applyLanguage] carries the settings-fixed language constant, and is the
+  /// one part of the filter set that differs by map scope. The WORLD map
+  /// always applies it. A COURSE-scoped map does not: its pins are fetched at
+  /// the COURSE's own L2 ([WorldMapPinsManager.loadCourseScopedPins]), so
+  /// narrowing them by the learner's *settings* L2 would empty the map of any
+  /// course taught in another language — with no lever to widen, since
+  /// language is deliberately not one. The course scope is itself the
+  /// narrowing there; the pills and the query still apply (#7716).
+  bool include(
+    QuestActivityCard card,
+    ActivityPinState state, {
+    bool applyLanguage = true,
+  }) {
+    return (!applyLanguage || _langMatches(card)) &&
         _cefrMatches(card) &&
         _partyMatches(card) &&
         _statusMatches(state) &&
@@ -140,9 +152,14 @@ class WorldMapFilterState {
 
   /// Language + query only — the "would clearing every pill surface matches?"
   /// probe behind [MapEmptyVerdict.filtersHideMatches]. Language stays applied
-  /// (it is settings-fixed, not a pill the learner can widen in-app).
-  bool matchesIgnoringPills(QuestActivityCard card) =>
-      _langMatches(card) && card.matchesQuery(_filter.query);
+  /// (it is settings-fixed, not a pill the learner can widen in-app) wherever
+  /// [include] applies it — see [applyLanguage] there.
+  bool matchesIgnoringPills(
+    QuestActivityCard card, {
+    bool applyLanguage = true,
+  }) =>
+      (!applyLanguage || _langMatches(card)) &&
+      card.matchesQuery(_filter.query);
 
   bool _langMatches(QuestActivityCard card) {
     final filterL2 = _filter.l2;

--- a/lib/routes/world/world_map_search_overlay.dart
+++ b/lib/routes/world/world_map_search_overlay.dart
@@ -15,11 +15,12 @@ import 'package:fluffychat/widgets/pangea_search_bar.dart';
 /// supersedes it. Still consumed by [WorldMapSignalUtils.reduceActivityCompletions].
 enum MapCompletionFilter { notStarted, inProgress, completed }
 
-/// The Google-Maps-style search + filter surface floating over the World map.
+/// The Google-Maps-style search + filter surface floating over the map.
 /// Presentational: the map owns the pin set, the filter state, and the
 /// filtering — this renders the bar, the [WorldMapFilterBar] pills, and the
-/// results, reporting user intent via callbacks. World-only (the shell hides it
-/// elsewhere). See world-map.instructions.md.
+/// results, reporting user intent via callbacks. Scope-agnostic: it rides the
+/// world map and a course-scoped map alike (#7716), sized to whatever map
+/// sliver the open panels leave. See world-map.instructions.md.
 class WorldMapSearchOverlay extends StatefulWidget {
   final WorldMapFilter filter;
 

--- a/lib/routes/world/world_map_view.dart
+++ b/lib/routes/world/world_map_view.dart
@@ -1005,20 +1005,13 @@ class _WorldMapViewState extends State<WorldMapView> {
           )
         : const SizedBox.shrink();
 
-    // A course shows its plain map (plus the controls); the world map adds the
-    // search + filter overlay.
-    if (!widget.controller.isWorld) {
-      return Semantics(
-        label: L10n.of(context).activityMapLabel,
-        container: true,
-        child: Stack(
-          children: [
-            Positioned.fill(child: map),
-            controls,
-          ],
-        ),
-      );
-    }
+    // The search + filter overlay rides BOTH scopes (#7716): a selected course
+    // narrows which activities compete, not whether the learner can search or
+    // filter within them (world-map.instructions.md). Nothing here is
+    // scope-aware — the sliver rule below is what decides visibility, so an
+    // open course panel hides the overlay exactly like any other left panel
+    // that squeezes the map, and closing that panel brings it back.
+    //
     // The overlay lives in the EXPOSED map sliver: right of the open left
     // panels, clear of the right column / the top-right cluster gutter (a fixed
     // 360 slid under the cluster and off-screen whenever panels squeezed the

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -483,6 +483,12 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
   GoRouterState get state => widget.state;
   _ShellLayout get layout => widget.layout;
 
+  /// The learner tapped the minimized search icon back open over a
+  /// course-scoped map. Ephemeral view state; re-minimizes when the scope
+  /// changes (routing.instructions.md → Single-column search bar).
+  bool _searchRestored = false;
+  String? _lastScopeId;
+
   @override
   Widget build(BuildContext context) {
     final l10n = L10n.of(context);
@@ -522,25 +528,31 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
     final cavitySection = cavityToken?.type.cavitySection;
 
     // The floating search bar (routing.instructions.md → Single-column search
-    // bar), riding the widget's topAttachment slot. WORLD scope only: it drives
-    // the world map's own filter (reached through the persistent map's State).
-    // There is no narrow results list — the pins ARE the results. The
-    // verdict-driven empty-view card and the collapsible filter surface mount
-    // ABOVE the bar, since the bar sits at the bottom on narrow layouts. A
-    // course-scoped map has no working query search (its pins are not filtered
-    // by the query), so the bar is hidden there entirely, matching the web
-    // overlay (which only renders in world scope).
+    // bar), riding the widget's topAttachment slot. It drives the map's own
+    // filter (reached through the persistent map's State) in BOTH scopes — a
+    // course scope narrows which activities compete, not whether the learner
+    // can search within them (#7716). There is no narrow results list — the
+    // pins ARE the results. The verdict-driven empty-view card and the
+    // collapsible filter surface mount ABOVE the bar, since the bar sits at the
+    // bottom on narrow layouts.
     final mapController =
         _persistentWorldMapKey.currentState as WorldMapController?;
-    // World map only (activeSpaceId is the course scope, `?c=`), and not over a
-    // selected activity or an open section sheet: the bar only rode the exposed
-    // map band, which those cover (#7640).
-    final showsSearchBar = activeSpaceId == null && cavityToken == null;
+    // Not over a selected activity or an open section sheet: the bar only rides
+    // the exposed map band, which those cover (#7640). Over a bare COURSE-scoped
+    // map it shows minimized — the compact icon, restorable by tap and
+    // re-minimizing when the scope changes.
+    if (_lastScopeId != activeSpaceId) {
+      _lastScopeId = activeSpaceId;
+      _searchRestored = false;
+    }
+    final showsSearchBar = cavityToken == null;
     final searchBar = showsSearchBar && mapController != null
         ? MobileSearchBar(
             hintText: l10n.mapSearchHint,
             query: mapController.filter.query,
             onQueryChanged: mapController.setQuery,
+            minimized: activeSpaceId != null && !_searchRestored,
+            onRestore: () => setState(() => _searchRestored = true),
             // The verdict-driven empty-view card (the web overlay's twin):
             // when the view shows no matches, the controller diagnoses WHY
             // (off-screen matches / pill-excluded matches / a dead query) and

--- a/test/pangea/navigation/mobile_search_bar_test.dart
+++ b/test/pangea/navigation/mobile_search_bar_test.dart
@@ -26,6 +26,8 @@ void main() {
     VoidCallback? onWidenSearch,
     VoidCallback? onZoomOut,
     Listenable? viewRevision,
+    bool minimized = false,
+    VoidCallback? onRestore,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -38,6 +40,8 @@ void main() {
               hintText: hintText,
               query: query,
               onQueryChanged: onQueryChanged ?? (_) {},
+              minimized: minimized,
+              onRestore: onRestore,
               filtersChild: filtersChild,
               emptyVerdict: emptyVerdict,
               canZoomOut: canZoomOut,
@@ -190,6 +194,35 @@ void main() {
     );
     expect(find.textContaining('in this area'), findsOneWidget);
     expect(find.text('Zoom out'), findsOneWidget);
+  });
+
+  testWidgets('minimized: one icon button, no field, filters or card', (
+    tester,
+  ) async {
+    // The course-scoped resting state (#7716, routing.instructions.md →
+    // Single-column search bar): the scoped map's own chrome owns the band, so
+    // search waits behind one tap — and everything that rides the expanded bar
+    // waits with it.
+    await pumpBar(
+      tester,
+      minimized: true,
+      filtersChild: const Text('FILTER CHIPS', key: Key('chips')),
+      emptyVerdict: () => MapEmptyVerdict.matchesOffscreen,
+      canZoomOut: () => true,
+    );
+    expect(find.byIcon(Icons.search), findsOneWidget);
+    expect(find.byType(TextField), findsNothing);
+    expect(find.byKey(const Key('chips')), findsNothing);
+    expect(find.byType(WorldMapEmptyViewCard), findsNothing);
+  });
+
+  testWidgets('minimized: tapping the icon asks the shell to restore', (
+    tester,
+  ) async {
+    var restored = false;
+    await pumpBar(tester, minimized: true, onRestore: () => restored = true);
+    await tester.tap(find.byIcon(Icons.search));
+    expect(restored, isTrue);
   });
 
   testWidgets('a viewRevision tick re-reads the live verdict', (tester) async {

--- a/test/pangea/world/world_map_filter_scope_test.dart
+++ b/test/pangea/world/world_map_filter_scope_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/languages/language_model.dart';
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+import 'package:fluffychat/routes/world/world_map_filter.dart';
+import 'package:fluffychat/routes/world/world_map_ranking.dart';
+
+/// The scope-dependence of the candidate filter (#7716). A selected course
+/// narrows WHICH activities compete, not whether the learner can search or
+/// filter within them (world-map.instructions.md, "Filters") — so the pills and
+/// the query apply in both scopes. The one term that does not is the
+/// settings-fixed language: course pins are fetched at the COURSE's own L2, so
+/// applying the learner's settings L2 there would empty the map of a course
+/// taught in another language, with no lever to widen.
+QuestActivityCard _card(
+  String id, {
+  String l2 = 'es',
+  String cefr = 'A2',
+  int? roleCount,
+  String? title,
+}) => QuestActivityCard(
+  activityId: id,
+  title: title ?? id,
+  l2: l2,
+  coordinates: null,
+  learningObjectiveRefs: const [],
+  cefr: cefr,
+  roleCount: roleCount,
+);
+
+void main() {
+  final spanish = LanguageModel(langCode: 'es', displayName: 'Spanish');
+
+  WorldMapFilterState stateWithL2() => WorldMapFilterState()..setL2(spanish);
+
+  group('the language constant is scope-dependent', () {
+    test('world scope drops a pin outside the settings L2', () {
+      final filter = stateWithL2();
+      expect(
+        filter.include(_card('a', l2: 'fr'), ActivityPinState.available),
+        isFalse,
+      );
+    });
+
+    test('course scope keeps it — the course owns the language', () {
+      final filter = stateWithL2();
+      expect(
+        filter.include(
+          _card('a', l2: 'fr'),
+          ActivityPinState.available,
+          applyLanguage: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('matchesIgnoringPills follows the same scope rule', () {
+      final filter = stateWithL2();
+      final offLanguage = _card('a', l2: 'fr');
+      expect(filter.matchesIgnoringPills(offLanguage), isFalse);
+      expect(
+        filter.matchesIgnoringPills(offLanguage, applyLanguage: false),
+        isTrue,
+      );
+    });
+  });
+
+  group('the pills and query still narrow a course scope', () {
+    test('the Level pill excludes an off-level pin', () {
+      final filter = stateWithL2()..setCefrLevel(LanguageLevelTypeEnum.b2);
+      expect(
+        filter.include(
+          _card('a', l2: 'fr', cefr: 'A2'),
+          ActivityPinState.available,
+          applyLanguage: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('the Party size pill matches the designed role count exactly', () {
+      final filter = stateWithL2()..setPartySize(3);
+      bool includes(int roles) => filter.include(
+        _card('a', roleCount: roles),
+        ActivityPinState.available,
+        applyLanguage: false,
+      );
+      expect(includes(3), isTrue);
+      expect(includes(4), isFalse);
+    });
+
+    test('the Status pill matches the resolved pin state', () {
+      final filter = stateWithL2()..setStatus(ActivityPinState.joinable);
+      expect(
+        filter.include(
+          _card('a'),
+          ActivityPinState.joinable,
+          applyLanguage: false,
+        ),
+        isTrue,
+      );
+      expect(
+        filter.include(
+          _card('a'),
+          ActivityPinState.available,
+          applyLanguage: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('the free-text query narrows on the card text', () {
+      final filter = stateWithL2()..setQuery('market');
+      bool includes(String title) => filter.include(
+        _card('a', title: title),
+        ActivityPinState.available,
+        applyLanguage: false,
+      );
+      expect(includes('At the market'), isTrue);
+      expect(includes('At the airport'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
### What

The map's search + filter surface now renders on a **course-scoped** map, on both layouts, and the filter actually applies to course pins.

### Why

Closes #7716

The wide overlay and the narrow bar were both gated to world scope, and `visiblePins` short-circuited to "include everything" under a course — so a selected course had no way to search or refine its activities, whether or not the course panel was open.

Design intent for this is already in the docs; the code hadn't implemented it:
- [world-map.instructions.md → Filters](.github/instructions/world-map.instructions.md#filters) — a course scope "only changes which items compete"; the content/ranking/display pipeline is "identical either way".
- [routing.instructions.md → Single-column search bar](.github/instructions/routing.instructions.md#single-column-search-bar) — describes the narrow course-scoped state as the bar **minimizing to a compact search icon**, restorable by tap. #8075 changed it to hide entirely, on the reasoning that "a course-scoped map has no working query search" — which is circular with the `visiblePins` short-circuit this PR removes. This restores the documented behavior.

### Changes

- `world_map_filter.dart` — `include` / `matchesIgnoringPills` take `applyLanguage`. **The only scope-dependent filter term.** Course pins are fetched at the *course's* own L2 (`loadCourseScopedPins`), so narrowing them by the learner's *settings* L2 would blank the map for any course taught in another language — with no lever to widen, since language deliberately isn't one. Pills and query apply in both scopes.
- `world_map.dart` — `visiblePins` drops the `if (!isWorld) return true` short-circuit and passes `applyLanguage: isWorld`; `emptyVerdict` drops its `!isWorld` guard so the empty-view card and its remedies work under a course too.
- `world_map_view.dart` — removes the course-scope early return. Nothing in the overlay path is scope-aware now; the existing exposed-sliver rule alone decides visibility, so an open course panel squeezes it like any other left panel and closing it brings the overlay back.
- `mobile_search_bar.dart` — restores the `minimized` / `onRestore` compact-icon state removed in #8075. The empty-view card and filter chips stay hidden while minimized.
- `workspace_shell.dart` — restores `_searchRestored` / `_lastScopeId`; `showsSearchBar` drops the `activeSpaceId == null` gate (keeping #8075's "not over an open cavity" rule), and a course scope starts the bar minimized, re-minimizing when the scope changes.
- `test/pangea/world/world_map_filter_scope_test.dart` — new; pins the scope-dependence of the language term and that each pill + the query still narrow under a course.
- `test/pangea/navigation/mobile_search_bar_test.dart` — covers the minimized state and its restore tap.

**Follow-up, not in this PR:** [world-map.instructions.md → Filters](.github/instructions/world-map.instructions.md#filters) currently calls language one of "the two **constant** filters, always applied and never removable", which the course-scope carve-out above narrows. That one-line clarification is a doc change and needs its own sign-off in chat — per [prs.instructions.md](https://github.com/pangeachat/.github/blob/main/.github/instructions/prs.instructions.md), a PR is not the venue for it.

Also worth a look in QA: the query/pills persist across a scope change (world → course and back). On wide that's visible in the bar with its Reset control; on narrow it sits behind the minimized icon, which is what routing.instructions.md describes ("the search bar **and its active filters** minimize").

### Testing

**Unit** — `fvm flutter test test/pangea`: 2213 pass, 4 skipped, 1 fail. The failure is `activity_session_history_visibility_test.dart` ("the room is still created private"), a fake-server timeout under full-suite load: it passes in isolation both with this diff and with the diff stashed. `fvm flutter analyze lib test`: clean.

**Manual (web, local stack, this branch)** — logged in as the local-stack learner:
- Wide (1440×900), course selected, course details **open** → overlay renders in the exposed sliver beside the panel.
- Wide, course details **closed** → overlay stays, course scope preserved (only that course's pins). This is the issue's exact repro.
- Wide, course scope, typed `coffee` → pins narrowed to the matching activity and the results dropdown listed it. Previously the query did nothing here.
- Narrow (375×812), course scope, sheet closed → compact search icon above the nav rail; tapping it restored the full bar with filter toggle, and the `matchesOffscreen` empty-view card ("There are matches outside your view") rendered — a verdict that always returned `none` under a course before.

### Deploy Notes

None.
