### PR TITLE
ci(staging): enable live streaming STT on staging web

### DIFF
--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -125,6 +125,13 @@ jobs:
           # (task_definition_staging.json). NOT set on production (release.yaml) until
           # validated on staging.
           echo "DOSAGE_SIGNALS_ENABLED=true" >> build/web/.env
+          # Staging only: turn on the live streaming-STT capture path so voice
+          # messages transcribe over the choreo WebSocket relay instead of batch.
+          # The choreo master flag (STREAMING_LIVE_ENABLED) is already on in staging;
+          # this is the matching client gate (Environment.liveStreamingSttEnabled).
+          # Client falls back to batch on any relay/provider failure. NOT set on
+          # production (release.yaml) until validated on staging.
+          echo "LIVE_STREAMING_STT_ENABLED=true" >> build/web/.env
           touch build/web/assets/envs.json
           echo "$ENV_OVERRIDES" >> build/web/assets/envs.json
           mkdir -p build/web/.well-known


### PR DESCRIPTION
## What

Adds one line to the **staging** web build (`.github/workflows/main_deploy.yaml`), beside the existing staging-only feature flags:

```
echo "LIVE_STREAMING_STT_ENABLED=true" >> build/web/.env
```

This turns on the client streaming-STT gate (`Environment.liveStreamingSttEnabled`) so staging voice messages transcribe over the choreo WebSocket relay instead of batch.

## Why now

The choreo backend is live and verified on staging:
- Master flag `STREAMING_LIVE_ENABLED=true` deployed (choreo #2963), 4 workers, no 429s.
- Full WS path confirmed against a real **subscribed** staging account: accept + Matrix auth + subscription entitlement + wire v2 + Soniox provider connect (`{"type":"provider","id":"soniox","degraded":false}`).

The only thing dark is this client gate. Flipping it lets us test the true client→relay→transcript flow end to end.

## Scope & safety

- **Staging only** — this is the staging deploy workflow; production (`release.yaml`) is untouched.
- Gated by language support; client **falls back to batch** on any relay/provider failure.
- Backend request rate limiter is unaffected (workers not pinned; the earlier 429 issue is fixed).
- **Revert** = one-line revert PR.

## Deploy note

Merging to `main` runs `main_deploy.yaml` and redeploys the staging web app with streaming on. That merge is the deploy event.

Closes #8166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled live streaming speech-to-text capture in the staging environment.
  * Retained client-side fallback behavior for uninterrupted speech recognition.
  * Production behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->