### PR TITLE
Add tab ordering to home page

### DIFF
--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -241,201 +241,205 @@ class WorkspaceShell extends StatelessWidget {
     return Semantics(
       label: L10n.of(context).home,
       child: ScaffoldMessenger(
-        child: Scaffold(
-          // No bottomNavigationBar slot: the narrow chrome is the FLOATING nav
-          // widget (rail + expandable cavity) stacked over the map below, so it
-          // can grow upward and let the map show through around it. See
-          // `routing.instructions.md` → Single-column bottom nav.
-          // The persistent WorldMap stays full-bleed (edge to edge, behind the
-          // status bar) as the base layer — routing.instructions.md. Only the
-          // foreground chrome/panels sit inside the SafeArea below.
-          body: Stack(
-            fit: StackFit.expand,
-            children: [
-              /// Persistent world map — the base layer everything overlays. Overlays pad the
-              /// camera so a course fit lands in the exposed area: left = rail + column +
-              /// detail; right = the panel zone.
-              WorldMap(
-                key: _persistentWorldMapKey,
-                leftOverlayWidth: l.mapLeftOverlay,
-                rightOverlayWidth: l.allocation.mapRightOverlay,
-                bottomOverlayHeight: l.mapBottomOverlay,
-                availableVisibleMapWidth: l.availableVisibleMapWidth,
-                focus: mapFocusFor(state),
-              ),
+        child: FocusTraversalGroup(
+          policy: OrderedTraversalPolicy(),
+          child: Scaffold(
+            // No bottomNavigationBar slot: the narrow chrome is the FLOATING nav
+            // widget (rail + expandable cavity) stacked over the map below, so it
+            // can grow upward and let the map show through around it. See
+            // `routing.instructions.md` → Single-column bottom nav.
+            // The persistent WorldMap stays full-bleed (edge to edge, behind the
+            // status bar) as the base layer — routing.instructions.md. Only the
+            // foreground chrome/panels sit inside the SafeArea below.
+            body: Stack(
+              fit: StackFit.expand,
+              children: [
+                /// Persistent world map — the base layer everything overlays. Overlays pad the
+                /// camera so a course fit lands in the exposed area: left = rail + column +
+                /// detail; right = the panel zone.
+                WorldMap(
+                  key: _persistentWorldMapKey,
+                  leftOverlayWidth: l.mapLeftOverlay,
+                  rightOverlayWidth: l.allocation.mapRightOverlay,
+                  bottomOverlayHeight: l.mapBottomOverlay,
+                  availableVisibleMapWidth: l.availableVisibleMapWidth,
+                  focus: mapFocusFor(state),
+                ),
 
-              // Everything above the map respects the device safe area; the
-              // map itself does not (it is full-bleed, see above).
-              Positioned.fill(
-                child: SafeArea(
-                  child: Stack(
-                    fit: StackFit.expand,
-                    children: [
-                      /// The route canvas, as one stable child
-                      Positioned(
-                        left: l.leftInset,
-                        top: 0,
-                        bottom: 0,
-                        right: 0,
-                        width: null,
-                        child: Offstage(child: l.canvasChild),
-                      ),
-
-                      /// The narrow floating nav widget: the 4-item rail with the
-                      /// expandable cavity above it hosting the focused section surface
-                      /// (the chat list, the Courses hub, a course card) bare — the widget
-                      /// is the card. Hidden while a map-pin preview sheet is open (the
-                      /// map owns that selection; the notifier carries the signal up), and
-                      /// entirely absent under a focused full-screen surface. See
-                      /// `routing.instructions.md` → Single-column bottom nav.
-                      if (l.navWidgetVisible)
-                        ValueListenableBuilder<bool>(
-                          valueListenable: WorldMapPinsManager.notifier,
-                          builder: (context, pinSheetOpen, child) =>
-                              pinSheetOpen ? const SizedBox.shrink() : child!,
-                          child: _MobileNavLayer(
-                            state: state,
-                            layout: l,
-                            screenPadding: MediaQuery.viewPaddingOf(context),
-                            // Only the keyboard's overlap BEYOND the bottom safe
-                            // area (home indicator) should trim the cavity: once
-                            // the keyboard covers that strip, the SafeArea stops
-                            // reserving it and the bottom-anchored nav layer
-                            // already drops by that much. Trimming by the raw
-                            // inset would double-count it and settle the cavity
-                            // top ~34pt low. Read above the Scaffold, where
-                            // `viewInsets` is still intact (#7754).
-                            keyboardInset:
-                                (MediaQuery.viewInsetsOf(context).bottom -
-                                        MediaQuery.viewPaddingOf(
-                                          context,
-                                        ).bottom)
-                                    .clamp(0.0, double.infinity),
-                          ),
+                // Everything above the map respects the device safe area; the
+                // map itself does not (it is full-bleed, see above).
+                Positioned.fill(
+                  child: SafeArea(
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        /// The route canvas, as one stable child
+                        Positioned(
+                          left: l.leftInset,
+                          top: 0,
+                          bottom: 0,
+                          right: 0,
+                          width: null,
+                          child: Offstage(child: l.canvasChild),
                         ),
 
-                      /// The nav rail must size to its content, NOT fill the Stack: this Stack is
-                      /// StackFit.expand, which forces non-positioned children to full size — and the
-                      /// rail's root (opaque-canvas) Material would then paint over the entire
-                      /// persistent map below it (blank map; mobile was fine because the rail is
-                      /// `SizedBox.shrink` there). Align tops it left at its natural size so the map
-                      /// stays full-bleed behind it.
-                      Align(
-                        alignment: Alignment.topLeft,
-                        child: Padding(
-                          padding: const EdgeInsets.all(
-                            _ShellLayout.chromeMargin,
-                          ),
-                          child: SpacesNavigationRail(
-                            state: state,
-                            showNavRail: l.navRail,
-                            naviRailWidth: FluffyThemes.navRailWidth + 1.0,
-                            activeSpaceId: activeSpaceIdFor(state.uri),
-                          ),
-                        ),
-                      ),
-
-                      /// Left-column panels (the chat list, a live room, a course, the
-                      /// settings/profile menu) from `?left=`, each at its allocator slot. The
-                      /// floating-card chrome AND margin live in [PanelCard] (inside
-                      /// WorkspaceLeftPanel), shared with the right column and the center detail.
-                      /// Keyed by token so opening/closing a sibling panel doesn't shift indices and
-                      /// remount this one; a `room` panel additionally carries a roomId GlobalKey so
-                      /// its ChatController repositions rather than remounts when the slot moves.
-                      ...[
-                        for (var i = 0; i < l.leftTokens.length; i++)
-                          // Skip the cavity-hosted surface (the chat list, the Courses
-                          // hub, a course card) — it renders inside the nav widget's
-                          // cavity, not as a full-screen left panel (no double-render).
-                          if (i != l.cavityIndex &&
-                              l.allocation.left[i].vis != PanelVis.hidden)
-                            Positioned(
-                              key: ValueKey(l.leftTokens[i].encode()),
-                              // The narrow full-screen focus (a live room / session) is
-                              // FULL-BLEED: no card chrome, edge to edge, top 0 — its own
-                              // app bar absorbs the status-bar inset, and skipping the
-                              // shell's extra safe-area offset removes the doubled top
-                              // padding (#7554). Column-mode / non-focused panels keep
-                              // the card and respect the top inset so their close/back
-                              // control clears the system top bar (#7143); PanelCard's
-                              // 12px top margin aligns them with the top-right cluster.
-                              top: 0,
-                              bottom: 0,
-                              left: l.allocation.left[i].left,
-                              width: l.allocation.left[i].width,
-                              child: LeftPanelLayer(
-                                token: l.leftTokens[i],
-                                state: state,
-                                foldedOver: l.allocation.left[i].foldedOver,
-                                getRoomKey: _roomKeyFor,
-                                bare:
-                                    !l.isColumnMode &&
-                                    l.allocation.left[i].vis == PanelVis.full,
-                              ),
+                        /// The narrow floating nav widget: the 4-item rail with the
+                        /// expandable cavity above it hosting the focused section surface
+                        /// (the chat list, the Courses hub, a course card) bare — the widget
+                        /// is the card. Hidden while a map-pin preview sheet is open (the
+                        /// map owns that selection; the notifier carries the signal up), and
+                        /// entirely absent under a focused full-screen surface. See
+                        /// `routing.instructions.md` → Single-column bottom nav.
+                        if (l.navWidgetVisible)
+                          ValueListenableBuilder<bool>(
+                            valueListenable: WorldMapPinsManager.notifier,
+                            builder: (context, pinSheetOpen, child) =>
+                                pinSheetOpen ? const SizedBox.shrink() : child!,
+                            child: _MobileNavLayer(
+                              state: state,
+                              layout: l,
+                              screenPadding: MediaQuery.viewPaddingOf(context),
+                              // Only the keyboard's overlap BEYOND the bottom safe
+                              // area (home indicator) should trim the cavity: once
+                              // the keyboard covers that strip, the SafeArea stops
+                              // reserving it and the bottom-anchored nav layer
+                              // already drops by that much. Trimming by the raw
+                              // inset would double-count it and settle the cavity
+                              // top ~34pt low. Read above the Scaffold, where
+                              // `viewInsets` is still intact (#7754).
+                              keyboardInset:
+                                  (MediaQuery.viewInsetsOf(context).bottom -
+                                          MediaQuery.viewPaddingOf(
+                                            context,
+                                          ).bottom)
+                                      .clamp(0.0, double.infinity),
                             ),
-                      ],
+                          ),
 
-                      /// Right-column panels (analytics summary, a vocab/grammar detail, a
-                      /// completed-activity review) from `?right=`, each placed at its allocator
-                      /// slot. The slots tile and never overlap by construction; a folded slot is
-                      /// `hidden` (not drawn), its content one back-step away on the higher-priority
-                      /// sibling that stayed.
-                      ...[
-                        for (var i = 0; i < l.rightTokens.length; i++)
-                          if (l.allocation.right[i].vis != PanelVis.hidden)
-                            Positioned(
-                              // Keyed by token so a left-column open/close (which shifts sibling
-                              // indices in this Stack) reconciles the right panel by identity, not
-                              // position — otherwise its stateful content (analytics, a detail) would
-                              // remount and re-fetch.
-                              key: ValueKey(l.rightTokens[i].encode()),
-                              // Respect the top safe-area inset so the close/back control clears the
-                              // system top bar (#7143). On narrow the analytics bar heads the panel
-                              // ("the analytics bar itself remains visible at the top throughout" —
-                              // routing.instructions.md), so the panel starts below it.
-                              top: l.isColumnMode
-                                  ? 0
-                                  : _ShellLayout.analyticsBarAllowance,
-                              bottom: 0,
-                              left: l.allocation.right[i].left,
-                              width: l.allocation.right[i].width,
-                              child: FocusTraversalGroup(
-                                policy: OrderedTraversalPolicy(),
-                                child: WorkspaceRightPanel(
-                                  token: l.rightTokens[i],
-                                  currentUri: state.uri,
-                                  foldedOver: l.allocation.right[i].foldedOver,
+                        /// The nav rail must size to its content, NOT fill the Stack: this Stack is
+                        /// StackFit.expand, which forces non-positioned children to full size — and the
+                        /// rail's root (opaque-canvas) Material would then paint over the entire
+                        /// persistent map below it (blank map; mobile was fine because the rail is
+                        /// `SizedBox.shrink` there). Align tops it left at its natural size so the map
+                        /// stays full-bleed behind it.
+                        Align(
+                          alignment: Alignment.topLeft,
+                          child: Padding(
+                            padding: const EdgeInsets.all(
+                              _ShellLayout.chromeMargin,
+                            ),
+                            child: SpacesNavigationRail(
+                              state: state,
+                              showNavRail: l.navRail,
+                              naviRailWidth: FluffyThemes.navRailWidth + 1.0,
+                              activeSpaceId: activeSpaceIdFor(state.uri),
+                            ),
+                          ),
+                        ),
+
+                        /// Left-column panels (the chat list, a live room, a course, the
+                        /// settings/profile menu) from `?left=`, each at its allocator slot. The
+                        /// floating-card chrome AND margin live in [PanelCard] (inside
+                        /// WorkspaceLeftPanel), shared with the right column and the center detail.
+                        /// Keyed by token so opening/closing a sibling panel doesn't shift indices and
+                        /// remount this one; a `room` panel additionally carries a roomId GlobalKey so
+                        /// its ChatController repositions rather than remounts when the slot moves.
+                        ...[
+                          for (var i = 0; i < l.leftTokens.length; i++)
+                            // Skip the cavity-hosted surface (the chat list, the Courses
+                            // hub, a course card) — it renders inside the nav widget's
+                            // cavity, not as a full-screen left panel (no double-render).
+                            if (i != l.cavityIndex &&
+                                l.allocation.left[i].vis != PanelVis.hidden)
+                              Positioned(
+                                key: ValueKey(l.leftTokens[i].encode()),
+                                // The narrow full-screen focus (a live room / session) is
+                                // FULL-BLEED: no card chrome, edge to edge, top 0 — its own
+                                // app bar absorbs the status-bar inset, and skipping the
+                                // shell's extra safe-area offset removes the doubled top
+                                // padding (#7554). Column-mode / non-focused panels keep
+                                // the card and respect the top inset so their close/back
+                                // control clears the system top bar (#7143); PanelCard's
+                                // 12px top margin aligns them with the top-right cluster.
+                                top: 0,
+                                bottom: 0,
+                                left: l.allocation.left[i].left,
+                                width: l.allocation.left[i].width,
+                                child: LeftPanelLayer(
+                                  token: l.leftTokens[i],
+                                  state: state,
+                                  foldedOver: l.allocation.left[i].foldedOver,
+                                  getRoomKey: _roomKeyFor,
+                                  bare:
+                                      !l.isColumnMode &&
+                                      l.allocation.left[i].vis == PanelVis.full,
                                 ),
                               ),
-                            ),
-                      ],
+                        ],
 
-                      /// The right column's entry point. In column mode: the persistent
-                      /// top-right vertical cluster, in the gutter the allocator reserves.
-                      /// On narrow: the horizontal ANALYTICS NAV BAR pinned to the top
-                      /// safe area — full form only, on the surfaces where it IS
-                      /// navigation (the map/cavity ground and the right panels it
-                      /// heads). A full-screen chat hosts the avatar in its own app bar
-                      /// instead, and a route-driven detail page shows nothing. See
-                      /// `routing.instructions.md` → Single-column analytics nav bar.
-                      if (l.isColumnMode && l.allocation.clusterVisible)
-                        Positioned(
-                          top: _ShellLayout.chromeMargin,
-                          right: _ShellLayout.chromeMargin,
-                          child: WorldUserCluster(key: _userClusterKey),
-                        )
-                      else if (l.analyticsBarVisible)
-                        Positioned(
-                          top: _ShellLayout.chromeMargin,
-                          left: _ShellLayout.chromeMargin,
-                          right: _ShellLayout.chromeMargin,
-                          child: WorldAnalyticsBar(key: _userClusterKey),
-                        ),
-                    ],
+                        /// Right-column panels (analytics summary, a vocab/grammar detail, a
+                        /// completed-activity review) from `?right=`, each placed at its allocator
+                        /// slot. The slots tile and never overlap by construction; a folded slot is
+                        /// `hidden` (not drawn), its content one back-step away on the higher-priority
+                        /// sibling that stayed.
+                        ...[
+                          for (var i = 0; i < l.rightTokens.length; i++)
+                            if (l.allocation.right[i].vis != PanelVis.hidden)
+                              Positioned(
+                                // Keyed by token so a left-column open/close (which shifts sibling
+                                // indices in this Stack) reconciles the right panel by identity, not
+                                // position — otherwise its stateful content (analytics, a detail) would
+                                // remount and re-fetch.
+                                key: ValueKey(l.rightTokens[i].encode()),
+                                // Respect the top safe-area inset so the close/back control clears the
+                                // system top bar (#7143). On narrow the analytics bar heads the panel
+                                // ("the analytics bar itself remains visible at the top throughout" —
+                                // routing.instructions.md), so the panel starts below it.
+                                top: l.isColumnMode
+                                    ? 0
+                                    : _ShellLayout.analyticsBarAllowance,
+                                bottom: 0,
+                                left: l.allocation.right[i].left,
+                                width: l.allocation.right[i].width,
+                                child: FocusTraversalGroup(
+                                  policy: OrderedTraversalPolicy(),
+                                  child: WorkspaceRightPanel(
+                                    token: l.rightTokens[i],
+                                    currentUri: state.uri,
+                                    foldedOver:
+                                        l.allocation.right[i].foldedOver,
+                                  ),
+                                ),
+                              ),
+                        ],
+
+                        /// The right column's entry point. In column mode: the persistent
+                        /// top-right vertical cluster, in the gutter the allocator reserves.
+                        /// On narrow: the horizontal ANALYTICS NAV BAR pinned to the top
+                        /// safe area — full form only, on the surfaces where it IS
+                        /// navigation (the map/cavity ground and the right panels it
+                        /// heads). A full-screen chat hosts the avatar in its own app bar
+                        /// instead, and a route-driven detail page shows nothing. See
+                        /// `routing.instructions.md` → Single-column analytics nav bar.
+                        if (l.isColumnMode && l.allocation.clusterVisible)
+                          Positioned(
+                            top: _ShellLayout.chromeMargin,
+                            right: _ShellLayout.chromeMargin,
+                            child: WorldUserCluster(key: _userClusterKey),
+                          )
+                        else if (l.analyticsBarVisible)
+                          Positioned(
+                            top: _ShellLayout.chromeMargin,
+                            left: _ShellLayout.chromeMargin,
+                            right: _ShellLayout.chromeMargin,
+                            child: WorldAnalyticsBar(key: _userClusterKey),
+                          ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [x] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation order within the workspace interface.
  * Existing workspace layout, panels, and map views remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->