### PR TITLE
fix(settings): restore the Privacy Policy link

### DIFF
--- a/lib/routes/settings/settings_view.dart
+++ b/lib/routes/settings/settings_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 import 'package:fluffychat/config/app_config.dart';
@@ -198,6 +199,15 @@ class SettingsView extends StatelessWidget {
                         child: const Icon(Icons.open_in_new_outlined),
                       ),
                     ),
+                    ListTile(
+                      leading: const Icon(Icons.privacy_tip_outlined),
+                      title: Text(L10n.of(context).privacy),
+                      onTap: () => launchUrl(AppConfig.privacyUrl),
+                      trailing: Semantics(
+                        label: L10n.of(context).openNewTab,
+                        child: const Icon(Icons.open_in_new_outlined),
+                      ),
+                    ),
                     if (MatrixState
                         .pangeaController
                         .userController
@@ -276,11 +286,6 @@ class SettingsView extends StatelessWidget {
                     //       activeRoute.startsWith('/settings/homeserver')
                     //       ? theme.colorScheme.surfaceContainerHigh
                     //       : null,
-                    // ),
-                    // ListTile(
-                    //   leading: const Icon(Icons.privacy_tip_outlined),
-                    //   title: Text(L10n.of(context).privacy),
-                    //   onTap: () => launchUrl(AppConfig.privacyUrl),
                     // ),
                     // ListTile(
                     //   leading: const Icon(Icons.info_outline_rounded),


### PR DESCRIPTION
## What

Restore the Privacy Policy link in Settings.

## Why

Closes #8171 — the Privacy `ListTile` was commented out, leaving no in-app path to the privacy policy.

The tile now sits directly below **Terms and Conditions** and follows that tile's external-link pattern (`open_in_new_outlined` trailing icon + `openNewTab` semantics label) rather than the bare form it had while commented out — both are external legal links, so they read as a pair. `AppConfig.privacyUrl` was already correct and is unchanged.

## Testing

- **Unit/widget (`flutter test`)**: 2241 passed, 4 skipped, 1 failed — `choreo_endpoint_test.dart › Custom course endpoint test`. Confirmed pre-existing: it fails identically on the unmodified base commit (local choreo has no LLM access).
- **Manual, local stack (Flutter web, logged in as `learner`)**: Settings shows **Privacy** below Terms and Conditions with the open-in-new icon. Tapping it calls `window.open("https://www.pangeachat.com/privacy")` — verified by spying on `window.open` — which matches `AppConfig.privacyUrl`; that URL returns 200.
- **Accessibility**: `scripts/a11y_floor_check.py` passes; the semantics tree announces the control as `button "Privacy Open in new tab"`, matching the Terms tile.
- **Playwright e2e**: not run locally — those specs run against staging.

## Deploy Notes

None.
