### PR TITLE
fix(onboarding): stop page semantics container absorbing descendant roles

### DIFF
--- a/lib/routes/onboarding/onboarding_page.dart
+++ b/lib/routes/onboarding/onboarding_page.dart
@@ -168,7 +168,15 @@ class OnboardingController extends State<Onboarding> {
           return content;
         }
 
+        // `explicitChildNodes` keeps this a labelled container rather than an
+        // annotation that merges with the first mergeable descendant config it
+        // finds. Without it the page node absorbs a descendant's role — the
+        // step views show a `CircularProgressIndicator` while `BotFace` loads,
+        // and its `loadingSpinner` role lands on the page container, which then
+        // stops being exposed as a labelled group. `container: true` does not
+        // prevent this; only `explicitChildNodes` does.
         return Semantics(
+          explicitChildNodes: true,
           label: L10n.of(
             context,
           ).pageLabel(labelByStepIndex(_navigation.currentStepIndex)),

--- a/lib/routes/onboarding/onboarding_step_views/free_trial_step_view.dart
+++ b/lib/routes/onboarding/onboarding_step_views/free_trial_step_view.dart
@@ -30,7 +30,11 @@ class FreeTrialStepView extends StatelessWidget {
         ? theme.textTheme.displayMedium
         : theme.textTheme.headlineMedium;
 
+    // See the note on the same wrapper in onboarding_page.dart —
+    // `explicitChildNodes` stops this page container from absorbing a
+    // descendant's semantics config.
     return Semantics(
+      explicitChildNodes: true,
       label: L10n.of(context).pageLabel(L10n.of(context).freeTrial),
       child: Scaffold(
         appBar: AppBar(


### PR DESCRIPTION
### What

Add `explicitChildNodes: true` to the two page-level `Semantics(label: ...)` wrappers on the onboarding surface.

### Why

Closes #7582

Both wrappers (added in #7584) are *non-explicit* annotations, so Flutter merges them with the first mergeable descendant config rather than emitting a labelled container. Dumping the real semantics tree — real `OnboardingStepView`, real steps, `CourseCodeStepView` → back → `UserTypeStepView` — the page node comes out as:

```
SemanticsNode#4
  label: "step page"
  role: loadingSpinner      <- leaked up from a descendant
```

The `loadingSpinner` is the `CircularProgressIndicator` placeholder inside `BotFace` → `CachedNetworkImage`, climbing five levels onto the page container. Going back rebuilds the step view from scratch, so `BotFace` remounts with `_controller == null` and that placeholder is on screen exactly around the transition the issue describes.

Confirmed against the real `<flt-semantics>` DOM in a browser: with no spinner in the subtree the page container is `role="group" aria-label="Page N"`; with one, the `role` attribute disappears and it becomes an unroled element carrying an `aria-label` — a named generic, which ARIA prohibits and screen readers expose inconsistently.

`explicitChildNodes: true` keeps the label on its own container and leaves every descendant as its own node. **`container: true` does not fix this** — measured, see below.

### Testing

Semantics-tree probe against the real onboarding views, three annotation variants (temporary local test, not committed — see the note below):

| wrapper | page node |
|---|---|
| as-is | `label: "step page"` + `role: loadingSpinner` |
| `container: true` | `label: "step page"` + `role: loadingSpinner` (unchanged) |
| `explicitChildNodes: true` | `label: "step page"`, spinner is its own sibling node |

Also run locally on this branch:

- `fvm flutter test test/` — 2228 passed, 3 skipped, 0 failed
- `fvm flutter test test/pangea/onboarding_tests/` — 9 passed
- `fvm flutter analyze lib/routes/onboarding/` — no issues
- `fvm dart format` — clean
- `python3 scripts/a11y_floor_check.py` — no unlabeled controls

**No regression test committed — environment blocker.** `rive_native` can't load its dylib in the `flutter test` VM host, so any widget test that pumps the real onboarding step views (they all render `BotFace`) fails on that before it can assert. The probe above only produced usable output because the dumps print before the failure. Guarding this would mean changing `BotFace`, which is outside this fix.

**Screen-reader verification still outstanding.** Per [accessibility.instructions.md](.github/instructions/accessibility.instructions.md), actual SR output only closes through a manual pass. I reproduced the semantics-tree and DOM defect, not the reported announcement behaviour — the issue's TO TEST steps should be walked with a real screen reader before this is called done.

### Deploy Notes

None