### PR TITLE
fix(analytics): restore the level-up chime

### DIFF
--- a/lib/routes/world/level_up_badge_celebration.dart
+++ b/lib/routes/world/level_up_badge_celebration.dart
@@ -12,42 +12,6 @@ import 'package:fluffychat/features/analytics_data/analytics_update_dispatcher.d
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 
-/// Plays the level-up chime (issue #7881).
-///
-/// The chime is part of the celebration moment
-/// (analytics-system.instructions.md → "User Levels"). It shipped with the old
-/// full-screen level-up banner; #7533 deleted that banner and took the sound
-/// with it, leaving the celebration silent. Same asset, same volume rule as
-/// before — only the widget that fires it changed.
-///
-/// The mp3 lives in the client assets bucket, not `assets/sounds/`, so this is
-/// a [UrlSource] rather than an `AssetSource`. Failure is non-fatal: a level-up
-/// with no sound still celebrates, so nothing here is awaited by the caller.
-Future<void> playLevelUpChime() async {
-  final player = AudioPlayer();
-  try {
-    await player.setVolume(min(0.25, AppSettings.volume.value));
-    await player.play(
-      UrlSource(
-        "${AppConfig.assetsBaseURL}/${AnalyticsConstants.levelUpAudioFileName}",
-      ),
-    );
-    // Let the clip finish before the player is torn down.
-    await Future.delayed(const Duration(seconds: 2));
-  } catch (e, s) {
-    // Once, not per level-up: the failure modes here are standing ones (no
-    // network, browser autoplay policy), so repeat reports say nothing new.
-    await ErrorHandler.logErrorOnce(
-      key: "level_up_chime",
-      e: e,
-      s: s,
-      data: {"message": "Failed to play level up sound"},
-    );
-  } finally {
-    await player.dispose();
-  }
-}
-
 /// A level-up celebration anchored to the level badge it wraps (issue #7432).
 ///
 /// Replaces the old top-down chat snackbar: instead of chrome dropping over
@@ -92,14 +56,14 @@ class LevelUpBadgeCelebration extends StatefulWidget {
 
   /// Fired alongside the pulse. Defaults to the real chime; widget tests pass
   /// a no-op so they never reach for the audio plugin or the network.
-  final Future<void> Function() playChime;
+  final Future<void> Function()? playChime;
 
   const LevelUpBadgeCelebration({
     required this.child,
     this.levelUpdates,
     this.chipDuration = defaultChipDuration,
     this.pulseDuration = defaultPulseDuration,
-    this.playChime = playLevelUpChime,
+    this.playChime,
     super.key,
   });
 
@@ -131,6 +95,33 @@ class _LevelUpBadgeCelebrationState extends State<LevelUpBadgeCelebration>
   late final AnimationController _chipController;
   late final Animation<double> _chipOpacity;
   late final Animation<double> _chipScale;
+
+  Future<void> _playChime() => widget.playChime?.call() ?? _playLevelUpChime();
+
+  Future<void> _playLevelUpChime() async {
+    final player = AudioPlayer();
+    try {
+      await player.setVolume(min(0.25, AppSettings.volume.value));
+      await player.play(
+        UrlSource(
+          "${AppConfig.assetsBaseURL}/${AnalyticsConstants.levelUpAudioFileName}",
+        ),
+      );
+      // Let the clip finish before the player is torn down.
+      await Future.delayed(const Duration(seconds: 2));
+    } catch (e, s) {
+      // Once, not per level-up: the failure modes here are standing ones (no
+      // network, browser autoplay policy), so repeat reports say nothing new.
+      await ErrorHandler.logErrorOnce(
+        key: "level_up_chime",
+        e: e,
+        s: s,
+        data: {"message": "Failed to play level up sound"},
+      );
+    } finally {
+      await player.dispose();
+    }
+  }
 
   @override
   void initState() {
@@ -207,7 +198,7 @@ class _LevelUpBadgeCelebrationState extends State<LevelUpBadgeCelebration>
     _pulseController.forward(from: 0.0);
     _chipController.forward();
     // Not awaited: the chime outlives the pulse and must not gate the visuals.
-    unawaited(widget.playChime());
+    unawaited(_playChime());
 
     _chipTimer?.cancel();
     _chipTimer = Timer(widget.chipDuration, () {

--- a/lib/routes/world/level_up_badge_celebration.dart
+++ b/lib/routes/world/level_up_badge_celebration.dart
@@ -1,18 +1,66 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 
+import 'package:audioplayers/audioplayers.dart';
+
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/config/setting_keys.dart';
+import 'package:fluffychat/features/analytics/analytics_constants.dart';
 import 'package:fluffychat/features/analytics_data/analytics_update_dispatcher.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+
+/// Plays the level-up chime (issue #7881).
+///
+/// The chime is part of the celebration moment
+/// (analytics-system.instructions.md → "User Levels"). It shipped with the old
+/// full-screen level-up banner; #7533 deleted that banner and took the sound
+/// with it, leaving the celebration silent. Same asset, same volume rule as
+/// before — only the widget that fires it changed.
+///
+/// The mp3 lives in the client assets bucket, not `assets/sounds/`, so this is
+/// a [UrlSource] rather than an `AssetSource`. Failure is non-fatal: a level-up
+/// with no sound still celebrates, so nothing here is awaited by the caller.
+Future<void> playLevelUpChime() async {
+  final player = AudioPlayer();
+  try {
+    await player.setVolume(min(0.25, AppSettings.volume.value));
+    await player.play(
+      UrlSource(
+        "${AppConfig.assetsBaseURL}/${AnalyticsConstants.levelUpAudioFileName}",
+      ),
+    );
+    // Let the clip finish before the player is torn down.
+    await Future.delayed(const Duration(seconds: 2));
+  } catch (e, s) {
+    // Once, not per level-up: the failure modes here are standing ones (no
+    // network, browser autoplay policy), so repeat reports say nothing new.
+    await ErrorHandler.logErrorOnce(
+      key: "level_up_chime",
+      e: e,
+      s: s,
+      data: {"message": "Failed to play level up sound"},
+    );
+  } finally {
+    await player.dispose();
+  }
+}
 
 /// A level-up celebration anchored to the level badge it wraps (issue #7432).
 ///
 /// Replaces the old top-down chat snackbar: instead of chrome dropping over
-/// the conversation, the badge itself briefly pulses (scale + gold glow) and a
-/// small "Level N!" chip pops out beside it, then fades away on its own. This
-/// keeps the learner's eye on the analytics surface the level actually lives
-/// on, per the issue's intent.
+/// the conversation, the badge itself briefly pulses (scale + gold glow), a
+/// small "Level N!" chip pops out beside it, and the level-up chime plays; the
+/// chip then fades away on its own. This keeps the learner's eye on the
+/// analytics surface the level actually lives on, per the issue's intent.
+///
+/// Only one of these is ever mounted at a time — the shell picks the cluster
+/// (column mode) or the analytics bar (narrow), and a full-screen chat's app
+/// bar hosts the avatar only where the bar is absent (routing.instructions.md
+/// → Single-column analytics nav bar). That is what keeps a single level-up
+/// from playing the chime two or three times over.
 ///
 /// Contract (routing.instructions.md, "Single-column analytics nav bar" — no
 /// stacked chrome, no timed controls):
@@ -42,11 +90,16 @@ class LevelUpBadgeCelebration extends StatefulWidget {
   /// One full pulse run (a few scale/glow beats). Tests shorten this.
   final Duration pulseDuration;
 
+  /// Fired alongside the pulse. Defaults to the real chime; widget tests pass
+  /// a no-op so they never reach for the audio plugin or the network.
+  final Future<void> Function() playChime;
+
   const LevelUpBadgeCelebration({
     required this.child,
     this.levelUpdates,
     this.chipDuration = defaultChipDuration,
     this.pulseDuration = defaultPulseDuration,
+    this.playChime = playLevelUpChime,
     super.key,
   });
 
@@ -153,6 +206,8 @@ class _LevelUpBadgeCelebrationState extends State<LevelUpBadgeCelebration>
     setState(() => _celebratedLevel = update.newLevel);
     _pulseController.forward(from: 0.0);
     _chipController.forward();
+    // Not awaited: the chime outlives the pulse and must not gate the visuals.
+    unawaited(widget.playChime());
 
     _chipTimer?.cancel();
     _chipTimer = Timer(widget.chipDuration, () {

--- a/test/pangea/navigation/level_up_badge_celebration_test.dart
+++ b/test/pangea/navigation/level_up_badge_celebration_test.dart
@@ -24,8 +24,9 @@ void main() {
 
   Future<void> pumpCelebration(
     WidgetTester tester,
-    Stream<LevelUpdate> levelUpdates,
-  ) async {
+    Stream<LevelUpdate> levelUpdates, {
+    Future<void> Function()? playChime,
+  }) async {
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates: L10n.localizationsDelegates,
@@ -36,6 +37,10 @@ void main() {
               levelUpdates: levelUpdates,
               chipDuration: chipDuration,
               pulseDuration: pulseDuration,
+              // Never the real chime here: the default reaches for the audio
+              // plugin and the assets bucket, neither of which exists in a
+              // widget test.
+              playChime: playChime ?? () async {},
               child: const SizedBox(key: badgeKey, width: 40, height: 44),
             ),
           ),
@@ -95,6 +100,50 @@ void main() {
     await tester.pump(fadeOut);
     await tester.pumpAndSettle();
     expect(find.text(chipText), findsNothing);
+    await controller.close();
+  });
+
+  testWidgets('a level bump plays the chime (#7881)', (tester) async {
+    var chimes = 0;
+    final controller = StreamController<LevelUpdate>.broadcast();
+    await pumpCelebration(
+      tester,
+      controller.stream,
+      playChime: () async => chimes++,
+    );
+
+    expect(chimes, 0);
+
+    controller.add(const LevelUpdate(prevLevel: 3, newLevel: 4));
+    await tester.pump();
+    await tester.pump();
+
+    // Once per level-up, fired with the pulse rather than after it.
+    expect(chimes, 1);
+
+    await tester.pump(pulseDuration);
+    await tester.pump(chipDuration + fadeOut);
+    await tester.pumpAndSettle();
+    await controller.close();
+  });
+
+  testWidgets('no chime when the level did not increase (#7881)', (
+    tester,
+  ) async {
+    var chimes = 0;
+    final controller = StreamController<LevelUpdate>.broadcast();
+    await pumpCelebration(
+      tester,
+      controller.stream,
+      playChime: () async => chimes++,
+    );
+
+    controller.add(const LevelUpdate(prevLevel: 4, newLevel: 4));
+    controller.add(const LevelUpdate(prevLevel: 4, newLevel: 3));
+    await tester.pump();
+    await tester.pump();
+
+    expect(chimes, 0);
     await controller.close();
   });
 


### PR DESCRIPTION
### What

Restore the level-up chime, which the badge-anchored celebration dropped.

### Why

Closes #7881

[#7533](https://github.com/pangeachat/client/pull/7533) replaced the full-screen level-up banner with `LevelUpBadgeCelebration` and deleted `lib/routes/chat/level_up_banner.dart` — the only caller of the chime. The asset and its constant survived: `AnalyticsConstants.levelUpAudioFileName` is still declared, and `LevelUp_chime.mp3` is still served from the client assets bucket (HTTP 200, unmodified since 2025-01-21). Only the playback code went away, so the celebration has been silent since 7 July.

The chime is part of the celebration moment per [analytics-system.instructions.md → User Levels](.github/instructions/analytics-system.instructions.md); this restores it in the widget that now owns that moment.

### Changes

- `LevelUpBadgeCelebration` fires `playLevelUpChime()` alongside the pulse — same asset, same `min(0.25, AppSettings.volume.value)` rule the banner used. Not awaited: the clip outlives the pulse and must not gate the visuals.
- Injectable via a `playChime` constructor param, matching the widget's existing "tests shorten this" pattern for durations, so widget tests never reach the audio plugin or the network.
- Failure reporting uses `logErrorOnce` rather than the banner's `logError` — the failure modes here are standing ones (offline, browser autoplay policy), so per-level-up repeats add nothing.
- Only one celebration widget is mounted at a time (shell picks cluster *or* analytics bar; the chat app bar hosts the avatar only where the bar is absent), so a single level-up plays a single chime. Noted in the widget doc comment.

### Testing

- `fvm flutter test test/pangea` — 2208 passed, 3 skipped, 0 failed.
- `fvm flutter test test/pangea/navigation/level_up_badge_celebration_test.dart` — 7 passed, including two new cases: a level bump fires the chime exactly once, and a flat/decreasing level fires none.
- `fvm flutter analyze` on both changed files — no issues.
- Asset reachability confirmed independently (`HEAD` on the bucket URL → 200).
- **Not verified at runtime**: reaching a real level-up needs ~500 XP against a local stack, so the audible chime is unverified locally — QA on staging covers it (the issue's TO TEST is "hear jingle when leveling up"). Worth listening for specifically on web, where browser autoplay policy can suppress a sound that isn't tied to a user gesture; the banner had the same constraint and was audible in practice, since a level-up follows a message send.

### Deploy Notes

None.

### Accessibility

- [x] No new or changed controls. The chime is redundant with the existing visual celebration, and the "Level N!" chip is already a polite live region — sound carries no information on its own.
