### PR TITLE
fix(client): stop the screen-size warning from reacting a resize late

### DIFF
--- a/lib/widgets/adaptive_dialogs/screen_size_warning_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/screen_size_warning_dialog.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/widgets/adaptive_dialogs/adaptive_dialog_action.dart';
+
+/// Shortest window (logical pixels) the app still lays out acceptably in.
+/// Below this the user is asked to expand their browser window.
+const double kMinScreenHeight = 550;
+
+/// Resize events arrive in bursts: dragging a browser window edge fires them
+/// continuously, and dismissing a mobile on-screen keyboard reports a briefly
+/// shrunken window before the viewport settles back to full height. Wait for
+/// the measurements to stop moving before acting on them, so a transient size
+/// never triggers (or hides) the warning.
+const Duration kScreenSizeSettleDelay = Duration(milliseconds: 500);
+
+/// Height of the window in logical pixels, measured from the [FlutterView]
+/// rather than from [MediaQuery].
+///
+/// Two reasons not to use `MediaQuery.heightOf` for this:
+///
+/// 1. It is stale inside [WidgetsBindingObserver.didChangeMetrics]. The
+///    `MediaQuery` the app installs refreshes itself from that same callback
+///    via `setState`, so the new size only lands on the next frame — another
+///    observer reading `MediaQuery` during the callback sees the *previous*
+///    size and therefore reacts one resize behind (#8179).
+/// 2. On mobile web the on-screen keyboard is reported through `viewInsets`
+///    rather than by shrinking the window, so adding the bottom inset back
+///    measures the window the user could actually expand. Opening or closing
+///    a keyboard then never reads as "the window shrank".
+double windowHeight(BuildContext context) {
+  final view = View.of(context);
+  return (view.physicalSize.height + view.viewInsets.bottom) /
+      view.devicePixelRatio;
+}
+
+/// Whether the window is too short for the app to lay out acceptably.
+bool screenIsTooShort(BuildContext context) =>
+    windowHeight(context) <= kMinScreenHeight;
+
+/// Owns the "expand your screen size" warning: puts it up when the window is
+/// too short, and takes it back down once the window is big enough again.
+///
+/// The warning is driven from here rather than from inside the dialog so that
+/// one place decides, from one measurement, whether it should be on screen —
+/// and so that closing it is a route this object holds, never "whatever is
+/// currently on top of the navigator".
+class ScreenSizeWarning {
+  Route<void>? _route;
+
+  /// Whether the user has already been warned about the current too-short
+  /// window. Cleared when the window grows back, so the warning shows once per
+  /// shrink instead of returning every time the user resizes while short.
+  bool _warned = false;
+
+  bool get isShowing => _route?.isActive ?? false;
+
+  /// Feed the settled window height. [navigatorContext] is where the dialog is
+  /// pushed from; pass null while no navigator is mounted yet.
+  void onWindowHeight(double height, BuildContext? navigatorContext) {
+    if (height > kMinScreenHeight) {
+      _warned = false;
+      dismiss();
+      return;
+    }
+
+    if (_warned || isShowing || navigatorContext == null) return;
+    _warned = true;
+    _show(navigatorContext);
+  }
+
+  void _show(BuildContext context) {
+    final navigator = Navigator.of(context, rootNavigator: true);
+    final route = DialogRoute<void>(
+      context: context,
+      themes: InheritedTheme.capture(from: context, to: navigator.context),
+      builder: (context) => const ScreenSizeWarningDialog(),
+    );
+    _route = route;
+    navigator.push(route).whenComplete(() {
+      if (identical(_route, route)) _route = null;
+    });
+  }
+
+  /// Takes the warning back down. No-op when it isn't showing — including when
+  /// the user already closed it themselves.
+  void dismiss() {
+    final route = _route;
+    _route = null;
+    if (route == null || !route.isActive) return;
+    route.navigator?.removeRoute(route);
+  }
+}
+
+/// Asks the user to expand a too-short window. Put up and taken down by
+/// [ScreenSizeWarning]; the user can also close it by hand.
+class ScreenSizeWarningDialog extends StatelessWidget {
+  const ScreenSizeWarningDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) => AlertDialog.adaptive(
+    // This warning only ever shows on a short window, where the wrapped title
+    // can be taller than the room the dialog has.
+    scrollable: true,
+    title: ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 256),
+      child: Text(L10n.of(context).screenSizeWarning),
+    ),
+    actions: [
+      AdaptiveDialogAction(
+        onPressed: () => Navigator.of(context).pop(),
+        autofocus: true,
+        child: Text(L10n.of(context).close),
+      ),
+    ],
+  );
+}

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -34,6 +34,7 @@ import 'package:fluffychat/utils/client_manager.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_file_extension.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 import 'package:fluffychat/utils/uia_request_manager.dart';
+import 'package:fluffychat/widgets/adaptive_dialogs/screen_size_warning_dialog.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/announcing_snackbar.dart';
 import 'package:fluffychat/widgets/fluffy_chat_app.dart';
@@ -350,7 +351,7 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _setAppLanguage();
       _setLanguageListener();
-      _showScreenSizeDialog();
+      _checkScreenSize();
       // Debug-only: `?devlogin=1` signs the local build into the test account,
       // bypassing the canvas login form. No-op without the param. See
       // dev_login.dart / matrix-auth.instructions.md.
@@ -361,54 +362,31 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
   }
 
   // #Pangea
-  bool _showingScreenSizeDialog = false;
-  // Tracks whether the screen was too small on the last check. The popup is
-  // only shown when transitioning from "big enough" → "too small" (or on the
-  // initial frame check), so resizing from small → big never triggers it.
-  bool _screenWasTooSmall = false;
+  final ScreenSizeWarning _screenSizeWarning = ScreenSizeWarning();
+  Timer? _screenSizeTimer;
+
   @override
   void didChangeMetrics() {
-    _showScreenSizeDialog();
+    // Debounced: a resize (or an on-screen keyboard opening/closing) fires a
+    // burst of metrics changes, and only the size it settles on is meaningful.
+    _screenSizeTimer?.cancel();
+    _screenSizeTimer = Timer(kScreenSizeSettleDelay, _checkScreenSize);
     super.didChangeMetrics();
   }
 
-  Future<void> _showScreenSizeDialog() async {
-    if (!kIsWeb) return;
+  void _checkScreenSize() {
+    if (!kIsWeb || !mounted) return;
 
-    final height = MediaQuery.heightOf(context);
-    if (height > 550) {
-      // Screen is now big enough — reset so a future shrink can show the popup.
-      _screenWasTooSmall = false;
-      return;
-    }
-
-    // Screen is too small. Guard against: dialog already open, or screen was
-    // already too small (i.e. we're mid-resize within the too-small range).
-    if (_showingScreenSizeDialog || _screenWasTooSmall) return;
-
-    // Mark immediately so any didChangeMetrics calls fired during the navigator
-    // retry loop (e.g. mid-expansion resize events) are blocked by the guard
-    // above and don't trigger a spurious dialog show.
-    _screenWasTooSmall = true;
-
-    // The navigator may not be ready on the initial frame — retry next frame,
-    // resetting the flag so the retry can re-evaluate height and navigator.
+    // The navigator may not be mounted yet on the initial frame — retry next
+    // frame, but only while the window is short enough to warrant a warning.
     final navigatorContext =
         FluffyChatApp.router.routerDelegate.navigatorKey.currentContext;
-    if (navigatorContext == null) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        _screenWasTooSmall = false;
-        _showScreenSizeDialog();
-      });
+    if (navigatorContext == null && screenIsTooShort(context)) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _checkScreenSize());
       return;
     }
 
-    _showingScreenSizeDialog = true;
-    await showOkAlertDialog(
-      context: navigatorContext,
-      title: L10n.of(context).screenSizeWarning,
-    );
-    _showingScreenSizeDialog = false;
+    _screenSizeWarning.onWindowHeight(windowHeight(context), navigatorContext);
   }
 
   StreamSubscription? _languageListener;
@@ -713,6 +691,7 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
     _languageListener?.cancel();
     _appLanguageSettingsListener?.cancel();
     _uriListener?.cancel();
+    _screenSizeTimer?.cancel();
     notifPermissionNotifier.dispose();
     // Pangea#
 

--- a/test/pangea/screen_size_warning_test.dart
+++ b/test/pangea/screen_size_warning_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/widgets/adaptive_dialogs/screen_size_warning_dialog.dart';
+
+/// #8179: the "expand your screen size" warning must react to the window the
+/// user could actually resize. It has to read that height live — not from a
+/// `MediaQuery` that only refreshes on the next frame, which made it react one
+/// resize late — and it has to ignore a mobile on-screen keyboard, which is
+/// reported as a bottom view inset rather than as a shorter window.
+void main() {
+  /// Logical pixels == physical pixels, and undo the size overrides afterwards.
+  void useTestView(WidgetTester tester) {
+    addTearDown(tester.view.reset);
+    tester.view.devicePixelRatio = 1.0;
+  }
+
+  /// Pumps an app and returns a context under its navigator, the way
+  /// `MatrixState` hands the router's navigator context to the warning.
+  Future<BuildContext> pumpApp(WidgetTester tester) async {
+    late BuildContext navigatorContext;
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            navigatorContext = context;
+            return const Scaffold();
+          },
+        ),
+      ),
+    );
+    // L10n is deferred-loaded, so the subtree only builds once it resolves.
+    await tester.pumpAndSettle();
+    return navigatorContext;
+  }
+
+  final warningFinder = find.byType(ScreenSizeWarningDialog);
+
+  testWidgets('warns on a too-short window', (tester) async {
+    useTestView(tester);
+    final context = await pumpApp(tester);
+
+    ScreenSizeWarning().onWindowHeight(400, context);
+    await tester.pumpAndSettle();
+    expect(warningFinder, findsOneWidget);
+  });
+
+  testWidgets('closes itself once the window is tall enough again', (
+    tester,
+  ) async {
+    useTestView(tester);
+    final context = await pumpApp(tester);
+    final warning = ScreenSizeWarning();
+
+    warning.onWindowHeight(400, context);
+    await tester.pumpAndSettle();
+    expect(warningFinder, findsOneWidget);
+
+    warning.onWindowHeight(900, context);
+    await tester.pumpAndSettle();
+    expect(warningFinder, findsNothing);
+    expect(warning.isShowing, isFalse);
+  });
+
+  testWidgets('stays up while the window is still too short', (tester) async {
+    useTestView(tester);
+    final context = await pumpApp(tester);
+    final warning = ScreenSizeWarning();
+
+    warning.onWindowHeight(400, context);
+    await tester.pumpAndSettle();
+
+    warning.onWindowHeight(300, context);
+    await tester.pumpAndSettle();
+    expect(warningFinder, findsOneWidget);
+  });
+
+  testWidgets('does not warn again until the window has grown back', (
+    tester,
+  ) async {
+    useTestView(tester);
+    final context = await pumpApp(tester);
+    final warning = ScreenSizeWarning();
+
+    warning.onWindowHeight(400, context);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Close'));
+    await tester.pumpAndSettle();
+    expect(warningFinder, findsNothing);
+
+    // Still short: the user has been told, don't nag on every resize.
+    warning.onWindowHeight(420, context);
+    await tester.pumpAndSettle();
+    expect(warningFinder, findsNothing);
+
+    // Grown back and shrunk again: that's a new occasion to warn.
+    warning.onWindowHeight(900, context);
+    warning.onWindowHeight(400, context);
+    await tester.pumpAndSettle();
+    expect(warningFinder, findsOneWidget);
+  });
+
+  testWidgets('an on-screen keyboard does not shorten the window', (
+    tester,
+  ) async {
+    useTestView(tester);
+    late BuildContext context;
+    await tester.pumpWidget(
+      Builder(
+        builder: (c) {
+          context = c;
+          return const SizedBox();
+        },
+      ),
+    );
+
+    tester.view.physicalSize = const Size(800, 400);
+    expect(screenIsTooShort(context), isTrue);
+
+    // Same window, now with a keyboard covering the bottom 300px: the window
+    // itself hasn't changed, so there is nothing for the user to expand.
+    tester.view.viewInsets = const FakeViewPadding(bottom: 300);
+    expect(windowHeight(context), 700);
+    expect(screenIsTooShort(context), isFalse);
+  });
+
+  testWidgets('window height is current inside didChangeMetrics', (
+    tester,
+  ) async {
+    useTestView(tester);
+    tester.view.physicalSize = const Size(800, 900);
+
+    final observer = _HeightObserver();
+    await tester.pumpWidget(
+      Builder(
+        builder: (context) {
+          observer.context = context;
+          return const SizedBox();
+        },
+      ),
+    );
+    WidgetsBinding.instance.addObserver(observer);
+    addTearDown(() => WidgetsBinding.instance.removeObserver(observer));
+
+    tester.view.physicalSize = const Size(800, 400);
+
+    // Measured during the metrics callback, before any frame is built: the
+    // height must already be the new one, not the one we resized away from.
+    expect(observer.heights.last, 400);
+  });
+}
+
+/// Records the window height as measured from inside [didChangeMetrics].
+class _HeightObserver with WidgetsBindingObserver {
+  late BuildContext context;
+  final List<double> heights = [];
+
+  @override
+  void didChangeMetrics() => heights.add(windowHeight(context));
+}


### PR DESCRIPTION
## What

The "please expand your screen size" warning now tracks the settled window height instead of reacting one resize late, ignores a mobile on-screen keyboard, and closes itself once the window is tall enough.

## Why

Closes #8179

Root cause: the check ran in `didChangeMetrics` and read `MediaQuery.heightOf`. The app's `MediaQuery` refreshes itself from that same callback via `setState`, so its value only lands on the *next* frame — the check always saw the previous size. Shrinking the window therefore did nothing, and the popup appeared on the *following* resize instead, which on mobile web is typically the on-screen keyboard being dismissed (the web engine briefly reports a shrunken window while the keyboard goes away).

What changed:

- Measure the window from the `FlutterView` (`physicalSize`), which is current at callback time, instead of from `MediaQuery`.
- Add `viewInsets.bottom` back into the height: on mobile web the keyboard is reported as a bottom inset rather than a shorter window, so opening/closing it can no longer read as "the window shrank".
- Debounce metrics changes by 500ms — a drag-resize and a keyboard dismissal both fire bursts, and only the size they settle on is meaningful.
- `ScreenSizeWarning` (new, in `lib/widgets/adaptive_dialogs/screen_size_warning_dialog.dart`) owns the warning's route: it puts the dialog up once per shrink and removes that specific route when the window grows back, so a user who fixes their window doesn't have to dismiss it by hand.

No instructions doc covers this warning; the expected behavior is the issue's TO TEST list.

## Testing

- `fvm flutter test test/pangea/screen_size_warning_test.dart` — 6 new tests: warns on a short window, closes itself when the window grows, stays up while still short, doesn't nag again until the window has grown back, keyboard insets don't count as a shorter window, and the height read inside `didChangeMetrics` is the new one (the regression this fixes).
- `fvm flutter test` (full suite) — 2236 pass, 3 skip, 2 fail: `choreo_endpoint_test` setUpAll and `cms_endpoint_test` languages, both pre-existing local-environment failures (no local choreo/CMS reachable), unrelated to this change.
- Manual, local web build (`flutter run -d web-server`, dark theme, logged out): shrinking the window to 420px tall showed the warning on the *first* adjustment (~0.5s); growing back to 900px closed it with no user action; shrinking again re-armed and showed it once more. Screenshots taken at each step.
- Not verified locally: the mobile on-screen-keyboard path — a desktop browser has no soft keyboard, so that leg needs QA on a real device on staging.

## Deploy Notes

None
