### PR TITLE
fix(wa): stop clicks on the writing-assistance card falling through (Closes #8181)

### DIFF
--- a/lib/features/overlay/overlay.dart
+++ b/lib/features/overlay/overlay.dart
@@ -1,4 +1,5 @@
 import 'dart:developer';
+import 'dart:ui' as ui show SemanticsHitTestBehavior;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -22,6 +23,31 @@ class OverlayUtil {
       if (displayDetails.closePrevOverlay) {
         MatrixState.pAnyState.closeOverlay();
       }
+
+      // Stop taps on the card from reaching whatever sits behind the overlay
+      // (#8181). Two separate hit-test paths have to be closed:
+      //
+      // * `hitTestBehavior: opaque` covers web with the semantics tree on
+      //   (staging forces it via ENABLE_SEMANTICS). There, a click lands on a
+      //   `flt-semantics` DOM element, not on Flutter's hit test — the card is
+      //   inert decoration and publishes no tappable node, so the click hits
+      //   the *message's* tappable node underneath and opens its toolbar. This
+      //   makes the card's own node accept pointer events; the engine z-orders
+      //   it above the message by paint order. Same tool `ModalRoute` uses.
+      // * The opaque `Listener` covers the framework hit test (mobile, and web
+      //   without semantics) for cards that aren't opaque on their own, e.g.
+      //   `addBorder: false`. It joins no gesture arena, so the card's own
+      //   buttons keep working.
+      //
+      // Both sit inside the positioning widgets below so the absorbing area
+      // follows the card, not the overlay's origin.
+      final Widget positionedChild = displayDetails.blockPointerThrough
+          ? Semantics(
+              container: true,
+              hitTestBehavior: ui.SemanticsHitTestBehavior.opaque,
+              child: Listener(behavior: HitTestBehavior.opaque, child: child),
+            )
+          : child;
 
       final OverlayEntry entry = OverlayEntry(
         builder: (_) => Stack(
@@ -48,12 +74,14 @@ class OverlayUtil {
                   link: MatrixState.pAnyState.layerLinkAndKey(targetId).link,
                   showWhenUnlinked: false,
                   offset: offset ?? Offset.zero,
-                  child: child,
+                  child: positionedChild,
                 ),
               CenteredOverlayDisplayDetails() => CenteredOverlayWidget(
-                child: child,
+                child: positionedChild,
               ),
-              TopOverlayDisplayDetails() => TopOverlayWidget(child: child),
+              TopOverlayDisplayDetails() => TopOverlayWidget(
+                child: positionedChild,
+              ),
             },
           ],
         ),

--- a/lib/features/overlay/overlay_display_details.dart
+++ b/lib/features/overlay/overlay_display_details.dart
@@ -13,6 +13,14 @@ sealed class OverlayDisplayDetails {
   final bool backDropToDismiss;
   final bool closePrevOverlay;
   final bool ignorePointer;
+
+  /// Makes the overlay's own content opaque to hit testing — both Flutter's
+  /// hit test and, on web, the semantics DOM — so taps that land on it never
+  /// fall through to whatever sits behind the overlay (#8181).
+  /// Off by default: decorative overlays (animations, confetti) cover large
+  /// areas and must stay click-through.
+  final bool blockPointerThrough;
+
   final bool canPop;
 
   final VoidCallback? onDismiss;
@@ -27,6 +35,7 @@ sealed class OverlayDisplayDetails {
     this.backDropToDismiss = true,
     this.closePrevOverlay = true,
     this.ignorePointer = false,
+    this.blockPointerThrough = false,
     this.canPop = true,
     this.onDismiss,
   });
@@ -55,6 +64,7 @@ class TransformOverlayDisplayDetails extends OverlayDisplayDetails {
     super.backDropToDismiss = true,
     super.closePrevOverlay = true,
     super.ignorePointer = false,
+    super.blockPointerThrough = false,
     super.canPop = true,
     super.onDismiss,
   });
@@ -78,6 +88,7 @@ class TransformOverlayDisplayDetails extends OverlayDisplayDetails {
     backDropToDismiss: backDropToDismiss,
     closePrevOverlay: closePrevOverlay,
     ignorePointer: ignorePointer,
+    blockPointerThrough: blockPointerThrough,
     canPop: canPop,
     onDismiss: onDismiss,
   );
@@ -94,6 +105,7 @@ class CenteredOverlayDisplayDetails extends OverlayDisplayDetails {
     super.backDropToDismiss = true,
     super.closePrevOverlay = true,
     super.ignorePointer = false,
+    super.blockPointerThrough = false,
     super.canPop = true,
     super.onDismiss,
   });
@@ -110,6 +122,7 @@ class TopOverlayDisplayDetails extends OverlayDisplayDetails {
     super.backDropToDismiss = true,
     super.closePrevOverlay = true,
     super.ignorePointer = false,
+    super.blockPointerThrough = false,
     super.canPop = true,
     super.onDismiss,
   });
@@ -142,6 +155,7 @@ class PositionedOverlayDisplayDetails extends TransformOverlayDisplayDetails {
     super.backDropToDismiss = true,
     super.closePrevOverlay = true,
     super.ignorePointer = false,
+    super.blockPointerThrough = false,
     super.canPop = true,
     super.onDismiss,
   });

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -3039,6 +3039,9 @@ class ChatController extends State<ChatPageWithRoom>
             maxWidth: maxWidth,
             transformTargetId: ChoreoConstants.inputTransformTargetKey,
             ignorePointer: true,
+            // Taps outside the card still reach the input field and other
+            // highlights, but taps on the card stop there (#8181).
+            blockPointerThrough: true,
             isScrollable: false,
           ),
           overlayPosition: OverlayPosition.above,

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -3072,6 +3072,7 @@ class ChatController extends State<ChatPageWithRoom>
           ignorePointer: true,
           targetAnchor: Alignment.topCenter,
           followerAnchor: Alignment.bottomCenter,
+          blockPointerThrough: true,
         ),
       ),
     );

--- a/test/pangea/overlay_block_pointer_through_test.dart
+++ b/test/pangea/overlay_block_pointer_through_test.dart
@@ -1,0 +1,136 @@
+import 'dart:ui' as ui show SemanticsHitTestBehavior;
+
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/overlay/overlay.dart';
+import 'package:fluffychat/features/overlay/overlay_display_details.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+
+/// #8181: taps landing on the writing-assistance card fell through to the
+/// message list behind it. Two hit-test paths had to be closed — Flutter's own
+/// (inert card content never absorbs) and, on web with the semantics tree on,
+/// the DOM one (the card publishes no tappable `flt-semantics` node, so the
+/// browser hands the click to the message's node underneath).
+void main() {
+  const targetId = 'block-pointer-target';
+  const overlayKey = 'block-pointer-overlay';
+  const cardKey = ValueKey('card');
+
+  Widget buildHarness({
+    required bool blockPointerThrough,
+    VoidCallback? onTapBehind,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) {
+            return Stack(
+              children: [
+                // Stands in for the message list behind the card.
+                Positioned.fill(
+                  child: GestureDetector(
+                    behavior: HitTestBehavior.opaque,
+                    onTap: onTapBehind,
+                  ),
+                ),
+                Center(
+                  child: CompositedTransformTarget(
+                    link: MatrixState.pAnyState.layerLinkAndKey(targetId).link,
+                    child: SizedBox(
+                      key: MatrixState.pAnyState.layerLinkAndKey(targetId).key,
+                      width: 10,
+                      height: 10,
+                    ),
+                  ),
+                ),
+                Positioned(
+                  bottom: 0,
+                  child: TextButton(
+                    onPressed: () => OverlayUtil.showOverlay(
+                      context: context,
+                      // Inert content, like the card's padding and background:
+                      // nothing here is hit-testable on its own.
+                      child: const SizedBox(
+                        key: cardKey,
+                        width: 200,
+                        height: 100,
+                      ),
+                      displayDetails: TransformOverlayDisplayDetails(
+                        overlayKey: overlayKey,
+                        transformTargetId: targetId,
+                        ignorePointer: true,
+                        blockPointerThrough: blockPointerThrough,
+                      ),
+                    ),
+                    child: const Text('open'),
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  tearDown(() => MatrixState.pAnyState.closeAllOverlays(force: true));
+
+  testWidgets('taps on the card do not reach the content behind it', (
+    tester,
+  ) async {
+    var tapsBehind = 0;
+    await tester.pumpWidget(
+      buildHarness(blockPointerThrough: true, onTapBehind: () => tapsBehind++),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    await tester.tapAt(tester.getCenter(find.byKey(cardKey)));
+    await tester.pumpAndSettle();
+
+    expect(tapsBehind, 0);
+  });
+
+  testWidgets('the card absorbs pointer events in the semantics tree', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(buildHarness(blockPointerThrough: true));
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getSemantics(find.byKey(cardKey)).hitTestBehavior,
+      ui.SemanticsHitTestBehavior.opaque,
+    );
+
+    semantics.dispose();
+  });
+
+  testWidgets('overlays stay click-through by default', (tester) async {
+    final semantics = tester.ensureSemantics();
+    var tapsBehind = 0;
+    await tester.pumpWidget(
+      buildHarness(blockPointerThrough: false, onTapBehind: () => tapsBehind++),
+    );
+
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.getSemantics(find.byKey(cardKey)).hitTestBehavior,
+      ui.SemanticsHitTestBehavior.defer,
+    );
+
+    await tester.tapAt(tester.getCenter(find.byKey(cardKey)));
+    await tester.pumpAndSettle();
+
+    expect(tapsBehind, 1);
+
+    semantics.dispose();
+  });
+}


### PR DESCRIPTION
## What

Clicks landing on the writing-assistance span card no longer pass through to the message behind it.

## Why

Closes #8181

The card is inert decoration (decorated boxes + text), so it publishes no tappable semantics node. On web with the semantics tree on — staging forces it via `ENABLE_SEMANTICS` — a click is dispatched by a `flt-semantics` DOM element, not by Flutter's hit test, so it landed on the *message's* tappable node underneath and opened its toolbar. Same class of problem as the `flutter_map` semantics note in `world_map_view.dart` (#8013).

Fix: new opt-in `blockPointerThrough` on `OverlayDisplayDetails`. When set, the overlay's content is wrapped in `Semantics(hitTestBehavior: opaque)` (closes the web DOM path — the engine z-orders it above the message by paint order) plus an opaque `Listener` (closes the framework hit-test path on mobile / semantics-off web, for cards that aren't opaque on their own, e.g. `addBorder: false`). Off by default, so decorative overlays that cover large areas (animations, confetti, star rain) stay click-through. Only the WA span card opts in.

Taps *outside* the card are unchanged — the backdrop keeps `ignorePointer: true`, so the input field and other highlights stay reachable while the card is open, per [writing-assistance.instructions.md](.github/instructions/writing-assistance.instructions.md#interaction-model).

## Testing

- **Unit/widget** — `flutter test test/pangea` (2228 pass). One pre-existing local-only failure: `choreo_endpoint_test.dart › Custom course endpoint test` (hits the local choreo stack; unrelated to overlays). New `test/pangea/overlay_block_pointer_through_test.dart` covers all three behaviors: taps on an inert card are absorbed, the card's semantics node reports `hitTestBehavior: opaque`, and overlays stay click-through by default.
- **Manual, local web + local stack, `ENABLE_SEMANTICS=true`** (matching staging):
  - Reproduced first: with the card open over a message, a click in the card's empty area closed the card and opened the message's toolbar. `document.elementFromPoint` at that spot returned the message's `flt-semantics` node (`flt-tappable`, `pointer-events: all`).
  - After the fix: same click does nothing — card stays open, no toolbar. `elementFromPoint` now returns the card's own node (`pointer-events: all`, sized to the card).
  - The card's own controls still work (✕ closes it).
- Not verified locally: iOS/Android (the framework hit-test path); the widget test covers it.

## Deploy Notes

None