### PR TITLE
feat(nav): badge the narrow Courses tab when a course invite is waiting

### DIFF
--- a/lib/pangea/common/widgets/invited_course_badge.dart
+++ b/lib/pangea/common/widgets/invited_course_badge.dart
@@ -13,11 +13,29 @@ class InvitedCourseBadge extends StatelessWidget {
   final b.BadgePosition? position;
   final Widget? child;
 
-  const InvitedCourseBadge({super.key, this.position, this.child});
+  /// Announces the badge to a screen reader. Null on an avatar the surrounding
+  /// tile already labels "Invited" (`add_course_tile.dart`); set where the
+  /// badge is the only sign of the invite, as on the narrow Courses tab.
+  final String? semanticLabel;
+
+  /// False leaves the child bare. For callers that show the same subtree in
+  /// both states — the Courses rail item, which is badged only while an
+  /// invitation is waiting — so the button isn't rebuilt from scratch as the
+  /// badge comes and goes.
+  final bool showBadge;
+
+  const InvitedCourseBadge({
+    super.key,
+    this.position,
+    this.child,
+    this.semanticLabel,
+    this.showBadge = true,
+  });
 
   @override
   Widget build(BuildContext context) {
     return b.Badge(
+      showBadge: showBadge,
       badgeStyle: b.BadgeStyle(
         badgeColor: AppConfig.goldByTheme(context),
         elevation: 4,
@@ -28,6 +46,7 @@ class InvitedCourseBadge extends StatelessWidget {
         Icons.mail,
         color: AppConfig.onGoldByTheme(context),
         size: 12,
+        semanticLabel: semanticLabel,
       ),
       position: position,
       child: child,

--- a/lib/pangea/spaces/client_spaces_extension.dart
+++ b/lib/pangea/spaces/client_spaces_extension.dart
@@ -33,6 +33,12 @@ extension SpacesClientExtension on Client {
     ),
   );
 
+  /// A course invitation is waiting. Same predicate as the invited half of
+  /// [sortedCourses] — what this reports is exactly what the courses list
+  /// sorts to its top.
+  bool get hasInvitedCourse =>
+      rooms.any((r) => r.isSpace && r.membership == Membership.invite);
+
   /// In the nav rail and courses tab, prioritize invited courses,
   /// then sort alphebetically by title
   List<Room> sortedCourses(L10n l10n) =>

--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -1,10 +1,14 @@
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+
+import 'package:badges/badges.dart' show BadgePosition;
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/features/navigation/app_section.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/widgets/invited_course_badge.dart';
 import 'package:fluffychat/pangea/common/widgets/pangea_icon_button.dart';
 import 'package:fluffychat/widgets/layouts/cavity_controls.dart';
 
@@ -54,6 +58,15 @@ class MobileNavWidget extends StatefulWidget {
   /// rebuilds — so this widget stays presentational. Null renders the plain
   /// button.
   final Widget Function(Widget child)? chatsBadgeBuilder;
+
+  /// A course invitation is waiting, so the Courses item wears the invite
+  /// badge. The web rail shows an invited course as its own badged avatar in
+  /// the rail; on one column the courses live behind this tab, so the tab
+  /// itself has to carry the invite (#8190). A listenable rather than a plain
+  /// bool: the shell owns the Matrix lookup behind it, and an arriving invite
+  /// then repaints the badge alone instead of the whole nav layer and its
+  /// cavity. Null never badges.
+  final ValueListenable<bool>? courseInvitePending;
 
   /// The open section/course content hosted in the cavity. Null means nothing
   /// is cavity-hosted (rail-only, no matter the last height).
@@ -170,6 +183,7 @@ class MobileNavWidget extends StatefulWidget {
     required this.onCourseShortcutTap,
     required this.onSectionTap,
     this.chatsBadgeBuilder,
+    this.courseInvitePending,
     this.cavityChild,
     this.cavitySection,
     this.courseShortcutHostsCavity = false,
@@ -551,6 +565,10 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
   Widget _withChatsBadge(Widget child) =>
       widget.chatsBadgeBuilder?.call(child) ?? child;
 
+  /// Stands in for a null [MobileNavWidget.courseInvitePending] — never fires,
+  /// so the Courses item simply stays unbadged.
+  static final ValueNotifier<bool> _neverPending = ValueNotifier(false);
+
   void _onCourseShortcutTap() {
     // The shortcut's own toggle: when its course IS the hosted sheet, the tap
     // collapses/re-expands like any active rail item — a same-URL navigation
@@ -748,18 +766,38 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
                                           _onRailItemTap(AppSection.chats),
                                     ),
                                   ),
-                                  _RailButton(
-                                    icon: Icons.map_outlined,
-                                    selectedIcon: Icons.map,
-                                    // The specific course's highlight (the
-                                    // shortcut) outranks the section icon.
-                                    selected:
-                                        widget.activeSection ==
-                                            AppSection.courses &&
-                                        !widget.courseShortcutSelected,
-                                    tooltip: l10n.courses,
-                                    onTap: () =>
-                                        _onRailItemTap(AppSection.courses),
+                                  ValueListenableBuilder<bool>(
+                                    valueListenable:
+                                        widget.courseInvitePending ??
+                                        _neverPending,
+                                    builder: (context, pending, child) =>
+                                        InvitedCourseBadge(
+                                          showBadge: pending,
+                                          // The chats badge's corner, so the
+                                          // two rail badges sit alike.
+                                          position: BadgePosition.topEnd(
+                                            top: -1,
+                                            end: -1,
+                                          ),
+                                          // Nothing else on the rail says
+                                          // "invite", so the badge carries the
+                                          // announcement itself.
+                                          semanticLabel: l10n.invited,
+                                          child: child,
+                                        ),
+                                    child: _RailButton(
+                                      icon: Icons.map_outlined,
+                                      selectedIcon: Icons.map,
+                                      // The specific course's highlight (the
+                                      // shortcut) outranks the section icon.
+                                      selected:
+                                          widget.activeSection ==
+                                              AppSection.courses &&
+                                          !widget.courseShortcutSelected,
+                                      tooltip: l10n.courses,
+                                      onTap: () =>
+                                          _onRailItemTap(AppSection.courses),
+                                    ),
                                   ),
                                   _CourseShortcutButton(
                                     icon: widget.courseShortcutIcon,

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
@@ -518,6 +519,36 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
   bool _searchRestored = false;
   String? _lastScopeId;
 
+  /// Whether a course invitation is waiting, kept fresh from sync so the
+  /// Courses tab's badge appears the moment the invite lands and clears when
+  /// it is accepted or declined (#8190). A notifier rather than State: the
+  /// badge is all that repaints, not the cavity's whole hosted surface.
+  final ValueNotifier<bool> _courseInvitePending = ValueNotifier(false);
+  StreamSubscription<SyncUpdate>? _courseInviteSubscription;
+  Client? _courseInviteClient;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Re-subscribes if the account is switched under the shell; the guard
+    // makes every other dependency change a no-op.
+    final client = Matrix.of(context).client;
+    if (identical(client, _courseInviteClient)) return;
+    _courseInviteClient = client;
+    _courseInviteSubscription?.cancel();
+    _courseInvitePending.value = client.hasInvitedCourse;
+    _courseInviteSubscription = client.onSync.stream
+        .where((sync) => sync.hasRoomUpdate)
+        .listen((_) => _courseInvitePending.value = client.hasInvitedCourse);
+  }
+
+  @override
+  void dispose() {
+    _courseInviteSubscription?.cancel();
+    _courseInvitePending.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = L10n.of(context);
@@ -771,6 +802,12 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
             child: child,
           ),
         ),
+        // The web rail announces a pending course invite with the invited
+        // course's own badged avatar, which sits in the rail beside the
+        // Courses item. On one column there are no per-course avatars — the
+        // invited courses are behind this tab, at the top of the hub list — so
+        // the tab carries the announcement instead (#8190).
+        courseInvitePending: _courseInvitePending,
         onSectionTap: (section) => context.go(switch (section) {
           // World is home: clear every panel and reveal the full map.
           AppSection.world => WorkspaceNav.clearAll(),

--- a/test/pangea/navigation/courses_invite_badge_test.dart
+++ b/test/pangea/navigation/courses_invite_badge_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/pangea/common/widgets/invited_course_badge.dart';
+import 'package:fluffychat/pangea/spaces/client_spaces_extension.dart';
+import '../get_test_client.dart';
+
+/// The signal behind the Courses tab's invite badge on one column (#8190).
+/// The web rail shows a pending course invite as the invited course's own
+/// badged avatar; the narrow rail has no per-course avatars, so the tab wears
+/// the badge — and it must light for exactly the courses `sortedCourses` puts
+/// at the top of the hub list, no more.
+void main() {
+  late Client client;
+
+  const userId = '@test:fakeServer.notExisting';
+
+  setUp(() async {
+    client = await getTestClient();
+  });
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  Room space(String id, {required Membership membership}) {
+    final room = Room(id: id, client: client, membership: membership);
+    room.setState(
+      Event(
+        type: EventTypes.RoomCreate,
+        content: {'type': RoomCreationTypes.mSpace},
+        stateKey: '',
+        senderId: userId,
+        eventId: '\$create_$id',
+        originServerTs: DateTime.utc(2026, 1, 1, 12),
+        room: room,
+      ),
+    );
+    client.rooms.add(room);
+    return room;
+  }
+
+  Room chat(String id, {required Membership membership}) {
+    final room = Room(id: id, client: client, membership: membership);
+    client.rooms.add(room);
+    return room;
+  }
+
+  test('no rooms at all: no badge', () {
+    expect(client.hasInvitedCourse, isFalse);
+  });
+
+  test('an invited course lights the badge', () {
+    space('!invited:fakeServer.notExisting', membership: Membership.invite);
+    expect(client.hasInvitedCourse, isTrue);
+  });
+
+  test('joined courses alone do not light the badge', () {
+    space('!joined:fakeServer.notExisting', membership: Membership.join);
+    expect(client.hasInvitedCourse, isFalse);
+  });
+
+  test('an invite to a plain chat is not a course invite', () {
+    chat('!dm:fakeServer.notExisting', membership: Membership.invite);
+    expect(client.hasInvitedCourse, isFalse);
+  });
+
+  test('a left course does not light the badge', () {
+    space('!left:fakeServer.notExisting', membership: Membership.leave);
+    expect(client.hasInvitedCourse, isFalse);
+  });
+
+  test('one invite among joined courses still lights the badge', () {
+    space('!joined:fakeServer.notExisting', membership: Membership.join);
+    space('!other:fakeServer.notExisting', membership: Membership.join);
+    space('!invited:fakeServer.notExisting', membership: Membership.invite);
+    expect(client.hasInvitedCourse, isTrue);
+  });
+
+  // On the rail the badge is the ONLY sign of the invite — no "Invited" pill
+  // beside it, as the hub tile has — so a screen reader has to get it from the
+  // badge itself.
+  testWidgets('the badge announces itself when given a label', (tester) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: InvitedCourseBadge(
+            semanticLabel: 'Invited',
+            child: Icon(Icons.map_outlined),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Invited'), findsOneWidget);
+    semantics.dispose();
+  });
+
+  testWidgets('and stays silent without one, for labeled tiles', (
+    tester,
+  ) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: InvitedCourseBadge(child: Icon(Icons.map_outlined)),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Invited'), findsNothing);
+    semantics.dispose();
+  });
+
+  // A hidden badge stays mounted (it fades in and out), so silencing it is a
+  // real requirement, not a side effect of it being gone.
+  testWidgets('a hidden badge announces nothing', (tester) async {
+    final semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: InvitedCourseBadge(
+            showBadge: false,
+            semanticLabel: 'Invited',
+            child: Icon(Icons.map_outlined),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.bySemanticsLabel('Invited'), findsNothing);
+    semantics.dispose();
+  });
+}

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 
@@ -5,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:fluffychat/features/navigation/app_section.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/widgets/invited_course_badge.dart';
 import 'package:fluffychat/widgets/layouts/mobile_nav_widget.dart';
 
 /// Coverage for the world_v2 single-column bottom chrome: one floating
@@ -35,6 +37,7 @@ void main() {
     ValueChanged<bool>? onCavityFullChanged,
     double keyboardInset = 0.0,
     Widget Function(Widget child)? chatsBadgeBuilder,
+    ValueListenable<bool>? courseInvitePending,
     bool settle = true,
   }) async {
     tester.view.physicalSize = const Size(400, 800);
@@ -63,6 +66,7 @@ void main() {
             onCavityFullChanged: onCavityFullChanged,
             keyboardInset: keyboardInset,
             chatsBadgeBuilder: chatsBadgeBuilder,
+            courseInvitePending: courseInvitePending,
           ),
         ),
       ),
@@ -216,6 +220,93 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tapped, [AppSection.chats]);
+    });
+
+    // The badge is mounted at zero opacity when no invite is pending (the
+    // badges package's own appear/disappear animation), so "is it showing" is
+    // a question about the semantics tree, not about the widget tree. Matched
+    // loosely because the rail row merges the badge's label into its own node.
+    Finder shownInviteBadge() => find.bySemanticsLabel(RegExp('Invited'));
+
+    testWidgets(
+      'a pending course invite badges the Courses item — and only the '
+      'Courses item (#8190)',
+      (tester) async {
+        final semantics = tester.ensureSemantics();
+        await pumpNav(tester, courseInvitePending: ValueNotifier(true));
+
+        expect(shownInviteBadge(), findsOneWidget);
+        expect(
+          find.descendant(
+            of: find.byType(InvitedCourseBadge),
+            matching: find.byTooltip('Courses'),
+          ),
+          findsOneWidget,
+          reason: 'the badge must enclose the Courses rail item',
+        );
+        for (final other in ['World', 'All chats', 'Add a course']) {
+          expect(
+            find.descendant(
+              of: find.byType(InvitedCourseBadge),
+              matching: find.byTooltip(other),
+            ),
+            findsNothing,
+            reason: 'only the Courses item carries the invite badge',
+          );
+        }
+        semantics.dispose();
+      },
+    );
+
+    testWidgets('no pending invite leaves the Courses item bare', (
+      tester,
+    ) async {
+      final semantics = tester.ensureSemantics();
+      await pumpNav(tester, courseInvitePending: ValueNotifier(false));
+      expect(shownInviteBadge(), findsNothing);
+
+      // And a shell that passes nothing at all is the same as no invite.
+      await unmountNav(tester);
+      await pumpNav(tester);
+      expect(shownInviteBadge(), findsNothing);
+      semantics.dispose();
+    });
+
+    testWidgets('the badge follows the invite arriving and being resolved', (
+      tester,
+    ) async {
+      // The whole reason this is a listenable: sync flips it under a nav
+      // widget that is otherwise not rebuilding.
+      final semantics = tester.ensureSemantics();
+      final pending = ValueNotifier(false);
+      addTearDown(pending.dispose);
+      await pumpNav(tester, courseInvitePending: pending);
+      expect(shownInviteBadge(), findsNothing);
+
+      pending.value = true;
+      await tester.pumpAndSettle();
+      expect(shownInviteBadge(), findsOneWidget);
+
+      pending.value = false;
+      await tester.pumpAndSettle();
+      expect(shownInviteBadge(), findsNothing);
+      semantics.dispose();
+    });
+
+    testWidgets('a badged Courses item still taps through to onSectionTap', (
+      tester,
+    ) async {
+      final tapped = <AppSection>[];
+      await pumpNav(
+        tester,
+        onSectionTap: tapped.add,
+        courseInvitePending: ValueNotifier(true),
+      );
+
+      await tester.tap(find.byTooltip('Courses'));
+      await tester.pumpAndSettle();
+
+      expect(tapped, [AppSection.courses]);
     });
   });
 


### PR DESCRIPTION
## What

On one column, the Courses tab in the bottom nav wears a gold envelope badge while a course invitation is waiting.

## Why

Closes #8190

On the wide rail a pending course invite is already visible: the invited course sits in the rail as its own avatar, badged and sorted to the top (`sortedCourses`). The narrow rail has no per-course avatars — invited courses are only reachable behind the Courses tab — so nothing on screen said an invite had arrived.

`MobileNavWidget` takes a `ValueListenable<bool> courseInvitePending` and wraps its own Courses item in the existing `InvitedCourseBadge` — the same gold envelope the course avatars wear, at the chats badge's corner. The listenable is what keeps the widget presentational (no Matrix lookups, as with `chatsBadgeBuilder`) while an arriving invite repaints the badge alone rather than the nav layer and its whole hosted cavity.

`_MobileNavLayer` in the shell owns the data side: one `onSync` subscription driving the notifier, re-subscribing if the account is switched underneath it. New `Client.hasInvitedCourse` uses the same predicate as the invited half of `sortedCourses`, so the tab lights for exactly what the hub list sorts to its top.

`InvitedCourseBadge` gained `showBadge` (so the button subtree is stable as the badge fades in and out) and an optional `semanticLabel` — null everywhere it was already used, since those tiles carry their own "Invited" pill. The rail passes `l10n.invited`, an existing key, so there are no new strings to translate.

The bottom nav's design lives in [routing.instructions.md → Single-column bottom nav](.github/instructions/routing.instructions.md); it describes the 4 rail items but not their badges, which are implementation detail alongside the existing chats badge.

## Testing

- **Unit/widget** — `fvm flutter test` (2262 pass, 3 skipped — the endpoint suites, which need `TEST_MATRIX_*` creds and a reachable backend). New `test/pangea/navigation/courses_invite_badge_test.dart` covers the `hasInvitedCourse` predicate (an invited space lights it; joined-only, a left course, and an invited plain chat do not) and the badge's announcement, including that a hidden badge announces nothing — it stays mounted at zero opacity, so that is a real requirement. Three more in `mobile_nav_widget_test.dart` pin the rail: a pending invite badges the Courses item and only that item, no pending invite (or none passed at all) leaves it bare, and flipping the listenable makes the badge appear and clear.
- **Manual, local web (375×812) against the local stack** — invited `@learner` to a space from a second account via the Matrix API:
  - The badge appeared on the Courses tab **live on the invite's sync**, no reload, and again on a cold load.
  - Opening the tab showed the invited course at the top of the hub with its own envelope badge and "Invited" pill — the badge leads where it says it does.
  - Declining the invite (`POST /leave`) **cleared the badge live**, again with no reload.
  - With the semantics tree on, the rail's accessibility node reads `… Navigation options Invited …` while the invite is pending, and drops "Invited" once it is declined.
  - At 1280×800 the wide rail is unchanged: plain Courses icon, invited course avatar badged below it.
- Not verified locally: iOS/Android builds. The change is layout-agnostic Flutter with no platform surface.

## Deploy Notes

None
