### PR TITLE
feat(chat list): gold Invited marking for pending invites

### DIFF
--- a/lib/features/join_codes/knocked_rooms_extension.dart
+++ b/lib/features/join_codes/knocked_rooms_extension.dart
@@ -11,6 +11,17 @@ import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart'
 extension KnockRoomExtension on Room {
   bool get hasKnocked => client.hasKnockedRoom(id);
 
+  /// Someone invited the learner here and they haven't answered yet — the state
+  /// the gold "Invited" marking is for (`InvitedChip`, and the gold unread
+  /// badge in the nav; #8191).
+  ///
+  /// Narrower than `membership == Membership.invite`, because [acceptKnock]
+  /// grants a knock by *inviting* the knocker: an approved knock arrives on
+  /// this client wearing exactly that membership. That is the learner's own
+  /// request coming back answered, so it must never be dressed up as an
+  /// unsolicited invitation.
+  bool get isPendingInvite => membership == Membership.invite && !hasKnocked;
+
   Future<JoinResponse?> joinKnockedRoom() async {
     try {
       final resp = await joinWithAccessCheck();

--- a/lib/pangea/common/widgets/invited_chip.dart
+++ b/lib/pangea/common/widgets/invited_chip.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+
+/// The gold "Invited" pill worn by anything the learner has been invited to but
+/// hasn't joined yet — a course tile in the Courses hub, a room row in the chat
+/// list. Gold rather than error-colored, and an envelope rather than a warning
+/// glyph: an invitation is an opportunity, not a problem (#7636). It is the
+/// text half of the same state marker `InvitedCourseBadge` puts on the avatar.
+///
+/// One widget for every surface so the pill can't drift between them, or from
+/// the badge beside it. The fill is [AppConfig.goldByTheme] used as given —
+/// washing it with a translucent surface first dragged the dark theme's gold
+/// toward the near-black surface and left it muddy and visibly off the badge on
+/// the same tile (#8109).
+class InvitedChip extends StatelessWidget {
+  final double fontSize;
+  final double iconSize;
+
+  const InvitedChip({super.key, this.fontSize = 12.0, this.iconSize = 12.0});
+
+  @override
+  Widget build(BuildContext context) {
+    final foregroundColor = AppConfig.onGoldByTheme(context);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppConfig.goldByTheme(context),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        spacing: 4.0,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.mail, size: iconSize, color: foregroundColor),
+          Text(
+            L10n.of(context).invited,
+            style: TextStyle(fontSize: fontSize, color: foregroundColor),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/chat_list/chat_list_item.dart
+++ b/lib/routes/chat_list/chat_list_item.dart
@@ -3,7 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/join_codes/knocked_rooms_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/widgets/invited_chip.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat_list/chat_list_item_subtitle.dart';
 import 'package:fluffychat/routes/chat_list/unread_bubble.dart';
@@ -82,6 +84,8 @@ class ChatListItem extends StatelessWidget {
     final String chatSemanticsLabel = unread
         ? '$displayname, ${L10n.of(context).unread}, '
         : '$displayname, ';
+
+    final isPendingInvite = room.isPendingInvite;
     // Pangea#
 
     return Padding(
@@ -334,7 +338,21 @@ class ChatListItem extends StatelessWidget {
                         : const SizedBox.shrink(),
                   ),
                   Expanded(
-                    child: room.isSpace && room.membership == Membership.join
+                    // #Pangea: a pending invite wears the same gold "Invited"
+                    // pill an invited course tile wears, so an activity invite
+                    // is as hard to walk past here as it is in the Courses hub
+                    // (#8191) — it replaces the grey "Invite chat" line, which
+                    // said the same thing in the colour of everything else.
+                    // `isPendingInvite`, not the raw membership: an approved
+                    // knock arrives as an invite too, and keeps the plain
+                    // subtitle rather than claiming someone invited them.
+                    child: isPendingInvite
+                        ? const Align(
+                            alignment: Alignment.centerLeft,
+                            child: InvitedChip(),
+                          )
+                        // Pangea#
+                        : room.isSpace && room.membership == Membership.join
                         ? Text(
                             // #Pangea
                             // L10n.of(

--- a/lib/routes/courses/add_course_tile.dart
+++ b/lib/routes/courses/add_course_tile.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
-import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/widgets/course_avatar.dart';
+import 'package:fluffychat/pangea/common/widgets/invited_chip.dart';
 import 'package:fluffychat/routes/courses/add_course_tile_content.dart';
 import 'package:fluffychat/routes/courses/course_info_chip_widget.dart';
 
@@ -102,19 +102,7 @@ class AddCourseTile extends StatelessWidget {
                             runSpacing: 8.0,
                             crossAxisAlignment: WrapCrossAlignment.center,
                             children: [
-                              if (invited)
-                                CourseInfoChip(
-                                  icon: Icons.mail,
-                                  text: L10n.of(context).invited,
-                                  fontSize: 12.0,
-                                  iconSize: 12.0,
-                                  highlightColor: AppConfig.goldByTheme(
-                                    context,
-                                  ),
-                                  foregroundColor: AppConfig.onGoldByTheme(
-                                    context,
-                                  ),
-                                ),
+                              if (invited) const InvitedChip(),
                               if (members != null && !invited)
                                 Semantics(
                                   label: L10n.of(

--- a/lib/routes/courses/course_info_chip_widget.dart
+++ b/lib/routes/courses/course_info_chip_widget.dart
@@ -13,18 +13,6 @@ class CourseInfoChip extends StatelessWidget {
   final double? iconSize;
   final EdgeInsets? padding;
 
-  /// The chip's pill fill, used as given. It used to be washed with a
-  /// translucent [ColorScheme.surface] first, which in the dark theme dragged
-  /// the invited chip's gold toward the near-black surface and left it muddy
-  /// and visibly off the gold of the `InvitedCourseBadge` sitting right beside
-  /// it on the same tile (#8109). The chip and the badge are one state marker,
-  /// so they wear one color — the same gold the level-up chip wears.
-  final Color? highlightColor;
-
-  /// Ink for the icon and text. Needed when [highlightColor] is dark or
-  /// saturated enough that the ambient text color stops being legible on it.
-  final Color? foregroundColor;
-
   const CourseInfoChip({
     super.key,
     required this.icon,
@@ -32,36 +20,20 @@ class CourseInfoChip extends StatelessWidget {
     required this.fontSize,
     required this.iconSize,
     this.padding,
-    this.highlightColor,
-    this.foregroundColor,
   });
 
   @override
   Widget build(BuildContext context) {
-    final row = Row(
-      spacing: 4.0,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Icon(icon, size: iconSize, color: foregroundColor),
-        Text(
-          text,
-          style: TextStyle(fontSize: fontSize, color: foregroundColor),
-        ),
-      ],
-    );
-
     return Padding(
       padding: padding ?? EdgeInsets.zero,
-      child: highlightColor == null
-          ? row
-          : Container(
-              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-              decoration: BoxDecoration(
-                color: highlightColor,
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: row,
-            ),
+      child: Row(
+        spacing: 4.0,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: iconSize),
+          Text(text, style: TextStyle(fontSize: fontSize)),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/unread_rooms_badge.dart
+++ b/lib/widgets/unread_rooms_badge.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:badges/badges.dart' as b;
 import 'package:matrix/matrix.dart';
 
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/join_codes/knocked_rooms_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'matrix.dart';
@@ -25,12 +27,28 @@ class UnreadRoomsBadge extends StatelessWidget {
 
     // #Pangea
     // final unreadCount = Matrix.of(context).client.rooms
-    final unreadCount = Matrix.of(context).client.rooms
+    final counted = Matrix.of(context).client.rooms
         .where((r) => !r.isHiddenRoom && !r.isSpace)
         // Pangea#
         .where(filter)
         .where((r) => (r.isUnread || r.membership == Membership.invite))
-        .length;
+        // #Pangea
+        .toList();
+    final unreadCount = counted.length;
+
+    // At least one of the counted rooms is an invitation waiting on the
+    // learner, so the badge wears the invited gold instead of the ordinary
+    // unread purple — the same colour the invited course tile and its avatar
+    // badge wear, so an unanswered invite reads the same wherever it surfaces
+    // (#8191). It still carries the full unread count: the gold says something
+    // about what is in the count, it doesn't change the count.
+    //
+    // `isPendingInvite` excludes an approved knock, which arrives wearing
+    // `Membership.invite` but is the learner's own request coming back
+    // answered. Same test the chat list row's chip uses, so a gold badge
+    // always has a gold row behind it.
+    final hasInvite = counted.any((r) => r.isPendingInvite);
+    // Pangea#
     final unreadText = unreadCount < 100
         ? unreadCount.toString()
         : L10n.of(context).unreadPlus;
@@ -38,8 +56,10 @@ class UnreadRoomsBadge extends StatelessWidget {
       badgeStyle: b.BadgeStyle(
         // #Pangea
         padding: const EdgeInsetsGeometry.all(1),
+        badgeColor: hasInvite
+            ? AppConfig.goldByTheme(context)
+            : theme.colorScheme.primary,
         // Pangea#
-        badgeColor: theme.colorScheme.primary,
         elevation: 4,
         borderSide: BorderSide(color: theme.colorScheme.surface, width: 2),
       ),
@@ -56,7 +76,12 @@ class UnreadRoomsBadge extends StatelessWidget {
           child: Text(
             unreadText,
             semanticsLabel: L10n.of(context).unreadLabel(unreadText),
-            style: TextStyle(color: theme.colorScheme.onPrimary, fontSize: 12),
+            style: TextStyle(
+              color: hasInvite
+                  ? AppConfig.onGoldByTheme(context)
+                  : theme.colorScheme.onPrimary,
+              fontSize: 12,
+            ),
           ),
         ),
       ),

--- a/test/pangea/chat_list_invited_chip_test.dart
+++ b/test/pangea/chat_list_invited_chip_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/join_codes/knocked_rooms_extension.dart';
+import 'package:fluffychat/features/join_codes/knocked_rooms_model.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/widgets/invited_chip.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/routes/chat_list/chat_list_item.dart';
+import 'get_test_client.dart';
+
+/// #8191 — an activity invite is easy to miss in the chat list when it reads in
+/// the same grey as every other row ("📨 Invite chat"). It now wears the gold
+/// `InvitedChip` an invited course tile wears, so an unanswered invitation looks
+/// the same wherever the learner meets it.
+///
+/// The nav badge that turns gold alongside it ([UnreadRoomsBadge]) needs a
+/// mounted `MatrixState`, so its half of the change is covered through the
+/// shared predicate both surfaces read — [KnockRoomExtension.isPendingInvite].
+void main() {
+  late Client client;
+
+  const userId = '@test:fakeServer.notExisting';
+  const roomId = '!chat:fakeServer.notExisting';
+
+  setUpAll(() {
+    // `Avatar` resolves the bot name from the environment at build time.
+    dotenv.testLoad(fileInput: 'BOT_NAME=@bot:example.org');
+  });
+
+  setUp(() async {
+    client = await getTestClient();
+  });
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  /// Marks [roomId] as a room this learner knocked on, which is how an accepted
+  /// knock comes back wearing `Membership.invite`.
+  void recordKnock(String id) {
+    client.accountData[PangeaEventTypes.knockedRooms] = BasicEvent(
+      type: PangeaEventTypes.knockedRooms,
+      content: KnockedRoomsModel(knockedRoomIds: [id]).toJson(),
+    );
+  }
+
+  Room room({required Membership membership, String id = roomId}) {
+    final room = Room(id: id, client: client, membership: membership);
+    room.setState(
+      Event(
+        type: EventTypes.RoomName,
+        content: {'name': 'Farewell Lunch Face-off'},
+        stateKey: '',
+        senderId: userId,
+        eventId: '\$name',
+        originServerTs: DateTime.now(),
+        room: room,
+      ),
+    );
+    return room;
+  }
+
+  Future<void> pumpItem(WidgetTester tester, Room room) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(width: 380, child: ChatListItem(room, onTap: () {})),
+        ),
+      ),
+    );
+    // L10n's delegate resolves from a deferred library, so the row isn't in the
+    // tree until localizations finish loading.
+    await tester.pumpAndSettle();
+  }
+
+  group('isPendingInvite', () {
+    test('an unanswered invite is one', () {
+      expect(room(membership: Membership.invite).isPendingInvite, isTrue);
+    });
+
+    test('a joined room is not', () {
+      expect(room(membership: Membership.join).isPendingInvite, isFalse);
+    });
+
+    test('an approved knock is not, though it arrives as an invite', () {
+      recordKnock(roomId);
+      final knocked = room(membership: Membership.invite);
+
+      expect(knocked.membership, Membership.invite);
+      expect(
+        knocked.isPendingInvite,
+        isFalse,
+        reason:
+            'acceptKnock grants a knock by inviting the knocker — the learner '
+            'asked to be here, so nothing may claim they were invited',
+      );
+    });
+  });
+
+  testWidgets('an invited chat wears the gold Invited chip', (tester) async {
+    await pumpItem(tester, room(membership: Membership.invite));
+
+    final context = tester.element(find.byType(ChatListItem));
+
+    expect(find.byType(InvitedChip), findsOneWidget);
+    expect(find.text(L10n.of(context).invited), findsOneWidget);
+    expect(
+      find.text(L10n.of(context).inviteChat),
+      findsNothing,
+      reason: 'the grey line the chip replaces',
+    );
+  });
+
+  testWidgets('a joined chat wears no chip', (tester) async {
+    await pumpItem(tester, room(membership: Membership.join));
+    expect(find.byType(InvitedChip), findsNothing);
+  });
+
+  testWidgets('an approved knock is not dressed up as an invitation', (
+    tester,
+  ) async {
+    recordKnock(roomId);
+    await pumpItem(tester, room(membership: Membership.invite));
+
+    expect(find.byType(InvitedChip), findsNothing);
+  });
+}

--- a/test/pangea/courses/invited_course_tile_test.dart
+++ b/test/pangea/courses/invited_course_tile_test.dart
@@ -7,10 +7,10 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/widgets/invited_chip.dart';
 import 'package:fluffychat/pangea/common/widgets/invited_course_badge.dart';
 import 'package:fluffychat/routes/courses/add_course_tile.dart';
 import 'package:fluffychat/routes/courses/add_course_tile_content.dart';
-import 'package:fluffychat/routes/courses/course_info_chip_widget.dart';
 
 /// Coverage for #7636: a course the learner has been *invited* to must read as
 /// an invitation, not as an error. In the courses list that means a gold
@@ -77,16 +77,35 @@ void main() {
     final context = tester.element(find.byType(AddCourseTile));
     final l10n = L10n.of(context);
 
-    final chip = tester.widget<CourseInfoChip>(
-      find.byWidgetPredicate(
-        (w) => w is CourseInfoChip && w.text == l10n.invited,
+    expect(find.byType(InvitedChip), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byType(InvitedChip),
+        matching: find.text(l10n.invited),
+      ),
+      findsOneWidget,
+    );
+
+    final icon = tester.widget<Icon>(
+      find.descendant(
+        of: find.byType(InvitedChip),
+        matching: find.byType(Icon),
+      ),
+    );
+    final pill = tester.widget<Container>(
+      find.descendant(
+        of: find.byType(InvitedChip),
+        matching: find.byType(Container),
       ),
     );
 
-    expect(chip.icon, Icons.mail);
-    expect(chip.highlightColor, AppConfig.goldByTheme(context));
+    expect(icon.icon, Icons.mail);
     expect(
-      chip.foregroundColor,
+      (pill.decoration! as BoxDecoration).color,
+      AppConfig.goldByTheme(context),
+    );
+    expect(
+      icon.color,
       AppConfig.onGoldByTheme(context),
       reason: 'gold is a light fill; the label needs dark ink to stay legible',
     );
@@ -134,7 +153,7 @@ void main() {
 
         final pill = tester.widget<Container>(
           find.descendant(
-            of: find.byType(CourseInfoChip),
+            of: find.byType(InvitedChip),
             matching: find.byType(Container),
           ),
         );
@@ -158,7 +177,7 @@ void main() {
 
     final pill = tester.widget<Container>(
       find.descendant(
-        of: find.byType(CourseInfoChip),
+        of: find.byType(InvitedChip),
         matching: find.byType(Container),
       ),
     );
@@ -198,27 +217,23 @@ void main() {
   // The joined branch of the tile renders `UnreadRoomsBadge`, which needs a
   // `Provider<MatrixState>` this change doesn't touch — so the chip's own
   // contract is covered directly instead of through a fully-mounted tile.
-  testWidgets('chip paints icon and text with the given foreground', (
-    tester,
-  ) async {
-    const ink = Color(0xFF123456);
-
+  testWidgets('chip paints icon and text with the on-gold ink', (tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(
-          body: CourseInfoChip(
-            icon: Icons.mail,
-            text: 'Invited',
-            fontSize: 12.0,
-            iconSize: 12.0,
-            highlightColor: AppConfig.gold,
-            foregroundColor: ink,
-          ),
-        ),
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: const Scaffold(body: InvitedChip()),
       ),
     );
+    await tester.pumpAndSettle();
+
+    final context = tester.element(find.byType(InvitedChip));
+    final ink = AppConfig.onGoldByTheme(context);
 
     expect(tester.widget<Icon>(find.byIcon(Icons.mail)).color, ink);
-    expect(tester.widget<Text>(find.text('Invited')).style?.color, ink);
+    expect(
+      tester.widget<Text>(find.text(L10n.of(context).invited)).style?.color,
+      ink,
+    );
   });
 }


### PR DESCRIPTION
## What

A pending invite in the chats list wears the gold "Invited" pill a course invite wears, and the all-chats nav badge turns gold while one is waiting.

## Why

Closes #8191

An activity invite was easy to walk past: it read as a grey "📨 Invite chat" subtitle, the same colour as every other row, while a course invite got a bright gold pill and envelope badge.

**Scope note** (confirmed with @ggurdin before implementing): the pill applies to **every** room invite in the chats list, not only activity sessions. The nav badge counts all invites the same way, so gating the pill to activities would leave a DM invite turning the Chats icon gold with no gold row behind it.

## Changes

- **`InvitedChip`** (new, `lib/pangea/common/widgets/`) — the gold pill lifted out of `AddCourseTile`, so one widget serves the course tile and the chat list row and the gold can't drift between them. `CourseInfoChip` loses its now-unused `highlightColor` / `foregroundColor` and goes back to being a plain chip (no other caller passed them; swept the tree).
- **`ChatListItem`** — a pending invite renders the chip in place of the grey line.
- **`UnreadRoomsBadge`** — badge fill and count ink go gold when any counted room is a pending invite. It keeps the full unread count: the gold says what is *in* the count, it doesn't change the count. This is the same widget behind the web rail's Chats item, the mobile nav's Chats tab, the course avatar's child-room count, and the chat back-button badge, so all four pick it up.
- **`Room.isPendingInvite`** (new, beside `hasKnocked`) — the shared test, deliberately narrower than `membership == Membership.invite`: `acceptKnock` grants a knock by *inviting* the knocker, so an approved knock arrives wearing that membership. That's the learner's own request coming back answered and must never be dressed up as an unsolicited invitation (per the auto-accept invariant in [joining-courses.instructions.md](.github/instructions/joining-courses.instructions.md)). Both surfaces read the same getter, so a gold badge always has a gold row behind it.

## Testing

- `fvm flutter analyze lib/ test/` — clean.
- `fvm flutter test` — full suite, **2249 passed, 3 skipped, 0 failed** (skips are the endpoint suites, which need `TEST_MATRIX_*` creds).
- `test/pangea/chat_list_invited_chip_test.dart` (new) — `isPendingInvite` for invite / joined / approved-knock; `ChatListItem` shows the chip for an invite, not for a joined room, and not for an approved knock.
- `test/pangea/courses/invited_course_tile_test.dart` — the existing #7636 / #8109 coverage retargeted at `InvitedChip`; still asserts the pill and the avatar badge paint the *same* gold in both themes, and that the dark theme wears `goldLight`.
- `UnreadRoomsBadge` itself isn't widget-tested — it needs a mounted `MatrixState` that no test in the repo stands up today. Its half of the change is the `isPendingInvite` predicate, which is covered directly; the colour swap on top of it is two ternaries.
- Not QA'd live: the two-account flow in the issue's TO TEST needs a real invite between two accounts, which the local stack can't stand up cheaply. Left for staging QA.

## Deploy Notes

None
