### PR TITLE
fix(chat): open the user popup when a mention pill is tapped

### DIFF
--- a/lib/routes/chat/html_message.dart
+++ b/lib/routes/chat/html_message.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'package:collection/collection.dart';
 import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:go_router/go_router.dart';
 import 'package:highlight/highlight.dart' show highlight;
 import 'package:html/dom.dart' as dom;
 import 'package:html/parser.dart' as parser;
@@ -28,6 +29,7 @@ import 'package:fluffychat/routes/chat/toolbar/reading_assistance/token_emoji_bu
 import 'package:fluffychat/utils/code_highlight_theme.dart';
 import 'package:fluffychat/utils/event_checkbox_extension.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
+import 'package:fluffychat/widgets/adaptive_dialogs/user_dialog.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/hover_builder.dart';
@@ -1148,11 +1150,51 @@ class MatrixPill extends StatelessWidget {
     // Pangea#
   });
 
+  // #Pangea
+  /// A user pill opens that user's profile popup in-app. Only a non-user pill
+  /// (a room or alias) falls through to the URL launcher — handing a user's
+  /// `matrix.to` link to the browser sent the reader out of the app
+  /// (pangeachat/client#8187).
+  Future<void> _onTap() async {
+    final userId = this.userId;
+    if (userId == null) {
+      UrlLauncher(outerContext, uri).launchUrl();
+      return;
+    }
+    // The room's in-memory user is a bare fallback for someone who isn't a
+    // member here, so prefer the server profile — it's usually already cached,
+    // and awaiting it directly keeps the popup one tap away (a
+    // showFutureLoadingDialog wrapper here suppresses the popup entirely).
+    // What the pill renders is the fallback, so the two can't disagree.
+    var noProfileWarning = false;
+    Profile profile;
+    try {
+      profile = await Matrix.of(
+        outerContext,
+      ).client.getProfileFromUserId(userId);
+    } catch (_) {
+      noProfileWarning = true;
+      profile = Profile(userId: userId, displayName: name, avatarUrl: avatar);
+    }
+    if (!outerContext.mounted) return;
+    await UserDialog.show(
+      context: outerContext,
+      profile: profile,
+      noProfileWarning: noProfileWarning,
+      uri: GoRouterState.of(outerContext).uri,
+    );
+  }
+
+  // Pangea#
+
   @override
   Widget build(BuildContext context) {
     return InkWell(
       splashColor: Colors.transparent,
-      onTap: UrlLauncher(outerContext, uri).launchUrl,
+      // #Pangea
+      // onTap: UrlLauncher(outerContext, uri).launchUrl,
+      onTap: _onTap,
+      // Pangea#
       // #Pangea
       child: RichText(
         textScaler: TextScaler.noScaling,

--- a/lib/routes/chat/html_message.dart
+++ b/lib/routes/chat/html_message.dart
@@ -1150,23 +1150,14 @@ class MatrixPill extends StatelessWidget {
     // Pangea#
   });
 
-  // #Pangea
-  /// A user pill opens that user's profile popup in-app. Only a non-user pill
-  /// (a room or alias) falls through to the URL launcher — handing a user's
-  /// `matrix.to` link to the browser sent the reader out of the app
-  /// (pangeachat/client#8187).
   Future<void> _onTap() async {
     final userId = this.userId;
     if (userId == null) {
       UrlLauncher(outerContext, uri).launchUrl();
       return;
     }
-    // The room's in-memory user is a bare fallback for someone who isn't a
-    // member here, so prefer the server profile — it's usually already cached,
-    // and awaiting it directly keeps the popup one tap away (a
-    // showFutureLoadingDialog wrapper here suppresses the popup entirely).
-    // What the pill renders is the fallback, so the two can't disagree.
-    var noProfileWarning = false;
+
+    bool noProfileWarning = false;
     Profile profile;
     try {
       profile = await Matrix.of(
@@ -1177,6 +1168,7 @@ class MatrixPill extends StatelessWidget {
       profile = Profile(userId: userId, displayName: name, avatarUrl: avatar);
     }
     if (!outerContext.mounted) return;
+
     await UserDialog.show(
       context: outerContext,
       profile: profile,
@@ -1184,8 +1176,6 @@ class MatrixPill extends StatelessWidget {
       uri: GoRouterState.of(outerContext).uri,
     );
   }
-
-  // Pangea#
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## What

Tapping a mention pill in chat opens that user's profile popup instead of launching its `matrix.to` link in a browser tab.

## Why

Closes #8187.

## What changed

`MatrixPill` handles a user pill itself — tap opens `UserDialog`, the same popup the member list and invite surfaces already use.

- **Only user pills change.** A room or alias pill has no `userId` and still falls through to `UrlLauncher`, exactly as before.
- The profile comes from the server (normally already cached, so no perceptible delay) so the popup shows the real avatar and displayname; if that fetch fails it falls back to what the pill itself renders, so popup and pill can't disagree. It's awaited directly rather than wrapped in `showFutureLoadingDialog` — that wrapper suppresses the popup entirely.

## Testing

- `fvm flutter test`: 2243 pass, 0 fail, 3 skipped (the endpoint suites, which skip without local `TEST_MATRIX_*` credentials). `fvm flutter analyze` clean.
- Manual, Flutter web against the local stack (Synapse :8008, semantics off so clicks go through real hit testing): posted a message containing `<a href="https://matrix.to/#/@learner2:local.pangea.chat">`; tapping the pill opens the learner2 popup — avatar, displayname, mxid, last active, language badges, Start conversation / Block / Close — with no browser navigation. Verified the popup opens on the first tap, not only after a warm profile cache.
- No automated test: driving `MatrixPill`'s tap needs a `Matrix` ancestor plus a Navigator to observe the dialog, which is more scaffolding than the one-branch change warrants.

## Deploy Notes

None.
