### PR TITLE
fix(wa): re-check the corrected text on manual rerun

### DIFF
--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -3150,16 +3150,29 @@ class ChatController extends State<ChatPageWithRoom>
       return;
     }
 
-    // If assistance is complete, but the user manually requests corrections,
-    // update the feedback to say that the message still contains errors
-    if (feedback == null &&
+    // Assistance is complete and the user manually asks for another pass. That
+    // click means one of two things (#8193):
+    //
+    // - Corrections were applied since the last request, so the message is
+    //   different text now. Re-check that text. Re-sending the previous request
+    //   would rewind the input to its pre-correction state and make the user
+    //   click through every match again.
+    // - Nothing was applied, so assistance found nothing to fix and the user
+    //   disagrees. Send feedback so the server escalates to a stronger model.
+    final bool isManualRecheck =
+        feedback == null &&
         manual &&
-        assistanceState == AssistanceStateEnum.igcComplete) {
+        assistanceState == AssistanceStateEnum.igcComplete;
+
+    if (isManualRecheck && !choreographer.igcController.hasAppliedMatches) {
       feedback = ChoreoConstants.incorrectCompleteIgcFeedback;
     }
 
     feedback == null
-        ? await choreographer.requestWritingAssistance(manual: manual)
+        ? await choreographer.requestWritingAssistance(
+            manual: manual,
+            recheck: isManualRecheck,
+          )
         : await choreographer.rerunWithFeedback(feedback);
 
     if (choreographer.assistanceState == AssistanceStateEnum.fetched) {

--- a/lib/routes/chat/choreographer/choreographer.dart
+++ b/lib/routes/chat/choreographer/choreographer.dart
@@ -219,8 +219,18 @@ class Choreographer extends ChangeNotifier {
     textController.editType = EditTypeEnum.keyboard;
   }
 
-  Future<void> requestWritingAssistance({bool manual = false}) async {
-    if (assistanceState != AssistanceStateEnum.notFetched) return;
+  /// Requests writing assistance for the current text.
+  ///
+  /// [recheck] runs assistance again over a message it has already finished
+  /// with, discarding the previous run's matches. The corrections the user
+  /// accepted are already part of the text, so the new run starts from the text
+  /// as it stands now rather than from the text of the previous request
+  /// (#8193).
+  Future<void> requestWritingAssistance({
+    bool manual = false,
+    bool recheck = false,
+  }) async {
+    if (!recheck && assistanceState != AssistanceStateEnum.notFetched) return;
     final SubscriptionPaywallStatus canSendStatus =
         MatrixState.pangeaController.subscriptionController.paywallStatus;
 
@@ -256,6 +266,11 @@ class Choreographer extends ChangeNotifier {
     }
 
     _resetDebounceTimer();
+
+    // Drop the finished run's matches and cached request/response so the new
+    // run is built from the current text. The choreo record is deliberately
+    // kept — the corrections it already recorded really happened.
+    if (recheck) igcController.clear();
 
     // init choreo record to record the original text before any matches are applied
     _choreoRecord ??= ChoreoRecordModel(

--- a/lib/routes/chat/choreographer/igc/igc_controller.dart
+++ b/lib/routes/chat/choreographer/igc/igc_controller.dart
@@ -24,6 +24,12 @@ class IgcController {
   bool _isFetching = false;
   String? _currentText;
 
+  /// The text the last response was about, before any of its matches were
+  /// applied. Taken from the response rather than the request so server-side
+  /// normalization of the input doesn't read as a correction. Compared against
+  /// [_currentText] to tell whether assistance has since changed the message.
+  String? _checkedText;
+
   /// Last request made - stored for feedback rerun
   IGCRequestModel? _lastRequest;
 
@@ -40,6 +46,18 @@ class IgcController {
   ValueNotifier<PangeaMatchState?> get activeMatch => _activeMatch;
 
   String? get currentText => _currentText;
+
+  /// Whether writing assistance has replaced any text since the last response
+  /// arrived — i.e. the user accepted a correction, or a surface correction was
+  /// auto-applied.
+  ///
+  /// When true, [currentText] is no longer the text the server was asked about,
+  /// so re-sending [_lastRequest] would rewind the input field to its
+  /// pre-correction state (#8193).
+  bool get hasAppliedMatches =>
+      _checkedText != null &&
+      _currentText != null &&
+      _currentText != _checkedText;
 
   List<PangeaMatchState> get matches => _matches;
 
@@ -84,6 +102,7 @@ class IgcController {
   void clear() {
     _isFetching = false;
     _currentText = null;
+    _checkedText = null;
     _lastRequest = null;
     _lastResponse = null;
     clearMatches();
@@ -343,9 +362,19 @@ class IgcController {
 
     if (!_isFetching) return false;
 
-    _lastResponse = res.result!;
-    _currentText = res.result!.originalInput;
-    for (final match in res.result!.matches) {
+    adoptResponse(res.result!);
+    _isFetching = false;
+    return true;
+  }
+
+  /// Adopts [response] as the current writing-assistance state, snapshotting
+  /// the text it was about so later replacements can be detected.
+  @visibleForTesting
+  void adoptResponse(IGCResponseModel response) {
+    _lastResponse = response;
+    _checkedText = response.originalInput;
+    _currentText = response.originalInput;
+    for (final match in response.matches) {
       final matchState = PangeaMatchState(
         match: match.match,
         status: PangeaMatchStatusEnum.open,
@@ -353,7 +382,5 @@ class IgcController {
       );
       _matches.add(matchState);
     }
-    _isFetching = false;
-    return true;
   }
 }

--- a/test/pangea/writing_assistance_recheck_test.dart
+++ b/test/pangea/writing_assistance_recheck_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/common/constants/model_keys.dart';
+import 'package:fluffychat/routes/chat/choreographer/igc/igc_controller.dart';
+import 'package:fluffychat/routes/chat/choreographer/igc/igc_response_model.dart';
+import 'package:fluffychat/routes/chat/choreographer/igc/pangea_match_status_enum.dart';
+
+/// Covers the signal the manual re-check branches on (#8193).
+///
+/// When the user taps the assistance ring on a message assistance has already
+/// finished with, [IgcController.hasAppliedMatches] decides what happens next:
+///
+/// - `true`  — corrections are baked into the text, so re-check the text as it
+///   stands now. Reusing the previous request would rewind the input to its
+///   pre-correction state and make the user click through every match again.
+/// - `false` — assistance found nothing to fix and the user disagrees, so the
+///   click is feedback and the server escalates to a stronger model.
+void main() {
+  IGCResponseModel responseFor(
+    String input, {
+    List<Map<String, dynamic>> matches = const [],
+  }) => IGCResponseModel.fromJson({
+    'original_input': input,
+    'full_text_correction': null,
+    'matches': matches,
+    ModelKey.userL1: 'en',
+    ModelKey.userL2: 'es',
+  });
+
+  Map<String, dynamic> spanJson({
+    required int offset,
+    required int length,
+    required String replacement,
+  }) => {
+    'message': 'Check the verb ending',
+    'short_message': 'verb',
+    'choices': [
+      {'value': replacement, 'type': 'suggestion'},
+    ],
+    ModelKey.offset: offset,
+    ModelKey.length: length,
+    'type': 'verbConjugation',
+  };
+
+  late IgcController igc;
+
+  setUp(() => igc = IgcController((_) {}, () {}));
+  tearDown(() => igc.dispose());
+
+  test('no applied matches when assistance returned nothing to fix', () {
+    igc.adoptResponse(responseFor('Yo quiero hablar español.'));
+
+    expect(igc.currentText, 'Yo quiero hablar español.');
+    expect(igc.hasAppliedMatches, isFalse);
+  });
+
+  test('no applied matches while a returned match is still open', () {
+    igc.adoptResponse(
+      responseFor(
+        'Yo querer hablar español.',
+        matches: [spanJson(offset: 3, length: 6, replacement: 'quiero')],
+      ),
+    );
+
+    expect(igc.hasAppliedMatches, isFalse);
+  });
+
+  test('accepting a match marks the text as changed since the check', () {
+    igc.adoptResponse(
+      responseFor(
+        'Yo querer hablar español.',
+        matches: [spanJson(offset: 3, length: 6, replacement: 'quiero')],
+      ),
+    );
+
+    final match = igc.matches.single;
+    match.selectBestChoice();
+    igc.updateMatchStatus(match, PangeaMatchStatusEnum.accepted);
+
+    expect(igc.currentText, 'Yo quiero hablar español.');
+    expect(igc.hasAppliedMatches, isTrue);
+  });
+
+  test('undoing every accepted match restores the checked text', () {
+    igc.adoptResponse(
+      responseFor(
+        'Yo querer hablar español.',
+        matches: [spanJson(offset: 3, length: 6, replacement: 'quiero')],
+      ),
+    );
+
+    final match = igc.matches.single;
+    match.selectBestChoice();
+    igc.updateMatchStatus(match, PangeaMatchStatusEnum.accepted);
+    igc.updateMatchStatus(match, PangeaMatchStatusEnum.undo);
+
+    expect(igc.currentText, 'Yo querer hablar español.');
+    expect(igc.hasAppliedMatches, isFalse);
+  });
+
+  test('the next check starts from the text the previous run produced', () {
+    igc.adoptResponse(
+      responseFor(
+        'Yo querer hablar español.',
+        matches: [spanJson(offset: 3, length: 6, replacement: 'quiero')],
+      ),
+    );
+
+    final match = igc.matches.single;
+    match.selectBestChoice();
+    igc.updateMatchStatus(match, PangeaMatchStatusEnum.accepted);
+
+    // What Choreographer.requestWritingAssistance(recheck: true) does before
+    // sending the new request: drop the finished run, then check the corrected
+    // text rather than the text the previous request was about.
+    final corrected = igc.currentText!;
+    igc.clear();
+
+    expect(igc.hasAppliedMatches, isFalse);
+    expect(igc.matches, isEmpty);
+
+    igc.adoptResponse(responseFor(corrected));
+
+    expect(igc.currentText, 'Yo quiero hablar español.');
+    expect(igc.hasAppliedMatches, isFalse);
+  });
+}


### PR DESCRIPTION
## What

Tapping the assistance ring again on a finished message re-checks the text as it stands now instead of rewinding it to the pre-correction text.

## Why

Closes #8193

`_onRequestWritingAssistance` routed every manual tap on a complete message through `rerunWithFeedback`, which reuses `IgcController._lastRequest` — whose `fullText` predates every correction the user accepted. The response echoed that stale text back into `_currentText`, and the first match update pushed it into the input field via `setSystemText`, wiping the accepted edits and re-presenting the same matches.

The tap now branches on whether assistance actually changed the text (`IgcController.hasAppliedMatches`):

- **Corrections applied** — the message is different text now, so run a fresh check over it. Nothing rewinds; the choreo record keeps the steps it already recorded.
- **Nothing applied** (assistance returned no matches and the user disagrees) — unchanged: send `incorrectCompleteIgcFeedback` so the server escalates to a stronger model, per the Feedback Architecture in [`llm-base-handler-inference.instructions.md`](https://github.com/pangeachat/2-step-choreographer/blob/main/.github/instructions/llm-base-handler-inference.instructions.md).

Splitting on that condition keeps escalation where the user is genuinely rejecting a response, and keeps a rejection Audit off a response the user accepted and applied.

The span-card flag path (`onWritingAssistanceFeedback`) is deliberately unchanged — there the user is rejecting the correction set itself, so regenerating over the text that response was about is the documented behavior.

## Testing

- `fvm flutter test` — 2248 passed, 3 skipped, 2 failed. Both failures are pre-existing and environment-bound, reproduced identically with the diff stashed: `choreo_endpoint_test.dart` asserts on missing `TEST_MATRIX_USERNAME` (no staging credentials in the local `.env`), and `cms_endpoint_test.dart` fails on GetStorage binding init. The choreo endpoint bucket therefore did not run against this change; contract surfaces (`IGCRequestModel` / `IGCResponseModel`) are untouched by the diff.
- `fvm dart analyze lib test` — clean.
- New: `test/pangea/writing_assistance_recheck_test.dart` — 5 tests over the signal the branch reads: no applied matches for a zero-match response or a still-open match, applied after accepting a choice, back to not-applied after undo, and a second check starting from the text the first run produced.
- Not verified end-to-end locally: the flow needs a subscription and live `/grammar_v2` calls. The issue's TO TEST steps are the staging QA path.

## Deploy Notes

None