### PR TITLE
fix: pass current text on rerun with feedback to prevent text reset

### DIFF
--- a/lib/routes/chat/choreographer/choreographer.dart
+++ b/lib/routes/chat/choreographer/choreographer.dart
@@ -280,7 +280,10 @@ class Choreographer extends ChangeNotifier {
     _startLoading();
 
     feedbackText != null
-        ? await igcController.rerunWithFeedback(feedbackText)
+        ? await igcController.rerunWithFeedback(
+            textController.text,
+            feedbackText,
+          )
         : await igcController.getIGCTextData(textController.text, []);
 
     if (igcController.openNormalizationMatches.isNotEmpty) {

--- a/lib/routes/chat/choreographer/igc/igc_controller.dart
+++ b/lib/routes/chat/choreographer/igc/igc_controller.dart
@@ -270,18 +270,22 @@ class IgcController {
 
   /// Re-runs IGC with user feedback about the previous response.
   /// Returns true if feedback was submitted, false if no previous data.
-  Future<bool> rerunWithFeedback(String feedbackText) async {
+  Future<bool> rerunWithFeedback(String text, String feedbackText) async {
+    final lastResponse = _lastResponse;
+    final lastRequest = _lastRequest;
+    final currentText = _currentText;
+
     debugPrint('rerunWithFeedback called with: $feedbackText');
-    debugPrint('_lastRequest: $_lastRequest, _lastResponse: $_lastResponse');
-    if (_lastRequest == null || _lastResponse == null) {
+    debugPrint('_lastRequest: $lastRequest, _lastResponse: $lastResponse');
+    if (lastRequest == null || lastResponse == null) {
       ErrorHandler.logError(
         e: StateError(
           'rerunWithFeedback called without prior request/response',
         ),
         data: {
-          'hasLastRequest': _lastRequest != null,
-          'hasLastResponse': _lastResponse != null,
-          'currentText': _currentText,
+          'hasLastRequest': lastRequest != null,
+          'hasLastResponse': lastResponse != null,
+          'currentText': currentText,
         },
       );
       return false;
@@ -294,7 +298,7 @@ class IgcController {
     // Create feedback containing the original response
     final feedback = LLMFeedbackModel<IGCResponseModel>(
       feedback: feedbackText,
-      content: _lastResponse!,
+      content: lastResponse,
       contentToJson: (r) => r.toJson(),
     );
 
@@ -302,12 +306,12 @@ class IgcController {
     clearMatches();
 
     // Create request with feedback attached
-    final requestWithFeedback = _lastRequest!.copyWithFeedback([feedback]);
+    final requestWithFeedback = lastRequest.copyWithFeedback([feedback], text);
     debugPrint(
       'requestWithFeedback.feedback.length: ${requestWithFeedback.feedback.length}',
     );
     debugPrint('requestWithFeedback.hashCode: ${requestWithFeedback.hashCode}');
-    debugPrint('_lastRequest.hashCode: ${_lastRequest!.hashCode}');
+    debugPrint('_lastRequest.hashCode: ${lastRequest.hashCode}');
     debugPrint('Calling IgcRepo.get...');
     return _fetchIGC(requestWithFeedback);
   }

--- a/lib/routes/chat/choreographer/igc/igc_request_model.dart
+++ b/lib/routes/chat/choreographer/igc/igc_request_model.dart
@@ -55,6 +55,7 @@ class IGCRequestModel extends BaseRequest with BaseRequestModel {
   /// Creates a copy of this request with optional feedback.
   IGCRequestModel copyWithFeedback(
     List<LLMFeedbackModel<IGCResponseModel>> newFeedback,
+    String fullText,
   ) => IGCRequestModel(
     fullText: fullText,
     enableIGC: enableIGC,


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
