### PR TITLE
fix(chat): send voice message on one click of the send button

### DIFF
--- a/lib/routes/chat/recording_input_row.dart
+++ b/lib/routes/chat/recording_input_row.dart
@@ -103,17 +103,19 @@ class RecordingInputRow extends StatelessWidget {
                 )
               : const Icon(Icons.send_outlined),
           // #Pangea
-          // Streaming, still recording: the primary button STOPS to the editable
-          // transcript (D7 finalizing -> editableClean) rather than sending
-          // immediately, so the learner can review/correct before sending. In
-          // the editable state (and on the batch path) it sends.
+          // One-click send (#8209): the send button always SENDS, on every
+          // path. While streaming, stopAndSend stops the capture, synthesizes
+          // the retained WAV, and sends it with the settled transcript
+          // embedded verbatim — no intermediate stop-to-editable-review step
+          // (that stop read as "pause instead of send"). The editable-review
+          // machinery (stopStreamingToEditable + the TextField above) stays,
+          // and stopAndSend still routes its editable/degraded states.
           // onPressed: state.isSending ? null : () => state.stopAndSend(onSend),
-          // While the finalizing->editable transition is in flight the stop is
-          // disabled so a double-tap cannot re-enter stopStreamingToEditable.
+          // While a terminal degrade's retained-WAV recovery is in flight the
+          // send stays disabled (isFinalizingToEditable covers that window) so
+          // the batch payload cannot be sent before it exists.
           onPressed: state.isSending || state.isFinalizingToEditable
               ? null
-              : state.shouldStopStreamingToEditable
-              ? () => state.stopStreamingToEditable()
               : () => state.stopAndSend(onSend),
           // Pangea#
         ),

--- a/lib/routes/chat/recording_view_model.dart
+++ b/lib/routes/chat/recording_view_model.dart
@@ -212,14 +212,6 @@ class RecordingViewModelState extends State<RecordingViewModel> {
       _finalizingToEditable ||
       (_streaming?.isDegradingToBatch == true && _pendingResult == null);
 
-  /// Whether the live-stream button should enter transcript editing. A terminal
-  /// recovery owns the same button and must complete into the batch-send path.
-  bool get shouldStopStreamingToEditable =>
-      _streaming != null &&
-      _editable == null &&
-      !_degradedToBatch &&
-      _streaming?.isDegradingToBatch != true;
-
   /// The editable buffer's controller for the `TextField`, or `null` off the
   /// editable path.
   EditableTranscriptController? get editableController => _editable?.controller;
@@ -570,9 +562,16 @@ class RecordingViewModelState extends State<RecordingViewModel> {
   /// the batch path uses (D5a). Wave 5 threads the settled transcript through
   /// this call; wave 3 sends the WAV exactly like today.
   Future<void> _stopStreamingAndSend(VoiceMessageSend onSend) async {
-    _recorderSubscription?.cancel();
     final session = _streaming;
-    if (session == null) return;
+    // In-method re-entrancy guard: one-click send (#8209) makes this the
+    // primary streaming send path, and stopAndSynthesize's memoized future
+    // would let an overlapping second tap resume past the await and send the
+    // same WAV twice. Marking isSending BEFORE the await both closes that
+    // window and disables cancel/pause for the finalizing drain, so a
+    // teardown cannot race the synth into sending a cancelled recording.
+    if (session == null || isSending) return;
+    setState(() => isSending = true);
+    _recorderSubscription?.cancel();
 
     final result = await session.stopAndSynthesize();
     if (result == null) {
@@ -615,7 +614,6 @@ class RecordingViewModelState extends State<RecordingViewModel> {
       langCode: session.lang,
     );
 
-    setState(() => isSending = true);
     try {
       await onSend(
         result.wavPath,

--- a/test/pangea/streaming_stt/recording_view_model_streaming_test.dart
+++ b/test/pangea/streaming_stt/recording_view_model_streaming_test.dart
@@ -451,6 +451,110 @@ void main() {
     },
   );
 
+  testWidgets(
+    'one-click send (#8209): a single tap of the send button while streaming '
+    'sends the settled transcript verbatim — no editable-review stop — and an '
+    'overlapping second send is a no-op',
+    (tester) async {
+      final capture = _FakeCapture();
+      final channel = _FakeWebSocketChannel();
+      final repo = SttStreamRepo(
+        wsUrl: 'wss://api.example/choreo/speech_to_text/stream',
+        accessToken: 'TOKEN',
+        connector: (uri, {protocols}) => channel,
+      );
+      final session = StreamingSttSession(
+        capture: capture,
+        repo: repo,
+        tempFileWriter: (_) async => '/tmp/one_click_retained.wav',
+        // Bound the finalizing drain: the fake socket never closes on its own.
+        finalizeTimeout: const Duration(milliseconds: 40),
+      );
+
+      var sendCalls = 0;
+      StreamingSttSendData? streamed;
+      Future<void> onSend(
+        String path,
+        int duration,
+        List<int> waveform,
+        String? fileName, {
+        StreamingSttSendData? streamedTranscript,
+      }) async {
+        sendCalls++;
+        streamed = streamedTranscript;
+      }
+
+      late RecordingViewModelState state;
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          supportedLocales: L10n.supportedLocales,
+          home: RecordingViewModel(
+            streamingSessionFactory: () => session,
+            builder: (context, s) {
+              state = s;
+              return Scaffold(
+                body: RecordingInputRow(state: s, onSend: onSend),
+              );
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.runAsync(() => session.start());
+      state.debugAttachStreamingSession(session);
+      expect(capture.started, isTrue);
+
+      // Non-silent audio (empty-audio guard) and a settled final to embed.
+      session.debugOnFrame(
+        Uint8List.fromList(<int>[0, 64, 0, 64, 0, 64, 0, 64]),
+      );
+      session.debugApplyPartial(
+        const SttPartial(
+          transcript: 'hola mundo',
+          words: <SttWord>[],
+          isFinal: true,
+          speechFinal: false,
+        ),
+      );
+      await tester.pump();
+
+      // ONE tap: the send is in flight (spinner), never an editable review.
+      await tester.tap(find.byIcon(Icons.send_outlined));
+      await tester.pump();
+      expect(state.isSending, isTrue);
+      expect(state.isEditingTranscript, isFalse);
+
+      // A second send racing the in-flight one (the double-tap window before
+      // the disabled button repaints) must be swallowed by the in-method
+      // isSending guard — stopAndSynthesize's memoized future would otherwise
+      // let it resume past the await and send the same WAV twice.
+      final second = state.stopAndSend(onSend);
+
+      // Drive the send to completion: the bounded 40ms drain timer lives on
+      // the test clock (created a few microtask hops into the tap), so
+      // alternate fake-clock pumps with real-async flushes until it lands.
+      for (var i = 0; i < 10 && sendCalls == 0; i++) {
+        await tester.pump(const Duration(milliseconds: 50));
+        await tester.runAsync(
+          () => Future<void>.delayed(const Duration(milliseconds: 10)),
+        );
+      }
+      await tester.runAsync(() => second);
+      await tester.pump();
+
+      expect(sendCalls, 1);
+      expect(streamed, isNotNull);
+      expect(streamed!.text, 'hola mundo');
+      expect(streamed!.isEdited, isFalse);
+      expect(state.isEditingTranscript, isFalse);
+      expect(state.isStreaming, isFalse);
+      expect(capture.stopped, isTrue);
+      expect(channel.isClosed, isTrue);
+    },
+  );
+
   group('degradation banner (H9b live / B4 batch)', () {
     Future<
       ({


### PR DESCRIPTION
Closes #8209

## What

After recording a voice message, pressing the send button paused the recording instead of sending it. On the streaming-STT path (Voice V2, #8154) the send button's first tap deliberately stopped to the editable-transcript review step, and only a second tap sent — the stop read as "pause instead of send" (see the issue video: tap send → waveform freezes, nothing sends).

The send button now always sends, on every path:

- **Streaming**: one tap stops the capture, synthesizes the retained WAV, and sends it with the settled transcript embedded verbatim (`isEdited: false`) — the existing direct-send path, now primary. The spinner shows through the finalizing drain.
- **Batch / degraded-to-batch / editable**: unchanged — `stopAndSend` already routed these.

## Details

- `_stopStreamingAndSend` gains an in-method `isSending` re-entrancy guard: `stopAndSynthesize`'s memoized future would otherwise let a double-tap resume past the await and send the same WAV twice. Marking `isSending` before the await also disables cancel/pause during the finalizing drain, so a teardown can't race the synth into sending a cancelled recording.
- The editable-review machinery (`stopStreamingToEditable`, the diff TextField, provenance) is kept — `stopAndSend` still routes the editable and degraded states, and its tests stay green — but it is no longer reachable from the send button. The now-unused `shouldStopStreamingToEditable` getter is removed.
- Send stays disabled while a terminal degrade's retained-WAV recovery is in flight (`isFinalizingToEditable` covers that window).

## Testing

- New widget test: one tap of the send button while streaming calls `onSend` exactly once with the settled transcript verbatim, and an overlapping second send is a no-op.
- `flutter test test/pangea/streaming_stt/` — all 241 tests pass.
- `dart analyze lib test` — clean except a pre-existing unrelated error in `join_code_login_bounce_test.dart` (also present on main).

**TO TEST**
- [ ] Record an audio message and press the send button. The message should send with one click.
- [ ] Same with the streaming live-transcript pilot enabled (English L2 + `LIVE_STREAMING_STT_ENABLED`): one tap sends; the sent message carries the streamed transcript.
- [ ] Delete (trash) and pause/resume controls still work while recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)