### PR TITLE
ci(prod): enable live streaming STT flag on production web deploy

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -132,6 +132,12 @@ jobs:
         # that owns the environment.
         run: |
           echo "$WEB_APP_ENV" > build/web/.env
+          # Production streaming-STT client gate (Environment.liveStreamingSttEnabled),
+          # enabled the same way staging does in main_deploy.yaml. The choreo backend
+          # gates the actual behavior: while prod streaming is still dark, the session
+          # fails pre-`ready` and the recorder falls back to batch (today's behavior),
+          # so this is safe to ship ahead of the backend flip.
+          echo "LIVE_STREAMING_STT_ENABLED=true" >> build/web/.env
       - name: Set up AWS CLI
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:


### PR DESCRIPTION
## What

One line in `release.yaml`'s **`deploy_web`** job (the job whose `.env` actually ships to S3/CloudFront — the build-time `.env` is dropped on artifact upload, per the workflow's own comment):

```
echo "LIVE_STREAMING_STT_ENABLED=true" >> build/web/.env
```

Turns on the client streaming-STT gate (`Environment.liveStreamingSttEnabled`) in **production**, the same way staging enables it in `main_deploy.yaml`.

## Why now / safety

Ships **ahead of** the choreo backend deliberately, and it's safe: prod choreo streaming is still dark (`api.pangea.chat/choreo/streaming/ready` = 404). `StreamingSttSession.start()` awaits the `ready` handshake — a pre-`ready` connect failure returns `false` → `_StreamStartOutcome.failed` → the recorder falls back to **batch** (today's exact behavior). The streaming UX (incl. #8209) only engages **post-`ready`**, i.e. once the backend is live.

- **Staging-inert:** this is prod-only (`release.yaml`); staging streams via `main_deploy.yaml`, unchanged. Merging to `main` doesn't alter staging behavior.
- Once merged to `main`, the next production sync (`main` → `production`) carries it — **no separate client release needed** for the flag.
- Codex read-only review: GREEN (correct job for the shipped `.env`; `>`/`>>` no-clobber; no impact to other flags or non-streaming users; batch-fallback sound).

Backend enablement (choreo `prod_enabled` + task-def + ALB/CMS) is tracked separately and must land before this actually streams in prod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled live streaming speech-to-text capabilities in production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->