### PR TITLE
ci(mobile): enable live streaming STT flag on iOS + Android builds

### DIFF
--- a/.github/workflows/android-playstore.yml
+++ b/.github/workflows/android-playstore.yml
@@ -67,6 +67,10 @@ jobs:
         run: |
           rm -f .env
           echo "$WEB_APP_ENV" > .env
+          # Live streaming-STT client gate, same as the web deploy (release.yaml).
+          # Dark until the choreo backend is enabled: the session fails pre-`ready`
+          # and the recorder falls back to batch (today's behavior).
+          echo "LIVE_STREAMING_STT_ENABLED=true" >> .env
           touch assets/envs.json
           echo "$ENV_OVERRIDES" >> assets/envs.json
       - name: Apply .env patch

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -74,6 +74,10 @@ jobs:
         run: |
           rm -f .env
           echo "$WEB_APP_ENV" > .env
+          # Live streaming-STT client gate, same as the web deploy (release.yaml).
+          # Dark until the choreo backend is enabled: the session fails pre-`ready`
+          # and the recorder falls back to batch (today's behavior).
+          echo "LIVE_STREAMING_STT_ENABLED=true" >> .env
       - name: Apply .env patch
         run: git apply ./scripts/enable_mobile_env.patch
       - name: Remove Emoji Font


### PR DESCRIPTION
## What

Follow-up to #8226 (which did **web** only). Adds `LIVE_STREAMING_STT_ENABLED=true` to the `.env` written by **`android-playstore.yml`** and **`ios-testflight.yml`**, so mobile builds carry the same client streaming-STT gate (`Environment.liveStreamingSttEnabled`) as web.

These two workflows are parameterized by an `environment` input (staging + production), so this covers **both** — consistent with staging web (which already streams) and prod.

## Why / safety (same as #8226)

Ships **ahead of** the choreo backend deliberately, and it's safe: while prod streaming is dark, `StreamingSttSession.start()` fails **pre-`ready`** → `_StreamStartOutcome.failed` → the recorder falls back to **batch** (today's exact behavior). The streaming UX only engages once the backend is live.

- Mobile `.env` is bundled at build time via `enable_mobile_env.patch` (unchanged); this just adds the flag line, mirroring the web deploy.
- No app-code change; no impact to non-streaming users or other flags.

Answers @ggurdin's question on #8226 ("what needs to change for future iOS/Android builds").