### PR TITLE
feat(tts): read a selected message aloud on tap

### DIFF
--- a/.github/instructions/message-read-aloud.instructions.md
+++ b/.github/instructions/message-read-aloud.instructions.md
@@ -42,6 +42,16 @@ A message is read only when all of these hold:
 - It is in the learner's L2 (target language). Messages in the L1 or an unknown language offer no listening practice.
 - It arrived in the currently open chat, while that chat was open. Opening a chat reads nothing retroactively — a backlog of unheard messages would be noise rather than practice — and messages in background rooms have no visible counterpart on screen to follow along with.
 
+## Reading on select
+Tapping a message is a deliberate request to engage with it, so for a learner who already opted into read-aloud it speaks that message. Same toggle, same qualifying conditions, same device-only source as an arriving message — only the trigger differs.
+
+- **Same conditions as an arriving message** (received, in the L2, text, synced, not redacted), minus the arrived-while-open rule. That rule exists to stop a backlog of unheard messages playing at once; a message the learner picked out and tapped is by definition on screen and asked for.
+- **Gated on the same toggle.** A learner who has not opted into read-aloud hears nothing on tap. No second setting: this is the same feature reached a second way.
+- **Device only**, through the same known-good-voice gate — silence when the device has no good L2 voice. Voice mode's backend exception does not extend here; a tap is not a spoken exchange.
+- **Not when a token was tapped.** Tapping a word selects that token and plays the word. The more specific request wins, and the two would otherwise talk over each other.
+- **Not when the tutorial opens the toolbar.** The reading-assistance tutorial selects a message on the learner's behalf and speaks its own instruction over it. Tutorial-driven selections are marked at the call site rather than inferred from how the toolbar was opened.
+- **Chat only.** The example-message toolbar on analytics detail pages is a reference lookup, not a message in a conversation.
+
 ## Audio source
 Device text-to-speech only for setting-driven reads; that flow never calls the choreographer. Backend TTS is paid per request, and unlike a deliberate word tap this fires on every eligible incoming message, so the volume is unbounded and driven by how much other people type rather than by the learner.
 
@@ -52,11 +62,11 @@ The known-good-voice gate in [word-text-to-speech.instructions.md](word-text-to-
 ## One message at a time
 Playback holds a single waiting slot: while a message is being read, at most one message waits, and a newer arrival replaces whichever message was waiting. The learner stays at most one message behind the conversation, so what they hear is still on screen. Reading every message in order would fall progressively further behind; ignoring everything that arrives mid-playback would instead skip the newest messages and drift the audio away from where the learner is looking.
 
-Read-aloud shares the single TtsController with word-level playback, so only one utterance plays anywhere in the app — tapping a word interrupts read-aloud.
+Read-aloud shares the single TtsController with word-level playback, so only one utterance plays anywhere in the app — tapping a word interrupts read-aloud, and the toolbar's sentence-audio button stops it before starting its own.
 
 ## When it stops
 - The chat closes or loses focus. Audio stops immediately.
-- A message is selected. Read-aloud does not start while a message is selected, and selecting one stops playback in progress. The selected message has the learner's attention and its own audio controls.
+- A message is selected. Automatic read-aloud does not start while a message is selected, and selecting one stops playback in progress and drops the waiting message — the conversation has moved past what the learner is now looking at. Selection may then speak the *selected* message instead, see [Reading on select](#reading-on-select).
 - The learner starts drafting. Playback stops and any waiting message is dropped rather than held for later. Read-aloud stays suppressed while the input bar holds text, resuming once the draft is sent or cleared — composing a reply is the moment an interruption costs the most.
 - The learner is recording a voice message. Recording is inline rather than modal, so none of the conditions above catch it, and in voice mode the learner is recording by construction. Without this, playback would go out loud into a hot mic, be captured by the recorder and uploaded to speech-to-text.
 - The learner sends text, which additionally ends [Voice mode](#voice-mode) itself.

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -754,7 +754,12 @@ class ChatController extends State<ChatPageWithRoom>
         final token = tutorialToken;
         if (event == null) return;
         // Re-open the toolbar so SelectModeButtons mounts and picks up the queued tutorial.
-        showToolbar(event, bypassBlockingOverlays: true, selectedToken: token);
+        showToolbar(
+          event,
+          bypassBlockingOverlays: true,
+          selectedToken: token,
+          isTutorial: true,
+        );
         return;
       case TutorialEnum.writingAssistance:
         // The writing-assistance tutorial starts from the text input which is
@@ -778,7 +783,11 @@ class ChatController extends State<ChatPageWithRoom>
           TutorialStepData(
             targetKey: event.eventId,
             onTap: () async {
-              showToolbar(event, bypassBlockingOverlays: true);
+              showToolbar(
+                event,
+                bypassBlockingOverlays: true,
+                isTutorial: true,
+              );
             },
             canShowNextStep: () => isToolbarOpen,
           ),
@@ -2774,6 +2783,12 @@ class ChatController extends State<ChatPageWithRoom>
     Event? nextEvent,
     Event? prevEvent,
     bool bypassBlockingOverlays = false,
+
+    /// Whether a tutorial opened the toolbar rather than the learner. Marked at
+    /// the call site rather than inferred, so read-aloud does not talk over the
+    /// tutorial's own instruction. See "Reading on select" in
+    /// client/.github/instructions/message-read-aloud.instructions.md
+    bool isTutorial = false,
   }) async {
     if (event.redacted ||
         event.text == '' ||
@@ -2874,6 +2889,19 @@ class ChatController extends State<ChatPageWithRoom>
         ),
       );
     }
+
+    // A deliberate tap on a message is a request to hear it, for learners who
+    // opted into read-aloud. The controller owns which selections qualify.
+    readAloudController.readSelectedMessage(
+      pangeaMessageEvent ??
+          PangeaMessageEvent(
+            event: event,
+            timeline: timeline!,
+            ownMessage: event.senderId == event.room.client.userID,
+          ),
+      isTutorial: isTutorial,
+      tokenSelected: selectedToken != null,
+    );
 
     GoogleAnalytics.openMessageToolbar();
   }

--- a/lib/routes/chat/events/text_to_speech/message_read_aloud_controller.dart
+++ b/lib/routes/chat/events/text_to_speech/message_read_aloud_controller.dart
@@ -24,6 +24,9 @@ import 'package:fluffychat/widgets/matrix.dart';
 /// Decides which arriving messages qualify; [ReadAloudQueue] owns the
 /// one-at-a-time playback scheduling.
 ///
+/// The same setting also reads a message the learner deliberately taps, via
+/// [readSelectedMessage] — one feature reached two ways, not two features.
+///
 /// Design — what qualifies to be read, the single waiting slot, and the stop
 /// conditions: client/.github/instructions/message-read-aloud.instructions.md
 class MessageReadAloudController {
@@ -149,16 +152,77 @@ class MessageReadAloudController {
     // Nothing retroactive: a backlog of unheard messages would be noise rather
     // than practice, so only what arrives after the chat opens is read.
     if (!event.originServerTs.isAfter(openedAt)) return false;
+    if (!_isReadableContent(event)) return false;
+    return qualifies(
+      settingEnabled: _isEnabled,
+      voiceReply: _isVoiceReply(event),
+    );
+  }
+
+  /// Whether the event is the kind of message read-aloud can speak at all,
+  /// independent of what prompted the read. Shared by arrival and by
+  /// [readSelectedMessage] so a tap can never read something an arrival
+  /// wouldn't.
+  bool _isReadableContent(Event event) {
     if (event.senderId == room.client.userID) return false;
     if (event.type != EventTypes.Message) return false;
     if (event.messageType != MessageTypes.Text) return false;
-    if (!qualifies(
-      settingEnabled: _isEnabled,
-      voiceReply: _isVoiceReply(event),
-    )) {
-      return false;
-    }
     return !event.redacted && event.status.isSynced;
+  }
+
+  /// Whether opening the toolbar over a message should speak that message.
+  ///
+  /// Gated on the same toggle as an arriving message — no second setting, this
+  /// is the same feature reached a second way. A tutorial that opens the
+  /// toolbar on the learner's behalf speaks its own instruction over it, and a
+  /// tapped token plays the word instead: the more specific request wins.
+  ///
+  /// Pure so the decision is unit-testable without Matrix, TTS or app state.
+  @visibleForTesting
+  static bool readsOnSelect({
+    required bool settingEnabled,
+    required bool isTutorial,
+    required bool tokenSelected,
+  }) => settingEnabled && !isTutorial && !tokenSelected;
+
+  /// Reads a message the learner deliberately selected.
+  ///
+  /// Same toggle and the same qualifying conditions as an arriving message,
+  /// minus the arrived-while-open rule: that rule stops a backlog playing at
+  /// once, and a message the learner picked out and tapped is on screen and
+  /// asked for by definition.
+  ///
+  /// Device-only and gated: voice mode's backend exception does not extend
+  /// here, because a tap is not a spoken exchange.
+  ///
+  /// Design — "Reading on select":
+  /// client/.github/instructions/message-read-aloud.instructions.md
+  Future<void> readSelectedMessage(
+    PangeaMessageEvent message, {
+    required bool isTutorial,
+    required bool tokenSelected,
+  }) {
+    if (!readsOnSelect(
+      settingEnabled: _isEnabled,
+      isTutorial: isTutorial,
+      tokenSelected: tokenSelected,
+    )) {
+      return Future.value();
+    }
+    if (!_isReadableContent(message.event)) return Future.value();
+    if (!_isInTargetLanguage(message)) return Future.value();
+
+    // Ends the automatic read first. Selecting a message clears the queue
+    // anyway, but that happens once the overlay registers the selection — after
+    // this call — and would otherwise stop the audio being started here.
+    stopAndClear();
+
+    return TtsController.tryToSpeak(
+      message.messageDisplayText,
+      langCode: message.messageDisplayLangCode,
+      useCase: TtsUseCase.incomingMessage,
+      allowChoreoPlay: false,
+    );
   }
 
   bool _isInTargetLanguage(PangeaMessageEvent message) {

--- a/test/pangea/text_to_speech/read_aloud_on_select_test.dart
+++ b/test/pangea/text_to_speech/read_aloud_on_select_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/chat/events/text_to_speech/message_read_aloud_controller.dart';
+
+// Reading on select: tapping a message is a deliberate request to hear it, so
+// for a learner who opted into read-aloud it speaks that message. Same toggle,
+// no second setting -- the same feature reached a second way.
+//
+// Design ("Reading on select"):
+// client/.github/instructions/message-read-aloud.instructions.md
+
+void main() {
+  group('readsOnSelect', () {
+    test('a plain tap on a message with the setting on reads it', () {
+      expect(
+        MessageReadAloudController.readsOnSelect(
+          settingEnabled: true,
+          isTutorial: false,
+          tokenSelected: false,
+        ),
+        isTrue,
+      );
+    });
+
+    // No second setting: a learner who never opted into read-aloud must not
+    // start getting unrequested audio out of an ordinary message tap.
+    test('the setting off reads nothing on select', () {
+      expect(
+        MessageReadAloudController.readsOnSelect(
+          settingEnabled: false,
+          isTutorial: false,
+          tokenSelected: false,
+        ),
+        isFalse,
+      );
+    });
+
+    // The tutorial opens the toolbar on the learner's behalf and speaks its own
+    // instruction over it; message audio would talk across it.
+    test('a tutorial-driven selection stays silent', () {
+      expect(
+        MessageReadAloudController.readsOnSelect(
+          settingEnabled: true,
+          isTutorial: true,
+          tokenSelected: false,
+        ),
+        isFalse,
+      );
+    });
+
+    // Tapping a word plays that word. The more specific request wins, and both
+    // firing would have the two utterances cut each other off.
+    test('tapping a token reads the word, not the message', () {
+      expect(
+        MessageReadAloudController.readsOnSelect(
+          settingEnabled: true,
+          isTutorial: false,
+          tokenSelected: true,
+        ),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
### What

Selecting a message plays it aloud with device TTS, for learners who have the read-aloud toggle on.

### Why

Closes #8227.

Design agreed in chat and written into [message-read-aloud.instructions.md](.github/instructions/message-read-aloud.instructions.md) — see the new **Reading on select** section for what qualifies and why, and the amended selection bullet under **When it stops** (which previously said the opposite: that a selected message has "its own audio controls"). Not restated here.

### Changes

- `message-read-aloud.instructions.md` — new **Reading on select** section; selection bullet under **When it stops** rewritten; **One message at a time** now names the toolbar sentence-audio button as an interrupter (it already called `TtsController.forceStop()`).
- `MessageReadAloudController.readSelectedMessage()` — new. Gated on `audioIncomingMessages`, device-only (`allowChoreoPlay: false`, `TtsUseCase.incomingMessage`). Calls `stopAndClear()` first so the selection's own queue-clear (fired later, when the overlay registers the selected event) can't stop the audio it just started.
- `MessageReadAloudController.readsOnSelect()` — new pure static holding the whole "does this selection speak" decision (setting on, not a tutorial, no token tapped), next to the existing `isVoiceReply` / `qualifies` predicates.
- `_isReadableContent()` — extracted from `_isReadableMessage()`, so a tap can never read something an arrival wouldn't. Arrival keeps its extra arrived-while-open check; selection deliberately doesn't have it.
- `ChatController.showToolbar()` — new `isTutorial` flag (default false), passed `true` by the two tutorial call sites; calls `readSelectedMessage` once the overlay is shown.

Interruption needed no new code: `tryToSpeak` stops current playback first, and the toolbar audio button already calls `forceStop()`.

### Testing

- `fvm flutter test test/pangea/text_to_speech/` — 52 passed, including 4 new cases in `read_aloud_on_select_test.dart` covering `readsOnSelect` (plays / setting off / tutorial / token tapped).
- `fvm dart analyze lib test` — no issues.
- **Manual QA deferred, not run.** The issue's TO TEST needs a logged-in session, a received L2 message and a known-good device voice; this checkout has no staging test credentials (`TEST_MATRIX_*` are unset), so the audio itself was never heard locally. Needs the TO TEST steps on staging.

### Deploy Notes

None.

### Accessibility

No new or changed controls — no new semantics surface.
