### PR TITLE
fix: auto-send an empty streamed transcript instead of parking (#8209)

### DIFF
--- a/lib/routes/chat/recording_input_row.dart
+++ b/lib/routes/chat/recording_input_row.dart
@@ -133,7 +133,7 @@ class RecordingInputRow extends StatelessWidget {
                 onPressed: state.isSending || state.isFinalizingToEditable
                     ? null
                     : state.shouldStopStreamingToEditable
-                    ? () => state.stopStreamingToEditable()
+                    ? () => state.stopStreamingToEditable(onSend)
                     : () => state.stopAndSend(onSend),
                 // Pangea#
               ),

--- a/lib/routes/chat/recording_view_model.dart
+++ b/lib/routes/chat/recording_view_model.dart
@@ -680,7 +680,7 @@ class RecordingViewModelState extends State<RecordingViewModel> {
   /// buffer-level contract + defense-in-depth if that wiring ever changes; the
   /// VM relies on the subscription lifecycle, not on calling it. (Covered by the
   /// "no partial reaches the editable buffer after stop" integration test.)
-  Future<void> stopStreamingToEditable() async {
+  Future<void> stopStreamingToEditable(VoiceMessageSend onSend) async {
     final session = _streaming;
     // The `_finalizingToEditable` guard closes the double-tap window: the
     // `_editable == null` check alone is not enough because `_editable` stays
@@ -722,7 +722,14 @@ class RecordingViewModelState extends State<RecordingViewModel> {
 
       _pendingResult = result;
       _pendingWaveform = _waveformFromAmplitudes(amps);
-      if (_routeEmptyStreamToBatch(result)) return;
+      if (_routeEmptyStreamToBatch(result)) {
+        // #8209: an empty streamed transcript has nothing to review — send it
+        // immediately through the batch path (reuses stopAndSend's
+        // `_degradedToBatch && _pendingResult` branch) instead of parking in
+        // batch-ready and forcing the learner to tap send a second time.
+        await stopAndSend(onSend);
+        return;
+      }
       _editable = EditableTranscript(
         originalAsrText: result.transcript,
         words: session.finalWords,

--- a/test/pangea/streaming_stt/recording_view_model_late_final_test.dart
+++ b/test/pangea/streaming_stt/recording_view_model_late_final_test.dart
@@ -104,6 +104,18 @@ class _FakeWakelock extends WakelockPlusPlatformInterface
   Future<bool> get enabled async => false;
 }
 
+/// No-op send for the NON-EMPTY-transcript tests: they settle a real transcript
+/// ('hola mundo'), so `stopStreamingToEditable` takes the editable-review path
+/// and NEVER auto-sends — this callback exists only to satisfy the signature and
+/// must not fire on those paths.
+Future<void> _noopSend(
+  String path,
+  int duration,
+  List<int> waveform,
+  String? fileName, {
+  StreamingSttSendData? streamedTranscript,
+}) async {}
+
 void main() {
   final List<String> writtenPaths = <String>[];
   Future<String> tempWriter(Uint8List wav) async {
@@ -181,7 +193,7 @@ void main() {
 
       // Stop -> the bounded drain runs, subscriptions are cancelled, the socket
       // closes, and the settled final becomes the editable buffer.
-      await tester.runAsync(() => state.stopStreamingToEditable());
+      await tester.runAsync(() => state.stopStreamingToEditable(_noopSend));
       await tester.pump();
 
       expect(state.isEditingTranscript, isTrue);
@@ -271,8 +283,8 @@ void main() {
       // `_editable == null` check across the drain await and each run a full
       // stopAndSynthesize -> two WAV writes + an overwritten (leaked) buffer.
       await tester.runAsync(() async {
-        final f1 = state.stopStreamingToEditable();
-        final f2 = state.stopStreamingToEditable();
+        final f1 = state.stopStreamingToEditable(_noopSend);
+        final f2 = state.stopStreamingToEditable(_noopSend);
         await Future.wait([f1, f2]);
       });
       await tester.pump();
@@ -344,7 +356,7 @@ void main() {
       // while it is in flight, then let the stop resume. cancel() bumps the
       // generation + nulls _streaming, so the resumed continuation must bail.
       await tester.runAsync(() async {
-        final stop = state.stopStreamingToEditable();
+        final stop = state.stopStreamingToEditable(_noopSend);
         state.cancel();
         await stop;
       });
@@ -466,7 +478,7 @@ void main() {
           speechFinal: false,
         ),
       );
-      await tester.runAsync(() => state.stopStreamingToEditable());
+      await tester.runAsync(() => state.stopStreamingToEditable(_noopSend));
       await tester.pump();
 
       StreamingSttSendData? captured;
@@ -488,6 +500,99 @@ void main() {
       // the recording-time session lang.
       expect(captured, isNotNull);
       expect(captured!.langCode, 'es');
+    },
+  );
+
+  testWidgets(
+    '#8209 empty-stream auto-send: a settled EMPTY final AUTO-SENDS via the batch '
+    'path on the single stop tap — onSend fires once and NO editable review opens',
+    (tester) async {
+      final capture = _FakeCapture();
+      final channel = _FakeWebSocketChannel();
+      final repo = SttStreamRepo(
+        wsUrl: 'wss://api.example/choreo/speech_to_text/stream',
+        accessToken: 'TOKEN',
+        connector: (uri, {protocols}) => channel,
+      );
+      final session = StreamingSttSession(
+        capture: capture,
+        repo: repo,
+        tempFileWriter: tempWriter,
+        finalizeTimeout: const Duration(milliseconds: 40),
+        frameWatchdogTimeout: const Duration(seconds: 30),
+      );
+
+      late RecordingViewModelState state;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RecordingViewModel(
+            streamingSessionFactory: () => session,
+            builder: (context, s) {
+              state = s;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      await tester.runAsync(() => session.start());
+      state.debugAttachStreamingSession(session);
+
+      // Real audio (non-silence) so the empty-AUDIO guard passes — there IS a WAV
+      // to send; only the TRANSCRIPT is empty (the ~1/10 provider miss #8209
+      // targets).
+      final loud = Uint8List.fromList(<int>[0, 64, 0, 64, 0, 64, 0, 64]);
+      capture.pushFrame(loud);
+      capture.pushFrame(loud);
+      // Settle an EMPTY final: the provider streamed but produced no transcript.
+      session.debugApplyPartial(
+        const SttPartial(
+          transcript: '',
+          words: <SttWord>[],
+          isFinal: true,
+          speechFinal: false,
+        ),
+      );
+
+      var sends = 0;
+      Future<void> onSend(
+        String path,
+        int duration,
+        List<int> waveform,
+        String? fileName, {
+        StreamingSttSendData? streamedTranscript,
+      }) async {
+        sends++;
+      }
+
+      // A single stop tap. Pre-#8209 this parked in batch-ready (isEditing false
+      // but sends == 0) and forced a SECOND tap to send. Post-fix the empty
+      // stream auto-sends through the batch path on this one call.
+      await tester.runAsync(() async {
+        await state.stopStreamingToEditable(onSend);
+        // The batch send auto-disposes the retained WAV via cancel()'s
+        // fire-and-forget teardown (_disposeTempArtifact). Drain the real event
+        // loop until that delete lands so the shared tearDown does not race it
+        // (a harmless PathNotFound on the same path otherwise).
+        for (var i = 0; i < 200; i++) {
+          if (writtenPaths.every((p) => !File(p).existsSync())) break;
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+        }
+      });
+      await tester.pump();
+
+      expect(
+        sends,
+        1,
+        reason:
+            'an empty streamed transcript must auto-send once on the single stop '
+            'tap (batch path) — not wait for a second tap',
+      );
+      expect(
+        state.isEditingTranscript,
+        isFalse,
+        reason: 'an empty transcript has nothing to review — no editable field',
+      );
     },
   );
 }


### PR DESCRIPTION
Closes #8209.

**Bug:** while streaming a voice message, the first send tap stops to an editable transcript for review (2nd tap sends). When the streamed transcript came back **empty**, the code parked in batch-ready with no review view and without sending, so the send button needed a **second** tap — it read as "send just pauses" (thanks @ggurdin for the catch).

**Fix:** `stopStreamingToEditable` now takes `onSend` and, on the empty path, sends immediately via the existing proven `stopAndSend` batch branch instead of parking. Non-empty is unchanged (editable review still shows, 2nd tap sends). Exactly your "if it's not available, send right away; if it is, show it."

**Tests:** new test asserts a single stop tap auto-sends (`sends == 1`) with no editable review (`isEditingTranscript == false`); the existing non-empty test still asserts the review shows and does not send. No assertions weakened.

Gates: dart format (0 changed), import_sorter (clean), `flutter analyze` (no issues), `flutter test` (all pass, incl. the new test). Codex adversarial review: GREEN (production logic correct, tests honest).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Voice messages with an empty final transcript are now sent automatically when recording stops.
  * Prevented users from needing a second action to send audio when no transcript text is available.
  * Improved handling of temporary audio cleanup after automatic sending.

* **Tests**
  * Added coverage for empty-transcript voice message behavior and verified messages are sent only once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->