### PR TITLE
fix(profile): keep a resolved avatar through chat rebuilds

### DIFF
--- a/lib/pangea/common/widgets/user_profile_builder.dart
+++ b/lib/pangea/common/widgets/user_profile_builder.dart
@@ -30,11 +30,14 @@ String profileDisplayName(String userId, Profile? profile, L10n l10n) =>
 /// back to the localpart. The global profile is the one source always
 /// available.
 ///
-/// The SDK owns the caching: [Client.getProfileFromUserId] serves from its
+/// The SDK owns the freshness: [Client.getProfileFromUserId] serves from its
 /// database, de-duplicates concurrent requests for the same id, and marks
-/// entries outdated off the sync loop. This widget adds no cache of its own,
-/// so a resolved profile still costs a future — the fallback shows for a frame
-/// whenever this State is built fresh rather than merely rebuilt.
+/// entries outdated off the sync loop. That lookup is always a future though,
+/// even on a hit, so a [State] starting from null draws the fallback letter
+/// circle for at least a frame — and cards mount fresh far more often than the
+/// profile changes. The process-wide seed below closes that gap: a mount starts
+/// from the last value resolved for that id, and the refetch still runs and
+/// overwrites.
 ///
 /// Prefer [UserProfileAvatar] / [UserProfileName]; reach for this directly only
 /// where a card needs the raw [Profile].
@@ -54,38 +57,72 @@ class UserProfileBuilder extends StatefulWidget {
     required this.builder,
   });
 
+  @visibleForTesting
+  static void clearLastResolvedForTest() => _lastResolved.clear();
+
   @override
   State<UserProfileBuilder> createState() => _UserProfileBuilderState();
 }
 
+/// Profiles this process has already resolved, by user id — the synchronous
+/// seed a fresh [_UserProfileBuilderState] starts from instead of null.
+///
+/// It exists because a remount is not a rare event here. The role cards sit
+/// inside the chat timeline, which rebuilds on every event; a rebuild that
+/// changes the shape of an ancestor's child list (the goals header appearing,
+/// the media carousel collapsing) drops and recreates the subtree, and the old
+/// behaviour flashed the letter circle every time (#8233).
+///
+/// Deliberately never evicted: an entry is a user id, display name and avatar
+/// URL, it is overwritten by the refetch every mount performs, and the set of
+/// users one session sees is small.
+final Map<String, Profile> _lastResolved = {};
+
 class _UserProfileBuilderState extends State<UserProfileBuilder> {
   Profile? _profile;
+
+  /// Whether [didChangeDependencies] has already kicked off the first resolve.
+  bool _requested = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _profile = _lastResolved[widget.userId];
+  }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     // Not initState: resolving reads the client off the Provider, which isn't
-    // available until dependencies are in place.
+    // available until dependencies are in place. Guarded, because this also
+    // fires on every later dependency change — re-resolving there is what used
+    // to blank an already-resolved avatar (#8233).
+    if (_requested) return;
+    _requested = true;
     _resolve();
   }
 
   @override
   void didUpdateWidget(UserProfileBuilder old) {
     super.didUpdateWidget(old);
-    if (old.userId != widget.userId) _resolve();
+    if (old.userId == widget.userId) return;
+    // A different user: what we hold describes the old one, so fall back to
+    // whatever is already known about the new one (null until it resolves).
+    _profile = _lastResolved[widget.userId];
+    _resolve();
   }
 
   void _resolve() {
-    _profile = null;
     final userId = widget.userId;
     // Null is an unfilled activity seat: nothing to look up, and the caller
     // draws its own empty-seat treatment.
     if (userId == null) return;
 
     Matrix.of(context).client.getProfileFromUserId(userId).then((profile) {
+      _lastResolved[userId] = profile;
       // Drop a stale completion: the widget may have moved to another user
       // (marker recycling) while this lookup was in flight.
-      if (mounted && widget.userId == userId) {
+      if (mounted && widget.userId == userId && _profile != profile) {
         setState(() => _profile = profile);
       }
     });

--- a/test/pangea/widgets/user_profile_builder_cache_test.dart
+++ b/test/pangea/widgets/user_profile_builder_cache_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+import 'package:provider/provider.dart';
+
+import 'package:fluffychat/pangea/common/widgets/user_profile_builder.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import '../../utils/test_client.dart';
+
+/// #8233: the avatar on an activity role card flickered back to the letter
+/// placeholder whenever a chat event rebuilt the timeline around it. The
+/// profile lookup is always a future, so both a remount and a plain dependency
+/// change used to hand the builder a null profile again for a frame or more.
+class _FakeMatrixState extends MatrixState {
+  _FakeMatrixState(this._client);
+
+  final Client _client;
+
+  @override
+  Client get client => _client;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const userId = '@avarose20:example.invalid';
+
+  late Client client;
+
+  setUpAll(() async {
+    client = await prepareTestClient();
+    // Seed the SDK's profile cache so the lookup resolves from the database
+    // and never reaches the network — the same path a warm client takes.
+    await client.database.storeUserProfile(
+      userId,
+      CachedProfileInformation.fromProfile(
+        ProfileInformation(
+          displayname: 'Ava Rose',
+          avatarUrl: Uri.parse('mxc://example.invalid/ava'),
+        ),
+        outdated: false,
+        updated: DateTime.now(),
+      ),
+    );
+  });
+
+  tearDownAll(() => client.dispose());
+
+  late List<Profile?> built;
+
+  setUp(() {
+    UserProfileBuilder.clearLastResolvedForTest();
+    built = [];
+  });
+
+  Widget host({Key? key, Brightness brightness = Brightness.light}) =>
+      MaterialApp(
+        theme: ThemeData(brightness: brightness),
+        home: Provider<MatrixState>.value(
+          value: _FakeMatrixState(client),
+          child: UserProfileBuilder(
+            key: key,
+            userId: userId,
+            builder: (context, profile) {
+              // The real callers (UserProfileAvatar, UserProfileName) read
+              // L10n/Theme off this context, so the element carries inherited
+              // dependencies. Without one, didChangeDependencies never fires a
+              // second time and the regression is invisible.
+              Theme.of(context);
+              built.add(profile);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+  testWidgets('a remount draws the resolved profile on its first frame', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host(key: const ValueKey('first')));
+    await tester.pumpAndSettle();
+    expect(built.last?.displayName, 'Ava Rose');
+
+    // A new key forces the State to be recreated, which is what an ancestor
+    // rebuilding its child list into a different shape does to these cards.
+    built = [];
+    await tester.pumpWidget(host(key: const ValueKey('second')));
+    await tester.pump();
+
+    expect(
+      built,
+      isNotEmpty,
+      reason: 'the remounted builder should have been built',
+    );
+    expect(
+      built.map((p) => p?.displayName),
+      everyElement('Ava Rose'),
+      reason: 'a remount must not flash the fallback before re-resolving',
+    );
+  });
+
+  testWidgets('a dependency change does not blank a resolved profile', (
+    tester,
+  ) async {
+    await tester.pumpWidget(host());
+    await tester.pumpAndSettle();
+    expect(built.last?.displayName, 'Ava Rose');
+
+    // Same State, new inherited theme: this drives didChangeDependencies.
+    built = [];
+    await tester.pumpWidget(host(brightness: Brightness.dark));
+    await tester.pumpAndSettle();
+
+    expect(built, isNotEmpty);
+    expect(
+      built.map((p) => p?.displayName),
+      everyElement('Ava Rose'),
+      reason: 'a dependency change must not reset the resolved profile',
+    );
+  });
+}


### PR DESCRIPTION
## What

`UserProfileBuilder` keeps the profile it has already resolved, so an avatar drawn from a bare user id stops falling back to the letter placeholder when the chat rebuilds around it.

## Why

Closes #8233

The lookup behind `UserProfileAvatar` / `UserProfileName` (`Client.getProfileFromUserId`) is always a future, even on a database hit, and the `State` threw away what it held every time it re-resolved. Two things made that visible in a live activity session:

- `_resolve()` ran from `didChangeDependencies`, which fires on *every* later inherited-dependency change, not just the first — and it began by setting `_profile = null`.
- A fresh `State` started from null. These cards sit in the chat timeline, which rebuilds on every event; a rebuild that changes the shape of an ancestor's child list drops and recreates the subtree.

This is the trade-off #8197 called out when it introduced the widget ("an avatar shows its fallback letter for a frame whenever its State is built fresh… worth an eye during QA"). Stepping through the issue's video at 0.1s: three flicker episodes (≈1.0s, ≈10.9s, ≈12.4s), each ~0.1–0.2s, all on the same role-card avatar, each landing as the goal stars changed.

## What changed

`lib/pangea/common/widgets/user_profile_builder.dart`:

- Resolve once per mount instead of on every `didChangeDependencies`; a dependency change no longer blanks a resolved profile.
- A process-wide `_lastResolved` map seeds a fresh `State` synchronously with the last profile resolved for that user id. The refetch still runs on every mount and overwrites, so freshness is unchanged — only the null-for-a-frame gap goes away. Never evicted: entries are a user id, display name and avatar URL, and one session sees few users.
- The completion drops a redundant `setState` when the refetch returns an equal `Profile` (the SDK's `Profile` has value equality).

## Testing

- New `test/pangea/widgets/user_profile_builder_cache_test.dart` (2 tests): a remount draws the resolved profile on its first frame; a dependency change does not blank it. Verified both **fail** against the pre-fix widget (the second reports the builder sequence `['Ava Rose', null, null, 'Ava Rose']` — the flicker) and pass after.
- `fvm flutter test test/` — 2274 pass, 3 skipped, 0 failures.
- `fvm flutter analyze` clean on the touched files; `fvm dart format` clean.
- **Not** verified live. Reproducing needs a two-person activity session earning goal stars mid-conversation, which this machine has no staging credentials for; that is the manual QA step on the issue.

## Deploy Notes

None
