### PR TITLE
fix(activities): treat an unknown room as already left

### DIFF
--- a/lib/pangea/extensions/leave_room_extension.dart
+++ b/lib/pangea/extensions/leave_room_extension.dart
@@ -1,0 +1,26 @@
+import 'package:matrix/matrix.dart';
+
+extension LeaveRoomExtension on Room {
+  /// The responses Synapse gives `/leave` when it no longer knows the room —
+  /// the state an old activity session reaches once no local user is left in
+  /// it. The SDK's [leave] reads them as a leave as well: it drops the room
+  /// from the local database and then rethrows anyway.
+  static const _unknownRoomErrors = {
+    MatrixError.M_NOT_FOUND,
+    MatrixError.M_UNKNOWN,
+  };
+
+  /// [leave], counting a room the homeserver no longer knows as already left.
+  ///
+  /// The room is gone from the client either way, so the exception can only
+  /// produce an error dialog — and a Sentry report — for work that finished
+  /// (#8234). Every other failure still throws: the room is still joined, and
+  /// the learner has to be told the leave did not happen.
+  Future<void> leaveIgnoringUnknownRoom() async {
+    try {
+      await leave();
+    } on MatrixException catch (e) {
+      if (!_unknownRoomErrors.contains(e.error)) rethrow;
+    }
+  }
+}

--- a/lib/routes/chat/activity_sessions/activity_session_start_page.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_start_page.dart
@@ -23,6 +23,7 @@ import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/common/widgets/feedback_dialog.dart';
 import 'package:fluffychat/pangea/common/widgets/feedback_response_dialog.dart';
+import 'package:fluffychat/pangea/extensions/leave_room_extension.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/archived_session_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/confirmed_role_session_controller.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/full_session_controller.dart';
@@ -423,7 +424,9 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
   /// Leave the session room of a removed activity and close its panel — the
   /// only exit for a session that can never be continued (#8064). Same
   /// confirm-then-wait-for-sync flow as the chat's own leave, so the room is
-  /// gone from the list before the panel closes.
+  /// gone from the list before the panel closes. A session this old is often
+  /// one the homeserver has already forgotten, hence
+  /// [LeaveRoomExtension.leaveIgnoringUnknownRoom].
   Future<void> leaveArchivedSession() async {
     final room = activityRoom;
     if (room == null) return;
@@ -440,7 +443,7 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
 
     final result = await showFutureLoadingDialog(
       context: context,
-      future: room.leave,
+      future: room.leaveIgnoringUnknownRoom,
     );
     if (result.isError || !mounted) return;
 

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -60,6 +60,7 @@ import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/controllers/pangea_controller.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
+import 'package:fluffychat/pangea/extensions/leave_room_extension.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/pangea/morphs/morph_features_enum.dart';
 import 'package:fluffychat/pangea/morphs/morph_icon.dart';
@@ -3380,7 +3381,7 @@ class ChatController extends State<ChatPageWithRoom>
     if (confirmed != OkCancelResult.ok) return;
     final result = await showFutureLoadingDialog(
       context: context,
-      future: widget.room.leave,
+      future: widget.room.leaveIgnoringUnknownRoom,
     );
 
     if (result.isError) return;

--- a/lib/widgets/chat_settings_popup_menu.dart
+++ b/lib/widgets/chat_settings_popup_menu.dart
@@ -8,6 +8,7 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/features/navigation/route_facts.dart';
 import 'package:fluffychat/features/navigation/route_paths.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/extensions/leave_room_extension.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/adaptive_dialogs/show_ok_cancel_alert_dialog.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
@@ -74,7 +75,7 @@ class ChatSettingsPopupMenuState extends State<ChatSettingsPopupMenu> {
                 if (confirmed != OkCancelResult.ok) return;
                 final result = await showFutureLoadingDialog(
                   context: context,
-                  future: () => widget.room.leave(),
+                  future: () => widget.room.leaveIgnoringUnknownRoom(),
                 );
                 if (result.error == null) {
                   router.go(PRoutes.chatsList);

--- a/test/pangea/leave_room_extension_test.dart
+++ b/test/pangea/leave_room_extension_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/pangea/extensions/leave_room_extension.dart';
+import 'get_test_client.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const roomId = '!archived:fakeServer.notExisting';
+  const leavePath = '/client/v3/rooms/!archived%3AfakeServer.notExisting/leave';
+
+  late Client client;
+  late FakeMatrixApi api;
+
+  setUp(() async {
+    client = await getTestClient();
+    api = FakeMatrixApi.currentApi!;
+  });
+
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  Room joinedRoom() =>
+      Room(id: roomId, client: client, membership: Membership.join);
+
+  group('leaveIgnoringUnknownRoom', () {
+    test('completes when the homeserver does not know the room', () async {
+      api.api['POST']![leavePath] = (_) => {
+        'errcode': 'M_UNKNOWN',
+        'error': 'Not a known room',
+      };
+
+      await expectLater(joinedRoom().leaveIgnoringUnknownRoom(), completes);
+    });
+
+    test('completes when the homeserver cannot find the room', () async {
+      api.api['POST']![leavePath] = (_) => {
+        'errcode': 'M_NOT_FOUND',
+        'error': 'Room not found',
+      };
+
+      await expectLater(joinedRoom().leaveIgnoringUnknownRoom(), completes);
+    });
+
+    test('rethrows a leave the homeserver refused', () async {
+      api.api['POST']![leavePath] = (_) => {
+        'errcode': 'M_FORBIDDEN',
+        'error': 'You are not allowed to leave this room',
+      };
+
+      await expectLater(
+        joinedRoom().leaveIgnoringUnknownRoom(),
+        throwsA(
+          isA<MatrixException>().having(
+            (e) => e.error,
+            'error',
+            MatrixError.M_FORBIDDEN,
+          ),
+        ),
+      );
+    });
+
+    test('leaves a room the homeserver does know', () async {
+      var left = false;
+      api.api['POST']![leavePath] = (_) {
+        left = true;
+        return <String, Object?>{};
+      };
+
+      await joinedRoom().leaveIgnoringUnknownRoom();
+      expect(left, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
### What

Leaving a room the homeserver no longer knows now counts as a successful leave instead of raising an error dialog.

### Why

Closes #8234.

Synapse answers `/leave` with `404 M_UNKNOWN: Not a known room` once no local user is left in the room — where an old activity session ends up after everyone has gone. The SDK's `Room.leave()` reads that response as a leave too (it drops the room from the local database via a fake sync) and *then* rethrows, so the leave genuinely succeeded and the only thing left for the caller to do with the exception was show "Not a known room" — plus a Sentry report, since `LoadingDialog` logs every future error.

New `Room.leaveIgnoringUnknownRoom()` (`lib/pangea/extensions/leave_room_extension.dart`) swallows exactly the two errors the SDK already turns into a local leave (`M_NOT_FOUND`, `M_UNKNOWN`) and rethrows everything else — a leave that really failed still tells the learner.

Wired into the three user-initiated "Leave" dialogs, all the same action on the same class of room:
- the archived-session CTA (`leaveArchivedSession`) — the surface in the issue
- the chat's own leave (`ChatController.onLeave`)
- chat settings' leave (`ChatSettingsPopupMenu`)

Background/best-effort leaves (preview cleanup, `leaveSpace`, invite decline) already catch and are untouched.

### Testing

- New `test/pangea/leave_room_extension_test.dart` — 4 tests driving the real SDK leave path against `FakeMatrixApi`: completes on `M_UNKNOWN` and on `M_NOT_FOUND`, rethrows `M_FORBIDDEN`, and still calls `/leave` on the happy path.
- `fvm flutter test` — 2276 pass, 3 skipped (endpoint suites, no local creds). `fvm flutter analyze` on the touched files — no issues. `dart format` and the import-sorter push gate — clean.
- Not manually reproduced: a room the homeserver has forgotten can't be conjured locally, so the unit test stands in with the exact production response body. Worth QA'ing on staging/prod against a genuinely old activity session, per the issue's TO TEST.

### Deploy Notes

None.
