### PR TITLE
feat(quests): hide retired quests from the course creation picker

### DIFF
--- a/lib/features/quests/repo/quest_plans_repo.dart
+++ b/lib/features/quests/repo/quest_plans_repo.dart
@@ -41,8 +41,19 @@ class QuestPlansRepo {
   /// Translate a v1-style [CourseFilter] into a v3 quest-plans `where` clause.
   /// Field names differ (v1: top-level ``l1``/``l2``/``cefrLevel``; v3: nested
   /// under ``req.target_l1``/``req.target_language``/``req.target_cefr``).
+  ///
+  /// The ``hidden`` clause is unconditional: a retired quest must not be
+  /// reachable from the picker by paging or by any filter combination. It is
+  /// scoped to *search* on purpose — [get] and [getMany] stay unfiltered so a
+  /// learner whose course was built from a since-hidden quest keeps resolving
+  /// it. Hiding a quest never touches the activities under its objectives;
+  /// those carry their own ``hidden`` flag.
   static Map<String, dynamic> _whereFor(CourseFilter filter) {
-    final clauses = <Map<String, dynamic>>[];
+    final clauses = <Map<String, dynamic>>[
+      {
+        'hidden': {'not_equals': true},
+      },
+    ];
     if (filter.targetLanguage != null) {
       clauses.add({
         'req.target_language': {'equals': filter.targetLanguage!.langCodeShort},
@@ -60,7 +71,6 @@ class QuestPlansRepo {
         'req.target_cefr': {'equals': filter.cefrLevel!.string},
       });
     }
-    if (clauses.isEmpty) return const {};
     if (clauses.length == 1) return clauses.first;
     return {'and': clauses};
   }


### PR DESCRIPTION
Companion to the CMS `quest-plans.hidden` field — pangeachat/cms#408. Choreo side: pangeachat/2-step-choreographer#2983.

The creation picker reads `quest-plans` CMS-direct rather than through choreo, so the filter has to live here too.

The clause is unconditional — a retired quest must not be reachable by paging or by any filter combination — and is scoped to `searchByFilter` on purpose:

- `get` and `getMany` stay unfiltered, so a learner whose course was built from a since-hidden quest keeps resolving it;
- the public course catalog keeps listing already-published course spaces, which it decides from room state and never from the quest behind it (see `public-courses.instructions.md`).

Hiding a quest stops NEW courses being created from it; it does not withdraw published ones. It also never touches the activities under the quest's objectives — those carry their own `hidden` flag.

Drops the now-dead `clauses.isEmpty` early return: with the hidden clause always present, the list is never empty.

## ⚠️ Deploy order — do not merge before the CMS PR

Payload returns **400** on a `where` naming a field it does not know. Landing this before pangeachat/cms#408 is deployed makes the course picker 400 and render nothing.

## Testing

`dart analyze` and `dart format --set-exit-if-changed` both clean on the changed file. The CMS-side behaviour this depends on is covered by 7 integration tests in pangeachat/cms#408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quest-plan searches now automatically exclude hidden records.
  * Direct retrieval of quest plans remains unchanged and can still return hidden records.
  * Searches without course filters now return visible quest plans instead of an empty result query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->