### PR TITLE
fix(profile): don't reserve space for an absent level chip

### DIFF
--- a/lib/widgets/adaptive_dialogs/user_dialog.dart
+++ b/lib/widgets/adaptive_dialogs/user_dialog.dart
@@ -89,7 +89,6 @@ class UserDialog extends StatelessWidget {
 
               return SingleChildScrollView(
                 child: Column(
-                  spacing: 8,
                   mainAxisSize: .min,
                   crossAxisAlignment: .stretch,
                   children: [
@@ -149,6 +148,7 @@ class UserDialog extends StatelessWidget {
                         ),
                       ),
                     ),
+                    const SizedBox(height: 8),
                     Center(
                       child: ExcludeSemantics(
                         child: Avatar(
@@ -165,21 +165,28 @@ class UserDialog extends StatelessWidget {
                         ),
                       ),
                     ),
-                    if (presenceText != null)
+                    if (presenceText != null) ...[
+                      const SizedBox(height: 8),
                       Text(
                         presenceText,
                         style: const TextStyle(fontSize: 10),
                         textAlign: TextAlign.center,
                       ),
-                    Padding(
-                      padding: const EdgeInsets.all(4.0),
-                      child: Column(
-                        children: [
-                          LevelDisplayName(userId: profile.userId),
-                          CountryDisplay(userId: profile.userId),
-                          AboutMeDisplay(userId: profile.userId),
-                        ],
-                      ),
+                    ],
+                    // Each of these draws nothing at all when the user has no
+                    // such data — the bot has none of it — so nothing may pad
+                    // or space them from the outside: that padding is what left
+                    // an empty band under the activeness status (#8238). Each
+                    // line brings its own spacing when it has something to say.
+                    Column(
+                      children: [
+                        LevelDisplayName(
+                          userId: profile.userId,
+                          padding: const EdgeInsets.symmetric(vertical: 8.0),
+                        ),
+                        CountryDisplay(userId: profile.userId),
+                        AboutMeDisplay(userId: profile.userId),
+                      ],
                     ),
                   ],
                 ),

--- a/lib/widgets/users/level_display_name.dart
+++ b/lib/widgets/users/level_display_name.dart
@@ -6,133 +6,148 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/users/level_ribbon.dart';
 
+/// The learner chip — language pair and level — for [userId]'s public profile.
+///
+/// It draws nothing, and takes no space, for a user with no learning data to
+/// show: the bot and the support account have an empty analytics profile, and
+/// so does an account that has not picked a language pair yet. Callers stack it
+/// with the other public-profile lines ([CountryDisplay], [AboutMeDisplay]),
+/// each of which is empty for its own reasons, so a chip that padded itself
+/// even while rendering nothing left a band of dead space under the profile
+/// (#8238).
 class LevelDisplayName extends StatelessWidget {
   final String userId;
   final TextStyle? textStyle;
   final double? iconSize;
   final bool showFlags;
 
+  /// Space around the chip when there is something to draw. The default is the
+  /// tight spacing the member list and the invite list want; the profile dialog
+  /// passes more, because there it is the first of the public-profile lines and
+  /// has to clear the activeness status above it.
+  final EdgeInsetsGeometry padding;
+
   const LevelDisplayName({
     required this.userId,
     this.textStyle,
     this.iconSize,
     this.showFlags = true,
+    this.padding = const EdgeInsets.symmetric(vertical: 2.0),
     super.key,
   });
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 2.0),
-      child: FutureBuilder(
-        future: MatrixState.pangeaController.userController.getPublicProfile(
-          userId,
-        ),
-        builder: (context, snapshot) {
-          final analytics = snapshot.data?.analytics;
-          final base = analytics?.baseLanguage;
-          final target = analytics?.targetLanguage;
-          final level = analytics?.level;
+    return FutureBuilder(
+      future: MatrixState.pangeaController.userController.getPublicProfile(
+        userId,
+      ),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return Padding(
+            padding: padding,
+            child: const Padding(
+              padding: EdgeInsets.all(4.0),
+              child: SizedBox(
+                width: 12.0,
+                height: 12.0,
+                child: CircularProgressIndicator.adaptive(),
+              ),
+            ),
+          );
+        }
 
-          return Row(
+        final analytics = snapshot.data?.analytics;
+        final base = analytics?.baseLanguage;
+        final target = analytics?.targetLanguage;
+        final level = analytics?.level;
+
+        // Nothing learned to show — including the failed-lookup case, which
+        // resolves to a null profile.
+        if (base == null && target == null && level == null) {
+          return const SizedBox.shrink();
+        }
+
+        return Padding(
+          padding: padding,
+          child: Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              if (!snapshot.hasData)
-                const Padding(
-                  padding: EdgeInsets.all(4.0),
-                  child: SizedBox(
-                    width: 12.0,
-                    height: 12.0,
-                    child: CircularProgressIndicator.adaptive(),
+              if (base != null && target != null) ...[
+                if (showFlags) ...[
+                  ExcludeSemantics(
+                    child: SvgPicture.network(
+                      base.svgUrl.toString(),
+                      errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                      placeholderBuilder: (_) => Center(
+                        child: const CircularProgressIndicator(
+                          strokeWidth: 0.5,
+                        ),
+                      ),
+                      width: iconSize ?? 12.0,
+                      height: iconSize ?? 12.0,
+                    ),
                   ),
-                )
-              else if (snapshot.hasError || snapshot.data == null)
-                const SizedBox()
-              else
-                Row(
-                  children: [
-                    if (base != null && target != null) ...[
-                      if (showFlags) ...[
-                        ExcludeSemantics(
-                          child: SvgPicture.network(
-                            base.svgUrl.toString(),
-                            errorBuilder: (_, _, _) => const SizedBox.shrink(),
-                            placeholderBuilder: (_) => Center(
-                              child: const CircularProgressIndicator(
-                                strokeWidth: 0.5,
-                              ),
-                            ),
-                            width: iconSize ?? 12.0,
-                            height: iconSize ?? 12.0,
+                  SizedBox(width: 4.0),
+                ],
+                Semantics(
+                  label:
+                      "${L10n.of(context).sourceLanguage}: ${base.displayName}",
+                  child: ExcludeSemantics(
+                    child: Text(
+                      base.langCodeShort.toUpperCase(),
+                      style:
+                          textStyle ??
+                          TextStyle(
+                            fontWeight: FontWeight.bold,
+                            color: Theme.of(context).colorScheme.primary,
                           ),
-                        ),
-                        SizedBox(width: 4.0),
-                      ],
-                      Semantics(
-                        label:
-                            "${L10n.of(context).sourceLanguage}: ${base.displayName}",
-                        child: ExcludeSemantics(
-                          child: Text(
-                            base.langCodeShort.toUpperCase(),
-                            style:
-                                textStyle ??
-                                TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  color: Theme.of(context).colorScheme.primary,
-                                ),
-                          ),
-                        ),
-                      ),
-                      Icon(
-                        Icons.chevron_right_outlined,
-                        size: iconSize ?? 16.0,
-                      ),
-                    ],
-                    if (target != null) ...[
-                      if (showFlags) ...[
-                        ExcludeSemantics(
-                          child: SvgPicture.network(
-                            target.svgUrl.toString(),
-                            errorBuilder: (_, _, _) => const SizedBox.shrink(),
-                            placeholderBuilder: (_) => Center(
-                              child: const CircularProgressIndicator(
-                                strokeWidth: 0.5,
-                              ),
-                            ),
-                            width: iconSize ?? 12.0,
-                            height: iconSize ?? 12.0,
-                          ),
-                        ),
-                        SizedBox(width: 4.0),
-                      ],
-                      Semantics(
-                        label:
-                            "${L10n.of(context).targetLanguage}: ${target.displayName}",
-                        child: ExcludeSemantics(
-                          child: Text(
-                            target.langCodeShort.toUpperCase(),
-                            style:
-                                textStyle ??
-                                TextStyle(
-                                  fontWeight: FontWeight.bold,
-                                  color: Theme.of(context).colorScheme.primary,
-                                ),
-                          ),
-                        ),
-                      ),
-                    ],
-                    const SizedBox(width: 4.0),
-                    if (level != null)
-                      LevelRibbon(
-                        level: level,
-                        height: (iconSize ?? 16.0) + 2.0,
-                      ),
-                  ],
+                    ),
+                  ),
                 ),
+                Icon(Icons.chevron_right_outlined, size: iconSize ?? 16.0),
+              ],
+              if (target != null) ...[
+                if (showFlags) ...[
+                  ExcludeSemantics(
+                    child: SvgPicture.network(
+                      target.svgUrl.toString(),
+                      errorBuilder: (_, _, _) => const SizedBox.shrink(),
+                      placeholderBuilder: (_) => Center(
+                        child: const CircularProgressIndicator(
+                          strokeWidth: 0.5,
+                        ),
+                      ),
+                      width: iconSize ?? 12.0,
+                      height: iconSize ?? 12.0,
+                    ),
+                  ),
+                  SizedBox(width: 4.0),
+                ],
+                Semantics(
+                  label:
+                      "${L10n.of(context).targetLanguage}: ${target.displayName}",
+                  child: ExcludeSemantics(
+                    child: Text(
+                      target.langCodeShort.toUpperCase(),
+                      style:
+                          textStyle ??
+                          TextStyle(
+                            fontWeight: FontWeight.bold,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                    ),
+                  ),
+                ),
+              ],
+              if (level != null) ...[
+                const SizedBox(width: 4.0),
+                LevelRibbon(level: level, height: (iconSize ?? 16.0) + 2.0),
+              ],
             ],
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/test/pangea/users/level_display_name_test.dart
+++ b/test/pangea/users/level_display_name_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:fluffychat/features/languages/language_model.dart';
+import 'package:fluffychat/features/user/analytics_profile_model.dart';
+import 'package:fluffychat/features/user/public_profile_model.dart';
+import 'package:fluffychat/features/user/user_controller.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/controllers/pangea_controller.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'package:fluffychat/widgets/users/level_display_name.dart';
+import '../../utils/test_client.dart';
+
+/// Regression coverage for #8238 ("Don't reserve space below activeness status
+/// in profile"): the bot has no language pair and no level, but the chip padded
+/// itself and drew a spacer regardless, so every profile that showed it kept a
+/// band of empty space for a widget that was never there.
+class _FakeMatrixState extends MatrixState {
+  _FakeMatrixState(this._client);
+
+  final Client _client;
+
+  @override
+  Client get client => _client;
+}
+
+/// Stands in for the network fetch, which is all [LevelDisplayName] uses the
+/// controller for.
+class _StubUserController extends UserController {
+  _StubUserController(this.profiles);
+
+  final Map<String, PublicProfileModel> profiles;
+
+  @override
+  Future<PublicProfileModel?> getPublicProfile(String userId) async =>
+      profiles[userId];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const botId = '@bot:example.invalid';
+  const learnerId = '@learner:example.invalid';
+  const unknownId = '@unknown:example.invalid';
+
+  final english = LanguageModel(langCode: 'en', displayName: 'English');
+  final german = LanguageModel(langCode: 'de', displayName: 'German');
+
+  late Client client;
+
+  setUpAll(() async {
+    client = await prepareTestClient();
+    // The controller builds a PLanguageStore, which reads its cache from
+    // shared preferences on construction.
+    SharedPreferences.setMockInitialValues({});
+    MatrixState.pangeaController = PangeaController(
+      matrixState: _FakeMatrixState(client),
+    );
+    MatrixState.pangeaController.userController = _StubUserController({
+      // What the bot and any account that hasn't started learning resolve to.
+      botId: PublicProfileModel(analytics: AnalyticsProfileModel()),
+      learnerId: PublicProfileModel(
+        analytics: AnalyticsProfileModel(
+          baseLanguage: english,
+          targetLanguage: german,
+          languageAnalytics: {german: LanguageAnalyticsProfileEntry(2, 0)},
+        ),
+      ),
+    });
+  });
+
+  tearDownAll(() => client.dispose());
+
+  Future<void> pumpChip(WidgetTester tester, String userId) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          // Loose constraints, like the column of profile lines the chip sits
+          // in — so its own size is what's measured.
+          body: Center(
+            child: LevelDisplayName(userId: userId, showFlags: false),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('a profile with nothing learned takes up no space', (
+    tester,
+  ) async {
+    await pumpChip(tester, botId);
+    expect(tester.getSize(find.byType(LevelDisplayName)), Size.zero);
+  });
+
+  testWidgets('a profile that fails to resolve takes up no space', (
+    tester,
+  ) async {
+    await pumpChip(tester, unknownId);
+    expect(tester.getSize(find.byType(LevelDisplayName)), Size.zero);
+  });
+
+  testWidgets('a learner still gets the language pair and level', (
+    tester,
+  ) async {
+    await pumpChip(tester, learnerId);
+    expect(
+      tester.getSize(find.byType(LevelDisplayName)).height,
+      greaterThan(0),
+    );
+    expect(find.text('EN'), findsOneWidget);
+    expect(find.text('DE'), findsOneWidget);
+    expect(find.text('2'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What

The profile dialog no longer reserves space for the language/level chip when the user has none — the empty band under the activeness status on the bot's profile is gone.

## Why

Closes #8238

Two things reserved that space:

- `LevelDisplayName` wrapped itself in padding and emitted a 4px spacer even when the profile had no language pair and no level, so it was never zero-height. (It also spun forever on a failed lookup — `!snapshot.hasData` is true for a null result, so the "no data" branch below it was dead.)
- `UserDialog` wrapped the public-profile lines (level / country / about) in `Padding(all: 4)` and separated them from the presence line with the column's `spacing: 8` — both applied whether or not any of those lines drew anything.

The bot has no language pair, level, country or about, so all of it stacked up under "Currently active".

`LevelDisplayName` now renders `SizedBox.shrink()` when there is nothing to say, and the dialog adds no padding or spacing around the group — each line brings its own spacing when it has content (as `CountryDisplay` and `AboutMeDisplay` already did). The chip keeps its tight default padding for the member list / invite list; the dialog opts into the larger one.

## Testing

- New `test/pangea/users/level_display_name_test.dart` — zero size for a profile with nothing learned, zero size for a lookup that fails, and language codes + level still rendered for a learner. Negative control: with the empty-state guard removed, the first two fail at `Size(0.0, 4.0)`.
- `fvm flutter test` — 2297 passed, 3 skipped.
- `fvm flutter analyze` clean on the changed files.
- Local web build against the local stack: the chip still renders `EN › ES` + level in the course participants grid and the member popup menu.
- Not verified live: the profile dialog itself. The local stack has no bot account (`@bot:local.pangea.chat` isn't registered, so it can't be searched or invited), and the dialog's other entry points — a mention pill in a message, a user-directory hit — weren't reachable there. Needs the staging pass on the linked issue.

## Deploy Notes

None
