### PR TITLE
8210 fix token feedback corrections silently dropped on received messages

### DIFF
--- a/.github/instructions/events-and-tokens.instructions.md
+++ b/.github/instructions/events-and-tokens.instructions.md
@@ -84,6 +84,8 @@ A text representation of a message, stored as `pangea.representation` event:
 - `langCode` — detected language
 - `originalSent` — true if this is the text that was actually sent
 - `originalWritten` — true if this is what the user originally typed
+- `isCorrection` - true if this is a correction of an inaccurate representation event
+- `tokens` - embedded PangeaMessageTokens for this representation, used to keep correction representation events atomic
 
 Interpretation matrix:
 
@@ -107,6 +109,10 @@ Key capabilities:
 - Trigger TTS/STT
 - Get associated practice exercises
 
+PangeaMessageEvent exposes many different accessors for message representations. These include:
+- **originalSent**: the original representation that the user sent, with the embedded choreo record and original tokens
+- **correctedSent**: the corrected version of the originalSent representation, used for display (see [Correcting tokens after the fact](#correcting-tokens-after-the-fact) for more info on representation corrections)
+
 ### PangeaRepresentationEvent (`events/event_wrappers/pangea_representation_event.dart`)
 
 Wraps a `pangea.representation` event. Provides typed access to `PangeaRepresentation` content.
@@ -128,3 +134,15 @@ Wraps a `pangea.record` event. Provides typed access to `ChoreoRecordModel` (edi
 1. **Writing**: Choreographer gets tokens from `/tokenize` on send
 2. **Saving**: `PangeaMessageContentModel` bundles tokens + choreo record + representations → saved as Matrix child events
 3. **Reading**: `PangeaMessageEvent` loads child events → toolbar uses `PangeaToken` list for word cards, practice exercises, analytics
+
+### Correcting tokens after the fact
+
+A token-info-feedback correction (re-tokenization or language re-detection) is persisted as a single child pangea.representation event with the isCorrection flag (crctn) and the corrected tokens embedded in its content (tkns) — one atomic event, no separate child tokens event to race or orphan.
+
+Invariant: a correction is never an m.replace edit. Anyone in the room may author a correction; authorship is not restricted to the message sender.
+
+Read resolution: correctedSent = newest correction with usable tokens, else the embedded originalSent. A correction without usable tokens is ignored (a partial correction can never override a token-rich original); when multiple exist, newest wins. The display path prefers a same-language token-rich correction; a correction in a different language never hijacks a language match.
+
+Invariant: provenance, choreo, and analytics consumers always read originalSent. A correction refines what the message is (language identity, interactive tokens); it never rewrites what the sender actually produced (construct uses, activity summaries, chat export, choreo history).
+
+See [token-info-feedback-v2](token-info-feedback-v2.instructions.md) for more details on token corrections.

--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_data_service.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_data_service.dart
@@ -169,7 +169,7 @@ class AnalyticsPracticeDataService {
       ownMessage: event.senderId == client.userID,
     );
 
-    final tokens = pangeaEvent.originalSent?.tokens;
+    final tokens = pangeaEvent.correctedSent?.tokens;
     if (tokens == null || tokens.length > 25) {
       throw Exception("Too many tokens in _prefetchAudioInfo");
     }

--- a/lib/routes/analytics/construct_analytics/practice/grammar_error_target_generator.dart
+++ b/lib/routes/analytics/construct_analytics/practice/grammar_error_target_generator.dart
@@ -108,6 +108,9 @@ class GrammarErrorTargetGenerator {
     final List<AnalyticsPracticeTarget> targets = [];
     final l2Code =
         MatrixState.pangeaController.userController.userL2!.langCodeShort;
+    // Deliberately originalSent, not correctedSent: these targets derive from
+    // the send-time choreo record, and the tokens must stay aligned with it —
+    // token-feedback corrections carry no choreo.
     final originalSent = event.originalSent;
     if (originalSent?.langCode.split("-").first != l2Code) {
       return targets;

--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -704,7 +704,7 @@ class ChatController extends State<ChatPageWithRoom>
       ownMessage: event.senderId == Matrix.of(context).client.userID,
     );
 
-    final msgLang = pangeaMessageEvent.originalSent?.langCode.split('-').first;
+    final msgLang = pangeaMessageEvent.correctedSent?.langCode.split('-').first;
 
     if (msgLang != l2) return;
 
@@ -713,7 +713,7 @@ class ChatController extends State<ChatPageWithRoom>
     );
     if (newTokens.isEmpty) return;
     final newTokenText = newTokens.first;
-    final token = pangeaMessageEvent.originalSent?.tokens?.firstWhereOrNull(
+    final token = pangeaMessageEvent.correctedSent?.tokens?.firstWhereOrNull(
       (t) => newTokenText == t.text,
     );
     if (token == null) return;

--- a/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
+++ b/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
@@ -13,7 +13,6 @@ import 'package:fluffychat/features/analytics/constructs_model.dart';
 import 'package:fluffychat/pangea/common/constants/model_keys.dart';
 import 'package:fluffychat/pangea/common/models/llm_feedback_model.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
-import 'package:fluffychat/routes/chat/choreographer/choreo_constants.dart';
 import 'package:fluffychat/routes/chat/choreographer/choreo_record_model.dart';
 import 'package:fluffychat/routes/chat/events/constants/message_constants.dart';
 import 'package:fluffychat/routes/chat/events/event_wrappers/pangea_representation_event.dart';
@@ -937,29 +936,33 @@ class PangeaMessageEvent {
           );
   }
 
-  /// Persists a token-info-feedback correction ([tokensSent]) for this
-  /// message.
-  Future<void> sendTokenCorrection(
+  /// Persists a token-info-feedback correction ([tokensSent]) as an atomic
+  /// correction representation: a child `pangea.representation` event with
+  /// the corrected tokens embedded in its content. Not an `m.replace` edit —
+  /// a third party cannot edit someone else's message (the read path discards
+  /// such edits, spec-correctly), but anyone may relate a correction event,
+  /// so this works on received messages too.
+  Future<Event?> sendTokenCorrection(
     String fullText,
     PangeaMessageTokens tokensSent,
   ) async {
-    // No dosage message-envelope emit here: this is an EDIT/re-send of an
-    // already-counted message (token-feedback correction), not a new learner
-    // turn — emitting would double-count. A.3 reconciles turns from the
-    // event_log by distinct message, so the original send already counts.
-    await room.pangeaSendTextEvent(
-      fullText,
-      editEventId: eventId,
-      originalWritten: originalWritten?.content,
-      tokensSent: tokensSent,
-      tokensWritten: originalWritten?.tokens != null
-          ? PangeaMessageTokens(
-              tokens: originalWritten!.tokens!,
-              detections: originalWritten?.detections,
-            )
-          : null,
-      choreo: originalSent?.choreo,
-      messageTag: ChoreoConstants.tokenFeedbackEdit,
+    final representation = PangeaRepresentation(
+      langCode:
+          tokensSent.detections?.firstOrNull?.langCode ??
+          correctedSent?.langCode ??
+          LanguageKeys.unknownLanguage,
+      text: fullText,
+      originalSent: false,
+      originalWritten: false,
+      isCorrection: true,
+      tokens: tokensSent,
+    );
+
+    _representations = null;
+    return room.sendPangeaEvent(
+      content: representation.toJson(),
+      parentEventId: _latestEdit.eventId,
+      type: PangeaEventTypes.representation,
     );
   }
 

--- a/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
+++ b/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
@@ -13,6 +13,7 @@ import 'package:fluffychat/features/analytics/constructs_model.dart';
 import 'package:fluffychat/pangea/common/constants/model_keys.dart';
 import 'package:fluffychat/pangea/common/models/llm_feedback_model.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
+import 'package:fluffychat/routes/chat/choreographer/choreo_constants.dart';
 import 'package:fluffychat/routes/chat/choreographer/choreo_record_model.dart';
 import 'package:fluffychat/routes/chat/events/constants/message_constants.dart';
 import 'package:fluffychat/routes/chat/events/event_wrappers/pangea_representation_event.dart';
@@ -899,6 +900,32 @@ class PangeaMessageEvent {
               originalWritten: false,
             ),
           );
+  }
+
+  /// Persists a token-info-feedback correction ([tokensSent]) for this
+  /// message.
+  Future<void> sendTokenCorrection(
+    String fullText,
+    PangeaMessageTokens tokensSent,
+  ) async {
+    // No dosage message-envelope emit here: this is an EDIT/re-send of an
+    // already-counted message (token-feedback correction), not a new learner
+    // turn — emitting would double-count. A.3 reconciles turns from the
+    // event_log by distinct message, so the original send already counts.
+    await room.pangeaSendTextEvent(
+      fullText,
+      editEventId: eventId,
+      originalWritten: originalWritten?.content,
+      tokensSent: tokensSent,
+      tokensWritten: originalWritten?.tokens != null
+          ? PangeaMessageTokens(
+              tokens: originalWritten!.tokens!,
+              detections: originalWritten?.detections,
+            )
+          : null,
+      choreo: originalSent?.choreo,
+      messageTag: ChoreoConstants.tokenFeedbackEdit,
+    );
   }
 
   Future<String?> _sendRepresentationEvent(

--- a/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
+++ b/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
@@ -248,11 +248,19 @@ class PangeaMessageEvent {
   /// The newest correction representation with usable tokens, if any.
   /// Corrections without usable tokens are ignored, so a partial or malformed
   /// correction can never override a token-rich original.
-  RepresentationEvent? get _sentCorrection => representations.firstWhereOrNull(
-    (element) =>
-        element.content.isCorrection &&
-        hasUsableRepresentationTokens(element.tokens),
-  );
+  RepresentationEvent? get _sentCorrection =>
+      representations.firstWhereOrNull(_isUsableCorrection);
+
+  /// A malformed related representation must be treated as absent, never throw
+  /// out of the display path.
+  static bool _isUsableCorrection(RepresentationEvent rep) {
+    try {
+      return rep.content.isCorrection &&
+          hasUsableRepresentationTokens(rep.tokens);
+    } catch (_) {
+      return false;
+    }
+  }
 
   /// The sent representation with any correction applied. Language-identity
   /// and interactive-token consumers read this; provenance, choreo, and

--- a/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
+++ b/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
@@ -246,6 +246,21 @@ class PangeaMessageEvent {
     (element) => element.content.originalSent,
   );
 
+  /// The newest correction representation with usable tokens, if any.
+  /// Corrections without usable tokens are ignored, so a partial or malformed
+  /// correction can never override a token-rich original.
+  RepresentationEvent? get _sentCorrection => representations.firstWhereOrNull(
+    (element) =>
+        element.content.isCorrection &&
+        hasUsableRepresentationTokens(element.tokens),
+  );
+
+  /// The sent representation with any correction applied. Language-identity
+  /// and interactive-token consumers read this; provenance, choreo, and
+  /// analytics consumers keep reading [originalSent] — a correction never
+  /// rewrites what the sender actually produced.
+  RepresentationEvent? get correctedSent => _sentCorrection ?? originalSent;
+
   /// Vocab + morph construct uses the sender actually produced in this
   /// message — the single source for analytics and used-vocab tracking.
   /// Typed messages read the sent representation's tokens; voice messages
@@ -284,14 +299,14 @@ class PangeaMessageEvent {
     final bool immersionMode = MatrixState.pangeaController.userController
         .isToolEnabled(ToolSetting.immersionMode);
 
-    final String? originalLangCode = originalSent?.langCode;
+    final String? sentLangCode = correctedSent?.langCode;
 
-    final String? langCode = immersionMode ? _l2Code : originalLangCode;
+    final String? langCode = immersionMode ? _l2Code : sentLangCode;
     return langCode ?? LanguageKeys.unknownLanguage;
   }
 
   RepresentationEvent? get messageDisplayRepresentation =>
-      _representationByLanguage(messageDisplayLangCode);
+      _representationByLanguage(messageDisplayLangCode, preferCorrection: true);
 
   /// Gets the message display text for the current language code.
   /// If the message display text is not available for the current language code,
@@ -308,14 +323,32 @@ class PangeaMessageEvent {
     _representations = null;
   }
 
+  /// The first representation matching [langCode]. With [preferCorrection], a
+  /// token-rich correction among the matches beats the embedded original —
+  /// `representations` lists embeds first, then related events newest-first,
+  /// so the first matching correction is the newest one.
   RepresentationEvent? _representationByLanguage(
     String langCode, {
     bool Function(RepresentationEvent)? filter,
-  }) => representations.firstWhereOrNull(
-    (element) =>
-        element.langCode.split("-")[0] == langCode.split("-")[0] &&
-        (filter?.call(element) ?? true),
-  );
+    bool preferCorrection = false,
+  }) {
+    final matches = representations.where(
+      (element) =>
+          element.langCode.split("-")[0] == langCode.split("-")[0] &&
+          (filter?.call(element) ?? true),
+    );
+
+    if (preferCorrection) {
+      final correction = matches.firstWhereOrNull(
+        (element) =>
+            element.content.isCorrection &&
+            hasUsableRepresentationTokens(element.tokens),
+      );
+      if (correction != null) return correction;
+    }
+
+    return matches.firstOrNull;
+  }
 
   /// The newest representation carrying a `speechToText` payload. When
   /// [preferTokens] is set, a token-rich representation (usable transcript AND
@@ -790,14 +823,14 @@ class PangeaMessageEvent {
 
     final langCode = resp.detections.firstOrNull?.langCode;
     if (langCode == null) return null;
-    if (langCode == originalSent?.langCode) {
-      return originalSent?.event?.eventId;
+    if (langCode == correctedSent?.langCode) {
+      return correctedSent?.event?.eventId;
     }
 
     final res = await _requestRepresentation(
-      originalSent?.content.text ?? _latestEdit.body,
+      correctedSent?.content.text ?? _latestEdit.body,
       langCode,
-      originalSent?.langCode ?? LanguageKeys.unknownLanguage,
+      correctedSent?.langCode ?? LanguageKeys.unknownLanguage,
       originalSent: originalSent == null,
     );
 
@@ -840,9 +873,11 @@ class PangeaMessageEvent {
     final includedIT =
         originalSent?.choreo?.endedWithIT(originalSent!.text) == true;
 
+    // srcLang is language identity, so a correction wins; the includedIT
+    // checks above are send-time process history and stay on originalSent.
     final String srcLang = includedIT
         ? (originalWritten?.langCode ?? _l1Code!)
-        : (originalSent?.langCode ?? _l2Code!);
+        : (correctedSent?.langCode ?? _l2Code!);
 
     final text = includedIT ? originalWrittenContent : messageDisplayText;
     final resp = await FullTextTranslationRepo.instance.get(

--- a/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
+++ b/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
@@ -322,11 +322,26 @@ class PangeaMessageEvent {
     _representations = null;
   }
 
-  /// The first representation matching [langCode]. With [preferCorrection], a
-  /// token-rich correction among the matches beats the embedded original —
-  /// `representations` lists embeds first, then related events newest-first,
-  /// so the first matching correction is the newest one.
   RepresentationEvent? _representationByLanguage(
+    String langCode, {
+    bool Function(RepresentationEvent)? filter,
+    bool preferCorrection = false,
+  }) => pickRepresentationByLanguage(
+    representations,
+    langCode,
+    filter: filter,
+    preferCorrection: preferCorrection,
+  );
+
+  /// The first of [representations] matching [langCode]. With
+  /// [preferCorrection], a token-rich correction among the matches beats the
+  /// embedded original — [representations] lists embeds first, then related
+  /// events newest-first, so the first matching correction is the newest one.
+  /// A correction in a DIFFERENT language never hijacks a match, and a
+  /// correction without usable tokens is ignored. Pure -> unit-testable.
+  @visibleForTesting
+  static RepresentationEvent? pickRepresentationByLanguage(
+    List<RepresentationEvent> representations,
     String langCode, {
     bool Function(RepresentationEvent)? filter,
     bool preferCorrection = false,
@@ -946,16 +961,10 @@ class PangeaMessageEvent {
     String fullText,
     PangeaMessageTokens tokensSent,
   ) async {
-    final representation = PangeaRepresentation(
-      langCode:
-          tokensSent.detections?.firstOrNull?.langCode ??
-          correctedSent?.langCode ??
-          LanguageKeys.unknownLanguage,
-      text: fullText,
-      originalSent: false,
-      originalWritten: false,
-      isCorrection: true,
-      tokens: tokensSent,
+    final representation = buildTokenCorrection(
+      fullText: fullText,
+      tokensSent: tokensSent,
+      fallbackLangCode: correctedSent?.langCode,
     );
 
     _representations = null;
@@ -965,6 +974,27 @@ class PangeaMessageEvent {
       type: PangeaEventTypes.representation,
     );
   }
+
+  /// Pure builder behind [sendTokenCorrection]: the correction's language
+  /// comes from its own detections (where the feedback flow records a
+  /// language update), falling back to [fallbackLangCode] — the current sent
+  /// representation's language. Pure -> unit-testable.
+  @visibleForTesting
+  static PangeaRepresentation buildTokenCorrection({
+    required String fullText,
+    required PangeaMessageTokens tokensSent,
+    String? fallbackLangCode,
+  }) => PangeaRepresentation(
+    langCode:
+        tokensSent.detections?.firstOrNull?.langCode ??
+        fallbackLangCode ??
+        LanguageKeys.unknownLanguage,
+    text: fullText,
+    originalSent: false,
+    originalWritten: false,
+    isCorrection: true,
+    tokens: tokensSent,
+  );
 
   Future<String?> _sendRepresentationEvent(
     PangeaRepresentation representation,

--- a/lib/routes/chat/events/event_wrappers/pangea_representation_event.dart
+++ b/lib/routes/chat/events/event_wrappers/pangea_representation_event.dart
@@ -61,7 +61,8 @@ class RepresentationEvent {
 
   String get langCode => content.langCode;
 
-  List<LanguageDetectionModel>? get detections => _tokens?.detections;
+  List<LanguageDetectionModel>? get detections =>
+      (_tokens ?? content.tokens)?.detections;
 
   Set<Event> get tokenEvents =>
       _event?.aggregatedEvents(timeline, PangeaEventTypes.tokens) ?? {};
@@ -80,6 +81,15 @@ class RepresentationEvent {
 
   List<PangeaToken>? get tokens {
     if (_tokens != null) return _tokens!.tokens;
+
+    // tokens embedded in the representation content (an atomic correction)
+    // take precedence over child token events
+    final embedded = content.tokens;
+    if (embedded != null) {
+      _tokens = embedded;
+      return embedded.tokens;
+    }
+
     if (_event == null) return null;
 
     if (tokenEvents.isEmpty) return null;

--- a/lib/routes/chat/events/event_wrappers/pangea_representation_event.dart
+++ b/lib/routes/chat/events/event_wrappers/pangea_representation_event.dart
@@ -85,7 +85,7 @@ class RepresentationEvent {
     // tokens embedded in the representation content (an atomic correction)
     // take precedence over child token events
     final embedded = content.tokens;
-    if (embedded != null) {
+    if (embedded != null && embedded.tokens.isNotEmpty) {
       _tokens = embedded;
       return embedded.tokens;
     }

--- a/lib/routes/chat/events/models/representation_content_model.dart
+++ b/lib/routes/chat/events/models/representation_content_model.dart
@@ -8,6 +8,7 @@ import 'package:fluffychat/routes/chat/choreographer/igc/pangea_match_model.dart
 import 'package:fluffychat/routes/chat/choreographer/igc/pangea_match_status_enum.dart';
 import 'package:fluffychat/routes/chat/choreographer/igc/span_choice_type_enum.dart';
 import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
+import 'package:fluffychat/routes/chat/events/models/tokens_event_content_model.dart';
 import 'package:fluffychat/routes/chat/events/speech_to_text/speech_to_text_response_model.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
@@ -29,8 +30,21 @@ class PangeaRepresentation {
   bool originalSent;
   bool originalWritten;
 
+  /// this representation supersedes the message's sent representation for
+  /// language identity and interactive tokens (e.g. a re-tokenization from
+  /// token-info feedback); it may be authored by a user other than the
+  /// message sender. never claims [originalSent] — provenance, choreo, and
+  /// analytics consumers keep reading the embedded original.
+  bool isCorrection;
+
   // a representation can be create via speech to text on the original message
   SpeechToTextResponseModel? speechToText;
+
+  /// tokens embedded directly in the representation content, so a correction
+  /// is a single atomic event — no separate child tokens event to race or
+  /// orphan. non-correction representations keep tokens in child
+  /// [PangeaTokensEvent]s.
+  PangeaMessageTokens? tokens;
 
   // how do we know which representation was sent by author?
   // RepresentationEvent.text == PangeaMessageEvent.event.body
@@ -59,7 +73,9 @@ class PangeaRepresentation {
     required this.text,
     required this.originalSent,
     required this.originalWritten,
+    this.isCorrection = false,
     this.speechToText,
+    this.tokens,
   });
 
   factory PangeaRepresentation.fromJson(Map<String, dynamic> json) {
@@ -68,9 +84,15 @@ class PangeaRepresentation {
       text: json[_textKey],
       originalSent: json[_originalSentKey] ?? false,
       originalWritten: json[_originalWrittenKey] ?? false,
+      isCorrection: json[_isCorrectionKey] ?? false,
       speechToText: json[_speechToTextKey] == null
           ? null
           : SpeechToTextResponseModel.fromJson(json[_speechToTextKey]),
+      tokens: json[_tokensKey] == null
+          ? null
+          : PangeaMessageTokens.fromJson(
+              Map<String, dynamic>.from(json[_tokensKey]),
+            ),
     );
   }
 
@@ -78,7 +100,9 @@ class PangeaRepresentation {
   static const _langCodeKey = "lang";
   static const _originalSentKey = "snt";
   static const _originalWrittenKey = "wrttn";
+  static const _isCorrectionKey = "crctn";
   static const _speechToTextKey = "stt";
+  static const _tokensKey = "tkns";
 
   Map<String, dynamic> toJson() {
     final data = <String, dynamic>{};
@@ -86,8 +110,12 @@ class PangeaRepresentation {
     data[_langCodeKey] = langCode;
     if (originalSent) data[_originalSentKey] = originalSent;
     if (originalWritten) data[_originalWrittenKey] = originalWritten;
+    if (isCorrection) data[_isCorrectionKey] = isCorrection;
     if (speechToText != null) {
       data[_speechToTextKey] = speechToText!.toJson();
+    }
+    if (tokens != null) {
+      data[_tokensKey] = tokens!.toJson();
     }
     return data;
   }

--- a/lib/routes/chat/events/text_to_speech/message_read_aloud_controller.dart
+++ b/lib/routes/chat/events/text_to_speech/message_read_aloud_controller.dart
@@ -229,7 +229,7 @@ class MessageReadAloudController {
     final targetLangCode =
         MatrixState.pangeaController.userController.userL2?.langCodeShort;
     if (targetLangCode == null) return false;
-    final messageLangCode = message.originalSent?.langCode.split('-').first;
+    final messageLangCode = message.correctedSent?.langCode.split('-').first;
     return messageLangCode == targetLangCode;
   }
 

--- a/lib/routes/chat/events/token_info_feedback/token_info_feedback_dialog.dart
+++ b/lib/routes/chat/events/token_info_feedback/token_info_feedback_dialog.dart
@@ -2,10 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/widgets/feedback_dialog.dart';
-import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/pangea/lemmas/lemma_info_repo.dart';
 import 'package:fluffychat/pangea/lemmas/lemma_info_response.dart';
-import 'package:fluffychat/routes/chat/choreographer/choreo_constants.dart';
 import 'package:fluffychat/routes/chat/events/event_wrappers/pangea_message_event.dart';
 import 'package:fluffychat/routes/chat/events/models/language_detection_model.dart';
 import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
@@ -86,24 +84,7 @@ class TokenInfoFeedbackDialog extends StatelessWidget {
     );
 
     if (requestData.fullText != null && event != null) {
-      // No dosage message-envelope emit here: this is an EDIT/re-send of an
-      // already-counted message (token-feedback correction), not a new learner
-      // turn — emitting would double-count. A.3 reconciles turns from the
-      // event_log by distinct message, so the original send already counts.
-      await event!.room.pangeaSendTextEvent(
-        requestData.fullText!,
-        editEventId: event!.eventId,
-        originalWritten: event!.originalWritten?.content,
-        tokensSent: tokensSent,
-        tokensWritten: event!.originalWritten?.tokens != null
-            ? PangeaMessageTokens(
-                tokens: event!.originalWritten!.tokens!,
-                detections: event!.originalWritten?.detections,
-              )
-            : null,
-        choreo: originalSent?.choreo,
-        messageTag: ChoreoConstants.tokenFeedbackEdit,
-      );
+      await event!.sendTokenCorrection(requestData.fullText!, tokensSent);
     }
 
     return response.userFriendlyMessage;

--- a/lib/routes/chat/events/token_info_feedback/token_info_feedback_dialog.dart
+++ b/lib/routes/chat/events/token_info_feedback/token_info_feedback_dialog.dart
@@ -50,15 +50,17 @@ class TokenInfoFeedbackDialog extends StatelessWidget {
       await _updatePhoneticTranscription(response.updatedPhonetics!);
     }
 
-    final originalSent = event?.originalSent;
+    // baseline for "did the language change" is the corrected sent rep, so a
+    // second round of feedback compares against the prior correction
+    final sent = event?.correctedSent;
 
     // if no other changes, just return the message
     final hasTokenUpdate =
         response.updatedTokens != null || response.updatedToken != null;
     final hasLangUpdate =
-        originalSent != null &&
+        sent != null &&
         response.updatedLanguage != null &&
-        response.updatedLanguage != originalSent.langCode;
+        response.updatedLanguage != sent.langCode;
 
     if (!hasTokenUpdate && !hasLangUpdate) {
       return response.userFriendlyMessage;
@@ -72,8 +74,7 @@ class TokenInfoFeedbackDialog extends StatelessWidget {
       tokens[requestData.selectedToken] = response.updatedToken!;
     }
 
-    final updatedLanguage =
-        response.updatedLanguage ?? event?.originalSent?.langCode;
+    final updatedLanguage = response.updatedLanguage ?? sent?.langCode;
 
     final tokensSent = PangeaMessageTokens(
       tokens: tokens,

--- a/lib/routes/chat/toolbar/reading_assistance/select_mode_buttons.dart
+++ b/lib/routes/chat/toolbar/reading_assistance/select_mode_buttons.dart
@@ -368,7 +368,7 @@ class SelectModeButtonsState extends State<SelectModeButtons> {
 
   Future<void> modeDisabled() async {
     final chat = widget.controller.chatController;
-    final targetLangCode = controller.messageEvent.originalSent?.langCode;
+    final targetLangCode = controller.messageEvent.correctedSent?.langCode;
     LanguageModel? targetLang;
     if (targetLangCode != null) {
       targetLang = PLanguageStore.byLangCode(targetLangCode);

--- a/lib/routes/chat/toolbar/word_card/reading_assistance_content.dart
+++ b/lib/routes/chat/toolbar/word_card/reading_assistance_content.dart
@@ -32,7 +32,7 @@ class ReadingAssistanceContent extends StatelessWidget {
       return const SizedBox();
     }
 
-    final tokens = overlayController.pangeaMessageEvent.originalSent?.tokens;
+    final tokens = overlayController.pangeaMessageEvent.correctedSent?.tokens;
     final selectedToken = overlayController.selectedToken;
     final selectedTokenIndex = selectedToken != null
         ? tokens?.indexWhere((t) => t.text == selectedToken.text) ?? -1

--- a/test/pangea/token_correction_test.dart
+++ b/test/pangea/token_correction_test.dart
@@ -1,0 +1,385 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/routes/chat/events/constants/message_constants.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/routes/chat/events/event_wrappers/pangea_message_event.dart';
+import 'package:fluffychat/routes/chat/events/models/language_detection_model.dart';
+import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
+import 'package:fluffychat/routes/chat/events/models/representation_content_model.dart';
+import 'package:fluffychat/routes/chat/events/models/tokens_event_content_model.dart';
+import 'get_test_client.dart';
+
+/// #8210 — token-info-feedback corrections as atomic correction
+/// representations.
+///
+/// Write side: `buildTokenCorrection` (the pure builder behind
+/// `sendTokenCorrection`) marks the rep `isCorrection` and embeds the tokens
+/// in its content. Read side: `correctedSent` / `pickRepresentationByLanguage`
+/// prefer a token-rich correction over the stale embedded original — the fix
+/// for corrections silently dropped on received messages — while
+/// `originalSent` keeps reporting what the sender actually produced.
+///
+/// The read-path tests feed the exact `toJson` output of the builder through
+/// a timeline rep event, so the write and read paths are tested against each
+/// other with no network.
+
+PangeaToken _token(String content, int offset) => PangeaToken.fromJson({
+  'text': {'content': content, 'offset': offset, 'length': content.length},
+  'lemma': {'text': content, 'save_vocab': true, 'form': content},
+  'pos': 'NOUN',
+  'morph': <String, dynamic>{},
+});
+
+/// The mis-tokenized shape from the issue: the whole phrase as ONE token.
+PangeaMessageTokens _hugeTokenEmbed() => PangeaMessageTokens(
+  tokens: [_token('buenosdías', 0)],
+  detections: const [LanguageDetectionModel(langCode: 'es', confidence: 1)],
+);
+
+/// The corrected shape: the phrase split into individual words.
+PangeaMessageTokens _splitTokens({String langCode = 'es'}) =>
+    PangeaMessageTokens(
+      tokens: [_token('buenos', 0), _token('días', 7)],
+      detections: [LanguageDetectionModel(langCode: langCode, confidence: 1)],
+    );
+
+void main() {
+  group('PangeaRepresentation wire format', () {
+    test('round-trips isCorrection and embedded tokens', () {
+      final rep = PangeaRepresentation(
+        langCode: 'es',
+        text: 'buenos días',
+        originalSent: false,
+        originalWritten: false,
+        isCorrection: true,
+        tokens: _splitTokens(),
+      );
+
+      final parsed = PangeaRepresentation.fromJson(rep.toJson());
+      expect(parsed.isCorrection, isTrue);
+      expect(parsed.tokens, isNotNull);
+      expect(parsed.tokens!.tokens.map((t) => t.text.content), [
+        'buenos',
+        'días',
+      ]);
+      expect(parsed.tokens!.detections?.first.langCode, 'es');
+    });
+
+    test('legacy json without the new keys parses as a non-correction', () {
+      final parsed = PangeaRepresentation.fromJson({
+        'txt': 'buenos días',
+        'lang': 'es',
+      });
+      expect(parsed.isCorrection, isFalse);
+      expect(parsed.tokens, isNull);
+    });
+
+    test('toJson omits the new keys on a non-correction (legacy shape '
+        'byte-stable)', () {
+      final json = PangeaRepresentation(
+        langCode: 'es',
+        text: 'buenos días',
+        originalSent: true,
+        originalWritten: false,
+      ).toJson();
+      expect(json.containsKey('crctn'), isFalse);
+      expect(json.containsKey('tkns'), isFalse);
+    });
+  });
+
+  group('with a live timeline', () {
+    late Client client;
+    late Room room;
+    late Timeline timeline;
+    late PangeaMessageEvent message;
+
+    const messageEventId = r'$msg:fakeServer.notExisting';
+
+    setUp(() async {
+      client = await getTestClient();
+      room = Room(id: '!chat:fakeServer.notExisting', client: client);
+      timeline = await room.getTimeline();
+      // A RECEIVED text message (sender != the test client's user) whose
+      // embedded tokensSent carries the mis-tokenized single huge token.
+      message = PangeaMessageEvent(
+        event: Event(
+          type: EventTypes.Message,
+          eventId: messageEventId,
+          senderId: '@othertest:fakeServer.notExisting',
+          originServerTs: DateTime.now(),
+          content: {
+            'msgtype': 'm.text',
+            'body': 'buenosdías',
+            MessageConstants.tokensSent: _hugeTokenEmbed().toJson(),
+          },
+          room: room,
+        ),
+        timeline: timeline,
+        ownMessage: false,
+      );
+    });
+
+    tearDown(() async {
+      timeline.cancelSubscriptions();
+      await client.dispose();
+    });
+
+    /// A correction rep event whose content is EXACTLY what the write path
+    /// produces (`buildTokenCorrection(...).toJson()`).
+    Event correctionEvent(
+      String eventId,
+      DateTime ts, {
+      PangeaMessageTokens? tokensSent,
+      String text = 'buenosdías',
+    }) => Event(
+      type: PangeaEventTypes.representation,
+      eventId: eventId,
+      senderId: client.userID!,
+      originServerTs: ts,
+      content: {
+        PangeaEventTypes.representation: PangeaMessageEvent.buildTokenCorrection(
+          fullText: text,
+          tokensSent: tokensSent ?? _splitTokens(),
+          fallbackLangCode: 'es',
+        ).toJson(),
+      },
+      room: room,
+    );
+
+    void inject(List<Event> repEvents) {
+      timeline.aggregatedEvents[messageEventId] = {
+        PangeaEventTypes.representation: repEvents.toSet(),
+      };
+    }
+
+    test('without a correction, correctedSent falls back to originalSent', () {
+      expect(message.originalSent, isNotNull);
+      expect(message.correctedSent, same(message.originalSent));
+      expect(message.correctedSent!.tokens!.map((t) => t.text.content), [
+        'buenosdías',
+      ]);
+    });
+
+    test('a token-rich correction wins over the stale embed on a RECEIVED '
+        'message; originalSent still reports what the sender produced', () {
+      inject([correctionEvent(r'$corr:s', DateTime.now())]);
+
+      // Teeth: before #8210 the correction (an m.replace by a third party)
+      // was discarded and the huge token stayed the only readable shape.
+      expect(message.correctedSent!.tokens!.map((t) => t.text.content), [
+        'buenos',
+        'días',
+      ]);
+      expect(message.correctedSent!.event?.eventId, r'$corr:s');
+
+      // Provenance is untouched: analytics/choreo consumers still see the
+      // sender's actual production through originalSent.
+      expect(message.originalSent!.tokens!.map((t) => t.text.content), [
+        'buenosdías',
+      ]);
+    });
+
+    test('a correction WITHOUT usable tokens is ignored (a partial correction '
+        'can never override a token-rich original)', () {
+      inject([
+        correctionEvent(
+          r'$corr-empty:s',
+          DateTime.now(),
+          tokensSent: PangeaMessageTokens(tokens: []),
+        ),
+      ]);
+
+      expect(message.correctedSent, same(message.originalSent));
+    });
+
+    test('with two corrections, the NEWEST wins', () {
+      final now = DateTime.now();
+      inject([
+        correctionEvent(
+          r'$corr-old:s',
+          now.subtract(const Duration(minutes: 1)),
+        ),
+        correctionEvent(
+          r'$corr-new:s',
+          now,
+          tokensSent: PangeaMessageTokens(
+            tokens: [_token('buenos', 0), _token('día', 7), _token('s', 10)],
+            detections: const [
+              LanguageDetectionModel(langCode: 'es', confidence: 1),
+            ],
+          ),
+        ),
+      ]);
+
+      expect(message.correctedSent!.event?.eventId, r'$corr-new:s');
+      expect(message.correctedSent!.tokens, hasLength(3));
+    });
+
+    test('a language-update correction changes correctedSent.langCode', () {
+      inject([
+        correctionEvent(
+          r'$corr-lang:s',
+          DateTime.now(),
+          tokensSent: _splitTokens(langCode: 'pt'),
+        ),
+      ]);
+
+      expect(message.originalSent!.langCode, 'es');
+      expect(message.correctedSent!.langCode, 'pt');
+    });
+
+    group('RepresentationEvent token sourcing', () {
+      test('content-embedded tokens win over a child tokens event', () {
+        final correction = correctionEvent(r'$corr2:s', DateTime.now());
+        inject([correction]);
+        // A stale child tokens event under the correction: embedded must win.
+        timeline.aggregatedEvents[correction.eventId] = {
+          PangeaEventTypes.tokens: {
+            Event(
+              type: PangeaEventTypes.tokens,
+              eventId: r'$childtokens:s',
+              senderId: client.userID!,
+              originServerTs: DateTime.now(),
+              content: {
+                PangeaEventTypes.tokens: PangeaMessageTokens(
+                  tokens: [_token('stale', 0)],
+                ).toJson(),
+              },
+              room: room,
+            ),
+          },
+        };
+
+        expect(message.correctedSent!.tokens!.map((t) => t.text.content), [
+          'buenos',
+          'días',
+        ]);
+      });
+
+      test('a rep without embedded tokens still reads its child tokens event '
+          '(pre-correction path intact)', () {
+        final plainRep = Event(
+          type: PangeaEventTypes.representation,
+          eventId: r'$plainrep:s',
+          senderId: client.userID!,
+          originServerTs: DateTime.now(),
+          content: {
+            PangeaEventTypes.representation: PangeaRepresentation(
+              langCode: 'en',
+              text: 'good morning',
+              originalSent: false,
+              originalWritten: false,
+            ).toJson(),
+          },
+          room: room,
+        );
+        inject([plainRep]);
+        timeline.aggregatedEvents[plainRep.eventId] = {
+          PangeaEventTypes.tokens: {
+            Event(
+              type: PangeaEventTypes.tokens,
+              eventId: r'$childtokens2:s',
+              senderId: client.userID!,
+              originServerTs: DateTime.now(),
+              content: {
+                PangeaEventTypes.tokens: PangeaMessageTokens(
+                  tokens: [_token('good', 0), _token('morning', 5)],
+                ).toJson(),
+              },
+              room: room,
+            ),
+          },
+        };
+
+        final rep = message.representations.firstWhere(
+          (r) => r.event?.eventId == r'$plainrep:s',
+        );
+        expect(rep.tokens!.map((t) => t.text.content), ['good', 'morning']);
+      });
+    });
+
+    group('pickRepresentationByLanguage', () {
+      test('preferCorrection: a same-language token-rich correction beats the '
+          'earlier embed match', () {
+        inject([correctionEvent(r'$corr3:s', DateTime.now())]);
+        final picked = PangeaMessageEvent.pickRepresentationByLanguage(
+          message.representations,
+          'es',
+          preferCorrection: true,
+        );
+        expect(picked?.event?.eventId, r'$corr3:s');
+      });
+
+      test('a correction in a DIFFERENT language never hijacks the display '
+          'match', () {
+        inject([
+          correctionEvent(
+            r'$corr-fr:s',
+            DateTime.now(),
+            tokensSent: _splitTokens(langCode: 'fr'),
+          ),
+        ]);
+        final picked = PangeaMessageEvent.pickRepresentationByLanguage(
+          message.representations,
+          'es',
+          preferCorrection: true,
+        );
+        // The es-language match is still the embedded original.
+        expect(picked, same(message.originalSent));
+      });
+
+      test('without preferCorrection the embed keeps winning (legacy display '
+          'behavior)', () {
+        inject([correctionEvent(r'$corr4:s', DateTime.now())]);
+        final picked = PangeaMessageEvent.pickRepresentationByLanguage(
+          message.representations,
+          'es',
+        );
+        expect(picked, same(message.originalSent));
+      });
+    });
+  });
+
+  group('buildTokenCorrection', () {
+    test('marks the rep a correction and embeds the tokens', () {
+      final rep = PangeaMessageEvent.buildTokenCorrection(
+        fullText: 'buenosdías',
+        tokensSent: _splitTokens(),
+      );
+      expect(rep.isCorrection, isTrue);
+      expect(rep.originalSent, isFalse);
+      expect(rep.originalWritten, isFalse);
+      expect(rep.text, 'buenosdías');
+      expect(rep.tokens!.tokens, hasLength(2));
+    });
+
+    test('langCode comes from the correction detections first', () {
+      final rep = PangeaMessageEvent.buildTokenCorrection(
+        fullText: 'bom dia',
+        tokensSent: _splitTokens(langCode: 'pt'),
+        fallbackLangCode: 'es',
+      );
+      expect(rep.langCode, 'pt');
+    });
+
+    test('falls back to fallbackLangCode, then unknown', () {
+      final noDetections = PangeaMessageTokens(tokens: [_token('hola', 0)]);
+      expect(
+        PangeaMessageEvent.buildTokenCorrection(
+          fullText: 'hola',
+          tokensSent: noDetections,
+          fallbackLangCode: 'es',
+        ).langCode,
+        'es',
+      );
+      expect(
+        PangeaMessageEvent.buildTokenCorrection(
+          fullText: 'hola',
+          tokensSent: noDetections,
+        ).langCode,
+        'unk',
+      );
+    });
+  });
+}

--- a/test/pangea/token_correction_test.dart
+++ b/test/pangea/token_correction_test.dart
@@ -138,11 +138,12 @@ void main() {
       senderId: client.userID!,
       originServerTs: ts,
       content: {
-        PangeaEventTypes.representation: PangeaMessageEvent.buildTokenCorrection(
-          fullText: text,
-          tokensSent: tokensSent ?? _splitTokens(),
-          fallbackLangCode: 'es',
-        ).toJson(),
+        PangeaEventTypes.representation:
+            PangeaMessageEvent.buildTokenCorrection(
+              fullText: text,
+              tokensSent: tokensSent ?? _splitTokens(),
+              fallbackLangCode: 'es',
+            ).toJson(),
       },
       room: room,
     );


### PR DESCRIPTION
*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for corrected message representations with embedded language tokens.
  * Improved token corrections, including persistence, language handling, translation, speech recognition, and text-to-speech.
  * Reading assistance now uses corrected text and token data when available.
  * Token-feedback corrections are saved through the updated correction flow.

* **Bug Fixes**
  * Improved handling of invalid, incomplete, or malformed corrections.

* **Documentation**
  * Documented correction behavior, precedence, language matching, authorship, and provenance rules.

* **Tests**
  * Added comprehensive coverage for correction formats, selection, serialization, language handling, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->