### PR TITLE
feat(courses): badge the mobile Courses tab on a pending course invite

### DIFF
--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -55,6 +55,12 @@ class MobileNavWidget extends StatefulWidget {
   /// button.
   final Widget Function(Widget child)? chatsBadgeBuilder;
 
+  /// Wraps the Courses rail item with the invited-course badge, so a pending
+  /// course invitation is visible without opening the hub (#8190). Injected by
+  /// the shell for the same reason as [chatsBadgeBuilder]. Null renders the
+  /// plain button.
+  final Widget Function(Widget child)? coursesBadgeBuilder;
+
   /// The open section/course content hosted in the cavity. Null means nothing
   /// is cavity-hosted (rail-only, no matter the last height).
   final Widget? cavityChild;
@@ -170,6 +176,7 @@ class MobileNavWidget extends StatefulWidget {
     required this.onCourseShortcutTap,
     required this.onSectionTap,
     this.chatsBadgeBuilder,
+    this.coursesBadgeBuilder,
     this.cavityChild,
     this.cavitySection,
     this.courseShortcutHostsCavity = false,
@@ -551,6 +558,9 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
   Widget _withChatsBadge(Widget child) =>
       widget.chatsBadgeBuilder?.call(child) ?? child;
 
+  Widget _withCoursesBadge(Widget child) =>
+      widget.coursesBadgeBuilder?.call(child) ?? child;
+
   void _onCourseShortcutTap() {
     // The shortcut's own toggle: when its course IS the hosted sheet, the tap
     // collapses/re-expands like any active rail item — a same-URL navigation
@@ -765,18 +775,20 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
                                       ),
                                     ),
                                   ),
-                                  _RailButton(
-                                    icon: Icons.map_outlined,
-                                    selectedIcon: Icons.map,
-                                    // The specific course's highlight (the
-                                    // shortcut) outranks the section icon.
-                                    selected:
-                                        widget.activeSection ==
-                                            AppSection.courses &&
-                                        !widget.courseShortcutSelected,
-                                    tooltip: l10n.courses,
-                                    onTap: () =>
-                                        _onRailItemTap(AppSection.courses),
+                                  _withCoursesBadge(
+                                    _RailButton(
+                                      icon: Icons.map_outlined,
+                                      selectedIcon: Icons.map,
+                                      // The specific course's highlight (the
+                                      // shortcut) outranks the section icon.
+                                      selected:
+                                          widget.activeSection ==
+                                              AppSection.courses &&
+                                          !widget.courseShortcutSelected,
+                                      tooltip: l10n.courses,
+                                      onTap: () =>
+                                          _onRailItemTap(AppSection.courses),
+                                    ),
                                   ),
                                   _CourseShortcutButton(
                                     icon: widget.courseShortcutIcon,

--- a/lib/widgets/layouts/workspace_shell.dart
+++ b/lib/widgets/layouts/workspace_shell.dart
@@ -20,6 +20,7 @@ import 'package:fluffychat/features/navigation/token_params/room_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/widgets/course_avatar.dart';
+import 'package:fluffychat/pangea/common/widgets/invited_course_badge.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/pangea/spaces/client_spaces_extension.dart';
 import 'package:fluffychat/pangea/spaces/knocking_users_badge.dart';
@@ -769,6 +770,27 @@ class _MobileNavLayerState extends State<_MobileNavLayer> {
             badgePosition: BadgePosition.topEnd(top: -1, end: -1),
             child: child,
           ),
+        ),
+        // The same gold envelope the invited course's own avatar wears in the
+        // hub list, on the tab that opens it: a pending invitation is
+        // otherwise invisible until the learner opens the Courses hub (#8190).
+        // Same invited-space predicate as `sortedCourses`, so the badge shows
+        // exactly when the hub has an invited course to show.
+        coursesBadgeBuilder: (child) => StreamBuilder(
+          stream: client.onSync.stream
+              .where((s) => s.hasRoomUpdate)
+              .rateLimit(const Duration(seconds: 1)),
+          builder: (context, _) =>
+              client.rooms.any(
+                (r) => r.isSpace && r.membership == Membership.invite,
+              )
+              ? InvitedCourseBadge(
+                  // The unread badge's position on the sibling Chats tab —
+                  // both ride the corner of a 24px rail icon.
+                  position: BadgePosition.topEnd(top: -1, end: -1),
+                  child: child,
+                )
+              : child,
         ),
         onSectionTap: (section) => context.go(switch (section) {
           // World is home: clear every panel and reveal the full map.

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -35,6 +35,7 @@ void main() {
     ValueChanged<bool>? onCavityFullChanged,
     double keyboardInset = 0.0,
     Widget Function(Widget child)? chatsBadgeBuilder,
+    Widget Function(Widget child)? coursesBadgeBuilder,
     bool settle = true,
   }) async {
     tester.view.physicalSize = const Size(400, 800);
@@ -63,6 +64,7 @@ void main() {
             onCavityFullChanged: onCavityFullChanged,
             keyboardInset: keyboardInset,
             chatsBadgeBuilder: chatsBadgeBuilder,
+            coursesBadgeBuilder: coursesBadgeBuilder,
           ),
         ),
       ),
@@ -201,6 +203,43 @@ void main() {
             ),
             findsNothing,
             reason: 'only the Chats item carries the unread badge',
+          );
+        }
+      },
+    );
+
+    testWidgets(
+      'the injected badge wraps the Courses item — and only the Courses item '
+      '(#8190)',
+      (tester) async {
+        // Same seam as the Chats badge, for the invited-course envelope the
+        // shell injects when a course invitation is pending.
+        const badgeKey = ValueKey('invitedCourseBadge');
+        await pumpNav(
+          tester,
+          coursesBadgeBuilder: (child) =>
+              KeyedSubtree(key: badgeKey, child: child),
+        );
+
+        expect(
+          find.descendant(
+            of: find.byKey(badgeKey),
+            matching: find.ancestor(
+              of: find.byTooltip('Courses'),
+              matching: find.byType(IconButton),
+            ),
+          ),
+          findsOneWidget,
+          reason: 'the badge must enclose the Courses rail item',
+        );
+        for (final other in ['World', 'All chats', 'Add a course']) {
+          expect(
+            find.descendant(
+              of: find.byKey(badgeKey),
+              matching: find.byTooltip(other),
+            ),
+            findsNothing,
+            reason: 'only the Courses item carries the invite badge',
           );
         }
       },


### PR DESCRIPTION
## What

The mobile nav rail's Courses tab now wears the gold invited-course envelope while a course invitation is pending.

## Why

Closes #8190

The invite marker only existed inside the Courses hub (the tile avatar + "Invited" chip), so from the collapsed rail a pending invitation was invisible.

## Testing

- `flutter test test/pangea/navigation/` — all pass, including a new case mirroring the #8129 chats-badge test: the injected badge encloses the Courses rail item and no other rail item.
- `flutter analyze` clean on both touched files.
- Badge placement checked by rendering the rail with the real `InvitedCourseBadge` injected: it sits at the icon's top-end corner, fully visible, at the same offset as the sibling Chats unread badge.
- Not exercised end-to-end locally — that needs a real course invite arriving over sync; the issue's TO TEST covers it.

Implementation notes:
- `MobileNavWidget` gains a `coursesBadgeBuilder` seam, the exact mirror of the existing `chatsBadgeBuilder` (#8129), so the widget stays presentational and free of Matrix lookups.
- `WorkspaceShell` injects `InvitedCourseBadge` on the shared sync stream when any invited space is present — the same predicate `sortedCourses` uses, so the badge shows exactly when the hub has an invited course to show.

## Deploy Notes

None
