### PR TITLE
feat(courses): show the knocking badge on the courses list

### DIFF
--- a/lib/routes/courses/add_course_tile.dart
+++ b/lib/routes/courses/add_course_tile.dart
@@ -11,11 +11,17 @@ class AddCourseTile extends StatelessWidget {
   final VoidCallback? onTap;
   final bool expanded;
 
+  /// Someone is knocking on this course and the viewer is an admin who can act
+  /// on it — the avatar wears the red "!" badge, outranking the course-ping
+  /// bell. Supplied by [AddCourseTileList], which watches the member list.
+  final bool hasKnockingUsers;
+
   const AddCourseTile({
     super.key,
     required this.content,
     this.onTap,
     this.expanded = false,
+    this.hasKnockingUsers = false,
   });
 
   @override
@@ -31,11 +37,18 @@ class AddCourseTile extends StatelessWidget {
 
     // An invited course hides its member/level chips, so the participant count
     // would announce detail that isn't on screen — lead with the state instead.
-    final label = invited
+    final courseLabel = invited
         ? '$title, ${L10n.of(context).invited}'
         : members != null
         ? '$title, ${L10n.of(context).countParticipants(members)}'
         : title;
+
+    // The knock badge is a bare icon nested inside the tile's own labeled
+    // button node, so the state rides the tile label as well — the same way
+    // `invited` does — rather than relying on the nested node being announced.
+    final label = hasKnockingUsers
+        ? '$courseLabel, ${L10n.of(context).aUserIsKnocking}'
+        : courseLabel;
 
     return Material(
       type: MaterialType.transparency,
@@ -67,6 +80,7 @@ class AddCourseTile extends StatelessWidget {
                       unreadCoursePingEvent: unreadCoursePingEvent,
                       courseChildrenIds: courseChildrenIds,
                       invite: invited,
+                      hasKnockingUsers: hasKnockingUsers,
                     ),
                     Expanded(
                       child: Column(

--- a/lib/routes/courses/add_course_tile_content.dart
+++ b/lib/routes/courses/add_course_tile_content.dart
@@ -19,6 +19,12 @@ abstract class AddCourseTileContent {
   /// chips read the same quest outline the course itself does.
   String? get courseRoomId => null;
 
+  /// The course space behind this tile, for the tile chrome that needs the
+  /// live room rather than a snapshot of it — currently the knock badge, which
+  /// watches the member list. Null for tiles with no room yet (public-course
+  /// previews, course-plan suggestions), which skip that chrome entirely.
+  Room? get space => null;
+
   bool get isKnock => false;
 
   bool? get invited => null;
@@ -31,6 +37,7 @@ abstract class AddCourseTileContent {
 }
 
 class RoomAddCourseTileContent extends AddCourseTileContent {
+  @override
   final Room space;
   RoomAddCourseTileContent(this.space);
 

--- a/lib/routes/courses/add_course_tile_list.dart
+++ b/lib/routes/courses/add_course_tile_list.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import 'package:fluffychat/pangea/spaces/knocking_users_builder.dart';
 import 'package:fluffychat/routes/courses/add_course_tile.dart';
 import 'package:fluffychat/routes/courses/add_course_tile_content.dart';
 
@@ -32,9 +33,23 @@ class AddCourseTileList extends StatelessWidget {
           final adjustedIndex = index - content.length;
           return extraContent?[adjustedIndex] ?? SizedBox.shrink();
         }
-        return AddCourseTile(
-          content: content[index],
-          onTap: () => onTap(index),
+        // Mobile has no nav rail, so the courses list is where an admin sees
+        // that someone is knocking — the same red "!" the rail's course avatar
+        // wears (#8246). Only room-backed tiles can have a knock; previews and
+        // course-plan suggestions skip the member request entirely.
+        final tileContent = content[index];
+        final space = tileContent.space;
+        if (space == null) {
+          return AddCourseTile(content: tileContent, onTap: () => onTap(index));
+        }
+
+        return KnockingUsersBuilder(
+          room: space,
+          builder: (context, knockingUsers) => AddCourseTile(
+            content: tileContent,
+            onTap: () => onTap(index),
+            hasKnockingUsers: knockingUsers.isNotEmpty,
+          ),
         );
       },
     );

--- a/lib/routes/world/left_panel/left_panel_courses_list_view.dart
+++ b/lib/routes/world/left_panel/left_panel_courses_list_view.dart
@@ -6,7 +6,9 @@ import 'package:matrix/matrix.dart';
 import 'package:fluffychat/features/analytics_access/join_room_analytics_consent_handler.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/pangea/spaces/client_spaces_extension.dart';
+import 'package:fluffychat/routes/chat/chat_details/space_details_content.dart';
 import 'package:fluffychat/routes/courses/add_course_options.dart';
 import 'package:fluffychat/routes/courses/add_course_tile_content.dart';
 import 'package:fluffychat/routes/courses/add_course_tile_list.dart';
@@ -80,7 +82,15 @@ class LeftPanelCoursesListView extends StatelessWidget {
 
     if (!{Membership.invite, Membership.leave}.contains(membership)) {
       context.go(
-        WorkspaceNav.openCourseSection(uri, course.id, keepRoom: false),
+        WorkspaceNav.openCourseSection(
+          uri,
+          course.id,
+          keepRoom: false,
+          // Same as the web rail: a badged course opens on the Chats tab —
+          // where the knock notification lives — instead of the Course Plan
+          // default, every time, until the knock is accepted or denied (#8139).
+          tab: course.knockingUsers.isNotEmpty ? SpaceSettingsTabs.chat : null,
+        ),
       );
       return;
     }

--- a/test/pangea/courses/knocking_course_tile_test.dart
+++ b/test/pangea/courses/knocking_course_tile_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/constants/default_power_level.dart';
+import 'package:fluffychat/pangea/common/widgets/course_avatar.dart';
+import 'package:fluffychat/pangea/spaces/knocking_users_builder.dart';
+import 'package:fluffychat/pangea/spaces/space_constants.dart';
+import 'package:fluffychat/routes/courses/add_course_tile.dart';
+import 'package:fluffychat/routes/courses/add_course_tile_content.dart';
+import 'package:fluffychat/routes/courses/add_course_tile_list.dart';
+import '../get_test_client.dart';
+
+/// Coverage for #8246: mobile has no nav rail, so the courses list is where a
+/// course admin learns that someone is knocking. The rail's red "!" badge has
+/// to reach the list tiles too — admin-only, and only for tiles that have a
+/// real course room behind them.
+///
+/// The tiles here deliberately leave `unreadCoursePingEvent` null: the badged
+/// branch of [CourseAvatar] sits under an `UnreadRoomsBadge`, which needs a
+/// mounted `MatrixState` these tests don't have. What is under test is the
+/// wiring — which tiles get a [KnockingUsersBuilder], and what the builder's
+/// answer does to the tile — so the avatar's own flag and the tile's announced
+/// label are the assertions.
+class _StubCourseTileContent extends AddCourseTileContent {
+  @override
+  final Room? space;
+
+  _StubCourseTileContent({this.space});
+
+  @override
+  String title(L10n l10n) => 'Elementary German I';
+
+  @override
+  int? get members => 12;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Client client;
+
+  const userId = '@test:fakeServer.notExisting';
+  const knockerId = '@knocker:fakeServer.notExisting';
+
+  setUpAll(() {
+    // `Avatar` inside `CourseAvatar` resolves the bot name from the environment
+    // at build time; initialize dotenv inline so no real `.env` is needed.
+    dotenv.testLoad(fileInput: 'BOT_NAME=@bot:example.org');
+  });
+
+  setUp(() async {
+    client = await getTestClient();
+  });
+
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  /// A course space with one user knocking on it. [ownPowerLevel] decides
+  /// whether the viewer is the admin who can act on that knock.
+  Room courseRoom({required int ownPowerLevel}) {
+    final room = Room(
+      id: '!course:fakeServer.notExisting',
+      client: client,
+      membership: Membership.join,
+    );
+    room.setState(
+      Event(
+        type: EventTypes.RoomPowerLevels,
+        content: {
+          ...RoomDefaults.defaultPowerLevelsContent(),
+          'users': {userId: ownPowerLevel},
+        },
+        stateKey: '',
+        senderId: userId,
+        eventId: '\$powerLevels',
+        originServerTs: DateTime.now(),
+        room: room,
+      ),
+    );
+    room.setState(
+      Event(
+        type: EventTypes.RoomMember,
+        content: {'membership': 'knock'},
+        stateKey: knockerId,
+        senderId: knockerId,
+        eventId: '\$knock',
+        originServerTs: DateTime.now(),
+        room: room,
+      ),
+    );
+    return room;
+  }
+
+  Future<void> pumpList(
+    WidgetTester tester,
+    AddCourseTileContent content,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(
+            width: 360,
+            child: AddCourseTileList(content: [content], onTap: (_) {}),
+          ),
+        ),
+      ),
+    );
+    // L10n's delegate resolves from a deferred library, so the tile isn't in
+    // the tree until localizations finish loading.
+    await tester.pumpAndSettle();
+  }
+
+  bool avatarIsBadged(WidgetTester tester) =>
+      tester.widget<CourseAvatar>(find.byType(CourseAvatar)).hasKnockingUsers;
+
+  testWidgets('a course admin sees the knock badge on the list tile', (
+    tester,
+  ) async {
+    await pumpList(
+      tester,
+      _StubCourseTileContent(
+        space: courseRoom(ownPowerLevel: SpaceConstants.powerLevelOfAdmin),
+      ),
+    );
+
+    expect(avatarIsBadged(tester), isTrue);
+
+    final context = tester.element(find.byType(AddCourseTile));
+    final semantics = tester.widget<Semantics>(
+      find
+          .descendant(
+            of: find.byType(AddCourseTile),
+            matching: find.byType(Semantics),
+          )
+          .first,
+    );
+    expect(
+      semantics.properties.label,
+      contains(L10n.of(context).aUserIsKnocking),
+      reason: 'the badge is a bare icon; the tile has to say it out loud',
+    );
+  });
+
+  testWidgets('a non-admin member never sees the knock badge', (tester) async {
+    await pumpList(
+      tester,
+      _StubCourseTileContent(space: courseRoom(ownPowerLevel: 0)),
+    );
+
+    expect(avatarIsBadged(tester), isFalse);
+
+    final context = tester.element(find.byType(AddCourseTile));
+    expect(
+      tester
+          .widget<Semantics>(
+            find
+                .descendant(
+                  of: find.byType(AddCourseTile),
+                  matching: find.byType(Semantics),
+                )
+                .first,
+          )
+          .properties
+          .label,
+      isNot(contains(L10n.of(context).aUserIsKnocking)),
+    );
+  });
+
+  testWidgets('a tile with no room behind it never loads knocking members', (
+    tester,
+  ) async {
+    await pumpList(tester, _StubCourseTileContent());
+
+    expect(
+      find.byType(KnockingUsersBuilder),
+      findsNothing,
+      reason: 'public-course previews have no members to request',
+    );
+    expect(avatarIsBadged(tester), isFalse);
+  });
+}


### PR DESCRIPTION
### What

Course tiles in the Courses list now wear the same red (!) knock badge the nav rail's course avatar does, and tapping a badged tile opens the Course Chats tab instead of the Course Plan default.

### Why

Closes #8246

Mobile has no nav rail, so an admin on a phone had no course-level cue that someone was waiting to get in — the badge from #8139 only reached the web rail and the mobile course shortcut.

### What changed

- `AddCourseTileContent` gains a `Room? space` getter (non-null only for `RoomAddCourseTileContent`). `AddCourseTileList` wraps room-backed tiles in the existing `KnockingUsersBuilder` and hands the answer to `AddCourseTile` → `CourseAvatar`, which already knows how to wear the badge over the course-ping bell. Public-course previews and course-plan suggestions have no room, so they never request a member list.
- `LeftPanelCoursesListView.onTapCourse` passes `SpaceSettingsTabs.chat` while knocks are pending — the same expression, and the same "every tap until accepted/denied" behavior, as the web rail (`navigation_rail.dart`).
- The tile's own semantics label announces the knock; the badge itself is a bare icon nested inside that labeled button node.

Design intent for the badge and the tab redirect is #8139; nothing here changes it.

### Testing

- `fvm flutter test` — full suite green locally (2315 passed, 3 skipped, 0 failed).
- New `test/pangea/courses/knocking_course_tile_test.dart`: admin sees the badge and the announced label, a non-admin member sees neither, and a roomless tile never mounts a `KnockingUsersBuilder`.
- `fvm flutter analyze` — no issues.
- Manual QA on the local stack, mobile viewport (375x812), as a course admin with a second account knocking on the course via the Matrix `/knock` API: the Courses list tile shows the red (!) on its avatar, and its accessible name reads "…, 1 participants, 1 user is requesting to join your course". Accepting the knock clears the badge (tile drops back to a plain avatar, member count 1 → 2).
- **Not** verified live: the tap → Chats tab redirect. Synthetic taps don't complete on the CanvasKit surface in the browser-pane harness — the already-shipped mobile course-shortcut tap (#8139) fails the same way there, so it's the harness, not this change. The redirect is the rail's expression verbatim, and `openCourseSection(tab:)` is covered by `workspace_nav_test`. Confirm it on staging via the issue's TO TEST.

### Accessibility

- The knock state rides the tile's `Semantics` label (verified in the running app's accessibility tree), on top of the badge icon's own `semanticLabel` from #8139.

### Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
