### PR TITLE
fix(layouts): hold the keyboard floor for every open cavity, not only a focused one

### DIFF
--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -237,14 +237,19 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
   static const double _peekHeight = 128.0;
   static const Duration _animationDuration = Duration(milliseconds: 240);
 
-  /// The least the keyboard trim may leave of a cavity that HOLDS FOCUS — the
-  /// drag handle plus one text-field row. Trimming past it drops the hosted
-  /// surface entirely (see `showContent` in [build]), which disposes the
-  /// focused field's node, which closes the keyboard, which un-trims the
-  /// cavity, which remounts the field: the #8072 loop where a tapped input
-  /// deselects itself. Applies only while something inside the cavity is
-  /// focused, so the plain keyboard trim of #7754 is unchanged.
-  static const double _focusedKeyboardFloor = 96.0;
+  /// The least the keyboard trim may leave of an OPEN cavity — the drag handle
+  /// plus one text-field row. Trimming past it drops the hosted surface
+  /// entirely (see `showContent` in [build]), and whatever interaction summoned
+  /// the keyboard dies with it: a focused field's node is disposed, which
+  /// closes the keyboard, which un-trims the cavity, which remounts the field —
+  /// the #8072 loop where a tapped input deselects itself. The floor is
+  /// UNCONDITIONAL (any open cavity, any keyboard) because the keyboard's owner
+  /// can sit outside the cavity's focus subtree while its anchor sits inside:
+  /// a hosted dropdown opens an overlay-route menu whose search field summons
+  /// the keyboard, and gating the floor on in-cavity focus let the trim unmount
+  /// the menu's anchor and dismiss it (#8072 reopened). The trim itself
+  /// (#7754) still absorbs everything above the floor.
+  static const double _keyboardFloor = 96.0;
 
   /// The rest stop the cavity currently sits at. Non-null means the drawn
   /// fraction is DERIVED from this each build ([_currentFraction]), so it
@@ -270,8 +275,9 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
   bool _reportedFull = false;
 
   /// Something inside [MobileNavWidget.cavityChild] holds focus — in practice a
-  /// text input the learner just tapped. Drives both the grow-to-full below and
-  /// the [_focusedKeyboardFloor] in [build].
+  /// text input the learner just tapped. Drives the grow-to-full below. (The
+  /// [_keyboardFloor] deliberately does NOT depend on this: focus can live in
+  /// an overlay route — a dropdown's menu — that is not a cavity descendant.)
   bool _cavityHasFocus = false;
 
   /// The grow-to-full has already fired for the current focus/keyboard episode,
@@ -694,18 +700,15 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
                                     0.0,
                                     animatedHeight,
                                   );
-                              // Hold the floor while the cavity holds focus, so
-                              // the grow-to-full above has frames to run in
-                              // without the trim unmounting the very field that
-                              // triggered it (#8072).
-                              final visible =
-                                  _cavityHasFocus && baseCavityPx > 0
+                              // Hold the floor for every open cavity, so the
+                              // trim can never unmount the hosted surface —
+                              // and with it the field or overlay anchor whose
+                              // keyboard caused the trim (#8072). A no-op
+                              // whenever the trim leaves more than the floor.
+                              final visible = baseCavityPx > 0
                                   ? max(
                                       trimmed,
-                                      min(
-                                        animatedHeight,
-                                        _focusedKeyboardFloor,
-                                      ),
+                                      min(animatedHeight, _keyboardFloor),
                                     )
                                   : trimmed;
                               // Drop the content the instant the cavity is

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -1111,17 +1111,20 @@ void main() {
       expect(cavityHeightOf(tester), closeTo(maxHeightPx * 0.5 - 200.0, 1.0));
     });
 
-    testWidgets('a keyboard taller than the cavity clamps to zero, not '
-        'negative', (tester) async {
+    testWidgets('a keyboard taller than the cavity stops at the floor, '
+        'keeping the surface mounted', (tester) async {
       await pumpNav(
         tester,
         cavityChild: const Text('Chat list'),
         cavityKey: 'chats',
         maxHeightFraction: 0.75,
-        // Half height is 300px; a 500px inset would drive it negative.
+        // Half height is 300px; a 500px inset would trim past zero. The floor
+        // holds instead: trimming to nothing unmounts the hosted surface, and
+        // with it whatever interaction summoned the keyboard (#8072).
         keyboardInset: 500.0,
       );
-      expect(cavityHeightOf(tester), 0.0);
+      expect(cavityHeightOf(tester), closeTo(96.0, 1.0));
+      expect(find.text('Chat list'), findsOneWidget);
     });
   });
 
@@ -1211,13 +1214,61 @@ void main() {
       expect(cavityHeightOf(tester), closeTo(128.0, 1.0));
     });
 
-    testWidgets('leaves an unfocused cavity to the plain #7754 trim', (
+    testWidgets('holds the floor — but does not grow — without cavity focus', (
       tester,
     ) async {
-      // The search bar riding ABOVE the widget owns this keyboard; nothing in
-      // the cavity is focused, so the cavity neither grows nor holds a floor.
+      // A keyboard whose owner is outside the cavity's focus subtree (the
+      // search bar above the widget, or a hosted dropdown's overlay menu).
+      // The cavity must not grow to full — that height belongs to an
+      // in-cavity input — but it must keep the floor: the keyboard's owner
+      // can still be anchored inside (the dropdown case below).
       await pumpCourseCavity(tester, keyboardInset: 300.0);
-      expect(cavityHeightOf(tester), 0.0);
+      expect(cavityHeightOf(tester), closeTo(96.0, 1.0));
+      expect(find.byType(TextField), findsOneWidget);
+    });
+
+    testWidgets('keeps a hosted dropdown\'s menu open when a keyboard trims '
+        'the cavity', (tester) async {
+      // Kel's reopen of #8072: the add-course language dropdown opens an
+      // overlay-route menu with its own search field. That field's keyboard
+      // trims the cavity; focus lives in the OVERLAY, not the cavity subtree,
+      // so the focus-gated floor didn't hold — the trim unmounted the hosted
+      // flow, disposing the menu's anchor and dismissing menu + keyboard.
+      final dropdown = DropdownButton<String>(
+        value: 'de',
+        items: const [
+          DropdownMenuItem(value: 'de', child: Text('German')),
+          DropdownMenuItem(value: 'el', child: Text('Greek')),
+        ],
+        onChanged: (_) {},
+      );
+      Future<void> pumpDropdownCavity(
+        WidgetTester tester, {
+        double keyboardInset = 0.0,
+      }) => pumpNav(
+        tester,
+        cavityChild: dropdown,
+        cavityKey: 'course-a',
+        cavityContextId: 'course-a',
+        cavityDefaultsToPeek: true,
+        maxHeightFraction: 0.75,
+        keyboardInset: keyboardInset,
+      );
+
+      await pumpDropdownCavity(tester);
+      await tester.tap(find.text('German'));
+      await tester.pumpAndSettle();
+      // Menu open: the unselected option is visible in the overlay.
+      expect(find.text('Greek'), findsOneWidget);
+
+      // The menu's search field summons a keyboard taller than the peek.
+      await pumpDropdownCavity(tester, keyboardInset: 500.0);
+      expect(
+        find.text('Greek'),
+        findsOneWidget,
+        reason: 'the trim must not unmount the menu\'s anchor',
+      );
+      expect(find.byType(DropdownButton<String>), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
## What

The nav cavity's keyboard floor now applies to any open cavity while a keyboard trims it — no focus, height, or screen-size conditions — so the trim can never unmount the hosted surface.

## Why

Closes #8072 (reopened). The #8074 fix gated the floor on focus being *inside* the cavity subtree. A hosted dropdown (the add-course language selector, Kel's video) opens its menu as an overlay route: the menu's search field summons the keyboard while focus sits in the overlay, so the floor dropped, the trim reached zero, the hosted flow unmounted, and the menu's anchor was disposed — closing the menu and keyboard.

The invariant: the #7754 keyboard trim may shrink the cavity but must never unmount the hosted surface, because whatever interaction summoned the keyboard — a focused field or an overlay's anchor — dies with it. Grow-to-full stays focus-gated: full is the right height for typing into an in-cavity input; an overlay menu only needs its anchor kept alive.

## Testing

- `fvm flutter test test/pangea/navigation/mobile_nav_widget_test.dart` — 43/43 pass, including a new regression test reproducing the dropdown-overlay repro (menu stays open when a 500px keyboard trims a peek-height cavity) and an unfocused-floor test replacing the old "unfocused cavity trims to zero" expectation.
- `fvm flutter analyze` clean on both touched files.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)