### PR TITLE
fix: display commit sha in settings, use datetime to determine build …

### DIFF
--- a/.github/instructions/ci.instructions.md
+++ b/.github/instructions/ci.instructions.md
@@ -26,22 +26,24 @@ Branch protection is **non-strict** — a PR need not be rebased onto the latest
 - **On push to `main`:** the above **plus** `build_debug_apk` and `build_debug_ios` (gated by `if: github.event_name == 'push'`). This catches native regressions at merge, where a break is cheap to spot, without paying for a native build on every PR push.
 - **`concurrency: cancel-in-progress`** for `pull_request` only. Superseded PR-iteration pushes cancel; `merge_group` and `main` runs finish (they gate merges / warm caches).
 
-## Version and build number
+## Version, build number, and commit
 
-Settings shows `Version: <semver>+<build>` as a debugging aid. The two halves come from different places.
+Settings shows `Version: <semver>+<build>` with the build's commit SHA beneath it, as a debugging aid. The three parts answer different questions.
 
 **The semantic version** lives in `pubspec.yaml` and is bumped by hand. Pubspec's `+N` is no longer what web users see, but it still gates the release tag, so a release must still bump it. When to bump, and at which level, is part of the release process — see [deployment.instructions.md](deployment.instructions.md).
 
-**The build number is stamped at build time, from three unrelated per-platform sources:**
+**The build number is stamped at build time, by one of two schemes:**
 
 | Platform | Stamped from |
 |---|---|
 | Web | a UTC `ddHHMM` timestamp, applied identically by both web workflows |
-| Android | the Play Store internal track's highest version code, via fastlane |
-| iOS | the latest TestFlight build number, via fastlane |
+| Android, iOS | a UTC `YYMMDDnn` date code — `26081103` is the third build on 2026-08-10 — assigned by fastlane |
 
-- **A build number only identifies a build within its own platform.** Mobile numbers come from store state, web from a clock. They are not comparable, and mobile cannot be folded into the web sequence — the stores own those counters. Capture the platform alongside the number when logging a bug report.
-- **The web stamp identifies a build; it does not order one.** Dropping year and month keeps it short, at the cost of resetting on the 1st — so a later build can carry a smaller number, and web build numbers must not be compared to judge which is newer. Both web workflows share one scheme so staging and production draw from the same sequence; per-workflow run counters were tried first and drifted thousands of builds apart.
+- **One date code serves both stores.** Google requires a strictly increasing integer across every upload (ceiling 2,100,000,000), and Apple requires one that increases within a version train, so a single always-rising number satisfies both at once. Fastlane takes whichever is higher: the date code, or the store's current highest build plus one. The store is the floor, which is what makes the number strictly increasing rather than merely usually increasing.
+- **The web stamp identifies a build; it does not order one.** Dropping year and month keeps it short, at the cost of resetting on the 1st — so a later build can carry a smaller number, and web build numbers must not be compared to judge which is newer. That reset is also why web's scheme cannot be reused for mobile. Both web workflows share one scheme so staging and production draw from the same sequence; per-workflow run counters were tried first and drifted thousands of builds apart.
+- **Web and mobile numbers are still not comparable** — one is a clock reading, the other a date code. Capture the platform alongside the number.
+
+**The commit SHA says what code is in the build.** A build number has to be a monotonic integer, which makes it good at ordering builds and bad at identifying one — so it is not asked to. Every build workflow passes the 8-character SHA it built from into the app as a compile-time define, and Settings shows it under the version. **This is what to capture in a bug report**: the number orders builds, the SHA resolves back to code. It is empty on a locally-run build, which has no pushed commit, and Settings then shows nothing. The web deploys stamp the same SHA into `index.html`, where it serves as the Sentry release and as the cache-busting token on the asset manifests.
 
 **Latent coupling.** [`app_version_util.dart`](../../lib/routes/chat_list/app_version_util.dart) also compares build numbers numerically when deciding whether to prompt an update. That path is inert: the force-upgrade gate is semantic-version-based by design, and the endpoint's build number is vestigial — see [client-version-gating.instructions.md](https://github.com/pangeachat/2-step-choreographer/blob/main/.github/instructions/client-version-gating.instructions.md). If that ever changes, the monthly reset would suppress the web update prompt; revisit the stamp format then.
 

--- a/.github/instructions/ci.instructions.md
+++ b/.github/instructions/ci.instructions.md
@@ -37,7 +37,7 @@ Settings shows `Version: <semver>+<build>` with the build's commit SHA beneath i
 | Platform | Stamped from |
 |---|---|
 | Web | a UTC `ddHHMM` timestamp, applied identically by both web workflows |
-| Android, iOS | a UTC `YYMMDDnn` date code — `26081103` is the third build on 2026-08-10 — assigned by fastlane |
+| Android, iOS | a UTC `YYMMDDnn` date code — `26081103` is the third build on 2026-08-11 — assigned by fastlane |
 
 - **One date code serves both stores.** Google requires a strictly increasing integer across every upload (ceiling 2,100,000,000), and Apple requires one that increases within a version train, so a single always-rising number satisfies both at once. Fastlane takes whichever is higher: the date code, or the store's current highest build plus one. The store is the floor, which is what makes the number strictly increasing rather than merely usually increasing.
 - **The web stamp identifies a build; it does not order one.** Dropping year and month keeps it short, at the cost of resetting on the 1st — so a later build can carry a smaller number, and web build numbers must not be compared to judge which is newer. That reset is also why web's scheme cannot be reused for mobile. Both web workflows share one scheme so staging and production draw from the same sequence; per-workflow run counters were tried first and drifted thousands of builds apart.

--- a/.github/instructions/deployment.instructions.md
+++ b/.github/instructions/deployment.instructions.md
@@ -36,6 +36,8 @@ The semantic version in `pubspec.yaml` is bumped by hand. (The build number afte
 
 Choosing a level is answering one question: *would we ever force someone onto this?* If no, it is a patch.
 
+These definitions are analogous to the SemVer standard definitions for these version numbers, except defined in terms for the need for user-side forced updates instead of in terms of backwards compatibility.
+
 **Bumping is a judgment call, not a per-PR obligation** — most PRs need none. Raise it when a PR is the thing a future floor-raise would target, or when a release is being cut. A release must bump `+N` regardless, because the release workflow tags from the full version string and silently fails on a tag that already exists.
 
 ## Environment Config (`.env`)

--- a/.github/instructions/deployment.instructions.md
+++ b/.github/instructions/deployment.instructions.md
@@ -36,7 +36,7 @@ The semantic version in `pubspec.yaml` is bumped by hand. (The build number afte
 
 Choosing a level is answering one question: *would we ever force someone onto this?* If no, it is a patch.
 
-These definitions are analogous to the SemVer standard definitions for these version numbers, except defined in terms for the need for user-side forced updates instead of in terms of backwards compatibility.
+These definitions are analogous to the SemVer standard definitions for these version numbers, except defined in terms of the need for user-side forced updates instead of in terms of backwards compatibility.
 
 **Bumping is a judgment call, not a per-PR obligation** — most PRs need none. Raise it when a PR is the thing a future floor-raise would target, or when a release is being cut. A release must bump `+N` regardless, because the release workflow tags from the full version string and silently fails on a tag that already exists.
 

--- a/.github/workflows/android-playstore.yml
+++ b/.github/workflows/android-playstore.yml
@@ -93,10 +93,13 @@ jobs:
       - name: Capture build version
         id: version
         # prepare-android-release.sh (set_build_code_internal) rewrites pubspec
-        # with the Play Store build code, so this reads e.g. "5.0.0+3828".
+        # with the date-encoded build code, so this reads e.g. "5.0.0+26081103".
         run: echo "version=$(grep -m1 '^version:' pubspec.yaml | awk '{print $2}')" >> $GITHUB_OUTPUT
       - name: Build Android Release
-        run: flutter build appbundle --target-platform android-arm,android-arm64,android-x64
+        # BUILD_COMMIT_SHA is the only part of the version display that says
+        # which code is in the build — the Play Store owns the build code, so
+        # it orders builds without identifying them. See ci.instructions.md.
+        run: flutter build appbundle --target-platform android-arm,android-arm64,android-x64 --dart-define=BUILD_COMMIT_SHA=${GITHUB_SHA::8}
       - name: Deploy Android Release
         env:
           RELEASE_NOTES: ${{ inputs.new_release_notes }}

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Capture build version
         id: version
         # Semantic version only — fastlane assigns the iOS build number itself
-        # (latest TestFlight build + 1), so pubspec's +N is not meaningful here.
+        # (a date-encoded YYMMDDnn code), so pubspec's +N is not meaningful here.
         run: echo "version=$(grep -m1 '^version:' pubspec.yaml | awk '{print $2}' | cut -d+ -f1)" >> $GITHUB_OUTPUT
       - uses: subosito/flutter-action@fd55f4c5af5b953cc57a2be44cb082c8f6635e8e # v2
         with:
@@ -86,7 +86,11 @@ jobs:
           yq -i 'del( .flutter.fonts[] | select(.family == "NotoEmoji") )' pubspec.yaml
       - run: flutter pub get
       - name: Build iOS (unsigned)
-        run: flutter build ios --release --no-codesign
+        # BUILD_COMMIT_SHA is the only part of the version display that says
+        # which code is in the build — fastlane derives the build number from
+        # TestFlight state, so it orders builds without identifying them.
+        # See ci.instructions.md.
+        run: flutter build ios --release --no-codesign --dart-define=BUILD_COMMIT_SHA=${GITHUB_SHA::8}
       - name: Load match repo deploy key
         uses: webfactory/ssh-agent@a6f90b1f127823b31d4d4a8d96047790581349bd # v0.9.1
         with:

--- a/.github/workflows/main_deploy.yaml
+++ b/.github/workflows/main_deploy.yaml
@@ -48,13 +48,15 @@ jobs:
         # production share one sequence instead of each workflow's own run_number
         # (those had drifted to 3890 vs 104). Build-time only — nothing is
         # committed back, and the release tag still reads pubspec's `+N`.
-        # Resets monthly, so it identifies a build, never orders one.
-        # See ci.instructions.md.
+        # Resets monthly, so it identifies a build, never orders one — the
+        # BUILD_COMMIT_SHA dart-define is what says which code is running, and
+        # Settings shows it next to the version. Same define in release.yaml
+        # and both mobile workflows. See ci.instructions.md.
         run: |
           flutter config --enable-web
           flutter clean
           flutter pub get
-          ./scripts/build-web-versioned-canvaskit.sh --pwa-strategy=none --profile --source-maps --build-number=$(date -u +%d%H%M)
+          ./scripts/build-web-versioned-canvaskit.sh --pwa-strategy=none --profile --source-maps --build-number=$(date -u +%d%H%M) --dart-define=BUILD_COMMIT_SHA=${GITHUB_SHA::8}
 
       - name: Version Material Icons font
         run: |
@@ -71,6 +73,13 @@ jobs:
           echo "Renamed $OLD_NAME -> $NEW_NAME"
 
       - name: Inject build version into index.html
+        # Fills the __BUILD_VERSION__ placeholder index.html ships with. That
+        # token is the Sentry release for the service-worker killswitch and the
+        # `?v=` cache-buster index.html appends to the four asset manifests, so
+        # leaving it unsubstituted pins every deploy to one release and one
+        # cache key, and browsers keep serving stale manifests. Must run before
+        # any step that copies build/web. Identical step in release.yaml, which
+        # went without it until #8245.
         run: |
           VERSION=${GITHUB_SHA::8}
           sed -i "s|__BUILD_VERSION__|$VERSION|g" build/web/index.html

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,9 +73,22 @@ jobs:
         # production share one sequence instead of each workflow's own run_number
         # (those had drifted to 3890 vs 104). Build-time only — nothing is
         # committed back, and the release tag still reads pubspec's `+N`.
-        # Resets monthly, so it identifies a build, never orders one.
-        # See ci.instructions.md.
-        run: ./scripts/build-web-versioned-canvaskit.sh --pwa-strategy=none --release --source-maps --build-number=$(date -u +%d%H%M)
+        # Resets monthly, so it identifies a build, never orders one — the
+        # BUILD_COMMIT_SHA dart-define is what says which code is running, and
+        # Settings shows it next to the version. Same define in main_deploy.yaml
+        # and both mobile workflows. See ci.instructions.md.
+        run: ./scripts/build-web-versioned-canvaskit.sh --pwa-strategy=none --release --source-maps --build-number=$(date -u +%d%H%M) --dart-define=BUILD_COMMIT_SHA=${GITHUB_SHA::8}
+      - name: Inject build version into index.html
+        # Fills the __BUILD_VERSION__ placeholder index.html ships with. That
+        # token is the Sentry release for the service-worker killswitch and the
+        # `?v=` cache-buster index.html appends to the four asset manifests, so
+        # leaving it unsubstituted pins every deploy to one release and one
+        # cache key, and browsers keep serving stale manifests. Must run before
+        # any step that copies build/web. Identical step in main_deploy.yaml;
+        # this workflow went without it until #8245.
+        run: |
+          VERSION=${GITHUB_SHA::8}
+          sed -i "s|__BUILD_VERSION__|$VERSION|g" build/web/index.html
       # The web app fetches /.env from the web root at runtime; it is not a
       # bundled asset, so the build output needs an explicit copy.
       - name: Add env to web root

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -19,7 +19,7 @@ update_fastlane
 default_platform(:android)
 
 # Date-encoded build code: YYMMDDnn in UTC, e.g. 26081103 for the third build
-# on 2026-08-10. Mirrored in ios/fastlane/Fastfile so one integer is valid on
+# on 2026-08-11. Mirrored in ios/fastlane/Fastfile so one integer is valid on
 # both stores. A store build code has to be a monotonic integer, so it can
 # order builds but never say what is in one — encoding the date at least makes
 # the ordering readable at a glance. The commit SHA is what identifies the

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -18,6 +18,22 @@ update_fastlane
 
 default_platform(:android)
 
+# Date-encoded build code: YYMMDDnn in UTC, e.g. 26081103 for the third build
+# on 2026-08-10. Mirrored in ios/fastlane/Fastfile so one integer is valid on
+# both stores. A store build code has to be a monotonic integer, so it can
+# order builds but never say what is in one — encoding the date at least makes
+# the ordering readable at a glance. The commit SHA is what identifies the
+# code; see ci.instructions.md.
+#
+# Never below the store's current max + 1, so the switch away from the old
+# sequential codes cannot regress and Google's strictly-increasing rule holds.
+# Google's ceiling is 2,100,000,000; this scheme peaks at 99,123,199. Past 99
+# builds in one UTC day the counter rolls into the next day's slot — still
+# increasing and still accepted, just no longer readable as a date.
+def date_encoded_build_code(last_version)
+  [Time.now.utc.strftime("%y%m%d").to_i * 100 + 1, last_version.to_i + 1].max
+end
+
 platform :android do
   lane :set_build_code_internal do
     versions = google_play_track_version_codes(
@@ -25,12 +41,13 @@ platform :android do
         json_key: "./keys.json"
       )
     last_version = versions.map(&:to_i).max
+    build_code = date_encoded_build_code(last_version)
     Dir.chdir("../..") do
       re = /version:\s([0-9]*\.[0-9]*\.[0-9]*)\+[0-9]*/i
       config = File.read("./pubspec.yaml")
       version_name = config.match(re).captures
 
-      subst = "version: #{version_name[0]}+#{last_version+1}"
+      subst = "version: #{version_name[0]}+#{build_code}"
 
       result = config.gsub(re, subst)
 
@@ -39,15 +56,18 @@ platform :android do
   end
 
   lane :deploy_internal_test do
-    versions = google_play_track_version_codes(
-        track: "internal",
-        json_key: "./keys.json"
-      )
-    last_version = versions.map(&:to_i).max
+    # Read back what set_build_code_internal wrote rather than deriving it a
+    # second time: gradle already baked that number into the .aab as the
+    # versionCode, and a second derivation is a second chance to disagree.
+    build_code = nil
+    Dir.chdir("../..") do
+      config = File.read("./pubspec.yaml")
+      build_code = config.match(/version:\s[0-9]*\.[0-9]*\.[0-9]*\+([0-9]*)/i).captures[0]
+    end
     upload_to_play_store(
       track: 'internal',
       aab: '../build/app/outputs/bundle/release/app-release.aab',
-      version_code: "#{last_version+1}",
+      version_code: build_code,
     )
   end
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -16,7 +16,7 @@
 default_platform(:ios)
 
 # Date-encoded build number: YYMMDDnn in UTC, e.g. 26081103 for the third build
-# on 2026-08-10. Mirrored from android/fastlane/Fastfile — the point of the
+# on 2026-08-11. Mirrored from android/fastlane/Fastfile — the point of the
 # scheme is that one integer is valid on both stores; see the comment there and
 # ci.instructions.md for why the number orders builds and the commit SHA, not
 # the number, identifies them.

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -15,6 +15,18 @@
 
 default_platform(:ios)
 
+# Date-encoded build number: YYMMDDnn in UTC, e.g. 26081103 for the third build
+# on 2026-08-10. Mirrored from android/fastlane/Fastfile — the point of the
+# scheme is that one integer is valid on both stores; see the comment there and
+# ci.instructions.md for why the number orders builds and the commit SHA, not
+# the number, identifies them.
+#
+# Never below TestFlight's current build + 1, so the switch away from the old
+# sequential numbers cannot regress within a version train.
+def date_encoded_build_code(last_version)
+  [Time.now.utc.strftime("%y%m%d").to_i * 100 + 1, last_version.to_i + 1].max
+end
+
 platform :ios do
   desc "One-time: mint the App Store distribution cert + profile into the match repo"
   lane :bootstrap_certs do
@@ -44,7 +56,7 @@ platform :ios do
     match(type: "appstore", api_key: api_key, readonly: true)
     increment_build_number(
       xcodeproj: "Runner.xcodeproj",
-      build_number: latest_testflight_build_number(api_key: api_key) + 1
+      build_number: date_encoded_build_code(latest_testflight_build_number(api_key: api_key))
     )
     re = /version:\s([0-9]*\.[0-9]*\.[0-9]*)\+[0-9]*/i
     config = File.read("../../pubspec.yaml")

--- a/lib/pangea/common/config/environment.dart
+++ b/lib/pangea/common/config/environment.dart
@@ -9,6 +9,21 @@ import 'package:fluffychat/pangea/common/constants/local.key.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 
 class Environment {
+  /// The 8-character git commit SHA this build was compiled from, passed in by
+  /// the build workflows as `--dart-define=BUILD_COMMIT_SHA=...`.
+  ///
+  /// This is the only part of the version display that identifies *what code*
+  /// is running. Build numbers cannot: they are per-platform monotonic counters
+  /// owned by the stores (or, on web, a clock), so they order builds without
+  /// saying what is in one. See `ci.instructions.md`.
+  ///
+  /// Compile-time, so it must be `const` — a non-const read would always be
+  /// empty. Empty on any locally-run build, which is not built from a pushed
+  /// commit; the Settings tile omits it then.
+  static const String buildCommitSha = String.fromEnvironment(
+    "BUILD_COMMIT_SHA",
+  );
+
   static bool get itIsTime =>
       DateTime.utc(2023, 1, 25).isBefore(DateTime.now());
 

--- a/lib/routes/settings/settings_view.dart
+++ b/lib/routes/settings/settings_view.dart
@@ -225,10 +225,17 @@ class SettingsView extends StatelessWidget {
                               ),
                               onTap: () async {
                                 if (snapshot.data == null) return;
+                                // The commit SHA is what makes a pasted bug
+                                // report reproducible — build numbers are
+                                // per-platform counters and do not identify
+                                // code — so it rides along in the copy.
                                 await Clipboard.setData(
                                   ClipboardData(
-                                    text:
-                                        "${snapshot.data!.version}+${snapshot.data!.buildNumber}",
+                                    text: [
+                                      "${snapshot.data!.version}+${snapshot.data!.buildNumber}",
+                                      if (Environment.buildCommitSha.isNotEmpty)
+                                        Environment.buildCommitSha,
+                                    ].join(" "),
                                   ),
                                 );
                                 ScaffoldMessenger.of(
@@ -249,6 +256,12 @@ class SettingsView extends StatelessWidget {
                                       )
                                     : L10n.of(context).versionNotFound,
                               ),
+                              // A commit SHA is an identifier, not copy, so it
+                              // is shown raw rather than through a translated
+                              // label. Absent on local builds.
+                              subtitle: Environment.buildCommitSha.isEmpty
+                                  ? null
+                                  : Text(Environment.buildCommitSha),
                             );
                           } else if (snapshot.hasError) {
                             return ListTile(


### PR DESCRIPTION
…number

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Version information now includes the build’s abbreviated commit identifier when available.
  * Users can view and copy the commit identifier from the developer settings screen.

* **Improvements**
  * Android and iOS builds now use date-based build numbers that remain higher than existing store builds.
  * Web, Android, and iOS builds consistently include commit identification for release tracking.

* **Documentation**
  * Clarified versioning, build numbering, commit identification, and deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->