### PR TITLE
fix(navigation): re-assert cavity full height so the analytics bar can't stay hidden (#8247)

### DIFF
--- a/lib/widgets/layouts/mobile_nav_widget.dart
+++ b/lib/widgets/layouts/mobile_nav_widget.dart
@@ -136,12 +136,18 @@ class MobileNavWidget extends StatefulWidget {
   /// barrier: tap-outside collapse is their whole dismissal model.
   final bool mapStaysLive;
 
-  /// Fires when the hosted cavity settles at (or leaves) its FULL height, so
-  /// the shell can drop the floating search bar over a full course sheet and
-  /// hand that reserved strip to the course content (#7697). Latched to the
-  /// settled rest state — it deliberately does NOT toggle mid-drag, so the
-  /// reserved height (and thus the drag's coordinate space) stays stable while
-  /// the finger moves.
+  /// Reports whether the hosted cavity is settled at its FULL height, so the
+  /// shell can drop the floating search bar over a full course sheet and hand
+  /// that reserved strip to the course content (#7697). Latched to the settled
+  /// rest state — it deliberately does NOT toggle mid-drag, so the reserved
+  /// height (and thus the drag's coordinate space) stays stable while the
+  /// finger moves.
+  ///
+  /// LEVEL-triggered, not edge-triggered: the latched value is re-sent after
+  /// every frame, including the first frame of a fresh mount. Consumers must
+  /// dedupe (#8247 — the shell's consumer is a process-global the shell reads
+  /// even when this widget is gone, so the live State has to keep asserting it
+  /// rather than assume a previous instance left it false).
   final ValueChanged<bool>? onCavityFullChanged;
 
   /// A tap on the hosted surface's dead space (not a button) expands the cavity
@@ -269,10 +275,6 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
   /// mid-drag. That keeps the shell's search-bar reservation (#7697) from
   /// thrashing (and the box from jumping) while the finger is dragging.
   bool _fullLatched = false;
-
-  /// Last value handed to [MobileNavWidget.onCavityFullChanged]; the post-frame
-  /// notify in [build] fires only on a real change.
-  bool _reportedFull = false;
 
   /// Something inside [MobileNavWidget.cavityChild] holds focus — in practice a
   /// text input the learner just tapped. Drives the grow-to-full below. (The
@@ -445,14 +447,24 @@ class _MobileNavWidgetState extends State<MobileNavWidget> {
     setState(() => _restState = height);
   }
 
-  /// Notify the shell of a latched full-height change AFTER the frame — calling
+  /// Re-assert the latched full height to the shell AFTER the frame — calling
   /// back synchronously from build would `setState` the shell mid-build.
+  ///
+  /// Unconditional, every build. The report used to be edge-triggered off a
+  /// per-State `_reportedFull`, which stranded the shell's PROCESS-GLOBAL
+  /// `ActivitySheetFull` at true whenever this State was disposed while full
+  /// — launching a session from a full activity plan drops the plan token
+  /// (`liveView` siblings), tearing the widget down with nothing left to
+  /// report false. The next State started at false, matched its own latched
+  /// false, and stayed silent, so the analytics bar rendered at opacity 0 for
+  /// the rest of the process (#8247). The value the shell derives also folds
+  /// in ITS own state (`isActivityCavity && full`), which an edge trigger on
+  /// our half alone can never track. `ActivitySheetFull.set` dedupes, so the
+  /// repeats cost nothing.
   void _syncFullReport() {
-    if (_fullLatched == _reportedFull) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted || _fullLatched == _reportedFull) return;
-      _reportedFull = _fullLatched;
-      widget.onCavityFullChanged?.call(_reportedFull);
+      if (!mounted) return;
+      widget.onCavityFullChanged?.call(_fullLatched);
     });
   }
 

--- a/test/pangea/navigation/mobile_nav_widget_test.dart
+++ b/test/pangea/navigation/mobile_nav_widget_test.dart
@@ -1272,7 +1272,11 @@ void main() {
     });
   });
 
-  group('full-height reporting (#7697)', () {
+  group('full-height reporting (#7697, #8247)', () {
+    // The report is LEVEL-triggered: the latched value is re-sent after every
+    // frame, so these assert the LAST report, not the exact sequence. The
+    // repeats are what keeps the shell's process-global honest across a
+    // dispose (#8247, below).
     testWidgets('reports full only on settle, and toggles back on collapse', (
       tester,
     ) async {
@@ -1284,18 +1288,18 @@ void main() {
         maxHeightFraction: 0.75,
         onCavityFullChanged: reports.add,
       );
-      // Opens at half — never full — so nothing is reported yet.
-      expect(reports, isEmpty);
+      // Opens at half — never full — so it reports not-full.
+      expect(reports.last, isFalse);
 
-      // Handle tap settles at full: one true report.
+      // Handle tap settles at full.
       await tester.tap(handleFinder());
       await tester.pumpAndSettle();
-      expect(reports, [true]);
+      expect(reports.last, isTrue);
 
-      // Handle tap settles back at half: reports false. Only real changes fire.
+      // Handle tap settles back at half.
       await tester.tap(handleFinder());
       await tester.pumpAndSettle();
-      expect(reports, [true, false]);
+      expect(reports.last, isFalse);
     });
 
     testWidgets('an ephemeral tap-outside collapse reports not-full', (
@@ -1313,12 +1317,40 @@ void main() {
       );
       await tester.tap(handleFinder()); // -> full
       await tester.pumpAndSettle();
-      expect(reports, [true]);
+      expect(reports.last, isTrue);
 
       // Tap outside collapses ephemerally — the sheet is no longer full.
       await tester.tapAt(const Offset(200, 20));
       await tester.pumpAndSettle();
-      expect(reports, [true, false]);
+      expect(reports.last, isFalse);
+    });
+
+    testWidgets('a fresh mount re-asserts not-full after a full sheet was '
+        'disposed (#8247)', (tester) async {
+      final reports = <bool>[];
+      await pumpNav(
+        tester,
+        cavityChild: const Text('Activity plan'),
+        cavityKey: 'activity:a',
+        maxHeightFraction: 0.75,
+        onCavityFullChanged: reports.add,
+      );
+      await tester.tap(handleFinder()); // -> full
+      await tester.pumpAndSettle();
+      expect(reports.last, isTrue);
+
+      // Launching the session drops the plan token (`liveView` siblings), so
+      // the widget goes away WITHOUT a close: didUpdateWidget's closedNow
+      // branch never runs and the State is disposed still latched full.
+      await unmountNav(tester);
+      reports.clear();
+
+      // Back at the bare map: a genuinely fresh State with no cavity. It must
+      // assert not-full rather than assume the last instance left it that way
+      // — otherwise the shell's ActivitySheetFull stays true and the analytics
+      // bar renders at opacity 0 for the rest of the process.
+      await pumpNav(tester, onCavityFullChanged: reports.add);
+      expect(reports.last, isFalse);
     });
   });
 }


### PR DESCRIPTION
Closes #8247.

## What happened

The analytics/settings bar never failed to mount — it was mounted and painted at **zero opacity**, for the rest of the process.

When the activity plan's sheet sits at full it grows over the bar's band, so the shell fades the bar out rather than unmounting it (it keeps its counts and stream subs across the toggle). That gate reads `ActivitySheetFull`, a **process-global** `ValueNotifier<bool>`.

Its only writer was an **edge-triggered** report off a per-`State` `_reportedFull`, and `_MobileNavWidgetState` has no `dispose()`. So a per-instance dedupe was guarding a per-process flag:

1. Open an activity plan on a phone, drag it to full → `ActivitySheetFull = true`, bar fades out (correct).
2. Start the session. `ActivityPanelDef` is in the `liveView` sibling group alongside `room`/`session`, so the plan token is dropped, the nav widget unmounts in the same frame, and the `State` is disposed still latched full. `didUpdateWidget`'s `closedNow` branch never runs — nothing reports `false`.
3. Leave the session. A fresh `State` starts at `_reportedFull = false`, matches its own latched `false`, early-returns, and never re-asserts. **Global still `true`.**
4. The bar is invisible and untappable from then on. Only killing the app resets the static — exactly the recovery the reporter described.

Other paths dispose the `State` the same way: the pin sheet swapping the layer for `SizedBox.shrink()`, and `showNavRail` going false on a `roomid`/`:construct`/non-root `spaceid` route.

There is also a **stale-true** variant needing no unmount — activity-at-full, then tap Chats where the chat list's remembered height is also full: `_fullLatched` doesn't change, so the dedupe suppresses the call while the shell's `isActivityCavity` has flipped to `false`.

Introduced in #8170 (2026-08-07), which shipped in `5.0.0+6` (cut 08-10). Reported 08-11.

## The fix

Report the latched value after **every** frame instead of on the edge. `ActivitySheetFull.set` already dedupes, so the repeats cost nothing and no extra shell rebuild happens; a fresh mount now clears any stranded `true` on its first frame.

This also covers the stale-true case: the value the shell derives is `isActivityCavity && full` — a function of *its* state and *ours*. An edge trigger on our half alone can never track that. Re-asserting re-evaluates the shell's closure.

Considered and rejected:
- A `dispose()` override — element unmount runs inside `finalizeTree`'s `lockState`, so a synchronous `set` there trips "setState() called when widget tree was locked." It would have to defer anyway (more code), and it still wouldn't close the stale-true case.
- Also gating the shell on `isActivityCavity` — masks the map case but can't close the one where an activity cavity is open at a *non-full* height with the flag stranded, since the shell doesn't know the sheet's height. The re-assert fixes it at the source.

## Tests

- **New regression test**, `full-height reporting (#7697, #8247)`: settle a cavity at full, `unmountNav` (the harness's stand-in for a full-screen surface mounting over it — exactly the `liveView` session launch), remount fresh, assert it reports not-full. Verified it **fails on the pre-fix code** and passes after.
- The two existing tests in that group asserted exact report sequences and are relaxed to last-value assertions. That churn is the contract change, not collateral — the callback is now level-triggered, documented on `onCavityFullChanged`.
- `fvm flutter test test/pangea/navigation/` — 377 pass. `flutter analyze` clean on both files.

## TO TEST

Narrow/single-column only — the bug can't reproduce in column mode (both visibility flags require `!isColumnMode`, and wide renders `WorldUserCluster` instead). Narrow the window to ≤ 840px on web, or use a phone.

- [ ] Open an activity plan in the cavity and drag/tap it to **full** — the analytics bar still fades out (unchanged, intended)
- [ ] From the full plan, start/join the session, then close it and return to the bare map — **the analytics bar is back**
- [ ] Same, but return to the Courses hub or the chat list instead of the map — bar present
- [ ] Plan at full → tap the **Chats** rail item with the chat list previously left at full — bar visible over the chats sheet
- [ ] Drag the cavity around normally (course card peek/half/full, chat list) — no flicker in the bar, no jump in the floating search bar over a full course sheet (#7697 behaviour unchanged)
- [ ] Wide screen: the top-right cluster is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)