### PR TITLE
fix(analytics): left-align the example-message toolbar so word cards grow right

### DIFF
--- a/lib/routes/chat/toolbar/layout/message_selection_positioner.dart
+++ b/lib/routes/chat/toolbar/layout/message_selection_positioner.dart
@@ -148,7 +148,12 @@ class MessageSelectionPositionerState extends State<MessageSelectionPositioner>
     return null;
   }
 
+  /// Drives every horizontal choice in the overlay: which edge the bubble
+  /// anchors to and which way the word card grows. Hosts that left-align
+  /// their messages force it false, so an own message there behaves like a
+  /// received one (#8252).
   bool get ownMessage =>
+      !widget.overlayController.config.alignMessageLeft &&
       widget.event.senderId == widget.event.room.client.userID;
 
   double get _toolbarMaxWidth {

--- a/lib/routes/chat/toolbar/message_toolbar_host.dart
+++ b/lib/routes/chat/toolbar/message_toolbar_host.dart
@@ -46,11 +46,19 @@ class MessageToolbarConfig {
   /// page underneath the open overlay.
   final bool enableWordCardAnalyticsNavigation;
 
+  /// Lay the overlay out from the left edge of the message, whatever the
+  /// sender. Chat mirrors the timeline, so the user's own messages anchor
+  /// right and the word card grows leftward. Hosts that left-align every
+  /// message (the analytics example chips) set this so the card grows into
+  /// the free space on the right instead of being squeezed (#8252).
+  final bool alignMessageLeft;
+
   const MessageToolbarConfig({
     required this.showPracticeButton,
     required this.showMoreButton,
     required this.showReactionPicker,
     required this.enableWordCardAnalyticsNavigation,
+    required this.alignMessageLeft,
   });
 
   static const chat = MessageToolbarConfig(
@@ -58,6 +66,7 @@ class MessageToolbarConfig {
     showMoreButton: true,
     showReactionPicker: true,
     enableWordCardAnalyticsNavigation: true,
+    alignMessageLeft: false,
   );
 
   static const analyticsExample = MessageToolbarConfig(
@@ -65,5 +74,6 @@ class MessageToolbarConfig {
     showMoreButton: false,
     showReactionPicker: false,
     enableWordCardAnalyticsNavigation: false,
+    alignMessageLeft: true,
   );
 }

--- a/test/pangea/message_toolbar_config_test.dart
+++ b/test/pangea/message_toolbar_config_test.dart
@@ -15,6 +15,8 @@ void main() {
       expect(config.showMoreButton, isTrue);
       expect(config.showReactionPicker, isTrue);
       expect(config.enableWordCardAnalyticsNavigation, isTrue);
+      // Chat mirrors the timeline: own messages anchor right.
+      expect(config.alignMessageLeft, isFalse);
     });
 
     test('analyticsExample preset hides chat-only surfaces', () {
@@ -23,6 +25,9 @@ void main() {
       expect(config.showMoreButton, isFalse);
       expect(config.showReactionPicker, isFalse);
       expect(config.enableWordCardAnalyticsNavigation, isFalse);
+      // Example chips are left-aligned whoever sent them, so the word card
+      // grows right instead of being squeezed against the left edge (#8252).
+      expect(config.alignMessageLeft, isTrue);
     });
   });
 


### PR DESCRIPTION
## What

Lay the analytics example-message toolbar out from the left edge of the message, so the word card grows into the free space on the right.

## Why

Closes #8252

The vocab details page renders every example chip left-aligned, but the toolbar overlay chose its anchor by sender. A chip from the user's own message therefore anchored right, and the word card grew leftward from the chip's right edge — squeezing the card to the width of a short message while the whole right half of the screen sat empty.

`MessageToolbarConfig` gains `alignMessageLeft`; the positioner's `ownMessage` getter (the single source for anchor edge, card direction, and column alignment) reads it. `MessageToolbarConfig.chat` keeps `false`, so chat still mirrors the timeline.

## Testing

- `fvm flutter test test/pangea/message_toolbar_config_test.dart test/pangea/lemma_use_example_messages_test.dart` — pass (preset assertions extended to cover the new flag).
- `fvm flutter analyze` on both changed files — clean.
- Manual, local stack (web, 800px-wide narrow layout, learner account): vocab analytics → open a lemma → tap a word in the example chip. With a short example (`Gato.`, ~80px wide) the card now renders at full width extending right of the chip; the overlay bubble still lands exactly over the chip. Previously the card was capped at the chip's right edge.
- Regression check on the shared path: tapping the same own message inside chat still anchors the card to the right edge with right-aligned toolbar buttons.

## Deploy Notes

None
