### PR TITLE
fix(analytics): drop the level-up chip below the badge on the narrow bar

### DIFF
--- a/lib/routes/world/level_up_badge_celebration.dart
+++ b/lib/routes/world/level_up_badge_celebration.dart
@@ -16,8 +16,8 @@ import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 ///
 /// Replaces the old top-down chat snackbar: instead of chrome dropping over
 /// the conversation, the badge itself briefly pulses (scale + gold glow), a
-/// small "Level N!" chip pops out beside it, and the level-up chime plays; the
-/// chip then fades away on its own. This keeps the learner's eye on the
+/// small "Level N!" chip pops out beside it (or below it — see [chipBelow]),
+/// and the level-up chime plays; the chip then fades away on its own. This keeps the learner's eye on the
 /// analytics surface the level actually lives on, per the issue's intent.
 ///
 /// Only one of these is ever mounted at a time — the shell picks the cluster
@@ -58,12 +58,19 @@ class LevelUpBadgeCelebration extends StatefulWidget {
   /// a no-op so they never reach for the audio plugin or the network.
   final Future<void> Function()? playChime;
 
+  /// Drops the chip below the badge instead of beside it. Opt-in per host,
+  /// because only one of them has no room beside the badge: on the narrow
+  /// analytics bar the badge overhangs the pill's left end near the screen's
+  /// edge, so a chip hanging off its leading edge runs off-screen (#8257).
+  final bool chipBelow;
+
   const LevelUpBadgeCelebration({
     required this.child,
     this.levelUpdates,
     this.chipDuration = defaultChipDuration,
     this.pulseDuration = defaultPulseDuration,
     this.playChime,
+    this.chipBelow = false,
     super.key,
   });
 
@@ -80,7 +87,7 @@ class _LevelUpBadgeCelebrationState extends State<LevelUpBadgeCelebration>
   static const double _maxScaleBoost = 0.18;
   static const int _pulseBeats = 3;
 
-  /// Gap between the chip's trailing edge and the badge's leading edge.
+  /// Gap between the chip and the badge edge it hangs off.
   static const double _chipGap = 6.0;
 
   StreamSubscription<LevelUpdate>? _subscription;
@@ -247,10 +254,11 @@ class _LevelUpBadgeCelebrationState extends State<LevelUpBadgeCelebration>
           child: widget.child,
         ),
         if (celebratedLevel != null)
-          // The chip hangs just past the badge's leading edge, vertically
-          // centered on it: the OverflowBox lets it take its intrinsic width
-          // without an overflow error, and the FractionalTranslation shifts
-          // it fully outside so it reads as popping out of the badge.
+          // The chip hangs just past one badge edge — the bottom under
+          // [chipBelow], otherwise the leading edge — centered on it the other
+          // way: the OverflowBox lets it take its intrinsic size without an
+          // overflow error, and the FractionalTranslation shifts it fully
+          // outside so it reads as popping out of the badge.
           Positioned.fill(
             child: IgnorePointer(
               child: OverflowBox(
@@ -260,11 +268,17 @@ class _LevelUpBadgeCelebrationState extends State<LevelUpBadgeCelebration>
                 maxWidth: double.infinity,
                 minHeight: 0.0,
                 maxHeight: double.infinity,
-                alignment: Alignment.centerLeft,
+                alignment: widget.chipBelow
+                    ? Alignment.bottomCenter
+                    : Alignment.centerLeft,
                 child: FractionalTranslation(
-                  translation: const Offset(-1.0, 0.0),
+                  translation: widget.chipBelow
+                      ? const Offset(0.0, 1.0)
+                      : const Offset(-1.0, 0.0),
                   child: Padding(
-                    padding: const EdgeInsets.only(right: _chipGap),
+                    padding: widget.chipBelow
+                        ? const EdgeInsets.only(top: _chipGap)
+                        : const EdgeInsets.only(right: _chipGap),
                     child: FadeTransition(
                       opacity: _chipOpacity,
                       child: ScaleTransition(

--- a/lib/routes/world/world_analytics_bar.dart
+++ b/lib/routes/world/world_analytics_bar.dart
@@ -323,6 +323,10 @@ class _PowerupsRow extends StatelessWidget {
                         // overhangs.
                         child: LevelUpBadgeCelebration(
                           levelUpdates: viewModel.levelUpdates,
+                          // The badge overhangs the pill near the screen's
+                          // left edge here, so the chip drops below it — beside
+                          // it, the chip ran off-screen (#8257).
+                          chipBelow: true,
                           child: HexLevelBadge(
                             level: level,
                             selected:

--- a/test/pangea/navigation/level_up_badge_celebration_test.dart
+++ b/test/pangea/navigation/level_up_badge_celebration_test.dart
@@ -26,6 +26,7 @@ void main() {
     WidgetTester tester,
     Stream<LevelUpdate> levelUpdates, {
     Future<void> Function()? playChime,
+    bool chipBelow = false,
   }) async {
     await tester.pumpWidget(
       MaterialApp(
@@ -41,6 +42,7 @@ void main() {
               // plugin and the assets bucket, neither of which exists in a
               // widget test.
               playChime: playChime ?? () async {},
+              chipBelow: chipBelow,
               child: const SizedBox(key: badgeKey, width: 40, height: 44),
             ),
           ),
@@ -177,6 +179,51 @@ void main() {
     // Pulse and chip are paint-time effects only — the celebration never
     // grows the badge's layout box (so it can't push the surfaces around).
     expect(tester.getSize(find.byType(LevelUpBadgeCelebration)), badgeSize);
+
+    await tester.pump(pulseDuration);
+    await tester.pump(chipDuration + fadeOut);
+    await tester.pumpAndSettle();
+    await controller.close();
+  });
+
+  testWidgets('the chip sits beside the badge by default', (tester) async {
+    final controller = StreamController<LevelUpdate>.broadcast();
+    await pumpCelebration(tester, controller.stream);
+    final chipText = l10nOf(tester).levelUpChip(4);
+
+    controller.add(const LevelUpdate(prevLevel: 3, newLevel: 4));
+    await tester.pump();
+    await tester.pump();
+
+    final badge = tester.getRect(find.byKey(badgeKey));
+    final chip = tester.getRect(find.text(chipText));
+    expect(chip.right, lessThanOrEqualTo(badge.left));
+    expect(chip.center.dy, moreOrLessEquals(badge.center.dy, epsilon: 1.0));
+
+    await tester.pump(pulseDuration);
+    await tester.pump(chipDuration + fadeOut);
+    await tester.pumpAndSettle();
+    await controller.close();
+  });
+
+  testWidgets('chipBelow drops the chip under the badge instead (#8257)', (
+    tester,
+  ) async {
+    final controller = StreamController<LevelUpdate>.broadcast();
+    await pumpCelebration(tester, controller.stream, chipBelow: true);
+    final chipText = l10nOf(tester).levelUpChip(4);
+
+    controller.add(const LevelUpdate(prevLevel: 3, newLevel: 4));
+    await tester.pump();
+    await tester.pump();
+
+    // Below the badge and centered on it — the analytics bar's badge sits at
+    // the screen's left edge, where a chip hanging off its leading edge would
+    // be cut off.
+    final badge = tester.getRect(find.byKey(badgeKey));
+    final chip = tester.getRect(find.text(chipText));
+    expect(chip.top, greaterThanOrEqualTo(badge.bottom));
+    expect(chip.center.dx, moreOrLessEquals(badge.center.dx, epsilon: 1.0));
 
     await tester.pump(pulseDuration);
     await tester.pump(chipDuration + fadeOut);

--- a/test/pangea/navigation/world_analytics_bar_test.dart
+++ b/test/pangea/navigation/world_analytics_bar_test.dart
@@ -202,6 +202,42 @@ void main() {
       expect(find.text(chipText), findsNothing);
       await controller.close();
     });
+
+    testWidgets('the chip stays on-screen on a narrow phone (#8257)', (
+      tester,
+    ) async {
+      // The bug: the badge overhangs the pill's left end near the screen's
+      // edge, so a chip hanging off its LEADING edge was mostly cut off. The
+      // bar passes `chipBelow`, which drops it under the badge instead.
+      tester.view.physicalSize = const Size(375, 812);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+
+      final controller = StreamController<LevelUpdate>.broadcast();
+      final viewModel = MockUserClusterViewModel(
+        levelUpdates: controller.stream,
+      );
+      await pumpBar(tester, viewModel: viewModel);
+      final chipText = l10nOf(tester).levelUpChip(2);
+
+      controller.add(const LevelUpdate(prevLevel: 1, newLevel: 2));
+      await tester.pump();
+      await tester.pump();
+
+      final badge = tester.getRect(find.byType(HexLevelBadge));
+      final chip = tester.getRect(find.text(chipText));
+      expect(chip.top, greaterThanOrEqualTo(badge.bottom));
+      expect(chip.left, greaterThanOrEqualTo(0.0));
+      expect(chip.right, lessThanOrEqualTo(375.0));
+
+      await tester.pump(LevelUpBadgeCelebration.defaultPulseDuration);
+      await tester.pump(
+        LevelUpBadgeCelebration.defaultChipDuration +
+            const Duration(milliseconds: 300),
+      );
+      await tester.pumpAndSettle();
+      await controller.close();
+    });
   });
 
   /// The open-panel highlight: the bar is the single-column rendering of the


### PR DESCRIPTION
## What

The level-up "Level N!" chip now drops below the hex badge on the narrow analytics bar instead of beside it, so it stays on screen.

## Why

Closes #8257

On the narrow analytics bar the hex badge overhangs the pill's left end, close to the screen edge, so a chip hanging off the badge's leading edge ran off-screen — most of "Level N!" was cut away on a small phone.

`LevelUpBadgeCelebration` gets an opt-in `chipBelow`, set only by `WorldAnalyticsBar`. The web cluster and the chat app bar's avatar both have room beside their badge, so they keep the side placement.

## Testing

- `fvm flutter test` — full suite, 2320 passed / 3 skipped.
- New unit coverage in `level_up_badge_celebration_test.dart`: the chip sits beside the badge by default, and `chipBelow` puts it under the badge, centred on it.
- New regression test in `world_analytics_bar_test.dart`: at 375×812, the chip's rect is below the badge and fully inside `0..375` — the geometry the issue's screenshot violated.

No manual pass on device: a level-up needs real analytics XP against the local stack. Golden-image capture was tried and is not usable here — the chip lives inside a `FadeTransition`, whose compositing layer the test-environment capture drops, so both the old and new placements come out blank. The rect assertions are the verification.

## Deploy Notes

None
