### PR TITLE
test(analytics): cover chat + vocab example chip rendering the same event

### DIFF
--- a/test/pangea/lemma_use_example_messages_test.dart
+++ b/test/pangea/lemma_use_example_messages_test.dart
@@ -9,9 +9,16 @@ import 'package:fluffychat/features/analytics/construct_type_enum.dart';
 import 'package:fluffychat/features/analytics/construct_use_model.dart';
 import 'package:fluffychat/features/analytics/construct_use_type_enum.dart';
 import 'package:fluffychat/features/analytics/constructs_model.dart';
+import 'package:fluffychat/features/user/user_controller.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/controllers/pangea_controller.dart';
+import 'package:fluffychat/routes/analytics/construct_analytics/construct_analytics_details/example_message_toolbar.dart';
 import 'package:fluffychat/routes/analytics/construct_analytics/construct_analytics_details/lemma_use_example_messages.dart';
+import 'package:fluffychat/routes/chat/events/constants/message_constants.dart';
 import 'package:fluffychat/routes/chat/events/event_wrappers/pangea_message_event.dart';
 import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
+import 'package:fluffychat/routes/chat/message_content.dart';
+import 'package:fluffychat/widgets/matrix.dart';
 import 'get_test_client.dart';
 
 /// #8081 — the vocab details example-message walk: one example per source
@@ -35,6 +42,7 @@ void main() {
 
   setUp(() async {
     client = await getTestClient();
+    MatrixState.pangeaController = _FakePangeaController(client);
     room = Room(id: '!examples:fakeServer.notExisting', client: client);
     timeline = await room.getTimeline();
   });
@@ -70,6 +78,31 @@ void main() {
           senderId: client.userID!,
           originServerTs: DateTime.now(),
           content: {'msgtype': 'm.text', 'body': message},
+          room: room,
+        ),
+        timeline: timeline,
+        ownMessage: true,
+      );
+
+  /// A message event carrying its tokens in `tokens_sent`, so the renderer's
+  /// `messageDisplayRepresentation` resolves without a choreo round trip.
+  PangeaMessageEvent tokenizedMessageEvent(String eventId, String message) =>
+      PangeaMessageEvent(
+        event: Event(
+          type: EventTypes.Message,
+          eventId: eventId,
+          senderId: client.userID!,
+          originServerTs: DateTime.now(),
+          content: {
+            'msgtype': 'm.text',
+            'body': message,
+            MessageConstants.tokensSent: {
+              'tokens': [for (final token in tokenize(message)) token.toJson()],
+              'detections': [
+                {'lang_code': 'es', 'confidence': 1.0},
+              ],
+            },
+          },
           room: room,
         ),
         timeline: timeline,
@@ -219,4 +252,104 @@ void main() {
     await tester.pumpAndSettle();
     expect(calls, hasLength(1));
   });
+
+  // #8254 — a chat panel and the vocab details page can be on screen at the
+  // same time on a wide window, both rendering the SAME message event. Every
+  // rendered token wraps itself in a `CompositedTransformTarget` plus a
+  // `MouseRegion` keyed from [PangeaAnyState.layerLinkAndKey], which hands out
+  // one `LayerLink` + one `GlobalKey` per id process-wide. If both surfaces ask
+  // for the same id, Flutter reparents the keyed elements into whichever
+  // subtree built last and the other message renders as an empty bubble — so
+  // only one of the two ever shows its text. [PangeaToken.analyticsExampleTargetKey]
+  // is what keeps the chip's ids distinct; this test fails if that namespacing
+  // stops reaching the chip.
+  testWidgets('chat message and example chip both render the same event', (
+    tester,
+  ) async {
+    const text = 'corro mucho';
+    final event = tokenizedMessageEvent('\$e1', text);
+    final tokens = tokenize(text);
+
+    final host = AnalyticsMessageToolbarHost(
+      messageEvent: event,
+      context: _FakeBuildContext(),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: Row(
+            children: [
+              // The open chat's timeline render of the event.
+              Expanded(
+                child: MessageContent(
+                  event.event,
+                  textColor: Colors.black,
+                  linkColor: Colors.blue,
+                  borderRadius: BorderRadius.circular(8),
+                  timeline: timeline,
+                  selected: false,
+                  pangeaMessageEvent: event,
+                  controller: host,
+                ),
+              ),
+              // The vocab details page's example-message chip for the event.
+              Expanded(
+                child: LemmaUseExampleMessages(
+                  construct: constructFor([
+                    use('correr', 'corro', '\$e1', DateTime(2026, 1, 1)),
+                  ]),
+                  client: client,
+                  resolveExampleMessage: (_) async =>
+                      ExampleMessage(messageEvent: event, tokens: tokens),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('mucho', findRichText: true), findsNWidgets(2));
+  });
+}
+
+/// [AnalyticsMessageToolbarHost] only stores the context (it uses it to close
+/// the overlay), so the chip renders fine with a stub.
+class _FakeBuildContext implements BuildContext {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+/// The chip and the chat both read tokens off the message event, so the
+/// rendering test needs a [PangeaController] to answer the tool-setting and
+/// user-profile lookups behind `messageDisplayRepresentation`.
+class _FakePangeaController implements PangeaController {
+  @override
+  final UserController userController = UserController();
+
+  @override
+  final MatrixState matrixState;
+
+  _FakePangeaController(Client client) : matrixState = _FakeMatrixState(client);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeMatrixState implements MatrixState {
+  @override
+  final Client client;
+
+  _FakeMatrixState(this.client);
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) =>
+      '_FakeMatrixState';
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
 }


### PR DESCRIPTION
## What

Regression test: an open chat and the vocab details page rendering the **same** message event at once must both show their text.

## Why

Closes #8254.

The reported symptom — only one of the two messages shows its text at a time — is a duplicate `GlobalKey`/`LayerLink` collision. Every rendered token wraps itself in a `CompositedTransformTarget` plus a keyed `MouseRegion` built from `PangeaAnyState.layerLinkAndKey`, which hands out one link + one key per id, process-wide. When two surfaces claim the same id, Flutter reparents the keyed elements into whichever subtree built last, and the other message collapses to an empty bubble.

`PangeaToken.analyticsExampleTargetKey` (added in #8169, on `main` since Aug 7) already gives the example-message chips their own namespace, so **`main` and staging no longer reproduce this**. What was missing is a test: nothing failed when the chip and the chat shared a namespace, which is how the collision reached users in the first place.

Production is still serving a bundle from before that change — its `main.dart.js` has the `-overlay`/`-practice`/base token-key branches but no `-analytics-example` branch — so the issue reproduces there until the next production release.

## Testing

- `fvm flutter test` — 2332 passed, 4 skipped, 1 pre-existing environment failure (`choreo_endpoint_test.dart` "Custom course endpoint test": `401 … Matrix account has no email 3pid`, unrelated to this change).
- New test verified to actually catch the regression: flipping the chip's `isAnalyticsExample` back to `false` makes it fail with `Duplicate GlobalKeys detected in widget tree` and only 1 of the 2 messages rendering.
- Manual, local stack (Flutter web, wide window), following the issue's TO TEST: sent a tokenized L2 message in a chat, opened Vocab → `gato` in the second panel — chat bubble and example chip both render their text, including across toolbar open/close on both sides.

## Deploy Notes

None.
