### PR TITLE
fix(chats): hide default chat creation tiles when the chat already exists

### DIFF
--- a/lib/routes/chat_list/course_chats_page.dart
+++ b/lib/routes/chat_list/course_chats_page.dart
@@ -181,7 +181,15 @@ class CourseChatsController extends State<CourseChats> with CoursePlanProvider {
 
   bool showDefaultChatCreation(CourseDefaultChatsEnum type) {
     if (space == null || !space!.isRoomAdmin) return false;
-    return !space!.dismissedDefaultChat(type) && !space!.hasDefaultChat(type);
+    if (space!.dismissedDefaultChat(type) || space!.hasDefaultChat(type)) {
+      return false;
+    }
+    // The chat can exist without being joined yet, in which case it's not in
+    // client.rooms (which hasDefaultChat checks) but in the discovered
+    // hierarchy children.
+    return !(_discoveredChildren ?? []).any(
+      (chunk) => (chunk.canonicalAlias?.localpart ?? '').startsWith(type.alias),
+    );
   }
 
   void _setRoomSubscription() {


### PR DESCRIPTION
## What

Hide the "Create Introductions/Announcements Chat" tiles when the default chat already exists but the viewing admin hasn't joined it yet.

## Why

Closes #8260

`showDefaultChatCreation` only checked joined rooms (`hasDefaultChat`), so an admin who hadn't joined an existing default chat saw both the chat in the discovered list and the tile offering to create it. The fix also checks the discovered hierarchy children, using the same alias-prefix rule `_joinDefaultChats` already matches on (so it covers both current `introductionChat_<space>_<ts>` and legacy `introductionChat_<space>` aliases).

## Testing

- `fvm dart analyze` clean; full unit suite green locally (2317 passed, 3 skipped).
- No unit test added: the predicate lives on the controller State and would need full Matrix/provider scaffolding to pump; the new logic is a 3-line alias-prefix check reusing the existing match rule.
- Manual multi-admin repro (admin who hasn't joined the chats) deferred to staging QA per the issue's TO TEST.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)