### PR TITLE
fix(activities): repair a session archive a co-player's write overwrote

### DIFF
--- a/lib/features/activity_sessions/activity_auto_save_service.dart
+++ b/lib/features/activity_sessions/activity_auto_save_service.dart
@@ -49,22 +49,25 @@ class ActivityAutoSaveService {
   StreamSubscription? _roleStateSub;
   final Set<String> _saving = {};
 
-  /// DURABLE idempotency (across process restarts) is NOT these in-memory sets —
-  /// it is the SERVER-AUTHORITATIVE `archived_at` in the role state: [start]
-  /// waits for the first `/sync` before sweeping, so a restart sees the archived
-  /// role, `hasArchivedActivity` is true, the gate (`!hasArchivedActivity`) is
-  /// closed, and the session is never re-saved or re-emitted. The two sets below
-  /// only close the INTRA-RUN pre-sync window (before that first sync echoes the
-  /// archive back), and a restart resets them harmlessly.
+  /// DURABLE idempotency (across process restarts) is NOT in-memory state — it
+  /// is the SERVER-AUTHORITATIVE `archived_at` in the role state: [start] waits
+  /// for the first `/sync` before sweeping, so a restart sees the archived role,
+  /// `hasArchivedActivity` is true, the gate (`!hasArchivedActivity`) is closed,
+  /// and the session is never re-saved or re-emitted.
   ///
-  /// Session rooms this run has already SAVED (analytics + archive). Without
-  /// this, a pre-sync sweep would re-archive and stamp a NEWER `archived_at`,
-  /// leaving the already-emitted outcome's timestamp stale. Once saved, the
-  /// first archive is authoritative and the room is never re-saved this run.
-  final Set<String> _saved = {};
+  /// The archived-at this run persisted per session room. An archive is NOT
+  /// final once written: every role lives in one shared `pangea.activity_roles`
+  /// event, so a co-player archiving from a stale read overwrites the whole map
+  /// and drops this user's `archived_at` — the session pops back into the chat
+  /// list and its stars unbank until the next app start (#8258). The role-state
+  /// listener sees that overwrite and the gate re-opens, so the repair is simply
+  /// to archive again — replaying the REMEMBERED instant, so the repaired room
+  /// state still matches the dosage outcome already emitted against it.
+  final Map<String, DateTime> _archivedAt = {};
 
   /// Session rooms whose dosage outcome has already been emitted this run (the
-  /// intra-run outcome guard; see [_saved] for why a restart can't double-emit).
+  /// intra-run outcome guard; a restart can't double-emit because the synced
+  /// `archived_at` closes the gate before the sweep runs).
   final Set<String> _emittedOutcomes = {};
   bool _disposed = false;
 
@@ -111,11 +114,6 @@ class ActivityAutoSaveService {
       return;
     }
 
-    // Already saved this run: the first archive is authoritative. The gate above
-    // stays open until the archive syncs back, so without this a pre-sync sweep
-    // would re-archive with a newer timestamp.
-    if (!shouldSave(room.id, _saved)) return;
-
     // Reading the plan triggers hydration for reference rooms; a null here is
     // retried via the repo listener. A room with no resolvable plan at all
     // can't determine its target language and is skipped.
@@ -128,6 +126,9 @@ class ActivityAutoSaveService {
     if (lang == null) return;
 
     if (!_saving.add(room.id)) return;
+    // A repair pass re-persists an archive a co-player's write dropped; the
+    // session completed once, so it must not be COUNTED again.
+    final isRepair = _archivedAt.containsKey(room.id);
     try {
       // Analytics room first: if this write fails, archived_at stays unset and
       // the save retries on the next role-state event or sweep.
@@ -135,39 +136,35 @@ class ActivityAutoSaveService {
       // archiveActivity returns the canonical archived-at it persisted, so the
       // outcome below uses it directly instead of re-reading room state the
       // archive write may not have synced back yet — a race that would skip the
-      // emit permanently once the gate closes on the archived role.
-      final archivedAt = await room.archiveActivity();
+      // emit permanently once the gate closes on the archived role. Replaying
+      // `_archivedAt` keeps a repair write (see the field doc) on the instant
+      // this run first banked, so a second pass is idempotent in content.
+      final archivedAt = await room.archiveActivity(at: _archivedAt[room.id]);
 
-      // Saved successfully: mark authoritative FIRST — BEFORE any best-effort
-      // telemetry — so a pre-sync sweep can't re-archive with a newer timestamp,
-      // and a throw from the emit below can never leave a completed archive
-      // unmarked. On archive failure this line isn't reached and it retries on
-      // the next role-state event or sweep.
-      _saved.add(room.id);
+      // Remember the canonical instant FIRST — BEFORE any best-effort telemetry
+      // — so a throw from the emit below can never lose it. On archive failure
+      // this line isn't reached and it retries on the next role-state event or
+      // sweep.
+      if (archivedAt != null) _archivedAt[room.id] = archivedAt;
 
       // Best-effort dosage session outcome at the archive moment (stars bank
       // here). Fire-and-forget + fully guarded; never blocks or fails the save.
       _emitDosageSessionOutcome(room, archivedAt);
 
-      GoogleAnalytics.completeActivity(
-        plan.activityId,
-        room.id,
-        versionPinHonored: !plan.usedFallbackVersion,
-        fallbackCause: plan.fallbackCause,
-      );
+      if (!isRepair) {
+        GoogleAnalytics.completeActivity(
+          plan.activityId,
+          room.id,
+          versionPinHonored: !plan.usedFallbackVersion,
+          fallbackCause: plan.fallbackCause,
+        );
+      }
     } catch (e, s) {
       ErrorHandler.logError(e: e, s: s, data: {'roomId': room.id});
     } finally {
       _saving.remove(room.id);
     }
   }
-
-  /// Whether a session room still needs saving: false once it has been saved
-  /// this run (the first archive is authoritative). The gate that keeps a
-  /// pre-sync sweep from re-archiving with a newer timestamp.
-  @visibleForTesting
-  static bool shouldSave(String roomId, Set<String> saved) =>
-      !saved.contains(roomId);
 
   /// Fire-and-forget the best-effort dosage session-outcome signal at the
   /// archive moment. Every field is a client-side HINT the server re-verifies

--- a/lib/features/activity_sessions/activity_roles_room_extension.dart
+++ b/lib/features/activity_sessions/activity_roles_room_extension.dart
@@ -258,7 +258,15 @@ extension ActivityRolesRoomExtension on Room {
   /// `ownRoleState.archivedAt` right after this races the sync echo and can read
   /// null). Returns the existing archived-at when the role is already archived
   /// (no re-write), or null when there is no finished role to archive.
-  Future<DateTime?> archiveActivity() async {
+  ///
+  /// [at] re-persists an archived-at this client already banked instead of
+  /// stamping a fresh one. Every role lives in ONE shared state event, so
+  /// archiving is a read-modify-write of the whole role map and a co-player
+  /// archiving from a stale read drops this user's `archived_at` (#8258). The
+  /// re-write that repairs that must replay the original instant, or the room
+  /// would end up disagreeing with the dosage outcome already emitted against
+  /// it.
+  Future<DateTime?> archiveActivity({DateTime? at}) async {
     final currentRoles = activityRoles ?? ActivityRolesModel.empty;
     final role = ownRoleState;
     if (role == null || !role.isFinished) return null;
@@ -267,7 +275,7 @@ extension ActivityRolesRoomExtension on Room {
     // UTC so the persisted archived_at (and the dosage completed_at derived from
     // it) is an unambiguous instant with an offset, never a bare local
     // wall-clock the server would have to guess a zone for.
-    final archivedAt = DateTime.now().toUtc();
+    final archivedAt = at ?? DateTime.now().toUtc();
     role.archivedAt = archivedAt;
     currentRoles.updateRole(role);
     await client.setRoomStateWithKey(

--- a/test/pangea/activity_archive_activity_test.dart
+++ b/test/pangea/activity_archive_activity_test.dart
@@ -120,6 +120,28 @@ void main() {
     },
   );
 
+  test('re-archiving after a co-player overwrote the role map replays the '
+      'original instant, not a fresh one', () async {
+    // Every role lives in ONE shared state event, so a co-player archiving
+    // from a stale read drops this user's archived_at (#8258): the session
+    // pops back into the chat list and its stars unbank. The repair write
+    // must carry the instant this client first banked, or the room would
+    // disagree with the dosage outcome already emitted against it.
+    final banked = DateTime.utc(2026, 1, 1, 12, 30);
+    final room = roomWithRole(finishedRole());
+    FakeMatrixApi.calledEndpoints.clear();
+
+    final returned = await room.archiveActivity(at: banked);
+
+    expect(returned, banked);
+    final body = lastRolePutBody();
+    expect(body, isNotNull, reason: 'the repair was persisted');
+    expect(
+      ((body!['roles'] as Map)['role-1'] as Map)['archived_at'],
+      banked.toIso8601String(),
+    );
+  });
+
   test('returns null when there is no finished role to archive', () async {
     final room = roomWithRole(
       ActivityRoleModel(id: 'role-1', userId: userId, role: 'Interviewer'),

--- a/test/pangea/activity_auto_save_gate_test.dart
+++ b/test/pangea/activity_auto_save_gate_test.dart
@@ -38,9 +38,15 @@ void main() {
     // gate (a restart with empty in-memory sets still closes the gate purely
     // because the server-synced archived_at makes hasArchivedActivity true,
     // which is the already-saved case above). It is exercised where it actually
-    // lives — the empty-set first pass in the shouldSave / shouldEmitOutcome
-    // groups below — so no vacuous restart-flavoured duplicate of the
-    // already-saved assertion is kept here.
+    // lives — the empty-set first pass in the shouldEmitOutcome group below —
+    // so no vacuous restart-flavoured duplicate of the already-saved assertion
+    // is kept here.
+    //
+    // The same first case also covers the #8258 repair: when a co-player's
+    // stale-read write drops this user's archived_at, hasArchivedActivity goes
+    // false again and the gate re-opens, which is what lets the service
+    // re-archive. The replay of the ORIGINAL instant is asserted in
+    // activity_archive_activity_test.dart.
 
     test('session still in progress does not save', () {
       expect(
@@ -135,31 +141,6 @@ void main() {
         ActivityAutoSaveService.shouldEmitOutcome('!b:x', emitted),
         isTrue,
       );
-    });
-  });
-
-  group('shouldSave (first archive authoritative)', () {
-    test('saves the first time; a saved room is never re-saved', () {
-      final saved = <String>{};
-      expect(
-        ActivityAutoSaveService.shouldSave('!s:x', saved),
-        isTrue,
-        reason: 'first pass saves and archives',
-      );
-      saved.add('!s:x'); // the service marks it saved on success
-      expect(
-        ActivityAutoSaveService.shouldSave('!s:x', saved),
-        isFalse,
-        reason:
-            'the gate re-opens until the archive syncs back; a pre-sync sweep '
-            'must NOT re-archive with a newer timestamp — first archive wins',
-      );
-    });
-
-    test('tracks each session room independently', () {
-      final saved = <String>{'!a:x'};
-      expect(ActivityAutoSaveService.shouldSave('!a:x', saved), isFalse);
-      expect(ActivityAutoSaveService.shouldSave('!b:x', saved), isTrue);
     });
   });
 


### PR DESCRIPTION
## What

Re-archive a completed session when a co-player's write overwrites this learner's save, so the chat leaves the list and its stars bank without an app refresh.

## Why

Closes #8258

Every role lives in one shared `pangea.activity_roles` state event, so archiving is a read-modify-write of the whole role map ([activities.instructions.md → Completion saves itself](.github/instructions/activities.instructions.md)). When two learners finish a session, the second learner's finish opens the auto-save gate on **both** clients at once; they archive within milliseconds of each other, and the later write — built from a read taken before the earlier one landed — drops the other learner's `archived_at`. For that learner the session pops back into the chat list and its stars unbank, until the next app start re-runs the startup sweep. That is the "seems to happen on app refresh" in the issue.

The role-state listener already sees the overwrite and the gate already re-opens on it. What blocked the repair was the `_saved` set, which treated the first archive as final for the run. It is replaced by the archived-at this run persisted, so the repair is just archiving again — replaying the remembered instant, so the repaired room state still matches the dosage outcome already emitted against it. `GoogleAnalytics.completeActivity` fires only on the first save.

Two learners racing now converge: whichever archive gets clobbered is rewritten off the clobbering event, and every write carries its own author's archive.

**Not in this PR:** the issue's "preferably with some satisfying animation of the user analytics cluster". The cluster has no count-change animation today, and a star-bank celebration would be a new entry in the analytics doc's Celebration Moments table — a design decision that gets agreed in chat before the edit exists, not settled in a PR. The counter updates live either way, which is what the issue's TO TEST asks for.

## Testing

- `fvm flutter test test/pangea` — 2308 pass, 4 skipped, 1 fail: `choreo_endpoint_test.dart › Custom course endpoint test`, the known local baseline failure (no staging credentials locally), unrelated to this change. A first run also failed `activity_session_history_visibility_test.dart` on a 10s timeout; it passes in isolation and did not recur on the second full run — parallel-load flake, not this change.
- `fvm flutter analyze lib/features/activity_sessions test/pangea` — clean.
- New unit coverage: `archiveActivity(at:)` replays the banked instant instead of stamping a fresh one (`test/pangea/activity_archive_activity_test.dart`). Dropped the `shouldSave` group, whose invariant ("first archive wins for the run") is exactly what caused the bug.
- Manual, local stack (web, `learner`): finished a two-role session, let the client archive, then wrote the co-player's stale-read archive over it via the Matrix API — reproducing the lost update at the state level (`archived_at` gone from the room).
  - Before the fix: the session reappeared in the chat list and its 2 stars unbanked (cluster back to 0) — the issue's screenshot, exactly.
  - After the fix: the client re-archived off the clobbering event; the session stayed out of the chat list and the cluster held at 2. No refresh.

## Deploy Notes

None
