### PR TITLE
fix(chat-details): pass selected child rooms to deleteSpace

### DIFF
--- a/lib/routes/chat/chat_details/delete_room_extension.dart
+++ b/lib/routes/chat/chat_details/delete_room_extension.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:http/http.dart';
 import 'package:matrix/matrix.dart';
 import 'package:matrix/matrix_api_lite/generated/api.dart';
@@ -52,22 +53,27 @@ extension DeleteRoom on Room {
   }
 
   Future<void> deleteSpace(List<String> spaceChildRoomIds) async {
-    final List<Future<void>> futures = [];
-    for (final roomId in spaceChildRoomIds) {
-      final roomInstance = client.getRoomById(roomId);
-      if (roomInstance != null) {
-        // Niether delete not leave activities the user has archived,
-        // since they're hidden in the main chat UI.
-        if (roomInstance.isActivitySession) {
-          if (!roomInstance.hasArchivedActivity) {
-            futures.add(roomInstance.leave());
+    // Deleting a room is expensive server-side (kicks + purge), so cap
+    // concurrency instead of firing every child delete at once.
+    const batchSize = 5;
+    for (final batch in spaceChildRoomIds.slices(batchSize)) {
+      final List<Future<void>> futures = [];
+      for (final roomId in batch) {
+        final roomInstance = client.getRoomById(roomId);
+        if (roomInstance != null) {
+          // Niether delete not leave activities the user has archived,
+          // since they're hidden in the main chat UI.
+          if (roomInstance.isActivitySession) {
+            if (!roomInstance.hasArchivedActivity) {
+              futures.add(roomInstance.leave());
+            }
+          } else {
+            futures.add(roomInstance.delete());
           }
-        } else {
-          futures.add(roomInstance.delete());
         }
       }
+      await Future.wait(futures);
     }
-    await Future.wait(futures);
     await delete();
   }
 }

--- a/lib/routes/chat/chat_details/delete_space_dialog.dart
+++ b/lib/routes/chat/chat_details/delete_space_dialog.dart
@@ -38,7 +38,7 @@ class DeleteSpaceDialog extends StatefulWidget {
 
     List<String>? deleteRoomIds;
     if (roomChunks.isNotEmpty) {
-      final deleteRoomIds = await showDialog<List<String>?>(
+      deleteRoomIds = await showDialog<List<String>?>(
         context: context,
         builder: (_) => DeleteSpaceDialog(roomsChunks: roomChunks),
       );


### PR DESCRIPTION
## What

- One-line fix: the checkbox selection in the delete-space "Select Chats" dialog now actually reaches `deleteSpace()`.
- Batching: `deleteSpace()` now deletes child rooms in batches of 5 instead of firing every delete concurrently, so large courses (100+ chats) don't flood Synapse.

## Why

Closes #8261. An inner `final deleteRoomIds` in `DeleteSpaceDialog.show()` shadowed the outer variable, so `deleteSpace()` always received `[]` — selected child chats were never deleted. Introduced in #7650. Batching added per review request: a space delete was one concurrent request per child room.

## Testing

- `fvm flutter analyze` on both files: clean.
- Manual flow on the local stack (web client + local Synapse, as `learner`):
  - Space with 2 child chats → Delete → select all → Delete: three `POST /_synapse/client/pangea/v1/delete_room` (2 children + space), all 200; all three rooms gone from `/joined_rooms`; app reset to the world map.
  - Batching re-test with 7 child chats: request trace shows 5 POSTs → 2 POSTs → 1 POST (two batches of children, then the space), all 200; all 8 rooms gone server-side.
  - Cancel path: cancelling the Select Chats dialog aborts the flow — no delete requests, rooms untouched.
- `fvm flutter test` (after both commits): 2331 passed, 1 pre-existing environmental failure (`choreo_endpoint_test.dart` "Custom course endpoint test") — fails identically with the changed files at origin/main.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)