### PR TITLE
fix(notifications): suppress pushes for analytics rooms

### DIFF
--- a/lib/features/user/pangea_push_rules_extension.dart
+++ b/lib/features/user/pangea_push_rules_extension.dart
@@ -2,8 +2,31 @@ import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_room_types.dart';
 
 extension PangeaPushRulesExtension on Client {
+  /// Whether this sync update contains an analytics room newly appearing as
+  /// joined or invited. Rooms that appear mid-session need their dontNotify
+  /// rule set then — [setPangeaPushRules] alone only covers rooms present at
+  /// app start.
+  bool isNewAnalyticsRoomSyncUpdate(SyncUpdate update) {
+    bool isAnalyticsCreate(StrippedStateEvent event) =>
+        event.type == EventTypes.RoomCreate &&
+        event.content['type'] == PangeaRoomTypes.analytics;
+
+    final joined =
+        update.rooms?.join?.values.any(
+          (room) => room.state?.any(isAnalyticsCreate) ?? false,
+        ) ??
+        false;
+    final invited =
+        update.rooms?.invite?.values.any(
+          (room) => room.inviteState?.any(isAnalyticsCreate) ?? false,
+        ) ??
+        false;
+    return joined || invited;
+  }
+
   Future<void> setPangeaPushRules() async {
     if (!isLogged()) return;
     if (prevBatch == null) await onSync.stream.first;

--- a/lib/pangea/common/controllers/pangea_controller.dart
+++ b/lib/pangea/common/controllers/pangea_controller.dart
@@ -37,6 +37,7 @@ class PangeaController {
   StreamSubscription? _languageSubscription;
   StreamSubscription? _settingsSubscription;
   StreamSubscription? _joinSpaceSubscription;
+  StreamSubscription? _analyticsRoomMuteSubscription;
 
   ///Matrix Variables
   final MatrixState matrixState;
@@ -113,9 +114,11 @@ class PangeaController {
     _languageSubscription?.cancel();
     _settingsSubscription?.cancel();
     _joinSpaceSubscription?.cancel();
+    _analyticsRoomMuteSubscription?.cancel();
     _languageSubscription = null;
     _settingsSubscription = null;
     _joinSpaceSubscription = null;
+    _analyticsRoomMuteSubscription = null;
 
     GoogleAnalytics.logout();
     _clearCache();
@@ -164,6 +167,11 @@ class PangeaController {
     _joinSpaceSubscription ??= matrixState.client.onSync.stream
         .where(matrixState.client.isJoinSpaceSyncUpdate)
         .listen((_) => matrixState.client.addAnalyticsRoomsToSpaces());
+
+    _analyticsRoomMuteSubscription?.cancel();
+    _analyticsRoomMuteSubscription = matrixState.client.onSync.stream
+        .where(matrixState.client.isNewAnalyticsRoomSyncUpdate)
+        .listen((_) => matrixState.client.setPangeaPushRules());
   }
 
   Future<void> _clearCache({List<String> exclude = const []}) async {

--- a/lib/utils/push_helper.dart
+++ b/lib/utils/push_helper.dart
@@ -17,6 +17,7 @@ import 'package:fluffychat/features/join_codes/space_code_repo.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/extensions/localized_display_name_extension.dart';
+import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/utils/client_download_content_extension.dart';
 import 'package:fluffychat/utils/client_manager.dart';
 import 'package:fluffychat/utils/matrix_sdk_extensions/matrix_locals.dart';
@@ -137,6 +138,13 @@ Future<void> _tryPushHelper(
   Logs().v('Push helper got notification event of type ${event.type}.');
 
   // #Pangea
+  // Analytics rooms are internal data stores and must never produce a
+  // notification, no matter which server path generated the push.
+  if (event.room.isAnalyticsRoom) {
+    Logs().v('Push message is for an analytics room. Do not display.');
+    return;
+  }
+
   if (event.type == EventTypes.RoomMember) {
     final membership = event.content.tryGet<String>('membership');
     if (membership == 'invite') {

--- a/test/pangea/analytics_room_mute_sync_test.dart
+++ b/test/pangea/analytics_room_mute_sync_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/user/pangea_push_rules_extension.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_room_types.dart';
+import 'get_test_client.dart';
+
+/// Analytics rooms that appear mid-session (auto-granted instructor access,
+/// force-joins) must be detected in sync so their dontNotify rule is set
+/// without waiting for the next app start (#8267).
+void main() {
+  late Client client;
+
+  setUp(() async {
+    client = await getTestClient();
+  });
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  MatrixEvent createEvent(String? roomType) => MatrixEvent(
+    type: EventTypes.RoomCreate,
+    content: {'type': ?roomType},
+    senderId: '@student:fakeServer.notExisting',
+    stateKey: '',
+    eventId: '\$create',
+    originServerTs: DateTime.utc(2026, 1, 1),
+  );
+
+  SyncUpdate sync({RoomsUpdate? rooms}) =>
+      SyncUpdate(nextBatch: 'batch', rooms: rooms);
+
+  test('matches a newly joined analytics room', () {
+    final update = sync(
+      rooms: RoomsUpdate(
+        join: {
+          '!analytics:server': JoinedRoomUpdate(
+            state: [createEvent(PangeaRoomTypes.analytics)],
+          ),
+        },
+      ),
+    );
+    expect(client.isNewAnalyticsRoomSyncUpdate(update), isTrue);
+  });
+
+  test('matches an analytics room invite via stripped state', () {
+    final update = sync(
+      rooms: RoomsUpdate(
+        invite: {
+          '!analytics:server': InvitedRoomUpdate(
+            inviteState: [
+              StrippedStateEvent(
+                type: EventTypes.RoomCreate,
+                content: {'type': PangeaRoomTypes.analytics},
+                senderId: '@student:fakeServer.notExisting',
+                stateKey: '',
+              ),
+            ],
+          ),
+        },
+      ),
+    );
+    expect(client.isNewAnalyticsRoomSyncUpdate(update), isTrue);
+  });
+
+  test('ignores ordinary rooms, spaces and empty updates', () {
+    expect(client.isNewAnalyticsRoomSyncUpdate(sync()), isFalse);
+    expect(
+      client.isNewAnalyticsRoomSyncUpdate(
+        sync(
+          rooms: RoomsUpdate(
+            join: {
+              '!chat:server': JoinedRoomUpdate(state: [createEvent(null)]),
+              '!space:server': JoinedRoomUpdate(
+                state: [createEvent('m.space')],
+              ),
+            },
+          ),
+        ),
+      ),
+      isFalse,
+    );
+  });
+
+  test('ignores non-create analytics-typed events', () {
+    final update = sync(
+      rooms: RoomsUpdate(
+        join: {
+          '!chat:server': JoinedRoomUpdate(
+            state: [
+              MatrixEvent(
+                type: EventTypes.RoomMember,
+                content: {'type': PangeaRoomTypes.analytics},
+                senderId: '@student:fakeServer.notExisting',
+                stateKey: '@teacher:fakeServer.notExisting',
+                eventId: '\$member',
+                originServerTs: DateTime.utc(2026, 1, 1),
+              ),
+            ],
+          ),
+        },
+      ),
+    );
+    expect(client.isNewAnalyticsRoomSyncUpdate(update), isFalse);
+  });
+}


### PR DESCRIPTION
## What

Suppress push notifications for analytics rooms: a client-side backstop in `pushHelper` plus mid-session muting of analytics rooms that newly appear in sync.

## Why

Closes #8267

The existing `p.rule.analytics_invite` override only matches invites carrying `content.reason == p.analytics_request`, which the auto-grant instructor-access path never sets — so its invite fell through to the default invite rule and pushed. Separately, `setPangeaPushRules` only muted analytics rooms present at app start, leaving rooms joined mid-session unmuted until the next launch, and `pushHelper` had no analytics check as a last line of defense.

- `pushHelper` now drops any push whose room's `m.room.create` type is `p.analytics`, regardless of which server path generated the event
- a new sync listener (`isNewAnalyticsRoomSyncUpdate`, same shape as the existing `isJoinSpaceSyncUpdate`) re-runs `setPangeaPushRules` when an analytics room newly appears as joined or invited, so its `dontNotify` rule is set server-side without an app restart

The optional synapse-side piece (setting `reason: p.analytics_request` on the grant endpoint's invite) is a [synapse-pangea-chat](https://github.com/pangeachat/synapse-pangea-chat) change and per the issue would get its own issue.

## Testing

- New unit test `test/pangea/analytics_room_mute_sync_test.dart` covers the sync filter: joined analytics room, invited analytics room (stripped state), ordinary rooms/spaces/empty updates, and non-create events.
- `fvm dart analyze` clean on touched files; full pangea suite green locally (2302 passed, 3 skipped).
- The `pushHelper` guard has no unit test: exercising it needs the local-notifications plugin and a push payload end to end; device verification is deferred to the issue's TO TEST on staging.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)