### PR TITLE
fix(navigation): block analytics rooms from opening as a chat

### DIFF
--- a/lib/features/notifications/notification_tap_utils.dart
+++ b/lib/features/notifications/notification_tap_utils.dart
@@ -200,6 +200,22 @@ class NotificationTapUtil {
       return;
     }
 
+    // An analytics room is an internal construct store, never a chat surface
+    // (#8268). Instructors are auto-joined to student analytics rooms, so the
+    // invite branch below never catches this — fail fast to the joined parent
+    // course (or the map) instead of relying on the room panel to reject it.
+    if (room.isAnalyticsRoom) {
+      final parentCourseId = room.pangeaSpaceParents
+          .firstWhereOrNull((p) => p.membership == Membership.join)
+          ?.id;
+      router.go(
+        parentCourseId != null
+            ? WorkspaceNav.openCourse(uri, parentCourseId)
+            : PRoutes.world,
+      );
+      return;
+    }
+
     Logs().w("Notification Body: $notification");
     if (notification?['type'] == EventTypes.RoomMember &&
         room.membership == Membership.invite &&

--- a/lib/routes/world/left_panel/left_panel_room_subpage.dart
+++ b/lib/routes/world/left_panel/left_panel_room_subpage.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
 
+import 'package:go_router/go_router.dart';
+
 import 'package:fluffychat/features/navigation/panel_types_enum.dart';
+import 'package:fluffychat/features/navigation/room_close_location.dart';
 import 'package:fluffychat/features/navigation/room_id_url.dart';
 import 'package:fluffychat/features/navigation/token_params/room_subpage_token.dart';
 import 'package:fluffychat/features/navigation/token_params/room_token.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
 import 'package:fluffychat/routes/chat/chat.dart';
 import 'package:fluffychat/routes/chat/chat_details/chat_details.dart';
 import 'package:fluffychat/routes/chat/chat_details/invite/pangea_invitation_selection.dart';
@@ -74,6 +78,23 @@ class LeftPanelRoomSubpage extends StatelessWidget {
     // archived rooms, and those stay viewable as read-only chats (#8148).
     if (room == null || room.isSpace) {
       return emptyPage;
+    }
+
+    // An analytics room is an internal construct store, never a chat surface
+    // (#8268). Every list hides it (isHiddenRoom), but a direct URL or a stale
+    // history entry can still name it in a panel token — drop that token as a
+    // history REPLACE (so back does not land here again), revealing the course
+    // context or map beneath, instead of rendering its timeline.
+    if (room.isAnalyticsRoom) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!context.mounted) return;
+        final close = roomTokenCloseLocation(
+          GoRouterState.of(context).uri,
+          roomId,
+        );
+        if (close != null) context.replace(close);
+      });
+      return const SizedBox.shrink();
     }
 
     // A jump-to-message (`e/<eventId>`) parses with no subPage, so it falls

--- a/test/pangea/notification_tap_analytics_room_test.dart
+++ b/test/pangea/notification_tap_analytics_room_test.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:matrix/matrix.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:fluffychat/features/navigation/route_facts.dart';
+import 'package:fluffychat/features/notifications/notification_tap_utils.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_room_types.dart';
+import 'get_test_client.dart';
+
+/// Regression coverage for #8268 — tapping a notification for an analytics
+/// room must never open it as a chat. The instructor is genuinely JOINED to
+/// student analytics rooms (auto-join / auto-grant), so the invite branch
+/// never catches this; the tap handler has to refuse the room itself and fall
+/// back to the joined parent course, or the world map when there is none.
+void main() {
+  sqfliteFfiInit();
+
+  // sqflite's ':memory:' database is shared process-wide, so rooms outlive a
+  // client (see chat_context_mark_read_test.dart). Distinct ids per test keep
+  // one test's parent course from leaking into the next.
+  const analyticsRoomId = '!analytics:example.com';
+  const orphanAnalyticsRoomId = '!analytics2:example.com';
+  const courseId = '!course:example.com';
+  const normalRoomId = '!normal:example.com';
+
+  late Client client;
+
+  setUp(() async {
+    client = await getTestClient();
+    FakeMatrixApi.client = client;
+  });
+
+  var eventCounter = 0;
+  MatrixEvent stateEvent({
+    required String type,
+    required Map<String, Object?> content,
+    String stateKey = '',
+  }) => MatrixEvent(
+    type: type,
+    content: content,
+    stateKey: stateKey,
+    senderId: '@teacher:example.com',
+    eventId: '\$state${eventCounter++}:example.com',
+    originServerTs: DateTime.fromMillisecondsSinceEpoch(0),
+  );
+
+  JoinedRoomUpdate roomUpdate({String? type}) => JoinedRoomUpdate(
+    state: [
+      stateEvent(type: EventTypes.RoomCreate, content: {'type': ?type}),
+    ],
+  );
+
+  /// Pump a bare router at `/`, run the tap handler for [roomId], and return
+  /// the location it navigated to.
+  Future<Uri> tapNotification(WidgetTester tester, String roomId) async {
+    final router = GoRouter(
+      initialLocation: '/',
+      routes: [GoRoute(path: '/', builder: (_, _) => const SizedBox.shrink())],
+    );
+    await tester.pumpWidget(MaterialApp.router(routerConfig: router));
+    await tester.pumpAndSettle();
+
+    await tester.runAsync(
+      () => NotificationTapUtil.handleNotificationTap(
+        client: client,
+        roomId: roomId,
+        notification: null,
+        router: router,
+      ),
+    );
+    await tester.pumpAndSettle();
+    return router.routerDelegate.currentConfiguration.uri;
+  }
+
+  testWidgets('analytics room falls back to the joined parent course', (
+    tester,
+  ) async {
+    await tester.runAsync(
+      () => client.handleSync(
+        SyncUpdate(
+          nextBatch: 'b1',
+          rooms: RoomsUpdate(
+            join: {
+              analyticsRoomId: roomUpdate(type: PangeaRoomTypes.analytics),
+              courseId: JoinedRoomUpdate(
+                state: [
+                  stateEvent(
+                    type: EventTypes.RoomCreate,
+                    content: {'type': 'm.space'},
+                  ),
+                  stateEvent(
+                    type: EventTypes.SpaceChild,
+                    stateKey: analyticsRoomId,
+                    content: {
+                      'via': ['example.com'],
+                    },
+                  ),
+                ],
+              ),
+            },
+          ),
+        ),
+      ),
+    );
+
+    final uri = await tapNotification(tester, analyticsRoomId);
+    expect(activeSpaceIdFor(uri), courseId);
+    expect(parseOpenPanels(uri).left.any((t) => t.type.isRoomPanel), isFalse);
+  });
+
+  testWidgets('analytics room with no parent course falls back to the map', (
+    tester,
+  ) async {
+    await tester.runAsync(
+      () => client.handleSync(
+        SyncUpdate(
+          nextBatch: 'b1',
+          rooms: RoomsUpdate(
+            join: {
+              orphanAnalyticsRoomId: roomUpdate(
+                type: PangeaRoomTypes.analytics,
+              ),
+            },
+          ),
+        ),
+      ),
+    );
+
+    final uri = await tapNotification(tester, orphanAnalyticsRoomId);
+    expect(uri.path, '/');
+    expect(parseOpenPanels(uri).left, isEmpty);
+  });
+
+  testWidgets('a normal joined room still opens as a chat', (tester) async {
+    await tester.runAsync(
+      () => client.handleSync(
+        SyncUpdate(
+          nextBatch: 'b1',
+          rooms: RoomsUpdate(join: {normalRoomId: roomUpdate()}),
+        ),
+      ),
+    );
+
+    final uri = await tapNotification(tester, normalRoomId);
+    final left = parseOpenPanels(uri).left;
+    expect(left.any((t) => t.type.isRoomPanel), isTrue);
+  });
+}


### PR DESCRIPTION
## What

Guard the room-panel surface and the notification tap handler so an analytics room can never render as a chat, whatever route names it.

## Why

Closes #8268

`isHiddenRoom` filtered every list surface but nothing guarded the room panel itself, so anything navigating by room id (notification tap, direct `room:` URL token, browser history) opened the analytics room as a normal chat. The instructor is genuinely joined (auto-join/auto-grant), so the tap handler's invite branch never caught it. Complements #8271 (#8267 silences the pushes; this closes the surface).

## What changed

- `LeftPanelRoomSubpage`: an analytics room refuses to resolve under **any** room-panel token (`room`, `session`, `archivedroom`) — the token is dropped via `roomTokenCloseLocation` as a history **replace**, so back does not land there again, and the course context or map beneath is revealed.
- `NotificationTapUtil.handleNotificationTap`: fails fast to the joined parent course (or the world map) before `openRoomById`.
- Scoped to `isAnalyticsRoom`, not all of `isHiddenRoom` as the issue sketch suggested: `hasArchivedActivity` rooms legitimately render as chats — the `session` review is the real timeline (routing.instructions.md → One live session at a time), and the live `room` token is still open at the moment auto-save archives a finished role — so an `isHiddenRoom` guard would eject users from just-finished activities.

## Testing

- New `test/pangea/notification_tap_analytics_room_test.dart`: analytics-room tap falls back to the joined parent course; orphan analytics room falls back to the world map; a normal joined room still opens as a chat.
- Full unit suite: 2323 passed, 3 skipped (endpoint tests skip without `.env` creds), 0 failures. `dart analyze` clean on touched files.
- Not locally verifiable: the full instructor flow in the issue's TO TEST (auto-granted analytics access) needs a staging course — covered by the issue's QA steps post-deploy.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)