### PR TITLE
fix(activities): only one vocab chip word card open at a time

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_vocab_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_vocab_widget.dart
@@ -170,6 +170,16 @@ class _VocabChipsState extends State<_VocabChips> with CollectableTokensMixin {
 
   void _showWordCard(Vocab vocab) {
     final target = _vocabKey(vocab);
+    // A pointer can't reach a chip while a card is open — the tap lands on
+    // the card's backdrop and dismisses it — but a screen reader activates
+    // chips straight through the semantics tree, stacking one card + backdrop
+    // per chip until every one has been dismissed (#8279). Close this
+    // widget's other card first so only one is ever open.
+    for (final other in widget.vocab) {
+      if (other != vocab) {
+        MatrixState.pAnyState.closeOverlay(_vocabKey(other));
+      }
+    }
     WidgetsBinding.instance.addPostFrameCallback(
       (_) => OverlayUtil.showPositionedCard(
         context: context,
@@ -179,7 +189,11 @@ class _VocabChipsState extends State<_VocabChips> with CollectableTokensMixin {
           target: target,
           onClose: () {
             WidgetsBinding.instance.addPostFrameCallback((_) {
-              if (mounted) setState(() => _selectedVocab = null);
+              // When closed as a side effect of opening another chip's card,
+              // _selectedVocab already points at the newer card — leave it.
+              if (mounted && _selectedVocab == vocab) {
+                setState(() => _selectedVocab = null);
+              }
             });
           },
         ),


### PR DESCRIPTION
## What

Close the previously open vocab-chip word card before opening another, so only one card (and one backdrop) is ever open.

## Why

Closes #8279

Pointer users can't reach a second chip while a card is open — the tap lands on the card's transparent backdrop and dismisses it. VoiceOver activates chips directly through the semantics tree, behind the backdrop, and with `closePrevOverlay: false` each activation stacked another card + full-screen backdrop; every backdrop then had to be dismissed one by one before anything else was clickable.

## What changed

- `_showWordCard` ([activity_vocab_widget.dart](https://github.com/pangeachat/client/blob/main/lib/routes/chat/activity_sessions/activity_vocab_widget.dart)): before opening a card, close any other card keyed by this widget's vocab (`closeOverlay` by exact key; no-op when none is open). `closePrevOverlay: true` wasn't an option — the keyless `closeOverlay()` it triggers pops the topmost overlay of *any* kind.
- `onClose` guard: when card A closes as a side effect of opening card B, A's dispose no longer clears B's chip-selected highlight.

## Testing

- Full pangea unit suite in the worktree: 2305 passed, 3 skipped, 0 failures. `flutter analyze` clean on the touched file.
- No new widget test: mounting `ActivityVocabWidget` needs a full MatrixState + analytics-service + TTS harness that doesn't exist in `test/pangea`, out of proportion to the 2-line behavior change.
- Manual VoiceOver pass needs a real activity session — covered by the issue's TO TEST on staging.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)