### PR TITLE
fix(analytics-practice): play tapped choice audio in vocab practice

### DIFF
--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_page.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_page.dart
@@ -367,7 +367,14 @@ class AnalyticsPracticeState extends State<AnalyticsPractice>
       _l2!.langCodeShort,
     );
 
-    if (!notifier.exerciseComplete(exercise)) return;
+    if (!notifier.exerciseComplete(exercise)) {
+      AnalyticsPracticeUiController.playChoiceAudio(
+        exercise,
+        choiceContent,
+        _l2!.langCodeShort,
+      );
+      return;
+    }
 
     _playExerciseAudio(exercise);
 

--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_ui_controller.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_ui_controller.dart
@@ -1,3 +1,4 @@
+import 'package:fluffychat/features/analytics/construct_identifier.dart';
 import 'package:fluffychat/features/analytics/construct_type_enum.dart';
 import 'package:fluffychat/routes/chat/events/text_to_speech/tts_controller.dart';
 import 'package:fluffychat/routes/chat/events/text_to_speech/tts_use_case.dart';
@@ -6,6 +7,26 @@ import 'package:fluffychat/routes/chat/toolbar/practice_exercises/practice_exerc
 class AnalyticsPracticeUiController {
   static String getChoiceTargetId(String choiceId, ConstructTypeEnum type) =>
       '${type.name}-choice-card-${choiceId.replaceAll(' ', '_')}';
+
+  /// Speak the lemma behind a tapped choice. Wrong taps flip the card to
+  /// reveal that lemma, so the reveal gets audio too, not just the correct
+  /// answer (#8277).
+  static void playChoiceAudio(
+    MultipleChoicePracticeExerciseModel exercise,
+    String choiceId,
+    String language,
+  ) {
+    if (exercise is! VocabMeaningPracticeExerciseModel) return;
+
+    final cId = ConstructIdentifier.fromString(choiceId);
+    if (cId == null) return;
+    TtsController.tryToSpeak(
+      cId.lemma,
+      langCode: language,
+      useCase: TtsUseCase.choices,
+      pos: cId.category,
+    );
+  }
 
   static void playTargetAudio(
     MultipleChoicePracticeExerciseModel exercise,


### PR DESCRIPTION
### What

Play the tapped choice's word audio on wrong answers in vocab analytics practice, not just on the correct one.

### Why

Closes #8277

### Changes

- New `AnalyticsPracticeUiController.playChoiceAudio`: speaks the lemma behind a tapped choice (`TtsUseCase.choices`, so the Choices audio toggle gates it). Scoped to `VocabMeaningPracticeExerciseModel` — the exercise whose cards flip to reveal the choice's word; the reveal now gets audio.
- `onSelectChoice` calls it on non-completing taps. The completing (correct) tap keeps the existing `playTargetAudio` path unchanged, so no double playback.
- Audio exercises (`lemmaAudio`) are untouched — they play no per-choice audio today, correct or not, and their choices already display the word.

### Testing

- `fvm dart analyze lib/routes/analytics` — no issues.
- `fvm flutter test` — full suite run locally — 2327 pass, 3 skipped.
- Audio playback itself isn't observable in local headless QA; the tapped-choice lemma is parsed with the same `ConstructIdentifier.fromString(choiceId)` call the flipped card uses for its reveal text. Manual QA per the issue's TO TEST list on staging.

### Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
