### PR TITLE
fix(tts): re-query device voices on every known-good-voice check

### DIFF
--- a/lib/routes/chat/events/text_to_speech/tts_controller.dart
+++ b/lib/routes/chat/events/text_to_speech/tts_controller.dart
@@ -167,10 +167,13 @@ class TtsController {
   /// the same gate `tryToSpeak` applies before read-aloud playback, so a
   /// caller checking upfront (the settings toggle) can never disagree with
   /// what playback will do. See message-read-aloud.instructions.md.
+  ///
+  /// Always re-queries the engine: the user may have just downloaded an
+  /// Enhanced/Premium voice after the dialog sent them to system settings, and
+  /// the cached list predates it (#8282). The refreshed list is shared with
+  /// playback, which then selects the new voice too.
   static Future<bool> hasKnownGoodVoiceFor(String langCode) async {
-    if (_availableLangCodes.isEmpty || kIsWeb) {
-      await setAvailableLanguages();
-    }
+    await setAvailableLanguages();
     return TtsRouting.selectVoice(_voices, langCode, isWeb: kIsWeb).isKnownGood;
   }
 

--- a/test/pangea/text_to_speech/tts_voice_refresh_test.dart
+++ b/test/pangea/text_to_speech/tts_voice_refresh_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/services.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/routes/chat/events/text_to_speech/tts_controller.dart';
+
+// Regression test for #8282: the known-good-voice gate must re-query the
+// engine on every check, so a voice downloaded mid-session (after the dialog
+// sent the user to system settings) is seen without an app restart.
+// Design: client/.github/instructions/message-read-aloud.instructions.md
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('flutter_tts');
+  late List<Map<String, String>> deviceVoices;
+
+  setUp(() {
+    deviceVoices = [
+      {'name': 'Anna', 'locale': 'de-DE', 'quality': 'default'},
+    ];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          switch (call.method) {
+            case 'getVoices':
+              return deviceVoices;
+            default:
+              return 1;
+          }
+        });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test(
+    'gate sees an enhanced voice downloaded after the first check',
+    () async {
+      expect(await TtsController.hasKnownGoodVoiceFor('de-DE'), isFalse);
+
+      // The user downloads an Enhanced voice in system settings and returns.
+      deviceVoices.add({
+        'name': 'Anna (Enhanced)',
+        'locale': 'de-DE',
+        'quality': 'enhanced',
+      });
+
+      expect(await TtsController.hasKnownGoodVoiceFor('de-DE'), isTrue);
+    },
+  );
+}


### PR DESCRIPTION
## What
Refresh the flutter_tts voice list on every `hasKnownGoodVoiceFor` check instead of caching it for the app's lifetime on native.

## Why
Closes #8282. The incoming-messages audio toggle gates on a known-good L2 voice ([message-read-aloud.instructions.md — Enabling requires a qualifying voice](https://github.com/pangeachat/client/blob/main/.github/instructions/message-read-aloud.instructions.md#enabling-requires-a-qualifying-voice)), but the gate read a voice list fetched once at startup. A voice downloaded after the dialog sent the user to system settings stayed invisible until app restart. The refreshed list is shared with playback, so the newly downloaded voice is also what plays.

## Testing
- New regression test `tts_voice_refresh_test.dart`: mocks the flutter_tts channel, asserts the gate sees a voice added between two checks. Verified it fails on the unfixed code.
- `fvm flutter test test/pangea/text_to_speech/` — 53/53 pass.
- `fvm flutter analyze` on touched surfaces — clean.
- The on-device flow (download Enhanced/Premium voice, return, re-toggle) can't be exercised locally — web already refreshed per call, so this change is a no-op there. The issue's TO TEST checklist covers it for QA on a native build.

## Deploy Notes
None

🤖 Generated with [Claude Code](https://claude.com/claude-code)