### PR TITLE
feat(world): show ACTFL names beside CEFR in level filter dropdown

### DIFF
--- a/lib/routes/world/world_map_filter_bar.dart
+++ b/lib/routes/world/world_map_filter_bar.dart
@@ -59,8 +59,9 @@ class WorldMapFilterBar extends StatelessWidget {
     ActivityPinState.inProgress,
   ];
 
-  // A short pill/dropdown label for a level — the CEFR code (Pre-A1 spelled
-  // prettily). Picking a level filters to exactly that level.
+  // The compact pill label for a selected level — the CEFR code (Pre-A1
+  // spelled prettily). The dropdown entries use the full ACTFL+CEFR title
+  // instead (LanguageLevelTypeEnum.title, e.g. "Novice Mid (A1)").
   String _levelLabel(LanguageLevelTypeEnum lvl) =>
       lvl == LanguageLevelTypeEnum.preA1 ? 'Pre-A1' : lvl.string;
 
@@ -90,7 +91,7 @@ class WorldMapFilterBar extends StatelessWidget {
       ),
       for (final lvl in _levelOptions)
         _FilterMenuEntry(
-          label: _levelLabel(lvl),
+          label: lvl.title(context),
           selected: level == lvl,
           onSelected: () => onSetLevel(lvl),
         ),
@@ -227,7 +228,10 @@ class _FilterDropdownPill extends StatelessWidget {
                       ? Icon(Icons.check, size: 18, color: scheme.primary)
                       : null,
                 ),
-                Text(e.label),
+                // Flexible so a label longer than the menu's max width (the
+                // ACTFL level titles, long translations) wraps instead of
+                // overflowing the row.
+                Flexible(child: Text(e.label)),
               ],
             ),
           ),

--- a/test/pangea/world/world_map_level_label_test.dart
+++ b/test/pangea/world/world_map_level_label_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+import 'package:fluffychat/routes/world/world_map_filter.dart';
+import 'package:fluffychat/routes/world/world_map_filter_bar.dart';
+
+/// The Level pill's two label registers (#8287): the dropdown entries carry the
+/// full ACTFL name beside the CEFR code (the settings-wide
+/// [LanguageLevelTypeEnum.title] strings), while the pill itself keeps the
+/// compact CEFR code (`✓ B1` per world-map.instructions.md).
+void main() {
+  Future<void> pump(WidgetTester tester, WorldMapFilter filter) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: WorldMapFilterBar(
+            filter: filter,
+            onSetLevel: (_) {},
+            onSetPartySize: (_) {},
+            onSetStatus: (_) {},
+            onReset: () {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('the level dropdown shows ACTFL names beside CEFR codes', (
+    tester,
+  ) async {
+    await pump(tester, const WorldMapFilter());
+    await tester.tap(find.text('All levels'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Novice Low (Pre A1)'), findsOneWidget);
+    expect(find.text('Novice Mid (A1)'), findsOneWidget);
+    expect(find.text('Superior (C2)'), findsOneWidget);
+  });
+
+  testWidgets('a selected level keeps the compact CEFR code on the pill', (
+    tester,
+  ) async {
+    await pump(
+      tester,
+      const WorldMapFilter(cefrFilter: {LanguageLevelTypeEnum.b1}),
+    );
+    expect(find.text('B1'), findsOneWidget);
+    expect(find.text('Intermediate Mid (B1)'), findsNothing);
+  });
+}


### PR DESCRIPTION
## What

The world-map Level filter dropdown now lists each level with its ACTFL name beside the CEFR code (e.g. "Novice Mid (A1)"), reusing the localized `LanguageLevelTypeEnum.title` strings from learning settings; the selected pill keeps the compact CEFR code (`✓ B1`) per [world-map.instructions.md](https://github.com/pangeachat/client/blob/main/.github/instructions/world-map.instructions.md#the-pill-row--one-pill-per-category-not-per-value).

## Why

Closes #8287

## Testing

- Added `test/pangea/world/world_map_level_label_test.dart`: dropdown entries show ACTFL+CEFR, selected pill stays compact. The longer labels surfaced a menu-row overflow; the label is now `Flexible` so long entries wrap.
- Ran locally (pass): the new test, `test/pangea/world/`, `test/pangea/navigation/world_map_mobile_filters_test.dart`, and the top-level `world_map_*` suites (238 tests). `flutter analyze` clean on touched dirs.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
