### PR TITLE
fix(stt): show stop icon on the recording button while live-streaming

### DIFF
--- a/lib/routes/chat/recording_input_row.dart
+++ b/lib/routes/chat/recording_input_row.dart
@@ -113,13 +113,28 @@ class RecordingInputRow extends StatelessWidget {
                   backgroundColor: theme.bubbleColor,
                   foregroundColor: theme.onBubbleColor,
                 ),
-                tooltip: L10n.of(context).sendAudio,
+                // #Pangea
+                // tooltip: L10n.of(context).sendAudio,
+                // While the button's press stops the live stream rather than
+                // sending (#8292), it must look like a stop control; it reverts
+                // to the send icon once the transcript is editable.
+                tooltip: state.shouldStopStreamingToEditable
+                    ? L10n.of(context).stop
+                    : L10n.of(context).sendAudio,
+                // Pangea#
                 icon: state.isSending
                     ? const SizedBox.square(
                         dimension: 24,
                         child: CircularProgressIndicator.adaptive(),
                       )
-                    : const Icon(Icons.send_outlined),
+                    // #Pangea
+                    // : const Icon(Icons.send_outlined),
+                    : Icon(
+                        state.shouldStopStreamingToEditable
+                            ? Icons.stop_circle_outlined
+                            : Icons.send_outlined,
+                      ),
+                // Pangea#
                 // #Pangea
                 // Streaming, still recording: the primary button STOPS to the
                 // editable transcript (D7 finalizing -> editableClean) rather

--- a/test/pangea/streaming_stt/recording_view_model_editable_test.dart
+++ b/test/pangea/streaming_stt/recording_view_model_editable_test.dart
@@ -74,6 +74,9 @@ void main() {
         EditableTranscriptState.editableClean,
       );
       expect(state.streamingSendData!.isEdited, isFalse);
+      // Once stopped, the primary button reverts from stop to send (#8292).
+      expect(find.byIcon(Icons.stop_circle_outlined), findsNothing);
+      expect(find.byIcon(Icons.send_outlined), findsOneWidget);
 
       state.cancel();
       await tester.pump();

--- a/test/pangea/streaming_stt/recording_view_model_streaming_test.dart
+++ b/test/pangea/streaming_stt/recording_view_model_streaming_test.dart
@@ -280,10 +280,16 @@ void main() {
       await tester.pump();
 
       expect(state.isStreaming, isTrue);
+      // While live-streaming the primary button STOPS (to the editable
+      // transcript), so it must show a stop icon, not send (#8292).
+      expect(find.byIcon(Icons.send_outlined), findsNothing);
+      expect(find.byIcon(Icons.stop_circle_outlined), findsOneWidget);
       // Exactly ONE read-only transcript line, rendered ABOVE the controls Row.
       expect(find.text('live one'), findsOneWidget);
       final lineDy = tester.getTopLeft(find.text('live one')).dy;
-      final sendDy = tester.getTopLeft(find.byIcon(Icons.send_outlined)).dy;
+      final sendDy = tester
+          .getTopLeft(find.byIcon(Icons.stop_circle_outlined))
+          .dy;
       expect(
         lineDy,
         lessThan(sendDy),


### PR DESCRIPTION
## What

Show a stop icon (instead of the send icon) on the recording row's primary button while streamed speech-to-text is live; it reverts to the send icon once recording stops into the editable transcript.

## Why

Closes #8292. While live-streaming, pressing the primary button stops to the editable transcript rather than sending, but it looked like a send button. The existing pause control is deliberately hidden on the streaming path (the pilot socket has no resumable pause), so the primary button carried a misleading send icon. The button's behavior is unchanged — only its icon and tooltip now match what it does (`stop` while `shouldStopStreamingToEditable`, `sendAudio` otherwise). The batch path and the degraded-to-batch path keep the send icon, since there the button really does send.

## Testing

- `flutter test test/pangea/streaming_stt/` — all 241 pass, including new assertions: streaming shows `Icons.stop_circle_outlined` and no send icon; the editable state reverts to `Icons.send_outlined`.
- `dart analyze` on changed files — no issues.

## Deploy Notes

None
