### PR TITLE
fix(activities): hide rating comment and submit until a thumb is picked

### DIFF
--- a/lib/routes/chat/activity_sessions/activity_rating_card.dart
+++ b/lib/routes/chat/activity_sessions/activity_rating_card.dart
@@ -13,7 +13,8 @@ import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 
 /// Post-play rating prompt, pinned to the bottom of a finished activity chat
 /// (issue #7194): thumbs up/down, an optional comment, submit, and a
-/// dismiss X.
+/// dismiss X. The comment field and submit button stay hidden until a thumb
+/// is chosen, keeping the card short (issue #8286).
 ///
 /// Visibility contract (Ava's design): appears once the learner's own role is
 /// finished ("I'm done" or an admin's "End for all"), disappears for good
@@ -180,39 +181,39 @@ class ActivityRatingCardState extends State<ActivityRatingCard> {
                                 ),
                               ],
                             ),
-                            TextField(
-                              controller: commentController,
-                              minLines: 1,
-                              maxLines: 3,
-                              maxLength: 2000,
-                              decoration: InputDecoration(
-                                hintText: l10n.rateActivityCommentHint,
-                                counterText: "",
-                                isDense: true,
-                              ),
-                            ),
-                            if (errorMessage != null)
-                              Text(
-                                errorMessage!,
-                                style: theme.textTheme.bodySmall?.copyWith(
-                                  color: theme.colorScheme.error,
+                            if (selectedRating != null) ...[
+                              TextField(
+                                controller: commentController,
+                                minLines: 1,
+                                maxLines: 3,
+                                maxLength: 2000,
+                                decoration: InputDecoration(
+                                  hintText: l10n.rateActivityCommentHint,
+                                  counterText: "",
+                                  isDense: true,
                                 ),
-                                textAlign: TextAlign.center,
                               ),
-                            ElevatedButton(
-                              onPressed: selectedRating == null || submitting
-                                  ? null
-                                  : submit,
-                              child: submitting
-                                  ? const SizedBox(
-                                      height: 20.0,
-                                      width: 20.0,
-                                      child: CircularProgressIndicator(
-                                        strokeWidth: 2.0,
-                                      ),
-                                    )
-                                  : Text(l10n.submit),
-                            ),
+                              if (errorMessage != null)
+                                Text(
+                                  errorMessage!,
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: theme.colorScheme.error,
+                                  ),
+                                  textAlign: TextAlign.center,
+                                ),
+                              ElevatedButton(
+                                onPressed: submitting ? null : submit,
+                                child: submitting
+                                    ? const SizedBox(
+                                        height: 20.0,
+                                        width: 20.0,
+                                        child: CircularProgressIndicator(
+                                          strokeWidth: 2.0,
+                                        ),
+                                      )
+                                    : Text(l10n.submit),
+                              ),
+                            ],
                           ],
                         ),
                 ),

--- a/lib/routes/chat/activity_sessions/activity_rating_card.dart
+++ b/lib/routes/chat/activity_sessions/activity_rating_card.dart
@@ -144,6 +144,7 @@ class ActivityRatingCardState extends State<ActivityRatingCard> {
                         )
                       : Column(
                           mainAxisSize: MainAxisSize.min,
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
                           spacing: 8.0,
                           children: [
                             Row(

--- a/test/pangea/activity_rating_card_test.dart
+++ b/test/pangea/activity_rating_card_test.dart
@@ -17,8 +17,9 @@ import 'package:fluffychat/routes/chat/events/constants/pangea_room_types.dart';
 import 'get_test_client.dart';
 
 /// Visibility contract of the post-play rating prompt (#7194): shows only for
-/// a finished own role on an unrated (activity, pinned version); submit is
-/// disabled until a thumb is picked; the X dismisses for the current view.
+/// a finished own role on an unrated (activity, pinned version); comment and
+/// submit stay hidden until a thumb is picked (#8286); the X dismisses for
+/// the current view.
 void main() {
   late Client client;
 
@@ -101,20 +102,22 @@ void main() {
     await pumpCard(tester, sessionRoom(finished: true));
     expect(find.byIcon(Icons.thumb_up_outlined), findsOneWidget);
     expect(find.byIcon(Icons.thumb_down_outlined), findsOneWidget);
-    expect(find.byType(TextField), findsOneWidget);
   });
 
-  testWidgets('submit is disabled until a thumb is picked', (tester) async {
+  testWidgets('comment and submit stay hidden until a thumb is picked', (
+    tester,
+  ) async {
     await pumpCard(tester, sessionRoom(finished: true));
 
-    final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
-    expect(button.onPressed, isNull);
+    expect(find.byType(TextField), findsNothing);
+    expect(find.byType(ElevatedButton), findsNothing);
 
     await tester.tap(find.byIcon(Icons.thumb_up_outlined));
     await tester.pumpAndSettle();
 
-    final enabled = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
-    expect(enabled.onPressed, isNotNull);
+    expect(find.byType(TextField), findsOneWidget);
+    final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+    expect(button.onPressed, isNotNull);
     expect(find.byIcon(Icons.thumb_up), findsOneWidget);
   });
 


### PR DESCRIPTION
### What

Hide the activity rating card's comment field and submit button until the learner taps thumbs up/down.

### Why

Closes #8286

### How

- [activity_rating_card.dart](https://github.com/pangeachat/client/blob/8286-hide-rating-input-until-rated/lib/routes/chat/activity_sessions/activity_rating_card.dart) — the comment `TextField`, error text, and submit button now render only once `selectedRating` is set. The card's existing `AnimatedSize` wrapper animates the reveal, so no new animation code.
- Submit no longer needs a disabled state for "no rating picked" — it can't exist without one — so its `onPressed` guard reduces to `submitting`.
- Rating-only flows (dismiss, already-rated, comment-rejected reword) are unchanged.

### Testing

- Updated [activity_rating_card_test.dart](https://github.com/pangeachat/client/blob/8286-hide-rating-input-until-rated/test/pangea/activity_rating_card_test.dart): pre-rating state has no comment field or submit button; both appear (with submit enabled) after tapping a thumb.
- Full `fvm flutter test test/pangea/` — 2312 passed, 3 skipped.

### Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)