### PR TITLE
fix(feedback): always show scrollbar in feedback dialog when content overflows

### DIFF
--- a/lib/pangea/common/widgets/feedback_dialog.dart
+++ b/lib/pangea/common/widgets/feedback_dialog.dart
@@ -23,10 +23,12 @@ class FeedbackDialog extends StatefulWidget {
 
 class _FeedbackDialogState extends State<FeedbackDialog> {
   final TextEditingController _feedbackController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
 
   @override
   void dispose() {
     _feedbackController.dispose();
+    _scrollController.dispose();
     super.dispose();
   }
 
@@ -92,7 +94,16 @@ class _FeedbackDialogState extends State<FeedbackDialog> {
               ),
             ],
           ),
-          Flexible(child: SingleChildScrollView(child: content)),
+          Flexible(
+            child: Scrollbar(
+              controller: _scrollController,
+              thumbVisibility: true,
+              child: SingleChildScrollView(
+                controller: _scrollController,
+                child: content,
+              ),
+            ),
+          ),
           ValueListenableBuilder<TextEditingValue>(
             valueListenable: _feedbackController,
             builder: (context, value, _) {


### PR DESCRIPTION
## What

Always-visible scrollbar in the shared `FeedbackDialog` scroll area when its content overflows (practice exercise flag popup, token info feedback, IGC span card, activity session feedback).

## Why

Closes #8285

## Testing

- Manual, via a throwaway web harness opening the dialog directly:
  - Tall content (30 pair rows): persistent scrollbar thumb painted on the right edge with no interaction; no controller assertion on open.
  - Short content: no scrollbar painted; feedback field and submit button fully visible.
- `dart analyze` clean on the changed file.
- No widget test added: `FeedbackDialog` embeds `BotFace`, whose `RiveNative.init()` and uncancelled 20–40s reload timers make it un-pumpable under `flutter_test` without an out-of-scope refactor.

Changes to look over (per issue TO TEST):
- `lib/pangea/common/widgets/feedback_dialog.dart` — the scroll area is now `Scrollbar(thumbVisibility: true)` with a shared `ScrollController`; this is the only file changed, and it affects every feedback dialog variant, not just practice.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)