### PR TITLE
fix(tts): fall back to device audio when phoneme playback fails, not silence

### DIFF
--- a/lib/routes/chat/events/text_to_speech/tts_routing.dart
+++ b/lib/routes/chat/events/text_to_speech/tts_routing.dart
@@ -124,16 +124,22 @@ class TtsRouting {
       ? const Duration(seconds: 10)
       : const Duration(seconds: 1);
 
-  /// Whether a failed backend fetch may fall back to a device voice.
+  /// Whether a failed backend attempt may fall back to a device voice.
   ///
-  /// Never for phoneme playback — device TTS would speak a different reading
-  /// than the transcription on screen (word-text-to-speech.instructions.md
-  /// grants the phoneme route no device fallback). Silence is honest;
-  /// mismatched audio teaches the wrong pronunciation.
+  /// Yes whenever the device has something to play, phoneme or not. What
+  /// protects the phoneme's correct reading is [backendTimeout], not this:
+  /// the phoneme route waits the full deadline, so reaching here means the
+  /// backend genuinely failed rather than merely lost a one-second race.
+  ///
+  /// Refusing the fallback on the phoneme route (the first cut of #8076) made
+  /// every such failure total silence — QA heard nothing at all for 还 on web
+  /// staging and production, while other words were fine because only
+  /// heteronyms take this route. An arbitrary reading is a poor outcome;
+  /// no audio at all is a worse one, and it reads as the feature being broken.
   static bool allowDeviceFallback({
     required bool hasPhoneme,
     required bool hasVoice,
-  }) => !hasPhoneme && hasVoice;
+  }) => hasVoice;
 
   static bool isGoodWebVoiceName(String name) {
     final lower = name.toLowerCase();

--- a/test/pangea/text_to_speech/tts_routing_test.dart
+++ b/test/pangea/text_to_speech/tts_routing_test.dart
@@ -306,21 +306,45 @@ void main() {
       );
     });
 
-    test('phoneme playback never falls back to device', () {
-      // Device TTS would speak a different reading than the transcription
-      // on screen — silence is honest, mismatched audio teaches the wrong
-      // pronunciation.
+    test('phoneme playback falls back too, rather than going silent', () {
+      // Refusing this made every backend failure total silence for
+      // heteronyms (#8076 QA: 还 played nothing on web staging and prod).
+      // The correct reading is protected by the full backendTimeout, not by
+      // withholding audio when the backend has genuinely failed.
       expect(
         TtsRouting.allowDeviceFallback(hasPhoneme: true, hasVoice: true),
-        isFalse,
+        isTrue,
       );
     });
 
     test('no device voice, nothing to fall back to', () {
-      expect(
-        TtsRouting.allowDeviceFallback(hasPhoneme: false, hasVoice: false),
-        isFalse,
-      );
+      for (final hasPhoneme in [true, false]) {
+        expect(
+          TtsRouting.allowDeviceFallback(
+            hasPhoneme: hasPhoneme,
+            hasVoice: false,
+          ),
+          isFalse,
+          reason: 'hasPhoneme: $hasPhoneme',
+        );
+      }
     });
+
+    test(
+      'a phoneme still never loses the race — it waits the full deadline',
+      () {
+        // The pairing that makes the fallback safe: by the time fallback is
+        // consulted on the phoneme route, 10s have passed, so device audio
+        // replaces a real failure rather than a slow success.
+        expect(
+          TtsRouting.backendTimeout(hasPhoneme: true, hasVoice: true),
+          const Duration(seconds: 10),
+        );
+        expect(
+          TtsRouting.allowDeviceFallback(hasPhoneme: true, hasVoice: true),
+          isTrue,
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## What

A failed backend attempt on the phoneme route now falls back to device audio instead of playing nothing.

## Why

Closes #8076 (reopened). Regression from my own #8079, shipped to production in v5.0.0+6.

That PR made the phoneme route refuse the device fallback, on the reasoning that silence is more honest than an arbitrary reading. In practice it meant **any** backend failure became total silence — QA heard nothing at all for 还 on web staging and production, and nothing else was affected because only heteronyms take that route.

The correct reading is protected by `backendTimeout`, not by withholding audio: the phoneme route already waits the full 10s, so reaching the fallback means the backend genuinely failed rather than losing the one-second race that #8079 removed. Withholding on top of that bought nothing and read as the feature being broken.

**What this does not yet explain.** Staging's backend is healthy — `/phonetic_transcription_v2` returns `hái/Pos=ADV` + `huán/Pos=VERB`, and `/text_to_speech` with `tts_phoneme` returns 200 with real audio (0.9s, −18.1 dB mean, −0.4 dB peak, verified with ffmpeg). So either the client's backend attempt fails for a reason not yet identified — which this PR now covers — or playback silently succeeds without sound on web, which it would not. Local browser verification is next; if it turns out to be the latter, a follow-up fixes the playback path itself. Shipping this first because production users currently get silence.

## Testing

- `fvm flutter test` — 2,335 pass (~3 skipped, pre-existing). Updated the two `allowDeviceFallback` cases that pinned the old rule, and added one asserting the timeout/fallback pairing that makes the fallback safe.
- `fvm dart analyze` clean.
- Staging backend verified healthy (above) — rules out the server side.

## Deploy Notes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enabled device text-to-speech fallback when a compatible voice is available, including phoneme playback.
  - Preserved phoneme correctness by allowing the backend its full processing timeout before falling back.
  - Prevented fallback when no device voice is available.
- **Tests**
  - Added coverage for phoneme and standard-word fallback behavior and timeout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->