### PR TITLE
ci(android): stop republishing the play store listing on every internal build

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -64,10 +64,19 @@ platform :android do
       config = File.read("./pubspec.yaml")
       build_code = config.match(/version:\s[0-9]*\.[0-9]*\.[0-9]*\+([0-9]*)/i).captures[0]
     end
+    # A build upload delivers a bundle and nothing else. Left to itself supply
+    # finds fastlane/metadata/android/ and republishes the whole store listing
+    # on every internal build — the icon, the descriptions, and a changelog
+    # still carrying upstream FluffyChat release notes. The listing is
+    # maintained in the Play Console; the checked-in copy is not its source.
     upload_to_play_store(
       track: 'internal',
       aab: '../build/app/outputs/bundle/release/app-release.aab',
       version_code: build_code,
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      skip_upload_changelogs: true,
     )
   end
 


### PR DESCRIPTION
### What

Pass supply's four skip flags in the `deploy_internal_test` lane so an internal-track build uploads a bundle and nothing else.

### Why

No issue — CI-only config with no client-app surface to QA, per the lifecycle's untestable-via-client exception.

The Play Console activity log shows the fastlane service account uploading a new app icon on every internal build. `upload_to_play_store` auto-detects `android/fastlane/metadata/android/` and, absent skip flags, uploads everything under it alongside the bundle (all four `skip_upload_*` options default to `false`). So each build was republishing:

- `en-US/images/icon.png` — the icon uploads visible in the activity log
- `en-US/title.txt`, `short_description.txt`, `full_description.txt` — store listing text
- `en-US/changelogs/default.txt` — **upstream FluffyChat 2.4.0 release notes about a sticker GUI**, published as the internal track's release notes

### How

- [android/fastlane/Fastfile](https://github.com/pangeachat/client/blob/ci/fastlane-skip-store-metadata/android/fastlane/Fastfile) — added `skip_upload_metadata`, `skip_upload_images`, `skip_upload_screenshots`, `skip_upload_changelogs` to `deploy_internal_test`. All four are needed: `skip_upload_metadata` excludes changelogs and `skip_upload_images` excludes screenshots.
- Fixed in the Fastfile rather than in `android-playstore.yml`, so it also covers the lane's other caller, `scripts/release-playstore-beta.sh`.
- `android/fastlane/metadata/` stays checked in. With the live lane skipping it, nothing there reaches Play; the Play Console is the listing's source of truth.
- `deploy_candidate` and `deploy_release` are untouched. Both are reachable only via `scripts/release-playstore.sh`, a GitLab-era script gated on `$CI_COMMIT_TAG`, which nothing in this repo sets.

Note for whoever next touches this workflow: `android-playstore.yml` exports `RELEASE_NOTES: ${{ inputs.new_release_notes }}` for the deploy step, but no Fastfile or script reads that name anywhere in the repo. That dead wiring is why `default.txt` was what reached the store. It is left as-is here — with changelog upload now skipped, the internal track takes its notes from the Play Console.

### Testing

No test bucket covers fastlane config; this change has no Dart surface. What was verified:

- `ruby -c android/fastlane/Fastfile` — Syntax OK.
- `fastlane lanes` — Fastfile parses, all four lanes still enumerate.
- Option names checked against supply's own `supply/lib/supply/options.rb` in both fastlane 2.226.0 and 2.238.0 (CI runs `bundle update fastlane` unpinned, so it will be on the latter or newer). All four keys exist; all default to `false`, which is the root cause.
- The lane itself was **not** run locally — `deploy_internal_test` performs a live upload to the internal track and supply has no dry run that exercises the metadata path without publishing.

Post-merge check: dispatch `android-playstore.yml` (staging) and confirm the Play Console activity log shows the new bundle with no icon, store-listing, or release-notes entries, and that the live listing is unchanged.

### Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
