### PR TITLE
ci(android): stop republishing the play store listing on every intern…

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -44,10 +44,19 @@ platform :android do
         json_key: "./keys.json"
       )
     last_version = versions.map(&:to_i).max
+    # A build upload delivers a bundle and nothing else. Left to itself supply
+    # finds fastlane/metadata/android/ and republishes the whole store listing
+    # on every internal build — the icon, the descriptions, and a changelog
+    # still carrying upstream FluffyChat release notes. The listing is
+    # maintained in the Play Console; the checked-in copy is not its source.
     upload_to_play_store(
       track: 'internal',
       aab: '../build/app/outputs/bundle/release/app-release.aab',
       version_code: "#{last_version+1}",
+      skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+      skip_upload_changelogs: true,
     )
   end
 


### PR DESCRIPTION
…al build

`upload_to_play_store` auto-detects android/fastlane/metadata/android/ and, given no skip flags, uploads everything under it alongside the bundle. Every internal-track build therefore re-published the app icon, the store listing text, and a changelog still carrying upstream FluffyChat 2.4.0 release notes.

Pass the four skip flags so the lane delivers a bundle and nothing else. Fixed in the Fastfile rather than the workflow so it also covers scripts/release-playstore-beta.sh.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [ ] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md). 

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [ ] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (The source-level gate enforces this; manual a11y review is owned by whoever changes the UI.)
<!-- Pangea# -->
