### PR TITLE
fix(courses): pad add-course buttons so wrapped labels don't crowd the icon

### DIFF
--- a/lib/routes/courses/add_course_options.dart
+++ b/lib/routes/courses/add_course_options.dart
@@ -102,7 +102,9 @@ class _HubButton extends StatelessWidget {
         style: FilledButton.styleFrom(
           backgroundColor: theme.colorScheme.primaryContainer,
           foregroundColor: theme.colorScheme.onPrimaryContainer,
-          padding: const EdgeInsets.symmetric(vertical: 14.0),
+          // Long labels (German, Greek) wrap and fill the button, so without
+          // horizontal padding the leading icon sits against the edge (#8299).
+          padding: const EdgeInsets.symmetric(vertical: 14.0, horizontal: 16.0),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(10.0),
           ),

--- a/test/pangea/courses/add_course_options_padding_test.dart
+++ b/test/pangea/courses/add_course_options_padding_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/courses/add_course_options.dart';
+
+void main() {
+  // #8299: the empty-state add-course buttons had no horizontal padding, so a
+  // label long enough to wrap (German, Greek) filled the whole button and left
+  // the leading icon flush against the rounded edge. One locale per file — a
+  // second one pumps an empty subtree.
+  testWidgets('leading icons keep padding when the label wraps', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        locale: Locale('de'),
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(body: SizedBox(width: 300.0, child: AddCourseOptions())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // The private-course label wraps at this width and the first one doesn't —
+    // the taller button is the case the bug reproduced on.
+    expect(
+      tester.getSize(find.byType(FilledButton).at(1)).height,
+      greaterThan(tester.getSize(find.byType(FilledButton).first).height),
+    );
+
+    for (final icon in [
+      Icons.auto_stories_outlined,
+      Icons.vpn_key_outlined,
+      Icons.travel_explore_outlined,
+    ]) {
+      final iconFinder = find.byIcon(icon);
+      final button = find.ancestor(
+        of: iconFinder,
+        matching: find.byType(FilledButton),
+      );
+      expect(
+        tester.getRect(iconFinder).left - tester.getRect(button).left,
+        greaterThanOrEqualTo(8.0),
+        reason: '$icon should not sit against the button edge',
+      );
+    }
+  });
+}


### PR DESCRIPTION
### What

Give the Courses empty-state add-course buttons horizontal padding, so a wrapped label no longer pushes its leading icon against the button edge.

### Why

Closes #8299

`_HubButton` set `padding: EdgeInsets.symmetric(vertical: 14.0)` — horizontal padding 0. In English the three labels are short, the button's `Row` shrink-wraps, and the leftover space hides the missing padding. In German and Greek the private-course label is long enough to wrap; the `Row` then spans the full button width and the key icon lands at x=0 of the content box, flush against the rounded corner.

### How

- [lib/routes/courses/add_course_options.dart](https://github.com/pangeachat/client/blob/8299-course-code-padding/lib/routes/courses/add_course_options.dart) — `horizontal: 16.0` on the button padding, matching Material's own leading-icon inset. Applies to all three buttons; only the wrapping one looked wrong, but the missing padding was shared.
- The compact header variant (`AddCourseHeaderActions`, shown once the learner has a course) is untouched — it uses `IconButton`, which carries its own padding.

### Testing

- New `test/pangea/courses/add_course_options_padding_test.dart` — pumps `AddCourseOptions` in German at 300px, asserts the private-course button is taller than the first (i.e. its label actually wrapped, reproducing the reported condition) and that all three icons sit at least 8px inside their button's left edge. Verified it fails on the pre-fix padding and passes after.
- `fvm flutter test test/pangea/courses/` — 31 passing.
- `fvm flutter analyze` on both changed files — clean.
- Not run in a live client; the change is a style constant in one widget and the widget test measures the exact geometry the issue reports.

### Deploy Notes

None

### Accessibility

- [x] No new or changed controls — padding only on three existing buttons that already carry their own text labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
