### PR TITLE
fix(subscription): give the selected plan card readable title ink

### DIFF
--- a/lib/routes/settings/settings_subscription/subscription_option_card.dart
+++ b/lib/routes/settings/settings_subscription/subscription_option_card.dart
@@ -32,6 +32,12 @@ class SubscriptionOptionCard extends StatelessWidget {
         ? AppConfig.goldByTheme(context)
         : theme.colorScheme.primaryContainer;
 
+    // The title sits on [frameColor], so its ink follows the frame — gold is a
+    // light fill in both themes, where onPrimaryContainer is unreadable (#8303).
+    final foregroundColor = selected
+        ? AppConfig.onGoldByTheme(context)
+        : theme.colorScheme.onPrimaryContainer;
+
     return Semantics(
       button: true,
       selected: selected,
@@ -49,11 +55,7 @@ class SubscriptionOptionCard extends StatelessWidget {
             title: plan.duration.cardTitle(l10n),
             frameColor: frameColor,
             backgroundColor: theme.colorScheme.surface,
-            foregroundColor: selected
-                ? (theme.brightness == Brightness.light
-                      ? theme.colorScheme.onSurface
-                      : theme.colorScheme.surface)
-                : theme.colorScheme.onPrimaryContainer,
+            foregroundColor: foregroundColor,
             padding: EdgeInsets.all(8.0),
             titlePadding: EdgeInsetsGeometry.symmetric(
               vertical: 8.0,
@@ -62,7 +64,7 @@ class SubscriptionOptionCard extends StatelessWidget {
             borderRadius: _borderRadius,
             titleStyle: textStyle?.copyWith(
               fontWeight: FontWeight.bold,
-              color: theme.colorScheme.onPrimaryContainer,
+              color: foregroundColor,
             ),
             child: Column(
               spacing: 8.0,

--- a/test/pangea/subscription_option_card_selected_title_test.dart
+++ b/test/pangea/subscription_option_card_selected_title_test.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/subscription/repo_v2/products_response.dart';
+import 'package:fluffychat/features/subscription/widgets/frame_container.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/settings/settings_subscription/subscription_option_card.dart';
+
+/// Covers #8303: a selected plan card wears gold on its title bar, but its
+/// title ink was pinned to `onPrimaryContainer` — near-white in the dark
+/// theme, so "Most popular" all but vanished on the gold. The ink now follows
+/// the frame in both themes; the unselected card is untouched.
+void main() {
+  const plan = ProductPlan(
+    planId: 'month',
+    amount: 999,
+    currency: 'usd',
+    interval: 'month',
+    intervalCount: 1,
+  );
+
+  // Seeded the way FluffyThemes.buildTheme seeds the real app, so the scheme
+  // roles under test are the ones the app actually resolves.
+  ThemeData themeFor(Brightness brightness) => ThemeData(
+    brightness: brightness,
+    colorScheme: ColorScheme.fromSeed(
+      brightness: brightness,
+      seedColor: AppConfig.primaryColor,
+    ),
+  );
+
+  Future<void> pump(
+    WidgetTester tester, {
+    required Brightness brightness,
+    required bool selected,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        theme: themeFor(brightness),
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 160.0,
+              child: SubscriptionOptionCard(
+                plan,
+                onTap: _noop,
+                selected: selected,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  FrameContainer frame(WidgetTester tester) =>
+      tester.widget<FrameContainer>(find.byType(FrameContainer));
+
+  /// The colour the title bar actually paints its text in.
+  Color titleInk(WidgetTester tester) {
+    final container = frame(tester);
+    return container.titleStyle!.color ?? container.foregroundColor;
+  }
+
+  for (final brightness in Brightness.values) {
+    group('${brightness.name} theme', () {
+      testWidgets('the selected card\'s title stays readable on gold', (
+        tester,
+      ) async {
+        await pump(tester, brightness: brightness, selected: true);
+
+        final ink = titleInk(tester);
+        expect(
+          ink,
+          AppConfig.onGoldByTheme(
+            tester.element(find.byType(SubscriptionOptionCard)),
+          ),
+          reason:
+              'the selected title bar is gold, so its ink is the shared '
+              'on-gold tone rather than a colour of its own',
+        );
+        expect(
+          _contrast(ink, frame(tester).frameColor),
+          greaterThan(4.5),
+          reason: 'WCAG AA for the title against the gold it sits on',
+        );
+      });
+
+      testWidgets('the unselected card is untouched', (tester) async {
+        await pump(tester, brightness: brightness, selected: false);
+
+        final scheme = themeFor(brightness).colorScheme;
+        expect(
+          titleInk(tester),
+          scheme.onPrimaryContainer,
+          reason: '#8303 is scoped to the selected card',
+        );
+        expect(frame(tester).frameColor, scheme.primaryContainer);
+      });
+    });
+  }
+}
+
+/// WCAG relative-contrast ratio between two opaque colours.
+double _contrast(Color a, Color b) {
+  final la = a.computeLuminance();
+  final lb = b.computeLuminance();
+  final hi = la > lb ? la : lb;
+  final lo = la > lb ? lb : la;
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+void _noop() {}


### PR DESCRIPTION
## What

The selected subscription plan card now paints its title in ink that follows the frame, so "Most popular" / "Most savings" stays readable on the gold highlight.

## Why

Closes #8303

`SubscriptionOptionCard` already computed a selected-state `foregroundColor` for `FrameContainer` — an on-gold dark tone — and then overrode it by pinning `titleStyle.color` to `onPrimaryContainer`. On the gold title bar that is near-white in the dark theme.

Title contrast against the gold it sits on:

| Theme | Before | After |
|---|---|---|
| Dark | 1.02:1 | 14.05:1 |
| Light | 5.64:1 | 10.27:1 |

The card now uses the shared `AppConfig.onGoldByTheme` helper (which it had open-coded) for both `foregroundColor` and the title style, so there is one on-gold tone rather than two. Light mode was already above AA; it changes from the dark purple to that shared near-black.

Both call sites of the card — the plan picker on the discount-code page and `subscription_options.dart` — pick this up.

## Testing

- New widget test `test/pangea/subscription_option_card_selected_title_test.dart` — asserts the selected title's ink is the on-gold tone and clears 4.5:1 against the frame in both themes, and that the unselected card is unchanged. Verified it fails on the pre-fix code (dark ink `E9DDFF`, light ink `4D3D75`) and passes after.
- `fvm flutter test` — 2338 passed, 3 skipped (the credential-gated endpoint suites; no `TEST_MATRIX_*` locally).
- `fvm flutter analyze` on the touched files — clean.
- No manual pass on a running client: reaching this surface needs an unsubscribed account plus a server-validated promo code, which isn't available locally. The colors are asserted at the widget level instead; QA on staging covers the visual per the issue's TO TEST.

## Deploy Notes

None
