### PR TITLE
fix(practice): keep picked choices visible across panel reopen

### DIFF
--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_choice_card_widget.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_choice_card_widget.dart
@@ -20,6 +20,7 @@ class AnalyticsPracticeExerciseChoiceCard extends StatelessWidget {
   final bool enabled;
   final bool shrinkWrap;
   final bool showHint;
+  final bool isSelected;
 
   const AnalyticsPracticeExerciseChoiceCard({
     super.key,
@@ -31,6 +32,7 @@ class AnalyticsPracticeExerciseChoiceCard extends StatelessWidget {
     required this.choiceText,
     required this.choiceEmoji,
     required this.showHint,
+    required this.isSelected,
     this.enabled = true,
     this.shrinkWrap = false,
   });
@@ -57,6 +59,7 @@ class AnalyticsPracticeExerciseChoiceCard extends StatelessWidget {
           isCorrect: isCorrect,
           height: cardHeight,
           isEnabled: enabled,
+          isSelected: isSelected,
         );
 
       case PracticeExerciseTypeEnum.lemmaAudio:
@@ -71,6 +74,7 @@ class AnalyticsPracticeExerciseChoiceCard extends StatelessWidget {
           onPressed: onPressed,
           isCorrect: isCorrect,
           isEnabled: enabled,
+          isSelected: isSelected,
           showHint: showHint,
         );
 
@@ -88,6 +92,7 @@ class AnalyticsPracticeExerciseChoiceCard extends StatelessWidget {
           isCorrect: isCorrect,
           height: cardHeight,
           enabled: enabled,
+          isSelected: isSelected,
         );
 
       case PracticeExerciseTypeEnum.grammarError:
@@ -103,6 +108,7 @@ class AnalyticsPracticeExerciseChoiceCard extends StatelessWidget {
           isCorrect: isCorrect,
           height: cardHeight,
           isEnabled: enabled,
+          isSelected: isSelected,
           child: Padding(
             padding: EdgeInsets.symmetric(horizontal: 8.0),
             child: Text(choiceText),
@@ -120,6 +126,7 @@ class AnalyticsPracticeExerciseChoiceCard extends StatelessWidget {
           isCorrect: isCorrect,
           height: cardHeight,
           isEnabled: enabled,
+          isSelected: isSelected,
           child: Padding(
             padding: EdgeInsets.symmetric(horizontal: 8.0),
             child: Text(choiceText),

--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_choices_widget.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_choices_widget.dart
@@ -19,6 +19,10 @@ class AnalyticsPracticeExerciseChoices extends StatelessWidget {
   final bool showHint;
   final Function(String) onSelectChoice;
 
+  /// Choices already picked in this exercise, held by the session rather than
+  /// the cards, so reopening the panel mid-exercise restores them (#8309).
+  final Set<String> selectedChoices;
+
   final List<InlineSpan>? audioExampleMessage;
   final String? audioTranslation;
 
@@ -30,6 +34,7 @@ class AnalyticsPracticeExerciseChoices extends StatelessWidget {
     required this.isComplete,
     required this.showHint,
     required this.onSelectChoice,
+    required this.selectedChoices,
     this.audioExampleMessage,
     this.audioTranslation,
   });
@@ -71,6 +76,7 @@ class AnalyticsPracticeExerciseChoices extends StatelessWidget {
                           choiceText: choice.choiceText,
                           choiceEmoji: choice.choiceEmoji,
                           enabled: !isComplete,
+                          isSelected: selectedChoices.contains(choice.choiceId),
                           shrinkWrap: true,
                         ),
                       )
@@ -98,6 +104,7 @@ class AnalyticsPracticeExerciseChoices extends StatelessWidget {
               choiceText: choice.choiceText,
               choiceEmoji: choice.choiceEmoji,
               enabled: !isComplete,
+              isSelected: selectedChoices.contains(choice.choiceId),
             ),
           )
           .toList(),

--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_notifier.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_notifier.dart
@@ -1,3 +1,5 @@
+import 'dart:collection';
+
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/pangea/common/utils/async_state.dart';
@@ -57,6 +59,8 @@ class AnalyticsPracticeNotifier extends ChangeNotifier {
   }
 
   bool hasSelectedChoice(String choice) => _clickedChoices.contains(choice);
+
+  Set<String> get selectedChoices => UnmodifiableSetView(_clickedChoices);
 
   void clearExerciseState() {
     _lastSelectedChoice = null;

--- a/lib/routes/analytics/construct_analytics/practice/choice_cards/audio_choice_card.dart
+++ b/lib/routes/analytics/construct_analytics/practice/choice_cards/audio_choice_card.dart
@@ -14,6 +14,7 @@ class AudioChoiceCard extends StatelessWidget {
   final bool isCorrect;
   final bool isEnabled;
   final bool showHint;
+  final bool isSelected;
 
   const AudioChoiceCard({
     required this.choiceId,
@@ -24,6 +25,7 @@ class AudioChoiceCard extends StatelessWidget {
     required this.isCorrect,
     this.isEnabled = true,
     this.showHint = false,
+    this.isSelected = false,
     super.key,
   });
 
@@ -37,6 +39,7 @@ class AudioChoiceCard extends StatelessWidget {
       onPressed: onPressed,
       isCorrect: isCorrect,
       isEnabled: isEnabled,
+      isSelected: isSelected,
       shrinkWrap: true,
       child: Column(
         mainAxisSize: MainAxisSize.min,

--- a/lib/routes/analytics/construct_analytics/practice/choice_cards/game_choice_card.dart
+++ b/lib/routes/analytics/construct_analytics/practice/choice_cards/game_choice_card.dart
@@ -16,6 +16,11 @@ class GameChoiceCard extends StatefulWidget {
   final bool isEnabled;
   final bool shrinkWrap;
 
+  /// Whether this choice was already picked in the session. The tint and the
+  /// flipped face are otherwise local State, so a card rebuilt after the
+  /// practice panel closed would come back blank (#8309).
+  final bool isSelected;
+
   const GameChoiceCard({
     required this.child,
     required this.onPressed,
@@ -26,6 +31,7 @@ class GameChoiceCard extends StatefulWidget {
     this.shouldFlip = false,
     this.isEnabled = true,
     this.shrinkWrap = false,
+    this.isSelected = false,
     super.key,
   });
 
@@ -38,8 +44,11 @@ class _GameChoiceCardState extends State<GameChoiceCard>
   late final AnimationController _controller;
   late final Animation<double> _scaleAnim;
 
-  bool _clicked = false;
-  bool _revealed = false;
+  late bool _clicked = widget.isSelected;
+
+  /// Seeded, not derived: an in-progress tap sets [widget.isSelected] before
+  /// the flip animation runs, so deriving it would skip the animation.
+  late bool _revealed = widget.isSelected;
 
   @override
   void initState() {

--- a/lib/routes/analytics/construct_analytics/practice/choice_cards/grammar_choice_card.dart
+++ b/lib/routes/analytics/construct_analytics/practice/choice_cards/grammar_choice_card.dart
@@ -17,6 +17,7 @@ class GrammarChoiceCard extends StatelessWidget {
   final bool isCorrect;
   final double height;
   final bool enabled;
+  final bool isSelected;
 
   const GrammarChoiceCard({
     required this.choiceId,
@@ -27,6 +28,7 @@ class GrammarChoiceCard extends StatelessWidget {
     required this.isCorrect,
     this.height = 72.0,
     this.enabled = true,
+    this.isSelected = false,
     super.key,
   });
 
@@ -50,6 +52,7 @@ class GrammarChoiceCard extends StatelessWidget {
       isCorrect: isCorrect,
       height: height,
       isEnabled: enabled,
+      isSelected: isSelected,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [

--- a/lib/routes/analytics/construct_analytics/practice/choice_cards/meaning_choice_card.dart
+++ b/lib/routes/analytics/construct_analytics/practice/choice_cards/meaning_choice_card.dart
@@ -13,6 +13,7 @@ class MeaningChoiceCard extends StatelessWidget {
   final bool isCorrect;
   final double height;
   final bool isEnabled;
+  final bool isSelected;
 
   const MeaningChoiceCard({
     required this.choiceId,
@@ -23,6 +24,7 @@ class MeaningChoiceCard extends StatelessWidget {
     required this.isCorrect,
     this.height = 72.0,
     this.isEnabled = true,
+    this.isSelected = false,
     super.key,
   });
 
@@ -40,6 +42,7 @@ class MeaningChoiceCard extends StatelessWidget {
       isCorrect: isCorrect,
       height: height,
       isEnabled: isEnabled,
+      isSelected: isSelected,
       altChild: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [

--- a/lib/routes/analytics/construct_analytics/practice/ongoing_analytics_practice_session_view.dart
+++ b/lib/routes/analytics/construct_analytics/practice/ongoing_analytics_practice_session_view.dart
@@ -185,6 +185,8 @@ class OngoingAnalyticsPracticeSessionView extends StatelessWidget {
                                       .exerciseComplete(exercise),
                                   showHint: controller.notifier.showHint,
                                   onSelectChoice: controller.onSelectChoice,
+                                  selectedChoices:
+                                      controller.notifier.selectedChoices,
                                   audioExampleMessage: audioExampleMessage,
                                   audioTranslation: audioTranslation,
                                 );

--- a/test/pangea/analytics_practice/game_choice_card_test.dart
+++ b/test/pangea/analytics_practice/game_choice_card_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/routes/analytics/construct_analytics/practice/choice_cards/game_choice_card.dart';
+
+/// A card rebuilt after the practice panel closed must come back showing the
+/// choice the learner already picked — the selection is session state, not
+/// card state (#8309).
+void main() {
+  Future<void> pumpCard(
+    WidgetTester tester, {
+    required bool isSelected,
+    bool shouldFlip = false,
+  }) => tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: GameChoiceCard(
+          targetId: 'target',
+          onPressed: () {},
+          isCorrect: false,
+          isSelected: isSelected,
+          shouldFlip: shouldFlip,
+          altChild: const Text('revealed'),
+          child: const Text('choice'),
+        ),
+      ),
+    ),
+  );
+
+  Color? tintOf(WidgetTester tester) {
+    final container = tester.widget<Container>(
+      find.descendant(
+        of: find.byType(GameChoiceCard),
+        matching: find.byType(Container),
+      ),
+    );
+    return (container.foregroundDecoration as BoxDecoration?)?.color;
+  }
+
+  group('GameChoiceCard', () {
+    testWidgets('an unselected choice is untinted', (tester) async {
+      await pumpCard(tester, isSelected: false);
+      expect(tintOf(tester), Colors.transparent);
+    });
+
+    testWidgets('a choice selected earlier in the session is tinted on first '
+        'build', (tester) async {
+      await pumpCard(tester, isSelected: true);
+      expect(tintOf(tester), AppConfig.error.withValues(alpha: 0.3));
+    });
+
+    testWidgets('a flip card selected earlier rebuilds already revealed', (
+      tester,
+    ) async {
+      await pumpCard(tester, isSelected: true, shouldFlip: true);
+      expect(find.text('revealed'), findsOneWidget);
+      expect(find.text('choice'), findsNothing);
+    });
+
+    testWidgets('tapping tints the card', (tester) async {
+      await pumpCard(tester, isSelected: false);
+      await tester.tap(find.byType(GameChoiceCard));
+      await tester.pump();
+      expect(tintOf(tester), AppConfig.error.withValues(alpha: 0.3));
+    });
+  });
+}


### PR DESCRIPTION
### What

Choices already picked in an analytics practice exercise stay tinted (and flipped) after closing and reopening the practice panel.

### Why

Closes #8309

The selection itself never got lost — it lives in the holder-owned `AnalyticsPracticeNotifier`, which is exactly why the audio exercise's progress bars kept showing partial completion. What got lost was the *rendering* of it: the tint and the flipped face were local `State` on `GameChoiceCard`, so a card rebuilt after panel teardown came back blank. That mismatch is what the reporter saw.

Session persistence itself is unchanged and already specified — see [practice-exercises.instructions.md § Session Persistence & Lifecycle](.github/instructions/practice-exercises.instructions.md#session-persistence--lifecycle).

### How

- `AnalyticsPracticeNotifier` exposes its selected-choice set.
- The set is threaded through the choices list and the four card wrappers to `GameChoiceCard` as `isSelected`.
- `GameChoiceCard` seeds `_clicked` / `_revealed` from `isSelected` rather than always starting false. Seeded, not derived: a live tap sets `isSelected` before the flip animation runs, so deriving would skip the animation.

Fixed once in `GameChoiceCard` — all four exercise types (meaning, audio, grammar category, grammar error) route through it, so all four are covered.

### Testing

- `fvm flutter test` — 2338 passed, 3 skipped.
- `fvm dart analyze lib test` — no issues.
- New `test/pangea/analytics_practice/game_choice_card_test.dart` covers an unselected card, a card selected earlier in the session, a flip card selected earlier, and a live tap. Verified the two regression cases fail with the seeding reverted.
- Smoke/eval/load: N/A — client-only widget state, no service surface.
- Not exercised in a running app: reproducing analytics practice locally needs a seeded local stack, and the change is a pure widget-state fix with direct test coverage. Manual QA follows the issue's TO TEST list on staging.

### Deploy Notes

None.

### Accessibility

- [x] No new or changed controls — the cards' existing selected-state rendering is restored, not redesigned. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md).