### PR TITLE
fix(practice): speak the tapped word in the vocab audio exercise

### DIFF
--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_page.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_page.dart
@@ -367,14 +367,21 @@ class AnalyticsPracticeState extends State<AnalyticsPractice>
       _l2!.langCodeShort,
     );
 
-    if (!notifier.exerciseComplete(exercise)) {
+    final isComplete = notifier.exerciseComplete(exercise);
+
+    // Every tap speaks the word it landed on. The audio exercise takes one tap
+    // per word it heard, and the tap that finishes it is a word tap like the
+    // rest (#8310); the meaning exercise instead replays its target there, so
+    // it would say the same lemma twice.
+    if (!isComplete || exercise is VocabAudioPracticeExerciseModel) {
       AnalyticsPracticeUiController.playChoiceAudio(
         exercise,
         choiceContent,
         _l2!.langCodeShort,
       );
-      return;
     }
+
+    if (!isComplete) return;
 
     _playExerciseAudio(exercise);
 

--- a/lib/routes/analytics/construct_analytics/practice/analytics_practice_ui_controller.dart
+++ b/lib/routes/analytics/construct_analytics/practice/analytics_practice_ui_controller.dart
@@ -1,3 +1,5 @@
+import 'package:collection/collection.dart';
+
 import 'package:fluffychat/features/analytics/construct_identifier.dart';
 import 'package:fluffychat/features/analytics/construct_type_enum.dart';
 import 'package:fluffychat/routes/chat/events/text_to_speech/tts_controller.dart';
@@ -16,6 +18,24 @@ class AnalyticsPracticeUiController {
     String choiceId,
     String language,
   ) {
+    // The audio exercise asks the learner to match a sound to a written word,
+    // so its choices are the words themselves — speaking the tapped one is the
+    // feedback the exercise is about (#8310). Only words drawn from the example
+    // message have a token; distractors speak with no pos or morph.
+    if (exercise is VocabAudioPracticeExerciseModel) {
+      final token = exercise.tokens.firstWhereOrNull(
+        (t) => t.text.content.toLowerCase() == choiceId.toLowerCase(),
+      );
+      TtsController.tryToSpeak(
+        choiceId,
+        langCode: language,
+        useCase: TtsUseCase.choices,
+        pos: token?.pos,
+        morph: token?.morph.map((k, v) => MapEntry(k.name, v)),
+      );
+      return;
+    }
+
     if (exercise is! VocabMeaningPracticeExerciseModel) return;
 
     final cId = ConstructIdentifier.fromString(choiceId);


### PR DESCRIPTION
## What

Tapping a choice in the vocab audio practice exercise now speaks that word.

## Why

Closes #8310

`AnalyticsPracticeUiController.playChoiceAudio` only handled the meaning exercise (#8277), so the one exercise that is entirely about sound gave no audio feedback on tap.

- Audio-exercise choices are the words themselves, so the choice id is the text to speak. Words drawn from the example message carry a token and pass `pos` + `morph` for phoneme disambiguation; distractors have no token and speak without.
- The tap that completes an audio exercise speaks too — it is a word tap like the other three. The meaning exercise still replays its target there instead, which is the same lemma, so nothing double-plays.
- Same `TtsUseCase.choices` gate as the meaning exercise, so the **Choices** audio setting governs it — see [word-text-to-speech.instructions.md](https://github.com/pangeachat/client/blob/main/.github/instructions/word-text-to-speech.instructions.md).

## Testing

- **Unit** — `fvm flutter test test/pangea/`: 2312 passed, 2 skipped, 3 failed. All three failures are the endpoint tier (`choreo_endpoint_test.dart`, `synapse_endpoint_test.dart`, `cms_endpoint_test.dart`), all on the same local env cause — the `.env` `SYNAPSE_URL` carries no scheme, so the real login errors with `No host specified in URI matrix.staging.pangea.chat/...` before any test body runs. Pre-existing and unrelated to this diff; that tier is documented as local-only / not a PR gate.
- **Analyze** — `fvm flutter analyze lib/routes/analytics/construct_analytics/practice/`: clean.
- **Manual, against staging** — ran the branch in the web preview, logged in as the staging test account with **Words** and **Choices** audio on, opened vocab practice and reached a real audio exercise ("Select all the words you hear in the audio"). Every choice tap fired TTS and played:
  - distractor `bonito` → `tryToSpeak: text="bonito" pos=null morph=null` → played
  - message word `hola` → `pos=INTJ morph={Pos: INTJ}`; `cómo` → `pos=ADV`; `qué` → `pos=DET`
  - the completing tap `tal` → `pos=ADJ` → played, then the exercise flipped to the example-message completion view
  - Regression check on the meaning exercise: the completing tap still produced exactly one `tryToSpeak`, with the `playTargetAudio` morph shape — no double-play.
- **Not run** — Playwright/e2e (no spec covers standalone practice; audio playback isn't assertable there).

## Deploy Notes

None
