### PR TITLE
fix(courses): keep activity card semantics when a scroll arrow shows; arrows hit-test opaque

### DIFF
--- a/lib/routes/courses/course_objectives/objective_section.dart
+++ b/lib/routes/courses/course_objectives/objective_section.dart
@@ -299,26 +299,15 @@ class ObjectiveSectionState extends State<ObjectiveSection> {
                     },
                   ),
                 ),
-                // Drop the card semantics beneath the arrows so a tap on an arrow
-                // can't fall through to a card on Flutter web (#7803). A single
-                // blocker painted after the ListView but before the arrows keeps
-                // the two arrows from clobbering each other's semantics: a
-                // per-arrow BlockSemantics would also drop the sibling arrow
-                // painted before it, routing its taps to the wrong arrow.
-                ListenableBuilder(
-                  listenable: Listenable.merge([
-                    _showBackArrowNotifier,
-                    _showForwardArrowNotifier,
-                  ]),
-                  builder: (context, _) {
-                    final blocking =
-                        _showBackArrowNotifier.value ||
-                        _showForwardArrowNotifier.value;
-                    return blocking
-                        ? const BlockSemantics()
-                        : const SizedBox.shrink();
-                  },
-                ),
+                // No BlockSemantics here (#8011): blocking is tree-order, not
+                // geometric, so it would drop every card's semantics node in the
+                // row — and on Flutter web with the semantics tree on (staging
+                // forces it via ENABLE_SEMANTICS) a node-less card cannot be
+                // clicked at all. Worse, the section's labeled container then
+                // merges with the only surviving node (the arrow) into one
+                // row-sized button, so every card click scrolls. Each arrow
+                // instead defends its own strip with an opaque semantics hit
+                // test — see ObjectiveSectionScrollArrow.
                 // The scroll arrows overlay the ends of the ListView. Only mount
                 // the arrow that is currently usable — a hidden-but-present arrow
                 // (IgnorePointer / opacity 0) still leaves a semantics node at the

--- a/lib/routes/courses/course_objectives/objective_section_scroll_arrow.dart
+++ b/lib/routes/courses/course_objectives/objective_section_scroll_arrow.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' as ui show SemanticsHitTestBehavior;
+
 import 'package:flutter/material.dart';
 
 import 'package:fluffychat/l10n/l10n.dart';
@@ -33,11 +35,17 @@ class ObjectiveSectionScrollArrow extends StatelessWidget {
     // accessibility layer is active, pointer events are dispatched through the
     // semantics DOM tree rather than the render tree, so the arrow needs its own
     // tappable semantics node that sits on top of the activity cards beneath it.
-    // The caller drops the card semantics underneath (a sibling BlockSemantics)
-    // so the cards can't intercept the tap (#7803). Do NOT wrap this in an
-    // AbsorbPointer / IgnorePointer: those strip this node's semantics and
-    // reintroduce the click-through.
+    // The opaque hit test is what keeps a tap on the arrow from falling through
+    // to the card node it overlaps (#7803): the engine gives this node pointer
+    // events and z-orders it above earlier-painted siblings — same tool
+    // ModalRoute uses, and the same fix as the WA span card (#8181). It guards
+    // only the arrow's own strip, so the cards keep their nodes (#8011). Do NOT
+    // wrap this in an AbsorbPointer / IgnorePointer (strips this node's
+    // semantics) and do NOT re-add a BlockSemantics beside the arrows (drops
+    // every card node in the row).
     return Semantics(
+      container: true,
+      hitTestBehavior: ui.SemanticsHitTestBehavior.opaque,
       button: true,
       label: direction.label(L10n.of(context)),
       child: MouseRegion(

--- a/test/pangea/courses/objective_section_semantics_test.dart
+++ b/test/pangea/courses/objective_section_semantics_test.dart
@@ -1,0 +1,257 @@
+import 'dart:ui' as ui show SemanticsHitTestBehavior;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_media_enum.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_request.dart';
+import 'package:fluffychat/features/quests/models/learning_objective_model.dart';
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/courses/course_objectives/objective_section.dart';
+import 'package:fluffychat/routes/courses/course_objectives/objective_section_scroll_arrow.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+
+/// Semantics contract for the activity strip in a Mission row.
+///
+/// On Flutter web, when the accessibility layer is active, pointer events are
+/// dispatched through the semantics DOM tree rather than the render tree. That
+/// makes "does this widget have a semantics node" equivalent to "can this widget
+/// be clicked at all" on web — which is why these are semantics assertions and
+/// not `tester.tap` assertions. A widget-test tap goes through the render tree
+/// and passes either way, so it cannot see this class of bug.
+///
+/// Two directions are pinned here, one per historical regression:
+///  - #8011 — a `BlockSemantics` added beside the arrows dropped EVERY card's
+///    semantics node in any overflowing row (blocking is not geometric), so no
+///    activity card could be opened on web while a chevron was showing.
+///  - #7803 — the arrows must still out-rank the cards they overlap, which they
+///    do by being painted after the ListView. Pinned as node order.
+void main() {
+  // The card's image widget reads Environment.cmsApi before it decides whether
+  // to fetch anything, so dotenv has to be loaded even though these tests never
+  // want a real image.
+  setUp(() {
+    dotenv.testLoad(mergeWith: {'CMS_API': 'https://cms.test.invalid'});
+  });
+
+  ActivityPlanModel plan(
+    String id,
+    String title,
+    int participants,
+  ) => ActivityPlanModel(
+    req: ActivityPlanRequest(
+      topic: '',
+      mode: '',
+      objective: '',
+      media: MediaEnum.nan,
+      cefrLevel: LanguageLevelTypeEnum.a2,
+      languageOfInstructions: 'en',
+      targetLanguage: 'es',
+      numberOfParticipants: participants,
+    ),
+    title: title,
+    learningObjective: '',
+    instructions: '',
+    vocab: const [],
+    activityId: id,
+    // A host outside AppConfig's image allowlist, so the card renders its
+    // no-image fallback instead of reaching for the network. Without this the
+    // model falls back to a real placeholder URL on the assets host.
+    imageURL: 'https://images.test.invalid/$id.png',
+  );
+
+  // Ascending participant counts so the widget's own sort keeps this order.
+  const titles = ['Alpha Activity', 'Beta Activity', 'Gamma Activity'];
+  const objectiveText = 'Can introduce self.';
+
+  QuestObjectiveGroup objectiveGroup() => QuestObjectiveGroup(
+    objective: LearningObjective(id: 'lo-1', objective: objectiveText),
+    activities: [
+      for (var i = 0; i < titles.length; i++)
+        QuestActivity(activityId: 'a-$i', plan: plan('a-$i', titles[i], 2 + i)),
+    ],
+  );
+
+  const cardWidth = 160.0;
+
+  Widget wrap({required double width, void Function(QuestActivity)? onTap}) =>
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Scaffold(
+          body: SizedBox(
+            width: width,
+            child: ObjectiveSection(
+              index: 0,
+              group: objectiveGroup(),
+              onTap: onTap ?? (_) {},
+              userStarsByActivity: (_) => 0,
+              hasCompletedActivity: (_) => false,
+              liveStateByActivity: (_) => (
+                state: null,
+                openSessions: 0,
+                participants: const <String>[],
+                openSlots: 0,
+              ),
+              availableParticipants: 10,
+              progress: null,
+              // No vertical padding, so each card gets the height it asks for.
+              spacing: 0.0,
+              cardWidth: cardWidth,
+              cardHeight: 220.0,
+            ),
+          ),
+        ),
+      );
+
+  /// Every non-empty semantics label in the live tree, in semantic child order.
+  /// Order matters: Flutter web builds its semantics DOM in this order, so a
+  /// node listed later sits above an overlapping node listed earlier.
+  ///
+  /// Anchored on the objective header, which sits outside the activity Stack and
+  /// so always has a node, then walked up to the root — the header is the one
+  /// node guaranteed to survive whatever the strip below it is doing.
+  List<String> labelsInOrder(WidgetTester tester) {
+    var root = tester.semantics.find(find.text(objectiveText));
+    while (root.parent != null) {
+      root = root.parent!;
+    }
+
+    final labels = <String>[];
+    void visit(SemanticsNode node) {
+      if (node.label.isNotEmpty) labels.add(node.label);
+      node.visitChildren((child) {
+        visit(child);
+        return true;
+      });
+    }
+
+    visit(root);
+    return labels;
+  }
+
+  /// Position of the first node whose label contains [needle], or -1. Cards merge
+  /// their title with the participant count into one node ('Alpha Activity\n2'),
+  /// so these lookups must be substring matches — an exact `indexOf` silently
+  /// returns -1 for every card and makes the ordering assertion below pass
+  /// without testing anything.
+  int indexOfLabelContaining(List<String> labels, String needle) =>
+      labels.indexWhere((label) => label.contains(needle));
+
+  group('ObjectiveSection activity strip semantics', () {
+    testWidgets('cards keep their semantics nodes while a scroll arrow is '
+        'showing (#8011)', (tester) async {
+      final handle = tester.ensureSemantics();
+      // 3 x 160 overflows a 360 viewport, so the forward arrow mounts.
+      await tester.pumpWidget(wrap(width: 360.0));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(ObjectiveSectionScrollArrow),
+        findsOneWidget,
+        reason: 'the overflowing strip should mount its forward arrow',
+      );
+
+      final labels = labelsInOrder(tester);
+      for (final title in titles) {
+        expect(
+          indexOfLabelContaining(labels, title),
+          isNonNegative,
+          reason:
+              '$title lost its semantics node while an arrow was showing — on '
+              'web that makes the card unclickable. Labels: $labels',
+        );
+      }
+      handle.dispose();
+    });
+
+    testWidgets('the arrow node is ordered after the cards it overlaps '
+        '(#7803)', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(wrap(width: 360.0));
+      await tester.pumpAndSettle();
+
+      final labels = labelsInOrder(tester);
+      final arrowIndex = indexOfLabelContaining(labels, 'Forward');
+      expect(
+        arrowIndex,
+        isNonNegative,
+        reason: 'the forward arrow needs its own node. Labels: $labels',
+      );
+
+      final lastCardIndex = titles
+          .map((t) => indexOfLabelContaining(labels, t))
+          .reduce((a, b) => a > b ? a : b);
+      // Guard the comparison below against passing on a not-found (-1) card.
+      expect(
+        lastCardIndex,
+        isNonNegative,
+        reason: 'the cards need nodes for this ordering check to mean anything',
+      );
+      expect(
+        arrowIndex,
+        greaterThan(lastCardIndex),
+        reason:
+            'the arrow must be painted after the cards so its node sits above '
+            'them and takes the tap instead of the card beneath it',
+      );
+      handle.dispose();
+    });
+
+    testWidgets('the arrow node hit-tests as opaque, so it defends its own '
+        'strip without a semantics blocker (#7803)', (tester) async {
+      final handle = tester.ensureSemantics();
+      await tester.pumpWidget(wrap(width: 360.0));
+      await tester.pumpAndSettle();
+
+      final arrowNode = tester.getSemantics(
+        find.byType(ObjectiveSectionScrollArrow),
+      );
+      expect(
+        arrowNode.hitTestBehavior,
+        ui.SemanticsHitTestBehavior.opaque,
+        reason:
+            'without an opaque semantics hit test, the engine does not '
+            'guarantee the arrow\'s DOM element wins pointer events over the '
+            'card nodes it overlaps, and #7803 comes back on web',
+      );
+      handle.dispose();
+    });
+
+    testWidgets('no arrow mounts when the strip fits, and the cards still '
+        'carry semantics', (tester) async {
+      final handle = tester.ensureSemantics();
+      // 3 x 160 = 480 fits a 600 viewport.
+      await tester.pumpWidget(wrap(width: 600.0));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ObjectiveSectionScrollArrow), findsNothing);
+      final labels = labelsInOrder(tester);
+      for (final title in titles) {
+        expect(
+          indexOfLabelContaining(labels, title),
+          isNonNegative,
+          reason: '$title has no semantics node. Labels: $labels',
+        );
+      }
+      handle.dispose();
+    });
+
+    testWidgets('tapping a card opens that activity', (tester) async {
+      final tapped = <String>[];
+      await tester.pumpWidget(
+        wrap(width: 360.0, onTap: (a) => tapped.add(a.activityId)),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(titles.first));
+      await tester.pumpAndSettle();
+      expect(tapped, ['a-0']);
+    });
+  });
+}


### PR DESCRIPTION
## What

Remove the `BlockSemantics` beside the course-plan scroll arrows, and give each arrow's own semantics node an **opaque hit test** (`Semantics(container: true, hitTestBehavior: SemanticsHitTestBehavior.opaque)`) so it defends its 40px strip geometrically instead of nuking the whole row's semantics.

## Why

Closes #8011 (reopened).

`BlockSemantics` blocks by paint order, not geometry: whenever a chevron showed, it dropped **every** card node in that Mission row. On Flutter web with the semantics tree on — **staging bakes `ENABLE_SEMANTICS=true` into its web build**, so all QA runs in this mode — clicks are dispatched by the `flt-semantics` DOM element under the cursor, so a node-less card can't be clicked. Since #8173 wrapped each section in a labeled semantics container, the container merges with the only surviving node (the arrow) into one **row-sized `Objective Forward` button** — which is why the reopen video shows card clicks scrolling the strip side to side: every click in the row was an arrow click. Verified pre-fix: `document.elementFromPoint` at any point in an overflowing row returned the same 672×285 button node.

## Why this succeeds where #8012 failed

#8012 removed the blocker but left the arrow as a plain `Semantics(button:)` node, with nothing guaranteeing the arrow's DOM element wins pointer events over the card nodes it overlaps — risking the return of #7803 (arrow taps falling through to cards), and it was reverted in #8017. The opaque hit test closes exactly that hole: the engine gives the arrow's node `pointer-events: all` and z-orders it above earlier-painted siblings (verified: `z-index: 2` on the arrow node, and `elementFromPoint` over the overlapped card edge returns the arrow). Same tool `ModalRoute` uses, and the same fix as the WA span card (#8181).

## Testing

**Browser, with `ENABLE_SEMANTICS=true` (the staging mode) — this is the verification #7980/#8012 couldn't do:**
- Pre-fix repro confirmed: overflowing row = one merged row-sized button; a click at a card center scrolled the strip (the reopened issue's video, replicated locally).
- Post-fix: every card has its own 160×248 button node while a chevron shows; card click opens the activity plan (router log confirms); **after clicking an arrow, a card click still opens the plan** (the reopen symptom); arrow click scrolls and does **not** open a plan (#7803 intact); with both arrows mounted, all cards keep their nodes (#7981 case).

**Unit tests** — restored the regression suite from #8012 (deleted by the revert) and added an assertion that each arrow's node hit-tests opaque, so the #7803 guard can't be silently dropped. Pre-fix: 3 of 5 fail (cards lose nodes, ordering, opaque). Post-fix: all 5 pass.

**Full suite**: 2353 passed; the only failures are the 3 live-endpoint tests (`choreo`/`synapse`/`cms`), which fail locally regardless of this change. `flutter analyze` clean on touched files, `dart format` clean.

Screen-reader spot checks (VoiceOver/TalkBack) per the issue TO TEST remain for staging QA.

## Deploy Notes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)