### PR TITLE
fix(invite-link): share a path URL, not a /#/ link, so web resolves it

### DIFF
--- a/lib/features/navigation/user_id_url.dart
+++ b/lib/features/navigation/user_id_url.dart
@@ -24,6 +24,19 @@ String shortUserId(String id, {String? domain}) =>
 String fullUserId(String segment, {String? domain}) =>
     fullRoomId(segment, domain: domain);
 
+/// The "Share invite link" URL that opens a DM with [userId].
+///
+/// A path, **not** a `/#/` link. Web runs under `usePathUrlStrategy`, where a
+/// fragment is not part of the route, so a hash link boots the app at `/` and
+/// the invite route never fires. Only the native app_links path ever unwrapped
+/// the fragment ([MatrixState.incomingUriToPath]), which is why a hash link
+/// worked on iOS and did nothing at all on web. CloudFront serves the SPA shell
+/// for every path, so a direct path load boots. [domain] overrides the home
+/// domain (for tests).
+String inviteLinkForUser(String frontendURL, String userId, {String? domain}) =>
+    '$frontendURL/invite_user/'
+    '${Uri.encodeComponent(shortUserId(userId, domain: domain))}';
+
 /// Read the `/invite_user/:userID` path param into the full mxid to open a DM
 /// with. The router percent-decodes a path param once on its own, but a shared
 /// link can reach us encoded twice — the share text encodes the id, and a chat

--- a/lib/utils/fluffy_share.dart
+++ b/lib/utils/fluffy_share.dart
@@ -49,7 +49,7 @@ abstract class FluffyShare {
       //   ownProfile.displayName ?? client.userID!,
       //   'https://matrix.to/#/${client.userID}?client=im.fluffychat',
       // ),
-      "${Environment.frontendURL}/#/invite_user/${Uri.encodeComponent(shortUserId(client.userID!))}",
+      inviteLinkForUser(Environment.frontendURL, client.userID!),
       // Pangea#
       context,
     );

--- a/test/pangea/navigation/invite_user_link_test.dart
+++ b/test/pangea/navigation/invite_user_link_test.dart
@@ -9,42 +9,63 @@ import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 
 /// End-to-end regression coverage for the `/invite_user/:userID` link
-/// (Share invite link): the same GoRouter wiring as `fluffy_chat_app.dart`
-/// (route + top-level redirect), driven the way `MatrixState`'s app_links
-/// listener actually delivers a shared link — a post-frame `router.go()` call
-/// after the app has already booted, not `initialLocation`.
+/// (Share invite link), across **both** ways a shared link reaches the router,
+/// using the same GoRouter wiring as `fluffy_chat_app.dart`:
 ///
-/// The builder calls [userIdFromUrlParam], the same single function
-/// `routes.dart` calls, so these pin the real read-side behavior rather than a
-/// copy of it. Guards against the id reaching the homeserver still
-/// percent-encoded, which reads as an invalid mxid.
+/// - **web** — `usePathUrlStrategy` means the router boots from the real path,
+///   so the link is the initial location. A `/#/` link lands here as `/` and
+///   never routes (#7922 reopened: worked on iOS, dead on web).
+/// - **native** — app_links replays the link post-boot via
+///   `MatrixState.incomingUriToPath`, which unwraps a fragment.
+///
+/// Links come from [inviteLinkForUser], the same function `fluffy_share.dart`
+/// ships, and the builder calls [userIdFromUrlParam], the same one
+/// `routes.dart` calls — so these pin real behavior, not a copy of it.
 const _homeDomain = 'staging.pangea.chat';
+const _frontend = 'https://app.staging.pangea.chat';
 
-/// Boots the router, replays [sharedLink] the way a tapped share link arrives,
-/// and returns the mxid the invite route resolved.
-Future<String?> _resolve(WidgetTester tester, String sharedLink) async {
+GoRouter _router(void Function(String) onInvite, String initialLocation) =>
+    GoRouter(
+      initialLocation: initialLocation,
+      redirect: (context, state) {
+        final legacy = LegacyRedirects.handle(state.uri);
+        if (legacy != null) return legacy;
+        return WorkspaceNav.preserveOpenPanels(state.uri);
+      },
+      routes: [
+        GoRoute(path: '/', builder: (context, state) => const SizedBox()),
+        GoRoute(
+          path: '/invite_user/:userID',
+          builder: (context, state) {
+            onInvite(
+              userIdFromUrlParam(
+                state.pathParameters['userID']!,
+                domain: _homeDomain,
+              ),
+            );
+            return const SizedBox();
+          },
+        ),
+      ],
+    );
+
+/// Web: the router boots directly from the shared link's path.
+Future<String?> _resolveOnWeb(WidgetTester tester, String sharedLink) async {
   String? captured;
-  final router = GoRouter(
-    initialLocation: '/',
-    redirect: (context, state) {
-      final legacy = LegacyRedirects.handle(state.uri);
-      if (legacy != null) return legacy;
-      return WorkspaceNav.preserveOpenPanels(state.uri);
-    },
-    routes: [
-      GoRoute(path: '/', builder: (context, state) => const SizedBox()),
-      GoRoute(
-        path: '/invite_user/:userID',
-        builder: (context, state) {
-          captured = userIdFromUrlParam(
-            state.pathParameters['userID']!,
-            domain: _homeDomain,
-          );
-          return const SizedBox();
-        },
-      ),
-    ],
+  final uri = Uri.parse(sharedLink);
+  // What the browser hands the path-strategy router: path + query, no fragment.
+  final location = uri.hasQuery ? '${uri.path}?${uri.query}' : uri.path;
+  await tester.pumpWidget(
+    MaterialApp.router(routerConfig: _router((v) => captured = v, location)),
   );
+  await tester.pumpAndSettle();
+  return captured;
+}
+
+/// Native: app_links replays the link after the app has already booted.
+Future<String?> _resolveOnNative(WidgetTester tester, String sharedLink) async {
+  String? captured;
+  final router = _router((v) => captured = v, '/');
   await tester.pumpWidget(MaterialApp.router(routerConfig: router));
   await tester.pumpAndSettle();
 
@@ -54,56 +75,74 @@ Future<String?> _resolve(WidgetTester tester, String sharedLink) async {
 }
 
 void main() {
-  testWidgets(
-    'a home-server id rides shortened and resolves to the full mxid',
-    (tester) async {
-      // The link fluffy_share.dart builds: shortUserId, then encoded once.
+  group('the link the app actually shares', () {
+    test('is a path, never a fragment', () {
+      // A `/#/` link is invisible to the path-strategy router: the whole
+      // reason the fix worked on iOS and did nothing on web (#7922 reopened).
+      final link = inviteLinkForUser(
+        _frontend,
+        '@william11:$_homeDomain',
+        domain: _homeDomain,
+      );
+      expect(link, '$_frontend/invite_user/%40william11');
+      expect(link, isNot(contains('#')));
+      expect(Uri.parse(link).fragment, isEmpty);
+    });
+
+    testWidgets('resolves on web, where the router boots from the path', (
+      tester,
+    ) async {
+      final link = inviteLinkForUser(
+        _frontend,
+        '@william11:$_homeDomain',
+        domain: _homeDomain,
+      );
+      expect(await _resolveOnWeb(tester, link), '@william11:$_homeDomain');
+    });
+
+    testWidgets('resolves on native, replayed by app_links', (tester) async {
+      final link = inviteLinkForUser(
+        _frontend,
+        '@william11:$_homeDomain',
+        domain: _homeDomain,
+      );
+      expect(await _resolveOnNative(tester, link), '@william11:$_homeDomain');
+    });
+  });
+
+  group('reading the id back', () {
+    testWidgets('a foreign-homeserver id keeps its own domain', (tester) async {
       expect(
-        await _resolve(
+        await _resolveOnWeb(
           tester,
-          'https://app.staging.pangea.chat/#/invite_user/%40william11',
+          '$_frontend/invite_user/%40will%3Amatrix.org',
+        ),
+        '@will:matrix.org',
+      );
+    });
+
+    testWidgets('a double-encoded link still resolves', (tester) async {
+      // A client that linkifies the shared message can encode it a second
+      // time. The router decodes once, which on its own would leave
+      // `%40william11...` and reach the homeserver as an invalid mxid.
+      expect(
+        await _resolveOnWeb(
+          tester,
+          '$_frontend/invite_user/%2540william11%253Astaging.pangea.chat',
         ),
         '@william11:$_homeDomain',
       );
-    },
-  );
+    });
 
-  testWidgets('a foreign-homeserver id keeps its own domain', (tester) async {
-    expect(
-      await _resolve(
-        tester,
-        'https://app.staging.pangea.chat/#/invite_user/%40will%3Amatrix.org',
-      ),
-      '@will:matrix.org',
-    );
-  });
-
-  testWidgets('a double-encoded link still resolves (the reported bug)', (
-    tester,
-  ) async {
-    // A client that linkifies the shared message can encode it a second time.
-    // The router decodes once, which on its own would leave `%40william11...`
-    // and reach the homeserver as an invalid mxid.
-    expect(
-      await _resolve(
-        tester,
-        'https://app.staging.pangea.chat/#/invite_user/%2540william11%253Astaging.pangea.chat',
-      ),
-      '@william11:$_homeDomain',
-    );
-  });
-
-  testWidgets('a malformed link does not throw out of the route builder', (
-    tester,
-  ) async {
-    expect(
-      await _resolve(
-        tester,
-        'https://app.staging.pangea.chat/#/invite_user/100%25',
-      ),
-      // Left as given; it fails id validation downstream, not here.
-      '100%:$_homeDomain',
-    );
-    expect(tester.takeException(), isNull);
+    testWidgets('a malformed link does not throw out of the route builder', (
+      tester,
+    ) async {
+      expect(
+        await _resolveOnWeb(tester, '$_frontend/invite_user/100%25'),
+        // Left as given; it fails id validation downstream, not here.
+        '100%:$_homeDomain',
+      );
+      expect(tester.takeException(), isNull);
+    });
   });
 }


### PR DESCRIPTION
## What

The Share invite link is built as `${frontendURL}/#/invite_user/<id>`. Web runs under `usePathUrlStrategy`, where a fragment is not part of the route, so that link boots the app at `/` and the invite route never fires. Only the native app_links path ever unwrapped the fragment (`MatrixState.incomingUriToPath`), which is why it worked on iOS and did nothing at all on web.

Emit a path instead. The link shape moves into `inviteLinkForUser` so it is testable, and the tests now cover **both** ways a link reaches the router.

Reproduced before/after:

| Entry path | Link form | Invite route fires? |
| --- | --- | --- |
| Web boot | `/#/invite_user/%40william11` (before) | **never fires** |
| Web boot | `/invite_user/%40william11` (after) | `@william11:staging.pangea.chat` |
| Native app_links | `/invite_user/%40william11` (after) | `@william11:staging.pangea.chat` |

## Why

Reopens/closes #7922. Verified on web by @TigToggle ("Did not work. Did not create a DM or take pages") after @Kelrap confirmed the iOS path worked — that platform split is the signature of this bug.

## This is the fourth link surface the path-URL cutover broke

`usePathUrlStrategy()` landed in #7820 (issue #7819, so logged-out join links survive the login bounce). It fixed join links by making the router read the real path at boot, and in doing so invalidated every assumption that only held while the hash strategy kept each page at `/`. Those have been found one at a time:

| | Surface broken | What the hash strategy had been hiding |
| --- | --- | --- |
| #7849 | Web SSO callback + `.env` fetch | Relative URLs resolved against `/`, so `auth.html` 404'd from `/home/login` |
| #7830 | Mobile-web shared links | The store bounce ran on every mobile load and dropped the link payload |
| #6117 | Class links on mobile | OS app links bypass the browser, so `index.html` redirect logic never ran |
| **this** | DM invite share link | The producer still emitted `/#/`, which the path router cannot see |

Same root each time: a link **producer** or redirect kept assuming the fragment was the route. Worth noting the docs still carry that assumption too — `deep-linking.instructions.md` opens with "The client is a hash-routed web/Flutter app" and `google-analytics.instructions.md` repeats it, while their own route tables list path-form contracts. Raising that separately rather than editing docs in a PR.

## Testing

- `flutter analyze` — clean on all touched files.
- `flutter test test/pangea/navigation/ test/pangea/incoming_uri_path_test.dart` — **389 passing**.
- `invite_user_link_test.dart` now drives both entry paths: **web** (router boots from the path, as `usePathUrlStrategy` does) and **native** (app_links replay through `incomingUriToPath`). The previous tests drove only the native path, which is exactly why they passed while web was dead — that gap is what this closes. Links under test come from `inviteLinkForUser`, the same function the app ships, and one test asserts the link carries no fragment, so re-introducing a `#` fails rather than shipping.
- No smoke/eval/load bucket applies — client-side routing and URL construction only.

## TO TEST

Test **on web first** — that is the surface that was broken.

1. On web staging, sign in and open **New direct message → Share invite link**. The copied link should read `https://app.staging.pangea.chat/invite_user/%40<yourname>` with **no `#`** in it.
2. Open that link in a different browser (or profile) signed in as a second account. It should open a DM with the first account, not just land on the world map.
3. Paste the link into a chat message, send it, and click it from the second account. It should still open the DM.
4. On iOS and Android, repeat steps 1–3 to confirm the native path still works.

## Deploy Notes

None. Links already shared under the old `/#/` form keep working on native and stay broken on web; re-share to get a working one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invite links now use readable `/invite_user/...` paths instead of hash-based fragments.
  * Links support shortened user IDs and optional home-server domain overrides.

* **Bug Fixes**
  * Improved invite-link handling across web startup and native deep-link navigation.
  * Added coverage for foreign-domain, double-encoded, and malformed invite links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->