### PR TITLE
fix(courses): give the course error state a close control

### DIFF
--- a/lib/routes/chat/chat_details/pangea_room_details.dart
+++ b/lib/routes/chat/chat_details/pangea_room_details.dart
@@ -21,7 +21,12 @@ class PangeaRoomDetailsView extends StatelessWidget {
       return Semantics(
         container: true,
         child: Scaffold(
-          appBar: AppBar(title: Text(L10n.of(context).oopsSomethingWentWrong)),
+          appBar: AppBar(
+            // Give the error state the panel's close control (#8322) so a
+            // stale or hand-edited course ID can't strand the user.
+            leading: controller.widget.embeddedCloseButton,
+            title: Text(L10n.of(context).oopsSomethingWentWrong),
+          ),
           body: Center(
             child: Text(L10n.of(context).youAreNoLongerParticipatingInThisChat),
           ),

--- a/test/pangea/navigation/course_details_error_close_button_test.dart
+++ b/test/pangea/navigation/course_details_error_close_button_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+import 'package:provider/provider.dart';
+
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/left_panel/left_panel_course_details_subpage.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import '../../utils/test_client.dart';
+
+/// #8322 — a stale or hand-edited `?c=` (e.g. `?c=!fakecourseId&left=course`)
+/// names a course the client cannot resolve, so the course card falls to its
+/// "oops, something went wrong" state. That state used to render a bare app bar
+/// with no leading control, stranding the learner on a panel they could not
+/// close. It now carries the panel's injected close control, the same fix
+/// [LeftPanelRoomSubpage] got in #7746.
+class _FakeMatrixState extends MatrixState {
+  _FakeMatrixState(this._client);
+
+  final Client _client;
+
+  @override
+  Client get client => _client;
+}
+
+void main() {
+  late Client client;
+
+  setUpAll(() async {
+    client = await prepareTestClient();
+  });
+
+  tearDownAll(() => client.dispose());
+
+  testWidgets('an unresolvable course id renders the panel close control', (
+    tester,
+  ) async {
+    const closeKey = Key('the-close-button');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: L10n.localizationsDelegates,
+        supportedLocales: L10n.supportedLocales,
+        home: Provider<MatrixState>.value(
+          value: _FakeMatrixState(client),
+          child: const LeftPanelCourseDetailsSubpage(
+            param: null,
+            spaceId: '!fakecourseId:fakeserver.notexisting',
+            closeButton: IconButton(
+              key: closeKey,
+              icon: Icon(Icons.close),
+              onPressed: null,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(closeKey), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## What

The course card's "Oops, something went wrong…" state now carries the panel's close control.

## Why

Closes #8322

An unresolvable `?c=` (a stale link, a hand-edited URL, a course the learner has left) drops the course card to the error state in `PangeaRoomDetailsView`. That state's `AppBar` had no `leading:` and discarded the `embeddedCloseButton` the left panel already threads down to it, so the learner was stuck on a panel with no way out. Same defect `LeftPanelRoomSubpage`'s empty state was fixed for in #7746.

Per the [close-affordance rule](https://github.com/pangeachat/client/blob/main/.github/instructions/routing.instructions.md#closing-a-panel-x-or-back-arrow), a page rendering its own chrome must place the panel's close control in that chrome.

## Testing

- New widget test `test/pangea/navigation/course_details_error_close_button_test.dart` — an unresolvable course id renders the injected close control. Verified red before the fix, green after.
- `fvm flutter test test/pangea/navigation/` — 381 pass.
- `fvm flutter test` (full suite) — 2368 pass, 4 skipped, 1 fail: `choreo_endpoint_test.dart` "Custom course endpoint test" (`401 POST /choreo/courses/request — Matrix account has no email 3pid`). Pre-existing local-stack account limitation, unrelated to this change.
- `fvm flutter analyze` on the changed files — no issues.
- Manual, local stack, web (`?devlogin=1` as `learner`): navigating to `/?c=!fakecourseId&left=course` shows the error card with an X labelled "Close course"; clicking it drops the panel and reveals the world map.

## Deploy Notes

None