### PR TITLE
fix(courses): give the course invite and emotes error states a close control

### DIFF
--- a/lib/routes/chat/chat_details/emotes/settings_emotes_view.dart
+++ b/lib/routes/chat/chat_details/emotes/settings_emotes_view.dart
@@ -23,7 +23,14 @@ class EmotesSettingsView extends StatelessWidget {
   Widget build(BuildContext context) {
     if (controller.widget.roomId != null && controller.room == null) {
       return Scaffold(
-        appBar: AppBar(title: Text(L10n.of(context).oopsSomethingWentWrong)),
+        appBar: AppBar(
+          // Give the error state the panel's close control (#8327) so an
+          // unresolvable `?c=` course id can't strand the user, the same fix
+          // the course card got in #8322. The save-mode cancel button that
+          // takes priority below can't apply here — there is no pack to edit.
+          leading: controller.widget.embeddedCloseButton,
+          title: Text(L10n.of(context).oopsSomethingWentWrong),
+        ),
         body: Center(
           child: Text(L10n.of(context).youAreNoLongerParticipatingInThisChat),
         ),

--- a/lib/routes/chat/chat_details/invite/pangea_invitation_selection_view.dart
+++ b/lib/routes/chat/chat_details/invite/pangea_invitation_selection_view.dart
@@ -34,7 +34,13 @@ class PangeaInvitationSelectionView extends StatelessWidget {
     ).client.getRoomById(controller.widget.roomId);
     if (room == null) {
       return Scaffold(
-        appBar: AppBar(title: Text(L10n.of(context).oopsSomethingWentWrong)),
+        appBar: AppBar(
+          // Give the error state the panel's close control (#8327) so an
+          // unresolvable `?c=` course id can't strand the user, the same fix
+          // the course card got in #8322.
+          leading: controller.widget.embeddedCloseButton,
+          title: Text(L10n.of(context).oopsSomethingWentWrong),
+        ),
         body: Center(
           child: Text(L10n.of(context).youAreNoLongerParticipatingInThisChat),
         ),

--- a/test/pangea/navigation/course_subpage_error_close_button_test.dart
+++ b/test/pangea/navigation/course_subpage_error_close_button_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+import 'package:provider/provider.dart';
+
+import 'package:fluffychat/features/navigation/token_params/room_subpage_token.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/routes/world/left_panel/left_panel_room_details_subpage.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import '../../utils/test_client.dart';
+
+/// #8327 — a `coursepage:<page>` panel reads its space id from `?c=`, and
+/// [LeftPanelRoomDetailsSubpage] hands it straight to the page with no
+/// room-existence gate of its own. A stale or hand-edited id (e.g.
+/// `?c=!fakecourseId&left=coursepage:invite`) therefore reaches the page's own
+/// "oops, something went wrong" state, which used to render a bare app bar with
+/// no leading control — stranding the learner on a panel they could not close.
+/// Each error state now carries the panel's injected close control, the same
+/// fix the course card got in #8322 and [LeftPanelRoomSubpage] in #7746.
+///
+/// The `room:<id>/...` path needs no equivalent test: [LeftPanelRoomSubpage]
+/// intercepts an unresolvable room with its own #7746 empty state before any
+/// of these pages build.
+class _FakeMatrixState extends MatrixState {
+  _FakeMatrixState(this._client);
+
+  final Client _client;
+
+  @override
+  Client get client => _client;
+}
+
+void main() {
+  late Client client;
+
+  setUpAll(() async {
+    client = await prepareTestClient();
+  });
+
+  tearDownAll(() => client.dispose());
+
+  for (final subpage in [RoomSubpageEnum.invite, RoomSubpageEnum.emotes]) {
+    testWidgets(
+      'an unresolvable course id on ${subpage.name} renders the panel close control',
+      (tester) async {
+        const closeKey = Key('the-close-button');
+
+        await tester.pumpWidget(
+          MaterialApp(
+            localizationsDelegates: L10n.localizationsDelegates,
+            supportedLocales: L10n.supportedLocales,
+            home: Provider<MatrixState>.value(
+              value: _FakeMatrixState(client),
+              child: LeftPanelRoomDetailsSubpage(
+                roomId: '!fakecourseId:fakeserver.notexisting',
+                param: RoomSubpageTokenParam(subpage: subpage),
+                closeButton: const IconButton(
+                  key: closeKey,
+                  icon: Icon(Icons.close),
+                  onPressed: null,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // Read the localized string from the live element tree rather than
+        // awaiting L10n.delegate.load — awaiting that future stalls the
+        // testWidgets fake-async clock.
+        final l10n = L10n.of(
+          tester.element(find.byType(LeftPanelRoomDetailsSubpage)),
+        );
+        expect(find.text(l10n.oopsSomethingWentWrong), findsOneWidget);
+        expect(find.byKey(closeKey), findsOneWidget);
+      },
+    );
+  }
+}


### PR DESCRIPTION
## What

Thread the panel's close control into the `coursepage:invite` and `coursepage:emotes` error states, so an unresolvable `?c=` course id can't strand the learner on a panel with no way out.

## Why

Closes #8327. Same defect as #8322 (course card) and #7746 (room panel empty state) — a page that renders its own chrome must place the panel's close control in its own header, per [routing.instructions.md, "Closing a panel: X or back arrow"](.github/instructions/routing.instructions.md).

`LeftPanelRoomDetailsSubpage` hands `coursepage:` its space id from `?c=` with no room-existence gate, so an unresolvable id reaches each page's own "oops, something went wrong" state — which discarded the `embeddedCloseButton` it was already given.

Two files listed as suspects were checked and deliberately left alone:

- `chat_search/chat_search_view.dart` and the `room:<id>/invite` path — not reachable. `LeftPanelRoomSubpage` intercepts an unresolvable room with its own #7746 empty state before either page builds. Verified with a throwaway probe test: both already render the close control today.
- `chat_details/settings_emotes/settings_emotes_view.dart` — dead code. Nothing imports it; it is an orphaned duplicate of `chat_details/emotes/settings_emotes_view.dart` left behind by the #7028 file move. Deleting it is out of this PR's path.

## Testing

- New `test/pangea/navigation/course_subpage_error_close_button_test.dart` pumps `LeftPanelRoomDetailsSubpage` with a bogus room id for both subpages and asserts the error state plus the injected close control. Both cases fail on `main` and pass here.
- `fvm flutter test test/pangea/navigation/` — 383 passing.
- `fvm flutter analyze` on the changed dirs — clean.

## Deploy Notes

None.