### PR TITLE
fix(settings): show message-audio toggles off without a known-good voice

### DIFF
--- a/lib/routes/settings/settings_learning/audio_settings_section.dart
+++ b/lib/routes/settings/settings_learning/audio_settings_section.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import 'package:fluffychat/config/app_config.dart';
 import 'package:fluffychat/l10n/l10n.dart';
-import 'package:fluffychat/routes/chat/events/text_to_speech/tts_controller.dart';
 import 'package:fluffychat/routes/settings/settings_learning/learning_settings_view_model.dart';
 import 'package:fluffychat/routes/settings/settings_learning/p_settings_switch_list_tile.dart';
 import 'package:fluffychat/routes/settings/settings_learning/read_aloud_voice_dialog.dart';
@@ -22,7 +21,7 @@ class AudioSettingsSection extends StatelessWidget {
   Future<bool> _onEnableReadAloud(BuildContext context) async {
     final language = viewModel.selectedTargetLanguage;
     if (language == null) return false;
-    if (await TtsController.hasKnownGoodVoiceFor(language.langCode)) {
+    if (await viewModel.refreshKnownGoodVoice()) {
       return true;
     }
     if (context.mounted) {

--- a/lib/routes/settings/settings_learning/learning_settings_view_model.dart
+++ b/lib/routes/settings/settings_learning/learning_settings_view_model.dart
@@ -9,6 +9,7 @@ import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/languages/language_service.dart';
 import 'package:fluffychat/features/languages/p_language_store.dart';
 import 'package:fluffychat/features/user/user_model.dart';
+import 'package:fluffychat/routes/chat/events/text_to_speech/tts_controller.dart';
 import 'package:fluffychat/routes/settings/settings_learning/gender_enum.dart';
 import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
 import 'package:fluffychat/routes/settings/settings_learning/tool_settings_enum.dart';
@@ -20,18 +21,38 @@ class LearningSettingsViewModel extends ChangeNotifier {
 
   LearningSettingsViewModel(Profile profile, {this.onUpdateProfile}) {
     _updatedProfile = profile;
+    refreshKnownGoodVoice();
   }
 
   Timer? _textDebounce;
   bool _hasResetTooltips = false;
+  bool _hasKnownGoodVoice = false;
+  bool _disposed = false;
 
   @override
   void dispose() {
     _textDebounce?.cancel();
+    _disposed = true;
     super.dispose();
   }
 
   bool get hasResetTooltips => _hasResetTooltips;
+
+  /// Re-runs the known-good-voice gate for the selected target language and
+  /// notifies if the answer changed, so the message-audio toggles show the
+  /// device's current state after the learner downloads a voice.
+  Future<bool> refreshKnownGoodVoice() async {
+    final langCode = selectedTargetLanguage?.langCode;
+    final hasVoice =
+        langCode != null && await TtsController.hasKnownGoodVoiceFor(langCode);
+    // The engine query outlives a page the learner backs out of.
+    if (_disposed) return hasVoice;
+    if (hasVoice != _hasKnownGoodVoice) {
+      _hasKnownGoodVoice = hasVoice;
+      notifyListeners();
+    }
+    return hasVoice;
+  }
 
   bool get haveSettingsChanged {
     final originalProfile = MatrixState.pangeaController.userController.profile;
@@ -113,10 +134,13 @@ class LearningSettingsViewModel extends ChangeNotifier {
         return _updatedProfile.userSettings.targetLanguage != null &&
             _selectedTargetLanguage != null &&
             toolSettings.audioChoices;
+      // Read-aloud is silent without a known-good device voice, so the toggle
+      // reads off there whatever the account setting says — otherwise a
+      // default-on toggle claims audio the device cannot produce (#8326).
       case ToolSetting.audioOnNewMessage:
-        return toolSettings.audioOnNewMessage;
+        return _hasKnownGoodVoice && toolSettings.audioOnNewMessage;
       case ToolSetting.audioOnMessageClick:
-        return toolSettings.audioOnMessageClick;
+        return _hasKnownGoodVoice && toolSettings.audioOnMessageClick;
       case ToolSetting.enableAutocorrect:
         return toolSettings.enableAutocorrect;
     }
@@ -215,6 +239,8 @@ class LearningSettingsViewModel extends ChangeNotifier {
     }
 
     _updateProfile(updated);
+    // The voice gate is per-language, so a new target language re-runs it.
+    if (targetLanguage != null) refreshKnownGoodVoice();
   }
 
   void setGender(GenderEnum? gender) {

--- a/test/pangea/audio_settings_section_test.dart
+++ b/test/pangea/audio_settings_section_test.dart
@@ -1,22 +1,68 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:fluffychat/features/languages/p_language_store.dart';
 import 'package:fluffychat/features/user/user_model.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/routes/settings/settings_learning/audio_settings_section.dart';
 import 'package:fluffychat/routes/settings/settings_learning/learning_settings_view_model.dart';
+import 'package:fluffychat/routes/settings/settings_learning/read_aloud_voice_dialog.dart';
 import 'package:fluffychat/routes/settings/settings_learning/tool_settings_enum.dart';
 
-/// #8117 / #8264 — the Audio section of learning settings: the per-surface
-/// audio toggles (Words, Choices, On new message, On message click).
+/// #8117 / #8264 / #8326 — the Audio section of learning settings: the
+/// per-surface audio toggles (Words, Choices, On new message, On message
+/// click), and the known-good-voice gate on the two message toggles.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  const ttsChannel = MethodChannel('flutter_tts');
+
+  /// The voices `flutter_tts.getVoices` reports for the next engine query.
+  /// `enhanced` clears the quality bar; `default` does not.
+  List<Map<String, String>> deviceVoices = [];
+
+  setUpAll(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(ttsChannel, (call) async {
+          if (call.method == 'getVoices') return deviceVoices;
+          return 1;
+        });
+
+    // The target language resolves through PLanguageStore, so seed its cache
+    // rather than letting initialize() reach the network.
+    SharedPreferences.setMockInitialValues({
+      PrefKey.lastFetched: DateTime.now().toIso8601String(),
+      PrefKey.languagesKey: jsonEncode({
+        PrefKey.languagesKey: [
+          {
+            'language_code': 'es',
+            'language_name': 'Spanish',
+            'l2_support': 'full',
+          },
+        ],
+      }),
+    });
+    await PLanguageStore.initialize();
+  });
+
+  setUp(() {
+    deviceVoices = [
+      {'name': 'Mónica (Enhanced)', 'locale': 'es-ES', 'quality': 'enhanced'},
+    ];
+  });
 
   LearningSettingsViewModel makeViewModel({
     UserToolSettings toolSettings = const UserToolSettings(),
   }) => LearningSettingsViewModel(
-    Profile(userSettings: UserSettings(), toolSettings: toolSettings),
+    Profile(
+      userSettings: UserSettings(sourceLanguage: 'en', targetLanguage: 'es'),
+      toolSettings: toolSettings,
+    ),
   );
 
   Future<void> pumpSection(
@@ -71,8 +117,24 @@ void main() {
     expect(viewModel.getToolSetting(ToolSetting.audioOnMessageClick), isFalse);
   });
 
-  testWidgets('enabling a message toggle without a target language is '
-      'blocked by the voice gate', (tester) async {
+  testWidgets('the message toggles read off without a known-good voice, '
+      'whatever the account setting says (#8326)', (tester) async {
+    deviceVoices = [
+      {'name': 'Mónica', 'locale': 'es-ES', 'quality': 'default'},
+    ];
+    // Both stored on — the default every account starts with (#8264).
+    final viewModel = makeViewModel();
+    await pumpSection(tester, viewModel);
+
+    expect(viewModel.getToolSetting(ToolSetting.audioOnNewMessage), isFalse);
+    expect(viewModel.getToolSetting(ToolSetting.audioOnMessageClick), isFalse);
+  });
+
+  testWidgets('enabling a message toggle without a known-good voice is '
+      'blocked by the gate', (tester) async {
+    deviceVoices = [
+      {'name': 'Mónica', 'locale': 'es-ES', 'quality': 'default'},
+    ];
     final viewModel = makeViewModel(
       toolSettings: const UserToolSettings(
         audioOnNewMessage: false,
@@ -83,10 +145,28 @@ void main() {
 
     await tester.tap(find.text('On new message'));
     await tester.pumpAndSettle();
+
+    expect(viewModel.getToolSetting(ToolSetting.audioOnNewMessage), isFalse);
+    expect(find.byType(ReadAloudVoiceDialog), findsOneWidget);
+  });
+
+  testWidgets('a toggle stored on reads on once a qualifying voice is '
+      'downloaded', (tester) async {
+    deviceVoices = [
+      {'name': 'Mónica', 'locale': 'es-ES', 'quality': 'default'},
+    ];
+    final viewModel = makeViewModel();
+    await pumpSection(tester, viewModel);
+    expect(viewModel.getToolSetting(ToolSetting.audioOnMessageClick), isFalse);
+
+    // The learner follows the dialog to system settings and comes back.
+    deviceVoices = [
+      {'name': 'Mónica (Enhanced)', 'locale': 'es-ES', 'quality': 'enhanced'},
+    ];
     await tester.tap(find.text('On message click'));
     await tester.pumpAndSettle();
 
-    expect(viewModel.getToolSetting(ToolSetting.audioOnNewMessage), isFalse);
-    expect(viewModel.getToolSetting(ToolSetting.audioOnMessageClick), isFalse);
+    expect(viewModel.getToolSetting(ToolSetting.audioOnMessageClick), isTrue);
+    expect(find.byType(ReadAloudVoiceDialog), findsNothing);
   });
 }


### PR DESCRIPTION
### What

The two message read-aloud toggles in learning settings > audio now read **off** wherever the device has no known-good voice for the L2, whatever the account setting holds.

### Why

Closes #8326

Both toggles default on (#8264), but the enable-time gate and playback both need a known-good device voice. On a device without one the toggle read on while nothing ever played, and once a learner turned it off the gate refused to turn it back on. Design: [message-read-aloud.instructions.md § Enabling requires a qualifying voice](.github/instructions/message-read-aloud.instructions.md).

- `LearningSettingsViewModel.refreshKnownGoodVoice()` runs the same gate playback uses, and `getToolSetting` folds the answer into the two message toggles — matching how `audioWords` / `audioChoices` already fold in target-language availability.
- The stored setting is untouched. The check is device-level, the setting is account-level.
- The gate re-runs when the section opens, when the target language changes, and when the learner taps a toggle, so a voice downloaded from the dialog flips the switch on with no further action.
- `AudioSettingsSection` now asks the view model rather than `TtsController` directly, so the enable path and the displayed value can never disagree.

A doc change recording the display rule is proposed separately, per [How a doc change gets made](https://github.com/pangeachat/.github/blob/main/.github/instructions/instructions-authoring.instructions.md#how-a-doc-change-gets-made) — not folded into this PR.

### Testing

- Unit/widget: full `fvm flutter test` suite locally — 2361 passed, 3 skipped, 0 failed.
- `test/pangea/audio_settings_section_test.dart` rewritten to mock the `flutter_tts` channel and seed `PLanguageStore`, so both branches of the gate are exercised. Five cases: section renders; disabling stays ungated; both toggles read off without a qualifying voice while stored on (#8326); enabling without one is blocked and shows `ReadAloudVoiceDialog`; a toggle stored on reads on once a qualifying voice appears.
- No manual device pass. Reproducing it needs a device with no Enhanced/Premium voice for the L2 — device QA is tracked on #8326.

### Deploy Notes

None.

### Accessibility

- [x] No new or changed controls; the existing `SwitchListTile`s keep their labels.
