### PR TITLE
fix(activities): hide "ping course participants" for world-launched sessions

### DIFF
--- a/lib/features/activity_sessions/activity_room_extension.dart
+++ b/lib/features/activity_sessions/activity_room_extension.dart
@@ -108,4 +108,20 @@ extension ActivityRoomExtension on Room {
   Room? get courseParent => pangeaSpaceParents.firstWhereOrNull(
     (parent) => parent.coursePlan != null,
   );
+
+  /// The joined course space this session was LAUNCHED from, or null when it was
+  /// launched from the world map.
+  ///
+  /// Launching also shares the session into every other eligible joined course
+  /// as an `m.space.child` (see `activities.instructions.md`), so a
+  /// world-launched session collects course parents it was never "in" and
+  /// [courseParent] picks an arbitrary one of them. Anything that acts ON the
+  /// course — pinging its roster, offering it on the invite page — keys off this
+  /// instead, so it stays silent for a learner who is not in a course at all
+  /// (#8097).
+  Room? get sourceCourse {
+    final sourceCourseId = pinnedSourceCourseId;
+    if (sourceCourseId == null) return null;
+    return pangeaSpaceParents.firstWhereOrNull((p) => p.id == sourceCourseId);
+  }
 }

--- a/lib/routes/chat/activity_sessions/activity_session_start_page.dart
+++ b/lib/routes/chat/activity_sessions/activity_session_start_page.dart
@@ -519,7 +519,6 @@ class ActivitySessionStartState extends State<ActivitySessionStartPage> {
           room: activityRoom!,
           activityId: widget.activityId,
           activity: activity,
-          course: course,
           controller: this,
         );
       case SessionState.selectedSessionFull:

--- a/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
+++ b/lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart
@@ -23,7 +23,6 @@ import 'package:fluffychat/widgets/matrix.dart';
 
 class ConfirmedRoleSession extends StatefulWidget {
   final Room room;
-  final Room? course;
   final String activityId;
   final ActivityPlanModel? activity;
   final ActivitySessionStartState controller;
@@ -33,7 +32,6 @@ class ConfirmedRoleSession extends StatefulWidget {
     required this.room,
     required this.activityId,
     required this.controller,
-    this.course,
     this.activity,
   });
 
@@ -60,7 +58,13 @@ class ConfirmedRoleSessionController extends State<ConfirmedRoleSession>
     super.dispose();
   }
 
-  bool get showPingCourse => widget.course != null;
+  /// The course whose roster the ping reaches: the one this session was launched
+  /// from, never a course it was merely fanned out into ([Room.sourceCourse]).
+  /// The page's borrowed course context can be any space parent, so it can't
+  /// drive a write against the course (#8097).
+  Room? get _course => widget.room.sourceCourse;
+
+  bool get showPingCourse => _course != null;
 
   bool get showInviteOptions => widget.room.isRoomAdmin;
 
@@ -128,7 +132,7 @@ class ConfirmedRoleSessionController extends State<ConfirmedRoleSession>
   Set<String> completedGoalIdsForRole(String id) => {};
 
   Future<bool> get canPingParticipants async {
-    final course = widget.course;
+    final course = _course;
     if (course == null) return false;
     if (_pingCooldown != null && _pingCooldown!.isActive) return false;
 
@@ -161,8 +165,9 @@ class ConfirmedRoleSessionController extends State<ConfirmedRoleSession>
       showFutureLoadingDialog(context: context, future: _pingCourse);
 
   Future<void> _pingCourse() async {
-    if (widget.course == null) {
-      throw Exception("Activity is not part of a course");
+    final course = _course;
+    if (course == null) {
+      throw Exception("Activity was not launched from a course");
     }
 
     if (!(await canPingParticipants)) {
@@ -175,7 +180,7 @@ class ConfirmedRoleSessionController extends State<ConfirmedRoleSession>
       if (mounted) setState(() {});
     });
 
-    await widget.room.courseParent!.sendActivityPing(
+    await course.sendActivityPing(
       L10n.of(context).pingParticipantsNotification(
         widget.room.client.userID!.localpart ?? widget.room.client.userID!,
         widget.room.getLocalizedDisplayname(MatrixLocals(L10n.of(context))),

--- a/lib/routes/chat/chat_details/invite/pangea_invitation_selection.dart
+++ b/lib/routes/chat/chat_details/invite/pangea_invitation_selection.dart
@@ -41,25 +41,16 @@ extension InvitationFiltersRoomExtension on Room {
   /// The course whose roster the "in this course" filter offers, or null when
   /// there is none to offer.
   ///
-  /// For an activity session this is the course the session was LAUNCHED from
-  /// (`source_course_id`) — NOT merely a space parent. Launching also shares the
-  /// session into every other eligible joined course as an `m.space.child` (see
-  /// `activities.instructions.md`), so a session started from the world map
-  /// collects course parents it was never "in". Offering those rosters reads as
-  /// "invite this course" to someone who is not in a course at all, and the
-  /// launcher has no reason to expect them (#8097). A world-launched session
-  /// pins no source course, so it gets no course filter.
+  /// For an activity session this is [Room.sourceCourse] — the course the session
+  /// was LAUNCHED from, not merely a space parent — so a world-launched session
+  /// gets no course filter (#8097).
   ///
   /// Every other room keeps the plain first-space-parent rule: a chat inside a
   /// course space really is "in this course".
   Room? get invitationCourseSpace {
+    if (isActivitySession) return sourceCourse;
     final parents = pangeaSpaceParents;
-    if (parents.isEmpty) return null;
-    if (!isActivitySession) return parents.first;
-
-    final sourceCourseId = pinnedSourceCourseId;
-    if (sourceCourseId == null) return null;
-    return parents.firstWhereOrNull((p) => p.id == sourceCourseId);
+    return parents.isEmpty ? null : parents.first;
   }
 
   /// Whether the invite page offers a roster ("participants") filter.

--- a/test/pangea/activity_source_course_test.dart
+++ b/test/pangea/activity_source_course_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_media_enum.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_request.dart';
+import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/activity_session_constants.dart';
+import 'package:fluffychat/features/course_plans/courses/course_plan_event.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_room_types.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+import 'get_test_client.dart';
+
+/// #8097 — the waiting room offered "Ping course participants" for a session
+/// launched from the world map. Launching shares the session into EVERY eligible
+/// joined course as an `m.space.child` while only the launched-from course is
+/// pinned as `source_course_id` (activities.instructions.md), so `courseParent`
+/// picks up a course the session was never launched from and the button both
+/// showed and would have broadcast into that course's room.
+void main() {
+  late Client client;
+
+  const userId = '@test:fakeServer.notExisting';
+  const activityId = 'activity-123';
+  const sessionId = '!session:fakeServer.notExisting';
+
+  setUp(() async {
+    client = await getTestClient();
+  });
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  Event stateEvent(
+    Room room, {
+    required String type,
+    required Map<String, dynamic> content,
+    String stateKey = '',
+  }) => Event(
+    type: type,
+    content: content,
+    stateKey: stateKey,
+    senderId: userId,
+    eventId: '\$${type}_$stateKey',
+    originServerTs: DateTime.utc(2026, 1, 1),
+    room: room,
+  );
+
+  /// A course space that lists [childId] as an `m.space.child`, registered on
+  /// the client so `pangeaSpaceParents` (which scans `client.rooms`) sees it.
+  /// It carries a course plan, so `courseParent` sees it too.
+  Room courseSpace(String id, {required String childId}) {
+    final space = Room(id: id, client: client, membership: Membership.join);
+    space.setState(
+      stateEvent(
+        space,
+        type: EventTypes.RoomCreate,
+        content: {'type': RoomCreationTypes.mSpace},
+      ),
+    );
+    space.setState(
+      stateEvent(
+        space,
+        type: PangeaEventTypes.coursePlan,
+        content: CoursePlanEvent(uuid: 'quest-1', l2: 'de').toJson(),
+      ),
+    );
+    space.setState(
+      stateEvent(
+        space,
+        type: EventTypes.SpaceChild,
+        content: {
+          'via': ['fakeServer.notExisting'],
+        },
+        stateKey: childId,
+      ),
+    );
+    client.rooms.add(space);
+    return space;
+  }
+
+  ActivityPlanModel plan() => ActivityPlanModel(
+    req: ActivityPlanRequest(
+      topic: 'jobs',
+      mode: 'Roleplay',
+      objective: 'introduce yourself',
+      media: MediaEnum.nan,
+      cefrLevel: LanguageLevelTypeEnum.a1,
+      languageOfInstructions: 'en',
+      targetLanguage: 'de',
+      numberOfParticipants: 2,
+    ),
+    title: 'Speed-Dating Interview',
+    learningObjective: 'introduce yourself',
+    instructions: 'i',
+    vocab: const [],
+    activityId: activityId,
+    roles: const {},
+  );
+
+  /// An activity session room, optionally pinning the course it was launched
+  /// from. No pin = launched from the world map. The plan is carried inline so
+  /// `isActivitySession` resolves without hydrating through `ActivityPlanRepo`.
+  Room activitySession({String? sourceCourseId}) {
+    final room = Room(
+      id: sessionId,
+      client: client,
+      membership: Membership.join,
+    );
+    room.setState(
+      stateEvent(
+        room,
+        type: EventTypes.RoomCreate,
+        content: {'type': '${PangeaRoomTypes.activitySession}:$activityId'},
+      ),
+    );
+    room.setState(
+      stateEvent(
+        room,
+        type: PangeaEventTypes.activityPlan,
+        content: {
+          ...plan().toJson(),
+          ActivitySessionConstants.sourceCourseId: ?sourceCourseId,
+        },
+      ),
+    );
+    client.rooms.add(room);
+    return room;
+  }
+
+  group('sourceCourse', () {
+    test('is null for a world-launched session fanned out into a course', () {
+      final session = activitySession();
+      courseSpace('!fannedOut:fakeServer.notExisting', childId: sessionId);
+
+      // The fan-out course is a real course parent — the old gate for the ping
+      // button — but the session was never launched from it.
+      expect(session.courseParent, isNotNull);
+      expect(session.sourceCourse, isNull);
+    });
+
+    test('is the launching course for a course-launched session', () {
+      const courseId = '!launchedFrom:fakeServer.notExisting';
+      final session = activitySession(sourceCourseId: courseId);
+      final course = courseSpace(courseId, childId: sessionId);
+
+      expect(session.sourceCourse, course);
+    });
+
+    test('picks the pinned course, not a fan-out course parent', () {
+      const courseId = '!launchedFrom:fakeServer.notExisting';
+      final session = activitySession(sourceCourseId: courseId);
+      // Registered first, so it is `courseParent` / `pangeaSpaceParents.first`.
+      final fannedOut = courseSpace(
+        '!fannedOut:fakeServer.notExisting',
+        childId: sessionId,
+      );
+      final course = courseSpace(courseId, childId: sessionId);
+
+      expect(session.courseParent, fannedOut);
+      expect(session.sourceCourse, course);
+    });
+
+    test('is null when the pinned course is no longer a parent', () {
+      final session = activitySession(
+        sourceCourseId: '!leftCourse:fakeServer.notExisting',
+      );
+      courseSpace('!fannedOut:fakeServer.notExisting', childId: sessionId);
+
+      expect(session.sourceCourse, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## What

The waiting room no longer offers "Ping course participants" for an activity session launched from the world map, and the ping it does send now goes to the course the session was launched from.

## Why

Closes #8097 — follow-up on [TigToggle's report](https://github.com/pangeachat/client/issues/8097#issuecomment-5271794191): activities started from the world map on Android still showed the button. #8104 fixed the invite page's "in this course" filter; the waiting-room ping is a second surface with the same defect and was missed.

Launching a session shares it into **every** eligible joined course as an `m.space.child`, while only the launched-from course is pinned as `source_course_id` ([activities.instructions.md](.github/instructions/activities.instructions.md)). The ping was gated on the start page's borrowed course context — any space parent — so a world-launched session picked up the fan-out courses it was never launched from. Worse than the display: the send itself targeted `courseParent`, an arbitrary course parent, so a learner who did tap it could broadcast the session into a course room unrelated to the one shown.

## Changes

- `lib/features/activity_sessions/activity_room_extension.dart` — new `Room.sourceCourse`: the space parent whose id matches `pinnedSourceCourseId`, or null when nothing is pinned (world-launched) or the pinned course is no longer a parent. Sits next to `courseParent`, which stays as-is for the display contexts that legitimately borrow any course parent.
- `lib/routes/chat/activity_sessions/confirmed_role_session_controller.dart` — `showPingCourse`, `canPingParticipants`, and the `sendActivityPing` target all read one `_course` getter backed by `sourceCourse`, so the gate, the cooldown check, and the write can't disagree about which course they mean. The `course` field on `ConfirmedRoleSession` is dropped — the ping was its only reader, and reading it is what caused this.
- `lib/routes/chat/chat_details/invite/pangea_invitation_selection.dart` — `invitationCourseSpace` delegates to `sourceCourse` instead of restating the rule. Behavior unchanged (its 8 existing tests still pass).
- `test/pangea/activity_source_course_test.dart` (new) — 4 unit tests over `sourceCourse`: world-launched with a fan-out course parent (asserting `courseParent` is non-null there, i.e. the old gate would have shown the button), course-launched, both parents present with the fan-out registered first (pinned wins over `courseParent`), and pinned course no longer a parent.

**Scope notes.** A session launched from a course is unchanged — it still shows the button and now pings that specific course rather than whichever parent came first. Only the confirmed-role waiting room is touched; the not-started step's course actions (`inviteFriendsToCourse`, `neededCourseParticipants`) keep using the page's course context, which is the course the learner opened the activity from.

## Testing

- `fvm dart analyze` on the changed files — clean.
- `fvm dart format` on the changed files — no changes.
- `fvm flutter test test/pangea/` — 2353 passed, 3 skipped (the credential-gated endpoint suites; no `TEST_MATRIX_*` locally).
- **Not manually exercised in-app.** Reproducing it needs a joined course whose objectives match the activity plus a world-map launch of that same activity, which this environment isn't provisioned for. The unit tests pin the decision the UI reads; the issue's TO TEST steps are the staging check — worth re-running the world-launch step on Android specifically, since that is where it was caught.

## Deploy Notes

None.
