### PR TITLE
fix(world-map): keep Zoom out live at the floor when matches sit off-screen

### DIFF
--- a/lib/routes/world/world_map_empty_view_card.dart
+++ b/lib/routes/world/world_map_empty_view_card.dart
@@ -8,13 +8,14 @@ import 'package:fluffychat/routes/world/world_map_filter.dart';
 /// remedy that fixes it — Zoom out when the matches exist but sit outside the
 /// viewport, Widen search when the pills are the excluder, and no lever at all
 /// when nothing would help (a query matching nothing). Zoom out leads and is
-/// DISABLED (not hidden) at the zoom floor, so the card never dangles an
-/// action that can't run. Presentational: the hosts decide when it mounts and
+/// DISABLED (not hidden) when it can't run, so the card never dangles a dead
+/// action. Presentational: the hosts decide when it mounts and
 /// where the callbacks route; rendering [MapEmptyVerdict.none] draws nothing.
 class WorldMapEmptyViewCard extends StatelessWidget {
   final MapEmptyVerdict verdict;
 
-  /// The camera is above its zoom-out floor; below it the zoom lever greys out.
+  /// The camera is above its zoom-out floor. It gates the lever only for
+  /// [MapEmptyVerdict.noActivities] — see [build].
   final bool canZoomOut;
 
   /// Clear every pill to "All …" / step the camera out one zoom level.
@@ -47,6 +48,14 @@ class WorldMapEmptyViewCard extends StatelessWidget {
         verdict == MapEmptyVerdict.matchesOffscreen ||
         verdict == MapEmptyVerdict.noActivities;
     final offersWiden = verdict == MapEmptyVerdict.filtersHideMatches;
+    // The lever runs `resetToWorld`, which RE-CENTERS as well as zooms
+    // (#8121), so with matches loaded off-screen it still has work to do at
+    // the zoom floor — the narrow-screen case the ticket is about, where the
+    // whole world doesn't fit however far out you pull. Only the
+    // nothing-loaded verdict has nothing to re-center on, so that one alone
+    // greys out at the floor.
+    final zoomRunnable =
+        canZoomOut || verdict == MapEmptyVerdict.matchesOffscreen;
 
     return Material(
       elevation: 4,
@@ -72,10 +81,9 @@ class WorldMapEmptyViewCard extends StatelessWidget {
                     FilledButton.tonalIcon(
                       icon: const Icon(Icons.zoom_out, size: 16),
                       label: Text(l10n.zoomOut),
-                      // Greyed at the floor rather than hidden: the card's
-                      // advice stays visible even when the camera can't
-                      // follow it any further.
-                      onPressed: canZoomOut ? onZoomOut : null,
+                      // Greyed rather than hidden when it can't run: the
+                      // card's advice stays visible either way.
+                      onPressed: zoomRunnable ? onZoomOut : null,
                     ),
                   if (offersWiden)
                     FilledButton.tonalIcon(

--- a/test/pangea/navigation/mobile_search_bar_test.dart
+++ b/test/pangea/navigation/mobile_search_bar_test.dart
@@ -137,13 +137,30 @@ void main() {
     expect(find.text('Widen search'), findsNothing);
   });
 
-  testWidgets('at the zoom floor the Zoom out lever greys out, not hides', (
+  testWidgets('off-screen matches keep the lever live at the zoom floor', (
+    tester,
+  ) async {
+    // #8121: the lever re-centers as well as zooms, and a narrow screen at the
+    // floor still can't show the whole world — so matches loaded off-screen
+    // are exactly when it must stay pressable, not grey out.
+    var zoomedOut = false;
+    await pumpBar(
+      tester,
+      emptyVerdict: () => MapEmptyVerdict.matchesOffscreen,
+      canZoomOut: () => false,
+      onZoomOut: () => zoomedOut = true,
+    );
+    await tester.tap(find.text('Zoom out'));
+    expect(zoomedOut, isTrue);
+  });
+
+  testWidgets('an empty area greys the lever out at the floor, not hides', (
     tester,
   ) async {
     var zoomedOut = false;
     await pumpBar(
       tester,
-      emptyVerdict: () => MapEmptyVerdict.matchesOffscreen,
+      emptyVerdict: () => MapEmptyVerdict.noActivities,
       canZoomOut: () => false,
       onZoomOut: () => zoomedOut = true,
     );


### PR DESCRIPTION
### What

The world map's empty-view **Zoom out** lever stays pressable at the zoom floor when matches are loaded off-screen.

### Why

Closes #8121 (reopened — Tig: "Doesn't appear to be changed on Web or Android").

#8141 made the lever's `resetToWorld` **re-center** on the fullest window of matching pins, not just zoom out. But the lever was still gated on `canZoomOut` — "the camera is above its zoom floor". On a narrow screen at the floor, where the whole world doesn't fit however far out you pull, the button greyed out at exactly the moment the re-centering was the only thing that could reveal the matches, so #8141's behaviour was unreachable from the card.

The lever is now enabled whenever the verdict is `matchesOffscreen`, at any zoom. `noActivities` (nothing loaded to re-center on) still greys out at the floor, so the card never dangles a dead action. See [world-map.instructions.md → The empty-view card](.github/instructions/world-map.instructions.md); that section's "greys out at the zoom floor" line now describes only the `noActivities` case and needs a doc update, raised with Will separately rather than in this PR.

Scope note: the on-map `−` button is untouched — it is a pure zoom step and correctly dead at the floor; the round **World** control next to it already re-centers and was already always enabled.

### Testing

- `fvm flutter test test/pangea/navigation/mobile_search_bar_test.dart` — 14/14. The floor test that asserted the old rule now covers `noActivities` (still disabled), plus a new test that `matchesOffscreen` at the floor fires `onZoomOut`.
- `fvm flutter test test/pangea/world_map_zoom_test.dart test/pangea/world/ test/pangea/navigation/` — 519/519.
- `fvm flutter analyze` on both changed files — clean.
- No local-stack run: this is a two-line enable rule in a presentational widget, and the camera behaviour it unblocks (`resetToWorld` re-centering on the pin cluster) was verified live on a 375×812 viewport in #8141.

### Deploy Notes

None.

*Thank you so much for your contribution to FluffyChat ❤️❤️❤️*

- [x] I have read and understood the [contributing guidelines](https://github.com/krille-chan/fluffychat/blob/main/CONTRIBUTING.md).

### Pull Request has been tested on:

- [ ] Android
- [ ] iOS
- [ ] Browser (Chromium based)
- [ ] Browser (Firefox based)
- [ ] Browser (WebKit based)
- [ ] Desktop Linux
- [ ] Desktop Windows
- [ ] Desktop macOS

<!-- #Pangea -->
### Accessibility

- [x] New or changed controls have an accessible name (`tooltip:` / `semanticLabel:`), and decorative images use `excludeFromSemantics: true`. See [accessibility.instructions.md](.github/instructions/accessibility.instructions.md). (No new controls — an existing labelled button changes only its enabled condition.)
<!-- Pangea# -->
