### PR TITLE
fix(world): refresh the cluster avatar when the profile picture changes

### DIFF
--- a/lib/routes/world/user_cluster_view_model.dart
+++ b/lib/routes/world/user_cluster_view_model.dart
@@ -74,6 +74,7 @@ class WorldUserClusterViewModel implements UserClusterViewModel {
   final ValueNotifier<String?> _displayName = ValueNotifier(null);
 
   late final Stream<LevelUpdate> _levelUpdates;
+  late final StreamSubscription<String> _ownProfileUpdates;
 
   WorldUserClusterViewModel({
     required this.analyticsService,
@@ -87,6 +88,11 @@ class WorldUserClusterViewModel implements UserClusterViewModel {
               .showSubscriptionGatedContent,
         );
     ActivityPlanRepo.instance.addListener(_onPlanHydrate);
+    // The cluster outlives the profile page that changes the avatar, so its
+    // only signal is the member event sync raises for the change (#8330).
+    _ownProfileUpdates = client.onUserProfileUpdate.stream
+        .where((userId) => userId == client.userID)
+        .listen((_) => _loadProfile());
   }
 
   final StreamController<void> _planHydrationStream =
@@ -99,6 +105,7 @@ class WorldUserClusterViewModel implements UserClusterViewModel {
   @override
   void dispose() {
     ActivityPlanRepo.instance.removeListener(_onPlanHydrate);
+    _ownProfileUpdates.cancel();
     _planHydrationStream.close();
     _avatarUrl.dispose();
     _displayName.dispose();
@@ -261,13 +268,21 @@ class WorldUserClusterViewModel implements UserClusterViewModel {
     ),
   );
 
+  bool _loadingProfile = false;
+
   Future<void> _loadProfile() async {
+    // One avatar edit rewrites the member event in every joined room, so the
+    // update stream arrives as a burst — one fetch covers the whole burst.
+    if (_loadingProfile) return;
+    _loadingProfile = true;
     try {
       final profile = await client.fetchOwnProfile();
       _avatarUrl.value = profile.avatarUrl;
       _displayName.value = profile.displayName;
     } catch (_) {
       // Avatar falls back to the initial; not worth surfacing.
+    } finally {
+      _loadingProfile = false;
     }
   }
 }

--- a/test/pangea/navigation/user_cluster_avatar_refresh_test.dart
+++ b/test/pangea/navigation/user_cluster_avatar_refresh_test.dart
@@ -1,0 +1,89 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import 'package:fluffychat/features/analytics_data/analytics_data_service.dart';
+import 'package:fluffychat/features/analytics_data/analytics_update_dispatcher.dart';
+import 'package:fluffychat/routes/world/user_cluster_view_model.dart';
+
+/// The view model only reads [updateDispatcher] off the analytics service, so a
+/// bare dispatcher stands in for the whole service — no DB, no sync.
+class _FakeAnalyticsService implements AnalyticsDataService {
+  @override
+  late final AnalyticsUpdateDispatcher updateDispatcher =
+      AnalyticsUpdateDispatcher(this);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+const _profileRoute = '/client/v3/profile/%40test%3AfakeServer.notExisting';
+
+/// #8330 — a profile picture changed from the settings page must reach the
+/// cluster avatar, which stays mounted and so never refetches on its own.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // The view model reaches ActivityPlanRepo, whose cache opens GetStorage.
+  setUpAll(() async {
+    final tempDir = await Directory.systemTemp.createTemp('cluster_avatar');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (_) async => tempDir.path,
+        );
+  });
+
+  test('own profile update reloads the cluster avatar', () async {
+    final api = FakeMatrixApi();
+    final routes = api.api['GET']!;
+    routes['/.well-known/matrix/client'] = (_) => {};
+    routes[_profileRoute] = (_) => {'avatar_url': 'mxc://server/first'};
+
+    final client = Client(
+      'Cluster avatar test',
+      httpClient: api,
+      database: await MatrixSdkDatabase.init(
+        'test',
+        database: await databaseFactoryFfi.openDatabase(':memory:'),
+        sqfliteFactory: databaseFactoryFfi,
+      ),
+    );
+    await client.checkHomeserver(Uri.parse('https://fakeserver.notexisting'));
+    await client.login(
+      LoginType.mLoginToken,
+      identifier: AuthenticationUserIdentifier(user: '@alice:example.invalid'),
+      password: '1234',
+    );
+
+    final viewModel = WorldUserClusterViewModel(
+      analyticsService: _FakeAnalyticsService(),
+      client: client,
+    );
+    addTearDown(viewModel.dispose);
+
+    viewModel.reloadProfile();
+    await pumpEventQueue();
+    expect(viewModel.avatarUrl.value.toString(), 'mxc://server/first');
+
+    routes[_profileRoute] = (_) => {'avatar_url': 'mxc://server/second'};
+    // The sync loop marks the profile outdated before announcing it; without
+    // that the client answers from its own cache.
+    await client.database.markUserProfileAsOutdated(client.userID!);
+
+    // Someone else's change leaves our circle alone.
+    client.onUserProfileUpdate.add('@someone:else.invalid');
+    await pumpEventQueue();
+    expect(viewModel.avatarUrl.value.toString(), 'mxc://server/first');
+
+    client.onUserProfileUpdate.add(client.userID!);
+    await pumpEventQueue();
+    expect(viewModel.avatarUrl.value.toString(), 'mxc://server/second');
+  });
+}


### PR DESCRIPTION
## What

The top-right cluster avatar now reloads when the user changes their own profile picture.

## Why

Closes #8330

`WorldUserClusterViewModel` fetched the own profile once (`reloadProfile`, guarded by a `_profileLoaded` flag) and never again. The cluster stays mounted while the settings profile page changes the picture, so its circle kept drawing the old one. It now subscribes to the SDK's `onUserProfileUpdate` stream, filtered to the user's own mxid, and reloads. An in-flight guard collapses the burst of member events one avatar change produces (one per joined room) into a single profile fetch.

Cluster design lives in [routing.instructions.md § The cluster is the right column's entry point](https://github.com/pangeachat/client/blob/main/.github/instructions/routing.instructions.md).

## Testing

- **Unit**: new `test/pangea/navigation/user_cluster_avatar_refresh_test.dart` — an own-profile update reloads the avatar; another user's update leaves it alone. Confirmed it fails on `main` (the final assertion) and passes with the fix.
- **Regression**: `fvm flutter test test/pangea/navigation/` — 386 passed.
- **Manual (web, staging homeserver)**: opened the settings profile page beside the cluster, picked a Pangea preset avatar — the top-right circle switched to it with no reload while the panel was still refreshing. Removed the avatar again — the circle went back to the initial. Test account restored to its original no-avatar state.
- Smoke/eval/load: N/A — no choreo or CMS surface touched.

## Deploy Notes

None
