### PR TITLE
fix(settings): follow profile changes made off the learning settings page

### DIFF
--- a/lib/routes/settings/settings_learning/learning_settings_view_model.dart
+++ b/lib/routes/settings/settings_learning/learning_settings_view_model.dart
@@ -21,10 +21,18 @@ class LearningSettingsViewModel extends ChangeNotifier {
 
   LearningSettingsViewModel(Profile profile, {this.onUpdateProfile}) {
     _updatedProfile = profile;
+    final userController = MatrixState.pangeaController.userController;
+    _profileListeners = [
+      userController.settingsUpdateStream.stream.listen(
+        (_) => _onProfileSynced(),
+      ),
+      userController.languageStream.stream.listen((_) => _onProfileSynced()),
+    ];
     refreshKnownGoodVoice();
   }
 
   Timer? _textDebounce;
+  late final List<StreamSubscription> _profileListeners;
   bool _hasResetTooltips = false;
   bool _hasKnownGoodVoice = false;
   bool _disposed = false;
@@ -32,8 +40,30 @@ class LearningSettingsViewModel extends ChangeNotifier {
   @override
   void dispose() {
     _textDebounce?.cancel();
+    for (final listener in _profileListeners) {
+      listener.cancel();
+    }
     _disposed = true;
     super.dispose();
+  }
+
+  /// The profile also changes from outside this page — the word card's audio
+  /// prompt writes the same profile, as do the language-mismatch prompts and
+  /// other devices. Adopt what synced so the tiles stop showing the snapshot
+  /// this page opened with (#8334).
+  void _onProfileSynced() {
+    final synced = MatrixState.pangeaController.userController.profile;
+    if (synced == _updatedProfile) return;
+
+    final targetLanguageChanged =
+        synced.userSettings.targetLanguage !=
+        _updatedProfile.userSettings.targetLanguage;
+
+    _updatedProfile = synced;
+    notifyListeners();
+
+    // The voice gate is per-language, so a new target language re-runs it.
+    if (targetLanguageChanged) refreshKnownGoodVoice();
   }
 
   bool get hasResetTooltips => _hasResetTooltips;

--- a/test/pangea/audio_settings_section_test.dart
+++ b/test/pangea/audio_settings_section_test.dart
@@ -4,19 +4,52 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart' show Client;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:fluffychat/features/languages/p_language_store.dart';
+import 'package:fluffychat/features/user/user_controller.dart';
 import 'package:fluffychat/features/user/user_model.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/controllers/pangea_controller.dart';
 import 'package:fluffychat/routes/settings/settings_learning/audio_settings_section.dart';
 import 'package:fluffychat/routes/settings/settings_learning/learning_settings_view_model.dart';
 import 'package:fluffychat/routes/settings/settings_learning/read_aloud_voice_dialog.dart';
 import 'package:fluffychat/routes/settings/settings_learning/tool_settings_enum.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import '../utils/test_client.dart';
 
-/// #8117 / #8264 / #8326 — the Audio section of learning settings: the
+class _FakeMatrixState extends MatrixState {
+  _FakeMatrixState(this._client);
+
+  final Client _client;
+
+  @override
+  Client get client => _client;
+}
+
+/// Keeps the profile in memory instead of reading Matrix account data, so a
+/// test can push a synced profile the way an account data sync would.
+class _StubUserController extends UserController {
+  _StubUserController(this.syncedProfile);
+
+  Profile syncedProfile;
+
+  @override
+  Profile get profile => syncedProfile;
+
+  /// What [UserController._onProfileUpdate] does when account data changes:
+  /// swap the cached profile, then announce it.
+  void sync(Profile updated) {
+    syncedProfile = updated;
+    settingsUpdateStream.add(updated);
+  }
+}
+
+/// #8117 / #8264 / #8326 / #8334 — the Audio section of learning settings: the
 /// per-surface audio toggles (Words, Choices, On new message, On message
-/// click), and the known-good-voice gate on the two message toggles.
+/// click), the known-good-voice gate on the two message toggles, and keeping
+/// all of them current with profile changes made off this page.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -25,6 +58,9 @@ void main() {
   /// The voices `flutter_tts.getVoices` reports for the next engine query.
   /// `enhanced` clears the quality bar; `default` does not.
   List<Map<String, String>> deviceVoices = [];
+
+  late Client client;
+  late _StubUserController userController;
 
   setUpAll(() async {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
@@ -48,7 +84,16 @@ void main() {
       }),
     });
     await PLanguageStore.initialize();
+
+    // The view model listens to the user controller's profile streams, so it
+    // needs a controller to reach through MatrixState.
+    client = await prepareTestClient();
+    MatrixState.pangeaController = PangeaController(
+      matrixState: _FakeMatrixState(client),
+    );
   });
+
+  tearDownAll(() => client.dispose());
 
   setUp(() {
     deviceVoices = [
@@ -58,12 +103,26 @@ void main() {
 
   LearningSettingsViewModel makeViewModel({
     UserToolSettings toolSettings = const UserToolSettings(),
-  }) => LearningSettingsViewModel(
-    Profile(
+  }) {
+    final profile = Profile(
       userSettings: UserSettings(sourceLanguage: 'en', targetLanguage: 'es'),
       toolSettings: toolSettings,
-    ),
-  );
+    );
+    // Swapped in per test so each one starts from its own profile, and so the
+    // PangeaController's own subscriptions stay on the controller it built.
+    userController = _StubUserController(profile);
+    MatrixState.pangeaController.userController = userController;
+    return LearningSettingsViewModel(profile);
+  }
+
+  bool toggleValue(WidgetTester tester, String title) => tester
+      .widget<SwitchListTile>(
+        find.ancestor(
+          of: find.text(title),
+          matching: find.byType(SwitchListTile),
+        ),
+      )
+      .value;
 
   Future<void> pumpSection(
     WidgetTester tester,
@@ -76,7 +135,13 @@ void main() {
         supportedLocales: L10n.supportedLocales,
         home: Scaffold(
           body: SingleChildScrollView(
-            child: AudioSettingsSection(viewModel: viewModel),
+            // The section redraws off the view model through the same
+            // ListenableBuilder LearningSettingsTiles mounts it under.
+            child: ListenableBuilder(
+              listenable: viewModel,
+              builder: (context, _) =>
+                  AudioSettingsSection(viewModel: viewModel),
+            ),
           ),
         ),
       ),
@@ -168,5 +233,29 @@ void main() {
 
     expect(viewModel.getToolSetting(ToolSetting.audioOnMessageClick), isTrue);
     expect(find.byType(ReadAloudVoiceDialog), findsNothing);
+  });
+
+  testWidgets('a toggle turned on elsewhere reads on here (#8334)', (
+    tester,
+  ) async {
+    final viewModel = makeViewModel(
+      toolSettings: const UserToolSettings(audioWords: false),
+    );
+    await pumpSection(tester, viewModel);
+    expect(toggleValue(tester, 'Words'), isFalse);
+
+    // What the word card's "enable audio" prompt writes, coming back on sync
+    // while this page is open beside the chat.
+    userController.sync(
+      viewModel.updatedProfile.copyWith(
+        toolSettings: viewModel.updatedProfile.toolSettings.copyWith(
+          audioWords: true,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(viewModel.getToolSetting(ToolSetting.audioWords), isTrue);
+    expect(toggleValue(tester, 'Words'), isTrue);
   });
 }

--- a/test/pangea/autocorrect_settings_tile_test.dart
+++ b/test/pangea/autocorrect_settings_tile_test.dart
@@ -1,13 +1,27 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart' show Client;
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:fluffychat/features/user/user_model.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/controllers/pangea_controller.dart';
 import 'package:fluffychat/routes/settings/settings_learning/autocorrect_settings_tile.dart';
 import 'package:fluffychat/routes/settings/settings_learning/enable_autocorrect_dialog.dart';
 import 'package:fluffychat/routes/settings/settings_learning/learning_settings_view_model.dart';
 import 'package:fluffychat/routes/settings/settings_learning/tool_settings_enum.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import '../utils/test_client.dart';
+
+class _FakeMatrixState extends MatrixState {
+  _FakeMatrixState(this._client);
+
+  final Client _client;
+
+  @override
+  Client get client => _client;
+}
 
 /// #8112 — on web the autocorrect toggle is disabled with a "Mobile only"
 /// subtitle instead of opening a warning dialog. Tapping the disabled tile
@@ -18,6 +32,21 @@ void main() {
   const mobileOnlyLabel = 'Mobile only';
   const snackBarWarning =
       'Device autocorrect is only available on the mobile app.';
+
+  late Client client;
+
+  setUpAll(() async {
+    // The view model listens to the user controller's profile streams, so it
+    // needs a controller to reach through MatrixState. The controller builds a
+    // PLanguageStore, which reads its cache from shared preferences.
+    SharedPreferences.setMockInitialValues({});
+    client = await prepareTestClient();
+    MatrixState.pangeaController = PangeaController(
+      matrixState: _FakeMatrixState(client),
+    );
+  });
+
+  tearDownAll(() => client.dispose());
 
   LearningSettingsViewModel makeViewModel({bool autocorrectOn = false}) =>
       LearningSettingsViewModel(


### PR DESCRIPTION
## What

Learning settings now follows profile changes made anywhere else — the word card's "enable audio" prompt, the language-mismatch prompts, another device — instead of showing the snapshot it opened with.

## Why

Closes #8334. `LearningSettingsViewModel` copies the profile once in its constructor and never re-reads it, so on a wide screen (settings open beside a chat) a toggle flipped from a word card left the settings page showing the old value until the learner navigated away and back. `SettingsLearningView` already rebuilds on every profile account-data sync, but the rebuild redrew the same stale buffer.

Every write goes through `UserController.updateProfile` → account data → sync → stream dispatch, per [profile.instructions.md](.github/instructions/profile.instructions.md); this page just wasn't listening.

## Changes

- `lib/routes/settings/settings_learning/learning_settings_view_model.dart` — subscribe to both `UserController` profile streams (`settingsUpdateStream` and `languageStream` — the controller routes a change to one or the other, never both) and adopt the synced profile into the editing buffer, notifying listeners. A changed target language also re-runs the known-good-voice gate, same as `setSelectedLanguage` does. Subscriptions cancel in `dispose`.
- `test/pangea/audio_settings_section_test.dart` — new test: Words stored off, an external write turns it on, the `SwitchListTile` reads on. Verified it fails on the pre-change view model. The section is now pumped under the same `ListenableBuilder` that `LearningSettingsTiles` mounts it under, so the assertion is on what the learner sees, not just view-model state.
- `test/pangea/audio_settings_section_test.dart`, `test/pangea/autocorrect_settings_tile_test.dart` — both construct the view model directly, which now reaches `MatrixState.pangeaController`, so both install a `PangeaController` over a test client in `setUpAll` (same shape as `test/pangea/users/level_display_name_test.dart`).

**Scope note.** The buffer is the page's edit surface and every local edit saves immediately, so the two are normally identical; adopting a synced profile only moves the buffer when something outside changed it.

## Testing

- `fvm flutter test test/` — 2377 passed, 3 skipped (the credential-gated endpoint suites; no `TEST_MATRIX_*` locally). Confirmed the new test fails without the view-model change.
- `fvm flutter analyze` — clean. `fvm dart format`, `import_sorter` — no changes.
- **Not manually exercised in-app.** The issue's TO TEST needs a wide-screen session with a chat, an L2 word card, and phonetics, which this environment isn't provisioned for. The widget test drives the same widget the toggle is built from, and the issue's steps are the staging check.

## Deploy Notes

None.
