### PR TITLE
fix(chat): guard scroll position read against detached list

### DIFF
--- a/lib/routes/chat/chat_event_list.dart
+++ b/lib/routes/chat/chat_event_list.dart
@@ -56,6 +56,13 @@ class ChatEventList extends StatelessWidget {
       child: NotificationListener<ScrollMetricsNotification>(
         onNotification: (_) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
+            // The list can detach (or the controller can be disposed) between
+            // the notification and this callback — leaving the chat, switching
+            // threads, or the timeline going null. Reading position then throws.
+            if (!controller.mounted ||
+                !controller.scrollController.hasClients) {
+              return;
+            }
             try {
               final scrollable =
                   controller.scrollController.position.maxScrollExtent > 0;


### PR DESCRIPTION
## What

Guard the chat scroll-position read against a detached list or a disposed controller.

## Why

Closes #8341. Sentry: [CLIENT-9Y7](https://pangea-chat.sentry.io/issues/CLIENT-9Y7) — 389 events, 25 users, first seen 2026-01-30, still firing on 5.0.1 in staging and productionC.

**Root cause**: the `ScrollMetricsNotification` handler reads `controller.scrollController.position` in a post-frame callback. `ScrollController.position` reads `_positions.single`, which throws `StateError: Bad state: No element` when no scroll view is attached. Between the notification and the callback the list can detach — the user leaves the chat, switches threads, or `timeline` goes null and `build` returns the spinner instead of the `ListView`. The same callback can also outlive `dispose`, where writing to the disposed `scrollableNotifier` throws.

Since #5693 the read has been inside a `try`/`catch` that reports to Sentry, so these are logged errors rather than crashes. The cost is the report volume plus a stale `scrollableNotifier`, which lets the scroll-to-bottom button show or hide wrongly for a frame.

**Fix**: return early when `controller.mounted` is false or `scrollController.hasClients` is false, matching the checks `chat.dart` already uses at lines 465 and 902. The `try`/`catch` stays so a genuinely unexpected failure still reports.

## Testing

- `fvm flutter analyze lib/routes/chat/chat_event_list.dart` — no issues.
- `fvm flutter test` — 2392 pass, 2 skip, 3 fail. The 3 failures are the endpoint suites (`synapse_endpoint_test`, `cms_endpoint_test`, `choreo_endpoint_test`), which need a reachable server and env config this machine lacks. Confirmed identical on `origin/main` with the change stashed.
- Runtime check of the scroll-to-bottom button deferred to the linked issue's TO TEST on staging: no local stack is running here, and a staging login needs credentials I don't enter.

## Deploy Notes

None.
