### PR TITLE
fix(activities): gate activity plan reads on the Pangea controller

### DIFF
--- a/lib/features/activity_sessions/activity_plan_repo.dart
+++ b/lib/features/activity_sessions/activity_plan_repo.dart
@@ -142,18 +142,44 @@ class ActivityPlanRepo
     return req.get(url: uri.toString());
   }
 
+  /// The `?? 'en'` covers a set-up controller whose user has no L1 yet — a
+  /// different case from the controller not existing, which [_request] gates.
   String get _viewerL1 =>
       MatrixState.pangeaController.userController.userL1Code ?? 'en';
 
-  ActivityPlanFetchRequest _request(
+  /// Null until `MatrixState` has assigned `pangeaController`, which it does in
+  /// `initState` after `initMatrix()`. Every entry point below turns that null
+  /// into its own "could not do it" value, so nothing in this repo touches the
+  /// controller — or the network — before it exists.
+  ///
+  /// The gate is on the whole request, not just on [_viewerL1], because the
+  /// repo reaches the controller down THREE paths and two of them ignore [l1]:
+  ///  - [_viewerL1] here, which crashed outright (Sentry CLIENT-D43): it runs
+  ///    while building the request, outside `BaseRepo._fetch`'s try/catch, so
+  ///    the `LateInitializationError` escaped the repo.
+  ///  - `BaseRepo.createRequests()`, for the access token — inside that
+  ///    try/catch, so it degrades to `Result.error`.
+  ///  - `PersistentRepoCache.init()`, via `BaseRepo._cacheInit`. This one is
+  ///    the reason an explicit [l1] is not exempt: `_cacheInit` is a
+  ///    `late final` Future, so ONE early failure is memoized and re-thrown by
+  ///    every later `get` for the life of the process, from outside any
+  ///    try/catch. Letting a single early call through would wedge the repo's
+  ///    cache permanently, not just lose that one plan.
+  ///
+  /// Declining is not reported: too early is expected during startup and
+  /// non-actionable, so it is not worth a Sentry event.
+  ActivityPlanFetchRequest? _request(
     String activityId,
     String? l1, {
     String? version,
-  }) => ActivityPlanFetchRequest(
-    activityId: activityId,
-    l1: l1 ?? _viewerL1,
-    version: version,
-  );
+  }) {
+    if (!MatrixState.isPangeaControllerInitialized) return null;
+    return ActivityPlanFetchRequest(
+      activityId: activityId,
+      l1: l1 ?? _viewerL1,
+      version: version,
+    );
+  }
 
   /// The plan for [activityId], localized to [l1] (viewer L1 by default), with
   /// media resolved. Cached (TTL + in-flight dedup); null on fetch failure.
@@ -185,6 +211,11 @@ class ActivityPlanRepo
     bool forceRefresh = false,
   }) async {
     final request = _request(activityId, l1, version: version);
+    // Not knowable yet, not gone: `failed` is the transient status, so callers
+    // keep the activity and retry rather than treating it as removed.
+    if (request == null) {
+      return const ActivityPlanLookup(ActivityPlanLookupStatus.failed);
+    }
     final result = await get(request, forceRefresh: forceRefresh);
     if (result.isError) {
       final error = result.asError!.error;
@@ -249,6 +280,9 @@ class ActivityPlanRepo
     String? version,
   }) {
     final request = _request(activityId, l1, version: version);
+    // Same answer as a cache miss, and the caller's next move is the same:
+    // [ensure], which will also decline until the controller lands.
+    if (request == null) return null;
     final raw = getCached(request);
     if (raw == null) {
       _resolved.remove(request.storageKey);
@@ -281,7 +315,12 @@ class ActivityPlanRepo
     // A confirmed-removed id can't hydrate; re-fetching on every rebuild of
     // the sync getter would loop 404s.
     if (_confirmedRemoved.contains(activityId)) return false;
-    final key = _request(activityId, l1, version: version).storageKey;
+    final request = _request(activityId, l1, version: version);
+    // Declines WITHOUT parking the key: the controller lands within a frame or
+    // two of startup, so the next rebuild must be free to fetch. Parking here
+    // would spend a 60s cooldown on a condition that clears in milliseconds.
+    if (request == null) return false;
+    final key = request.storageKey;
     // Checked before `_revalidated.add` so a revalidate token is never spent
     // on a call that is about to bail.
     if (_hydrating.contains(key)) return false;

--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -76,6 +76,26 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
   String? activeBundle;
   // #Pangea
   static late PangeaController pangeaController;
+
+  /// Whether [pangeaController] has been assigned yet.
+  ///
+  /// It is assigned in [initState], after `initMatrix()`, but widgets build —
+  /// and repos are reached from `build()` — before that runs. Reading the
+  /// field first throws `LateInitializationError`, which escapes any caller
+  /// that is not already inside a try/catch.
+  ///
+  /// Dart exposes no initialization check for a `late` field, so the read is
+  /// the test. Caught untyped on purpose: the error the runtime throws is
+  /// `LateError` from `dart:_internal`, which application code cannot name.
+  static bool get isPangeaControllerInitialized {
+    try {
+      pangeaController;
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   static PangeaAnyState pAnyState = PangeaAnyState();
   late StreamSubscription? _uriListener;
 

--- a/test/pangea/activity_plan_fetch_backoff_test.dart
+++ b/test/pangea/activity_plan_fetch_backoff_test.dart
@@ -8,6 +8,8 @@ import 'package:get_storage/get_storage.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_fetch_response.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
 import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'fake_pangea_controller.dart';
 
 /// Regression: staging 2026-08-04.
 ///
@@ -22,10 +24,13 @@ import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 /// The fix parks a key on the ATTEMPT, before the I/O, so it is total over
 /// outcomes nobody enumerated — including ones added later.
 ///
-/// These tests drive the real singleton. `createRequests()` reaches into
-/// `MatrixState`, which does not exist under test, so every fetch fails inside
-/// `BaseRepo._fetch`'s try/catch and surfaces as `Result.error`. That is
-/// exactly the shape under test: a failing fetch must not re-arm.
+/// These tests drive the real singleton. A stub controller is installed so the
+/// repo gets past its "is `MatrixState.pangeaController` assigned yet" gate
+/// (#8339) — the stub has no access token, so `createRequests()` still fails
+/// inside `BaseRepo._fetch`'s try/catch and every fetch surfaces as
+/// `Result.error`. That is exactly the shape under test: a failing fetch must
+/// not re-arm. Without the stub every `ensure` below would decline for the
+/// wrong reason and prove nothing about backoff.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -43,7 +48,10 @@ void main() {
   final repo = ActivityPlanRepo.instance;
   var clock = DateTime(2026, 8, 4, 12);
 
-  setUpAll(() => GetStorage.init('activity_plan_storage'));
+  setUpAll(() {
+    MatrixState.pangeaController = FakePangeaController();
+    return GetStorage.init('activity_plan_storage');
+  });
 
   setUp(() {
     clock = DateTime(2026, 8, 4, 12);

--- a/test/pangea/activity_plan_uninitialized_controller_test.dart
+++ b/test/pangea/activity_plan_uninitialized_controller_test.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_storage/get_storage.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'fake_pangea_controller.dart';
+
+/// Regression: Sentry CLIENT-D43 (#8339), 267 events on staging and production.
+///
+/// `MatrixState.pangeaController` is `static late`, assigned in
+/// `MatrixState.initState` after `initMatrix()`. `ActivityPlanRepo` read it
+/// while BUILDING the request — synchronously, before `BaseRepo.get` — so the
+/// read sat outside `BaseRepo._fetch`'s try/catch and a
+/// `LateInitializationError` escaped the repo entirely. The world map reaches
+/// `ensure`/`cachedPlan` from `build()`, so a cold start straight onto the map
+/// crashed.
+///
+/// `createRequests()` reads the same controller for the access token, but from
+/// INSIDE that try/catch, which is why it only ever degraded to `Result.error`.
+/// That difference is the whole bug, and it is why the guard belongs on the
+/// request-building path alone.
+///
+/// The fix must decline, not throw, and must not spend the 60s attempt cooldown
+/// on a condition that clears within a frame or two of startup.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Registered synchronously, BEFORE `ActivityPlanRepo.instance` is touched:
+  // the singleton's `PersistentRepoCache` field builds a `GetStorage` container
+  // on construction, which reaches for path_provider immediately.
+  final tempDir = Directory.systemTemp.createTempSync('plan_late_init_test');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        (methodCall) async => tempDir.path,
+      );
+
+  final repo = ActivityPlanRepo.instance;
+
+  setUpAll(() => GetStorage.init('activity_plan_storage'));
+
+  setUp(repo.resetBackoff);
+
+  // These run FIRST on purpose. `pangeaController` is a process-wide static, so
+  // once the group below assigns it there is no way back to the uninitialized
+  // state within this file. The precondition assert makes a reordering fail
+  // loudly here rather than quietly turning these into no-ops.
+  group('before MatrixState assigns its controller', () {
+    setUp(() {
+      expect(
+        MatrixState.isPangeaControllerInitialized,
+        isFalse,
+        reason:
+            'these cases describe the uninitialized state; something assigned '
+            'the controller before them',
+      );
+    });
+
+    test('ensure declines instead of throwing', () {
+      expect(repo.ensure('late-init-ensure'), isFalse);
+    });
+
+    test('cachedPlan returns null instead of throwing', () {
+      expect(repo.cachedPlan('late-init-cached'), isNull);
+    });
+
+    test('lookup reports failed, never removed', () async {
+      final result = await repo.lookup('late-init-lookup');
+      expect(
+        result.status,
+        ActivityPlanLookupStatus.failed,
+        reason:
+            'removed is terminal — it would strand a healthy activity behind '
+            'the removed-activity fallback for the rest of the session',
+      );
+      expect(result.plan, isNull);
+    });
+
+    test('getPlan returns null instead of throwing', () async {
+      expect(await repo.getPlan('late-init-get-plan'), isNull);
+    });
+
+    test('an explicit l1 is not an exemption', () {
+      // Supplying l1 skips `_viewerL1`, but NOT the other two controller reads
+      // on the same call. `PersistentRepoCache.init` is the dangerous one: it
+      // runs via `BaseRepo._cacheInit`, a `late final` Future, so one early
+      // failure is memoized and re-thrown by every later `get` for the life of
+      // the process — from outside any try/catch. Letting this through would
+      // wedge the repo's cache permanently rather than lose one plan.
+      expect(repo.ensure('late-init-explicit', l1: 'en'), isFalse);
+    });
+  });
+
+  group('once the controller exists', () {
+    setUp(() => MatrixState.pangeaController = FakePangeaController());
+
+    test('a declined ensure did not burn the attempt cooldown', () {
+      // The decline above must not park the key. Parking would cost 60s of
+      // silence for a condition that clears within a frame or two, leaving the
+      // map blank long after the controller landed.
+      expect(repo.ensure('late-init-rearm'), isTrue);
+    });
+
+    test('lookup reaches the fetch instead of short-circuiting', () async {
+      // Proves the gate released rather than latching. It still reports failed
+      // — the stub has no access token — but it got there through
+      // `BaseRepo.get`, not through the guard.
+      final result = await repo.lookup('late-init-viewer-l1');
+      expect(result.status, ActivityPlanLookupStatus.failed);
+    });
+  });
+}

--- a/test/pangea/fake_pangea_controller.dart
+++ b/test/pangea/fake_pangea_controller.dart
@@ -1,0 +1,32 @@
+import 'package:fluffychat/features/user/user_controller.dart';
+import 'package:fluffychat/pangea/common/controllers/pangea_controller.dart';
+
+/// The smallest controller that satisfies
+/// `MatrixState.isPangeaControllerInitialized` and serves a viewer L1.
+///
+/// Repos gate their reads on that getter (#8339), so a test that wants the repo
+/// to actually reach the network path must install one of these. It has no
+/// access token, so the fetch still fails inside `BaseRepo._fetch`'s try/catch
+/// and surfaces as `Result.error` — the shape most repo tests want.
+class FakePangeaController implements PangeaController {
+  @override
+  final UserController userController;
+
+  FakePangeaController({String? userL1Code = 'en'})
+    : userController = _FakeUserController(userL1Code);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeUserController implements UserController {
+  _FakeUserController(this._userL1Code);
+
+  final String? _userL1Code;
+
+  @override
+  String? get userL1Code => _userL1Code;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}


### PR DESCRIPTION
## What

`ActivityPlanRepo` declines instead of crashing when it is reached before `MatrixState` has assigned `pangeaController`.

## Why

Closes #8339 — Sentry [CLIENT-D43](https://pangea-chat.sentry.io/issues/CLIENT-D43), 267 events / 4 users, staging and production 5.0.0. Minified variants: CLIENT-E3D, CLIENT-DQ4, CLIENT-E4N, CLIENT-E4E, CLIENT-D36.

`pangeaController` is `static late`, assigned in `initState` after `initMatrix()`. The repo read it while **building** the request — synchronously, before `BaseRepo.get` — so the read sat outside `BaseRepo._fetch`'s try/catch and the `LateInitializationError` escaped the repo. The world map reaches `ensure`/`cachedPlan` from `build()`, so a cold start onto the map crashed.

## What changed

- `MatrixState.isPangeaControllerInitialized` — the field stays `static late` and its 224 read sites are untouched. Dart has no initialization check for a `late` field, so the getter reads it inside a try/catch. Caught untyped because the runtime throws `LateError` from `dart:_internal`, which application code cannot name.
- `ActivityPlanRepo._request` returns null until the controller exists. Each entry point turns that into the value it already defines for "could not do it": `cachedPlan` null, `ensure` false, `lookup` a transient `failed` (never `removed`, which would strand a healthy activity behind the removed-activity fallback for the session).
- `ensure` declines **before** parking the key, so the next rebuild is free to fetch once the controller lands. Parking would spend a 60s cooldown on a condition that clears within a frame or two.
- Nothing new is reported to Sentry. Per [repos-and-error-handling.instructions.md](.github/instructions/repos-and-error-handling.instructions.md), an expected non-actionable failure returns an empty value rather than an error every caller swallows.

The gate covers the whole request rather than just the viewer-L1 read, because two of the repo's three controller reads ignore `l1`. `PersistentRepoCache.init` is the reason an explicit `l1` is not exempt: it runs via `BaseRepo._cacheInit`, a `late final` Future, so **one** early failure is memoized and re-thrown by every later `get` for the life of the process, from outside any try/catch. Letting a single early call through would wedge the repo's cache permanently rather than lose one plan.

## Testing

- New `test/pangea/activity_plan_uninitialized_controller_test.dart` — `ensure`/`cachedPlan`/`lookup`/`getPlan` all decline without throwing while the controller is absent; an explicit `l1` is not an exemption; and once a controller exists `ensure` returns true immediately, proving the decline burned no cooldown.
- `test/pangea/activity_plan_fetch_backoff_test.dart` now installs the shared stub controller so its 10 cases get past the gate. The stub has no access token, so fetches still fail inside `_fetch`'s try/catch — the shape those tests were written against, and its header comment is updated to say so.
- `fvm flutter test test/pangea/activity_plan_uninitialized_controller_test.dart test/pangea/activity_plan_fetch_backoff_test.dart test/pangea/activity_plan_lookup_test.dart` — 23/23 pass.
- `fvm flutter test test/pangea/` — 2377 pass, 2 skipped, 3 fail. The 3 are the endpoint suites (`synapse`, `cms`, `choreo`), which need live credentials and a reachable server; they fail on a scheme-less `SYNAPSE_URL` and a missing test binding, both unrelated to this change and matching the documented local baseline.
- `fvm dart analyze` clean on every touched file.
- Staging smoke after deploy: cold-load onto the World map and confirm pins hydrate their cards. The change is a no-op once the controller exists, so the smoke is that the normal path did not regress.

## Deploy Notes

None.