### PR TITLE
fix(languages): load network SVGs through SvgRepo

### DIFF
--- a/lib/features/languages/language_display_name_postfix_widget.dart
+++ b/lib/features/languages/language_display_name_postfix_widget.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_svg/flutter_svg.dart';
-
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/widgets/network_svg.dart';
 
 class LanguageDisplayNamePostfixWidget extends StatelessWidget {
   final LanguageModel language;
@@ -35,11 +34,10 @@ class LanguageDisplayNamePostfixWidget extends StatelessWidget {
               child: SizedBox(
                 width: iconSize,
                 height: iconSize,
-                child: SvgPicture.network(
-                  language.svgUrl.toString(),
-                  errorBuilder: (_, _, _) => const SizedBox.shrink(),
-                  placeholderBuilder: (_) => Center(
-                    child: const CircularProgressIndicator(strokeWidth: 0.5),
+                child: NetworkSvg(
+                  svgUrl: language.svgUrl.toString(),
+                  placeholder: const Center(
+                    child: CircularProgressIndicator(strokeWidth: 0.5),
                   ),
                   width: iconSize,
                   height: iconSize,

--- a/lib/features/languages/language_display_name_prefix_widget.dart
+++ b/lib/features/languages/language_display_name_prefix_widget.dart
@@ -1,9 +1,8 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_svg/flutter_svg.dart';
-
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/widgets/network_svg.dart';
 
 class LanguageDisplayNamePrefixWidget extends StatelessWidget {
   final LanguageModel language;
@@ -28,12 +27,11 @@ class LanguageDisplayNamePrefixWidget extends StatelessWidget {
           width: iconSize,
           height: iconSize,
           child: language.shouldShowFlag
-              ? SvgPicture.network(
-                  language.svgUrl.toString(),
+              ? NetworkSvg(
+                  svgUrl: language.svgUrl.toString(),
                   width: iconSize,
                   height: iconSize,
-                  errorBuilder: (_, _, _) => const SizedBox.shrink(),
-                  placeholderBuilder: (_) => const Center(
+                  placeholder: const Center(
                     child: CircularProgressIndicator(strokeWidth: 0.5),
                   ),
                 )

--- a/lib/features/languages/language_flag_chip.dart
+++ b/lib/features/languages/language_flag_chip.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_svg/flutter_svg.dart';
-
 import 'package:fluffychat/features/languages/language_model.dart';
+import 'package:fluffychat/pangea/common/widgets/network_svg.dart';
 
 /// The primary-tinted language chip shared by the analytics cluster's
 /// `ClusterLanguageFlag` and the activity start page's info row. It never
@@ -79,14 +78,13 @@ class LanguageFlagChip extends StatelessWidget {
               borderRadius: BorderRadius.circular(radius),
               child: Stack(
                 children: [
-                  SvgPicture.network(
-                    language!.svgUrl.toString(),
+                  NetworkSvg(
+                    svgUrl: language!.svgUrl.toString(),
                     width: width,
                     height: height,
                     fit: BoxFit.cover,
-                    errorBuilder: (_, _, _) => outlinedText,
-                    placeholderBuilder: (_) =>
-                        SizedBox(width: width, height: height),
+                    errorWidget: outlinedText,
+                    placeholder: SizedBox(width: width, height: height),
                   ),
                   if (alwaysShowCode)
                     Positioned(child: Center(child: outlinedText)),

--- a/lib/pangea/common/utils/svg_repo.dart
+++ b/lib/pangea/common/utils/svg_repo.dart
@@ -15,7 +15,7 @@ class _SvgCacheEntry {
   Map<String, dynamic> toJson() => {'svg': svg, 'timestamp': timestamp};
 
   factory _SvgCacheEntry.fromJson(Map<String, dynamic> json) {
-    return _SvgCacheEntry(json['svg'] as String, json['timestamp'] as int);
+    return _SvgCacheEntry(json['svg'] as String?, json['timestamp'] as int);
   }
 
   static const Duration cacheDuration = Duration(days: 1);
@@ -25,8 +25,18 @@ class _SvgCacheEntry {
   ).isBefore(DateTime.now().subtract(cacheDuration));
 }
 
+/// Fetches SVG assets and owns their failures, per the repo contract in
+/// repos-and-error-handling.instructions.md: nothing escapes to the caller as a
+/// thrown exception, and each failure is reported to Sentry exactly once.
+///
+/// Successes persist for a day; failures are remembered for the session only,
+/// so a moment offline doesn't blank an icon until tomorrow.
 class SvgRepo {
   static final GetStorage _storage = GetStorage('svg_cache');
+
+  /// In-flight and settled fetches, keyed by URL. Deduping here is what keeps
+  /// a list of ~100 flags on a dead connection to one fetch and one report per
+  /// URL instead of one per widget per rebuild (#8338).
   static final Map<String, Future<Result<String>>> _cache = {};
 
   static Future<Result<String>> get(String url) async {
@@ -42,11 +52,7 @@ class SvgRepo {
   static Future<Result<String>> _fetch(String url) async {
     try {
       final cached = await _getCached(url);
-      if (cached != null) {
-        return cached.svg != null
-            ? Result.value(cached.svg!)
-            : Result.error(Exception('Failed to load SVG at $url'));
-      }
+      if (cached?.svg != null) return Result.value(cached!.svg!);
 
       final response = await http.get(Uri.parse(url));
       if (response.statusCode != 200) {
@@ -55,7 +61,6 @@ class SvgRepo {
           data: {"url": url},
           level: SentryLevel.warning,
         );
-        await _setCached(url, null);
         return Result.error(Exception('Failed to load SVG at $url'));
       }
 
@@ -68,8 +73,13 @@ class SvgRepo {
         e: Exception('Error fetching SVG: $e'),
         data: {"url": url},
         s: stack,
+        // A transport failure — offline, dropped connection, a blocked
+        // request — is transient and the caller renders a fallback. Anything
+        // else here is a bug in how we asked for the file.
+        level: e is http.ClientException
+            ? SentryLevel.warning
+            : SentryLevel.error,
       );
-      await _setCached(url, null);
       return Result.error(Exception('Failed to load SVG at $url'));
     }
   }
@@ -81,7 +91,9 @@ class SvgRepo {
 
     try {
       final svg = _SvgCacheEntry.fromJson(entry);
-      if (svg.isExpired) {
+      // A null body is a failure written by an older build; failures are no
+      // longer persisted, so treat it as a miss and drop it.
+      if (svg.isExpired || svg.svg == null) {
         await _storage.remove(url);
         return null;
       }
@@ -92,8 +104,8 @@ class SvgRepo {
     }
   }
 
-  static Future<void> _setCached(String url, String? svg) async {
-    if (svg != null && svg.length > 5200000) {
+  static Future<void> _setCached(String url, String svg) async {
+    if (svg.length > 5200000) {
       Logs().w('SVG content is very large, skipping cache for $url');
       return;
     }

--- a/lib/pangea/common/widgets/customized_svg.dart
+++ b/lib/pangea/common/widgets/customized_svg.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_svg/flutter_svg.dart';
+import 'package:fluffychat/pangea/common/widgets/network_svg.dart';
 
-import 'package:fluffychat/pangea/common/utils/svg_repo.dart';
-import 'package:fluffychat/widgets/future_loading_dialog.dart';
-
-class CustomizedSvg extends StatefulWidget {
+/// A [NetworkSvg] with its colors swapped out — used for assets we tint to the
+/// current theme (morph icons, analytics level icons).
+class CustomizedSvg extends StatelessWidget {
   /// URL of the SVG file
   final String svgUrl;
 
@@ -40,57 +39,11 @@ class CustomizedSvg extends StatefulWidget {
     this.fit,
   });
 
-  @override
-  State<CustomizedSvg> createState() => _CustomizedSvgState();
-}
-
-class _CustomizedSvgState extends State<CustomizedSvg> {
-  String? _svgContent;
-  bool _isLoading = false;
-  bool _hasError = false;
-
-  @override
-  void initState() {
-    super.initState();
-    _loadSvg();
-  }
-
-  @override
-  void didUpdateWidget(covariant CustomizedSvg oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.svgUrl != widget.svgUrl) {
-      _loadSvg();
-    }
-  }
-
-  String get _cacheKey {
-    final buffer = StringBuffer(widget.svgUrl);
-    widget.colorReplacements.forEach((k, v) {
-      buffer.write('$k->$v;');
-    });
-    return buffer.toString();
-  }
-
-  Future<void> _loadSvg() async {
-    setState(() {
-      _isLoading = true;
-      _hasError = false;
-      _svgContent = null;
-    });
-
-    final svg = await SvgRepo.get(widget.svgUrl);
-    if (svg.isError) {
-      _hasError = true;
-    } else {
-      _svgContent = _modifySVG(svg.result!);
-    }
-
-    if (mounted) setState(() => _isLoading = false);
-  }
-
+  /// Drops `fill="none"` so a replaced color actually paints, then applies the
+  /// replacements.
   String _modifySVG(String svgContent) {
     String modifiedSvg = svgContent.replaceAll("fill=\"none\"", '');
-    for (final entry in widget.colorReplacements.entries) {
+    for (final entry in colorReplacements.entries) {
       modifiedSvg = modifiedSvg.replaceAll(entry.key, entry.value);
     }
     return modifiedSvg;
@@ -98,24 +51,24 @@ class _CustomizedSvgState extends State<CustomizedSvg> {
 
   @override
   Widget build(BuildContext context) {
-    if (_isLoading) {
-      return widget.loadingPlaceholder ??
+    return NetworkSvg(
+      svgUrl: svgUrl,
+      transform: _modifySVG,
+      transformKey: colorReplacements.entries
+          .map((e) => '${e.key}->${e.value}')
+          .join(';'),
+      errorWidget: errorIcon,
+      placeholder:
+          loadingPlaceholder ??
           SizedBox(
-            width: widget.width,
-            height: widget.height,
+            width: width,
+            height: height,
             child: const Center(child: CircularProgressIndicator()),
-          );
-    } else if (_hasError || _svgContent == null) {
-      return widget.errorIcon;
-    } else {
-      return SvgPicture(
-        SvgStringLoader(_svgContent!),
-        key: ValueKey(_cacheKey),
-        width: widget.width,
-        height: widget.height,
-        fit: widget.fit ?? BoxFit.contain,
-      );
-    }
+          ),
+      width: width,
+      height: height,
+      fit: fit,
+    );
   }
 }
 

--- a/lib/pangea/common/widgets/network_svg.dart
+++ b/lib/pangea/common/widgets/network_svg.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+
+import 'package:flutter_svg/flutter_svg.dart';
+
+import 'package:fluffychat/pangea/common/utils/svg_repo.dart';
+
+/// An SVG fetched over the network, loaded through [SvgRepo].
+///
+/// Use this instead of `SvgPicture.network`. That constructor lets
+/// `vector_graphics` own the fetch, and on a transport failure it leaks the
+/// error onto a future nobody listens to — an unhandled zone error per failed
+/// load, even though [errorWidget] renders correctly (#8338). It also has no
+/// dedupe, so one offline moment on a list of flags fires an event per flag
+/// and again on every rebuild.
+///
+/// [SvgRepo] is the repo layer for these assets: it catches the failure,
+/// fetches once per URL per session, and owns the Sentry report.
+class NetworkSvg extends StatefulWidget {
+  /// URL of the SVG file.
+  final String svgUrl;
+
+  /// Applied to the fetched markup before it is rendered. Used by
+  /// `CustomizedSvg` to recolor; most callers render the file as-is.
+  final String Function(String)? transform;
+
+  /// Identifies what [transform] will produce. A closure is a fresh object on
+  /// every build, so it can't be compared to decide whether to re-transform —
+  /// callers pass a value-comparable stand-in (the recolor map flattened to a
+  /// string) and the SVG is re-read only when that changes.
+  final Object? transformKey;
+
+  /// Shown when the SVG can't be loaded.
+  final Widget errorWidget;
+
+  /// Shown while the SVG is loading.
+  final Widget? placeholder;
+
+  final double? width;
+  final double? height;
+  final BoxFit? fit;
+  final ColorFilter? colorFilter;
+
+  const NetworkSvg({
+    super.key,
+    required this.svgUrl,
+    this.transform,
+    this.transformKey,
+    this.errorWidget = const SizedBox.shrink(),
+    this.placeholder,
+    this.width = 24,
+    this.height = 24,
+    this.fit,
+    this.colorFilter,
+  });
+
+  @override
+  State<NetworkSvg> createState() => _NetworkSvgState();
+}
+
+class _NetworkSvgState extends State<NetworkSvg> {
+  String? _svgContent;
+  bool _isLoading = true;
+  bool _hasError = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSvg();
+  }
+
+  @override
+  void didUpdateWidget(covariant NetworkSvg oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.svgUrl != widget.svgUrl ||
+        oldWidget.transformKey != widget.transformKey) {
+      _loadSvg();
+    }
+  }
+
+  Future<void> _loadSvg() async {
+    final url = widget.svgUrl;
+    final transformKey = widget.transformKey;
+    if (mounted && !_isLoading) {
+      setState(() {
+        _isLoading = true;
+        _hasError = false;
+        _svgContent = null;
+      });
+    }
+
+    final svg = await SvgRepo.get(url);
+
+    // The widget may have been repointed while this was in flight; the load
+    // that superseded it owns the state now.
+    if (!mounted ||
+        url != widget.svgUrl ||
+        transformKey != widget.transformKey) {
+      return;
+    }
+
+    setState(() {
+      _isLoading = false;
+      _hasError = svg.isError;
+      _svgContent = svg.isError
+          ? null
+          : (widget.transform?.call(svg.asValue!.value) ?? svg.asValue!.value);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return widget.placeholder ??
+          SizedBox(width: widget.width, height: widget.height);
+    }
+
+    final svgContent = _svgContent;
+    if (_hasError || svgContent == null) return widget.errorWidget;
+
+    return SvgPicture(
+      SvgStringLoader(svgContent),
+      // Content changes at a stable URL (a recolor on theme flip) are picked up
+      // by SvgStringLoader's own equality, which VectorGraphic compares.
+      key: ValueKey(widget.svgUrl),
+      width: widget.width,
+      height: widget.height,
+      fit: widget.fit ?? BoxFit.contain,
+      colorFilter: widget.colorFilter,
+      // Markup we fetched but can't parse. Rare, and separate from the fetch
+      // failure above, but it should degrade the same way.
+      errorBuilder: (_, _, _) => widget.errorWidget,
+    );
+  }
+}

--- a/lib/routes/courses/private/course_code_page.dart
+++ b/lib/routes/courses/private/course_code_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import 'package:flutter_svg/svg.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:fluffychat/config/app_config.dart';
@@ -11,6 +10,7 @@ import 'package:fluffychat/features/join_codes/space_code_repo.dart';
 import 'package:fluffychat/features/navigation/token_params/add_course_token.dart';
 import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/widgets/network_svg.dart';
 import 'package:fluffychat/pangea/spaces/space_constants.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -258,8 +258,9 @@ class CourseCodePageState extends State<CourseCodePage> {
                       ),
                     ),
                     ExcludeSemantics(
-                      child: SvgPicture.network(
-                        "${AppConfig.assetsBaseURL}/${SpaceConstants.mapUnlockFileName}",
+                      child: NetworkSvg(
+                        svgUrl:
+                            "${AppConfig.assetsBaseURL}/${SpaceConstants.mapUnlockFileName}",
                         width: 120.0,
                         height: 120.0,
                         colorFilter: ColorFilter.mode(

--- a/lib/widgets/users/level_display_name.dart
+++ b/lib/widgets/users/level_display_name.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 
-import 'package:flutter_svg/svg.dart';
-
 import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/widgets/network_svg.dart';
 import 'package:fluffychat/widgets/matrix.dart';
 import 'package:fluffychat/widgets/users/level_ribbon.dart';
 
@@ -76,13 +75,10 @@ class LevelDisplayName extends StatelessWidget {
               if (base != null && target != null) ...[
                 if (showFlags) ...[
                   ExcludeSemantics(
-                    child: SvgPicture.network(
-                      base.svgUrl.toString(),
-                      errorBuilder: (_, _, _) => const SizedBox.shrink(),
-                      placeholderBuilder: (_) => Center(
-                        child: const CircularProgressIndicator(
-                          strokeWidth: 0.5,
-                        ),
+                    child: NetworkSvg(
+                      svgUrl: base.svgUrl.toString(),
+                      placeholder: const Center(
+                        child: CircularProgressIndicator(strokeWidth: 0.5),
                       ),
                       width: iconSize ?? 12.0,
                       height: iconSize ?? 12.0,
@@ -110,13 +106,10 @@ class LevelDisplayName extends StatelessWidget {
               if (target != null) ...[
                 if (showFlags) ...[
                   ExcludeSemantics(
-                    child: SvgPicture.network(
-                      target.svgUrl.toString(),
-                      errorBuilder: (_, _, _) => const SizedBox.shrink(),
-                      placeholderBuilder: (_) => Center(
-                        child: const CircularProgressIndicator(
-                          strokeWidth: 0.5,
-                        ),
+                    child: NetworkSvg(
+                      svgUrl: target.svgUrl.toString(),
+                      placeholder: const Center(
+                        child: CircularProgressIndicator(strokeWidth: 0.5),
                       ),
                       width: iconSize ?? 12.0,
                       height: iconSize ?? 12.0,

--- a/test/pangea/network_svg_test.dart
+++ b/test/pangea/network_svg_test.dart
@@ -1,0 +1,178 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:fluffychat/pangea/common/utils/svg_repo.dart';
+import 'package:fluffychat/pangea/common/widgets/network_svg.dart';
+
+/// Language flags used to render with `SvgPicture.network`, which lets
+/// vector_graphics own the fetch. On a transport failure it drops the future
+/// its `whenComplete` returns, so the error reached Sentry as an UNHANDLED zone
+/// error — 8,054 of them — even though the widget rendered its fallback fine.
+/// With no repo in front there was no dedupe either, so one offline moment on a
+/// list of flags fired an event per flag, and again on every rebuild (#8338).
+///
+/// [NetworkSvg] goes through [SvgRepo] instead. What's pinned here: a failed
+/// fetch surfaces as a value, never as a throw or an escaped async error, and
+/// one URL costs one fetch no matter how many widgets ask for it.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    // GetStorage needs path_provider; stub the channel to a temp dir.
+    final tempDir = await Directory.systemTemp.createTemp('svg_repo_test');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (methodCall) async => tempDir.path,
+        );
+    await GetStorage.init('svg_cache');
+  });
+
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"/>';
+
+  // SvgRepo memoizes by URL for the life of the session, so each case needs a
+  // URL no other case has used.
+  var urlCounter = 0;
+  String freshUrl() => 'https://assets.example.test/flag-${urlCounter++}.svg';
+
+  /// Runs [body] with every top-level `http` call served by [handler].
+  Future<T> withClient<T>(
+    Future<http.Response> Function(http.Request) handler,
+    Future<T> Function() body,
+  ) => http.runWithClient(body, () => MockClient(handler));
+
+  group('SvgRepo', () {
+    test(
+      'a transport failure returns an error result, it does not throw',
+      () async {
+        final url = freshUrl();
+        final result = await withClient(
+          (_) async => throw http.ClientException('Failed to fetch'),
+          () => SvgRepo.get(url),
+        );
+
+        expect(result.isError, isTrue);
+      },
+    );
+
+    test('a 404 returns an error result', () async {
+      final url = freshUrl();
+      final result = await withClient(
+        (_) async => http.Response('nope', 404),
+        () => SvgRepo.get(url),
+      );
+
+      expect(result.isError, isTrue);
+    });
+
+    test('one URL costs one fetch, however many callers ask', () async {
+      final url = freshUrl();
+      var fetches = 0;
+
+      await withClient(
+        (_) async {
+          fetches++;
+          return http.Response(svg, 200);
+        },
+        () async {
+          await Future.wait([SvgRepo.get(url), SvgRepo.get(url)]);
+          await SvgRepo.get(url);
+        },
+      );
+
+      expect(fetches, 1);
+    });
+
+    test('a failure is not retried for the rest of the session', () async {
+      final url = freshUrl();
+      var fetches = 0;
+
+      await withClient(
+        (_) async {
+          fetches++;
+          throw http.ClientException('Failed to fetch');
+        },
+        () async {
+          await SvgRepo.get(url);
+          await SvgRepo.get(url);
+        },
+      );
+
+      expect(fetches, 1);
+    });
+
+    test('a fetched SVG comes back intact', () async {
+      final url = freshUrl();
+      final result = await withClient(
+        (_) async => http.Response(svg, 200),
+        () => SvgRepo.get(url),
+      );
+
+      expect(result.asValue?.value, svg);
+    });
+  });
+
+  group('NetworkSvg', () {
+    /// Mounts the widget and lets the fetch actually run. The load reaches the
+    /// filesystem (the SVG cache) and the mock client, neither of which the
+    /// widget tester's fake clock will advance — hence [WidgetTester.runAsync].
+    Future<void> mountAndLoad(
+      WidgetTester tester,
+      String url,
+      Future<http.Response> Function(http.Request) handler,
+    ) async {
+      await tester.runAsync(() async {
+        await withClient(handler, () async {
+          await tester.pumpWidget(
+            MaterialApp(
+              home: NetworkSvg(
+                svgUrl: url,
+                errorWidget: const Text('fallback'),
+                placeholder: const Text('loading'),
+              ),
+            ),
+          );
+          expect(find.text('loading'), findsOneWidget);
+
+          // The widget awaits this exact memoized future.
+          await SvgRepo.get(url);
+          await Future<void>.delayed(Duration.zero);
+        });
+      });
+      await tester.pump();
+    }
+
+    testWidgets('a failed load shows the fallback and leaks no async error', (
+      tester,
+    ) async {
+      await mountAndLoad(
+        tester,
+        freshUrl(),
+        (_) async => throw http.ClientException('Failed to fetch'),
+      );
+
+      expect(find.text('fallback'), findsOneWidget);
+      // An escaped zone error would have failed this test by now — the old
+      // SvgPicture.network path is exactly what produced one.
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('a loaded SVG replaces the placeholder', (tester) async {
+      await mountAndLoad(
+        tester,
+        freshUrl(),
+        (_) async => http.Response(svg, 200),
+      );
+
+      expect(find.text('loading'), findsNothing);
+      expect(find.text('fallback'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## What

Render network SVGs (language flags, the join-code map graphic) through `SvgRepo` instead of `SvgPicture.network`.

## Why

Closes #8338. Sentry [CLIENT-B01](https://pangea-chat.sentry.io/issues/7414478656/) — `ClientException: Failed to fetch, uri=.../language-flags/<code>.svg`, 8,054 events, reported **unhandled**. Fixes CLIENT-B01.

Two things were wrong, and neither was the assets — the flag files return 200 with permissive CORS.

- **The error escaped.** `SvgPicture.network` hands the fetch to `vector_graphics`, whose `_loadPicture` attaches `result.whenComplete(...)` and drops the future that returns. On a transport failure that derived future carries the same error with no listener, so it escapes as an unhandled zone error and reaches Sentry through the browser's global `onerror` — even though the widget's own `errorBuilder` renders the fallback correctly. Nothing was broken for users; the events were pure leakage.
- **Nothing deduped it.** With no repo in front, a language picker showing ~100 flags on a dead connection fired ~100 events at once, and again on every rebuild.

`SvgRepo` already fronts morph icons and analytics level icons and implements the repo contract in [repos-and-error-handling.instructions.md](.github/instructions/repos-and-error-handling.instructions.md): it owns the request, the failure, and the Sentry report.

## What changed

- **`NetworkSvg`** (new) — loads through `SvgRepo`, renders `SvgPicture(SvgStringLoader(...))`. Replaces all six `SvgPicture.network` call sites (4 flag surfaces, the level/display-name pair, the course-code map graphic), since they all hit the same leak.
- **`CustomizedSvg`** is now a thin wrapper over it, passing its recolor as a `transform`. Recoloring behavior is unchanged — the `fill="none"` strip still happens for its callers only, so morph and level icons render exactly as before. It also picks up a theme flip now, which the old `svgUrl`-only comparison missed.
- **`SvgRepo`**: a transport failure reports at `warning` rather than `error` (transient, and the caller renders a fallback — per the severity table in the repo doc); anything else in that catch stays `error`.
- **`SvgRepo` negative caching**: `_SvgCacheEntry.fromJson` cast a null body to non-nullable `String`, so every persisted failure threw on read and was discarded. Failures are now explicitly session-scoped — the in-memory future map is what stops the storm, and repairing the cast instead would have activated a 24-hour window where one blip blanks an icon until tomorrow. Legacy null entries on disk are treated as a miss and dropped.

Residual, unchanged: a *decode* failure (markup we fetched but can't parse) still leaks through the same upstream `whenComplete`. It's a different failure, isn't firing, and can't be fixed from here — `NetworkSvg` at least degrades it to the same fallback widget.

## Testing

- `fvm flutter test test/pangea/network_svg_test.dart` — 7 new tests: a transport failure and a 404 come back as error `Result`s rather than throws; one URL costs one fetch however many callers ask; a failure isn't retried for the rest of the session; content round-trips; and the widget shows its fallback with `takeException()` null, which is what a leaked zone error would trip.
- `fvm flutter test` — 2,414 pass, 4 fail. The four are `cms_endpoint_test` / `choreo_endpoint_test`, which need a local CMS and choreographer (`Connection refused` on `localhost:13134`); they fail identically on untouched `main`, and this change touches neither service.
- `fvm flutter analyze lib` — clean.
- Smoke (Playwright): no suite triggered — none of the touched paths match a glob in `e2e/trigger-map.json`.

## Deploy Notes

None.
