### PR TITLE
fix(chat): guard recorder cancel against setState after dispose

### DIFF
--- a/lib/routes/chat/recording_view_model.dart
+++ b/lib/routes/chat/recording_view_model.dart
@@ -849,6 +849,11 @@ class RecordingViewModelState extends State<RecordingViewModel> {
     // Invalidate any in-flight streaming start so a pending start aborts instead
     // of falling through to the batch recorder after this teardown.
     _startGeneration++;
+    // Every send path calls cancel() AFTER awaiting onSend, so the recorder can
+    // already be gone by then (the user left the chat mid-upload). dispose() has
+    // run _reset() in that case, so there is nothing left to tear down — and
+    // setState on a defunct State throws (CLIENT-AN1).
+    if (!mounted) return;
     // Pangea#
     setState(() {
       _reset();

--- a/test/pangea/streaming_stt/recording_view_model_batch_test.dart
+++ b/test/pangea/streaming_stt/recording_view_model_batch_test.dart
@@ -599,4 +599,53 @@ void main() {
       },
     );
   });
+
+  testWidgets(
+    'a send that lands AFTER the recorder unmounts does not setState on a '
+    'defunct State (CLIENT-AN1)',
+    (tester) async {
+      late RecordingViewModelState state;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RecordingViewModel(
+            streamingSessionFactory: null,
+            builder: (context, s) {
+              state = s;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      final upload = Completer<void>();
+      late Future<void> send;
+      await tester.runAsync(() async {
+        await state.startRecording(room);
+        // Tick the amplitude timer so the send is not an EmptyAudioException.
+        await Future<void>.delayed(const Duration(milliseconds: 150));
+        send = state.stopAndSend(
+          (_, _, _, _, {streamedTranscript}) => upload.future,
+        );
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+      });
+
+      // The user leaves the chat while the upload is still in flight.
+      await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+
+      // stopAndSend still runs its trailing cancel() once the upload lands —
+      // on a State that is no longer in the tree.
+      Object? error;
+      await tester.runAsync(() async {
+        upload.complete();
+        try {
+          await send;
+        } catch (e) {
+          error = e;
+        }
+      });
+      await tester.pump();
+
+      expect(error, isNull);
+    },
+  );
 }


### PR DESCRIPTION
## What

Skip the `setState` in `RecordingViewModelState.cancel()` when the recorder is no longer mounted.

## Why

Closes #8345. Sentry: [CLIENT-AN1](https://pangea-chat.sentry.io/issues/CLIENT-AN1) — 7 events, 2 users, first seen 2026-03-19, last seen 2026-08-13 on 5.0.0+3834 (Android, productionC).

**Root cause**: every voice-message send path calls `cancel()` *after* awaiting `onSend` — `stopAndSend` at the end of the batch path, the degraded-to-batch branch, and `_stopStreamingAndSend`. The upload can outlive the recorder: the user taps send and leaves the chat before it finishes. `cancel()` then calls `setState` on a `State` that has already been disposed. In debug that is the `setState() called after dispose()` assertion; in a release build the assert is stripped and it surfaces as `Null check operator used on a null value` from `_element!.markNeedsBuild()` — framework.dart:1219 in Flutter 3.41.4, which is the frame in the reported stack trace.

**Fix**: return early from `cancel()` when `!mounted`. `dispose()` already runs `_reset()`, so an unmounted `cancel()` has nothing left to tear down — only a repaint to skip. One guard in `cancel()` covers all six call sites; the three that already sat behind a `mounted` check (`sendEditedTranscript`, `stopStreamingToEditable`, `onFatalError`) are unaffected.

The one caller that is not post-`await` is the row's cancel button (`recording_input_row.dart:40`), which fires from a mounted widget, so the guard is a no-op there.

## Testing

- `fvm flutter analyze` on both changed files — no issues.
- New regression test in `recording_view_model_batch_test.dart`: records, starts a send that blocks on a `Completer`, unmounts the recorder, then completes the upload and asserts `stopAndSend` finishes without throwing. Verified non-vacuous — with the `lib/` change stashed it fails with `setState() called after dispose(): RecordingViewModelState#... (lifecycle state: defunct, not mounted)`.
- `fvm flutter test test/pangea/streaming_stt/` — 242 pass.
- `fvm flutter test` — 2393 pass, 2 skip, 3 fail. The 3 failures are the endpoint suites (`choreo_endpoint_test`, `synapse_endpoint_test`, `cms_endpoint_test`), which need a reachable server plus credentials this machine's `.env` doesn't satisfy; running those three files alone reproduces exactly the same 3 failures and 2 skips, and none of them import the changed file.
- Runtime check on a device deferred to the linked issue's TO TEST on staging — no local stack is running here.

## Deploy Notes

None.
