### PR TITLE
fix(sentry): skip debug-build reporting; rename productionC env to production

### DIFF
--- a/lib/pangea/common/utils/error_handler.dart
+++ b/lib/pangea/common/utils/error_handler.dart
@@ -23,16 +23,18 @@ class ErrorHandler {
   ErrorHandler();
 
   static Future<void> initialize() async {
-    await SentryFlutter.init((options) {
-      options.dsn = Environment.sentryDsn;
-      options.tracesSampleRate = 0.02;
-      options.debug = kDebugMode;
-      options.environment = kDebugMode
-          ? "debug"
-          : Environment.isStagingEnvironment
-          ? "staging"
-          : "productionC";
-    });
+    // Debug builds never init Sentry: local-dev errors are visible in the
+    // console already, and reporting them buries staging/production signal.
+    // Every capture below no-ops without init.
+    if (!kDebugMode) {
+      await SentryFlutter.init((options) {
+        options.dsn = Environment.sentryDsn;
+        options.tracesSampleRate = 0.02;
+        options.environment = Environment.isStagingEnvironment
+            ? "staging"
+            : "production";
+      });
+    }
 
     // Error handling
     FlutterError.onError = (FlutterErrorDetails details) async {


### PR DESCRIPTION
## What
Debug builds no longer initialize Sentry, and non-debug builds report environment `production` (was `productionC`) / `staging`.

## Why
Closes #8347. Debug builds shipped 18.9k events/14d of local-dev noise, and the `productionC` name broke the org-standard `environment=production` triage filter for the client project.

## Testing
- `flutter analyze` on the changed file — clean
- `flutter test test/pangea/error_handler_log_once_test.dart` — pass (captures no-op safely without init)
- N/A for staging smoke — no user-facing runtime surface; verification is new client events landing under `production`/`staging` after the next release

## Deploy Notes
None

Related: pangeachat/2-step-choreographer#3033 (same Sentry signal-to-noise cleanup, backend side).