### PR TITLE
fix(join-codes): resolve coded-join landing from room state when sync lags

### DIFF
--- a/lib/features/join_codes/joined_target.dart
+++ b/lib/features/join_codes/joined_target.dart
@@ -1,0 +1,163 @@
+import 'package:collection/collection.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/activity_session_constants.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_room_types.dart';
+
+/// Where a code join lands (joining-courses.instructions.md): a course plan
+/// page ([course] — the joined space, or a coded chat's joined parent
+/// course), the activity page with a session bound ([activitySession]), or
+/// the joined room itself ([room] — a standalone coded chat, and the
+/// safe fallback when the room can't be classified).
+class JoinedTarget {
+  final String roomId;
+  final bool isSpace;
+  final String? activityId;
+
+  const JoinedTarget.course(this.roomId) : isSpace = true, activityId = null;
+
+  const JoinedTarget.room(this.roomId) : isSpace = false, activityId = null;
+
+  const JoinedTarget.activitySession(this.roomId, String this.activityId)
+    : isSpace = false;
+
+  /// The unsynced twin of [JoinedTargetRoomExtension.joinedTarget], over raw
+  /// state events: a space opens as a course; an activity session lands on
+  /// the activity page; a coded chat under a joined course (per
+  /// [isJoinedSpace], which reads LOCAL rooms — the joiner's own courses have
+  /// been in their store since before this fresh page load) lands on that
+  /// course; anything else opens as a room. Pure — unit-tested
+  /// (joined_target_test.dart).
+  factory JoinedTarget.fromRoomState(
+    String roomId,
+    List<MatrixEvent> state,
+    bool Function(String roomId) isJoinedSpace,
+  ) {
+    final roomType = state
+        .firstWhereOrNull((e) => e.type == EventTypes.RoomCreate)
+        ?.content
+        .tryGet<String>('type');
+    if (roomType == RoomCreationTypes.mSpace) {
+      return JoinedTarget.course(roomId);
+    }
+
+    final activityId = _activityIdFromState(roomType, state);
+    if (activityId != null) {
+      return JoinedTarget.activitySession(roomId, activityId);
+    }
+
+    final parentCourseId = state
+        .where(
+          (e) =>
+              e.type == EventTypes.SpaceParent &&
+              e.content.tryGetList<String>('via')?.isNotEmpty == true,
+        )
+        .map((e) => e.stateKey)
+        .whereType<String>()
+        .firstWhereOrNull(isJoinedSpace);
+    if (parentCourseId != null) {
+      return JoinedTarget.course(parentCourseId);
+    }
+    return JoinedTarget.room(roomId);
+  }
+
+  /// [ActivityRoomExtension.isActivitySession] + [ActivityRoomExtension.activityId]
+  /// without a local [Room]: the v3 room-type suffix
+  /// (`p.activity.session:<activity_id>`) is authoritative; a legacy room
+  /// embeds the full plan in `pangea.activity_plan` state (`bookmark_id`
+  /// marks the deprecated model, excluded like the synced path). A v3
+  /// reference plan WITHOUT the room type would need CMS hydration to be
+  /// recognized; that shape isn't minted (the type is set at session
+  /// creation), and an unhydrated plan resolves as a plain room locally too.
+  static String? _activityIdFromState(
+    String? roomType,
+    List<MatrixEvent> state,
+  ) {
+    final planContent = state
+        .firstWhereOrNull((e) => e.type == PangeaEventTypes.activityPlan)
+        ?.content;
+    ActivityPlanModel? embeddedPlan;
+    if (planContent != null &&
+        planContent[ActivitySessionConstants.activityPlanRequest] != null) {
+      try {
+        embeddedPlan = ActivityPlanModel.fromJson(planContent);
+      } catch (_) {
+        embeddedPlan = null;
+      }
+    }
+
+    if (roomType?.startsWith(PangeaRoomTypes.activitySession) == true) {
+      if (embeddedPlan?.isDeprecatedModel == true) return null;
+      return roomType!.split(':').last;
+    }
+    if (embeddedPlan == null || embeddedPlan.isDeprecatedModel) return null;
+    return embeddedPlan.activityId;
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      other is JoinedTarget &&
+      other.roomId == roomId &&
+      other.isSpace == isSpace &&
+      other.activityId == activityId;
+
+  @override
+  int get hashCode => Object.hash(roomId, isSpace, activityId);
+}
+
+extension JoinedTargetRoomExtension on Room {
+  /// Where a code join of this locally-synced room lands.
+  ///
+  /// An activity-session code is an invite INTO that session: land on the
+  /// activity page with the session room bound (join/resume), never the
+  /// parent course. Routing a shared-course invitee to the course hid the
+  /// activity entirely, and a no-shared-course invitee dragged an unjoinable
+  /// course panel open beside it (#8047).
+  ///
+  /// A code can attach to a CHAT within a course (announcements,
+  /// introductions). A join still lands on the course plan page, not inside
+  /// that chat: resolve to the room's joined parent course when one exists.
+  /// Only without any joined parent (a standalone coded chat) does the join
+  /// open the room itself.
+  JoinedTarget get joinedTarget {
+    if (isSpace) return JoinedTarget.course(id);
+    final sessionActivityId = activityId;
+    if (isActivitySession && sessionActivityId != null) {
+      return JoinedTarget.activitySession(id, sessionActivityId);
+    }
+    final parentCourse = spaceParents
+        .map((p) => p.roomId == null ? null : client.getRoomById(p.roomId!))
+        .whereType<Room>()
+        .firstWhereOrNull(
+          (parent) => parent.isSpace && parent.membership == Membership.join,
+        );
+    if (parentCourse != null) return JoinedTarget.course(parentCourse.id);
+    return JoinedTarget.room(id);
+  }
+}
+
+extension JoinedTargetClientExtension on Client {
+  /// Resolve the landing for a joined room sync has not yet surfaced, from
+  /// the room's state over HTTP — the join succeeded, so the state endpoints
+  /// work even mid-initial-sync.
+  Future<JoinedTarget> resolveUnsyncedJoinedTarget(String roomId) async {
+    try {
+      final state = await getRoomState(roomId);
+      return JoinedTarget.fromRoomState(roomId, state, (id) {
+        final parent = getRoomById(id);
+        return parent != null &&
+            parent.isSpace &&
+            parent.membership == Membership.join;
+      });
+    } catch (e, s) {
+      ErrorHandler.logError(e: e, s: s, data: {"roomId": roomId});
+      // Land on the room AS A ROOM: a wrong room-open shows a chat view the
+      // user can leave, while a wrong course-open spins forever (#8047).
+      return JoinedTarget.room(roomId);
+    }
+  }
+}

--- a/lib/features/join_codes/space_code_controller.dart
+++ b/lib/features/join_codes/space_code_controller.dart
@@ -11,11 +11,9 @@ import 'package:http/http.dart' hide Client;
 import 'package:matrix/matrix.dart' hide Result;
 import 'package:sentry_flutter/sentry_flutter.dart';
 
-import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
-import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
-import 'package:fluffychat/features/activity_sessions/activity_session_constants.dart';
 import 'package:fluffychat/features/analytics_access/join_room_analytics_access_extension.dart';
 import 'package:fluffychat/features/analytics_access/join_room_analytics_consent_handler.dart';
+import 'package:fluffychat/features/join_codes/joined_target.dart';
 import 'package:fluffychat/features/join_codes/knock_with_code_extension.dart';
 import 'package:fluffychat/features/join_codes/space_code_repo.dart';
 import 'package:fluffychat/features/join_codes/too_many_requests_dialog.dart';
@@ -25,8 +23,6 @@ import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
-import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
-import 'package:fluffychat/routes/chat/events/constants/pangea_room_types.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 
@@ -58,8 +54,8 @@ class SpaceCodeController {
   }
 
   /// The async half of the post-join hop: run the analytics-consent step where
-  /// the room is available locally, and resolve where to land — the course
-  /// plan page, also when the code's room is a child of a course (see below).
+  /// the room is available locally, and resolve where to land
+  /// ([JoinedTargetRoomExtension.joinedTarget]).
   /// Null means the learner declined consent — don't navigate. When sync
   /// hasn't surfaced the room yet the join is STILL done (the join API call
   /// succeeded, and its bounded sync-wait already ran out — see `_loadRoom`),
@@ -67,8 +63,7 @@ class SpaceCodeController {
   /// silently stranding the user on the join page as a secret member of the
   /// course (#7579); the consent notice, skipped there, resurfaces through
   /// the course-settings listener.
-  static Future<({String roomId, bool isSpace, String? activityId})?>
-  resolveJoinedTarget(
+  static Future<JoinedTarget?> resolveJoinedTarget(
     BuildContext context,
     Client client,
     JoinResponse joinResp,
@@ -78,7 +73,7 @@ class SpaceCodeController {
       // Assuming "course" here sent an activity-session joiner to a course
       // panel scoped to the session room's id, which can never resolve
       // (#8047) — the membership is real, so ask the server what we joined.
-      return _resolveUnsyncedTarget(client, joinResp.roomId);
+      return client.resolveUnsyncedJoinedTarget(joinResp.roomId);
     }
 
     // Recompute the notice from the room as it stands NOW: when the join-time
@@ -94,141 +89,14 @@ class SpaceCodeController {
     );
     final joinedRoomId = await handler.handle(context);
     if (joinedRoomId == null) return null;
-    if (room.isSpace) {
-      return (roomId: joinedRoomId, isSpace: true, activityId: null);
-    }
-
-    // An activity-session code is an invite INTO that session: land on the
-    // activity page with the session room bound (join/resume), never the
-    // parent course. Routing a shared-course invitee to the course hid the
-    // activity entirely, and a no-shared-course invitee dragged an
-    // unjoinable course panel open beside it (#8047).
-    final activityId = room.activityId;
-    if (room.isActivitySession && activityId != null) {
-      return (roomId: joinedRoomId, isSpace: false, activityId: activityId);
-    }
-
-    // A code can attach to a CHAT within a course (announcements,
-    // introductions). A join still lands on the course plan page, not inside
-    // that chat: resolve to the room's joined parent course when one exists.
-    // Only without any joined parent (a standalone coded chat) does the join
-    // open the room itself.
-    final parentCourse = room.spaceParents
-        .map((p) => p.roomId == null ? null : client.getRoomById(p.roomId!))
-        .whereType<Room>()
-        .firstWhereOrNull(
-          (parent) => parent.isSpace && parent.membership == Membership.join,
-        );
-    if (parentCourse != null) {
-      return (roomId: parentCourse.id, isSpace: true, activityId: null);
-    }
-    return (roomId: joinedRoomId, isSpace: false, activityId: null);
-  }
-
-  /// Resolve the landing for a joined room sync has not yet surfaced, from
-  /// the room's state over HTTP — the join succeeded, so the state endpoints
-  /// work even mid-initial-sync. The analytics-consent step needs the local
-  /// room and stays skipped here (see [resolveJoinedTarget]).
-  static Future<({String roomId, bool isSpace, String? activityId})>
-  _resolveUnsyncedTarget(Client client, String roomId) async {
-    try {
-      final state = await client.getRoomState(roomId);
-      return resolveTargetFromRoomState(roomId, state, (id) {
-        final parent = client.getRoomById(id);
-        return parent != null &&
-            parent.isSpace &&
-            parent.membership == Membership.join;
-      });
-    } catch (e, s) {
-      ErrorHandler.logError(e: e, s: s, data: {"roomId": roomId});
-      // Land on the room AS A ROOM: a wrong room-open shows a chat view the
-      // user can leave, while a wrong course-open spins forever (#8047).
-      return (roomId: roomId, isSpace: false, activityId: null);
-    }
-  }
-
-  /// The unsynced twin of [resolveJoinedTarget]'s local-room branches, over
-  /// raw state events: a space opens as a course; an activity session lands
-  /// on the activity page; a coded chat under a joined course (per
-  /// [isJoinedSpace], which reads LOCAL rooms — the joiner's own courses have
-  /// been in their store since before this fresh page load) lands on that
-  /// course; anything else opens as a room. Pure — unit-tested
-  /// (resolve_target_from_room_state_test.dart).
-  static ({String roomId, bool isSpace, String? activityId})
-  resolveTargetFromRoomState(
-    String roomId,
-    List<MatrixEvent> state,
-    bool Function(String roomId) isJoinedSpace,
-  ) {
-    final roomType = state
-        .firstWhereOrNull((e) => e.type == EventTypes.RoomCreate)
-        ?.content
-        .tryGet<String>('type');
-    if (roomType == RoomCreationTypes.mSpace) {
-      return (roomId: roomId, isSpace: true, activityId: null);
-    }
-
-    final activityId = _activityIdFromState(roomType, state);
-    if (activityId != null) {
-      return (roomId: roomId, isSpace: false, activityId: activityId);
-    }
-
-    final parentCourseId = state
-        .where(
-          (e) =>
-              e.type == EventTypes.SpaceParent &&
-              e.content.tryGetList<String>('via')?.isNotEmpty == true,
-        )
-        .map((e) => e.stateKey)
-        .whereType<String>()
-        .firstWhereOrNull(isJoinedSpace);
-    if (parentCourseId != null) {
-      return (roomId: parentCourseId, isSpace: true, activityId: null);
-    }
-    return (roomId: roomId, isSpace: false, activityId: null);
-  }
-
-  /// [ActivityRoomExtension.isActivitySession] + [activityId] without a local
-  /// [Room]: the v3 room-type suffix (`p.activity.session:<activity_id>`) is
-  /// authoritative; a legacy room embeds the full plan in
-  /// `pangea.activity_plan` state (`bookmark_id` marks the deprecated model,
-  /// excluded like the synced path). A v3 reference plan WITHOUT the room
-  /// type would need CMS hydration to be recognized; that shape isn't minted
-  /// (the type is set at session creation), and an unhydrated plan resolves
-  /// as a plain room locally too.
-  static String? _activityIdFromState(
-    String? roomType,
-    List<MatrixEvent> state,
-  ) {
-    final planContent = state
-        .firstWhereOrNull((e) => e.type == PangeaEventTypes.activityPlan)
-        ?.content;
-    ActivityPlanModel? embeddedPlan;
-    if (planContent != null &&
-        planContent[ActivitySessionConstants.activityPlanRequest] != null) {
-      try {
-        embeddedPlan = ActivityPlanModel.fromJson(planContent);
-      } catch (_) {
-        embeddedPlan = null;
-      }
-    }
-
-    if (roomType?.startsWith(PangeaRoomTypes.activitySession) == true) {
-      if (embeddedPlan?.isDeprecatedModel == true) return null;
-      return roomType!.split(':').last;
-    }
-    if (embeddedPlan == null || embeddedPlan.isDeprecatedModel) return null;
-    return embeddedPlan.activityId;
+    return room.joinedTarget;
   }
 
   /// The synchronous half of the post-join hop, split from
   /// [resolveJoinedTarget] so a caller that must rewrite its own URL first
   /// (the inbound-coded join page consuming its trigger, #7579) can do both
   /// in one tick — before the rebuild the rewrite schedules can dispose it.
-  static void goToJoinedTarget(
-    BuildContext context,
-    ({String roomId, bool isSpace, String? activityId}) target,
-  ) {
+  static void goToJoinedTarget(BuildContext context, JoinedTarget target) {
     final activityId = target.activityId;
     if (activityId != null) {
       context.go(

--- a/lib/features/join_codes/space_code_controller.dart
+++ b/lib/features/join_codes/space_code_controller.dart
@@ -11,7 +11,9 @@ import 'package:http/http.dart' hide Client;
 import 'package:matrix/matrix.dart' hide Result;
 import 'package:sentry_flutter/sentry_flutter.dart';
 
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/activity_session_constants.dart';
 import 'package:fluffychat/features/analytics_access/join_room_analytics_access_extension.dart';
 import 'package:fluffychat/features/analytics_access/join_room_analytics_consent_handler.dart';
 import 'package:fluffychat/features/join_codes/knock_with_code_extension.dart';
@@ -23,6 +25,8 @@ import 'package:fluffychat/features/navigation/workspace_nav.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/pangea/common/utils/firebase_analytics.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_room_types.dart';
 import 'package:fluffychat/utils/navigation_util.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
 
@@ -39,12 +43,10 @@ class SpaceCodeController {
   /// page, the public course preview): run the analytics-consent step where
   /// the room is available locally, then open the course. When sync hasn't
   /// surfaced the room yet the join is STILL done (the join API call
-  /// succeeded), so navigate to the course anyway — its panel renders a
-  /// loading state until sync catches up — instead of silently stranding the
-  /// user on the join page as a secret member of the course (#7579). The
-  /// course route is the right default for the not-yet-local case; the
-  /// consent notice, skipped here, resurfaces through the course-settings
-  /// listener.
+  /// succeeded), so resolve the landing from the room's state over HTTP
+  /// instead of silently stranding the user on the join page as a secret
+  /// member of the course (#7579); the consent notice, skipped there,
+  /// resurfaces through the course-settings listener.
   static Future<void> navigateAfterJoin(
     BuildContext context,
     Client client,
@@ -60,11 +62,11 @@ class SpaceCodeController {
   /// plan page, also when the code's room is a child of a course (see below).
   /// Null means the learner declined consent — don't navigate. When sync
   /// hasn't surfaced the room yet the join is STILL done (the join API call
-  /// succeeded), so resolve to the course anyway — its panel renders a
-  /// loading state until sync catches up — instead of silently stranding the
-  /// user on the join page as a secret member of the course (#7579); the
-  /// consent notice, skipped there, resurfaces through the course-settings
-  /// listener.
+  /// succeeded, and its bounded sync-wait already ran out — see `_loadRoom`),
+  /// so resolve the landing from the room's state over HTTP instead of
+  /// silently stranding the user on the join page as a secret member of the
+  /// course (#7579); the consent notice, skipped there, resurfaces through
+  /// the course-settings listener.
   static Future<({String roomId, bool isSpace, String? activityId})?>
   resolveJoinedTarget(
     BuildContext context,
@@ -73,7 +75,10 @@ class SpaceCodeController {
   ) async {
     final room = client.getRoomById(joinResp.roomId);
     if (room == null) {
-      return (roomId: joinResp.roomId, isSpace: true, activityId: null);
+      // Assuming "course" here sent an activity-session joiner to a course
+      // panel scoped to the session room's id, which can never resolve
+      // (#8047) — the membership is real, so ask the server what we joined.
+      return _resolveUnsyncedTarget(client, joinResp.roomId);
     }
 
     // Recompute the notice from the room as it stands NOW: when the join-time
@@ -118,6 +123,102 @@ class SpaceCodeController {
       return (roomId: parentCourse.id, isSpace: true, activityId: null);
     }
     return (roomId: joinedRoomId, isSpace: false, activityId: null);
+  }
+
+  /// Resolve the landing for a joined room sync has not yet surfaced, from
+  /// the room's state over HTTP — the join succeeded, so the state endpoints
+  /// work even mid-initial-sync. The analytics-consent step needs the local
+  /// room and stays skipped here (see [resolveJoinedTarget]).
+  static Future<({String roomId, bool isSpace, String? activityId})>
+  _resolveUnsyncedTarget(Client client, String roomId) async {
+    try {
+      final state = await client.getRoomState(roomId);
+      return resolveTargetFromRoomState(roomId, state, (id) {
+        final parent = client.getRoomById(id);
+        return parent != null &&
+            parent.isSpace &&
+            parent.membership == Membership.join;
+      });
+    } catch (e, s) {
+      ErrorHandler.logError(e: e, s: s, data: {"roomId": roomId});
+      // Land on the room AS A ROOM: a wrong room-open shows a chat view the
+      // user can leave, while a wrong course-open spins forever (#8047).
+      return (roomId: roomId, isSpace: false, activityId: null);
+    }
+  }
+
+  /// The unsynced twin of [resolveJoinedTarget]'s local-room branches, over
+  /// raw state events: a space opens as a course; an activity session lands
+  /// on the activity page; a coded chat under a joined course (per
+  /// [isJoinedSpace], which reads LOCAL rooms — the joiner's own courses have
+  /// been in their store since before this fresh page load) lands on that
+  /// course; anything else opens as a room. Pure — unit-tested
+  /// (resolve_target_from_room_state_test.dart).
+  static ({String roomId, bool isSpace, String? activityId})
+  resolveTargetFromRoomState(
+    String roomId,
+    List<MatrixEvent> state,
+    bool Function(String roomId) isJoinedSpace,
+  ) {
+    final roomType = state
+        .firstWhereOrNull((e) => e.type == EventTypes.RoomCreate)
+        ?.content
+        .tryGet<String>('type');
+    if (roomType == RoomCreationTypes.mSpace) {
+      return (roomId: roomId, isSpace: true, activityId: null);
+    }
+
+    final activityId = _activityIdFromState(roomType, state);
+    if (activityId != null) {
+      return (roomId: roomId, isSpace: false, activityId: activityId);
+    }
+
+    final parentCourseId = state
+        .where(
+          (e) =>
+              e.type == EventTypes.SpaceParent &&
+              e.content.tryGetList<String>('via')?.isNotEmpty == true,
+        )
+        .map((e) => e.stateKey)
+        .whereType<String>()
+        .firstWhereOrNull(isJoinedSpace);
+    if (parentCourseId != null) {
+      return (roomId: parentCourseId, isSpace: true, activityId: null);
+    }
+    return (roomId: roomId, isSpace: false, activityId: null);
+  }
+
+  /// [ActivityRoomExtension.isActivitySession] + [activityId] without a local
+  /// [Room]: the v3 room-type suffix (`p.activity.session:<activity_id>`) is
+  /// authoritative; a legacy room embeds the full plan in
+  /// `pangea.activity_plan` state (`bookmark_id` marks the deprecated model,
+  /// excluded like the synced path). A v3 reference plan WITHOUT the room
+  /// type would need CMS hydration to be recognized; that shape isn't minted
+  /// (the type is set at session creation), and an unhydrated plan resolves
+  /// as a plain room locally too.
+  static String? _activityIdFromState(
+    String? roomType,
+    List<MatrixEvent> state,
+  ) {
+    final planContent = state
+        .firstWhereOrNull((e) => e.type == PangeaEventTypes.activityPlan)
+        ?.content;
+    ActivityPlanModel? embeddedPlan;
+    if (planContent != null &&
+        planContent[ActivitySessionConstants.activityPlanRequest] != null) {
+      try {
+        embeddedPlan = ActivityPlanModel.fromJson(planContent);
+      } catch (_) {
+        embeddedPlan = null;
+      }
+    }
+
+    if (roomType?.startsWith(PangeaRoomTypes.activitySession) == true) {
+      if (embeddedPlan?.isDeprecatedModel == true) return null;
+      return roomType!.split(':').last;
+    }
+    if (embeddedPlan == null || embeddedPlan.isDeprecatedModel) return null;
+    return embeddedPlan.activityId;
   }
 
   /// The synchronous half of the post-join hop, split from

--- a/test/pangea/joined_target_test.dart
+++ b/test/pangea/joined_target_test.dart
@@ -1,13 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:matrix/matrix.dart';
 
-import 'package:fluffychat/features/join_codes/space_code_controller.dart';
+import 'package:fluffychat/features/join_codes/joined_target.dart';
 
-/// [SpaceCodeController.resolveTargetFromRoomState] — the landing-target
-/// resolution for a joined room sync has not yet surfaced (#8047), over raw
-/// `GET /rooms/{id}/state` events. Must mirror the local-room branches of
-/// `resolveJoinedTarget`: space → course, activity session → activity page,
-/// coded chat under a joined course → that course, anything else → the room.
+/// [JoinedTarget.fromRoomState] — the landing-target resolution for a joined
+/// room sync has not yet surfaced (#8047), over raw `GET /rooms/{id}/state`
+/// events. Must mirror [JoinedTargetRoomExtension.joinedTarget]: space →
+/// course, activity session → activity page, coded chat under a joined
+/// course → that course, anything else → the room.
 void main() {
   const roomId = '!session:example.com';
   const courseId = '!course:example.com';
@@ -49,47 +49,46 @@ void main() {
   bool noJoinedSpaces(String _) => false;
 
   test('a space resolves to itself as a course', () {
-    final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+    final target = JoinedTarget.fromRoomState(roomId, [
       createEvent('m.space'),
     ], noJoinedSpaces);
-    expect(target, (roomId: roomId, isSpace: true, activityId: null));
+    expect(target, const JoinedTarget.course(roomId));
   });
 
   test('a v3 activity session resolves the id from the room-type suffix', () {
-    final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+    final target = JoinedTarget.fromRoomState(roomId, [
       createEvent('p.activity.session:abc-123'),
     ], noJoinedSpaces);
-    expect(target, (roomId: roomId, isSpace: false, activityId: 'abc-123'));
+    expect(target, const JoinedTarget.activitySession(roomId, 'abc-123'));
   });
 
   test('a legacy embedded plan resolves the id from state', () {
-    final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+    final target = JoinedTarget.fromRoomState(roomId, [
       createEvent(null),
       state('pangea.activity_plan', embeddedPlanContent(idKey: 'activity_id')),
     ], noJoinedSpaces);
-    expect(target, (
-      roomId: roomId,
-      isSpace: false,
-      activityId: 'legacy-activity',
-    ));
+    expect(
+      target,
+      const JoinedTarget.activitySession(roomId, 'legacy-activity'),
+    );
   });
 
   test('a deprecated (bookmark) embedded plan is not a session', () {
-    final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+    final target = JoinedTarget.fromRoomState(roomId, [
       createEvent(null),
       state('pangea.activity_plan', embeddedPlanContent(idKey: 'bookmark_id')),
     ], noJoinedSpaces);
-    expect(target, (roomId: roomId, isSpace: false, activityId: null));
+    expect(target, const JoinedTarget.room(roomId));
   });
 
   test('a chat under a locally-joined course resolves to the course', () {
-    final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+    final target = JoinedTarget.fromRoomState(roomId, [
       createEvent(null),
       state(EventTypes.SpaceParent, {
         'via': ['example.com'],
       }, stateKey: courseId),
     ], (id) => id == courseId);
-    expect(target, (roomId: courseId, isSpace: true, activityId: null));
+    expect(target, const JoinedTarget.course(courseId));
   });
 
   test('a parent without via, or not locally joined, is ignored', () {
@@ -101,20 +100,16 @@ void main() {
         'via': ['example.com'],
       }, stateKey: '!other:example.com'),
     ]) {
-      final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+      final target = JoinedTarget.fromRoomState(roomId, [
         createEvent(null),
         parent,
       ], (id) => id == courseId);
-      expect(target, (roomId: roomId, isSpace: false, activityId: null));
+      expect(target, const JoinedTarget.room(roomId));
     }
   });
 
   test('an unrecognized room resolves to itself as a room, not a course', () {
-    final target = SpaceCodeController.resolveTargetFromRoomState(
-      roomId,
-      [],
-      noJoinedSpaces,
-    );
-    expect(target, (roomId: roomId, isSpace: false, activityId: null));
+    final target = JoinedTarget.fromRoomState(roomId, [], noJoinedSpaces);
+    expect(target, const JoinedTarget.room(roomId));
   });
 }

--- a/test/pangea/resolve_target_from_room_state_test.dart
+++ b/test/pangea/resolve_target_from_room_state_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/join_codes/space_code_controller.dart';
+
+/// [SpaceCodeController.resolveTargetFromRoomState] — the landing-target
+/// resolution for a joined room sync has not yet surfaced (#8047), over raw
+/// `GET /rooms/{id}/state` events. Must mirror the local-room branches of
+/// `resolveJoinedTarget`: space → course, activity session → activity page,
+/// coded chat under a joined course → that course, anything else → the room.
+void main() {
+  const roomId = '!session:example.com';
+  const courseId = '!course:example.com';
+
+  MatrixEvent state(
+    String type,
+    Map<String, Object?> content, {
+    String stateKey = '',
+  }) => MatrixEvent(
+    type: type,
+    content: content,
+    senderId: '@alice:example.com',
+    stateKey: stateKey,
+    eventId: '\$event:example.com',
+    originServerTs: DateTime.fromMillisecondsSinceEpoch(0),
+  );
+
+  MatrixEvent createEvent(String? roomType) =>
+      state(EventTypes.RoomCreate, roomType == null ? {} : {'type': roomType});
+
+  Map<String, Object?> embeddedPlanContent({required String idKey}) => {
+    idKey: 'legacy-activity',
+    'req': {
+      'topic': 'Ordering food',
+      'mode': 'discussion',
+      'objective': 'Practice ordering a meal',
+      'media': 'nan',
+      'language_of_instructions': 'en',
+      'target_language': 'es',
+      'count': 1,
+      'number_of_participants': 2,
+    },
+    'title': 'Ordering food',
+    'learning_objective': 'Practice ordering a meal',
+    'instructions': 'Order a meal at the cafe.',
+    'vocab': <Object?>[],
+  };
+
+  bool noJoinedSpaces(String _) => false;
+
+  test('a space resolves to itself as a course', () {
+    final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+      createEvent('m.space'),
+    ], noJoinedSpaces);
+    expect(target, (roomId: roomId, isSpace: true, activityId: null));
+  });
+
+  test('a v3 activity session resolves the id from the room-type suffix', () {
+    final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+      createEvent('p.activity.session:abc-123'),
+    ], noJoinedSpaces);
+    expect(target, (roomId: roomId, isSpace: false, activityId: 'abc-123'));
+  });
+
+  test('a legacy embedded plan resolves the id from state', () {
+    final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+      createEvent(null),
+      state('pangea.activity_plan', embeddedPlanContent(idKey: 'activity_id')),
+    ], noJoinedSpaces);
+    expect(target, (
+      roomId: roomId,
+      isSpace: false,
+      activityId: 'legacy-activity',
+    ));
+  });
+
+  test('a deprecated (bookmark) embedded plan is not a session', () {
+    final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+      createEvent(null),
+      state('pangea.activity_plan', embeddedPlanContent(idKey: 'bookmark_id')),
+    ], noJoinedSpaces);
+    expect(target, (roomId: roomId, isSpace: false, activityId: null));
+  });
+
+  test('a chat under a locally-joined course resolves to the course', () {
+    final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+      createEvent(null),
+      state(EventTypes.SpaceParent, {
+        'via': ['example.com'],
+      }, stateKey: courseId),
+    ], (id) => id == courseId);
+    expect(target, (roomId: courseId, isSpace: true, activityId: null));
+  });
+
+  test('a parent without via, or not locally joined, is ignored', () {
+    for (final parent in [
+      // Spec-invalid parent: no via — must be skipped even though joined.
+      state(EventTypes.SpaceParent, {}, stateKey: courseId),
+      // Valid parent the joiner is not in (the no-shared-course invitee).
+      state(EventTypes.SpaceParent, {
+        'via': ['example.com'],
+      }, stateKey: '!other:example.com'),
+    ]) {
+      final target = SpaceCodeController.resolveTargetFromRoomState(roomId, [
+        createEvent(null),
+        parent,
+      ], (id) => id == courseId);
+      expect(target, (roomId: roomId, isSpace: false, activityId: null));
+    }
+  });
+
+  test('an unrecognized room resolves to itself as a room, not a course', () {
+    final target = SpaceCodeController.resolveTargetFromRoomState(
+      roomId,
+      [],
+      noJoinedSpaces,
+    );
+    expect(target, (roomId: roomId, isSpace: false, activityId: null));
+  });
+}


### PR DESCRIPTION
## What

When a coded join finishes before initial sync surfaces the room locally, `resolveJoinedTarget` no longer guesses "course" — it fetches the room's state over HTTP (`GET /rooms/{id}/state`; the join succeeded, so state is readable mid-initial-sync) and runs the same branching as the synced path: space → course, activity session (v3 `p.activity.session:<id>` room-type suffix, legacy embedded plan fallback, bookmark-deprecated excluded) → activity page, coded chat under a locally-joined course → that course, else the room. If the state fetch itself fails, it lands on the room AS A ROOM (`isSpace: false`) — a wrong room-open is a recoverable chat view, a wrong course-open spins forever.

## Why

Closes #8047 (reopened). #8055 fixed the landing rule for the synced case, but on a fresh page load (a coded link IS one) the room routinely isn't local yet — the join flow's bounded 10s sync-wait (`_loadRoom`) runs out, and the old null-room fallback opened a course panel scoped to the session room's id (`?c=<session room>`), which can never resolve — TigToggle's infinite course spinner, intermittent because it races initial sync (matches the Chrome-vs-Opera / 1st-4th-5th-attempt pattern reported). Landing rule itself is unchanged, per joining-courses.instructions.md — this makes the not-yet-synced path honor it.

## Testing

- New `joined_target_test.dart` pins every branch of `JoinedTarget.fromRoomState` (space, v3 suffix, legacy embedded plan, deprecated bookmark excluded, joined-parent chat, no-`via`/unjoined parent ignored, unknown → room); 7 pass
- `course_code_auto_submit_test.dart` passes; analyze, format, import-sort clean
- Full local suite: 2414 pass / 2 skip; 3 failures are the live `.env`-dependent endpoint suites (choreo setUpAll, synapse login, cms languages), pre-existing and untouched by this change
- Not yet run: manual repro with `*/sync*` blocked in DevTools against a staging session code (the deterministic reproduction of the race) — #8047's TO TEST on staging covers both user pairs, logged in and logging in

## Deploy Notes

None.
