### PR TITLE
feat(activities): rebuild the activity summary — own feedback first, goals included

### DIFF
--- a/lib/features/activity_sessions/activity_summary_room_extension.dart
+++ b/lib/features/activity_sessions/activity_summary_room_extension.dart
@@ -49,6 +49,11 @@ extension ActivitySummaryRoomExtension on Room {
     return _activitySummary(l1);
   }
 
+  /// True once a generated summary is on screen. The summary carries the
+  /// learner's goals from then on, so the goal header steps aside (#8289).
+  bool get hasGeneratedActivitySummary =>
+      visibleActivitySummaryByL1?.summary != null;
+
   Future<void> _setActivitySummary(
     ActivitySummaryModel summary,
     String langCode,

--- a/lib/routes/chat/activity_sessions/activity_chat_controller.dart
+++ b/lib/routes/chat/activity_sessions/activity_chat_controller.dart
@@ -42,7 +42,6 @@ class ActivityChatController {
   bool _disposed = false;
   bool _loadingSummary = false;
 
-  final ScrollController carouselController = ScrollController();
   final ValueNotifier<Set<String>> usedVocab = ValueNotifier({});
   final ValueNotifier<ActivityRoleModel?> highlightedRole = ValueNotifier(null);
   final ValueNotifier<bool> showInstructions = ValueNotifier(false);
@@ -66,7 +65,6 @@ class ActivityChatController {
 
   Future<void> dispose() async {
     _disposed = true;
-    carouselController.dispose();
     _analyticsSubscription.cancel();
     usedVocab.dispose();
     highlightedRole.dispose();

--- a/lib/routes/chat/activity_sessions/activity_stats_menu.dart
+++ b/lib/routes/chat/activity_sessions/activity_stats_menu.dart
@@ -9,6 +9,7 @@ import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/activity_summary_room_extension.dart';
 import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/pangea_room_extension.dart';
@@ -88,7 +89,9 @@ class ActivityStatsMenu extends StatelessWidget with GoalProgressMixin {
 
   @override
   Widget build(BuildContext context) {
-    if (!room.showActivityChatUI) {
+    // Once the summary is on screen it carries the goals itself, so the header
+    // has nothing left to show and all completion lives in one place (#8289).
+    if (!room.showActivityChatUI || room.hasGeneratedActivitySummary) {
       return const SizedBox.shrink();
     }
 

--- a/lib/routes/chat/activity_sessions/activity_user_summaries_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_user_summaries_widget.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 
 import 'package:collection/collection.dart';
@@ -7,8 +5,8 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
-import 'package:fluffychat/features/activity_sessions/activity_role_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_summary_response_model.dart';
@@ -53,6 +51,11 @@ class ActivityUserSummaries extends StatelessWidget {
           Container(
             padding: const EdgeInsets.all(16.0),
             margin: const EdgeInsets.all(16.0),
+            // The block keeps the width the goal header and plan page use, so
+            // a long feedback grows downward instead of running edge to edge.
+            constraints: const BoxConstraints(
+              maxWidth: FluffyThemes.columnWidth * 1.5,
+            ),
             decoration: BoxDecoration(
               color: Theme.of(context).colorScheme.surface.withAlpha(128),
               borderRadius: BorderRadius.circular(12.0),
@@ -89,7 +92,7 @@ class ActivityUserSummaries extends StatelessWidget {
                         ),
                     ],
                   ),
-                ButtonControlledCarouselView(
+                ActivityParticipantSummaries(
                   summary: summary,
                   controller: controller,
                 ),
@@ -148,237 +151,231 @@ class _SummaryLoading extends StatelessWidget {
   }
 }
 
-class ButtonControlledCarouselView extends StatelessWidget {
+/// Whose feedback the summary shows: whoever the learner picked, else their
+/// own, else the first participant so the card is never empty (#8289).
+ParticipantSummaryModel selectedParticipantSummary({
+  required List<ParticipantSummaryModel> summaries,
+  required String? highlightedUserId,
+  required String? ownUserId,
+}) =>
+    summaries.firstWhereOrNull((p) => p.participantId == highlightedUserId) ??
+    summaries.firstWhereOrNull((p) => p.participantId == ownUserId) ??
+    summaries.first;
+
+/// The feedback body of the summary: one participant's card at a time — the
+/// viewer's own by default — with a picker for everyone else. A single card is
+/// what keeps the section free of horizontal scrolling (#8289).
+class ActivityParticipantSummaries extends StatelessWidget {
   final ActivitySummaryResponseModel summary;
   final ChatController controller;
-  const ButtonControlledCarouselView({
+
+  const ActivityParticipantSummaries({
     super.key,
     required this.summary,
     required this.controller,
   });
 
-  void _scrollToUser(ActivityRoleModel role, int index, double cardWidth) {
-    controller.activityController.highlightRole(role);
+  Room get room => controller.room;
 
-    final scrollController = controller.activityController.carouselController;
-
-    if (!scrollController.hasClients) return;
-
-    const spacing = 5.0;
-    final itemExtent = cardWidth + spacing;
-
-    final viewportWidth = scrollController.position.viewportDimension;
-
-    final itemCenter = (index * itemExtent) + (cardWidth / 2);
-
-    final targetOffset = itemCenter - (viewportWidth / 2);
-
-    final clampedOffset = targetOffset.clamp(
-      scrollController.position.minScrollExtent,
-      scrollController.position.maxScrollExtent,
-    );
-
-    scrollController.animateTo(
-      clampedOffset,
-      duration: const Duration(milliseconds: 300),
-      curve: Curves.easeOutCubic,
-    );
+  /// The summaries the room still holds a role for, in the plan's role order.
+  List<ParticipantSummaryModel> get _roleSummaries {
+    final assignedRoles = room.assignedRoles?.values ?? const [];
+    return summary.participants
+        .where(
+          (p) => assignedRoles.any((role) => role.userId == p.participantId),
+        )
+        .toList();
   }
 
   @override
   Widget build(BuildContext context) {
-    final room = controller.room;
     // Reference plan may not be hydrated yet; the surface rebuilds once it
     // lands (ActivityPlanRepo).
-    final activity = room.activityPlan;
-    if (activity == null) return const SizedBox.shrink();
-    final superlatives = room.activitySummaryByL1?.analytics
-        ?.generateSuperlatives();
-    final availableRoles = activity.roles;
-    final assignedRoles = room.assignedRoles ?? {};
-    final userSummaries = summary.participants
-        .where(
-          (p) => assignedRoles.values.any(
-            (role) => role.userId == p.participantId,
-          ),
-        )
-        .toList();
+    if (room.activityPlan == null) return const SizedBox.shrink();
 
-    if (userSummaries.isEmpty) {
-      return const SizedBox();
-    }
+    final roleSummaries = _roleSummaries;
+    if (roleSummaries.isEmpty) return const SizedBox();
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final cardWidth = userSummaries.length == 1
-            ? min(500.0, constraints.maxWidth)
-            : 335.0;
+    return ValueListenableBuilder(
+      valueListenable: controller.activityController.highlightedRole,
+      builder: (context, highlightedRole, _) {
+        final selected = selectedParticipantSummary(
+          summaries: roleSummaries,
+          highlightedUserId: highlightedRole?.userId,
+          ownUserId: room.client.userID,
+        );
         return Column(
+          spacing: 12.0,
+          mainAxisSize: MainAxisSize.min,
           children: [
-            SizedBox(
-              height: 300.0,
-              child: ListView.builder(
-                key: PageStorageKey('summaries-carousel-${room.id}'),
-                shrinkWrap: true,
-                controller: controller.activityController.carouselController,
-                scrollDirection: Axis.horizontal,
-                itemCount: userSummaries.length,
-                itemBuilder: (context, i) {
-                  final p = userSummaries[i];
-                  final user = room.getParticipants().firstWhereOrNull(
-                    (u) => u.id == p.participantId,
-                  );
-                  final userRole = assignedRoles.values.firstWhere(
-                    (role) => role.userId == p.participantId,
-                  );
-                  return Container(
-                    width: cardWidth,
-                    margin: i == userSummaries.length - 1
-                        ? null
-                        : const EdgeInsets.only(right: 5.0),
-                    padding: const EdgeInsets.all(12.0),
-                    decoration: ShapeDecoration(
-                      color: Color.alphaBlend(
-                        Theme.of(context).colorScheme.surface.withAlpha(70),
-                        AppConfig.gold,
-                      ),
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
+            if (roleSummaries.length > 1)
+              Wrap(
+                spacing: 8.0,
+                runSpacing: 8.0,
+                alignment: WrapAlignment.center,
+                children: [
+                  for (final participant in roleSummaries)
+                    _ParticipantPickerTile(
+                      participant: participant,
+                      controller: controller,
+                      selected:
+                          participant.participantId == selected.participantId,
                     ),
-                    child: Column(
-                      spacing: 4.0,
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Row(
-                          spacing: 10.0,
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Avatar(
-                              name: p.participantId.localpart,
-                              mxContent: user?.avatarUrl,
-                              size: 40,
-                            ),
-                            Flexible(
-                              child: Text(
-                                "${userRole.role ?? L10n.of(context).participant} | ${user?.localizedDisplayname(L10n.of(context)) ?? p.participantId.localpart}",
-                                style: const TextStyle(fontSize: 14.0),
-                                overflow: TextOverflow.ellipsis,
-                              ),
-                            ),
-                          ],
-                        ),
-                        Flexible(
-                          child: _SummaryText(
-                            text: p.displayFeedback(
-                              user?.localizedDisplayname(L10n.of(context)) ??
-                                  p.participantId.localpart ??
-                                  p.participantId,
-                            ),
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.all(8.0),
-                          child: Center(
-                            child: Wrap(
-                              alignment: WrapAlignment.center,
-                              spacing: 12,
-                              runSpacing: 8,
-                              children: [
-                                Text(
-                                  p.cefrLevel,
-                                  style: const TextStyle(fontSize: 14.0),
-                                ),
-                                //const SizedBox(width: 8),
-                                if (superlatives != null &&
-                                    (superlatives['vocab']!.contains(
-                                      p.participantId,
-                                    ))) ...[
-                                  const SuperlativeTile(
-                                    icon: Symbols.dictionary,
-                                  ),
-                                ],
-                                if (superlatives != null &&
-                                    (superlatives['grammar']!.contains(
-                                      p.participantId,
-                                    ))) ...[
-                                  const SuperlativeTile(
-                                    icon: Symbols.toys_and_games,
-                                  ),
-                                ],
-                                if (superlatives != null &&
-                                    (superlatives['xp']!.contains(
-                                      p.participantId,
-                                    ))) ...[
-                                  const SuperlativeTile(icon: Icons.star),
-                                ],
-                                if (p.superlatives.isNotEmpty) ...[
-                                  Text(
-                                    p.superlatives.first,
-                                    style: const TextStyle(fontSize: 14.0),
-                                  ),
-                                ],
-                              ],
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  );
-                },
+                ],
               ),
-            ),
-            const SizedBox(height: 12),
-            SizedBox(
-              height: 125.0,
-              child: ValueListenableBuilder(
-                valueListenable: controller.activityController.highlightedRole,
-                builder: (context, highlightedRole, _) {
-                  return ListView.builder(
-                    shrinkWrap: true,
-                    scrollDirection: Axis.horizontal,
-                    itemCount: userSummaries.length,
-                    itemBuilder: (context, index) {
-                      final p = userSummaries[index];
-                      final user = room.getParticipants().firstWhereOrNull(
-                        (u) => u.id == p.participantId,
-                      );
-                      final userRole = assignedRoles.values.firstWhere(
-                        (role) => role.userId == p.participantId,
-                      );
-                      // The assigned role id can be missing from the resolved
-                      // plan when the pinned plan version was evicted and a
-                      // fallback version (with regenerated role ids) was
-                      // served — fall back to the role name in room state.
-                      final roleName =
-                          availableRoles[userRole.id]?.name ??
-                          userRole.role ??
-                          L10n.of(context).participant;
-                      return SizedBox(
-                        width: 100.0,
-                        height: 125.0,
-                        child: Center(
-                          child: ActivityParticipantIndicator(
-                            name: roleName,
-                            userId: p.participantId,
-                            user: user,
-                            borderRadius: BorderRadius.circular(4),
-                            selected: highlightedRole?.id == userRole.id,
-                            onTap: () =>
-                                _scrollToUser(userRole, index, cardWidth),
-                            room: controller.room,
-                          ),
-                        ),
-                      );
-                    },
-                  );
-                },
-              ),
+            _ParticipantSummaryCard(
+              participant: selected,
+              controller: controller,
             ),
           ],
         );
       },
+    );
+  }
+}
+
+/// One face in the picker row. Tapping it swaps the card below.
+class _ParticipantPickerTile extends StatelessWidget {
+  final ParticipantSummaryModel participant;
+  final ChatController controller;
+  final bool selected;
+
+  const _ParticipantPickerTile({
+    required this.participant,
+    required this.controller,
+    required this.selected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final room = controller.room;
+    final role = room.assignedRoles?.values.firstWhereOrNull(
+      (role) => role.userId == participant.participantId,
+    );
+    if (role == null) return const SizedBox.shrink();
+
+    // The assigned role id can be missing from the resolved plan when the
+    // pinned plan version was evicted and a fallback version (with regenerated
+    // role ids) was served — fall back to the role name in room state.
+    final roleName =
+        room.activityPlan?.roles[role.id]?.name ??
+        role.role ??
+        L10n.of(context).participant;
+
+    return SizedBox(
+      width: 100.0,
+      child: ActivityParticipantIndicator(
+        name: roleName,
+        userId: participant.participantId,
+        user: room.getParticipants().firstWhereOrNull(
+          (u) => u.id == participant.participantId,
+        ),
+        borderRadius: BorderRadius.circular(4),
+        selected: selected,
+        onTap: () => controller.activityController.highlightRole(role),
+        room: room,
+      ),
+    );
+  }
+}
+
+/// One participant's feedback. The card grows to its text rather than
+/// scrolling inside a fixed height (#8289).
+class _ParticipantSummaryCard extends StatelessWidget {
+  final ParticipantSummaryModel participant;
+  final ChatController controller;
+
+  const _ParticipantSummaryCard({
+    required this.participant,
+    required this.controller,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final room = controller.room;
+    final user = room.getParticipants().firstWhereOrNull(
+      (u) => u.id == participant.participantId,
+    );
+    final role = room.assignedRoles?.values.firstWhereOrNull(
+      (role) => role.userId == participant.participantId,
+    );
+    final displayName =
+        user?.localizedDisplayname(L10n.of(context)) ??
+        participant.participantId.localpart ??
+        participant.participantId;
+    final superlatives = room.activitySummaryByL1?.analytics
+        ?.generateSuperlatives();
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12.0),
+      decoration: ShapeDecoration(
+        color: Color.alphaBlend(
+          Theme.of(context).colorScheme.surface.withAlpha(70),
+          AppConfig.gold,
+        ),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+      child: Column(
+        spacing: 8.0,
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            spacing: 10.0,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Avatar(
+                name: participant.participantId.localpart,
+                mxContent: user?.avatarUrl,
+                size: 40,
+              ),
+              Flexible(
+                child: Text(
+                  "${role?.role ?? L10n.of(context).participant} | $displayName",
+                  style: const TextStyle(fontSize: 14.0),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+          Text(
+            participant.displayFeedback(displayName),
+            style: const TextStyle(fontSize: 14.0),
+          ),
+          Center(
+            child: Wrap(
+              alignment: WrapAlignment.center,
+              spacing: 12,
+              runSpacing: 8,
+              children: [
+                Text(
+                  participant.cefrLevel,
+                  style: const TextStyle(fontSize: 14.0),
+                ),
+                if (superlatives?['vocab']?.contains(
+                      participant.participantId,
+                    ) ==
+                    true)
+                  const SuperlativeTile(icon: Symbols.dictionary),
+                if (superlatives?['grammar']?.contains(
+                      participant.participantId,
+                    ) ==
+                    true)
+                  const SuperlativeTile(icon: Symbols.toys_and_games),
+                if (superlatives?['xp']?.contains(participant.participantId) ==
+                    true)
+                  const SuperlativeTile(icon: Icons.star),
+                if (participant.superlatives.isNotEmpty)
+                  Text(
+                    participant.superlatives.first,
+                    style: const TextStyle(fontSize: 14.0),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 }
@@ -397,36 +394,6 @@ class SuperlativeTile extends StatelessWidget {
         const SizedBox(width: 2),
         const Text("1st", style: TextStyle(fontSize: 14.0)),
       ],
-    );
-  }
-}
-
-class _SummaryText extends StatefulWidget {
-  final String text;
-  const _SummaryText({required this.text});
-
-  @override
-  State<_SummaryText> createState() => _SummaryTextState();
-}
-
-class _SummaryTextState extends State<_SummaryText> {
-  final ScrollController _scrollController = ScrollController();
-
-  @override
-  void dispose() {
-    _scrollController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scrollbar(
-      controller: _scrollController,
-      thumbVisibility: true,
-      child: SingleChildScrollView(
-        controller: _scrollController,
-        child: Text(widget.text, style: const TextStyle(fontSize: 14.0)),
-      ),
     );
   }
 }

--- a/lib/routes/chat/activity_sessions/activity_user_summaries_widget.dart
+++ b/lib/routes/chat/activity_sessions/activity_user_summaries_widget.dart
@@ -7,6 +7,7 @@ import 'package:material_symbols_icons/symbols.dart';
 import 'package:matrix/matrix.dart';
 
 import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_role_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
 import 'package:fluffychat/features/activity_sessions/activity_room_extension.dart';
@@ -16,6 +17,8 @@ import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/extensions/localized_display_name_extension.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_participant_indicator.dart';
 import 'package:fluffychat/routes/chat/chat.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/goal_status_widget.dart';
+import 'package:fluffychat/routes/chat/choreographer/activity_orchestrator/orchestrator_room_extension.dart';
 import 'package:fluffychat/widgets/avatar.dart';
 
 class ActivityUserSummaries extends StatelessWidget {
@@ -42,6 +45,8 @@ class ActivityUserSummaries extends StatelessWidget {
           : const SizedBox();
     }
 
+    final goals = room.ownRole?.allGoals ?? const <ActivityRoleGoal>[];
+
     return Center(
       child: Stack(
         children: [
@@ -66,6 +71,24 @@ class ActivityUserSummaries extends StatelessWidget {
                     ],
                   ),
                 ),
+                // The goal header steps aside once the summary lands, so the
+                // learner's stars come along with it (#8289).
+                if (goals.isNotEmpty)
+                  Column(
+                    spacing: 8.0,
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      for (final goal in goals)
+                        GoalStatusWidget(
+                          goal: goal,
+                          complete: room.isOwnGoalCompleted(
+                            goal.id,
+                            goalSlug: goal.goalSlug,
+                          ),
+                        ),
+                    ],
+                  ),
                 ButtonControlledCarouselView(
                   summary: summary,
                   controller: controller,

--- a/lib/routes/chat/chat_event_list.dart
+++ b/lib/routes/chat/chat_event_list.dart
@@ -6,6 +6,7 @@ import 'package:scroll_to_index/scroll_to_index.dart';
 
 import 'package:fluffychat/config/themes.dart';
 import 'package:fluffychat/features/activity_sessions/activity_roles_room_extension.dart';
+import 'package:fluffychat/features/activity_sessions/activity_summary_room_extension.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/chat/activity_sessions/activity_user_summaries_widget.dart';
@@ -125,8 +126,10 @@ class ChatEventList extends StatelessWidget {
               // #Pangea
               if (i == events.length + 3) {
                 // Extra top spacer on activities so all content can scroll
-                // above the floating activity goals header.
-                return controller.room.ownRole?.allGoals.isNotEmpty == true
+                // above the floating activity goals header. The header is gone
+                // once the summary carries the goals, and so is the spacer.
+                return controller.room.ownRole?.allGoals.isNotEmpty == true &&
+                        !controller.room.hasGeneratedActivitySummary
                     ? SizedBox(height: 170)
                     : SizedBox.shrink();
               }

--- a/test/pangea/activity_summary_participant_selection_test.dart
+++ b/test/pangea/activity_summary_participant_selection_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_summary_response_model.dart';
+import 'package:fluffychat/routes/chat/activity_sessions/activity_user_summaries_widget.dart';
+
+/// Which participant's feedback the finished-activity summary shows.
+///
+/// The summary used to lay every participant out in a horizontally-scrolling
+/// carousel, so a learner had to scroll sideways to reach their own feedback
+/// (#8289). One card shows at a time now, and the default has to be the
+/// learner's own — the picker is for looking at somebody else on purpose.
+void main() {
+  ParticipantSummaryModel participant(String userId) => ParticipantSummaryModel(
+    participantId: userId,
+    feedback: 'feedback for $userId',
+    cefrLevel: 'A1',
+    superlatives: const [],
+  );
+
+  final alice = participant('@alice:example.com');
+  final bob = participant('@bob:example.com');
+  final carol = participant('@carol:example.com');
+  final summaries = [alice, bob, carol];
+
+  group('selectedParticipantSummary', () {
+    test('shows the viewer their own feedback before they pick anyone', () {
+      expect(
+        selectedParticipantSummary(
+          summaries: summaries,
+          highlightedUserId: null,
+          ownUserId: bob.participantId,
+        ),
+        bob,
+      );
+    });
+
+    test('a picked participant wins over the viewer\'s own', () {
+      expect(
+        selectedParticipantSummary(
+          summaries: summaries,
+          highlightedUserId: carol.participantId,
+          ownUserId: bob.participantId,
+        ),
+        carol,
+      );
+    });
+
+    test('an observer with no feedback of their own still sees a card', () {
+      expect(
+        selectedParticipantSummary(
+          summaries: summaries,
+          highlightedUserId: null,
+          ownUserId: '@dave:example.com',
+        ),
+        alice,
+      );
+    });
+
+    test('a pick that no longer has a summary falls back to the viewer\'s '
+        'own, not to an empty card', () {
+      expect(
+        selectedParticipantSummary(
+          summaries: summaries,
+          highlightedUserId: '@dave:example.com',
+          ownUserId: bob.participantId,
+        ),
+        bob,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Rebuilds the finished-activity summary as one block: the learner's goals, then one participant's feedback at a time, sized to its text.

## Why

Closes #8289.

**Only your own summary, unless you pick someone else.** The feedback cards were a horizontal carousel — reading your own meant scrolling sideways to find it. One card shows now, defaulting to the viewer's own (`selectedParticipantSummary`); the faces below become a picker for looking at someone else deliberately, and they `Wrap` instead of scrolling sideways too.

**The card grows to its text.** It was a fixed 300px row with a scrollbar inside each card, so a long feedback scrolled within a box inside the page. Both scrollers are gone; the card sizes to its content and the block takes the same max width as the goal header and plan page (`columnWidth * 1.5`) so long text grows downward rather than edge to edge.

**The goals move in and the header goes away.** By the time a summary exists the activity is finished for everyone, so the header's end-activity buttons are already gated off ([activities.instructions.md — The goal header](https://github.com/pangeachat/client/blob/main/.github/instructions/activities.instructions.md#the-goal-header)) and it is showing nothing but stars. `hasGeneratedActivitySummary` is the single gate: `ActivityStatsMenu` renders nothing behind it, and the chat's 170px top spacer — which exists only to let content clear the floating header — goes with it. A loading or failed summary leaves the header alone, so the goals are never nowhere.

Also drops what the carousel needed and nothing else does: `ActivityChatController.carouselController` and the per-card scrolling text widget.

Note for design review: the goal-header section of `activities.instructions.md` describes the header on a *running* activity and doesn't cover the finished state, so nothing there contradicts this — but if we keep it, that section wants a sentence about the handoff. Not edited here; that's an in-chat discussion first.

## Testing

- `fvm flutter test test/pangea` — 2396 passed, including 4 new cases covering who the card defaults to (own summary before any pick, a pick winning over own, an observer with no summary of their own, and a pick whose summary is gone).
- `fvm flutter analyze lib test` — clean.
- Not exercised in a running app: the surface needs a finished session with a backend-generated summary, which local can't produce. Layout review is on staging.

## Deploy Notes

None.
