### PR TITLE
fix(quests): memoize a confirmed quest 404 so it stops refetching

### DIFF
--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -452,10 +452,19 @@ class QuestRepo {
   /// GetStorage) because [QuestOutline] carries session-scoped media CDN URLs —
   /// same reasoning as `ActivityPlanRepo`'s in-memory resolve cache.
   ///
-  /// Holds SUCCESSES ONLY: caching an error would pin a transient failure (or
-  /// a since-restored quest) for the process lifetime, so every retry — the
-  /// world map's empty-cache self-heal, a panel reopen — would replay the
-  /// stale error instead of ever recovering (#8083).
+  /// Holds successes and confirmed 404s. Caching a TRANSIENT error would pin
+  /// it for the process lifetime, so every retry — the world map's empty-cache
+  /// self-heal, a panel reopen — would replay the stale error instead of ever
+  /// recovering (#8083); those stay uncached.
+  ///
+  /// A [MissingQuestException] is the exception, on the same reasoning as
+  /// `ActivityPlanRepo._confirmedRemoved`: the CMS has *stated* the quest is
+  /// gone, which is a fact about the resource rather than a failure to reach
+  /// it, and old course rooms keep referencing removed quests indefinitely — so
+  /// an uncached 404 is re-requested for the life of the process (~1,973 events
+  /// / 24 users in 10 days, CLIENT-DWK, #8358). Recovery is not lost: a
+  /// [forceRefresh] read bypasses the memo and a success replaces it, and the
+  /// cache is process-scoped, so a restarted app re-checks a restored quest.
   static final Map<String, Result<QuestOutline>> _outlineCache = {};
   static final Map<String, Future<Result<QuestOutline>>> _outlineInflight = {};
 
@@ -476,8 +485,9 @@ class QuestRepo {
   }
 
   /// The full outline: quest + objective groups (LOs in order, each with its
-  /// matching activities). Successes are cached per (quest id, course room);
-  /// errors are returned but never cached (see [_outlineCache]). Concurrent
+  /// matching activities). Successes and confirmed 404s are cached per (quest
+  /// id, course room); transient errors are returned but never cached (see
+  /// [_outlineCache]). Concurrent
   /// calls for the same key share one in-flight read. [courseRoomId] admits
   /// the quest owner's private activities when the caller is a joined member
   /// of that course. Pass [forceRefresh] to bypass the cache.
@@ -502,7 +512,7 @@ class QuestRepo {
 
     final outline = await future;
 
-    if (outline.isValue) {
+    if (outline.isValue || outline.error is MissingQuestException) {
       _outlineCache[cacheKey] = outline;
     }
     _outlineInflight.remove(cacheKey);

--- a/test/pangea/quests/quest_outline_error_cache_test.dart
+++ b/test/pangea/quests/quest_outline_error_cache_test.dart
@@ -7,10 +7,15 @@ import 'package:fluffychat/features/quests/models/quest_plan_model.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
 
 void main() {
-  // #8083: QuestRepo.outline must cache successes only. A cached error pins a
-  // transient failure (or a since-restored quest) for the process lifetime,
-  // which defeats the world map's empty-cache self-heal retry — the retry
-  // replays the stale error forever instead of recovering.
+  // #8083: QuestRepo.outline must not cache TRANSIENT errors. A cached
+  // transient failure pins it for the process lifetime, which defeats the world
+  // map's empty-cache self-heal retry — the retry replays the stale error
+  // forever instead of recovering.
+  //
+  // #8358: a confirmed 404 (MissingQuestException) is the exception. It is a
+  // statement about the resource, not a failure to reach it, so it IS cached —
+  // otherwise an old course room referencing a removed quest re-requests it for
+  // the life of the process.
   group('QuestRepo.outline error caching', () {
     const quest = QuestPlan(
       id: 'quest-1',
@@ -32,10 +37,10 @@ void main() {
       QuestRepo.resetOutlineCacheForTest();
     });
 
-    test('an error result is not cached — the next call retries', () async {
+    test('a transient error is not cached — the next call retries', () async {
       QuestRepo.debugBuildOutline = (id, {courseRoomId}) async {
         buildCalls++;
-        return Result.error(MissingQuestException());
+        return Result.error(Exception('timeout'));
       };
 
       final first = await QuestRepo.outline('quest-1');
@@ -46,7 +51,54 @@ void main() {
       expect(buildCalls, 2);
     });
 
-    test('a retry after an error can succeed and then caches', () async {
+    test(
+      'a retry after a transient error can succeed and then caches',
+      () async {
+        QuestRepo.debugBuildOutline = (id, {courseRoomId}) async {
+          buildCalls++;
+          if (buildCalls == 1) return Result.error(Exception('timeout'));
+          return Result.value(const QuestOutline(quest: quest, groups: []));
+        };
+
+        expect((await QuestRepo.outline('quest-1')).isError, isTrue);
+        expect((await QuestRepo.outline('quest-1')).isValue, isTrue);
+        // The success is now cached — no further build.
+        expect((await QuestRepo.outline('quest-1')).isValue, isTrue);
+        expect(buildCalls, 2);
+      },
+    );
+
+    test('a confirmed 404 is cached — later calls do not refetch', () async {
+      QuestRepo.debugBuildOutline = (id, {courseRoomId}) async {
+        buildCalls++;
+        return Result.error(MissingQuestException());
+      };
+
+      final first = await QuestRepo.outline('quest-1');
+      final second = await QuestRepo.outline('quest-1');
+      await QuestRepo.outline('quest-1');
+
+      expect(first.asError!.error, isA<MissingQuestException>());
+      // The memoized result is the same error, so callers keep rendering the
+      // known-missing state rather than a different failure.
+      expect(second.asError!.error, isA<MissingQuestException>());
+      expect(buildCalls, 1);
+    });
+
+    test('a cached 404 is scoped to its (quest id, course room) row', () async {
+      QuestRepo.debugBuildOutline = (id, {courseRoomId}) async {
+        buildCalls++;
+        return Result.error(MissingQuestException());
+      };
+
+      await QuestRepo.outline('quest-1');
+      await QuestRepo.outline('quest-1', courseRoomId: '!room:server');
+      await QuestRepo.outline('quest-2');
+
+      expect(buildCalls, 3);
+    });
+
+    test('forceRefresh recovers a restored quest past a cached 404', () async {
       QuestRepo.debugBuildOutline = (id, {courseRoomId}) async {
         buildCalls++;
         if (buildCalls == 1) return Result.error(MissingQuestException());
@@ -54,8 +106,11 @@ void main() {
       };
 
       expect((await QuestRepo.outline('quest-1')).isError, isTrue);
-      expect((await QuestRepo.outline('quest-1')).isValue, isTrue);
-      // The success is now cached — no further build.
+      expect(
+        (await QuestRepo.outline('quest-1', forceRefresh: true)).isValue,
+        isTrue,
+      );
+      // The success replaced the cached 404 — no further build.
       expect((await QuestRepo.outline('quest-1')).isValue, isTrue);
       expect(buildCalls, 2);
     });
@@ -84,13 +139,13 @@ void main() {
 
       final first = QuestRepo.outline('quest-1');
       final second = QuestRepo.outline('quest-1');
-      gate.complete(Result.error(MissingQuestException()));
+      gate.complete(Result.error(Exception('timeout')));
 
       expect((await first).isError, isTrue);
       expect((await second).isError, isTrue);
       expect(buildCalls, 1);
 
-      // The shared error was not cached — a later call retries.
+      // The shared transient error was not cached — a later call retries.
       await QuestRepo.outline('quest-1');
       expect(buildCalls, 2);
     });


### PR DESCRIPTION
### What

`QuestRepo.outline` now memoizes a confirmed quest 404 (`MissingQuestException`) alongside its successes, instead of refetching it for the life of the process.

### Why

Closes #8358. Sentry: [CLIENT-DWK](https://pangea-chat.sentry.io/issues/CLIENT-DWK) (~1,973 events / 24 users in 10 days), unminified twin [CLIENT-CY3](https://pangea-chat.sentry.io/issues/CLIENT-CY3).

The cache held successes only — deliberate in #8083, so a transient failure could self-heal. A confirmed 404 was swept up in that rule and re-requested forever. Old course rooms keep referencing removed quests, so this is a steady state, not a regression: a permanent 404 loop against the CMS plus Sentry noise that buries real quest failures.

### Caching semantics, and why

The issue left this open: memoize a confirmed 404 permanently for the process, or behind a cooldown so a restored quest recovers? **Resolved by following the in-repo precedent** rather than inventing new semantics — `ActivityPlanRepo` already answers exactly this question for activities (`_confirmedRemoved`), and two repos giving different answers to "what does a confirmed 404 mean?" is how the error-handling contract drifts.

That precedent splits the two error classes and this change ports the split verbatim:

- **Confirmed 404 → memoized for the process.** The backend has *stated* the resource is gone. That is a fact about the resource, not a failure to reach it, and the referencing room state does not change on its own, so re-asking cannot produce a different answer. Matches `repos-and-error-handling.instructions.md`, which already classifies 404 as "the resource is gone — a normal state."
- **Everything else → still never cached.** #8083's rule is untouched for timeouts, 5xx, and anything unenumerated.

Permanent-for-the-process does not strand a restored quest. Both of the precedent's recovery paths survive: `forceRefresh: true` bypasses the memo and a success overwrites it, and the cache is in-memory, so a restarted app re-checks. Recovery is bounded by an app restart, not by nothing.

The precedent's *other* half — the 60s attempt cooldown (`_nextAttempt`, `_rateLimitedUntil`) — is deliberately **not** ported here. It covers the transient outcomes, which is #8360's scope by that issue's own text; porting it would re-open the #8083 decision this change is careful to leave standing. The activity-side `ensure()` gap is #8359, worked separately.

### Testing

`fvm flutter test` (full suite, Flutter 3.41.4 per `.fvmrc`): **2421 passed, 3 skipped, 0 failed.** The 3 skips are the choreo / synapse / cms endpoint suites, which skip themselves when `client/.env` is absent — this ran in a fresh worktree with no `.env`.

`fvm flutter analyze` on the touched trees: no issues.

Test changes are in `test/pangea/quests/quest_outline_error_cache_test.dart`, the file that already owns this cache contract. The pre-existing #8083 cases used `MissingQuestException` as their stand-in error; since that class is now precisely what *is* cached, they were switched to a genuinely transient error so they keep pinning #8083's rule rather than silently inverting it. Four cases added: a 404 is cached and later calls do not refetch; the memo is scoped per (quest id, course room); `forceRefresh` recovers a restored quest past a cached 404; and a transient error still shares one in-flight build without being cached.

No integration or smoke bucket applies — the change is in-memory cache policy on an existing read path and adds no request shape, endpoint, or paid call.

Staging QA is the issue's TO TEST list (#8358), which covers the world map, mission lists, course switching, the unavailable-quest state, and the leave-it-open-2-minutes check.

### Deploy Notes

None.
