### PR TITLE
fix(activities): gate confirmed-404 activity reads on the shared read path

### DIFF
--- a/lib/features/activity_sessions/activity_plan_repo.dart
+++ b/lib/features/activity_sessions/activity_plan_repo.dart
@@ -76,8 +76,17 @@ class ActivityPlanRepo
   final Set<String> _hydrating = {};
   final Set<String> _revalidated = {};
 
-  /// Activity ids the backend confirmed removed (404) this app session, so
-  /// [ensure] stops re-fetching a known-missing id on every widget rebuild.
+  /// Activity ids the backend confirmed removed (404) this app session, so the
+  /// repo stops re-fetching a known-missing id.
+  ///
+  /// Enforced in [lookup], the shared read path — NOT only in [ensure], which
+  /// is where this gate first lived. [getPlan] delegates to [lookup] and
+  /// [ensure] calls [getPlan], so gating there is what makes the suppression
+  /// total over entry points; gating only in [ensure] left the start page and
+  /// the summary read re-requesting a gone activity for as long as the surface
+  /// stayed open (Sentry CLIENT-DWH: 753 events / 9 users in 24h, all for a
+  /// single activity id). Keyed by activity id, not by storage key: the
+  /// activity is gone, so no l1 or pinned version of it can resolve either.
   final Set<String> _confirmedRemoved = {};
 
   /// Earliest wall-clock time [ensure] may re-attempt a key.
@@ -115,11 +124,15 @@ class ActivityPlanRepo
   @visibleForTesting
   static DateTime Function() now = DateTime.now;
 
-  /// Drops all backoff state. Exposed for tests and for an explicit
-  /// user-initiated refresh, which must never be suppressed.
+  /// Drops all suppression state. Exposed for tests and for an explicit
+  /// user-initiated refresh, which must never be suppressed — which is why
+  /// [_confirmedRemoved] clears here too. It is the only way back out of the
+  /// removed gate, since nothing else can clear an id the repo refuses to
+  /// re-request.
   @visibleForTesting
   void resetBackoff() {
     _nextAttempt.clear();
+    _confirmedRemoved.clear();
     _rateLimitedUntil = null;
   }
 
@@ -210,6 +223,13 @@ class ActivityPlanRepo
     String? version,
     bool forceRefresh = false,
   }) async {
+    // Answered from memory, before any request is built: this is the same
+    // answer the backend already gave for this id, so re-asking can only cost a
+    // round trip and another 404. Checked ahead of [_request] so the gate does
+    // not depend on the controller being up, mirroring [ensure]'s ordering.
+    if (_confirmedRemoved.contains(activityId)) {
+      return const ActivityPlanLookup(ActivityPlanLookupStatus.removed);
+    }
     final request = _request(activityId, l1, version: version);
     // Not knowable yet, not gone: `failed` is the transient status, so callers
     // keep the activity and retry rather than treating it as removed.
@@ -313,7 +333,10 @@ class ActivityPlanRepo
     bool revalidate = false,
   }) {
     // A confirmed-removed id can't hydrate; re-fetching on every rebuild of
-    // the sync getter would loop 404s.
+    // the sync getter would loop 404s. [lookup] gates on the same set, so this
+    // is not what makes the suppression correct — it is what keeps a hydration
+    // that cannot succeed from spending a `_hydrating` slot and a 60s
+    // `_nextAttempt` park, and what lets the caller see `false`.
     if (_confirmedRemoved.contains(activityId)) return false;
     final request = _request(activityId, l1, version: version);
     // Declines WITHOUT parking the key: the controller lands within a frame or

--- a/test/pangea/activity_plan_confirmed_removed_test.dart
+++ b/test/pangea/activity_plan_confirmed_removed_test.dart
@@ -1,0 +1,207 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_plan_repo.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'fake_pangea_controller.dart';
+
+/// Regression: Sentry CLIENT-DWH — 753 events / 9 users in 24h, all for ONE
+/// activity id (#8359).
+///
+/// The repo has always remembered which ids the backend confirmed gone, but the
+/// `_confirmedRemoved` gate sat inside [ActivityPlanRepo.ensure] alone. Callers
+/// that reach [ActivityPlanRepo.lookup] / [ActivityPlanRepo.getPlan] directly —
+/// the activity start page, the summary read — walked straight past it, so a
+/// 404'd activity was re-requested for as long as the surface stayed open.
+///
+/// What is pinned here: the gate lives on the shared read path, so a confirmed
+/// 404 costs exactly one request per activity id per app session, no matter
+/// which entry point asks.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Registered synchronously, BEFORE `ActivityPlanRepo.instance` is touched:
+  // the singleton's `PersistentRepoCache` field builds a `GetStorage` container
+  // on construction, which reaches for path_provider immediately. Doing this in
+  // `setUpAll` is too late — the singleton is already built.
+  final tempDir = Directory.systemTemp.createTempSync('plan_removed_test');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+        const MethodChannel('plugins.flutter.io/path_provider'),
+        (methodCall) async => tempDir.path,
+      );
+
+  final repo = ActivityPlanRepo.instance;
+
+  setUpAll(() async {
+    // Unlike the backoff suite, these tests must reach the network: the stub
+    // controller therefore carries an access token so `createRequests()`
+    // succeeds and the MockClient below is what answers.
+    MatrixState.pangeaController = FakePangeaController(
+      accessToken: 'test-token',
+    );
+    dotenv.testLoad(mergeWith: {'CHOREO_API': 'https://choreo.test'});
+    await GetStorage.init('env_override');
+    await GetStorage.init('activity_plan_storage');
+  });
+
+  setUp(repo.resetBackoff);
+
+  /// Serves every top-level `http` call from [handler] while [body] runs, and
+  /// reports how many requests actually left the client.
+  Future<int> countingClient(
+    Future<http.Response> Function(http.Request) handler,
+    Future<void> Function() body,
+  ) async {
+    var requests = 0;
+    await http.runWithClient(body, () {
+      return MockClient((request) {
+        requests++;
+        return handler(request);
+      });
+    });
+    return requests;
+  }
+
+  Future<http.Response> gone(http.Request _) async =>
+      http.Response('{"detail":"Activity not found"}', 404);
+
+  Future<http.Response> unavailable(http.Request _) async =>
+      http.Response('{"detail":"upstream down"}', 503);
+
+  group('a confirmed 404 suppresses further reads', () {
+    test('lookup answers removed from memory, with no second request', () async {
+      const activityId = 'gone-lookup';
+
+      final first = await countingClient(gone, () async {
+        final result = await repo.lookup(activityId, l1: 'en');
+        expect(result.status, ActivityPlanLookupStatus.removed);
+      });
+      expect(first, 1, reason: 'the first read must actually ask the backend');
+
+      final later = await countingClient(gone, () async {
+        for (var i = 0; i < 50; i++) {
+          final result = await repo.lookup(activityId, l1: 'en');
+          expect(result.status, ActivityPlanLookupStatus.removed);
+        }
+      });
+      expect(
+        later,
+        0,
+        reason:
+            '50 further reads issued $later requests; before the fix this was '
+            '50 — the CLIENT-DWH loop itself',
+      );
+    });
+
+    test('getPlan is gated too — it delegates to lookup', () async {
+      const activityId = 'gone-get-plan';
+
+      await countingClient(gone, () => repo.getPlan(activityId, l1: 'en'));
+
+      final later = await countingClient(gone, () async {
+        expect(await repo.getPlan(activityId, l1: 'en'), isNull);
+      });
+      expect(later, 0);
+    });
+
+    test('a pinned-version read is gated by the same id', () async {
+      // `_confirmedRemoved` keys on the activity id, not the storage key: the
+      // activity is gone, so no version of it can resolve.
+      const activityId = 'gone-versioned';
+
+      await countingClient(gone, () => repo.getPlan(activityId, l1: 'en'));
+
+      final later = await countingClient(gone, () async {
+        final result = await repo.lookup(activityId, l1: 'en', version: 'v9');
+        expect(result.status, ActivityPlanLookupStatus.removed);
+      });
+      expect(later, 0);
+    });
+
+    test('ensure still declines, and never reaches the network', () async {
+      const activityId = 'gone-ensure';
+
+      await countingClient(gone, () => repo.getPlan(activityId, l1: 'en'));
+
+      final later = await countingClient(gone, () async {
+        expect(repo.ensure(activityId, l1: 'en'), isFalse);
+        expect(repo.ensure(activityId, l1: 'en', revalidate: true), isFalse);
+        await Future<void>.delayed(const Duration(milliseconds: 10));
+      });
+      expect(later, 0);
+    });
+
+    test('an unrelated activity is unaffected', () async {
+      await countingClient(
+        gone,
+        () => repo.getPlan('gone-neighbour', l1: 'en'),
+      );
+
+      final later = await countingClient(gone, () async {
+        final result = await repo.lookup('live-neighbour', l1: 'en');
+        expect(result.status, ActivityPlanLookupStatus.removed);
+      });
+      expect(
+        later,
+        1,
+        reason: 'one gone activity must not mute reads of every other id',
+      );
+    });
+  });
+
+  group('only a confirmed 404 suppresses', () {
+    test('a 5xx stays retryable', () async {
+      const activityId = 'flaky';
+
+      final first = await countingClient(unavailable, () async {
+        final result = await repo.lookup(activityId, l1: 'en');
+        expect(result.status, ActivityPlanLookupStatus.failed);
+      });
+      expect(first, 1);
+
+      final second = await countingClient(unavailable, () async {
+        final result = await repo.lookup(activityId, l1: 'en');
+        expect(result.status, ActivityPlanLookupStatus.failed);
+      });
+      expect(
+        second,
+        1,
+        reason:
+            'a transient failure is not terminal — the start page offers a '
+            'retry, and it has to be able to reach the backend',
+      );
+    });
+  });
+
+  group('resetBackoff', () {
+    test(
+      'clears the removed gate so an explicit refresh can re-check',
+      () async {
+        const activityId = 'gone-then-refreshed';
+
+        await countingClient(gone, () => repo.getPlan(activityId, l1: 'en'));
+        expect(
+          await countingClient(gone, () => repo.getPlan(activityId, l1: 'en')),
+          0,
+        );
+
+        repo.resetBackoff();
+        expect(
+          await countingClient(gone, () => repo.getPlan(activityId, l1: 'en')),
+          1,
+          reason:
+              'resetBackoff is the user-initiated-refresh seam; it must drop '
+              'every suppression the repo holds, not just the cooldowns',
+        );
+      },
+    );
+  });
+}

--- a/test/pangea/fake_pangea_controller.dart
+++ b/test/pangea/fake_pangea_controller.dart
@@ -5,27 +5,37 @@ import 'package:fluffychat/pangea/common/controllers/pangea_controller.dart';
 /// `MatrixState.isPangeaControllerInitialized` and serves a viewer L1.
 ///
 /// Repos gate their reads on that getter (#8339), so a test that wants the repo
-/// to actually reach the network path must install one of these. It has no
-/// access token, so the fetch still fails inside `BaseRepo._fetch`'s try/catch
-/// and surfaces as `Result.error` — the shape most repo tests want.
+/// to actually reach the network path must install one of these. By default it
+/// has no access token, so the fetch still fails inside `BaseRepo._fetch`'s
+/// try/catch and surfaces as `Result.error` — the shape most repo tests want.
+/// Pass [accessToken] when the test needs the request to be built and answered
+/// by an `http` MockClient instead.
 class FakePangeaController implements PangeaController {
   @override
   final UserController userController;
 
-  FakePangeaController({String? userL1Code = 'en'})
-    : userController = _FakeUserController(userL1Code);
+  FakePangeaController({String? userL1Code = 'en', String? accessToken})
+    : userController = _FakeUserController(userL1Code, accessToken);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;
 }
 
 class _FakeUserController implements UserController {
-  _FakeUserController(this._userL1Code);
+  _FakeUserController(this._userL1Code, this._accessToken);
 
   final String? _userL1Code;
+  final String? _accessToken;
 
   @override
   String? get userL1Code => _userL1Code;
+
+  /// Mirrors the real getter: non-nullable, and throws when the user is not
+  /// logged in — which is what makes the token-less default fail the fetch.
+  @override
+  String get accessToken =>
+      _accessToken ??
+      (throw "Trying to get accessToken with null token. User is not logged in.");
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;


### PR DESCRIPTION
### What

Move `ActivityPlanRepo`'s `_confirmedRemoved` gate from `ensure()` into `lookup()`, the shared read path, so a 404'd activity is requested at most once per id per app session regardless of entry point.

### Why

Closes #8359. Sentry [CLIENT-DWH](https://pangea-chat.sentry.io/issues/CLIENT-DWH) — 753 events / 9 users in 24h, all for a single activity id; related [CLIENT-DWD](https://pangea-chat.sentry.io/issues/CLIENT-DWD). Staging-only today, firing on the newest builds, so it ships to production on the next release if left alone.

`getPlan()` delegates to `lookup()` and `ensure()` calls `getPlan()`, so `lookup()` is the choke point every read passes through. With the gate only in `ensure()`, callers that reach `lookup()` / `getPlan()` directly — the activity start page, the summary read — walked past it and re-requested a known-gone activity for as long as the surface stayed open.

Behavior is unchanged from the caller's side: the gate answers `ActivityPlanLookupStatus.removed`, which is what the backend already said, so callers walk the same removed-activity fallback ladder ([activities.instructions.md](.github/instructions/activities.instructions.md#when-the-activity-cant-be-fetched)) — minus the round trip.

Three properties deliberately preserved:

- **Park-before-IO is untouched.** This is an extra pre-IO gate on a terminal outcome; `_nextAttempt` still parks in `ensure()` before the fetch, and no cooldown was added to `lookup()` — the start page's retry has to be able to reach the backend.
- **`ensure()` keeps its own early return.** It is no longer what makes the suppression correct, but it still stops a hydration that cannot succeed from spending a `_hydrating` slot and a 60s park, and lets callers observe `false`.
- **Only a confirmed 404 suppresses.** A 5xx/429/timeout stays retryable, so an outage can't mute healthy activities.

`resetBackoff()` now clears `_confirmedRemoved` too — it is the documented user-initiated-refresh seam ("must never be suppressed"), and nothing else can clear an id the repo refuses to re-request.

Sibling of #8358 (same defect class on the quest side), shipping separately per repo-independent deploys. No 429 backoff added to `QuestRepo` (#8360).

### Testing

- New `test/pangea/activity_plan_confirmed_removed_test.dart` (7 tests) drives the real singleton with an `http.MockClient` and counts requests that actually leave the client: 50 post-404 `lookup()` calls issue 0 requests; `getPlan()` and a pinned-version read are gated by the same id; `ensure()` still declines without touching the network; an unrelated id still fetches; a 5xx stays retryable; `resetBackoff()` re-opens the gate.
- Verified the suite fails against pre-fix code — 4 of the 7 fail (the first assertion reports 50 requests where the fix gives 0); the other 3 are guards that must pass both ways.
- `fvm flutter test` (full suite, pinned SDK 3.41.4): **2425 passed, 3 skipped, 0 failed**. The 3 skips are the choreo/synapse/CMS endpoint suites, which skip on `requires client/.env` — the worktree has no `.env`, so the usual 2 local credential failures did not occur.
- `fvm flutter analyze` clean on the changed files; `fvm dart format` run.
- Not manually exercised in a running app — the removed-activity path needs a backend 404, which is what the linked issue's TO TEST covers on staging.

### Deploy Notes

None.