### PR TITLE
fix(world): snapshot course spaces before the pinged scan

### DIFF
--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -288,15 +288,22 @@ class WorldMapPinsManager {
   /// for the host's recruit ping (carries `pangea.activity.id`), within a day.
   /// A ping leaves no persistent room state, so this proxy is intentionally
   /// approximate — its efficacy is worth watching (world-map.instructions.md).
+  ///
+  /// Reads the spaces through [ActivitySessionDiscovery.joinedCourseSpaces],
+  /// which snapshots `client.rooms` — load-bearing here, not just DRY (#8361,
+  /// CLIENT-DBW). The SDK mutates `client.rooms` IN PLACE from its sync handler
+  /// (`rooms.insert` on a join, `rooms.removeAt` on a leave), and this loop
+  /// awaits a timeline per space, so a lazy `where` view over that list threw
+  /// `Concurrent modification during iteration` when a course arrived or left
+  /// mid-scan — aborting the pass and stranding pinged pins stale until the
+  /// next clean one. The room list moving is correct SDK behaviour the map
+  /// can't block, so the scan reads a snapshot and picks up a course that
+  /// joined mid-pass on the next sync tick (which that join itself produces).
   Future<void> recomputePinged(Client client) async {
     final pinged = <String>{};
     final cutoff = DateTime.now().subtract(const Duration(hours: 24));
-    final spaces = client.rooms.where(
-      (r) =>
-          r.isSpace && r.membership == Membership.join && r.coursePlan != null,
-    );
 
-    for (final space in spaces) {
+    for (final space in client.joinedCourseRooms) {
       try {
         final timeline = await space.getTimeline();
         for (final e in timeline.events) {

--- a/test/pangea/world/world_map_pinged_concurrent_modification_test.dart
+++ b/test/pangea/world/world_map_pinged_concurrent_modification_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:matrix/matrix.dart';
+
+import 'package:fluffychat/features/course_plans/courses/course_plan_event.dart';
+import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
+import 'package:fluffychat/routes/world/world_map_pins_manager.dart';
+import '../get_test_client.dart';
+
+/// #8361 (Sentry CLIENT-DBW) — `recomputePinged` awaits `getTimeline()` once per
+/// course space, and the SDK's sync handler mutates `client.rooms` **in place**
+/// across those awaits (`rooms.insert` on a join, `rooms.removeAt` on a leave —
+/// `Client._handleRooms`). Iterating a lazy `client.rooms.where(...)` view over
+/// that list therefore threw `Concurrent modification during iteration`, aborting
+/// the scan partway and leaving pinged pins stale until the next clean pass.
+///
+/// The room list moving mid-scan is correct SDK behaviour and not something the
+/// map may block, so the scan reads a snapshot — these tests drive exactly the
+/// two mutations the sync path performs and assert the scan still completes.
+void main() {
+  late Client client;
+
+  const userId = '@test:fakeServer.notExisting';
+
+  setUp(() async {
+    client = await getTestClient();
+  });
+  tearDown(() async {
+    await client.dispose();
+  });
+
+  Event stateEvent(
+    Room room, {
+    required String type,
+    required Map<String, dynamic> content,
+    String stateKey = '',
+  }) => Event(
+    type: type,
+    content: content,
+    stateKey: stateKey,
+    senderId: userId,
+    eventId: '\$${type}_${room.id}_$stateKey',
+    originServerTs: DateTime.utc(2026, 1, 1),
+    room: room,
+  );
+
+  /// A joined course space — a space carrying a course plan, which is exactly
+  /// what the pinged scan selects out of `client.rooms`.
+  Room courseSpace(String id) {
+    final space = Room(id: id, client: client, membership: Membership.join);
+    space.setState(
+      stateEvent(
+        space,
+        type: EventTypes.RoomCreate,
+        content: {'type': RoomCreationTypes.mSpace},
+      ),
+    );
+    space.setState(
+      stateEvent(
+        space,
+        type: PangeaEventTypes.coursePlan,
+        content: CoursePlanEvent(uuid: 'quest-$id', l2: 'de').toJson(),
+      ),
+    );
+    client.rooms.add(space);
+    return space;
+  }
+
+  /// Several spaces, so the scan suspends on a `getTimeline()` await with more
+  /// of the collection still to walk — the window the sync handler writes into.
+  void seedCourseSpaces() {
+    for (var i = 0; i < 3; i++) {
+      courseSpace('!course$i:fakeServer.notExisting');
+    }
+  }
+
+  group('recomputePinged survives client.rooms moving mid-scan', () {
+    test(
+      'a course joined during the scan (the SDK sync-path rooms.insert)',
+      () {
+        seedCourseSpaces();
+        final manager = WorldMapPinsManager();
+
+        // Not awaited: the scan is now suspended on its first getTimeline().
+        final scan = manager.recomputePinged(client);
+        courseSpace('!joinedMidScan:fakeServer.notExisting');
+
+        expect(scan, completes);
+      },
+    );
+
+    test(
+      'a course left during the scan (the SDK sync-path rooms.removeAt)',
+      () {
+        seedCourseSpaces();
+        final manager = WorldMapPinsManager();
+
+        final scan = manager.recomputePinged(client);
+        client.rooms.removeLast();
+
+        expect(scan, completes);
+      },
+    );
+
+    test('a non-course room arriving during the scan — the list it walks is '
+        'the whole of client.rooms, so any room update is a mutation', () {
+      seedCourseSpaces();
+      final manager = WorldMapPinsManager();
+
+      final scan = manager.recomputePinged(client);
+      client.rooms.add(
+        Room(
+          id: '!chat:fakeServer.notExisting',
+          client: client,
+          membership: Membership.join,
+        ),
+      );
+
+      expect(scan, completes);
+    });
+  });
+}


### PR DESCRIPTION
### What

`WorldMapPinsManager.recomputePinged` now reads its course spaces from the existing `joinedCourseRooms` extension (an eager snapshot) instead of iterating a lazy `client.rooms.where(...)` view across its per-space `await`.

### Why

Closes #8361. Sentry: CLIENT-DBW.

The mutation source is the **Matrix SDK's own sync handler**, which mutates `client.rooms` **in place** — `rooms.insert` when a room is joined, `rooms.removeAt` when one is left (`Client._handleRooms`). The scan awaits `getTimeline()` once per space, so a course arriving or leaving during that await changed the list's length and the lazy `where` iterator threw `Concurrent modification during iteration` on its next `moveNext()`.

Not re-entrancy: `recomputePinged` never writes `client.rooms`, and concurrent runs of it only build local sets. The writer is the SDK, whose behaviour is correct and not something the map may block — so a snapshot is the right level, not a mask over a re-entrancy bug. A course that joins mid-pass is picked up on the next sync tick, which that join itself produces.

The design being implemented (best-effort pinged detection by scanning recent course-space messages) is unchanged — see world-map.instructions.md, "Pin state".

Sibling call sites were checked and already snapshot before their awaits (`loadSessionParticipants`, `discoverCoursemateSessions`, `activity_course_resolver`); `recomputePinged` was the only instance.

### Testing

- **New regression test** — `test/pangea/world/world_map_pinged_concurrent_modification_test.dart`. Written first, and confirmed to reproduce the exact Sentry signature against the unfixed code (`Concurrent modification during iteration ... WhereIterator.moveNext at world_map_pins_manager.dart:299`) in all three cases. Each drives one of the mutations the SDK sync path actually performs — a course joined mid-scan, a course left mid-scan, an unrelated room arriving mid-scan — and asserts the scan completes. All 3 pass with the fix.
- **Full unit/widget suite** — `fvm flutter test`: **2421 passed, 3 skipped, 0 failed**. The 3 skips are the choreo/synapse/CMS endpoint suites, which skip by design when `client/.env` is absent (none in a fresh worktree).
- `fvm flutter analyze lib/routes/world/ test/pangea/world/` — no issues. Formatted with the `.fvmrc`-pinned SDK (3.41.4).
- No smoke/eval/load bucket: the change touches no network, LLM, or paid-call surface.

### Deploy Notes

None.
