### PR TITLE
fix(quests): honor 429 backoff on quest activity reads

### DIFF
--- a/lib/features/quests/repo/activity_map_repo.dart
+++ b/lib/features/quests/repo/activity_map_repo.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
 
 import 'package:flutter_map/flutter_map.dart';
+import 'package:http/http.dart' as http;
 
 import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/widgets/matrix.dart';
@@ -15,13 +17,20 @@ class ActivityMapRepo {
   /// Thin pins whose coordinates fall within [bounds], optionally scoped to a
   /// target language [l2]. Card text is canonical-only — thin lists never
   /// translate (choreo #2736); large-card titles localize via plan hydration.
-  /// Returns up to [limit] placed activities; an empty list on any error so the
-  /// map stays usable.
-  static Future<List<QuestActivityCard>> bboxPins({
+  /// Returns up to [limit] placed activities.
+  ///
+  /// **Null means the read was not made** — choreo rate-limited us and
+  /// [QuestRepo.activityReadPause] is running (#8360). Distinct from an empty
+  /// list, which means the viewport genuinely holds no activities: the caller
+  /// must keep the pins it already has rather than blank the map for the whole
+  /// pause. Panning is what fires this read, so a per-viewport backoff would
+  /// be no backoff at all.
+  static Future<List<QuestActivityCard>?> bboxPins({
     required LatLngBounds bounds,
     String? l2,
     int limit = 200,
   }) async {
+    if (QuestRepo.activityReadPause.isPaused) return null;
     final params = <String, String>{
       'min_lat': '${bounds.south}',
       'min_lng': '${bounds.west}',
@@ -34,9 +43,17 @@ class ActivityMapRepo {
       PApiUrls.activitiesBbox,
     ).replace(queryParameters: params);
 
-    final response = await Requests(
-      accessToken: MatrixState.pangeaController.userController.accessToken,
-    ).get(url: uri.toString());
+    final http.Response response;
+    try {
+      response = await Requests(
+        accessToken: MatrixState.pangeaController.userController.accessToken,
+      ).get(url: uri.toString());
+    } catch (e) {
+      // Arms the shared pause, then lets the failure surface exactly as before
+      // — this repo does not own the reporting or the empty-map fallback.
+      QuestRepo.activityReadPause.recordFailure(e);
+      rethrow;
+    }
     if (response.statusCode != 200) return const [];
 
     final decoded = jsonDecode(response.body);

--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -15,6 +15,7 @@ import 'package:fluffychat/features/quests/models/quest_plan_model.dart';
 import 'package:fluffychat/features/quests/repo/activity_v2_mapper.dart';
 import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+import 'package:fluffychat/pangea/common/network/rate_limit_pause.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -187,13 +188,30 @@ class QuestRepo {
     };
   }
 
+  /// Repo-wide pause after choreo rate-limits the activity reads (#8360).
+  ///
+  /// [RateLimitPause] carries the reasoning; what this instance decides is its
+  /// SCOPE. Shared with `ActivityMapRepo` because the world map fires both
+  /// reads — the course-scoped quest listing here and the viewport bbox query
+  /// there — against the same `/choreo` activities budget, so honouring a 429
+  /// on one while hammering the other honours nothing. Not shared any wider:
+  /// choreo meters `/subscription` separately, and an activity 429 must never
+  /// stall checkout. `ActivityPlanRepo` holds its own for the same reason.
+  static final RateLimitPause activityReadPause = RateLimitPause();
+
   /// The quest's activities from the choreo course listing — the
   /// membership-aware read that may include the quest owner's private
   /// activities when [courseRoomId] names a course the caller has joined.
+  ///
+  /// Returns a [RateLimitedException] WITHOUT asking while
+  /// [activityReadPause] is running, and without reporting: the 429 that
+  /// started the pause was already captured once, and a second event for our
+  /// own deliberate suppression would be noise, not signal.
   static Future<Result<List<Map<String, dynamic>>>> _questActivityEntries(
     String questId, {
     String? courseRoomId,
   }) async {
+    if (activityReadPause.isPaused) return Result.error(RateLimitedException());
     try {
       final uri = Uri.parse(PApiUrls.questActivities(questId)).replace(
         queryParameters: {
@@ -213,6 +231,8 @@ class QuestRepo {
         questActivityEntriesFromJson(jsonDecode(response.body)),
       );
     } catch (e, s) {
+      // Before the report, so the pause is armed even if reporting throws.
+      activityReadPause.recordFailure(e);
       ErrorHandler.logError(
         e: e,
         s: s,

--- a/lib/pangea/common/network/rate_limit_pause.dart
+++ b/lib/pangea/common/network/rate_limit_pause.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/foundation.dart';
+
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+
+/// A read that was suppressed by a [RateLimitPause] rather than attempted.
+///
+/// Typed so a caller can tell "we deliberately did not ask" from "the request
+/// failed": the two want opposite handling on a display surface — a failure
+/// may empty it, a suppression must leave what is already there alone. The
+/// `toString()` matters for the same reason it does on `MissingQuestException`
+/// — without it any report arrives in Sentry as
+/// `Instance of 'RateLimitedException'` (repos-and-error-handling doc).
+class RateLimitedException implements Exception {
+  @override
+  String toString() =>
+      'RateLimitedException: read suppressed — the backend returned 429';
+}
+
+/// A repo-wide pause after the backend rate-limits us (HTTP 429).
+///
+/// A 429 is a statement about RATE, not about the key that happened to see it,
+/// so it pauses every read on the budget rather than that one key. Per-key
+/// backoff structurally cannot honour it: the world map hydrates one key per
+/// visible pin, so K keys each backing off independently still emit
+/// K/cooldown requests — at the 2026-08-04 incident's K=104 that is 104/min
+/// against a 60/min budget, still saturated. Only a pause that ignores the key
+/// restores the invariant "we stop when the server says stop", independent of
+/// K. `ActivityPlanRepo` reached the same conclusion first (#8160) and keeps
+/// its equivalent state inline.
+///
+/// **One instance per budget, never one global instance.** Choreo meters
+/// `/choreo` and `/subscription` separately, so an activity 429 must never
+/// stall checkout. The boundary that matters is the budget, not the class:
+/// reads that the same limiter counts together share an instance, and reads it
+/// counts apart never do.
+class RateLimitPause {
+  RateLimitPause([this.duration = defaultDuration]);
+
+  /// Matches the pause `ActivityPlanRepo` applies to the sibling activity read
+  /// and the window choreo's limiter meters over.
+  static const Duration defaultDuration = Duration(seconds: 60);
+
+  final Duration duration;
+
+  /// Earliest wall-clock time reads on this budget may resume.
+  DateTime? _until;
+
+  /// Test seam: the pause's clock. Backoff is wall-clock, so tests would
+  /// otherwise need real delays.
+  @visibleForTesting
+  static DateTime Function() now = DateTime.now;
+
+  /// Whether reads on this budget are currently suppressed. Clears itself once
+  /// the window has lapsed — a throttle is transient, never terminal.
+  bool get isPaused {
+    final until = _until;
+    if (until == null) return false;
+    if (now().isBefore(until)) return true;
+    _until = null;
+    return false;
+  }
+
+  /// Starts the pause when [error] is the backend asking us to stop (429).
+  /// Any other failure says something about the request, not about our rate:
+  /// pausing on those would let one bad row take down every read on the
+  /// budget.
+  void recordFailure(Object? error) {
+    if (PangeaHttpException.statusCodeOf(error) == 429) {
+      _until = now().add(duration);
+    }
+  }
+
+  /// Drops the pause. For tests, and for an explicit user-initiated refresh,
+  /// which must never be suppressed.
+  void reset() => _until = null;
+}

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -19,6 +19,7 @@ import 'package:fluffychat/features/quests/repo/activity_map_repo.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
 import 'package:fluffychat/features/room_summaries/activity_session_previews_extension.dart';
 import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
+import 'package:fluffychat/pangea/common/network/rate_limit_pause.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/world/joined_objective_cache.dart';
 import 'package:fluffychat/routes/world/world_map_client_extension.dart';
@@ -669,6 +670,10 @@ class WorldMapPinsManager {
     );
     final activityCards = activityCardsResult.result;
     if (activityCards == null) {
+      // A rate-limit pause means we never asked (#8360), so the course is not
+      // known to be empty — hold the pins we have instead of blanking the map
+      // for the length of the pause. Any real failure still empties it.
+      if (activityCardsResult.error is RateLimitedException) return;
       _pins = [];
       return;
     }
@@ -713,6 +718,10 @@ class WorldMapPinsManager {
     String? l2,
     String? l1,
   }) async {
-    _pins = await ActivityMapRepo.bboxPins(bounds: bounds, l2: l2);
+    final pins = await ActivityMapRepo.bboxPins(bounds: bounds, l2: l2);
+    // Null is "suppressed by the rate-limit pause", not "no activities here"
+    // (#8360) — keep the current pins rather than blanking the map.
+    if (pins == null) return;
+    _pins = pins;
   }
 }

--- a/test/pangea/quests/quest_activity_rate_limit_test.dart
+++ b/test/pangea/quests/quest_activity_rate_limit_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter_map/flutter_map.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+
+import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
+import 'package:fluffychat/features/quests/repo/activity_map_repo.dart';
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+import 'package:fluffychat/pangea/common/network/rate_limit_pause.dart';
+import 'package:fluffychat/widgets/future_loading_dialog.dart';
+
+/// #8360. The repo-wide 429 pause shipped in #8160 lived only in
+/// `ActivityPlanRepo`, so a 429 on the quest-activity reads was not honoured —
+/// the client kept issuing requests the server had already asked it to stop
+/// sending (Sentry CLIENT-DXS, CLIENT-E7P, CLIENT-DP3).
+///
+/// The reasoning carries over unchanged: backoff must be repo-wide, never per
+/// key. The world map fires one read per visible pin, so K keys each backing
+/// off independently still emit K/cooldown requests and blow the budget on
+/// their own.
+///
+/// These tests never touch the network. That is the point — a suppressed read
+/// must return its "we did not ask" answer *before* it reaches `Requests` (or
+/// even `MatrixState.pangeaController`), so an unconfigured test binding is
+/// itself proof the request was never issued.
+void main() {
+  var clock = DateTime(2026, 8, 14, 12);
+
+  setUp(() {
+    clock = DateTime(2026, 8, 14, 12);
+    RateLimitPause.now = () => clock;
+    QuestRepo.activityReadPause.reset();
+  });
+
+  tearDownAll(() {
+    RateLimitPause.now = DateTime.now;
+    QuestRepo.activityReadPause.reset();
+  });
+
+  PangeaHttpException http(int status) =>
+      PangeaHttpException(statusCode: status, method: 'GET', path: '/choreo');
+
+  group('RateLimitPause', () {
+    test('starts unpaused', () {
+      expect(RateLimitPause().isPaused, isFalse);
+    });
+
+    test('a 429 starts the pause', () {
+      final pause = RateLimitPause();
+      pause.recordFailure(http(429));
+      expect(pause.isPaused, isTrue);
+    });
+
+    test('only a 429 starts it — other failures are not backpressure', () {
+      // A 500 or a 404 says something about the request, not about our rate.
+      // Pausing every read on them would turn one bad row into a dead surface.
+      for (final status in [404, 500, 503]) {
+        final pause = RateLimitPause();
+        pause.recordFailure(http(status));
+        expect(
+          pause.isPaused,
+          isFalse,
+          reason: '$status is not the server asking us to slow down',
+        );
+      }
+      final pause = RateLimitPause();
+      pause.recordFailure(Exception('socket closed'));
+      expect(pause.isPaused, isFalse);
+    });
+
+    test('the pause lifts on its own — a throttle is not terminal', () {
+      final pause = RateLimitPause(const Duration(seconds: 60));
+      pause.recordFailure(http(429));
+      expect(pause.isPaused, isTrue);
+
+      clock = clock.add(const Duration(seconds: 59));
+      expect(pause.isPaused, isTrue);
+
+      clock = clock.add(const Duration(seconds: 2));
+      expect(pause.isPaused, isFalse);
+    });
+
+    test(
+      'reset drops the pause, so a user-initiated refresh is never held',
+      () {
+        final pause = RateLimitPause();
+        pause.recordFailure(http(429));
+        pause.reset();
+        expect(pause.isPaused, isFalse);
+      },
+    );
+
+    test('instances are independent — one budget never stalls another', () {
+      // Choreo meters `/choreo` and `/subscription` separately, so an activity
+      // 429 must never stall checkout.
+      final activities = RateLimitPause();
+      final other = RateLimitPause();
+      activities.recordFailure(http(429));
+
+      expect(activities.isPaused, isTrue);
+      expect(other.isPaused, isFalse);
+    });
+  });
+
+  group('QuestRepo.questActivityCards', () {
+    test('is suppressed while the repo is paused', () async {
+      QuestRepo.activityReadPause.recordFailure(http(429));
+
+      final result = await QuestRepo.questActivityCards('quest-1');
+
+      expect(result.isError, isTrue);
+      expect(
+        result.error,
+        isA<RateLimitedException>(),
+        reason:
+            'a suppressed read must be distinguishable from a failed one — '
+            'the caller keeps what it has rather than blanking the surface',
+      );
+    });
+
+    test('the pause is repo-wide, not per quest', () async {
+      // The whole defect: K quests each backing off independently still emit
+      // K/cooldown requests, which at world-map K exceeds the budget alone.
+      QuestRepo.activityReadPause.recordFailure(http(429));
+
+      for (final questId in ['q-a', 'q-b', 'q-c']) {
+        final result = await QuestRepo.questActivityCards(questId);
+        expect(
+          result.error,
+          isA<RateLimitedException>(),
+          reason: '$questId must not issue a request while paused',
+        );
+      }
+    });
+
+    test(
+      'suppression is time-boxed — reads resume once the pause lapses',
+      () async {
+        QuestRepo.activityReadPause.recordFailure(http(429));
+        expect(
+          (await QuestRepo.questActivityCards('quest-1')).error,
+          isA<RateLimitedException>(),
+        );
+
+        clock = clock.add(RateLimitPause.defaultDuration);
+        clock = clock.add(const Duration(seconds: 1));
+
+        // Asserted on the pause rather than by calling through again: past this
+        // point the read proceeds to the real network path, which a plain test
+        // binding cannot serve. What matters is that the gate has reopened — a
+        // 429 must throttle the client, never permanently mute a surface.
+        expect(QuestRepo.activityReadPause.isPaused, isFalse);
+      },
+    );
+  });
+
+  group('ActivityMapRepo.bboxPins', () {
+    final bounds = LatLngBounds(const LatLng(0, 0), const LatLng(1, 1));
+
+    test('shares the quest-activity pause — one budget, one pause', () async {
+      // The world map fires both reads: the course-scoped quest listing and
+      // this viewport query. They meter against the same `/choreo` activities
+      // budget, so honouring a 429 on one while hammering the other honours
+      // nothing.
+      QuestRepo.activityReadPause.recordFailure(http(429));
+
+      expect(await ActivityMapRepo.bboxPins(bounds: bounds), isNull);
+    });
+
+    test('returns null, never an empty list, when suppressed', () async {
+      // Null means "we did not ask"; an empty list means "the viewport has no
+      // activities". Conflating them blanks the map for the whole pause, which
+      // is exactly the silent-empty failure #8360's TO TEST guards against.
+      QuestRepo.activityReadPause.recordFailure(http(429));
+
+      final pins = await ActivityMapRepo.bboxPins(bounds: bounds);
+      expect(pins, isNull);
+      expect(
+        pins,
+        isNot(const <QuestActivityCard>[]),
+        reason: 'an empty list here would blank the map for the whole pause',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Give the quest-activity reads the repo-wide 429 pause that `ActivityPlanRepo` has had since #8160, so a 429 on `/choreo/quests/{id}/activities` actually stops the client from asking.

- New `RateLimitPause` (`lib/pangea/common/network/rate_limit_pause.dart`) — the pause from #8160 as a reusable unit: armed only by a 429, self-clearing after 60s, with an injectable clock and a `reset()` so tests and user-initiated refreshes are never held. `ActivityPlanRepo` keeps its own inline copy; this PR does not touch that file.
- `QuestRepo.activityReadPause` — one instance, consulted before `_questActivityEntries` issues anything and armed from its catch. A suppressed read returns `RateLimitedException` **without** reporting: the 429 that started the pause was already captured once, and a second event for our own deliberate suppression is noise.
- `ActivityMapRepo.bboxPins` shares that instance and now returns `List?`. **Null means "we did not ask"**, distinct from an empty list meaning "the viewport has no activities" — so `WorldMapPinsManager` holds the pins it has instead of blanking the map for the length of the pause. Same guard on the course-scoped path; any real failure still empties it as before.

Scope of the sharing is the **budget, not the class**: choreo meters `/choreo` and `/subscription` separately, and both of these are `/choreo` activity reads fired by the same world map, so honoring a 429 on one while hammering the other honors nothing. Nothing wider is touched — an activity 429 still must never stall checkout, which is the separation #8160's comment calls out.

Why repo-wide rather than per key is unchanged from #8160: the map hydrates one key per visible pin, so K keys each backing off independently still emit K/cooldown requests and exceed the budget on their own.

## Why

Closes #8360. Sentry: [CLIENT-DXS](https://pangea-chat.sentry.io/issues/CLIENT-DXS), [CLIENT-E7P](https://pangea-chat.sentry.io/issues/CLIENT-E7P), [CLIENT-DP3](https://pangea-chat.sentry.io/issues/CLIENT-DP3) (the bbox read, which is why `ActivityMapRepo` is in scope here).

Related to #8358 and #8359, both in flight in parallel. Those retire refetch *loops* that generate much of this 429 volume; this one is independent of whatever causes the load — honoring server backpressure is correct on its own, and stays correct after they land. Deliberately no overlap: this PR does not touch `ActivityPlanRepo` (#8359) or the quest 404-caching logic in `QuestRepo.outline`/`quest` (#8358).

## Testing

- New `test/pangea/quests/quest_activity_rate_limit_test.dart` — 13 tests, all passing. Covers: only a 429 arms the pause (404/500/503 and a non-HTTP error do not, so one bad row can't kill a surface); it lifts on its own; `reset()` releases it; instances are independent (the checkout separation); `questActivityCards` is suppressed repo-wide across distinct quest ids; `bboxPins` shares the pause and returns null rather than an empty list. The tests never touch the network — a suppressed read must answer before it reaches `Requests` or `MatrixState.pangeaController`, so an unconfigured binding is itself proof no request was issued.
- Full local suite (`fvm flutter test`): **2429 pass, 3 skip, 0 fail**. Two skips are the `.env`-dependent endpoint suites (`Skip: requires client/.env` — this is a fresh worktree with no `.env`), the third is a pre-existing unprojectable-candidate skip in `world_map_placement_test`. None are related to this change.
- `fvm flutter analyze` clean over `lib/features/quests`, `lib/pangea/common/network`, `lib/routes/world`, `test/pangea/quests`; `fvm dart format` and `import_sorter` clean.
- Not run: staging verification. The issue's TO TEST (heavy world-map panning, then course missions / activity start page) is the behavioral check and is best done against a deployed build.

## Deploy Notes

None.
