### PR TITLE
fix(errors): throw typed HTTP failures at the last three raw-Response sites

### DIFF
--- a/lib/features/activity_sessions/activity_summary_repo.dart
+++ b/lib/features/activity_sessions/activity_summary_repo.dart
@@ -7,6 +7,7 @@ import 'package:http/http.dart';
 import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_summary_request_model.dart';
 import 'package:fluffychat/features/activity_sessions/activity_summary_response_model.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
@@ -77,8 +78,10 @@ class ActivitySummaryRepo {
         body: request.toJson(),
       );
 
+      // `req.post` already threw typed for anything ≥ 400, so this only guards
+      // a success status the parser cannot consume (201/202/204/3xx).
       if (res.statusCode != 200) {
-        throw res;
+        throw PangeaHttpException.fromResponse(res);
       }
 
       final decodedBody = jsonDecode(utf8.decode(res.bodyBytes));
@@ -89,6 +92,7 @@ class ActivitySummaryRepo {
           e: e,
           s: s,
           data: {'activity_summary_request': request.toJson()},
+          level: PangeaHttpException.severityOf(e),
         );
       }
       return Result.error(e);

--- a/lib/features/analytics_access/grant_analytics_access_extension.dart
+++ b/lib/features/analytics_access/grant_analytics_access_extension.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:http/http.dart';
 import 'package:matrix/matrix_api_lite/generated/api.dart';
 
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+
 extension GrantAnalyticsAccessExtension on Api {
   Future<void> grantInstructorAnalyticsAccess(
     String courseRoomId,
@@ -22,7 +24,12 @@ extension GrantAnalyticsAccessExtension on Api {
     );
     final response = await httpClient.send(request);
     if (response.statusCode != 200) {
-      throw response;
+      // This call bypasses `Requests` (Synapse endpoint, Matrix SDK client and
+      // token), so it raises the typed failure itself rather than throwing the
+      // response — see repos-and-error-handling.instructions.md.
+      throw PangeaHttpException.fromResponse(
+        await Response.fromStream(response),
+      );
     }
   }
 }

--- a/lib/features/analytics_access/join_room_analytics_access_extension.dart
+++ b/lib/features/analytics_access/join_room_analytics_access_extension.dart
@@ -11,6 +11,7 @@ import 'package:fluffychat/features/course_plans/courses/course_plan_room_extens
 import 'package:fluffychat/features/languages/language_model.dart';
 import 'package:fluffychat/features/languages/p_language_store.dart';
 import 'package:fluffychat/features/quests/repo/quest_plans_repo.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
 
@@ -206,7 +207,12 @@ extension JoinRoomAnalyticsAccessClientExtension on Client {
 
       await grantInstructorAnalyticsAccess(roomId, analyticsRoomId);
     } catch (e, s) {
-      ErrorHandler.logError(e: e, s: s, data: {"joining_room_id": roomId});
+      ErrorHandler.logError(
+        e: e,
+        s: s,
+        data: {"joining_room_id": roomId},
+        level: PangeaHttpException.severityOf(e),
+      );
     }
   }
 
@@ -245,6 +251,7 @@ extension JoinRoomAnalyticsAccessClientExtension on Client {
           "analytics_room_id": analyticsRoomId,
           "analytics_lang_code": analyticsLangCode,
         },
+        level: PangeaHttpException.severityOf(e),
       );
     }
   }

--- a/lib/routes/onboarding/course_provider.dart
+++ b/lib/routes/onboarding/course_provider.dart
@@ -11,7 +11,6 @@ import 'package:fluffychat/routes/onboarding/custom_course_response_model.dart';
 import 'package:fluffychat/routes/onboarding/onboarding_client_extension.dart';
 import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
 import 'package:fluffychat/widgets/future_loading_dialog.dart';
-import 'package:fluffychat/widgets/matrix.dart';
 
 abstract class CourseProvider {
   String? getCachedJoinCode();
@@ -67,10 +66,7 @@ class ClientCourseProvider implements CourseProvider {
   @override
   Future<Result<CustomCourseResponseModel>> requestCustomCourse(
     CustomCourseRequestModel request,
-  ) => CustomCourseRepo.get(
-    request,
-    MatrixState.pangeaController.userController.accessToken,
-  );
+  ) => CustomCourseRepo.instance.get(request);
 }
 
 class MockCourseProvider implements CourseProvider {

--- a/lib/routes/onboarding/custom_course_repo.dart
+++ b/lib/routes/onboarding/custom_course_repo.dart
@@ -1,61 +1,32 @@
-import 'dart:convert';
-
-import 'package:async/async.dart';
 import 'package:http/http.dart';
 
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
-import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+import 'package:fluffychat/pangea/common/utils/base_repo.dart';
+import 'package:fluffychat/pangea/common/utils/memory_repo_cache.dart';
 import 'package:fluffychat/routes/onboarding/custom_course_request_model.dart';
 import 'package:fluffychat/routes/onboarding/custom_course_response_model.dart';
 
-class CustomCourseRepo {
-  static final Map<String, Future<Result<CustomCourseResponseModel>>> _cache =
-      {};
-
-  static Future<Result<CustomCourseResponseModel>> get(
-    CustomCourseRequestModel request,
-    String accessToken,
-  ) async {
-    final key = request.storageKey;
-
-    final cached = _cache[key];
-    if (cached != null) {
-      return cached;
-    }
-
-    final future = _fetch(request, accessToken);
-    _cache[key] = future;
-    final result = await future;
-
-    _cache.remove(key);
-    return result;
-  }
-
-  static Future<Result<CustomCourseResponseModel>> _fetch(
-    CustomCourseRequestModel request,
-    String accessToken,
-  ) async {
-    try {
-      final Requests req = Requests(accessToken: accessToken);
-      final Response res = await req.post(
-        url: PApiUrls.requestCustomCourse,
-        body: request.toJson(),
+class CustomCourseRepo
+    extends BaseRepo<CustomCourseRequestModel, CustomCourseResponseModel> {
+  CustomCourseRepo._internal()
+    : super(
+        cache: MemoryRepoCache(),
+        responseFromJson: CustomCourseResponseModel.fromJson,
+        cacheDuration: Duration.zero,
       );
 
-      if (res.statusCode != 200) {
-        throw res;
-      }
+  static final CustomCourseRepo _instance = CustomCourseRepo._internal();
+  static CustomCourseRepo get instance => _instance;
 
-      final Map<String, dynamic> json = jsonDecode(
-        utf8.decode(res.bodyBytes).toString(),
-      );
+  @override
+  Future<Response> fetch(Requests req, CustomCourseRequestModel request) =>
+      req.post(url: PApiUrls.requestCustomCourse, body: request.toJson());
 
-      final resp = CustomCourseResponseModel.fromJson(json);
-      return Result.value(resp);
-    } catch (e, s) {
-      ErrorHandler.logError(e: e, s: s, data: request.toJson());
-      return Result.error(e);
-    }
-  }
+  /// A submitted request is never memoized: each submission is its own backend
+  /// side effect, and the `generating` status it returns is stale the moment it
+  /// lands. `BaseRepo`'s in-flight dedupe still collapses a double-tap into one
+  /// POST, which is the only sharing this repo ever wanted.
+  @override
+  bool shouldCache(CustomCourseResponseModel response) => false;
 }

--- a/lib/routes/onboarding/custom_course_request_model.dart
+++ b/lib/routes/onboarding/custom_course_request_model.dart
@@ -1,7 +1,8 @@
 import 'package:fluffychat/pangea/common/constants/model_keys.dart';
+import 'package:fluffychat/pangea/common/utils/base_request.dart';
 import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
 
-class CustomCourseRequestModel {
+class CustomCourseRequestModel extends BaseRequest {
   final String name;
   final String languagePair;
   final LanguageLevelTypeEnum languageLevel;
@@ -10,7 +11,7 @@ class CustomCourseRequestModel {
   final String? notes;
   final bool? mock;
 
-  const CustomCourseRequestModel({
+  CustomCourseRequestModel({
     required this.name,
     required this.languagePair,
     required this.languageLevel,
@@ -20,9 +21,11 @@ class CustomCourseRequestModel {
     this.notes,
   });
 
+  @override
   String get storageKey =>
       "course-request-$name-$languagePair-${languageLevel.name}-$institution-$goals-$notes";
 
+  @override
   Map<String, dynamic> toJson() => {
     "name": name,
     "language_pair": languagePair,

--- a/lib/routes/onboarding/custom_course_response_model.dart
+++ b/lib/routes/onboarding/custom_course_response_model.dart
@@ -1,4 +1,6 @@
-class CustomCourseResponseModel {
+import 'package:fluffychat/pangea/common/utils/base_response.dart';
+
+class CustomCourseResponseModel extends BaseResponse {
   final String id;
   final String status;
 
@@ -7,4 +9,7 @@ class CustomCourseResponseModel {
   static CustomCourseResponseModel fromJson(Map<String, dynamic> json) {
     return CustomCourseResponseModel(id: json["id"], status: json["status"]);
   }
+
+  @override
+  Map<String, dynamic> toJson() => {"id": id, "status": status};
 }

--- a/test/pangea/activity_summary_repo_error_test.dart
+++ b/test/pangea/activity_summary_repo_error_test.dart
@@ -1,0 +1,173 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'package:fluffychat/features/activity_sessions/activity_media_enum.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_model.dart';
+import 'package:fluffychat/features/activity_sessions/activity_plan_request.dart';
+import 'package:fluffychat/features/activity_sessions/activity_summary_repo.dart';
+import 'package:fluffychat/features/activity_sessions/activity_summary_request_model.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'fake_pangea_controller.dart';
+
+/// `ActivitySummaryRepo` threw the raw `http.Response` on a non-200 and
+/// reported every failure at the default `error` level (#8362).
+///
+/// Two failure shapes reach the same `catch`, and both are covered here:
+/// `Requests` throws typed for anything ≥ 400, and the repo's own guard now
+/// throws typed for a *success* status the parser cannot consume (201/202/204),
+/// which is the only case that guard can still fire on. The `MockClient` is
+/// installed for the zone, so `Requests` runs for real.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const choreoApi = 'https://api.test.pangea.chat';
+  const summaryPath = '/choreo/activity_summary';
+  const roomId = '!activity:staging.pangea.chat';
+
+  setUpAll(() async {
+    final tempDir = await Directory.systemTemp.createTemp('summary_repo_test');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (methodCall) async => tempDir.path,
+        );
+    await GetStorage.init('env_override');
+    MatrixState.pangeaController = FakePangeaController(
+      accessToken: 'syt_test_token',
+    );
+  });
+
+  setUp(() => dotenv.testLoad(mergeWith: {'CHOREO_API': choreoApi}));
+
+  /// A distinct activity per call — the repo memoizes successes for 10 minutes
+  /// on roomId + activityId + langCode.
+  var seq = 0;
+  ActivitySummaryRequestModel request() => ActivitySummaryRequestModel(
+    activity: ActivityPlanModel(
+      req: ActivityPlanRequest(
+        topic: 'jobs',
+        mode: 'Roleplay',
+        objective: 'introduce yourself',
+        media: MediaEnum.nan,
+        cefrLevel: LanguageLevelTypeEnum.a1,
+        languageOfInstructions: 'en',
+        targetLanguage: 'de',
+        numberOfParticipants: 2,
+      ),
+      title: 'Speed-Dating Interview',
+      learningObjective: 'lo',
+      instructions: 'i',
+      vocab: const [],
+      activityId: 'act-${seq++}',
+    ),
+    activityResults: const [],
+    contentFeedback: const [],
+  );
+
+  Future<Object?> fetchError(int status, {String body = ''}) async {
+    final result = await runWithClient(
+      () => ActivitySummaryRepo.get(roomId, request()),
+      () => MockClient(
+        (request) async => Response(body, status, request: request),
+      ),
+    );
+    return result.asError?.error;
+  }
+
+  group('a failed summary fetch', () {
+    test('surfaces as Result.error, never as a throw', () async {
+      final result = await runWithClient(
+        () => ActivitySummaryRepo.get(roomId, request()),
+        () =>
+            MockClient((request) async => Response('', 500, request: request)),
+      );
+
+      expect(result.isError, isTrue);
+      expect(result.asError!.error, isA<PangeaHttpException>());
+    });
+
+    test('a 4xx/5xx is typed, never the raw response', () async {
+      final error = await fetchError(504);
+
+      expect(error, isA<PangeaHttpException>());
+      expect(error, isNot(isA<BaseResponse>()));
+      expect(error.toString(), isNot(contains('Instance of')));
+    });
+
+    test('toString carries status, method, and normalized path', () async {
+      expect(
+        (await fetchError(500)).toString(),
+        'PangeaHttpException: 500 POST $summaryPath',
+      );
+    });
+
+    test('a non-200 success status is typed too', () async {
+      // The only case the repo's own guard can still fire on: `Requests` has
+      // already thrown for everything ≥ 400, so a 202 with no parseable body
+      // is what reaches it. Before #8362 this threw the response itself.
+      for (final status in [201, 202, 204]) {
+        final error = await fetchError(status);
+        expect(error, isA<PangeaHttpException>());
+        expect(
+          error.toString(),
+          'PangeaHttpException: $status POST $summaryPath',
+        );
+      }
+    });
+
+    test('is reported at the shared severity table level', () async {
+      for (final status in [401, 404, 410, 429]) {
+        expect(
+          PangeaHttpException.severityOf(await fetchError(status)),
+          SentryLevel.warning,
+          reason: '$status is routine, not a page',
+        );
+      }
+      for (final status in [400, 403, 422, 500, 502]) {
+        expect(
+          PangeaHttpException.severityOf(await fetchError(status)),
+          SentryLevel.error,
+          reason: '$status is a code bug or a backend regression',
+        );
+      }
+    });
+
+    test('never carries the response body', () async {
+      final error =
+          await fetchError(
+                500,
+                body: jsonEncode({'summary': 'learner conversation text'}),
+              )
+              as PangeaHttpException;
+
+      expect(error.detail, isNull);
+      expect(error.toString(), isNot(contains('learner conversation text')));
+    });
+  });
+
+  test('a 200 parses into the response model', () async {
+    final result = await runWithClient(
+      () => ActivitySummaryRepo.get(roomId, request()),
+      () => MockClient(
+        (request) async => Response(
+          jsonEncode({'participants': [], 'summary': 'Gut gemacht!'}),
+          200,
+          request: request,
+        ),
+      ),
+    );
+
+    expect(result.asValue!.value.summary, 'Gut gemacht!');
+  });
+}

--- a/test/pangea/custom_course_repo_error_test.dart
+++ b/test/pangea/custom_course_repo_error_test.dart
@@ -1,0 +1,192 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+import 'package:fluffychat/pangea/common/utils/base_repo.dart';
+import 'package:fluffychat/routes/onboarding/custom_course_repo.dart';
+import 'package:fluffychat/routes/onboarding/custom_course_request_model.dart';
+import 'package:fluffychat/routes/onboarding/custom_course_response_model.dart';
+import 'package:fluffychat/routes/settings/settings_learning/language_level_type_enum.dart';
+import 'package:fluffychat/widgets/matrix.dart';
+import 'fake_pangea_controller.dart';
+
+/// `CustomCourseRepo` used to hand-roll its own in-flight cache and error
+/// handling, throw the raw `http.Response` on a non-200, and report every
+/// failure at the default `error` level (#8362). It now extends `BaseRepo`,
+/// which is where the doc puts that behavior
+/// (repos-and-error-handling.instructions.md § Adoption).
+///
+/// These tests drive the real singleton through a `MockClient` installed for
+/// the zone, so `Requests` runs for real and the assertions are about the
+/// contract callers see — not about a stubbed fetch.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const choreoApi = 'https://api.test.pangea.chat';
+  const requestPath = '/choreo/courses/request';
+
+  setUpAll(() async {
+    // Environment.appConfigOverride builds a GetStorage('env_override') box,
+    // which reaches for path_provider on construction.
+    final tempDir = await Directory.systemTemp.createTemp('custom_course_test');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (methodCall) async => tempDir.path,
+        );
+    await GetStorage.init('env_override');
+    MatrixState.pangeaController = FakePangeaController(
+      accessToken: 'syt_test_token',
+    );
+  });
+
+  setUp(() => dotenv.testLoad(mergeWith: {'CHOREO_API': choreoApi}));
+
+  /// A distinct request per call, so the singleton's in-flight dedupe never
+  /// hands one test the previous test's future.
+  var seq = 0;
+  CustomCourseRequestModel request() => CustomCourseRequestModel(
+    name: 'Course ${seq++}',
+    languagePair: 'en-es',
+    languageLevel: LanguageLevelTypeEnum.a1,
+    institution: 'Test School',
+    goals: 'Order coffee in Spanish',
+  );
+
+  Future<Object?> fetchError(int status, {String body = ''}) async {
+    final result = await runWithClient(
+      () => CustomCourseRepo.instance.get(request()),
+      () => MockClient(
+        (request) async => Response(body, status, request: request),
+      ),
+    );
+    return result.asError?.error;
+  }
+
+  group('a failed course request', () {
+    test('surfaces as Result.error, never as a throw', () async {
+      final result = await runWithClient(
+        () => CustomCourseRepo.instance.get(request()),
+        () =>
+            MockClient((request) async => Response('', 500, request: request)),
+      );
+
+      expect(result.isError, isTrue);
+      expect(result.asError!.error, isA<PangeaHttpException>());
+    });
+
+    test('is typed, never the raw response', () async {
+      final error = await fetchError(503);
+
+      expect(error, isA<PangeaHttpException>());
+      expect(error, isNot(isA<BaseResponse>()));
+      expect(error.toString(), isNot(contains('Instance of')));
+    });
+
+    test('toString carries status, method, and normalized path', () async {
+      expect(
+        (await fetchError(500)).toString(),
+        'PangeaHttpException: 500 POST $requestPath',
+      );
+    });
+
+    test('appends the backend detail, capped, never the body', () async {
+      final error =
+          await fetchError(
+                422,
+                body: jsonEncode({
+                  'detail': 'goals too long',
+                  'echo': 'learner-entered text',
+                }),
+              )
+              as PangeaHttpException;
+
+      expect(
+        error.toString(),
+        'PangeaHttpException: 422 POST $requestPath — goals too long',
+      );
+      expect(error.toString(), isNot(contains('learner-entered text')));
+    });
+
+    test('is reported at the shared severity table level', () async {
+      // BaseRepo.errorLevel is what the repo passes to ErrorHandler.logError.
+      for (final status in [401, 404, 410, 429]) {
+        expect(
+          BaseRepo.errorLevel((await fetchError(status))!),
+          SentryLevel.warning,
+          reason: '$status is routine, not a page',
+        );
+      }
+      for (final status in [400, 403, 422, 500, 502]) {
+        expect(
+          BaseRepo.errorLevel((await fetchError(status))!),
+          SentryLevel.error,
+          reason: '$status is a code bug or a backend regression',
+        );
+      }
+    });
+  });
+
+  group('a successful course request', () {
+    test('parses into the response model', () async {
+      final result = await runWithClient(
+        () => CustomCourseRepo.instance.get(request()),
+        () => MockClient(
+          (request) async => Response(
+            jsonEncode({'id': 'course-1', 'status': 'generating'}),
+            200,
+            request: request,
+          ),
+        ),
+      );
+
+      expect(result.asValue!.value.id, 'course-1');
+      expect(result.asValue!.value.status, 'generating');
+    });
+
+    test('is never memoized', () async {
+      // Each submission is its own backend side effect, and `generating` goes
+      // stale immediately — so the same request must reach the server twice.
+      final req = request();
+      var posts = 0;
+      final client = MockClient((request) async {
+        posts++;
+        return Response(
+          jsonEncode({'id': 'course-$posts', 'status': 'generating'}),
+          200,
+          request: request,
+        );
+      });
+
+      await runWithClient(
+        () => CustomCourseRepo.instance.get(req),
+        () => client,
+      );
+      final second = await runWithClient(
+        () => CustomCourseRepo.instance.get(req),
+        () => client,
+      );
+
+      expect(posts, 2);
+      expect(second.asValue!.value.id, 'course-2');
+    });
+
+    test('shouldCache refuses to pin a submission', () {
+      expect(
+        CustomCourseRepo.instance.shouldCache(
+          const CustomCourseResponseModel(id: 'x', status: 'generating'),
+        ),
+        isFalse,
+      );
+    });
+  });
+}

--- a/test/pangea/fake_pangea_controller.dart
+++ b/test/pangea/fake_pangea_controller.dart
@@ -5,27 +5,37 @@ import 'package:fluffychat/pangea/common/controllers/pangea_controller.dart';
 /// `MatrixState.isPangeaControllerInitialized` and serves a viewer L1.
 ///
 /// Repos gate their reads on that getter (#8339), so a test that wants the repo
-/// to actually reach the network path must install one of these. It has no
-/// access token, so the fetch still fails inside `BaseRepo._fetch`'s try/catch
-/// and surfaces as `Result.error` — the shape most repo tests want.
+/// to actually reach the network path must install one of these. By default it
+/// has no access token, so the fetch still fails inside `BaseRepo._fetch`'s
+/// try/catch and surfaces as `Result.error` — the shape most repo tests want.
+/// Pass [accessToken] to get past that and drive the real request path (against
+/// a `MockClient`), which is what a test of the failure *contract* needs.
 class FakePangeaController implements PangeaController {
   @override
   final UserController userController;
 
-  FakePangeaController({String? userL1Code = 'en'})
-    : userController = _FakeUserController(userL1Code);
+  FakePangeaController({String? userL1Code = 'en', String? accessToken})
+    : userController = _FakeUserController(userL1Code, accessToken);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;
 }
 
 class _FakeUserController implements UserController {
-  _FakeUserController(this._userL1Code);
+  _FakeUserController(this._userL1Code, this._accessToken);
 
   final String? _userL1Code;
+  final String? _accessToken;
 
   @override
   String? get userL1Code => _userL1Code;
+
+  /// Mirrors the real controller, which throws rather than serving a null token
+  /// when nobody is logged in.
+  @override
+  String get accessToken =>
+      _accessToken ??
+      (throw "Trying to get accessToken with null token. User is not logged in.");
 
   @override
   dynamic noSuchMethod(Invocation invocation) => null;

--- a/test/pangea/grant_analytics_access_error_test.dart
+++ b/test/pangea/grant_analytics_access_error_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:matrix/matrix_api_lite/generated/api.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'package:fluffychat/features/analytics_access/grant_analytics_access_extension.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+
+/// The grant call is the one live raw-`Response` throw site of #8362: it
+/// bypasses `Requests` entirely (Synapse endpoint, Matrix SDK client and
+/// token), so nothing upstream types its failures for it. Thrown raw, every
+/// grant failure arrived in Sentry titled `Instance of 'Response'`.
+///
+/// These tests pin the contract the doc actually asks for
+/// (repos-and-error-handling.instructions.md): the failure is a
+/// `PangeaHttpException`, its `toString()` names the endpoint, and it maps onto
+/// the one severity table.
+void main() {
+  const courseRoomId = '!course:staging.pangea.chat';
+  const analyticsRoomId = '!analytics:staging.pangea.chat';
+  const grantPath =
+      '/_synapse/client/pangea/v1/grant_instructor_analytics_access';
+
+  Api apiReturning(int status, {String body = ''}) => Api(
+    baseUri: Uri.parse('https://matrix.staging.pangea.chat'),
+    bearerToken: 'syt_test_token',
+    httpClient: MockClient(
+      (request) async => Response(body, status, request: request),
+    ),
+  );
+
+  /// The thrown object, or null when the call succeeded.
+  Future<Object?> grantFailure(Api api) async {
+    try {
+      await api.grantInstructorAnalyticsAccess(courseRoomId, analyticsRoomId);
+      return null;
+    } catch (e) {
+      return e;
+    }
+  }
+
+  group('grantInstructorAnalyticsAccess', () {
+    test('a 200 completes without throwing', () async {
+      expect(await grantFailure(apiReturning(200)), isNull);
+    });
+
+    test('throws the typed exception, never the response', () async {
+      final error = await grantFailure(apiReturning(403));
+
+      expect(error, isA<PangeaHttpException>());
+      // The regression itself: a thrown response has no toString() override.
+      expect(error, isNot(isA<BaseResponse>()));
+      expect(error.toString(), isNot(contains('Instance of')));
+    });
+
+    test('toString carries status, method, and the endpoint path', () async {
+      expect(
+        (await grantFailure(apiReturning(502))).toString(),
+        'PangeaHttpException: 502 POST $grantPath',
+      );
+    });
+
+    test('reports the status the server actually sent', () async {
+      for (final status in [400, 403, 404, 429, 500]) {
+        expect(
+          PangeaHttpException.statusCodeOf(
+            await grantFailure(apiReturning(status)),
+          ),
+          status,
+        );
+      }
+    });
+
+    test('the failure lands on the shared severity table', () async {
+      // The two callers in join_room_analytics_access_extension.dart report
+      // with exactly this level, so a routine 404 stops paging as an error.
+      for (final status in [401, 404, 410, 429]) {
+        expect(
+          PangeaHttpException.severityOf(
+            await grantFailure(apiReturning(status)),
+          ),
+          SentryLevel.warning,
+          reason: '$status is routine — the resource is gone or will retry',
+        );
+      }
+      for (final status in [400, 403, 500, 502]) {
+        expect(
+          PangeaHttpException.severityOf(
+            await grantFailure(apiReturning(status)),
+          ),
+          SentryLevel.error,
+          reason: '$status is a code bug or a backend regression',
+        );
+      }
+    });
+
+    test('never carries the response body', () async {
+      // Bodies carry learner content; only the parsed `detail` may travel.
+      final error =
+          await grantFailure(
+                apiReturning(500, body: '{"error":"secret learner text"}'),
+              )
+              as PangeaHttpException;
+
+      expect(error.detail, isNull);
+      expect(error.toString(), isNot(contains('secret learner text')));
+    });
+  });
+}


### PR DESCRIPTION
## What

Throw `PangeaHttpException` instead of a raw `http.Response` at the last three sites outside `Requests`, and put their Sentry reporting on the shared severity table.

## Why

Closes #8362

A thrown `http.Response` has no `toString()` override, so every failure arrives in Sentry titled `Instance of 'Response'`. #8133 enforced the typed throw inside `Requests`; these three still bypassed it, with no comment explaining why. Design intent is [repos-and-error-handling.instructions.md](.github/instructions/repos-and-error-handling.instructions.md) — this PR implements it, it does not restate it.

| Site | Now throws | Note |
| --- | --- | --- |
| `grant_analytics_access_extension.dart` | `PangeaHttpException.fromResponse(await Response.fromStream(...))` | The only genuinely live source. Bypasses `Requests` entirely (Synapse endpoint, Matrix SDK client and token), so it raises the typed failure itself — the one place that needed an in-code reason, which it now has. |
| `activity_summary_repo.dart` | `PangeaHttpException.fromResponse(res)` | `req.post` already threw typed for ≥400, so this guard can only fire on a success status the parser can't consume (201/202/204/3xx). |
| `custom_course_repo.dart` | — (guard removed) | Migrated onto `BaseRepo`, which already owns the typed throw, the timeout, the in-flight dedupe, and the severity table. |

`knock_with_code_extension.dart` is untouched: its raw throw is deliberate and documented in-code (downstream 429 handling reads `statusCode`). **The instructions-doc carve-out for that site is being written separately by the repo owner — no doc change rides in this PR.**

### Severity

Both repo sites called `ErrorHandler.logError` with no `level:`, so every failure reported as `error` regardless of status — the exact failure mode the doc's Adoption note predicts. They now pass `PangeaHttpException.severityOf`, as do the two grant callers in `join_room_analytics_access_extension.dart` (the reporting sites for site 1's throw — typing the exception without fixing severity would have left the live path still mis-severitized). A routine 404 stops paging as an error.

### `BaseRepo` migration — one done, one deferred

`CustomCourseRepo` migrated: self-contained, four files, no collision. `shouldCache` is overridden to `false` to preserve today's behavior exactly — a submission is its own backend side effect and its `generating` status is stale on arrival, so only the in-flight dedupe is wanted. It also picks up the 60s timeout and the `UnsubscribedException` guard it previously lacked (it was reporting that control-flow exception to Sentry).

`ActivitySummaryRepo` **not** migrated. `BaseRepo` keys off `request.storageKey`, but this repo's key needs `roomId`, which isn't on the request model — so migrating means threading it through and updating the callers in `activity_summary_room_extension.dart`, which #8356 is concurrently rewriting. Deferred as a coordination call, not a scope call; it gets the typed throw and the severity fix here.

### Reported separately, deliberately not fixed here

Both repos log the full `request.toJson()` as Sentry `data`, and it does carry learner-entered text — `custom_course` sends `goals`/`notes`/`institution`, and `activity_summary` sends `activity_results[].sent`, the learner's actual messages. Confirmed by test-run stdout. This is **not** a regression and not specific to these sites: `BaseRepo._fetch` does `data: request.toJson()` for every repo in the app, so it's systemic. The doc's body rule governs exception payloads, not the `data:` map, so no rule is being broken — but the exposure is real and wants its own decision. Left exactly as-is on both sides of the migration.

## Testing

- `fvm flutter test` — **2439 passed, 3 skipped, 0 failed.** The three skips are the choreo/synapse/CMS endpoint suites, which skip on a missing `client/.env` (absent in a fresh worktree by design).
- 21 new tests across three files. `MockClient` is installed for the zone via `runWithClient`, so `Requests` runs for real rather than against a stubbed fetch. Each asserts the thrown type, that `toString()` renders status + method + normalized path, and the severity level per the table:
  - `test/pangea/grant_analytics_access_error_test.dart`
  - `test/pangea/custom_course_repo_error_test.dart`
  - `test/pangea/activity_summary_repo_error_test.dart` — includes the 201/202/204 case, the only one that guard can still fire on
- `fvm flutter analyze lib/ test/` — no issues. `fvm dart format` run under the `.fvmrc`-pinned SDK.
- Playwright browser bucket not triggered: no changed path matches any glob in `e2e/trigger-map.json`.
- No manual device run — the linked issue's TO TEST covers the three user-facing flows for staging QA.

## Deploy Notes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for activity summaries and analytics access requests.
  * Errors now provide consistent status details and severity classification without exposing response bodies.
  * Custom course requests now use the standardized request flow and avoid caching submitted responses.

* **Tests**
  * Added coverage for successful requests, failures, error messaging, severity mapping, and response parsing across affected features.
  * Clarified test setup documentation for authenticated and unauthenticated request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->