### PR TITLE
fix(stt): capture the voice analytics sink at send start

### DIFF
--- a/lib/routes/chat/chat.dart
+++ b/lib/routes/chat/chat.dart
@@ -1738,9 +1738,14 @@ class ChatController extends State<ChatPageWithRoom>
       decoupleFlag: decoupleTokenizer,
       isStreamedSend: streamedTranscript != null,
     );
-    final VoiceAnalyticsSink? voiceAnalyticsSink = decoupledSend
-        ? Matrix.of(context).analyticsDataService.updateService.addAnalytics
-        : null;
+    // Captured UNCONDITIONALLY: BOTH send paths record analytics after the
+    // send's awaits, so both need the sink resolved here rather than from a
+    // possibly-defunct context later (#8371). `updateService` is a
+    // `late final` assigned in the service constructor, so this read cannot
+    // fail on a send that never reaches analytics.
+    final VoiceAnalyticsSink voiceAnalyticsSink = Matrix.of(
+      context,
+    ).analyticsDataService.updateService.addAnalytics;
     final capturedRoom = room;
     final capturedRoomId = roomId;
     final capturedClientUserId = sendingClient.userID;
@@ -1922,15 +1927,24 @@ class ChatController extends State<ChatPageWithRoom>
           eventId: eventId,
           baseStt: stt,
           snapshot: decoupleSnapshot!,
-          analyticsSink: voiceAnalyticsSink!,
+          analyticsSink: voiceAnalyticsSink,
           room: capturedRoom,
           roomId: capturedRoomId,
           clientUserId: capturedClientUserId,
         );
       } else if (!decoupledSend) {
-        // Flag OFF and not a streamed send: unchanged legacy inline analytics
-        // path (byte-parity with the pre-decouple behaviour).
-        _sendVoiceMessageAnalytics(eventId, stt);
+        // Flag OFF and not a streamed send: the legacy inline analytics path.
+        // Fire-and-forget like the decoupled branch above, so send never waits
+        // on analytics -- and `unawaited` makes that explicit rather than
+        // leaving a dropped Future.
+        unawaited(
+          _sendVoiceMessageAnalytics(
+            eventId,
+            stt,
+            voiceAnalyticsSink,
+            capturedRoomId,
+          ),
+        );
       }
     }
     // Pangea#
@@ -2950,47 +2964,29 @@ class ChatController extends State<ChatPageWithRoom>
     }
   }
 
+  /// Thin wiring for the flag-OFF send's inline analytics: the coordinator owns
+  /// the guards and the feedback/record ordering, so this reads NO widget
+  /// `context` and nothing escapes. [sink] and [roomId] are the t0 captures
+  /// from [onVoiceMessageSend] -- resolving the analytics service here instead
+  /// would crash on a defunct context once the learner navigates away mid-send,
+  /// and silently drop the record with it (#8371).
   Future<void> _sendVoiceMessageAnalytics(
     String eventId,
     SpeechToTextResponseModel stt,
-  ) async {
-    try {
-      // Exhausted-fallback: fromJson no longer throws for `results: []`
-      // (R0-2), so a voice message can now carry a real-but-empty stt. There
-      // is nothing to score; `transcript` assumes at least one result and
-      // would throw otherwise.
-      if (stt.results.isEmpty || stt.transcript.sttTokens.isEmpty) return;
-      final constructs = stt.constructs(roomId, eventId);
-      if (constructs.isEmpty) return;
-
-      final langCode = stt.langCode.split('-').first;
-      // Fire-and-forget the visual feedback, but wrap it so a fetch/overlay
-      // throw can never escape as an unhandled async error -- P1b made
-      // `_showAnalyticsFeedback` async/heavier, so the flag-OFF path needs the
-      // same swallow the decouple coordinator applies (H2, ON/OFF symmetric).
-      unawaited(
-        guardFeedbackDispatch(
-          () => _showAnalyticsFeedback(constructs, eventId, langCode),
-          (e, s) => ErrorHandler.logError(
-            e: e,
-            s: s,
-            data: {'roomId': roomId, 'eventId': eventId},
-          ),
-        ),
-      );
-      Matrix.of(context).analyticsDataService.updateService.addAnalytics(
-        eventId,
-        constructs,
-        langCode,
-      );
-    } catch (e, s) {
-      ErrorHandler.logError(
-        e: e,
-        s: s,
-        data: {'roomId': roomId, 'eventId': eventId},
-      );
-    }
-  }
+    VoiceAnalyticsSink sink,
+    String roomId,
+  ) => recordInlineVoiceAnalytics(
+    stt: stt,
+    roomId: roomId,
+    eventId: eventId,
+    sink: sink,
+    showFeedback: _showAnalyticsFeedback,
+    onError: (e, s) => ErrorHandler.logError(
+      e: e,
+      s: s,
+      data: {'roomId': roomId, 'eventId': eventId},
+    ),
+  );
 
   Future<async.Result<SpeechToTextResponseModel>> _getVoiceMessageTranscript(
     MatrixAudioFile file, {

--- a/lib/routes/chat/voice_analytics_feedback.dart
+++ b/lib/routes/chat/voice_analytics_feedback.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:fluffychat/features/analytics/constructs_model.dart';
+import 'package:fluffychat/routes/chat/events/speech_to_text/speech_to_text_response_model.dart';
 import 'package:fluffychat/routes/chat/events/speech_to_text/stt_token_enrichment.dart';
 
 /// The grammar + vocab counts shown in the transient analytics-feedback overlay.
@@ -40,6 +42,58 @@ Future<void> guardFeedbackDispatch(
     // Contain BOTH a synchronous throw and an async rejection of the logger's
     // returned Future (ErrorHandler.logError returns Future<void>), so a failing
     // logger can never escape as an unhandled async error.
+    reportErrorSafely(onError, e, s);
+  }
+}
+
+/// The flag-OFF (inline) counterpart of `runVoiceTranscriptEnrichment`'s
+/// analytics chain: the transcript is already tokenized when the send resolves,
+/// so there is nothing to enrich -- only the best-effort overlay and the record.
+///
+/// LIFECYCLE-INDEPENDENT, exactly like [buildVoiceAnalyticsRecorder]: [sink] is
+/// resolved at t0 while the widget is guaranteed live and passed in, so the
+/// record NEVER reads a `BuildContext` after the send's awaits. Resolving it
+/// late is unsound -- an unmounted `State.context` is `_element!`, which in a
+/// release build is a bare null-check crash, and the learner's spoken
+/// constructs go unrecorded (#8371).
+///
+/// Fully self-guarded so nothing escapes the caller's fire-and-forget: a
+/// throwing [sink], a throwing [showFeedback], and a rejecting [onError] logger
+/// are all contained. The returned future always completes normally.
+///
+/// [showFeedback] is dispatched BEFORE the record on purpose -- the overlay
+/// reports how many constructs are NEW, a count the record itself would zero.
+Future<void> recordInlineVoiceAnalytics({
+  required SpeechToTextResponseModel stt,
+  required String roomId,
+  required String eventId,
+  required VoiceAnalyticsSink sink,
+  Future<void> Function(
+    List<OneConstructUse> constructs,
+    String eventId,
+    String langCode,
+  )?
+  showFeedback,
+  FutureOr<void> Function(Object error, StackTrace stack)? onError,
+}) async {
+  try {
+    // An exhausted-fallback (`results: []`) or token-less transcript has
+    // nothing to score, and reading `transcript` on one would throw.
+    if (!stt.hasUsableTokens) return;
+    final constructs = stt.constructs(roomId, eventId);
+    if (constructs.isEmpty) return;
+    final langCode = stt.langCode.split('-').first;
+
+    if (showFeedback != null) {
+      unawaited(
+        guardFeedbackDispatch(
+          () => showFeedback(constructs, eventId, langCode),
+          (e, s) => reportErrorSafely(onError, e, s),
+        ),
+      );
+    }
+    await sink(eventId, constructs, langCode);
+  } catch (e, s) {
     reportErrorSafely(onError, e, s);
   }
 }

--- a/test/pangea/stt_send_path_test.dart
+++ b/test/pangea/stt_send_path_test.dart
@@ -8,6 +8,7 @@ import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/routes/chat/events/models/pangea_token_model.dart';
 import 'package:fluffychat/routes/chat/events/speech_to_text/speech_to_text_response_model.dart';
 import 'package:fluffychat/routes/chat/events/speech_to_text/stt_token_enrichment.dart';
+import 'package:fluffychat/routes/chat/voice_analytics_feedback.dart';
 
 /// P1b.4 — the flag-gated send path's background coordinator, analytics
 /// recorder, and interim embed.
@@ -536,6 +537,136 @@ void main() {
       expect(ctx.calls, 0);
     });
   });
+
+  group(
+    'recordInlineVoiceAnalytics (flag-OFF path) — lifecycle independence',
+    () {
+      test('records via the sink CAPTURED at send start even after the chat is '
+          'disposed mid-send; a late context read would have thrown', () async {
+        final ctx = _AnalyticsContext();
+        // PRODUCTION pattern (chat.dart): resolve the sink at t0, while the
+        // widget is GUARANTEED live.
+        final sink = ctx.sink;
+
+        // The learner navigates away while the STT round-trip + upload are in
+        // flight, so `ChatController` unmounts before analytics run.
+        ctx.disposed = true;
+
+        await recordInlineVoiceAnalytics(
+          stt: _rich(),
+          roomId: '!r:server',
+          eventId: r'$audio:server',
+          sink: sink,
+        );
+
+        // The spoken constructs are still recorded -- the signal is not lost.
+        expect(ctx.calls, 1);
+        // Teeth: reading the analytics service LATE (the pre-fix behaviour) is
+        // exactly the null-check crash this capture prevents.
+        expect(() => ctx.sink, throwsStateError);
+      });
+
+      test(
+        'dispatches the overlay BEFORE recording, so the new-construct counts '
+        'it reads are not zeroed by the record itself',
+        () async {
+          final ctx = _AnalyticsContext();
+          final order = <String>[];
+          final sink = ctx.sink;
+
+          await recordInlineVoiceAnalytics(
+            stt: _rich(),
+            roomId: '!r:server',
+            eventId: r'$audio:server',
+            sink: (id, constructs, langCode) async {
+              order.add('record');
+              return sink(id, constructs, langCode);
+            },
+            showFeedback: (_, _, _) async => order.add('feedback'),
+          );
+
+          expect(order, ['feedback', 'record']);
+          expect(ctx.calls, 1);
+        },
+      );
+
+      test(
+        'a THROWING feedback neither blocks the record nor escapes',
+        () async {
+          final ctx = _AnalyticsContext();
+          final errors = <Object>[];
+
+          await recordInlineVoiceAnalytics(
+            stt: _rich(),
+            roomId: '!r:server',
+            eventId: r'$audio:server',
+            sink: ctx.sink,
+            showFeedback: (_, _, _) async =>
+                throw StateError('overlay blew up'),
+            onError: (e, _) => errors.add(e),
+          );
+          await Future<void>.delayed(Duration.zero);
+
+          expect(
+            ctx.calls,
+            1,
+            reason: 'the record is independent of the overlay',
+          );
+          expect(errors, hasLength(1));
+        },
+      );
+
+      test(
+        'a THROWING sink is reported, never rethrown into the send path',
+        () async {
+          final errors = <Object>[];
+
+          await recordInlineVoiceAnalytics(
+            stt: _rich(),
+            roomId: '!r:server',
+            eventId: r'$audio:server',
+            sink: (_, _, _) async => throw StateError('analytics write failed'),
+            onError: (e, _) => errors.add(e),
+          );
+
+          expect(errors, hasLength(1));
+        },
+      );
+
+      test(
+        'SF: an ASYNC-throwing onError logger cannot reject the caller',
+        () async {
+          await expectLater(
+            recordInlineVoiceAnalytics(
+              stt: _rich(),
+              roomId: '!r:server',
+              eventId: r'$audio:server',
+              sink: (_, _, _) async =>
+                  throw StateError('analytics write failed'),
+              onError: (_, _) => Future<void>.error(StateError('logger down')),
+            ),
+            completes,
+          );
+        },
+      );
+
+      test(
+        'no-ops (no sink call) when the transcript carries no tokens',
+        () async {
+          final ctx = _AnalyticsContext();
+
+          await recordInlineVoiceAnalytics(
+            stt: _skipTokenizeBase(),
+            roomId: '!r:server',
+            eventId: r'$audio:server',
+            sink: ctx.sink,
+          );
+
+          expect(ctx.calls, 0);
+        },
+      );
+    },
+  );
 
   group('voiceTranscriptDecoupleEnabled flag plumbing', () {
     test('AppConfigOverride defaults the flag to null (off)', () {


### PR DESCRIPTION
## What

Resolve the voice-message analytics sink at send start instead of from a `BuildContext` after the send's awaits.

## Why

Closes #8371. Sentry `CLIENT-E7C` (production).

The flag-OFF voice send called `Matrix.of(context)` *after* the STT round-trip and the file upload. If the learner navigated away during that window the `ChatController` had unmounted, and `State.context` is `return _element!` — the release build strips the friendly assert above it, so it surfaced as a bare `Null check operator used on a null value`.

`onVoiceMessageSend` already captures everything context-derived at t0 for exactly this reason ("Nothing context-derived is resolved after ANY await"), but the analytics-sink capture was gated on the decouple flag, so the legacy branch fell outside the invariant.

Two consequences, not one: the crash, and — because the throw landed on the `addAnalytics` call — every construct from that voice message went unrecorded. The overlay is dispatched before the record, so the learner could see the "new words" feedback while the XP behind it was silently dropped.

## What changed

- Capture the sink unconditionally at t0 and inject it into both paths. `shouldScheduleDecoupledEnrichment` routing is unchanged (`sink` was non-null exactly when `decoupledSend` was true).
- `recordInlineVoiceAnalytics` — the flag-OFF counterpart of the decouple coordinator's analytics chain. Reads no `BuildContext`, fully self-guarded, and keeps the overlay-before-record ordering the new-construct counts depend on.
- `_sendVoiceMessageAnalytics` is now thin wiring, `unawaited` at the call site, and reports through `reportErrorSafely` — the direct `ErrorHandler.logError` in the old catch returns a `Future<void>` that could still reject out of the fire-and-forget.
- Gate on `hasUsableTokens`. The old `results.isEmpty` check let a results-non-empty / transcripts-empty response through to `stt.transcript`, which throws.

## Testing

- `fvm flutter test` — 2452 pass, 3 skipped (the credential-gated endpoint suites; no `.env` in a fresh worktree).
- New unit tests in `test/pangea/stt_send_path_test.dart` cover the regression directly, mirroring the existing `buildVoiceAnalyticsRecorder` lifecycle test: recording still happens through the captured sink after the chat is disposed, with teeth asserting a late read would have thrown. Plus overlay-before-record ordering, a throwing overlay, a throwing sink, and an async-rejecting logger. Verified failing before the fix.
- `fvm flutter analyze` on the changed files — no issues.

## Deploy Notes

None.