### PR TITLE
fix(subscriptions): read no-billing-account as a state, not an error

### DIFF
--- a/lib/features/subscription/repo_v2/billing_portal_repo.dart
+++ b/lib/features/subscription/repo_v2/billing_portal_repo.dart
@@ -1,7 +1,12 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
 import 'package:http/http.dart';
 
 import 'package:fluffychat/features/subscription/repo_v2/billing_portal_request.dart';
 import 'package:fluffychat/features/subscription/repo_v2/billing_portal_response.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/pangea/common/network/urls.dart';
 import 'package:fluffychat/pangea/common/utils/base_repo.dart';
@@ -20,7 +25,45 @@ class BillingPortalRepo
   static final BillingPortalRepo _instance = BillingPortalRepo._internal();
   static BillingPortalRepo get instance => _instance;
 
+  /// The choreographer's answer for a user with no canonical Stripe customer
+  /// row — comped, seat-sponsored, or simply never purchased.
+  static const int noBillingAccountStatus = 404;
+
   @override
-  Future<Response> fetch(Requests req, BillingPortalRequest _) =>
-      req.get(url: PApiUrls.billingPortal);
+  Future<Response> fetch(Requests req, BillingPortalRequest _) async {
+    try {
+      return await req.get(url: PApiUrls.billingPortal);
+    } catch (e) {
+      final noBillingAccount = noBillingAccountResponse(e);
+      if (noBillingAccount == null) rethrow;
+      return noBillingAccount;
+    }
+  }
+
+  /// The successful empty response for [error] when it is the expected
+  /// no-billing-account state, else null so [BaseRepo] reports and returns it
+  /// as the failure it is.
+  ///
+  /// A 404 here means "this user has no billing account", which is a normal
+  /// state rather than something the user can act on — the severity table
+  /// already reads 404 as "the resource is gone", and repos
+  /// "never return an error the user cannot be told about"
+  /// (repos-and-error-handling.instructions.md). Mapped inside [fetch] so
+  /// [BaseRepo] never sees an exception and never opens a Sentry issue for it
+  /// (#8374 / CLIENT-E43).
+  @visibleForTesting
+  static Response? noBillingAccountResponse(Object error) =>
+      PangeaHttpException.statusCodeOf(error) == noBillingAccountStatus
+      ? Response(
+          jsonEncode(BillingPortalResponse.noBillingAccount().toJson()),
+          200,
+        )
+      : null;
+
+  /// Never memoize the empty value: it flips the moment the user completes
+  /// checkout, and pinning it for the full [cacheDuration] would leave a
+  /// just-subscribed user unable to reach their billing portal.
+  @override
+  bool shouldCache(BillingPortalResponse response) =>
+      response.hasBillingAccount;
 }

--- a/lib/features/subscription/repo_v2/billing_portal_response.dart
+++ b/lib/features/subscription/repo_v2/billing_portal_response.dart
@@ -1,12 +1,24 @@
 import 'package:fluffychat/pangea/common/utils/base_response.dart';
 
 class BillingPortalResponse extends BaseResponse {
-  final String url;
+  /// The Stripe-hosted billing portal session, or null when the user has no
+  /// billing account to manage — see [BillingPortalResponse.noBillingAccount].
+  final String? url;
+
   BillingPortalResponse({required this.url});
+
+  /// The successful "there is nothing to manage" value. The portal exists only
+  /// to change a saved payment card (subscriptions.instructions.md), so a user
+  /// without a Stripe customer has no portal — an expected state, not a
+  /// failure.
+  factory BillingPortalResponse.noBillingAccount() =>
+      BillingPortalResponse(url: null);
+
+  bool get hasBillingAccount => url != null;
 
   @override
   Map<String, dynamic> toJson() => {"url": url};
 
   factory BillingPortalResponse.fromJson(Map<String, dynamic> json) =>
-      BillingPortalResponse(url: json["url"] as String);
+      BillingPortalResponse(url: json["url"] as String?);
 }

--- a/lib/routes/settings/settings_subscription/subscription_history.dart
+++ b/lib/routes/settings/settings_subscription/subscription_history.dart
@@ -97,7 +97,8 @@ class SubscriptionHistoryState extends State<SubscriptionHistory> {
       MatrixState.pangeaController.subscriptionController.subscriptionStatus;
 
   bool get _canManageSubscription =>
-      _subscriptionStatus?.manageEligible == true && _billingPortal != null;
+      _subscriptionStatus?.manageEligible == true &&
+      _billingPortalProvider.response?.hasBillingAccount == true;
 
   SubscriptionEntitlement? get _cancelableEntitlement =>
       _subscriptionStatus?.cancelableEntitlement;

--- a/lib/routes/settings/settings_subscription/subscription_history_view.dart
+++ b/lib/routes/settings/settings_subscription/subscription_history_view.dart
@@ -122,29 +122,42 @@ class SubscriptionHistoryView extends StatelessWidget {
                                               ? theme.textTheme.titleMedium
                                               : theme.textTheme.titleSmall,
                                         ),
-                                      UserSubscriptionPlanCard(
-                                        subscriptionTitle:
-                                            displayEntitlement
-                                                ?.subscriptionTitle(l10n) ??
-                                            l10n.currentSubscription,
-                                        paymentPeriodDescription:
-                                            displayEntitlement
-                                                ?.paymentPeriodDescription(
-                                                  l10n,
-                                                ),
-                                        priceDisplay:
-                                            subscriptionPlan?.priceDisplay ??
-                                            displayEntitlement?.priceDisplay(
-                                              l10n,
-                                            ),
-                                        showCancel: true,
-                                        canCancelNotifier:
-                                            canCancelSubscriptionNotifier,
-                                        onCancel: onCancelSubscription,
-                                        showManage: true,
-                                        canManageNotifier:
+                                      // The manage action is offered only once
+                                      // a billing portal actually resolved. A
+                                      // user with no billing account has no
+                                      // saved card to change, so the button is
+                                      // absent rather than permanently dead
+                                      // (#8374).
+                                      ValueListenableBuilder(
+                                        valueListenable:
                                             canManageSubscriptionNotifier,
-                                        onManage: onManageSubscription,
+                                        builder: (context, canManage, _) =>
+                                            UserSubscriptionPlanCard(
+                                              subscriptionTitle:
+                                                  displayEntitlement
+                                                      ?.subscriptionTitle(
+                                                        l10n,
+                                                      ) ??
+                                                  l10n.currentSubscription,
+                                              paymentPeriodDescription:
+                                                  displayEntitlement
+                                                      ?.paymentPeriodDescription(
+                                                        l10n,
+                                                      ),
+                                              priceDisplay:
+                                                  subscriptionPlan
+                                                      ?.priceDisplay ??
+                                                  displayEntitlement
+                                                      ?.priceDisplay(l10n),
+                                              showCancel: true,
+                                              canCancelNotifier:
+                                                  canCancelSubscriptionNotifier,
+                                              onCancel: onCancelSubscription,
+                                              showManage: canManage,
+                                              canManageNotifier:
+                                                  canManageSubscriptionNotifier,
+                                              onManage: onManageSubscription,
+                                            ),
                                       ),
                                     ],
                                   );

--- a/test/pangea/subscriptions/billing_portal_no_account_test.dart
+++ b/test/pangea/subscriptions/billing_portal_no_account_test.dart
@@ -1,0 +1,163 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/config/app_config.dart';
+import 'package:fluffychat/features/subscription/repo_v2/billing_portal_repo.dart';
+import 'package:fluffychat/features/subscription/repo_v2/billing_portal_response.dart';
+import 'package:fluffychat/l10n/l10n.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+import 'package:fluffychat/routes/settings/settings_subscription/user_subscription_plan_card.dart';
+
+/// Covers #8374 (Sentry CLIENT-E43): the choreographer answers
+/// `404 — No billing account` for a user with no canonical Stripe customer,
+/// which `BillingPortalRepo` reported as a failure and handed back as
+/// `Result.error`. Per repos-and-error-handling.instructions.md a 404 is "the
+/// resource is gone — a normal state", and "repos never return an error the
+/// user cannot be told about" — so this reads as a successful
+/// no-billing-account value instead, and the settings page stops rendering a
+/// permanently-dead "Change" button on top of it.
+void main() {
+  group('BillingPortalResponse — the no-billing-account value', () {
+    test('a payload without a url parses as no billing account', () {
+      final response = BillingPortalResponse.fromJson(const {});
+      expect(response.url, isNull);
+      expect(response.hasBillingAccount, isFalse);
+    });
+
+    test('a payload with a url parses as a usable portal', () {
+      final response = BillingPortalResponse.fromJson(const {
+        'url': 'https://billing.stripe.com/session',
+      });
+      expect(response.url, 'https://billing.stripe.com/session');
+      expect(response.hasBillingAccount, isTrue);
+    });
+
+    test('the no-billing-account value round-trips through json', () {
+      final round = BillingPortalResponse.fromJson(
+        jsonDecode(
+              jsonEncode(BillingPortalResponse.noBillingAccount().toJson()),
+            )
+            as Map<String, dynamic>,
+      );
+      expect(round.hasBillingAccount, isFalse);
+    });
+  });
+
+  group(
+    'BillingPortalRepo.noBillingAccountResponse — which failures are states',
+    () {
+      test('a 404 becomes a successful, empty portal response', () {
+        final synthesized = BillingPortalRepo.noBillingAccountResponse(
+          PangeaHttpException(
+            statusCode: 404,
+            method: 'GET',
+            path: '/subscription/billing_portal',
+            detail: 'No billing account',
+          ),
+        );
+
+        expect(synthesized, isNotNull);
+        expect(synthesized!.statusCode, 200);
+        expect(
+          BillingPortalResponse.fromJson(
+            jsonDecode(synthesized.body) as Map<String, dynamic>,
+          ).hasBillingAccount,
+          isFalse,
+        );
+      });
+
+      test('a 500 is left alone, so BaseRepo still reports it', () {
+        expect(
+          BillingPortalRepo.noBillingAccountResponse(
+            PangeaHttpException(
+              statusCode: 500,
+              method: 'GET',
+              path: '/subscription/billing_portal',
+            ),
+          ),
+          isNull,
+        );
+      });
+
+      test('a timeout is left alone, so BaseRepo still reports it', () {
+        expect(
+          BillingPortalRepo.noBillingAccountResponse(TimeoutException('slow')),
+          isNull,
+        );
+      });
+    },
+  );
+
+  group('BillingPortalRepo.shouldCache — the empty value is not pinned', () {
+    test('a real portal url is cached', () {
+      expect(
+        BillingPortalRepo.instance.shouldCache(
+          BillingPortalResponse(url: 'https://billing.stripe.com/session'),
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'no-billing-account is not cached, so a new purchase is picked up',
+      () {
+        expect(
+          BillingPortalRepo.instance.shouldCache(
+            BillingPortalResponse.noBillingAccount(),
+          ),
+          isFalse,
+        );
+      },
+    );
+  });
+
+  group('UserSubscriptionPlanCard — no dead "Change" control', () {
+    Future<void> pump(WidgetTester tester, {required bool canManage}) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          localizationsDelegates: L10n.localizationsDelegates,
+          supportedLocales: L10n.supportedLocales,
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(
+              seedColor: AppConfig.primaryColor,
+            ),
+          ),
+          home: Scaffold(
+            body: UserSubscriptionPlanCard(
+              subscriptionTitle: 'Pangea Pro',
+              // What the settings page now passes: the manage affordance is
+              // offered only once a billing portal actually resolved.
+              showManage: canManage,
+              canManageNotifier: ValueNotifier(canManage),
+              onManage: () {},
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('a billing portal renders an enabled Change button', (
+      tester,
+    ) async {
+      await pump(tester, canManage: true);
+
+      final button = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Change'),
+      );
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('no billing account renders no Change button at all', (
+      tester,
+    ) async {
+      await pump(tester, canManage: false);
+
+      expect(find.text('Change'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
### What

`GET /subscription/billing_portal` returning `404 — No billing account` is now read as a successful "no billing account" value instead of a repo error, and the subscription-history page stops rendering a permanently-dead **Change** button on top of it.

### Why

Closes #8374. Sentry: `CLIENT-E43` (production).

A user with no canonical Stripe customer row — comped, seat-sponsored, or never purchased — has no portal to open. That is an expected state, and [repos-and-error-handling.instructions.md](.github/instructions/repos-and-error-handling.instructions.md) already governs it: repos "never return an error the user cannot be told about", and the severity table reads 404 as "the resource is gone — a normal state".

### Changes

- `BillingPortalResponse.url` is nullable, with a `noBillingAccount()` value and a `hasBillingAccount` getter.
- `BillingPortalRepo.fetch` maps the 404 to that value **before** `BaseRepo` sees it, so no Sentry event is opened and callers get `Result.value`. Every other status (and timeouts) still propagates and is still reported at its table severity.
- `shouldCache` refuses to memoize the empty value — pinning it for the 10-minute `cacheDuration` would leave a just-subscribed user unable to reach their portal.
- The history page offers the **Change** action only once a portal actually resolved, so the no-billing-account case shows no button rather than a dead one. The plan card, cancel action, and payment history are unchanged.

No entitlement, checkout, or purchase logic is touched — `manageEligible` still gates manage exactly as before.

### Testing

- `fvm flutter test test/pangea/subscriptions/` — 65 passed, including 10 new cases in `billing_portal_no_account_test.dart` (parse contract, which failures are states vs. failures, cache policy, and the two button-rendering cases). Verified they fail against the unfixed code first.
- `fvm flutter test` (full suite) — 2456 passed, 3 skipped, no failures.
- `fvm flutter analyze` on the touched directories — no issues.
- Endpoint suites (`choreo_endpoint_test.dart`) skip without `TEST_MATRIX_*` credentials — not run here.
- No new user-facing strings, so no `intl_en.arb` change and no l10n-sync remediation needed.

### Notes for parallel sessions

Sibling branches #8368–#8375 are in flight in the same area. This diff touches only `features/subscription/repo_v2/billing_portal_*` and `routes/settings/settings_subscription/subscription_history*` — no shared files. In particular it does not touch `base_repo.dart` (#8373's `UnsubscribedException` handling) or `pangea_http_exception.dart` (#8369's 401 severity); the 404 mapping is contained in `BillingPortalRepo`'s own `fetch` override, and `UnsubscribedException` still propagates untouched.

### Deploy Notes

None.
