### PR TITLE
fix(matrix): guard the client getter against an empty account list

### DIFF
--- a/lib/widgets/matrix.dart
+++ b/lib/widgets/matrix.dart
@@ -97,7 +97,11 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
   }
 
   static PangeaAnyState pAnyState = PangeaAnyState();
-  late StreamSubscription? _uriListener;
+
+  /// Not `late`: [dispose] cancels it unconditionally, so an [initState] that
+  /// never reached its assignment would crash teardown with a
+  /// LateInitializationError that buries whatever actually failed.
+  StreamSubscription? _uriListener;
 
   final Map<String, AnalyticsDataService> _analyticsServices = {};
   final Map<String, ActivityAutoSaveService> _activityAutoSaveServices = {};
@@ -121,18 +125,43 @@ class MatrixState extends State<Matrix> with WidgetsBindingObserver {
   ValueNotifier<int> notifPermissionNotifier = ValueNotifier(0);
   // Pangea#
 
+  // #Pangea
+  /// The account [client] last resolved, retained so the getter keeps its
+  /// non-null contract while [Matrix.clients] holds none.
+  ///
+  /// Single-account logout empties that list (the `loggedOut` branch of
+  /// [_registerSubs]) and routes straight to `/home`, so every widget building
+  /// that route — auth guards, presence builders, the lifecycle observer —
+  /// reads [client] against an empty list. Handing back the account that just
+  /// logged out is truthful rather than silent: `isLogged()` is false, so
+  /// callers gate to the login screen exactly as they would for any signed-out
+  /// account, instead of the getter throwing `Bad state: No element` (#8368).
+  ///
+  /// Only ever a last resort — a live account in [Matrix.clients] always wins,
+  /// so the next login is never shadowed by the account it replaced.
+  Client? _lastResolvedClient;
+  // Pangea#
+
   Client get client {
     if (_activeClient < 0 || _activeClient >= widget.clients.length) {
       // #Pangea
-      currentBundle!.first!.homeserver = AppConfig.defaultHomeserverUri;
+      final fallback = currentBundle?.firstOrNull ?? _lastResolvedClient;
+      if (fallback == null) {
+        // Unreachable via ClientManager.getClients, which always yields at
+        // least one client. Named loudly so it can never read as the empty
+        // bundle above.
+        throw StateError('MatrixState.client read before any client existed');
+      }
+      fallback.homeserver = AppConfig.defaultHomeserverUri;
+      return _lastResolvedClient = fallback;
       // Pangea#
-      return currentBundle!.first!;
     }
 
     // #Pangea
-    widget.clients[_activeClient].homeserver = AppConfig.defaultHomeserverUri;
+    final activeClient = widget.clients[_activeClient];
+    activeClient.homeserver = AppConfig.defaultHomeserverUri;
+    return _lastResolvedClient = activeClient;
     // Pangea#
-    return widget.clients[_activeClient];
   }
 
   // #Pangea

--- a/test/pangea/matrix_state_client_no_accounts_test.dart
+++ b/test/pangea/matrix_state_client_no_accounts_test.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_storage/get_storage.dart';
+import 'package:matrix/matrix.dart' show Client;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:fluffychat/widgets/matrix.dart';
+import '../utils/test_client.dart';
+
+/// Keeps [MatrixState]'s real `client` getter but skips `initMatrix()`, which
+/// wires background push, notification listeners and the Pangea controller —
+/// none of which the getter reads, and none of which stand up under
+/// `flutter test`. `initState` itself reads `client`, so it cannot run here
+/// either.
+class _TestMatrixState extends MatrixState {
+  @override
+  // ignore: must_call_super
+  void initState() {}
+}
+
+class _TestMatrix extends Matrix {
+  const _TestMatrix({
+    required super.clients,
+    required super.store,
+    required super.child,
+  });
+
+  @override
+  MatrixState createState() => _TestMatrixState();
+}
+
+/// #8368 — `MatrixState.client` threw `Bad state: No element` on `/home`.
+///
+/// Single-account logout removes the account from `Matrix.clients` and routes
+/// straight to `/home` (the `loggedOut` branch of `_registerSubs`). Every
+/// widget that reads `client` while that route builds — auth guards, presence
+/// builders, the lifecycle observer — hit an empty list, and the getter's
+/// fallback did `currentBundle!.first!`.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Client client;
+  late Client otherClient;
+  late SharedPreferences store;
+
+  setUpAll(() async {
+    // The getter stamps `AppConfig.defaultHomeserverUri` onto the client it
+    // returns, which reads the env layer.
+    dotenv.testLoad(
+      mergeWith: {'SYNAPSE_URL': 'https://fakeserver.notexisting'},
+    );
+    final tempDir = await Directory.systemTemp.createTemp('matrix_state');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+          const MethodChannel('plugins.flutter.io/path_provider'),
+          (m) async => tempDir.path,
+        );
+    await GetStorage.init('env_override');
+    SharedPreferences.setMockInitialValues({});
+    store = await SharedPreferences.getInstance();
+    client = await prepareTestClient();
+    otherClient = await prepareTestClient();
+  });
+
+  tearDownAll(() async {
+    await client.dispose();
+    await otherClient.dispose();
+  });
+
+  Future<MatrixState> pumpMatrix(
+    WidgetTester tester,
+    List<Client> clients,
+  ) async {
+    await tester.pumpWidget(
+      _TestMatrix(clients: clients, store: store, child: const SizedBox()),
+    );
+    return tester.state<_TestMatrixState>(find.byType(_TestMatrix));
+  }
+
+  testWidgets('client survives the last account logging out', (tester) async {
+    final clients = <Client>[client];
+    final state = await pumpMatrix(tester, clients);
+
+    expect(state.client, same(client));
+
+    // What the loggedOut branch does on single-account logout: the list empties
+    // while /home is still building.
+    clients.remove(client);
+
+    expect(state.client, same(client));
+  });
+
+  testWidgets('a remaining account wins over the retained one', (tester) async {
+    final clients = <Client>[client, otherClient];
+    final state = await pumpMatrix(tester, clients);
+
+    expect(state.client, same(client));
+
+    clients.remove(client);
+
+    // The retained client is a last resort, never a shadow over a live account.
+    expect(state.client, same(otherClient));
+  });
+
+  testWidgets('a re-added account replaces the retained one', (tester) async {
+    final clients = <Client>[client];
+    final state = await pumpMatrix(tester, clients);
+
+    expect(state.client, same(client));
+    clients.remove(client);
+    expect(state.client, same(client));
+
+    // getLoginClient() adds the next account once login begins.
+    clients.add(otherClient);
+
+    expect(state.client, same(otherClient));
+  });
+}


### PR DESCRIPTION
## What

`MatrixState.client` retains the last account it resolved and falls back to it when `Matrix.clients` is empty, instead of throwing `Bad state: No element`.

## Why

Closes #8368. Sentry: CLIENT-E7Q, CLIENT-E51, CLIENT-E83, CLIENT-E82, CLIENT-E5Y, CLIENT-E7D.

**Root cause.** `ClientManager.getClients` guarantees at least one client at startup, so the getter's `_activeClient < 0` fallback path assumed `currentBundle` was non-empty. Single-account logout breaks that invariant: the `loggedOut` branch of `_registerSubs` does `widget.clients.remove(c)` and then routes to `/home`. A new client is only appended once `getLoginClient()` runs, so in the window between them the list is empty while `/home` builds — and every widget on that route that reads `client` (auth guards, presence builders, the lifecycle observer, `UserController`) hit `currentBundle!.first!` on an empty list. That is why the crash concentrates on the `/home` transaction.

**Six of the seven grouped issues share this cause** — CLIENT-E7Q, E51, E83, E82, E5Y and E7D each terminate in `MatrixState.client` → `List.first`/`get$first`, on web and iOS across 5.0.0 and 5.0.1.

**CLIENT-E55 does not, and is not addressed here.** Its trace names `ChatEventList` and `scroll_controller.dart`, terminates in a different getter, and never mentions `MatrixState`. That is the `ScrollController.position` (`_positions.single`) crash already fixed by #8342 (issue #8341, CLIENT-9Y7); its one event predates that merge. Same `Bad state: No element` message, different origin — so it grouped alongside these but needs no further work.

**Why a fallback rather than a nullable getter.** Callers assume a client exists, so returning null would only move the crash. The retained account is the one that just logged out: `isLogged()` is false, so auth guards route to login exactly as they would for any signed-out account — truthful, not silent. A live account in `Matrix.clients` always takes precedence, so a new login is never shadowed by the account it replaced.

Also drops `late` from `_uriListener`: `dispose()` cancels it unconditionally, so an `initState` that didn't reach the assignment crashed teardown with a LateInitializationError that buried the real failure.

## Testing

- `fvm flutter test` — 2449 pass, 3 skip, 0 fail. The 3 skips are the endpoint suites (`choreo_endpoint_test`, `synapse_endpoint_test`, `cms_endpoint_test`), which need the gitignored `.env` a fresh worktree doesn't have.
- New `test/pangea/matrix_state_client_no_accounts_test.dart` (3 cases): the last account being removed, a remaining account winning over the retained one, and a re-added account replacing it. Verified non-vacuous — with only the getter change reverted, all three fail with exactly `Bad state: No element`.
- `fvm flutter analyze lib/widgets/matrix.dart test/pangea/matrix_state_client_no_accounts_test.dart` — no issues.
- Runtime verification of the logout → `/home` flow is left to the linked issue's TO TEST on staging; no local stack is running here and a staging login needs credentials I don't enter.

## Deploy Notes

None.