### PR TITLE
fix(errors): apply the severity table by default, type the Synapse module throws

### DIFF
--- a/lib/features/join_codes/request_room_code_extension.dart
+++ b/lib/features/join_codes/request_room_code_extension.dart
@@ -4,6 +4,8 @@ import 'package:http/http.dart' hide Client;
 import 'package:matrix/matrix.dart';
 import 'package:matrix/matrix_api_lite/generated/api.dart';
 
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+
 extension SpaceCodeExtension on Api {
   Future<String> getSpaceCode() async {
     final requestUri = Uri(
@@ -16,8 +18,10 @@ extension SpaceCodeExtension on Api {
     final responseBody = await response.stream.toBytes();
     final responseString = utf8.decode(responseBody);
     if (response.statusCode != 200) {
-      throw Exception(
-        'HTTP error response: statusCode=${response.statusCode}, body=$responseString',
+      throw PangeaHttpException.fromStreamedResponse(
+        request,
+        response,
+        responseBody,
       );
     }
     final json = jsonDecode(responseString);

--- a/lib/features/room_summaries/activity_session_previews_extension.dart
+++ b/lib/features/room_summaries/activity_session_previews_extension.dart
@@ -5,6 +5,7 @@ import 'package:matrix/matrix.dart';
 import 'package:matrix/matrix_api_lite/generated/api.dart';
 
 import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 
 /// Consumer of the Synapse `activity_session_previews` module — space-scoped
 /// activity-session discovery. Given course-space ids, the server enumerates
@@ -35,8 +36,10 @@ extension ActivitySessionPreviewsApi on Api {
     final responseBody = await response.stream.toBytes();
     final responseString = utf8.decode(responseBody);
     if (response.statusCode != 200) {
-      throw Exception(
-        'HTTP error response: statusCode=${response.statusCode}, body=$responseString',
+      throw PangeaHttpException.fromStreamedResponse(
+        request,
+        response,
+        responseBody,
       );
     }
     final json = jsonDecode(responseString);

--- a/lib/features/room_summaries/room_summary_extension.dart
+++ b/lib/features/room_summaries/room_summary_extension.dart
@@ -15,6 +15,7 @@ import 'package:fluffychat/features/activity_sessions/activity_session_constants
 import 'package:fluffychat/features/activity_sessions/activity_summary_model.dart';
 import 'package:fluffychat/features/bot/utils/bot_name.dart';
 import 'package:fluffychat/features/course_plans/courses/course_plan_event.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/chat/events/constants/pangea_event_types.dart';
 
@@ -34,8 +35,10 @@ extension RoomSummaryExtension on Api {
     final responseBody = await response.stream.toBytes();
     final responseString = utf8.decode(responseBody);
     if (response.statusCode != 200) {
-      throw Exception(
-        'HTTP error response: statusCode=${response.statusCode}, body=$responseString',
+      throw PangeaHttpException.fromStreamedResponse(
+        request,
+        response,
+        responseBody,
       );
     }
     final json = jsonDecode(responseString);

--- a/lib/pangea/common/network/pangea_http_exception.dart
+++ b/lib/pangea/common/network/pangea_http_exception.dart
@@ -22,8 +22,9 @@ class PangeaHttpException implements Exception {
   /// rather than per resource. Query strings are dropped entirely.
   final String path;
 
-  /// The backend's parsed `detail` message, capped at [maxDetailLength].
-  /// Only ever the `detail` field — never the body.
+  /// The backend's parsed failure identifier, capped at [maxDetailLength] —
+  /// choreo's `detail` message, or a Synapse module's Matrix `errcode`. Only
+  /// ever one of those two fields — never the body.
   final String? detail;
 
   static const int maxDetailLength = 200;
@@ -49,6 +50,23 @@ class PangeaHttpException implements Exception {
       detail: detail ?? detailFromResponse(response),
     );
   }
+
+  /// The typed failure for a Synapse Pangea module call. Those sites reach the
+  /// homeserver through the Matrix SDK's `Api.httpClient` rather than
+  /// `Requests`, so they raise the typed failure themselves.
+  ///
+  /// [request] is taken from the caller rather than read off
+  /// [http.StreamedResponse.request], which is only as reliable as the client
+  /// implementation that filled it in — the method and path are the whole
+  /// point of the title, so they are not left to that. [body] is passed
+  /// separately because the caller has already drained [response]'s stream.
+  factory PangeaHttpException.fromStreamedResponse(
+    http.BaseRequest request,
+    http.StreamedResponse response,
+    List<int> body,
+  ) => PangeaHttpException.fromResponse(
+    http.Response.bytes(body, response.statusCode, request: request),
+  );
 
   static final _uuid = RegExp(
     r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$',
@@ -80,11 +98,15 @@ class PangeaHttpException implements Exception {
     return null;
   }
 
+  /// `detail` is the choreo (FastAPI) shape; `errcode` is the Matrix shape the
+  /// Synapse modules answer with. Both are short, server-generated identifiers.
+  /// Matrix's sibling `error` field is deliberately never read — it is
+  /// free text, which is the body rule's whole concern.
   static String? detailFromResponse(http.Response response) {
     try {
       final decoded = jsonDecode(utf8.decode(response.bodyBytes));
       if (decoded is! Map<String, dynamic>) return null;
-      final detail = decoded['detail'];
+      final detail = decoded['detail'] ?? decoded['errcode'];
       return detail is String ? detail : null;
     } catch (_) {
       return null;

--- a/lib/pangea/common/utils/error_handler.dart
+++ b/lib/pangea/common/utils/error_handler.dart
@@ -69,19 +69,28 @@ class ErrorHandler {
     StackTrace? s,
     String? m,
     required Map<String, dynamic> data,
-    SentryLevel level = SentryLevel.error,
+    SentryLevel? level,
   }) async {
     if (!_reportedOnceKeys.add(key)) return false;
     await logError(e: e, s: s, m: m, data: data, level: level);
     return true;
   }
 
+  /// Reports [e] to Sentry at [level], defaulting to the one severity table
+  /// ([PangeaHttpException.severityOf]): a timeout and the routine statuses
+  /// (401, 404, 410, 429) are warnings, everything else — including any
+  /// failure carrying no HTTP status — an error. Severity is a property of the
+  /// failure, not of the author's judgment at the call site, so it is decided
+  /// here rather than at each of ~240 reporting sites, which is where it
+  /// drifted before (repos-and-error-handling.instructions.md § Severity
+  /// policy). An explicit [level] still wins: a caller with context the
+  /// failure lacks may escalate.
   static Future<void> logError({
     Object? e,
     StackTrace? s,
     String? m,
     required Map<String, dynamic> data,
-    SentryLevel level = SentryLevel.error,
+    SentryLevel? level,
   }) async {
     if (e is PangeaWarningError) {
       // Custom handling for PangeaWarningError
@@ -97,7 +106,7 @@ class ErrorHandler {
       e ?? Exception(m ?? "no message supplied"),
       stackTrace: s ?? StackTrace.current,
       withScope: (scope) {
-        scope.level = level;
+        scope.level = level ?? PangeaHttpException.severityOf(e);
       },
     );
   }

--- a/lib/pangea/spaces/public_course_extension.dart
+++ b/lib/pangea/spaces/public_course_extension.dart
@@ -5,6 +5,7 @@ import 'package:matrix/matrix.dart';
 import 'package:matrix/matrix_api_lite/generated/api.dart';
 
 import 'package:fluffychat/pangea/common/constants/model_keys.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 
 extension PublicCourseExtension on Api {
   Future<PublicCoursesResponse> getPublicCourses({
@@ -27,8 +28,10 @@ extension PublicCourseExtension on Api {
     final responseBody = await response.stream.toBytes();
     final responseString = utf8.decode(responseBody);
     if (response.statusCode != 200) {
-      throw Exception(
-        'HTTP error response: statusCode=${response.statusCode}, body=$responseString',
+      throw PangeaHttpException.fromStreamedResponse(
+        request,
+        response,
+        responseBody,
       );
     }
     final json = jsonDecode(responseString);

--- a/test/pangea/error_handler_severity_test.dart
+++ b/test/pangea/error_handler_severity_test.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+
+/// The severity a report reaches Sentry with, asserted where it is actually
+/// decided — [ErrorHandler.logError] — rather than on the table in isolation.
+///
+/// #8369: the table exists ([PangeaHttpException.severityOf]) but only the
+/// repos that pass `level:` were applying it, so a routine 401 raised anywhere
+/// else still arrived as `error`. These tests pin the default to the table, and
+/// pin that an explicit level still wins — a caller with context may escalate,
+/// per repos-and-error-handling.instructions.md § The contract.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Completer<SentryEvent>? pending;
+
+  setUp(() async {
+    ErrorHandler.resetReportedOnceKeysForTest();
+    await Sentry.init((options) {
+      options.dsn = 'https://public@sentry.invalid/1';
+      options.beforeSend = (event, hint) {
+        pending?.complete(event);
+        // Dropped: the assertion is on the event, and nothing should leave
+        // the test.
+        return null;
+      };
+    });
+  });
+
+  tearDown(() async {
+    pending = null;
+    await Sentry.close();
+  });
+
+  /// The level of the single event [report] produces.
+  Future<SentryLevel?> levelOf(void Function() report) async {
+    final completer = Completer<SentryEvent>();
+    pending = completer;
+    report();
+    final event = await completer.future.timeout(const Duration(seconds: 5));
+    return event.level;
+  }
+
+  PangeaHttpException http(int status) => PangeaHttpException.fromResponse(
+    Response(
+      '',
+      status,
+      request: Request('GET', Uri.parse('https://api.pangea.chat/x')),
+    ),
+  );
+
+  group('ErrorHandler.logError default level', () {
+    test('a routine 401 is a warning, not an error', () async {
+      expect(
+        await levelOf(() => ErrorHandler.logError(e: http(401), data: {})),
+        SentryLevel.warning,
+      );
+    });
+
+    test('404, 410, and 429 are warnings', () async {
+      for (final status in [404, 410, 429]) {
+        expect(
+          await levelOf(() => ErrorHandler.logError(e: http(status), data: {})),
+          SentryLevel.warning,
+          reason: '$status should be a warning',
+        );
+      }
+    });
+
+    test('a timeout is a warning', () async {
+      expect(
+        await levelOf(
+          () => ErrorHandler.logError(e: TimeoutException('slow'), data: {}),
+        ),
+        SentryLevel.warning,
+      );
+    });
+
+    test(
+      '403 stays an error — we asked for something we should not have',
+      () async {
+        expect(
+          await levelOf(() => ErrorHandler.logError(e: http(403), data: {})),
+          SentryLevel.error,
+        );
+      },
+    );
+
+    test('other 4xx and all 5xx stay errors', () async {
+      for (final status in [400, 405, 422, 500, 502, 504]) {
+        expect(
+          await levelOf(() => ErrorHandler.logError(e: http(status), data: {})),
+          SentryLevel.error,
+          reason: '$status should be an error',
+        );
+      }
+    });
+
+    test('a non-HTTP failure stays an error', () async {
+      expect(
+        await levelOf(
+          () => ErrorHandler.logError(e: Exception('parse'), data: {}),
+        ),
+        SentryLevel.error,
+      );
+    });
+
+    test('a message-only report with no exception stays an error', () async {
+      expect(
+        await levelOf(() => ErrorHandler.logError(m: 'no exception', data: {})),
+        SentryLevel.error,
+      );
+    });
+  });
+
+  group('ErrorHandler explicit level', () {
+    test(
+      'an explicit level wins over the table — callers may escalate',
+      () async {
+        expect(
+          await levelOf(
+            () => ErrorHandler.logError(
+              e: http(401),
+              data: {},
+              level: SentryLevel.error,
+            ),
+          ),
+          SentryLevel.error,
+        );
+      },
+    );
+
+    test('an explicit level can also lower a 500', () async {
+      expect(
+        await levelOf(
+          () => ErrorHandler.logError(
+            e: http(500),
+            data: {},
+            level: SentryLevel.info,
+          ),
+        ),
+        SentryLevel.info,
+      );
+    });
+  });
+
+  group('ErrorHandler.logErrorOnce', () {
+    test('applies the same default table', () async {
+      expect(
+        await levelOf(
+          () => ErrorHandler.logErrorOnce(key: 'k401', e: http(401), data: {}),
+        ),
+        SentryLevel.warning,
+      );
+    });
+
+    test('still honors an explicit level', () async {
+      expect(
+        await levelOf(
+          () => ErrorHandler.logErrorOnce(
+            key: 'k401-escalated',
+            e: http(401),
+            data: {},
+            level: SentryLevel.error,
+          ),
+        ),
+        SentryLevel.error,
+      );
+    });
+  });
+}

--- a/test/pangea/synapse_module_http_error_test.dart
+++ b/test/pangea/synapse_module_http_error_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+import 'package:matrix/matrix_api_lite/generated/api.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'package:fluffychat/features/join_codes/request_room_code_extension.dart';
+import 'package:fluffychat/features/room_summaries/activity_session_previews_extension.dart';
+import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+import 'package:fluffychat/pangea/spaces/public_course_extension.dart';
+
+/// The four `Api` extensions that call Synapse Pangea modules directly (Matrix
+/// bearer token, `httpClient.send`, bypassing [Requests]) each threw a bare
+/// `Exception` interpolating the whole response body — untyped in Sentry, and
+/// carrying content the exception must never hold
+/// (repos-and-error-handling.instructions.md § What `Requests` throws).
+///
+/// #8369 / CLIENT-E4Z. These tests pin the typed throw, the diagnosable title,
+/// the absence of the body, and the severity the failure resolves to.
+void main() {
+  /// An [Api] whose every call answers [status] with [body].
+  Api api(int status, String body) => Api(
+    httpClient: MockClient((_) async => Response(body, status)),
+    baseUri: Uri.parse('https://matrix.staging.pangea.chat'),
+    bearerToken: 'syt_test_token',
+  );
+
+  /// What Synapse answers with when the access token has aged out — the shape
+  /// behind CLIENT-E4Z's `401 M_UNAUTHORIZED`. `error` is the free-text half
+  /// that must not reach Sentry.
+  const unauthorized =
+      '{"errcode":"M_UNAUTHORIZED","error":"Invalid access token passed."}';
+
+  /// Each site, as (name, path, call).
+  final sites = <String, (String, Future<void> Function(Api))>{
+    'room_preview': (
+      '/_synapse/client/unstable/org.pangea/room_preview',
+      (a) => a.getRoomSummaries(['!r:server'], l1Code: 'en'),
+    ),
+    'activity_session_previews': (
+      '/_synapse/client/pangea/v1/activity_session_previews',
+      (a) => a.getActivitySessionPreviews(['!s:server'], l1Code: 'en'),
+    ),
+    'request_room_code': (
+      '/_synapse/client/pangea/v1/request_room_code',
+      (a) => a.getSpaceCode(),
+    ),
+    'public_courses': (
+      '/_synapse/client/unstable/org.pangea/public_courses',
+      (a) => a.getPublicCourses(),
+    ),
+  };
+
+  sites.forEach((name, site) {
+    final (path, call) = site;
+
+    group('$name — 401', () {
+      Future<PangeaHttpException> thrown() async {
+        try {
+          await call(api(401, unauthorized));
+        } on PangeaHttpException catch (e) {
+          return e;
+        }
+        fail('expected a PangeaHttpException');
+      }
+
+      test(
+        'throws a typed PangeaHttpException, not a bare Exception',
+        () async {
+          await expectLater(
+            call(api(401, unauthorized)),
+            throwsA(isA<PangeaHttpException>()),
+          );
+        },
+      );
+
+      test(
+        'toString renders status, method, and the normalized path',
+        () async {
+          final e = await thrown();
+          expect(e.statusCode, 401);
+          expect(
+            e.toString(),
+            'PangeaHttpException: 401 GET $path — M_UNAUTHORIZED',
+          );
+        },
+      );
+
+      test('carries the errcode as detail, never the response body', () async {
+        final e = await thrown();
+        expect(e.detail, 'M_UNAUTHORIZED');
+        expect(e.toString(), isNot(contains('Invalid access token')));
+      });
+
+      test('resolves to warning — token lifecycle is routine', () async {
+        expect(
+          PangeaHttpException.severityOf(await thrown()),
+          SentryLevel.warning,
+        );
+      });
+    });
+
+    test('$name — a 403 stays an error', () async {
+      try {
+        await call(api(403, '{"errcode":"M_FORBIDDEN","error":"nope"}'));
+        fail('expected a PangeaHttpException');
+      } on PangeaHttpException catch (e) {
+        expect(e.statusCode, 403);
+        expect(PangeaHttpException.severityOf(e), SentryLevel.error);
+      }
+    });
+
+    test('$name — a 502 with an unparseable body carries no detail', () async {
+      try {
+        await call(api(502, '<html>Bad Gateway</html>'));
+        fail('expected a PangeaHttpException');
+      } on PangeaHttpException catch (e) {
+        expect(e.detail, isNull);
+        expect(e.toString(), 'PangeaHttpException: 502 GET $path');
+        expect(PangeaHttpException.severityOf(e), SentryLevel.error);
+      }
+    });
+  });
+
+  group('PangeaHttpException.detailFromResponse — Matrix errcode', () {
+    test('prefers the choreo detail field when both are present', () {
+      expect(
+        PangeaHttpException.detailFromResponse(
+          Response('{"detail":"from choreo","errcode":"M_UNKNOWN"}', 400),
+        ),
+        'from choreo',
+      );
+    });
+
+    test('falls back to the Matrix errcode', () {
+      expect(
+        PangeaHttpException.detailFromResponse(
+          Response('{"errcode":"M_UNKNOWN_TOKEN","error":"soft logout"}', 401),
+        ),
+        'M_UNKNOWN_TOKEN',
+      );
+    });
+
+    test('never reads the free-text error field', () {
+      expect(
+        PangeaHttpException.detailFromResponse(
+          Response('{"error":"learner typed this"}', 400),
+        ),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Report routine 401s at `warning`, and stop four Synapse-module call sites throwing an untyped exception that carried the raw response body.

## Why

Closes #8369
Sentry: CLIENT-E69, CLIENT-E4X (`401 GET /subscription/status`), CLIENT-E4Z (`401 M_UNAUTHORIZED`).

Design intent is [repos-and-error-handling.instructions.md](.github/instructions/repos-and-error-handling.instructions.md) — this PR implements it, it does not restate it. No doc change rides along.

### The severity default

The table existed (`PangeaHttpException.severityOf`, #8133) but only applied where a repo passed `level:`. `ErrorHandler.logError` defaulted to a flat `SentryLevel.error`, so **202 of 243** reporting sites — every un-leveled one, including `PlatformDispatcher.onError` — reported at `error` regardless of status. That call-site sprawl is the exact failure the doc's rationale describes.

`level` is now nullable and defaults to `severityOf(e)`. This is **not** a blanket 401 downgrade — it applies the table, which only ever lowers a timeout and 401/404/410/429. 403, other 4xx, 5xx, and any failure carrying no HTTP status (`statusCodeOf` → null → default) are byte-for-byte unchanged. An explicit `level:` still wins, so a caller with context the failure lacks may escalate.

### The untyped throw

Four `Api` extensions reach Synapse Pangea modules directly (Matrix bearer token, `httpClient.send`), bypassing `Requests`, and each threw `Exception('HTTP error response: statusCode=…, body=$responseString')`:

| Site | Endpoint |
| --- | --- |
| `room_summary_extension.dart` | `/_synapse/client/unstable/org.pangea/room_preview` |
| `activity_session_previews_extension.dart` | `/_synapse/client/pangea/v1/activity_session_previews` |
| `request_room_code_extension.dart` | `/_synapse/client/pangea/v1/request_room_code` |
| `public_course_extension.dart` | `/_synapse/client/unstable/org.pangea/public_courses` |

They now raise `PangeaHttpException` via a `fromStreamedResponse` factory. `detailFromResponse` gained an `errcode` fallback, so a Synapse failure keeps its Matrix diagnostic — Matrix's sibling `error` field is free text and is deliberately never read. Title goes from an untyped `_Exception` carrying the body to `PangeaHttpException: 401 GET /_synapse/client/pangea/v1/request_room_code — M_UNAUTHORIZED`.

The factory takes the `request` from the caller rather than reading `StreamedResponse.request`, which is only as reliable as the client that filled it in — `MockClient` leaves it null, and method+path are the whole point of the title.

**`requests.dart` is untouched** — #8373 owns `UnsubscribedException` handling there, and nothing here needed that file.

### Scope note

I could not read the Sentry events: the MCP server is unauthenticated in this session and no `SENTRY_AUTH_TOKEN` is set, so `sentry-api.sh` refuses. The defects were located from the issue's recorded titles plus the code. `/subscription/status` already routes through `BaseRepo`, which passed `level:` and so was already `warning` — meaning those two issues reach Sentry through one of the un-leveled sites, which this change fixes without my having confirmed which frame from an event.

## Testing

- `fvm flutter test` — **2484 passed, 3 skipped, 0 failed.** The 3 skips are the choreo/synapse/CMS endpoint suites, which skip on a missing `client/.env` (absent in a fresh worktree by design). Re-run after `dart format`; identical.
- `fvm flutter analyze lib test` — No issues found.
- 39 new tests across two files, all confirmed failing against unfixed code first (24 and 25 failures respectively):
  - `test/pangea/error_handler_severity_test.dart` — asserts the level on the **actual captured Sentry event**, via `Sentry.init` with a `beforeSend` that records and drops. Covers the routine statuses, that 403/other-4xx/5xx/non-HTTP stay `error`, that an explicit level still wins, and `logErrorOnce`.
  - `test/pangea/synapse_module_http_error_test.dart` — drives all four extensions through `MockClient`. Asserts the thrown type, that `toString()` renders status + method + normalized path, that `detail` is the errcode and the body's free text never appears, and the severity per the table (401 warning, 403 error).
- Playwright browser bucket not triggered: no changed path matches any glob in `e2e/trigger-map.json` (checked programmatically).
- No manual device run — the linked issue's TO TEST covers the four user-facing flows for staging QA.

## Deploy Notes

None
