### PR TITLE
fix(subscription): stop reporting UnsubscribedException to Sentry

### DIFF
--- a/lib/pangea/common/network/requests.dart
+++ b/lib/pangea/common/network/requests.dart
@@ -103,4 +103,16 @@ class Requests {
   }
 }
 
-class UnsubscribedException implements Exception {}
+/// An unsubscribed user reached a paid endpoint (401 + `No active
+/// subscription found`). Control flow, not an error — callers render a
+/// paywall, and [ErrorHandler.shouldReport] keeps it out of Sentry entirely
+/// (repos-and-error-handling.instructions.md).
+///
+/// The `toString()` is a backstop for the day it escapes that gate anyway:
+/// without it every such event grouped under the useless title `Instance of
+/// 'UnsubscribedException'` (CLIENT-E4T, #8373) — the same failure a real
+/// `toString()` fixed for [PangeaHttpException] and `MissingQuestException`.
+class UnsubscribedException implements Exception {
+  @override
+  String toString() => 'UnsubscribedException: no active subscription (401)';
+}

--- a/lib/pangea/common/utils/error_handler.dart
+++ b/lib/pangea/common/utils/error_handler.dart
@@ -8,6 +8,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:fluffychat/l10n/l10n.dart';
 import 'package:fluffychat/pangea/common/config/environment.dart';
 import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+import 'package:fluffychat/pangea/common/network/requests.dart';
 import 'package:fluffychat/utils/platform_infos.dart';
 
 class PangeaWarningError implements Exception {
@@ -38,6 +39,7 @@ class ErrorHandler {
 
     // Error handling
     FlutterError.onError = (FlutterErrorDetails details) async {
+      if (!shouldReport(details.exception)) return;
       if (!kDebugMode || PlatformInfos.isMobile) {
         Sentry.captureException(
           details.exception,
@@ -51,6 +53,20 @@ class ErrorHandler {
       return true;
     };
   }
+
+  /// Whether [e] belongs in Sentry at all. [UnsubscribedException] does not:
+  /// it is control flow — an unsubscribed user reaching a paid endpoint — and
+  /// repos-and-error-handling.instructions.md states it is never reported.
+  ///
+  /// The invariant is enforced here, at the one sink, rather than by an
+  /// `is! UnsubscribedException` guard at each call site. The guard had been
+  /// copied to four sites while every hand-rolled repo that bypasses
+  /// [BaseRepo], every `showFutureLoadingDialog`, and the global
+  /// unhandled-async sink in [initialize] had no guard at all — so it reached
+  /// production
+  /// as `Instance of 'UnsubscribedException'` (CLIENT-E4T, #8373). A rule
+  /// copied per call site drifts; a rule with one home cannot.
+  static bool shouldReport(Object? e) => e is! UnsubscribedException;
 
   /// Keys already reported this session via [logErrorOnce].
   static final Set<String> _reportedOnceKeys = {};
@@ -71,6 +87,9 @@ class ErrorHandler {
     required Map<String, dynamic> data,
     SentryLevel level = SentryLevel.error,
   }) async {
+    // Checked before the key is spent, so suppressing control flow does not
+    // consume the one report a genuine failure on this key is owed.
+    if (!shouldReport(e)) return false;
     if (!_reportedOnceKeys.add(key)) return false;
     await logError(e: e, s: s, m: m, data: data, level: level);
     return true;
@@ -83,6 +102,8 @@ class ErrorHandler {
     required Map<String, dynamic> data,
     SentryLevel level = SentryLevel.error,
   }) async {
+    if (!shouldReport(e)) return;
+
     if (e is PangeaWarningError) {
       // Custom handling for PangeaWarningError
       debugPrint("PangeaWarningError: ${e.message}");

--- a/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
+++ b/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
@@ -650,7 +650,11 @@ class PangeaMessageEvent {
     final result = await TextToSpeechRepo.instance.get(request);
 
     if (result.error != null) {
-      throw Exception("Error getting text to speech: ${result.error}");
+      // Rethrow the repo's error rather than wrapping it: wrapping erased the
+      // type, so an UnsubscribedException arrived at the audio card's catch as
+      // a generic Exception that no guard could recognize (#8373), and every
+      // other failure lost the diagnosable toString its own type carries.
+      throw result.error!;
     }
 
     final response = result.result!;

--- a/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
+++ b/lib/routes/chat/events/event_wrappers/pangea_message_event.dart
@@ -650,11 +650,7 @@ class PangeaMessageEvent {
     final result = await TextToSpeechRepo.instance.get(request);
 
     if (result.error != null) {
-      // Rethrow the repo's error rather than wrapping it: wrapping erased the
-      // type, so an UnsubscribedException arrived at the audio card's catch as
-      // a generic Exception that no guard could recognize (#8373), and every
-      // other failure lost the diagnosable toString its own type carries.
-      throw result.error!;
+      throw Exception("Error getting text to speech: ${result.error}");
     }
 
     final response = result.result!;

--- a/test/pangea/unsubscribed_exception_reporting_test.dart
+++ b/test/pangea/unsubscribed_exception_reporting_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+import 'package:fluffychat/pangea/common/network/requests.dart';
+import 'package:fluffychat/pangea/common/utils/error_handler.dart';
+
+/// CLIENT-E4T (#8373): `UnsubscribedException` is control flow — an
+/// unsubscribed user hitting a paid endpoint — and
+/// repos-and-error-handling.instructions.md says it is *never* reported. It
+/// reached production Sentry anyway, titled `Instance of
+/// 'UnsubscribedException'`, because the `is! UnsubscribedException` guard was
+/// copied into four call sites while a dozen other paths (hand-rolled repos
+/// that bypass [BaseRepo], `showFutureLoadingDialog`, and the global
+/// unhandled-async sink) had no guard at all. These pin both halves of the fix:
+/// the invariant enforced once at the reporting sink, and a diagnosable
+/// `toString()` as the backstop.
+void main() {
+  test('UnsubscribedException has a diagnosable toString', () {
+    expect(
+      UnsubscribedException().toString(),
+      'UnsubscribedException: no active subscription (401)',
+    );
+  });
+
+  group('ErrorHandler.shouldReport', () {
+    test('an unsubscribed user is control flow, never reported', () {
+      expect(ErrorHandler.shouldReport(UnsubscribedException()), isFalse);
+    });
+
+    test('a real HTTP failure is still reported', () {
+      expect(
+        ErrorHandler.shouldReport(
+          PangeaHttpException(
+            statusCode: 500,
+            method: 'GET',
+            path: '/lemma/{id}',
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('an untyped failure is still reported', () {
+      expect(
+        ErrorHandler.shouldReport(Exception('choreo unreachable')),
+        isTrue,
+      );
+    });
+
+    test('a message-only report with no exception is still reported', () {
+      expect(ErrorHandler.shouldReport(null), isTrue);
+    });
+  });
+
+  group('ErrorHandler.logErrorOnce', () {
+    setUp(ErrorHandler.resetReportedOnceKeysForTest);
+    tearDown(ErrorHandler.resetReportedOnceKeysForTest);
+
+    test(
+      'does not report an unsubscribed user, and does not burn the key',
+      () async {
+        expect(
+          await ErrorHandler.logErrorOnce(
+            key: 'course-outline-resolve:c1',
+            e: UnsubscribedException(),
+            data: {'courseUuid': 'c1'},
+          ),
+          isFalse,
+        );
+
+        // The key is still available — suppressing control flow must not spend
+        // the one report a genuine failure on this key is owed.
+        expect(
+          await ErrorHandler.logErrorOnce(
+            key: 'course-outline-resolve:c1',
+            e: Exception('choreo unreachable'),
+            data: {'courseUuid': 'c1'},
+          ),
+          isTrue,
+        );
+      },
+    );
+  });
+}


### PR DESCRIPTION
## What

Enforce "`UnsubscribedException` is never reported" once at the reporting sink, and give it a real `toString()`.

## Why

Closes #8373. Sentry: CLIENT-E4T (production).

`repos-and-error-handling.instructions.md` § What `Requests` throws states `UnsubscribedException` "keeps its own type — it is control flow, not an error, and is **never reported**." It was reaching production Sentry anyway, titled `Instance of 'UnsubscribedException'`.

`Requests` was not the leak — it throws the type and never reports. The leak is that the rule was enforced by an `is! UnsubscribedException` guard **copied into four call sites** (`base_repo`, `async_state`, `activity_summary_repo`, `analytics_practice_session_controller`), which leaves every path that doesn't pass through one of them unguarded. An audit of `lib/` found the exception can reach `ErrorHandler.logError` / `Sentry.captureException` unguarded from, among others:

- `future_loading_dialog.dart` — reports unconditionally, and *before* the `showError` suppression check, so even callers that deliberately hide the failure still report it
- hand-rolled repos that bypass `BaseRepo` and so miss its guard — `quest_repo`, `app_version_util`, `practice_generation_repo`, plus the `activity_feedback` / `activity_rating` / `token_info_feedback` / `grammar_meaning_feedback` repos whose callers catch and report
- `world_map.dart` → `ActivityMapRepo.bboxPins` rethrows into an unawaited future, landing in the global `PlatformDispatcher.onError` sink — a path **no per-call-site guard can cover**
- `world_map_pins_manager` and `quest_progression_resolver`, which `logErrorOnce` a `Result.error` re-thrown out of `joined_objective_cache`

A rule copied per call site drifts — the same failure mode the doc's own "the rule lives in `Requests` alone" line warns about. So rather than add a tenth copy of the guard, this adds `ErrorHandler.shouldReport` and checks it at the three places that actually reach Sentry: `logError`, `logErrorOnce`, and the `FlutterError.onError` handler that calls `Sentry.captureException` directly.

`logErrorOnce` checks it *before* spending the once-key, so suppressing control flow can't consume the single report a genuine failure on that key is owed.

Plus the `toString()` on `UnsubscribedException` — the backstop the issue asks for regardless, same reasoning that fixed `Instance of 'Response'` for `PangeaHttpException` and `Instance of 'MissingQuestException'` (#8094).

### Deliberately not fixed here

Two sites wrap the exception in a generic `Exception` before anything catches it, erasing the type so that no guard — central or per-site — can recognize it:

- `pangea_message_event`'s TTS wrap is **CLIENT-E4H / #8375**, which owns that line; left alone to avoid a conflicting edit.
- `activity_session_start_page` throws off an `ActivityPlanLookupStatus` enum carrying no error object, so preserving the type means changing the shared `ActivityPlanLookup` model.

Both surface under their own Sentry titles, not CLIENT-E4T.

## Testing

`test/pangea/unsubscribed_exception_reporting_test.dart` (new), modeled on the `missing_quest_reporting_test.dart` precedent:

- `UnsubscribedException().toString()` renders meaningfully
- `shouldReport` is false for `UnsubscribedException`, and still true for `PangeaHttpException`, an untyped `Exception`, and a message-only report with no exception — the guard must not swallow anything else
- `logErrorOnce` returns false for `UnsubscribedException` without spending the once-key

Verified **red first** against unfixed code — the `toString` assertion failed with `Actual: 'Instance of \'UnsubscribedException\''`, reproducing the exact Sentry title.

- `fvm flutter analyze lib test` — no issues
- `fvm flutter test` (full suite, Flutter 3.41.4 per `.fvmrc`) — **2452 passed, 3 skipped, 0 failed**. The 3 skips are the endpoint suites that skip without `TEST_MATRIX_*` creds in a fresh worktree — expected, not a pass. That run included the TTS change since reverted; the targeted suites (`unsubscribed_exception_reporting`, `error_handler_log_once`, `quests/`) plus a clean `analyze` were re-run after the revert.

Unit is the only bucket this surface has — no smoke/eval/load surface in the change.

The user-visible paywall behavior in #8373's TO TEST is unchanged by design (this only suppresses a Sentry capture), so those steps are for staging QA.

## Deploy Notes

None.

## Note for reviewers

`requests.dart` is shared with #8369 (401 severity). This PR touches only the `UnsubscribedException` class declaration at the bottom of the file and does not go near `_handleError`'s 401 branch.
