### PR TITLE
fix(quests): discriminate CMS auth-403 from a permission bug on quest reads

### DIFF
--- a/lib/features/quests/repo/quest_repo.dart
+++ b/lib/features/quests/repo/quest_repo.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 
 import 'package:async/async.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'package:fluffychat/features/activity_sessions/activity_media_block.dart';
 import 'package:fluffychat/features/activity_sessions/activity_media_repo.dart';
@@ -14,6 +15,7 @@ import 'package:fluffychat/features/quests/models/quest_activity_card.dart';
 import 'package:fluffychat/features/quests/models/quest_plan_model.dart';
 import 'package:fluffychat/features/quests/repo/activity_v2_mapper.dart';
 import 'package:fluffychat/pangea/common/config/environment.dart';
+import 'package:fluffychat/pangea/common/network/matrix_session.dart';
 import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
 import 'package:fluffychat/pangea/common/network/rate_limit_pause.dart';
 import 'package:fluffychat/pangea/common/network/requests.dart';
@@ -32,6 +34,24 @@ class MissingQuestException implements Exception {
   @override
   String toString() =>
       'MissingQuestException: quest plan not found in CMS (confirmed 404)';
+}
+
+/// How a failed quest read is classified before anything is reported: the
+/// error callers receive, and the level to report it at — or nothing, when the
+/// failure is a known benign state that must not reach Sentry at all.
+class QuestReadFailure {
+  /// The error handed back to callers.
+  final Object error;
+
+  /// The Sentry level to report at, or null to not report this failure.
+  final SentryLevel? reportAt;
+
+  /// A benign, known state — surfaced to callers, never reported.
+  const QuestReadFailure.silent(this.error) : reportAt = null;
+
+  /// A failure worth reporting, at [level].
+  const QuestReadFailure.report(this.error, SentryLevel level)
+    : reportAt = level;
 }
 
 /// The single home of the per-course activity-pin rule (org quests doc,
@@ -262,6 +282,52 @@ class QuestRepo {
     accessToken: MatrixState.pangeaController.userController.accessToken,
   );
 
+  /// Test seam for [_tokenRejected]: replaces the live homeserver probe, so
+  /// the 403 classification is testable without a Matrix client.
+  @visibleForTesting
+  static Future<bool> Function()? debugTokenRejected;
+
+  static Future<bool> _tokenRejected() =>
+      (debugTokenRejected ??
+      () => matrixTokenRejected(
+        MatrixState.pangeaController.userController.client,
+      ))();
+
+  /// Classify a failed quest-plans read into what callers get and what Sentry
+  /// gets.
+  ///
+  /// The 403 branch is the reason this exists (#8372). CMS read access to
+  /// `quest-plans` is `isMatrixUser || isServiceUser || isAdmin` — there is no
+  /// membership or course scoping on the collection, so a learner reading a
+  /// quest they have not joined is explicitly allowed and **cannot** be what a
+  /// 403 means. What a 403 does mean is that Payload resolved no user at all:
+  /// an absent, expired, refreshed-away or invalidated Matrix token yields the
+  /// identical 403 that a genuine permission failure would. The client's
+  /// severity policy reads every 403 as "we asked for something we should not
+  /// have — a code bug", which mis-files a routine token-lifecycle event as an
+  /// error the way the 401 row exists to prevent.
+  ///
+  /// So the 403 is **discriminated, never downgraded**: we re-ask the
+  /// homeserver the same question the CMS asked. Only a positive rejection
+  /// reclassifies ([matrixTokenRejected] is conservative by construction); a
+  /// 403 with a live token stays an `error`, because then it really is the
+  /// permission bug the policy is there to catch.
+  @visibleForTesting
+  static Future<QuestReadFailure> classifyQuestReadFailure(
+    Object e, {
+    required Future<bool> Function() tokenRejected,
+  }) async {
+    final status = PangeaHttpException.statusCodeOf(e);
+    if (status == 404) return QuestReadFailure.silent(MissingQuestException());
+    if (status == 403 && await tokenRejected()) {
+      return QuestReadFailure.report(
+        SessionExpiredException(),
+        SentryLevel.warning,
+      );
+    }
+    return QuestReadFailure.report(e, PangeaHttpException.severityOf(e));
+  }
+
   /// The quest with its ordered Learning Objective ids (one read). LO text is
   /// NOT populated by depth (Payload leaves the relationship-in-array a bare
   /// id), so [_learningObjectives] resolves it in a separate batch read.
@@ -274,17 +340,19 @@ class QuestRepo {
       );
       return Result.value(quest);
     } catch (e, s) {
-      if (PangeaHttpException.statusCodeOf(e) == 404) {
-        return Result.error(MissingQuestException());
-      }
-
-      ErrorHandler.logError(
-        e: e,
-        s: s,
-        data: {"quest_id": questId},
-        level: PangeaHttpException.severityOf(e),
+      final failure = await classifyQuestReadFailure(
+        e,
+        tokenRejected: _tokenRejected,
       );
-      return Result.error(e);
+      if (failure.reportAt != null) {
+        ErrorHandler.logError(
+          e: e,
+          s: s,
+          data: {"quest_id": questId},
+          level: failure.reportAt!,
+        );
+      }
+      return Result.error(failure.error);
     }
   }
 
@@ -476,6 +544,14 @@ class QuestRepo {
   /// it for the process lifetime, so every retry — the world map's empty-cache
   /// self-heal, a panel reopen — would replay the stale error instead of ever
   /// recovering (#8083); those stay uncached.
+  ///
+  /// A [SessionExpiredException] is emphatically NOT cached (#8372). A 404 is
+  /// a statement about the *resource*; a rejected token is a statement about
+  /// *this moment's credentials*, and the SDK's own soft-logout refresh is
+  /// expected to heal it seconds later. Memoizing it would pin every quest the
+  /// learner touched during a token refresh to "unavailable" for the life of
+  /// the process — the exact #8083 failure, and worse than the 403s it would
+  /// silence.
   ///
   /// A [MissingQuestException] is the exception, on the same reasoning as
   /// `ActivityPlanRepo._confirmedRemoved`: the CMS has *stated* the quest is

--- a/lib/pangea/common/network/matrix_session.dart
+++ b/lib/pangea/common/network/matrix_session.dart
@@ -1,0 +1,66 @@
+import 'package:matrix/matrix.dart';
+
+/// A read the CMS refused because our Matrix access token is no longer one the
+/// homeserver accepts — the session expired, was refreshed out from under the
+/// request, or was invalidated elsewhere (another device logged it out, the
+/// password changed).
+///
+/// This is a **token-lifecycle** state, not a permission bug: the learner was
+/// never forbidden the resource, we simply presented credentials the server had
+/// already retired. It exists as its own type because the CMS cannot say so
+/// itself — see [matrixTokenRejected].
+class SessionExpiredException implements Exception {
+  @override
+  String toString() =>
+      'SessionExpiredException: the homeserver rejected our Matrix access token';
+}
+
+/// The errcodes by which a homeserver states the access token we presented is
+/// no longer usable, as opposed to the request being wrong. Kept in one place
+/// because these four are the whole vocabulary for "your token is dead":
+/// `M_UNKNOWN_TOKEN` (unknown/retired session), `M_MISSING_TOKEN` (never
+/// arrived), `M_FORBIDDEN` (expired or invalidated) and `M_USER_DEACTIVATED`
+/// (the account is gone) — see the Common Errors table in
+/// `matrix-auth.instructions.md`.
+const Set<String> kRejectedTokenErrcodes = {
+  'M_UNKNOWN_TOKEN',
+  'M_MISSING_TOKEN',
+  'M_FORBIDDEN',
+  'M_USER_DEACTIVATED',
+};
+
+/// Whether [errcode] is the homeserver stating our token is dead.
+bool isRejectedTokenErrcode(String? errcode) =>
+    errcode != null && kRejectedTokenErrcodes.contains(errcode);
+
+/// Whether the homeserver **positively rejects** the token [client] currently
+/// holds, asked over the very endpoint the CMS validates against
+/// (`/_matrix/client/v3/account/whoami`).
+///
+/// Why this exists: Payload answers *both* "you are not authenticated" and "you
+/// are authenticated but not permitted" with the same **403** and the same
+/// body, `{"errors":[{"message":"You are not allowed to perform this
+/// action."}]}` — there is no 401 anywhere in the CMS surface. So a 403 alone
+/// cannot tell a dead session apart from a genuine permission bug, and the
+/// client's severity policy (403 → error, "a code bug") mis-reads the first as
+/// the second. Re-asking whoami is the discriminator, and it is decisive
+/// because it is the same question the CMS asked.
+///
+/// **Deliberately conservative.** Only an explicit rejection
+/// ([isRejectedTokenErrcode]) returns true. A success, a network failure, or
+/// any other exception returns false, so the caller falls through to its normal
+/// classification. A real permission bug can therefore never be reclassified
+/// into a session problem by a flaky probe — the failure mode is "still
+/// reported as an error", which is the safe direction.
+///
+/// Costs one request, on an already-failing path only.
+Future<bool> matrixTokenRejected(Client client) async {
+  try {
+    await client.getTokenOwner();
+    return false;
+  } on MatrixException catch (e) {
+    return isRejectedTokenErrcode(e.errcode);
+  } catch (_) {
+    return false;
+  }
+}

--- a/lib/routes/world/world_map_pins_manager.dart
+++ b/lib/routes/world/world_map_pins_manager.dart
@@ -19,6 +19,7 @@ import 'package:fluffychat/features/quests/repo/activity_map_repo.dart';
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
 import 'package:fluffychat/features/room_summaries/activity_session_previews_extension.dart';
 import 'package:fluffychat/features/room_summaries/room_summary_extension.dart';
+import 'package:fluffychat/pangea/common/network/matrix_session.dart';
 import 'package:fluffychat/pangea/common/network/rate_limit_pause.dart';
 import 'package:fluffychat/pangea/common/utils/error_handler.dart';
 import 'package:fluffychat/routes/world/joined_objective_cache.dart';
@@ -54,11 +55,22 @@ bool needsParticipantRefill({
 /// course panel renders it as a known state — so re-reporting it at `error`
 /// re-severitized a handled condition (CLIENT-DQC, #8094). It still reports at
 /// `warning` (once per course per session) because a dropped course blanks
-/// relevance banding with no other visible signal. Everything else keeps
-/// `error`: the outline read failing for any other reason is real breakage.
+/// relevance banding with no other visible signal.
+///
+/// [SessionExpiredException] rides the same rule (#8372). The repo already
+/// established, by asking the homeserver, that the CMS 403 was our token being
+/// rejected rather than a permission bug; this rebuild fans out over every
+/// joined course, so a single expired token would otherwise land one `error`
+/// per course. Escalating it here would re-severitize the very condition the
+/// repo just classified — the #8094 mistake again, at a different site.
+///
+/// Everything else keeps `error`: the outline read failing for any other reason
+/// is real breakage.
 @visibleForTesting
 SentryLevel courseOutlineErrorLevel(Object error) =>
-    error is MissingQuestException ? SentryLevel.warning : SentryLevel.error;
+    error is MissingQuestException || error is SessionExpiredException
+    ? SentryLevel.warning
+    : SentryLevel.error;
 
 /// Minimum spacing between empty-cache self-heal rebuilds of the objective
 /// cache. A set-change rebuild (course join/leave) is never subject to it —

--- a/test/pangea/quests/missing_quest_reporting_test.dart
+++ b/test/pangea/quests/missing_quest_reporting_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/pangea/common/network/matrix_session.dart';
 import 'package:fluffychat/routes/world/world_map_pins_manager.dart';
 
 /// CLIENT-DQC (#8094): a missing quest is a state the repo classified benign —
@@ -27,11 +28,32 @@ void main() {
       );
     });
 
+    // #8372: the same re-severitizing mistake, one site over. The repo already
+    // proved (by asking the homeserver) that the CMS 403 was our token being
+    // rejected, not a permission bug. This rebuild fans out over every joined
+    // course, so escalating here would turn one expired token into one `error`
+    // per course.
+    test('an expired session reports at warning, per course', () {
+      expect(
+        courseOutlineErrorLevel(SessionExpiredException()),
+        SentryLevel.warning,
+      );
+    });
+
     test('any other outline failure stays an error', () {
       expect(
         courseOutlineErrorLevel(Exception('choreo unreachable')),
         SentryLevel.error,
       );
     });
+  });
+
+  test('SessionExpiredException has a diagnosable toString', () {
+    // Same reason MissingQuestException needs one (#8094): without it every
+    // report arrives in Sentry titled `Instance of '...'`.
+    expect(
+      SessionExpiredException().toString(),
+      'SessionExpiredException: the homeserver rejected our Matrix access token',
+    );
   });
 }

--- a/test/pangea/quests/quest_read_403_classification_test.dart
+++ b/test/pangea/quests/quest_read_403_classification_test.dart
@@ -1,0 +1,146 @@
+import 'package:async/async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+import 'package:fluffychat/features/quests/models/quest_plan_model.dart';
+import 'package:fluffychat/features/quests/repo/quest_repo.dart';
+import 'package:fluffychat/pangea/common/network/matrix_session.dart';
+import 'package:fluffychat/pangea/common/network/pangea_http_exception.dart';
+
+PangeaHttpException _http(int status) => PangeaHttpException(
+  statusCode: status,
+  method: 'GET',
+  path: '/cms/api/quest-plans/{id}',
+);
+
+void main() {
+  // #8372: `PangeaHttpException: 403 GET /cms/api/quest-plans/{id}` was arriving
+  // in Sentry at `error` ("we asked for something we should not have — a code
+  // bug"). It is not one. CMS read access to quest-plans is
+  // `isMatrixUser || isServiceUser || isAdmin` — no membership scoping exists,
+  // so an un-joined learner reading a quest cannot be what the 403 means.
+  // Payload simply answers "no authenticated user" with the same 403 it answers
+  // "not permitted" with, and there is no 401 anywhere on the CMS surface.
+  //
+  // The fix DISCRIMINATES the two rather than downgrading either: only a
+  // homeserver that positively rejects our token reclassifies the failure.
+  group('quest read 403 classification', () {
+    Future<bool> rejected() async => true;
+    Future<bool> live() async => false;
+
+    test('a 403 with a homeserver-rejected token is token lifecycle', () async {
+      final failure = await QuestRepo.classifyQuestReadFailure(
+        _http(403),
+        tokenRejected: rejected,
+      );
+
+      expect(failure.error, isA<SessionExpiredException>());
+      // Reported, not swallowed — but at the level the severity table gives
+      // token lifecycle, matching its 401 row.
+      expect(failure.reportAt, SentryLevel.warning);
+    });
+
+    test('a 403 with a live token stays a reported error', () async {
+      final original = _http(403);
+      final failure = await QuestRepo.classifyQuestReadFailure(
+        original,
+        tokenRejected: live,
+      );
+
+      // The whole point of discriminating: a genuine permission bug must still
+      // surface as an error, with the original exception intact.
+      expect(failure.error, same(original));
+      expect(failure.reportAt, SentryLevel.error);
+    });
+
+    test('a 404 is still the silent, benign missing-quest state', () async {
+      var probed = false;
+      final failure = await QuestRepo.classifyQuestReadFailure(
+        _http(404),
+        tokenRejected: () async {
+          probed = true;
+          return true;
+        },
+      );
+
+      expect(failure.error, isA<MissingQuestException>());
+      expect(failure.reportAt, isNull);
+      // A 404 needs no session probe — it never reached the auth question.
+      expect(probed, isFalse);
+    });
+
+    test('a non-403 failure never probes the homeserver', () async {
+      var probed = false;
+      Future<bool> probe() async {
+        probed = true;
+        return true;
+      }
+
+      final server = await QuestRepo.classifyQuestReadFailure(
+        _http(500),
+        tokenRejected: probe,
+      );
+      expect(server.reportAt, SentryLevel.error);
+
+      final rateLimited = await QuestRepo.classifyQuestReadFailure(
+        _http(429),
+        tokenRejected: probe,
+      );
+      expect(rateLimited.reportAt, SentryLevel.warning);
+
+      expect(probed, isFalse);
+    });
+  });
+
+  group('rejected-token errcodes', () {
+    test('the homeserver vocabulary for a dead token', () {
+      expect(isRejectedTokenErrcode('M_UNKNOWN_TOKEN'), isTrue);
+      expect(isRejectedTokenErrcode('M_MISSING_TOKEN'), isTrue);
+      expect(isRejectedTokenErrcode('M_FORBIDDEN'), isTrue);
+      expect(isRejectedTokenErrcode('M_USER_DEACTIVATED'), isTrue);
+    });
+
+    test('an unrelated errcode is not a token rejection', () {
+      // Conservative by design: anything we do not positively recognize leaves
+      // the failure classified as it was, so a permission bug is never hidden.
+      expect(isRejectedTokenErrcode('M_LIMIT_EXCEEDED'), isFalse);
+      expect(isRejectedTokenErrcode('M_NOT_FOUND'), isFalse);
+      expect(isRejectedTokenErrcode(null), isFalse);
+    });
+  });
+
+  group('QuestRepo.outline does not cache a session expiry', () {
+    const quest = QuestPlan(
+      id: 'quest-1',
+      name: 'Quest',
+      description: '',
+      targetLanguage: 'es',
+      sequence: [],
+    );
+
+    setUp(QuestRepo.resetOutlineCacheForTest);
+
+    tearDown(() {
+      QuestRepo.debugBuildOutline = null;
+      QuestRepo.debugTokenRejected = null;
+      QuestRepo.resetOutlineCacheForTest();
+    });
+
+    test('a session expiry is retried, and recovers once refreshed', () async {
+      var buildCalls = 0;
+      QuestRepo.debugBuildOutline = (id, {courseRoomId}) async {
+        buildCalls++;
+        // The token refresh completes between the two reads.
+        if (buildCalls == 1) return Result.error(SessionExpiredException());
+        return Result.value(const QuestOutline(quest: quest, groups: []));
+      };
+
+      expect((await QuestRepo.outline('quest-1')).isError, isTrue);
+      // Unlike a confirmed 404, this must NOT be memoized: the SDK's soft-logout
+      // refresh heals it seconds later, and pinning it would leave every quest
+      // touched mid-refresh permanently unavailable (#8083's failure mode).
+      expect((await QuestRepo.outline('quest-1')).isValue, isTrue);
+      expect(buildCalls, 2);
+    });
+  });
+}


### PR DESCRIPTION
### What

On a 403 from `GET /cms/api/quest-plans/{id}`, ask the homeserver whether our Matrix token is still valid, and classify the failure on the answer instead of assuming a permission bug.

### Why

Closes #8372. Sentry `CLIENT-E4W` — 15 events / 2 users / 14d, production.

CMS read access to `quest-plans` is `isMatrixUser || isServiceUser || isAdmin` ([`cms/src/collections/quest-plans.ts`](https://github.com/pangeachat/cms/blob/main/src/collections/quest-plans.ts)) — there is **no membership or course scoping on the collection**, so an un-joined learner reading a quest is explicitly allowed and cannot be what the 403 means.

What it does mean is that Payload resolved no user at all. Verified against production — an absent, empty, or invalid Bearer token all return the identical `403 {"errors":[{"message":"You are not allowed to perform this action."}]}` a genuine permission failure would, and there is no 401 anywhere on the CMS surface. So a routine expired / refreshed / remotely-invalidated token was being filed as `error` per the 403 row of the severity policy — the case its own 401 row ("token lifecycle is routine") exists to classify. Soft-logout token refresh is enabled (`onSoftLogout: refreshAccessToken`), which is what makes the stale-token window recur.

Design: [repos-and-error-handling.instructions.md § Severity policy](.github/instructions/repos-and-error-handling.instructions.md), [quests-and-learning-objectives.instructions.md § Access](https://github.com/pangeachat/.github/blob/main/.github/instructions/quests-and-learning-objectives.instructions.md).

**Discriminated, not downgraded.** Only a positive token rejection reclassifies (to a typed `SessionExpiredException` at `warning`); a 403 with a live token stays an `error`, so a real permission bug is still caught. The probe is conservative by construction — a network failure or any unrecognized errcode leaves the original classification standing, so the failure mode is "still reported as an error".

Two deliberate calls:

- **The world map's objective-cache rebuild gets the same treatment.** It fans out over every joined course, so escalating there would turn one expired token into one `error` per course — the #8094 re-severitizing mistake at a second site.
- **The session expiry is NOT memoized** in the outline cache, unlike the confirmed 404 from #8363. A 404 states something about the *resource*; a rejected token states something about *this moment's credentials*, and the SDK's refresh heals it seconds later. Caching it would pin every quest touched mid-refresh to "unavailable" for the process lifetime — the #8083 failure, and worse than the 403s it would silence.

### Testing

- `fvm flutter test test/pangea/` — **2433 passed, 3 skipped**.
- `fvm flutter analyze lib/ test/` — no issues.
- New `test/pangea/quests/quest_read_403_classification_test.dart` (6 cases) verified **failing against unfixed code** before the fix landed: 403 + rejected token → `SessionExpiredException` at `warning`; 403 + live token → original error at `error` (the guard against hiding permission bugs); 404 unchanged and silent, with no probe; non-403 never probes.
- `test/pangea/quests/missing_quest_reporting_test.dart` extended for the world-map severity site and the new `toString()`.
- Production CMS auth behavior confirmed by direct probe (no credentials used): absent, empty, and invalid Bearer tokens each return 403, not 401.
- Staging-credentialed endpoint tests skip in a fresh worktree — not run, and not counted as a pass.

### Deploy Notes

None.